### PR TITLE
clinton / research frontmatter fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The `docs-website` project is the code and data behind the new docs.newrelic.com
 
 ## Getting Started
 
-You can serve this site locally to quickly see your changes and additions before you PR them. To get started, navigate into your new site’s directory and start it up, as follows.
+You can serve this site locally to quickly see your changes and additions before you PR them. To get started, navigate into your new site’s directory and start it up, as follows. 
 
 ```
 git clone git@github.com:newrelic/docs-website.git


### PR DESCRIPTION
# Identify what frontmatter fields we should support for each content type

## Research Goals

Create an example MDX file (including frontmatter) for a:
- "basic page"
- "troubleshooting page" (if applicable)
- "agent release note" (if applicable)
- "platform release note" (if applicable)
- "attribute definition" (if applicable)
- "agent API" (if applicable)
- "what's new page" (if applicable)

_Research for issue #35_

## Findings

### Combining fields into main body
A couple content types have separate fields that are authored in HTML. It's likely not a good editing experience to edit HTML in frontmatter as a string or in key value pairs. I couldn't find great info / examples of other sites doing this. It seems uncommon and not best practice, especially with some of the fields that have good amount of HTML. 

I think the best way to handle that is combining the relevant fields into the main body of the file. This makes the editing experience better, reduces need for extra templates, reduces need for extra processing when we start outputting JSON (Example: NR1 Help Center only uses one field to render a piece of content)

### Translation fields
I think we probably need to bring these over. Currently, if a piece of content has a Japanese version available, we use a field to indicate that. That fields is used on the front end to:
* add a `<link hreflang />` tag
* adds a class for OneLink (the vendor tool that proxies our site in Japanese) class to the content's link in the left nav
* adds swiftype meta tag to index the Japanese page's URL (that currently isn't used for anything)

### Global frontmatter fields
There are likely going to be global frontmatter fields that most/all content will optionally use. Examples include:
* `contentType`
* `metaRobots`
* `metaDescription`
* `redirects`
* `slug` / `path`? (seems like we may not support this)
* `tags`? (for swiftype auto search for related content)
* `title`
* `templateKey`
* `topics`? (very similar to tags, but maybe we want to split this out, esp if menu-ing or some specific functionality is tied to it)
* `translatedJapaneseLink`?

### Swiftype meta
We include several meta tags to add data to each page's Swiftype record. I believe most Swiftype meta tags can be generated from existing data via GraphQL query in the relevant template that renders the page.

## Recommendation
- [api-doc-example.mdx](https://gist.github.com/roadlittledawn/e3aa18a57d7284a4f29506503dcbf14f)
  - combine separate fields into main body of the file.
- attribute definitions. [See PR #37](https://github.com/newrelic/docs-website/pull/37)
- [basic-page-example.mdx](https://gist.github.com/roadlittledawn/d476551e878ad91b7abcc6f2b4361d3b)
- [nr1-announcement-example.mdx](https://gist.github.com/roadlittledawn/d5800ee6f5bbe6707970daa8e7af568d)
  - Use `field_products` field to populate the common `topics` (or whatever we end up calling it) frontmatter field
- [release-note-example.mdx](https://gist.github.com/roadlittledawn/76b64d9bf52ef4e4e4d6659b69725027)
- [release-note-platform-example.mdx](https://gist.github.com/roadlittledawn/633a54fbb3b17958e2ea2b2ec637abb6)
  - Use `field_products` field to populate the common `topics` (or whatever we end up calling it) frontmatter field
- [troubleshooting-doc-example.mdx](https://gist.github.com/roadlittledawn/1482bc2975c92b376ae970c432b8a2c9)
  - combine `problem`, `solution`, `cause` fields into the main body of the file

## Open Questions

Will authors be able to specify `path`/`slug` or no? Sounds like we were leaning to no.

What do we do with translation related fields? These may not be relevant once we migrate away from the proxy solution. But until then do we need to maintain parity? 

Will docs site also use similar Related Resources component? If so, will need to use `tags` field similar to developer site.

Do we need to bring over Short Title?

Do we add a common field (or use `tags`) to capture current site's categories/products taxonomy terms? That could be used as one way of providing secondary nav/collections of content, used to filter Swiftype results, etc.

Do we want to use `resources` links like developer site?

## Resources
[Content types on current site](https://docs-dev.newrelic.com/admin/structure/types)