### PR TITLE
Add authored directory index pages

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -6,6 +6,7 @@ module.exports = {
 
   TYPES: {
     BASIC_PAGE: 'page',
+    LANDING_PAGE: 'landing_page',
     API_DOC: 'api_doc',
     RELEASE_NOTE: 'release_notes',
     RELEASE_NOTE_PLATFORM: 'release_notes_platform',

--- a/scripts/convert-docs.js
+++ b/scripts/convert-docs.js
@@ -5,6 +5,7 @@ const toJSON = require('./converters/to-json');
 
 const converters = {
   [TYPES.BASIC_PAGE]: toMarkdown,
+  [TYPES.LANDING_PAGE]: toMarkdown,
   [TYPES.API_DOC]: toMarkdown,
   [TYPES.RELEASE_NOTE]: toMarkdown,
   [TYPES.RELEASE_NOTE_PLATFORM]: toMarkdown,

--- a/scripts/converters/to-markdown.js
+++ b/scripts/converters/to-markdown.js
@@ -38,7 +38,7 @@ const toMarkdown = (doc) => {
   const dir = path.join(BASE_DIR, ...getCategories(doc.docUrl));
   const slug = doc.docUrl.split('/').slice(-1);
   const fileName =
-    doc.type === 'landing_page' ? `${dir}/index.mdx` : `${dir}/${slug}.mdx`;
+    doc.type === TYPES.LANDING_PAGE ? `${dir}/index.mdx` : `${dir}/${slug}.mdx`;
 
   // Create frontmatter based on content type
   const frontmatter = getFrontmatter(doc.type, doc);

--- a/scripts/converters/to-markdown.js
+++ b/scripts/converters/to-markdown.js
@@ -6,6 +6,7 @@ const { BASE_DIR, TYPES } = require('../constants');
 
 const GATSBY_CONTENT_TYPES = {
   [TYPES.BASIC_PAGE]: 'page',
+  [TYPES.LANDING_PAGE]: 'landingPage',
   [TYPES.API_DOC]: 'apiDoc',
   [TYPES.RELEASE_NOTE]: 'releaseNote',
   [TYPES.RELEASE_NOTE_PLATFORM]: 'releaseNotePlatform',
@@ -16,6 +17,7 @@ const GATSBY_CONTENT_TYPES = {
 
 const GATSBY_TEMPLATE = {
   [TYPES.BASIC_PAGE]: 'basicDoc',
+  [TYPES.LANDING_PAGE]: 'basicDoc',
   [TYPES.API_DOC]: 'basicDoc',
   [TYPES.RELEASE_NOTE]: 'basicDoc',
   [TYPES.RELEASE_NOTE_PLATFORM]: 'basicDoc',
@@ -35,7 +37,8 @@ template: ${GATSBY_TEMPLATE[type]}
 const toMarkdown = (doc) => {
   const dir = path.join(BASE_DIR, ...getCategories(doc.docUrl));
   const slug = doc.docUrl.split('/').slice(-1);
-  const fileName = `${dir}/${slug}.mdx`;
+  const fileName =
+    doc.type === 'landing_page' ? `${dir}/index.mdx` : `${dir}/${slug}.mdx`;
 
   // Create frontmatter based on content type
   const frontmatter = getFrontmatter(doc.type, doc);


### PR DESCRIPTION
Closes #53 

I created a new JSON resource type for `landing_page` (similar in shape to `page` resource) and updated the migrate script to request content from that resource and create index.mdx files in same directory it would normally write the file. This runs before the script automatically creates index files, so the script skips writing an index file when it finds an existing index file.

I wonder if it might be good to eventually add something in the script that says if there's already an `index.mdx` file, create another file that contains the menu and call it something like `index-toc.mdx`.

For now, the landing pages just use the `basicPage` template.