### PR TITLE
Patch turndown

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "lint": "eslint src/",
     "lint:fix": "yarn lint --fix",
     "migrate": "node scripts/migrate.js",
-    "codemod": "node scripts/codemod.js"
+    "codemod": "node scripts/codemod.js",
+    "postinstall": "patch-package"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "eslint-plugin-react-hooks": "^4.1.0",
     "htmltojsx": "^0.3.0",
     "node-fetch": "^2.6.1",
+    "patch-package": "^6.2.2",
+    "postinstall-postinstall": "^2.1.0",
     "prettier": "2.0.5",
     "remark-frontmatter": "^2.0.0",
     "remark-mdx": "^2.0.0-next.8",

--- a/patches/turndown+6.0.0.patch
+++ b/patches/turndown+6.0.0.patch
@@ -1,0 +1,88 @@
+diff --git a/node_modules/turndown/lib/turndown.cjs.js b/node_modules/turndown/lib/turndown.cjs.js
+index 38ded76..2482d17 100644
+--- a/node_modules/turndown/lib/turndown.cjs.js
++++ b/node_modules/turndown/lib/turndown.cjs.js
+@@ -15,30 +15,55 @@ function repeat (character, count) {
+ }
+ 
+ var blockElements = [
+-  'address', 'article', 'aside', 'audio', 'blockquote', 'body', 'canvas',
+-  'center', 'dd', 'dir', 'div', 'dl', 'dt', 'fieldset', 'figcaption',
+-  'figure', 'footer', 'form', 'frameset', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+-  'header', 'hgroup', 'hr', 'html', 'isindex', 'li', 'main', 'menu', 'nav',
+-  'noframes', 'noscript', 'ol', 'output', 'p', 'pre', 'section', 'table',
+-  'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'ul'
+-];
++  'ADDRESS', 'ARTICLE', 'ASIDE', 'AUDIO', 'BLOCKQUOTE', 'BODY', 'CANVAS',
++  'CENTER', 'DD', 'DIR', 'DIV', 'DL', 'DT', 'FIELDSET', 'FIGCAPTION', 'FIGURE',
++  'FOOTER', 'FORM', 'FRAMESET', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'HEADER',
++  'HGROUP', 'HR', 'HTML', 'ISINDEX', 'LI', 'MAIN', 'MENU', 'NAV', 'NOFRAMES',
++  'NOSCRIPT', 'OL', 'OUTPUT', 'P', 'PRE', 'SECTION', 'TABLE', 'TBODY', 'TD',
++  'TFOOT', 'TH', 'THEAD', 'TR', 'UL'
++]
+ 
+ function isBlock (node) {
+-  return blockElements.indexOf(node.nodeName.toLowerCase()) !== -1
++  return is(node, blockElements);
+ }
+ 
+ var voidElements = [
+-  'area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input',
+-  'keygen', 'link', 'meta', 'param', 'source', 'track', 'wbr'
++  'AREA', 'BASE', 'BR', 'COL', 'COMMAND', 'EMBED', 'HR', 'IMG', 'INPUT',
++  'KEYGEN', 'LINK', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR'
+ ];
+ 
+ function isVoid (node) {
+-  return voidElements.indexOf(node.nodeName.toLowerCase()) !== -1
++  return is(node, voidElements);
+ }
+ 
+-var voidSelector = voidElements.join();
+ function hasVoid (node) {
+-  return node.querySelector && node.querySelector(voidSelector)
++  return has(node, voidElements);
++}
++
++var meaningfulWhenBlankElements = [
++  'A', 'TABLE', 'THEAD', 'TBODY', 'TFOOT', 'TH', 'TD', 'IFRAME', 'SCRIPT',
++  'AUDIO', 'VIDEO'
++];
++
++function isMeaningfulWhenBlank (node) {
++  return is(node, meaningfulWhenBlankElements);
++}
++
++function hasMeaningfulWhenBlank (node) {
++  return has(node, meaningfulWhenBlankElements);
++}
++
++function is (node, tagNames) {
++  return tagNames.indexOf(node.nodeName) >= 0;
++}
++
++function has (node, tagNames) {
++  return (
++    node.getElementsByTagName &&
++    tagNames.some(function (tagName) {
++      return node.getElementsByTagName(tagName).length
++    })
++  );
+ }
+ 
+ var rules = {};
+@@ -589,10 +614,11 @@ function Node (node) {
+ 
+ function isBlank (node) {
+   return (
+-    ['A', 'TH', 'TD', 'IFRAME', 'SCRIPT', 'AUDIO', 'VIDEO'].indexOf(node.nodeName) === -1 &&
+-    /^\s*$/i.test(node.textContent) &&
+     !isVoid(node) &&
+-    !hasVoid(node)
++    !isMeaningfulWhenBlank(node) &&
++    /^\s*$/i.test(node.textContent) &&
++    !hasVoid(node) &&
++    !hasMeaningfulWhenBlank(node)
+   )
+ }
+ 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2783,6 +2783,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 abab@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.4.tgz#6dfa57b417ca06d21b2478f0e638302f99c2405c"
@@ -7277,6 +7282,14 @@ find-versions@^3.0.0:
   dependencies:
     semver-regex "^2.0.0"
 
+find-yarn-workspace-root@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
+  integrity sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==
+  dependencies:
+    fs-extra "^4.0.3"
+    micromatch "^3.1.4"
+
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
@@ -7415,10 +7428,19 @@ fs-exists-cached@1.0.0, fs-exists-cached@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz#cf25554ca050dc49ae6656b41de42258989dcbce"
   integrity sha1-zyVVTKBQ3EmuZla0HeQiWJidy84=
 
-fs-extra@^4.0.2:
+fs-extra@^4.0.2, fs-extra@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -10803,6 +10825,13 @@ kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -12824,6 +12853,24 @@ password-prompt@^1.0.4:
     ansi-escapes "^3.1.0"
     cross-spawn "^6.0.5"
 
+patch-package@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.2.2.tgz#71d170d650c65c26556f0d0fbbb48d92b6cc5f39"
+  integrity sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+
 path-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
@@ -13422,6 +13469,11 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.3
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postinstall-postinstall@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
+  integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
 
 potrace@^2.1.8:
   version "2.1.8"
@@ -15282,6 +15334,11 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Description

Patches `turndown` to include the changes that fix the issue where `iframe`s are removed from the output due to how the library parses blank nodes.

This uses [patch-package](https://github.com/ds300/patch-package) to patch the changes from https://github.com/domchristie/turndown/pull/326 into the code. This will be safe to remove once turndown releases a new version with this fix.