### PR TITLE
Small tweaks to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "keywords": [
     "gatsby"
   ],
-  "license": "0BSD",
+  "license": "Apache-2",
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",


### PR DESCRIPTION
## Description

I noticed that `gatsby develop` output `You can now view gatsby-starter-default in the browser.` in the console. This PR addresses that + uses `yarn` for the `start` script.

