### PR TITLE
Simplify JSX codemod transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,6 @@
     "turndown": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/generator": "^7.11.6",
-    "@babel/parser": "^7.11.5",
-    "@babel/traverse": "^7.11.5",
-    "@babel/types": "^7.11.5",
     "@newrelic/eslint-plugin-newrelic": "^0.3.1",
     "chalk": "^4.1.0",
     "dotenv": "^8.2.0",

--- a/scripts/utils/codemod/jsx.js
+++ b/scripts/utils/codemod/jsx.js
@@ -1,8 +1,5 @@
-const { parse } = require('@babel/parser');
-const traverse = require('@babel/traverse').default;
-const generate = require('@babel/generator').default;
-const types = require('@babel/types');
 const visit = require('unist-util-visit');
+const babel = require('@babel/core');
 
 const jsx = ({ plugins }) => (tree) => {
   visit(tree, 'jsx', (node) => {
@@ -11,16 +8,12 @@ const jsx = ({ plugins }) => (tree) => {
 };
 
 const transformJSX = (jsx, plugins) => {
-  const ast = parse(jsx, {
-    plugins: ['jsx'],
+  const { code } = babel.transform(jsx, {
+    configFile: false,
+    plugins: ['@babel/plugin-syntax-jsx', ...plugins],
   });
 
-  const visitors = plugins.map((plugin) => plugin({ types }).visitor);
-  const visitor = traverse.visitors.merge(visitors);
-
-  traverse(ast, visitor);
-
-  return generate(ast).code.replace(/;$/, '');
+  return code.replace(/;$/, '');
 };
 
 module.exports = jsx;


### PR DESCRIPTION
## Description

Simplifies the JSX transform by using @babel/core instead of the separate babel packages. This also means the codemods will be fully compatible as a babel plugin.
