### PR TITLE
feat: add callout to MDXContainer via theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "^1.6.16",
     "@mdx-js/react": "^1.6.16",
-    "@newrelic/gatsby-theme-newrelic": "^1.9.1",
+    "@newrelic/gatsby-theme-newrelic": "^1.10.1",
     "@splitsoftware/splitio-react": "^1.2.0",
     "babel-jest": "^26.3.0",
     "front-matter": "^4.0.2",

--- a/src/components/MDXContainer.js
+++ b/src/components/MDXContainer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { MDXRenderer } from 'gatsby-plugin-mdx';
 import { MDXProvider } from '@mdx-js/react';
-import { MDXCodeBlock } from '@newrelic/gatsby-theme-newrelic';
+import { MDXCodeBlock, Callout } from '@newrelic/gatsby-theme-newrelic';
 
 const Wrapper = ({ children }) => (
   <div
@@ -61,6 +61,7 @@ const components = {
   code: MDXCodeBlock,
   pre: (props) => props.children,
   wrapper: Wrapper,
+  Callout,
 };
 
 const MDXContainer = ({ children }) => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,10 +1950,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^1.9.1":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.9.1.tgz#27d7405f638bfd25b0a27a0a7771ef8bed2085e3"
-  integrity sha512-s0MAIwFVJ9CSsJLT4/gVhUHcV1+40EmFg4FFZO2bMQgjew8ywGqXBXEz2VZ8EatjEq6s143tvAjykEt0p1Rxiw==
+"@newrelic/gatsby-theme-newrelic@^1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.10.1.tgz#5bd6f3282bdfea3987b0905915b5d6091891050f"
+  integrity sha512-ogpcaHhg3Bne2CjQFns0lqDY/vHf5HL2RvYo3kxyq2CtpRVSFw7i1OjwePM4GeM4uY6Rbaiw/VRHyjIexRZxUQ==
   dependencies:
     "@elastic/react-search-ui" "^1.4.1"
     "@elastic/react-search-ui-views" "^1.4.1"
@@ -1963,7 +1963,7 @@
     date-fns "^2.16.1"
     gatsby-plugin-emotion "^4.3.10"
     gatsby-plugin-mdx "^1.2.37"
-    gatsby-plugin-newrelic "^1.0.2"
+    gatsby-plugin-newrelic "^1.0.3"
     gatsby-plugin-react-helmet "^3.3.10"
     gatsby-plugin-robots-txt "^1.5.1"
     gatsby-plugin-sharp "^2.6.19"
@@ -7699,10 +7699,10 @@ gatsby-plugin-mdx@^1.2.37, gatsby-plugin-mdx@^1.2.39:
     unist-util-remove "^1.0.3"
     unist-util-visit "^1.4.1"
 
-gatsby-plugin-newrelic@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-newrelic/-/gatsby-plugin-newrelic-1.0.2.tgz#5d2831a59cc49e9652f3beed1ff6a0183967a15f"
-  integrity sha512-TWVysdMSuSRbzAAdHK+aZYxmMPQJDygvT1sKApApJBhVQ79ElBRiBnqIE5vDU26WH6sjqaxf8RlZFzmNWZ6n+A==
+gatsby-plugin-newrelic@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-newrelic/-/gatsby-plugin-newrelic-1.0.3.tgz#88dbe79d859256caadb3693fff4f7dda420fceca"
+  integrity sha512-2wxJ+K+DJ4Kx9wKMKq1JmA6lznG32BvReNRWfqTP5A51/OAZFmaloFggqVa5SLWzNLFiQKn28JKF4w/+YVhI4A==
   dependencies:
     "@babel/runtime" "^7.0.0"
 


### PR DESCRIPTION
* Adds `<Callout />` component to `MDXContainer`
* Bumps `@newrelic/gatsby-theme-newrelic` to current version to use newly added `<Callout />` component

Note that when using it in a .mdx file you have to pass the variant prop as a string and not the static variable.