### PR TITLE
Keep icons inside the `i` tag

### DIFF
--- a/scripts/utils/htmlToMarkdown.js
+++ b/scripts/utils/htmlToMarkdown.js
@@ -9,6 +9,7 @@ const SPECIAL_COMPONENTS = [
   { tag: 'div', className: 'callout-permissions' },
   { tag: 'div', className: 'callout-note' },
   { tag: 'div', className: 'callout-pricing' },
+  { tag: 'i', className: 'fa' },
 ];
 
 const escapes = [

--- a/src/content/docs/agents/go-agent/index.mdx
+++ b/src/content/docs/agents/go-agent/index.mdx
@@ -16,27 +16,57 @@ New Relic's Go agent monitors your Go language applications and microservices to
 
 To keep your agent up to date and ensure you have access to the latest features, see the [Go agent release notes](/docs/release-notes/agent-release-notes/go-release-notes).
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-terminal fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **Get started**. Discover [Go agent capabilities](/docs/agents/go-agent/get-started/introduction-new-relic-go) and how to get up and running. You can also visit [New Relic's Github repository](https://github.com/newrelic/go-agent/blob/master/README.md).
 
-_\[list icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-list-ol fa-2x"
+>
+  \[list icon]
+</i>
 
 **Install the Go agent**. Follow [standard installation procedures](/docs/agents/go-agent/get-started/get-new-relic-go) on [supported Golang versions](/docs/agents/go-agent/get-started/get-new-relic-go#requirements) for Linux, OS X, or Windows.
 
-_\[settings icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-cog fa-2x"
+>
+  \[settings icon]
+</i>
 
 **Configure the agent**. Use default [config settings](/docs/agents/go-agent/instrumentation/go-agent-configuration) and [logging options](/docs/agents/go-agent/instrumentation/go-agent-logging). Customize your config struct to fine-tune data collection that matters the most to your business.
 
-_\[tools icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-wrench fa-2x"
+>
+  \[tools icon]
+</i>
 
 **Extend agent instrumentation**. Customize [Go transactions](/docs/agents/go-agent/get-started/instrument-go-transactions) and [Go segments](/docs/agents/go-agent/get-started/instrument-go-segments). Adjust the destinations of default [attributes](/docs/agents/go-agent/instrumentation/go-agent-attributes), and create custom attributes.
 
-_\[database icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-database fa-2x"
+>
+  \[database icon]
+</i>
 
 **Explore new features**. Keep your Go agent up to date with New Relic's ongoing feature [releases](/docs/release-notes/agent-release-notes/go-release-notes).
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-life-ring fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **Troubleshoot common problems**. Use New Relic APM's [**Go runtime** page](/docs/agents/go-agent/features/go-runtime-ui-page) to troubleshoot performance issues related to Goroutines, CPU utilization, memory, and more.
 

--- a/src/content/docs/agents/java-agent/index.mdx
+++ b/src/content/docs/agents/java-agent/index.mdx
@@ -11,27 +11,57 @@ With New Relic's Java agent, you can track everything from performance issues to
 
 To keep your agent up to date and ensure you have access to the latest features, see the [Java agent release notes](/docs/release-notes/agent-release-notes/java-release-notes).
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-terminal fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **Get started**. Discover what you can do with the Java agent and how to [get started](/docs/agents/java-agent/getting-started/introduction-new-relic-java).
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-list-ol fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **Install the Java agent**. Learn how to [install the Java agent](/docs/agents/java-agent/installation/install-java-agent) on supported app servers and frameworks.
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-cog fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **Configure the agent**. Use [configuration options](/docs/agents/java-agent/configuration/java-agent-configuration-config-file) to further customize and fine-tune your installation. Enable [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing).
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-wrench fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **Customize monitoring.** Use the [Java agent API](/docs/agents/java-agent/custom-instrumentation/java-agent-api) or implement [custom instrumentation](/docs/agents/java-agent/custom-instrumentation/java-custom-instrumentation) to extend functionality.
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-database fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **Verify compatibility and requirements**. Check the [compatibility and requirements](/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent), including supported app/web servers, frameworks, JDBC drivers, JVMs, and more.
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-life-ring fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **Troubleshoot common problems**. Refer to the [Java troubleshooting documentation](/docs/agents/java-agent/troubleshooting) for help with common issues.
 

--- a/src/content/docs/agents/net-agent/index.mdx
+++ b/src/content/docs/agents/net-agent/index.mdx
@@ -11,27 +11,57 @@ New Relic's .NET agent monitors your .NET app, giving you an end-to-end view of 
 
 To keep your agent up to date and ensure you have access to the latest features, see the [.NET agent release notes](/docs/release-notes/agent-release-notes/net-release-notes).
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-terminal fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[Introduction to New Relic for .NET](/docs/agents/net-agent/getting-started/introduction-new-relic-net)**. Learn what you can do with the .NET agent and how to get started.
 
-_\[list icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-list-ol fa-2x"
+>
+  \[list icon]
+</i>
 
 **[Install the .NET agent](/docs/agents/net-agent/installation/install-enable-new-relic-net-agent)**. See the [install documentation](/docs/agents/net-agent/installation/install-enable-new-relic-net-agent).
 
-_\[cog icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-cog fa-2x"
+>
+  \[cog icon]
+</i>
 
 **[.NET agent configuration](/docs/agents/net-agent/installation-configuration/net-agent-configuration)**. Use options to fine-tune your installation. Also, be sure to [name your .NET app](/docs/agents/net-agent/installation-and-configuration/naming-your-net-application).
 
-_\[wrench icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-wrench fa-2x"
+>
+  \[wrench icon]
+</i>
 
 **[API](/docs/agents/net-agent/net-agent-api)** and **[custom instrumentation](/docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation)**. Control the agent or extend your instrumentation.
 
-_\[database icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-database fa-2x"
+>
+  \[database icon]
+</i>
 
 **Compatibility and requirements**. View supported frameworks, OS versions, and instrumentation for the .NET [Core agent](/docs/agents/net-agent/getting-started/compatibility-requirements-net-core-20-agent) and [Framework agent](/docs/agents/net-agent/getting-started/compatibility-requirements-net-framework-agent).
 
-_\[ilfe-ring icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-life-ring fa-2x"
+>
+  \[ilfe-ring icon]
+</i>
 
 **[Troubleshoot](/docs/agents/net-agent/troubleshooting/no-data-appears-net)**. What to do if the agent fails to report to New Relic.
 

--- a/src/content/docs/agents/nodejs-agent/index.mdx
+++ b/src/content/docs/agents/nodejs-agent/index.mdx
@@ -15,27 +15,57 @@ Pinpoint and solve issues down to the line of code with Node monitoring from New
 
 To keep your agent up to date and ensure you have access to the latest features, see the [Node.js agent release notes](/docs/release-notes/agent-release-notes/nodejs-release-notes).
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-terminal fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[Get started](/docs/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs)**. Discover Node.js agent capabilities and how to get up and running.
 
-_\[list icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-list-ol fa-2x"
+>
+  \[list icon]
+</i>
 
 **[Install the Node.js agent](/docs/agents/nodejs-agent/installation-configuration/install-nodejs-agent)**. Follow standard installation procedures on supported to install the New Relic Node.js agent.
 
-_\[settings icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-cog fa-2x"
+>
+  \[settings icon]
+</i>
 
 **[Configure the agent](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration)**. You can configure the agent by editing your **newrelic.js** config file, or by setting an environment variable.
 
-_\[tools icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-wrench fa-2x"
+>
+  \[tools icon]
+</i>
 
 **[Customize](/docs/agents/nodejs-agent/supported-features)**. Tailor your agent instrumentation with [custom instrumentation](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation) and [custom metrics](/docs/agents/nodejs-agent/supported-features/nodejs-custom-metrics).
 
-_\[database icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-database fa-2x"
+>
+  \[database icon]
+</i>
 
 **[Node.js agent API](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api)**. Use the agent API to extend your instrumentation.
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-life-ring fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[Troubleshoot common problems](/docs/agents/nodejs-agent/troubleshooting)**. See the full list of troubleshooting documentation for help with common issues.
 

--- a/src/content/docs/agents/php-agent/index.mdx
+++ b/src/content/docs/agents/php-agent/index.mdx
@@ -11,27 +11,57 @@ The New Relic PHP agent monitors your application to help you [identify and solv
 
 To keep your agent up to date and ensure you have access to the latest features, see the [PHP agent release notes](/docs/release-notes/agent-release-notes/php-release-notes).
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-terminal fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[Get started](/docs/agents/php-agent/getting-started)**. Get an introduction to New Relic for PHP to learn what you can do with the PHP agent and how to get up and running.
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-list-ol fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[Install the agent](/docs/agents/php-agent/installation)**. Get an installation overview and specific steps for standard installation on supported systems.
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-cog fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[Configure the agent](/docs/agents/php-agent/configuration/php-agent-configuration)**. Use a variety of configuration options to further customize and fine-tune your installation.
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-wrench fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[PHP agent API](/docs/agents/php-agent/configuration/php-agent-api)**. Use the agent API to customize and extend your instrumentation.
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-database fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[Frameworks, libraries, databases](/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements)**. View PHP agent compatibility and requirements. The agent also provides [additional functionality](/docs/agents/php-agent/frameworks-libraries) for some frameworks and libraries.
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-life-ring fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[Troubleshoot](/docs/agents/php-agent/troubleshooting)**. See our full list of troubleshooting documentation for help on common issues.
 

--- a/src/content/docs/agents/python-agent/index.mdx
+++ b/src/content/docs/agents/python-agent/index.mdx
@@ -11,27 +11,57 @@ New Relic for Python monitors your Python application to help you identify and s
 
 To keep your agent up to date and ensure you have access to the latest features, see the [Python agent release notes](/docs/release-notes/agent-release-notes/python-release-notes).
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-terminal fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[Get started](/docs/agents/python-agent/getting-started/introduction-new-relic-python)**. Get an introduction to New Relic for Python to learn what you can do with the Python agent and how to get it up and running.
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-list-ol fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[Install the Python agent](/docs/agents/python-agent/getting-started/python-agent-quick-start)**. The install process is quick and easy if you're using a [supported framework](/docs/agents/python-agent/getting-started/instrumented-python-packages).
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-cog fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[Configure the agent](/docs/agents/python-agent/installation-configuration/python-agent-configuration)**. Use configuration options to customize your installation. Enable [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing).
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-wrench fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[Python agent API](/docs/agents/python-agent/api/python-agent-api-guide)**. Use the agent API to customize and extend your instrumentation.
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-database fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[Web frameworks and web servers](/docs/agents/python-agent/web-frameworks-servers)**. The New Relic Python agent supports many web frameworks and servers, including [uWSGI](/docs/agents/python-agent/hosting-mechanisms/python-agent-uwsgi) and [Gunicorn WSGI](/docs/agents/python-agent/hosting-mechanisms/python-agent-gunicorn).
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-life-ring fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[Troubleshoot](/docs/agents/python-agent/troubleshooting)**. See the full list of troubleshooting documentation for help with common issues.
 

--- a/src/content/docs/agents/ruby-agent/index.mdx
+++ b/src/content/docs/agents/ruby-agent/index.mdx
@@ -15,27 +15,57 @@ As the first in New Relic's family of language agents, the Ruby agent combines y
 
 To keep your agent up to date and ensure you have access to the latest features, see the [Ruby agent release notes](/docs/release-notes/agent-release-notes/ruby-release-notes).
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-terminal fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[Get started](/docs/agents/ruby-agent/getting-started/)**. Discover Ruby agent capabilities and how to get up and running. Learn about New Relic's GitHub repository and **rdocs**.
 
-_\[list icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-list-ol fa-2x"
+>
+  \[list icon]
+</i>
 
 **[Install the Ruby agent](/docs/agents/ruby-agent/installation/install-new-relic-ruby-agent)**. Follow standard installation procedures on supported JRuby or MRI versions, or use the [Rails plugin on GitHub](/docs/agents/ruby-agent/installation/ruby-agent-installation-rails-plugin).
 
-_\[settings icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-cog fa-2x"
+>
+  \[settings icon]
+</i>
 
 **[Configure the agent](/docs/agents/ruby-agent/configuration/ruby-agent-configuration)**. Customize a variety of data collection options. Enable [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing).
 
-_\[tools icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-wrench fa-2x"
+>
+  \[tools icon]
+</i>
 
 **[Extend agent instrumentation](/docs/agents/ruby-agent/customization)**. Customize via method tracers, instrumentation, agent API, and more. Work with various [gems and middleware](/docs/agents/ruby-agent/instrumented-gems) supported by the Ruby agent.
 
-_\[database icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-database fa-2x"
+>
+  \[database icon]
+</i>
 
 **[Verify compatible frameworks](/docs/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks)**. Check the Ruby agent's version support for your web servers, web frameworks, databases, background jobs, HTTP clients, etc.
 
-_\[terminal icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-life-ring fa-2x"
+>
+  \[terminal icon]
+</i>
 
 **[Troubleshoot common problems](/docs/agents/ruby-agent/troubleshooting)**. Scan the full list of Ruby self-service documentation to troubleshoot and solve typical problems quickly.
 

--- a/src/content/docs/alerts-applied-intelligence/index.mdx
+++ b/src/content/docs/alerts-applied-intelligence/index.mdx
@@ -15,29 +15,59 @@ Applied intelligence helps you find, troubleshoot, and resolve problems faster. 
 
 **[one.newrelic.com](https://one.newrelic.com) > Alerts & AI: See all of the Alerts and Applied intelligence tools in one place.**
 
-_\[bolt icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-bolt fa-3x color_alerts"
+>
+  \[bolt icon]
+</i>
 
 [**Learn about alerting in New Relic.**](/docs/alerts/new-relic-alerts/getting-started/alerting-new-relic) Understand the fundamental principles of policies, conditions, thresholds, notification channels, and events.
 
-_\[arrow icon]_
+<i
+  aria-hidden="true"
+  className="fa Example of arrows-h fa-arrows-h fa-3x color_alerts"
+>
+  \[arrow icon]
+</i>
 
 [**Follow alert policy workflow.**](/docs/alerts/new-relic-alerts/configuring-alert-policies/alert-policy-workflow) Learn the basic process for creating an alert policy for New Relic products.
 
-_\[sliders icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-sliders fa-3x color_alerts"
+>
+  \[sliders icon]
+</i>
 
 [**Define alert conditions.**](/docs/alerts/new-relic-alerts/configuring-alert-policies/define-alert-conditions) Set the necessary criteria for New Relic Alerts to create an incident. Or, use the [REST API](/docs/alerts/new-relic-alerts/rest-api-alerts).
 
-_\[comment icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-commenting-o fa-3x color_alerts"
+>
+  \[comment icon]
+</i>
 
 [**Create notification channels.**](/docs/alerts/new-relic-alerts/managing-notification-channels/notification-channels-controlling-where-send-alerts) Specify how to get notified when critical violations occur, so you can quickly fix the issue.
 
-_\[triangle icon]_
+<i
+  aria-hidden="true"
+  className="fa  fa-exclamation-triangle fa-3x color_alerts"
+>
+  \[triangle icon]
+</i>
 
 [**Learn about AI.**](/docs/alerts/new-relic-alerts/reviewing-alert-incidents)
 
 Use [Proactive detection](/docs/alerts-applied-intelligence/applied-intelligence/proactive-detection/proactive-detection-new-relic-ai) to be warned when trouble is brewing. Group similar incidents with [Incident intelligence](/docs/alerts-applied-intelligence/incident-intelligence/get-started-incident-intelligence). [Incident workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/enhance-notifications-incident-workflows) will enrich your notifications with New Relic data.
 
-_\[wrench icon]_
+<i
+  aria-hidden="true"
+  className="fa  fa-wrench fa-3x color_alerts"
+>
+  \[wrench icon]
+</i>
 
 [**Resolve an issue.**](/docs/alerts/new-relic-alerts/reviewing-alert-incidents) [Acknowledge an incident](/docs/alerts/new-relic-alerts/reviewing-alert-incidents/acknowledge-alert-incidents) after it occurs, or [close a violation manually](/docs/alerts/new-relic-alerts/reviewing-alert-incidents/close-violations-manually) as needed.
 

--- a/src/content/docs/infrastructure/index.mdx
+++ b/src/content/docs/infrastructure/index.mdx
@@ -23,7 +23,12 @@ Using any of our hosted or containerized agents, integrations, APIs, and SDKs, y
 
 Work with actionable data about your infrastructure in New Relic One, and dive deeper with the Kubernetes cluster explorer.
 
-_\[checklist icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-check-square-o fa-3x "
+>
+  \[checklist icon]
+</i>
 
 **Get started.**
 
@@ -31,7 +36,12 @@ _\[checklist icon]_
 * Learn about our [integrations](/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations) with cloud and on-host systems.
 * [Install](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) your infrastructure agent on your hosts or on [Docker containers](/docs/infrastructure/install-infrastructure-agent/linux-installation/docker-container-infrastructure-monitoring).
 
-_\[exclamation icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-exclamation-triangle fa-3x "
+>
+  \[exclamation icon]
+</i>
 
 **Troubleshoot and resolve problems.**
 
@@ -39,7 +49,12 @@ _\[exclamation icon]_
 * Examine issues by using the [Infrastructure UI](/docs/infrastructure/infrastructure-ui-pages/infrastructure-ui).
 * Correlate your apps, related services, alerts, logs, and overall digital customer experience with our [Kubernetes cluster explorer](/docs/integrations/kubernetes-integration/understand-use-data/kubernetes-cluster-explorer) and [New Relic One](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one).
 
-_\[bar chart icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-bar-chart fa-3x "
+>
+  \[bar chart icon]
+</i>
 
 **Visualize your data.**
 

--- a/src/content/docs/mobile-apps/new-relic-mobile-apps/android-app/android-app-ui.mdx
+++ b/src/content/docs/mobile-apps/new-relic-mobile-apps/android-app/android-app-ui.mdx
@@ -21,7 +21,10 @@ The New Relic Android app includes:
 * New Relic Infrastructure utilization.
 * New Relic Plugins, including a list of their components or instances, and their charts and current values from the plugin's [Summary](/docs/plugins/viewing-the-plugin-summary).
 * New Relic Mobile, including [crash reports](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-dashboards/mobile-apps-crash-dashboard), network errors, API calls, and active user count.
-* Select the filter _filter_ icon to filter by [labels and categories](/docs/data-analysis/user-interface-functions/labels-categories-organize-your-apps-servers).
+* Select the filter <i className="fa fa-filter">
+  filter
+  </i>
+  icon to filter by [labels and categories](/docs/data-analysis/user-interface-functions/labels-categories-organize-your-apps-servers).
 * Event notifications, including [mobile alerts](/docs/mobile-apps/new-relic-ios-app/features/ios-alerting) wherever you are, plus [deployment notifications](/docs/applications-menu/deployments-dashboard) and [notes](/docs/site/public-and-private-notes).
 
 **Note:** New Relic's Android app does not have the full feature set of the New Relic web interface. For more detailed analysis, sign in to your New Relic account with a web browser.
@@ -37,7 +40,10 @@ When viewing an application or host, you can change the visible time frame by us
 
 ![Android app synthetics](/sites/default/files/thumbnails/image/synthetics_nexus.jpg "Android app synthetics")
 
-You can use the Android app to view your [New Relic Synthetics](/docs/synthetics/new-relic-synthetics/getting-started/new-relic-synthetics) data, including charts of your monitor's availability, load times, and load sizes. Select the caret _caret-down_ icon to view more detailed charts. You can mute or disable your monitor, and view details of any recent errors. For scripted monitors, you can view and search the script log.
+You can use the Android app to view your [New Relic Synthetics](/docs/synthetics/new-relic-synthetics/getting-started/new-relic-synthetics) data, including charts of your monitor's availability, load times, and load sizes. Select the caret <i className="fa fa-caret-down">
+caret-down
+</i>
+icon to view more detailed charts. You can mute or disable your monitor, and view details of any recent errors. For scripted monitors, you can view and search the script log.
 
 ## Alerts
 

--- a/src/content/docs/mobile-apps/new-relic-mobile-apps/ios-app/introduction-ios-mobile-app.mdx
+++ b/src/content/docs/mobile-apps/new-relic-mobile-apps/ios-app/introduction-ios-mobile-app.mdx
@@ -42,7 +42,10 @@ When viewing an application or host, you can change the visible time frame by us
 
 ## New Relic Synthetics
 
-![device-ios-synthetics-view-monitor](/sites/default/files/thumbnails/image/device-ios-synthetics-view-monitor.png "device-synthetics-view-monitor")You can use the iOS app to view your [New Relic Synthetics](/docs/synthetics/new-relic-synthetics/getting-started/new-relic-synthetics) data, including charts of your monitor's availability, load times, and load sizes. Select the caret _caret-down_ icon to view more detailed charts. You can mute or disable your monitor, and view details of any recent errors. For scripted monitors, you can view and search the script log.
+![device-ios-synthetics-view-monitor](/sites/default/files/thumbnails/image/device-ios-synthetics-view-monitor.png "device-synthetics-view-monitor")You can use the iOS app to view your [New Relic Synthetics](/docs/synthetics/new-relic-synthetics/getting-started/new-relic-synthetics) data, including charts of your monitor's availability, load times, and load sizes. Select the caret <i className="fa fa-caret-down">
+caret-down
+</i>
+icon to view more detailed charts. You can mute or disable your monitor, and view details of any recent errors. For scripted monitors, you can view and search the script log.
 
 ## Alerts
 

--- a/src/content/docs/plugins/index.mdx
+++ b/src/content/docs/plugins/index.mdx
@@ -22,21 +22,36 @@ Plugins in Plugin Central are not supported with accounts that host data in the 
 
 To view plugins in Plugin Central, go to **one.newrelic.com > More > Plugins**.
 
-_\[plug icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-plug fa-3x"
+>
+  \[plug icon]
+</i>
 
 **Get started.**
 
 * [Learn about plugins](/docs/plugins/plugins-new-relic/getting-started/introduction-new-relic-plugins) in Plugin Central.
 * [Install](/docs/plugins/plugins-new-relic/installing-plugins/install-plugin-central) available plugins.
 
-_\[chart icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-area-chart fa-3x"
+>
+  \[chart icon]
+</i>
 
 **Work with your data.**
 
 * Explore your [plugin's dashboard](/docs/plugins/plugins-new-relic/installing-plugins/use-plugin-central-plugin).
 * View [alert details](/docs/plugins/plugins-new-relic/installing-plugins/use-plugin-central-plugin#alert_details).
 
-_\[code file icon]_
+<i
+  aria-hidden="true"
+  className="fa fa-file-code-o fa-3x"
+>
+  \[code file icon]
+</i>
 
 **Build your own plugins.**
 


### PR DESCRIPTION
## Description

Ensures icons remain inside the `i` tag with the `className` to ensure we can migrate these more easily in the future.