### PR TITLE
Prototype Script To Fetch Docs & Create MDX Files

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint": "^7.7.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react-hooks": "^4.1.0",
+    "node-fetch": "^2.6.1",
     "prettier": "2.0.5"
   },
   "keywords": [

--- a/scripts/fetch-docs.js
+++ b/scripts/fetch-docs.js
@@ -5,6 +5,22 @@ const path = require('path');
 const BASE_URL = 'https://docs.newrelic.com/api/ui/content';
 const BASE_DIR = path.join(__dirname, '..', 'src/content');
 
+const GATSBY_CONTENT_TYPES = {
+  page: 'page',
+  api_doc: 'apiDoc',
+  release_notes: 'releaseNote',
+  release_notes_platform: 'releaseNotePlatform',
+  troubleshooting_doc: 'troubleshootingDoc',
+};
+
+const GATSBY_TEMPLATE = {
+  page: 'basicDocPageTemplate',
+  api_doc: 'basicDocPageTemplate',
+  release_notes: 'releaseNotePageTemplate',
+  release_notes_platform: 'releaseNotePlatformPageTemplate',
+  troubleshooting_doc: 'basicDocPageTemplate',
+};
+
 // IDs grouped by content type (related GH issue in comments)
 const input = [
   { type: 'page', ids: ['38576', '40431'] }, // #44
@@ -36,6 +52,14 @@ const getCategories = (url) => {
     .slice(0, -1);
 };
 
+const getFrontmatter = (type, doc) => `---
+title: ${doc.title}
+contentType: ${GATSBY_CONTENT_TYPES[type]}
+templateKey: ${GATSBY_TEMPLATE[type]}
+---
+
+`;
+
 const fetchPages = async () => {
   // Step 1: get the docs
   const requests = input.flatMap(({ type, ids }) =>
@@ -54,11 +78,21 @@ const fetchPages = async () => {
     // Step 3: create a file for each doc
     const slug = doc.docUrl.split('/').slice(-1);
     const fileName = `${dir}/${slug}.mdx`;
-    fs.writeFile(fileName, doc.body, (err) => {
+
+    // Step 4: create frontmatter based on content type
+    // NOTE: this should be returned in the JSON payload
+    const type = input.find(({ ids }) => ids.includes(doc.docId)).type;
+    const frontmatter = getFrontmatter(type, doc);
+
+    // Step 5: add content to file
+    const content = frontmatter + doc.body;
+    fs.writeFile(fileName, content, (err) => {
       if (err) {
         console.log(`Error, could not create ${fileName}`, e);
       }
     });
+
+    // Step 6: party!
   });
 };
 

--- a/scripts/fetch-docs.js
+++ b/scripts/fetch-docs.js
@@ -1,3 +1,5 @@
+const fetch = require('node-fetch');
+
 const BASE_URL = 'https://docs.newrelic.com/api/ui/content';
 
 // IDs grouped by content type (related GH issue in comments)
@@ -7,13 +9,33 @@ const input = [
   { type: 'release_notes', ids: ['40416', '40466'] }, // #48
   { type: 'release_notes_platform', ids: ['40531', '40506'] }, // #49
   { type: 'troubleshooting_doc', ids: ['40351', '15086'] }, // #50
-  { type: 'nr1_announcement', ids: ['40426', '40516'] }, // #47
+  // { type: 'nr1_announcement', ids: ['40491', '40516'] }, // #47
   { type: 'attribute_definition', ids: ['40336', '40016'] }, // 46
 ];
 
-const fetchPages = () => {
-  console.log('hello, world!');
+const getUrl = (type, id) => [BASE_URL, type, id].join('/');
+
+const fetchDoc = async (type, id) => {
+  const url = getUrl(type, id);
+  try {
+    const resp = await fetch(url);
+    const result = await resp.json();
+    return result.docs[0].doc;
+  } catch (e) {
+    console.log(`Error, could not fetch ${url}`, e);
+  }
 };
 
-// Run the script
+const fetchPages = async () => {
+  const requests = input.flatMap(({ type, ids }) =>
+    ids.map((id) => fetchDoc(type, id))
+  );
+
+  const results = await Promise.all(requests);
+  const titles = results.map((result) => result.title);
+
+  console.log(titles);
+};
+
+// Run the script via `node path_to_script`
 fetchPages();

--- a/scripts/fetch-docs.js
+++ b/scripts/fetch-docs.js
@@ -1,6 +1,9 @@
 const fetch = require('node-fetch');
+const fs = require('fs');
+const path = require('path');
 
 const BASE_URL = 'https://docs.newrelic.com/api/ui/content';
+const BASE_DIR = path.join(__dirname, '..', 'src/content');
 
 // IDs grouped by content type (related GH issue in comments)
 const input = [
@@ -10,7 +13,7 @@ const input = [
   { type: 'release_notes_platform', ids: ['40531', '40506'] }, // #49
   { type: 'troubleshooting_doc', ids: ['40351', '15086'] }, // #50
   // { type: 'nr1_announcement', ids: ['40491', '40516'] }, // #47
-  { type: 'attribute_definition', ids: ['40336', '40016'] }, // 46
+  // { type: 'attribute_definition', ids: ['40336', '40016'] }, // 46
 ];
 
 const getUrl = (type, id) => [BASE_URL, type, id].join('/');
@@ -26,15 +29,37 @@ const fetchDoc = async (type, id) => {
   }
 };
 
+const getCategories = (url) => {
+  return url
+    .replace('https://docs.newrelic.com/docs/', '')
+    .split('/')
+    .slice(0, -1);
+};
+
 const fetchPages = async () => {
+  // Step 1: get the docs
   const requests = input.flatMap(({ type, ids }) =>
     ids.map((id) => fetchDoc(type, id))
   );
 
   const results = await Promise.all(requests);
-  const titles = results.map((result) => result.title);
 
-  console.log(titles);
+  results.forEach((doc) => {
+    // Step 2: create the directory structure
+    const dir = path.join(BASE_DIR, ...getCategories(doc.docUrl));
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    // Step 3: create a file for each doc
+    const slug = doc.docUrl.split('/').slice(-1);
+    const fileName = `${dir}/${slug}.mdx`;
+    fs.writeFile(fileName, doc.body, (err) => {
+      if (err) {
+        console.log(`Error, could not create ${fileName}`, e);
+      }
+    });
+  });
 };
 
 // Run the script via `node path_to_script`

--- a/scripts/fetch-docs.js
+++ b/scripts/fetch-docs.js
@@ -1,0 +1,19 @@
+const BASE_URL = 'https://docs.newrelic.com/api/ui/content';
+
+// IDs grouped by content type (related GH issue in comments)
+const input = [
+  { type: 'page', ids: ['38576', '40431'] }, // #44
+  { type: 'api_doc', ids: ['37696', '40421'] }, // #45
+  { type: 'release_notes', ids: ['40416', '40466'] }, // #48
+  { type: 'release_notes_platform', ids: ['40531', '40506'] }, // #49
+  { type: 'troubleshooting_doc', ids: ['40351', '15086'] }, // #50
+  { type: 'nr1_announcement', ids: ['40426', '40516'] }, // #47
+  { type: 'attribute_definition', ids: ['40336', '40016'] }, // 46
+];
+
+const fetchPages = () => {
+  console.log('hello, world!');
+};
+
+// Run the script
+fetchPages();

--- a/yarn.lock
+++ b/yarn.lock
@@ -11569,6 +11569,11 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-forge@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"


### PR DESCRIPTION
## Description
A small script that gets a JSON representation of different content types from the docs site and creates `mdx` files for each. The implementation has a lot of gaps, but it should serve as a starting point and can help us think through upcoming hurdles.

The general flow for this script is:
1. Get the docs. We're using `node-fetch` library to help make the request.
2. Create the directory structure. Turn the URL path into a directory structure (excluding the slug).
3. Create a file for each doc.
4. Create frontmatter based on content type. We have some _very_ basic fields based on the proposed MDX files.
5. Add the content to the file.
6. 🎉 

## Related Issue(s)
* Closes #52 