### PR TITLE
Migration Script Refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "clean": "gatsby clean",
     "test": "jest",
     "lint": "eslint src/",
-    "lint:fix": "yarn lint --fix"
+    "lint:fix": "yarn lint --fix",
+    "migrate": "node scripts/migrate.js"
   },
   "husky": {
     "hooks": {

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -13,4 +13,24 @@ module.exports = {
     'nr1_announcement',
     'attribute_definition',
   ],
+
+  GATSBY_CONTENT_TYPES: {
+    page: 'page',
+    api_doc: 'apiDoc',
+    release_notes: 'releaseNote',
+    release_notes_platform: 'releaseNotePlatform',
+    troubleshooting_doc: 'troubleshootingDoc',
+    nr1_announcement: 'nr1Announcement',
+    attribute_definition: 'attributeDef',
+  },
+
+  GATSBY_TEMPLATE: {
+    page: 'basicDoc',
+    api_doc: 'basicDoc',
+    release_notes: 'basicDoc',
+    release_notes_platform: 'basicDoc',
+    troubleshooting_doc: 'basicDoc',
+    nr1_announcement: 'basicDoc',
+    attribute_definition: 'basicDoc',
+  },
 };

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,36 +1,38 @@
 const path = require('path');
 
+const TYPES = {
+  BASIC_PAGE: 'page',
+  API_DOC: 'api_doc',
+  RELEASE_NOTE: 'release_notes',
+  RELEASE_NOTE_PLATFORM: 'release_notes_platform',
+  TROUBLESHOOTING: 'troubleshooting_doc',
+  WHATS_NEW: 'nr1_announcement',
+  ATTRIBUTE_DEFINITION: 'attribute_definition',
+};
+
 module.exports = {
   BASE_URL: 'https://docs-dev.newrelic.com/api/migration/content',
   BASE_DIR: path.join(__dirname, '..', 'src/content'),
 
-  TYPES: [
-    'page',
-    'api_doc',
-    'release_notes',
-    'release_notes_platform',
-    'troubleshooting_doc',
-    'nr1_announcement',
-    'attribute_definition',
-  ],
+  TYPES,
 
   GATSBY_CONTENT_TYPES: {
-    page: 'page',
-    api_doc: 'apiDoc',
-    release_notes: 'releaseNote',
-    release_notes_platform: 'releaseNotePlatform',
-    troubleshooting_doc: 'troubleshootingDoc',
-    nr1_announcement: 'nr1Announcement',
-    attribute_definition: 'attributeDef',
+    [TYPES.BASIC_PAGE]: 'page',
+    [TYPES.API_DOC]: 'apiDoc',
+    [TYPES.RELEASE_NOTE]: 'releaseNote',
+    [TYPES.RELEASE_NOTE_PLATFORM]: 'releaseNotePlatform',
+    [TYPES.TROUBLESHOOTING]: 'troubleshootingDoc',
+    [TYPES.WHATS_NEW]: 'nr1Announcement',
+    [TYPES.ATTRIBUTE_DEFINITION]: 'attributeDef',
   },
 
   GATSBY_TEMPLATE: {
-    page: 'basicDoc',
-    api_doc: 'basicDoc',
-    release_notes: 'basicDoc',
-    release_notes_platform: 'basicDoc',
-    troubleshooting_doc: 'basicDoc',
-    nr1_announcement: 'basicDoc',
-    attribute_definition: 'basicDoc',
+    [TYPES.BASIC_PAGE]: 'basicDoc',
+    [TYPES.API_DOC]: 'basicDoc',
+    [TYPES.RELEASE_NOTE]: 'basicDoc',
+    [TYPES.RELEASE_NOTE_PLATFORM]: 'basicDoc',
+    [TYPES.TROUBLESHOOTING]: 'basicDoc',
+    [TYPES.WHATS_NEW]: 'basicDoc',
+    [TYPES.ATTRIBUTE_DEFINITION]: 'basicDoc',
   },
 };

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,38 +1,16 @@
 const path = require('path');
 
-const TYPES = {
-  BASIC_PAGE: 'page',
-  API_DOC: 'api_doc',
-  RELEASE_NOTE: 'release_notes',
-  RELEASE_NOTE_PLATFORM: 'release_notes_platform',
-  TROUBLESHOOTING: 'troubleshooting_doc',
-  WHATS_NEW: 'nr1_announcement',
-  ATTRIBUTE_DEFINITION: 'attribute_definition',
-};
-
 module.exports = {
   BASE_URL: 'https://docs-dev.newrelic.com/api/migration/content',
   BASE_DIR: path.join(__dirname, '..', 'src/content'),
 
-  TYPES,
-
-  GATSBY_CONTENT_TYPES: {
-    [TYPES.BASIC_PAGE]: 'page',
-    [TYPES.API_DOC]: 'apiDoc',
-    [TYPES.RELEASE_NOTE]: 'releaseNote',
-    [TYPES.RELEASE_NOTE_PLATFORM]: 'releaseNotePlatform',
-    [TYPES.TROUBLESHOOTING]: 'troubleshootingDoc',
-    [TYPES.WHATS_NEW]: 'nr1Announcement',
-    [TYPES.ATTRIBUTE_DEFINITION]: 'attributeDef',
-  },
-
-  GATSBY_TEMPLATE: {
-    [TYPES.BASIC_PAGE]: 'basicDoc',
-    [TYPES.API_DOC]: 'basicDoc',
-    [TYPES.RELEASE_NOTE]: 'basicDoc',
-    [TYPES.RELEASE_NOTE_PLATFORM]: 'basicDoc',
-    [TYPES.TROUBLESHOOTING]: 'basicDoc',
-    [TYPES.WHATS_NEW]: 'basicDoc',
-    [TYPES.ATTRIBUTE_DEFINITION]: 'basicDoc',
+  TYPES: {
+    BASIC_PAGE: 'page',
+    API_DOC: 'api_doc',
+    RELEASE_NOTE: 'release_notes',
+    RELEASE_NOTE_PLATFORM: 'release_notes_platform',
+    TROUBLESHOOTING: 'troubleshooting_doc',
+    WHATS_NEW: 'nr1_announcement',
+    ATTRIBUTE_DEFINITION: 'attribute_definition',
   },
 };

--- a/scripts/convert-docs.js
+++ b/scripts/convert-docs.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const TurndownService = require('turndown');
+
+const getCategories = require('./utils/get-categories');
+const {
+  BASE_DIR,
+  GATSBY_CONTENT_TYPES,
+  GATSBY_TEMPLATE,
+} = require('./constants');
+
+const getFrontmatter = (type, doc) => `---
+title: ${doc.title.replace(':', '-')}
+contentType: ${GATSBY_CONTENT_TYPES[type]}
+template: ${GATSBY_TEMPLATE[type]}
+---
+
+`;
+
+const convertDocs = (docs) => {
+  docs.flat().forEach((doc) => {
+    const dir = path.join(BASE_DIR, ...getCategories(doc.docUrl));
+    const slug = doc.docUrl.split('/').slice(-1);
+    const fileName = `${dir}/${slug}.mdx`;
+
+    // Create frontmatter based on content type
+    const frontmatter = getFrontmatter(doc.type, doc);
+
+    // Convert content to markdown
+    const turndownService = new TurndownService({
+      headingStyle: 'atx',
+    });
+
+    turndownService.addRule('codeBlocks', {
+      filter: ['pre'],
+      replacement: function (content) {
+        return `~~~\n${content}\n~~~\n`;
+      },
+    });
+
+    turndownService.keep(['table']);
+
+    const bodyContent = doc.body ? turndownService.turndown(doc.body) : '';
+    const content = frontmatter + bodyContent;
+
+    // Write the file
+    fs.writeFile(fileName, content, (err) => {
+      if (err) logger.error(`Could not create ${fileName}.`);
+    });
+  });
+};
+
+module.exports = convertDocs;

--- a/scripts/convert-docs.js
+++ b/scripts/convert-docs.js
@@ -2,15 +2,14 @@ const fs = require('fs');
 const { TYPES } = require('./constants');
 const toMarkdown = require('./converters/to-markdown');
 
-// TODO: no magic string
 const converters = {
-  page: toMarkdown,
-  api_doc: toMarkdown,
-  release_notes: toMarkdown,
-  release_notes_platform: toMarkdown,
-  troubleshooting_doc: toMarkdown,
-  nr1_announcement: toMarkdown,
-  attribute_definition: toMarkdown,
+  [TYPES.BASIC_PAGE]: toMarkdown,
+  [TYPES.API_DOC]: toMarkdown,
+  [TYPES.RELEASE_NOTE]: toMarkdown,
+  [TYPES.RELEASE_NOTE_PLATFORM]: toMarkdown,
+  [TYPES.TROUBLESHOOTING]: toMarkdown,
+  [TYPES.WHATS_NEW]: toMarkdown,
+  [TYPES.ATTRIBUTE_DEFINITION]: toMarkdown,
 };
 
 const convertDocs = (docs) => {

--- a/scripts/convert-docs.js
+++ b/scripts/convert-docs.js
@@ -1,47 +1,21 @@
 const fs = require('fs');
-const path = require('path');
-const TurndownService = require('turndown');
+const { TYPES } = require('./constants');
+const toMarkdown = require('./converters/to-markdown');
 
-const getCategories = require('./utils/get-categories');
-const {
-  BASE_DIR,
-  GATSBY_CONTENT_TYPES,
-  GATSBY_TEMPLATE,
-} = require('./constants');
-
-const getFrontmatter = (type, doc) => `---
-title: ${doc.title.replace(':', '-')}
-contentType: ${GATSBY_CONTENT_TYPES[type]}
-template: ${GATSBY_TEMPLATE[type]}
----
-
-`;
+// TODO: no magic string
+const converters = {
+  page: toMarkdown,
+  api_doc: toMarkdown,
+  release_notes: toMarkdown,
+  release_notes_platform: toMarkdown,
+  troubleshooting_doc: toMarkdown,
+  nr1_announcement: toMarkdown,
+  attribute_definition: toMarkdown,
+};
 
 const convertDocs = (docs) => {
   docs.flat().forEach((doc) => {
-    const dir = path.join(BASE_DIR, ...getCategories(doc.docUrl));
-    const slug = doc.docUrl.split('/').slice(-1);
-    const fileName = `${dir}/${slug}.mdx`;
-
-    // Create frontmatter based on content type
-    const frontmatter = getFrontmatter(doc.type, doc);
-
-    // Convert content to markdown
-    const turndownService = new TurndownService({
-      headingStyle: 'atx',
-    });
-
-    turndownService.addRule('codeBlocks', {
-      filter: ['pre'],
-      replacement: function (content) {
-        return `~~~\n${content}\n~~~\n`;
-      },
-    });
-
-    turndownService.keep(['table']);
-
-    const bodyContent = doc.body ? turndownService.turndown(doc.body) : '';
-    const content = frontmatter + bodyContent;
+    const { content, fileName } = converters[doc.type](doc);
 
     // Write the file
     fs.writeFile(fileName, content, (err) => {

--- a/scripts/converters/to-markdown.js
+++ b/scripts/converters/to-markdown.js
@@ -1,0 +1,47 @@
+const path = require('path');
+const TurndownService = require('turndown');
+
+const getCategories = require('../utils/get-categories');
+const {
+  BASE_DIR,
+  GATSBY_CONTENT_TYPES,
+  GATSBY_TEMPLATE,
+} = require('../constants');
+
+const getFrontmatter = (type, doc) => `---
+title: ${doc.title.replace(':', '-')}
+contentType: ${GATSBY_CONTENT_TYPES[type]}
+template: ${GATSBY_TEMPLATE[type]}
+---
+
+`;
+
+const toMarkdown = (doc) => {
+  const dir = path.join(BASE_DIR, ...getCategories(doc.docUrl));
+  const slug = doc.docUrl.split('/').slice(-1);
+  const fileName = `${dir}/${slug}.mdx`;
+
+  // Create frontmatter based on content type
+  const frontmatter = getFrontmatter(doc.type, doc);
+
+  // Convert content to markdown
+  const turndownService = new TurndownService({
+    headingStyle: 'atx',
+  });
+
+  turndownService.addRule('codeBlocks', {
+    filter: ['pre'],
+    replacement: function (content) {
+      return `~~~\n${content}\n~~~\n`;
+    },
+  });
+
+  turndownService.keep(['table']);
+
+  const bodyContent = doc.body ? turndownService.turndown(doc.body) : '';
+  const content = frontmatter + bodyContent;
+
+  return { content, fileName };
+};
+
+module.exports = toMarkdown;

--- a/scripts/converters/to-markdown.js
+++ b/scripts/converters/to-markdown.js
@@ -2,11 +2,27 @@ const path = require('path');
 const TurndownService = require('turndown');
 
 const getCategories = require('../utils/get-categories');
-const {
-  BASE_DIR,
-  GATSBY_CONTENT_TYPES,
-  GATSBY_TEMPLATE,
-} = require('../constants');
+const { BASE_DIR, TYPES } = require('../constants');
+
+const GATSBY_CONTENT_TYPES = {
+  [TYPES.BASIC_PAGE]: 'page',
+  [TYPES.API_DOC]: 'apiDoc',
+  [TYPES.RELEASE_NOTE]: 'releaseNote',
+  [TYPES.RELEASE_NOTE_PLATFORM]: 'releaseNotePlatform',
+  [TYPES.TROUBLESHOOTING]: 'troubleshootingDoc',
+  [TYPES.WHATS_NEW]: 'nr1Announcement',
+  [TYPES.ATTRIBUTE_DEFINITION]: 'attributeDef',
+};
+
+const GATSBY_TEMPLATE = {
+  [TYPES.BASIC_PAGE]: 'basicDoc',
+  [TYPES.API_DOC]: 'basicDoc',
+  [TYPES.RELEASE_NOTE]: 'basicDoc',
+  [TYPES.RELEASE_NOTE_PLATFORM]: 'basicDoc',
+  [TYPES.TROUBLESHOOTING]: 'basicDoc',
+  [TYPES.WHATS_NEW]: 'basicDoc',
+  [TYPES.ATTRIBUTE_DEFINITION]: 'basicDoc',
+};
 
 const getFrontmatter = (type, doc) => `---
 title: ${doc.title.replace(':', '-')}

--- a/scripts/create-directories.js
+++ b/scripts/create-directories.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+
+const getCategories = require('./utils/get-categories');
+const { BASE_DIR } = require('./constants');
+
+const createDirectories = (docs) => {
+  docs.flat().forEach((doc) => {
+    const dir = path.join(BASE_DIR, ...getCategories(doc.docUrl));
+
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+  });
+};
+
+module.exports = createDirectories;

--- a/scripts/fetch-docs.js
+++ b/scripts/fetch-docs.js
@@ -1,18 +1,8 @@
-const path = require('path');
-const fs = require('fs');
 const fetch = require('node-fetch');
-const TurndownService = require('turndown');
 require('dotenv').config();
 
 const logger = require('./utils/logger');
-const createIndexPages = require('./create-index-pages');
-const {
-  TYPES,
-  BASE_URL,
-  BASE_DIR,
-  GATSBY_CONTENT_TYPES,
-  GATSBY_TEMPLATE,
-} = require('./constants');
+const { TYPES, BASE_URL } = require('./constants');
 
 const getUrl = (type) => [BASE_URL, type, 'list'].join('/');
 
@@ -32,60 +22,11 @@ const fetchDoc = async (type) => {
   }
 };
 
-const getCategories = (url) => {
-  return url
-    .replace('https://docs-dev.newrelic.com/', '')
-    .split('/')
-    .slice(0, -1);
-};
-
-const getFrontmatter = (type, doc) => `---
-title: ${doc.title.replace(':', '-')}
-contentType: ${GATSBY_CONTENT_TYPES[type]}
-template: ${GATSBY_TEMPLATE[type]}
----
-
-`;
-
 const fetchDocs = async () => {
-  // Step 1: get the docs
-  logger.normal('Fetching JSON');
   const requests = TYPES.map(fetchDoc);
   const results = await Promise.all(requests);
 
-  logger.normal('Creating Directories');
-  results.flat().forEach((doc) => {
-    // Step 2: create the directory structure
-    const dir = path.join(BASE_DIR, ...getCategories(doc.docUrl));
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
-    }
-
-    // Step 3: create a file for each doc
-    const slug = doc.docUrl.split('/').slice(-1);
-    const fileName = `${dir}/${slug}.mdx`;
-
-    // Step 4: create frontmatter based on content type
-    const frontmatter = getFrontmatter(doc.type, doc);
-
-    // Step 5: Convert content to markdown and write to file
-    const turndownService = new TurndownService({
-      headingStyle: 'atx',
-    });
-    turndownService.addRule('codeBlocks', {
-      filter: ['pre'],
-      replacement: function (content) {
-        return `~~~\n${content}\n~~~\n`;
-      },
-    });
-    turndownService.keep(['table']);
-
-    const bodyContent = doc.body ? turndownService.turndown(doc.body) : '';
-    const content = frontmatter + bodyContent;
-    fs.writeFile(fileName, content, (err) => {
-      if (err) logger.error(`Could not create ${fileName}.`);
-    });
-  });
+  return results;
 };
 
 module.exports = fetchDocs;

--- a/scripts/fetch-docs.js
+++ b/scripts/fetch-docs.js
@@ -72,7 +72,7 @@ template: ${GATSBY_TEMPLATE[type]}
 
 `;
 
-const fetchPages = async () => {
+const fetchDocs = async () => {
   // Step 1: get the docs
   logger.normal('Fetching JSON');
   const requests = input.flatMap(({ type, ids }) =>
@@ -126,4 +126,5 @@ const fetchPages = async () => {
 };
 
 // Run the script via `node path_to_script`
-fetchPages();
+// fetchDocs();
+module.exports = fetchDocs;

--- a/scripts/fetch-docs.js
+++ b/scripts/fetch-docs.js
@@ -6,27 +6,13 @@ require('dotenv').config();
 
 const logger = require('./utils/logger');
 const createIndexPages = require('./create-index-pages');
-const { TYPES, BASE_URL, BASE_DIR } = require('./constants');
-
-const GATSBY_CONTENT_TYPES = {
-  page: 'page',
-  api_doc: 'apiDoc',
-  release_notes: 'releaseNote',
-  release_notes_platform: 'releaseNotePlatform',
-  troubleshooting_doc: 'troubleshootingDoc',
-  nr1_announcement: 'nr1Announcement',
-  attribute_definition: 'attributeDef',
-};
-
-const GATSBY_TEMPLATE = {
-  page: 'basicDoc',
-  api_doc: 'basicDoc',
-  release_notes: 'basicDoc',
-  release_notes_platform: 'basicDoc',
-  troubleshooting_doc: 'basicDoc',
-  nr1_announcement: 'basicDoc',
-  attribute_definition: 'basicDoc',
-};
+const {
+  TYPES,
+  BASE_URL,
+  BASE_DIR,
+  GATSBY_CONTENT_TYPES,
+  GATSBY_TEMPLATE,
+} = require('./constants');
 
 const getUrl = (type) => [BASE_URL, type, 'list'].join('/');
 
@@ -99,16 +85,7 @@ const fetchDocs = async () => {
     fs.writeFile(fileName, content, (err) => {
       if (err) logger.error(`Could not create ${fileName}.`);
     });
-
-    // Step 6: party!
   });
-
-  logger.normal('Creating index pages');
-  await createIndexPages();
-
-  logger.success('Migration complete');
 };
 
-// Run the script via `node path_to_script`
-// fetchDocs();
 module.exports = fetchDocs;

--- a/scripts/fetch-docs.js
+++ b/scripts/fetch-docs.js
@@ -23,7 +23,7 @@ const fetchDoc = async (type) => {
 };
 
 const fetchDocs = async () => {
-  const requests = TYPES.map(fetchDoc);
+  const requests = Object.values(TYPES).map(fetchDoc);
   const results = await Promise.all(requests);
 
   return results;

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,18 +1,28 @@
 const fetchDocs = require('./fetch-docs');
+const createDirectories = require('./create-directories');
+const convertDocs = require('./convert-docs');
 const createIndexPages = require('./create-index-pages');
 const logger = require('./utils/logger');
 
 const run = async () => {
+  logger.normal('Starting migration');
+
   try {
-    logger.normal('Starting migration');
-    await fetchDocs();
+    logger.normal('Fetching JSON');
+    const docs = await fetchDocs();
+
+    logger.normal('Creating directories');
+    createDirectories(docs);
+
+    logger.normal('Creating files for Gatsby');
+    convertDocs(docs);
 
     logger.normal('Creating index pages');
     await createIndexPages();
 
     logger.success('Migration complete!');
   } catch (err) {
-    logger.warn(`Error running migration: ${err}`);
+    logger.error(`Error running migration: ${err}`);
   }
 };
 

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,0 +1,9 @@
+const fetchDocs = require('./fetch-docs');
+const logger = require('./utils/logger');
+
+const run = async () => {
+  logger.normal('Starting migration');
+  await fetchDocs();
+};
+
+run();

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,9 +1,19 @@
 const fetchDocs = require('./fetch-docs');
+const createIndexPages = require('./create-index-pages');
 const logger = require('./utils/logger');
 
 const run = async () => {
-  logger.normal('Starting migration');
-  await fetchDocs();
+  try {
+    logger.normal('Starting migration');
+    await fetchDocs();
+
+    logger.normal('Creating index pages');
+    await createIndexPages();
+
+    logger.success('Migration complete!');
+  } catch (err) {
+    logger.warn(`Error running migration: ${err}`);
+  }
 };
 
 run();

--- a/scripts/utils/get-categories.js
+++ b/scripts/utils/get-categories.js
@@ -1,0 +1,8 @@
+const getCategories = (url) => {
+  return url
+    .replace('https://docs-dev.newrelic.com/', '')
+    .split('/')
+    .slice(0, -1);
+};
+
+module.exports = getCategories;


### PR DESCRIPTION
## Description

This PR moves the logic for our migration script into separate files, sets up a `yarn migrate` script, and makes it easier to convert docs to _other_ formats.

This is a hefty PR, but it's mostly just moving the existing logic around.