### PR TITLE
Create an MDXContainer component that wraps markdown

### DIFF
--- a/src/components/MDXContainer.js
+++ b/src/components/MDXContainer.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import { MDXRenderer } from 'gatsby-plugin-mdx';
+import { MDXProvider } from '@mdx-js/react';
+import { MDXCodeBlock } from '@newrelic/gatsby-theme-newrelic';
+
+const Wrapper = ({ children }) => (
+  <div
+    css={css`
+      > *:first-child {
+        margin-top: 0;
+      }
+
+      code {
+        padding: 0.125rem;
+        border-radius: 2px;
+      }
+
+      :not(pre) > code {
+        background: var(--tertiary-background-color);
+      }
+
+      p:last-child {
+        margin-bottom: 0;
+      }
+      h1,
+      h2 {
+        font-weight: bold;
+
+        &:not(:first-child) {
+          margin-top: 2rem;
+        }
+      }
+
+      h3,
+      h4 {
+        margin-top: 1rem;
+        font-weight: bold;
+      }
+
+      li {
+        margin-bottom: 1rem;
+      }
+
+      ul li ul {
+        margin-top: 1rem;
+        line-height: 1;
+      }
+    `}
+  >
+    {children}
+  </div>
+);
+
+Wrapper.propTypes = {
+  children: PropTypes.node,
+};
+
+const components = {
+  code: MDXCodeBlock,
+  pre: (props) => props.children,
+  wrapper: Wrapper,
+};
+
+const MDXContainer = ({ children }) => (
+  <MDXProvider components={components}>
+    <MDXRenderer>{children}</MDXRenderer>
+  </MDXProvider>
+);
+
+MDXContainer.propTypes = {
+  children: PropTypes.node,
+};
+
+export default MDXContainer;

--- a/src/templates/basicDoc.js
+++ b/src/templates/basicDoc.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
-import { MDXProvider } from '@mdx-js/react';
-import { MDXRenderer } from 'gatsby-plugin-mdx';
+import MDXContainer from '../components/MDXContainer';
 
 const basicDocPageTemplate = ({ data }) => {
   const { mdx } = data;
@@ -11,9 +10,7 @@ const basicDocPageTemplate = ({ data }) => {
   return (
     <>
       <h1>{frontmatter.title}</h1>
-      <MDXProvider>
-        <MDXRenderer>{body}</MDXRenderer>
-      </MDXProvider>
+      <MDXContainer>{body}</MDXContainer>
     </>
   );
 };

--- a/src/templates/releaseNote.js
+++ b/src/templates/releaseNote.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
-import { MDXProvider } from '@mdx-js/react';
-import { MDXRenderer } from 'gatsby-plugin-mdx';
+import MDXContainer from '../components/MDXContainer';
 
 const releaseNoteTemplate = ({ data }) => {
   const { mdx } = data;
@@ -16,9 +15,7 @@ const releaseNoteTemplate = ({ data }) => {
         <li>{`releaseVersion: ${releaseVersion}`}</li>
         <li>{`downloadLink: ${downloadLink}`}</li>
       </ul>
-      <MDXProvider>
-        <MDXRenderer>{body}</MDXRenderer>
-      </MDXProvider>
+      <MDXContainer>{body}</MDXContainer>
     </>
   );
 };

--- a/src/templates/releaseNotePlatform.js
+++ b/src/templates/releaseNotePlatform.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
-import { MDXProvider } from '@mdx-js/react';
-import { MDXRenderer } from 'gatsby-plugin-mdx';
+import MDXContainer from '../components/MDXContainer';
 
 const releaseNotePlatformTemplate = ({ data }) => {
   const { mdx } = data;
@@ -15,9 +14,7 @@ const releaseNotePlatformTemplate = ({ data }) => {
         <li>{`releaseDateTime: ${releaseDateTime}`}</li>
         <li>{`releaseImpact: ${releaseImpact}`}</li>
       </ul>
-      <MDXProvider>
-        <MDXRenderer>{body}</MDXRenderer>
-      </MDXProvider>
+      <MDXContainer>{body}</MDXContainer>
     </>
   );
 };

--- a/src/templates/whatsNew.js
+++ b/src/templates/whatsNew.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
-import { MDXProvider } from '@mdx-js/react';
-import { MDXRenderer } from 'gatsby-plugin-mdx';
+import MDXContainer from '../components/MDXContainer';
 
 const whatsNewTemplate = ({ data }) => {
   const { mdx } = data;
@@ -16,9 +15,7 @@ const whatsNewTemplate = ({ data }) => {
         <li>{`getStartedLink: ${getStartedLink}`}</li>
         <li>{`learnMoreLink: ${learnMoreLink}`}</li>
       </ul>
-      <MDXProvider>
-        <MDXRenderer>{body}</MDXRenderer>
-      </MDXProvider>
+      <MDXContainer>{body}</MDXContainer>
     </>
   );
 };


### PR DESCRIPTION
Closes  #68 

## Description

Adds an `MDXContainer` component that will be used to wrap the markdown content with styles + usable components.