### PR TITLE
Support for Attribute Definitions

### DIFF
--- a/scripts/convert-docs.js
+++ b/scripts/convert-docs.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const { TYPES } = require('./constants');
 const toMarkdown = require('./converters/to-markdown');
+const toJSON = require('./converters/to-json');
 
 const converters = {
   [TYPES.BASIC_PAGE]: toMarkdown,
@@ -9,7 +10,7 @@ const converters = {
   [TYPES.RELEASE_NOTE_PLATFORM]: toMarkdown,
   [TYPES.TROUBLESHOOTING]: toMarkdown,
   [TYPES.WHATS_NEW]: toMarkdown,
-  [TYPES.ATTRIBUTE_DEFINITION]: toMarkdown,
+  [TYPES.ATTRIBUTE_DEFINITION]: toJSON,
 };
 
 const convertDocs = (docs) => {

--- a/scripts/converters/to-json.js
+++ b/scripts/converters/to-json.js
@@ -1,20 +1,23 @@
 const path = require('path');
 const getCategories = require('../utils/get-categories');
-const { BASE_DIR } = require('../constants');
+const { TYPES, BASE_DIR } = require('../constants');
+
+const JSON_BY_TYPE = {
+  [TYPES.ATTRIBUTE_DEFINITION]: (doc) => ({
+    id: doc.docId,
+    title: doc.title,
+    description: doc.shortDescription,
+    eventTypes: doc.eventTypes,
+    relatedInfo: doc.relatedInfo,
+  }),
+};
 
 const toJSON = (doc) => {
   const dir = path.join(BASE_DIR, ...getCategories(doc.docUrl));
   const slug = doc.docUrl.split('/').slice(-1);
   const fileName = `${dir}/${slug}.json`;
 
-  const json = {
-    id: doc.docId,
-    title: doc.title,
-    description: doc.shortDescription,
-    eventTypes: doc.eventTypes,
-    relatedInfo: doc.relatedInfo,
-  };
-
+  const json = JSON_BY_TYPE[doc.type](doc);
   const content = JSON.stringify(json, null, 2);
 
   return { content, fileName };

--- a/scripts/converters/to-json.js
+++ b/scripts/converters/to-json.js
@@ -1,0 +1,23 @@
+const path = require('path');
+const getCategories = require('../utils/get-categories');
+const { BASE_DIR } = require('../constants');
+
+const toJSON = (doc) => {
+  const dir = path.join(BASE_DIR, ...getCategories(doc.docUrl));
+  const slug = doc.docUrl.split('/').slice(-1);
+  const fileName = `${dir}/${slug}.json`;
+
+  const json = {
+    id: doc.docId,
+    title: doc.title,
+    description: doc.shortDescription,
+    eventTypes: doc.eventTypes,
+    relatedInfo: doc.relatedInfo,
+  };
+
+  const content = JSON.stringify(json, null, 2);
+
+  return { content, fileName };
+};
+
+module.exports = toJSON;

--- a/scripts/create-index-pages.js
+++ b/scripts/create-index-pages.js
@@ -44,7 +44,9 @@ const getSubheading = (dir, level) => {
 
 const createIndexPage = async (dir, level = 2) => {
   // dont run for the attribute definitions
-  if (dir === path.join(BASE_DIR, 'attribute-dictionary')) return false;
+  if (dir === path.join(BASE_DIR, 'attribute-dictionary')) {
+    return false;
+  }
 
   const title = getTitle(dir);
 

--- a/scripts/create-index-pages.js
+++ b/scripts/create-index-pages.js
@@ -43,6 +43,9 @@ const getSubheading = (dir, level) => {
 };
 
 const createIndexPage = async (dir, level = 2) => {
+  // dont run for the attribute definitions
+  if (dir === path.join(BASE_DIR, 'attribute-dictionary')) return false;
+
   const title = getTitle(dir);
 
   try {


### PR DESCRIPTION
## Description
Adds support for converting docs into JSON (rather than markdown). This is done for any doc with the `type` of `attribute_definition`. This also prevents index pages for being created for those directories.

In an upcoming MMF, we should look at how we want to display these on the site. It would be nice if Gatsby could serve the JSON.

## Related Issue(s)
* Closes #46