### PR TITLE
Clamshell migration

### DIFF
--- a/codemods/clamshells.js
+++ b/codemods/clamshells.js
@@ -1,0 +1,46 @@
+const visit = require('unist-util-visit');
+const {
+  removeAttribute,
+  isMdxBlockElement,
+  hasClassName,
+  removeChild,
+  setAttribute,
+} = require('./utils/mdxast');
+
+const clamshells = () => (tree) => {
+  visit(
+    tree,
+    (node) =>
+      isMdxBlockElement('dl', node) && hasClassName('clamshell-list', node),
+    (dl) => {
+      dl.name = 'CollapserGroup';
+      removeAttribute('className', dl);
+
+      visit(
+        dl,
+        (node) => isMdxBlockElement('dt', node),
+        (dt, idx) => {
+          const dd = dl.children[idx + 1];
+
+          dt.name = 'Collapser';
+
+          visit(dt, 'text', (text) => {
+            setAttribute('title', text.value, dt);
+          });
+
+          dt.children = dd.children;
+        }
+      );
+
+      visit(
+        dl,
+        (node) => isMdxBlockElement('dd', node),
+        (dd) => {
+          removeChild(dd, dl);
+        }
+      );
+    }
+  );
+};
+
+module.exports = clamshells;

--- a/codemods/index.js
+++ b/codemods/index.js
@@ -1,11 +1,13 @@
 const indentedCodeBlock = require('./indentedCodeBlock');
 const paragraphsInsideTableCells = require('./paragraphsInsideTableCells');
 const callouts = require('./callouts');
+const clamshells = require('./clamshells');
 const videos = require('./videos');
 
 module.exports = [
   paragraphsInsideTableCells,
   indentedCodeBlock,
   callouts,
+  clamshells,
   videos,
 ];

--- a/codemods/utils/mdxast.js
+++ b/codemods/utils/mdxast.js
@@ -45,6 +45,16 @@ const hasClassName = (className, node) => {
   );
 };
 
+const setAttribute = (name, value, node) => {
+  const attribute = findAttribute(name, value);
+
+  if (attribute) {
+    attribute.value = value;
+  } else {
+    addAttribute(name, value, node);
+  }
+};
+
 const removeAttribute = curry((attribute, node) => {
   const idx = node.attributes.findIndex((attr) => {
     return typeof attribute === 'function'
@@ -86,4 +96,5 @@ module.exports = {
   removeAttribute,
   removeChild,
   isType,
+  setAttribute,
 };

--- a/scripts/utils/migrate/html-to-markdown.js
+++ b/scripts/utils/migrate/html-to-markdown.js
@@ -10,6 +10,7 @@ const SPECIAL_COMPONENTS = [
   { tag: 'div', className: 'callout-note' },
   { tag: 'div', className: 'callout-pricing' },
   { tag: 'i', className: 'fa' },
+  { tag: 'dl', className: 'clamshell-list' },
 ];
 
 const escapes = [
@@ -100,10 +101,6 @@ turndown
       return outerJSX.replace('|||', `\n${content}\n`);
     },
   })
-  .addRule('htmlToJSX', {
-    filter: ['dl'],
-    replacement: (_content, node) => htmlToJSXConverter.convert(node.outerHTML),
-  })
   .addRule('table', {
     filter: 'table',
     replacement: (content, node) => {
@@ -150,6 +147,14 @@ turndown
       );
     },
     replacement: (_content, node) => htmlToJSXConverter.convert(node.outerHTML),
+  })
+  .addRule('clamshellContents', {
+    filter: ['dt', 'dd'],
+    replacement: (content, node) => {
+      const [openingTag, closingTag] = extractTags(node);
+
+      return [openingTag, content, closingTag].join('\n');
+    },
   });
 
 module.exports = (html) => turndown.turndown(html);

--- a/scripts/utils/migrate/html-to-markdown.js
+++ b/scripts/utils/migrate/html-to-markdown.js
@@ -111,8 +111,8 @@ turndown
       );
     },
   })
-  .addRule('tableContents', {
-    filter: ['td', 'th', 'thead', 'tbody', 'tr'],
+  .addRule('innerElements', {
+    filter: ['td', 'th', 'thead', 'tbody', 'tr', 'dd', 'dt'],
     replacement: (content, node) => {
       const [openingTag, closingTag] = extractTags(node);
 
@@ -147,14 +147,6 @@ turndown
       );
     },
     replacement: (_content, node) => htmlToJSXConverter.convert(node.outerHTML),
-  })
-  .addRule('clamshellContents', {
-    filter: ['dt', 'dd'],
-    replacement: (content, node) => {
-      const [openingTag, closingTag] = extractTags(node);
-
-      return [openingTag, content, closingTag].join('\n');
-    },
   });
 
 module.exports = (html) => turndown.turndown(html);

--- a/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/no-data-appears-infrastructure.mdx
+++ b/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/no-data-appears-infrastructure.mdx
@@ -31,14 +31,125 @@ If no data appears in the UI, try the following steps to diagnose the problem:
 
 1. Use your package manager to verify that the infrastructure agent is installed:
 
-   <dl className="clamshell-list">
-     <dt id="apt-install-verify">Verify install for apt (Debian or Ubuntu)</dt><dd><ol><li><p>Use <code>dpkg</code> to verify that the agent is installed:</p><pre>dpkg -l | grep newrelic-infra</pre></li><li>If <code>dpkg</code> returns no output, see <a href="/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-linux#apt-based">Install with apt</a>.</li></ol></dd><dt id="yum-install-verify">Verify install for yum (Amazon Linux, CentOS, or RHEL)</dt><dd><ol><li><p>Use <code>rpm</code> to verify that agent is installed:</p><pre>rpm -qa | grep newrelic-infra</pre></li><li>If <code>rpm</code> returns no output, see <a href="/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-linux#yum-based">Install with yum</a>.</li></ol></dd><dt id="windows-install-verify">Verify install for Windows Server</dt><dd><ol><li><p>Use the Windows command prompt or Powershell to verify that the <a href="/docs/agents/manage-apm-agents/troubleshooting/find-agent-root-directory#infra-agent">agent directory</a> exists:</p><pre>dir "C:\\Program Files\\New Relic\\newrelic-infra"</pre></li><li>If you receive a <code>File not found</code> error, see <a href="/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-windows-server">Install for Windows Server</a>.</li></ol></dd>
-   </dl>
+   <CollapserGroup>
+     <Collapser
+       id="apt-install-verify"
+       title="Verify install for apt (Debian or Ubuntu)"
+     >
+       1. Use `dpkg` to verify that the agent is installed:
+
+          ```
+          dpkg -l | grep newrelic-infra
+          ```
+       2. If `dpkg` returns no output, see [Install with apt](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-linux#apt-based).
+     </Collapser>
+
+     <Collapser
+       id="yum-install-verify"
+       title="Verify install for yum (Amazon Linux, CentOS, or RHEL)"
+     >
+       1. Use `rpm` to verify that agent is installed:
+
+          ```
+          rpm -qa | grep newrelic-infra
+          ```
+       2. If `rpm` returns no output, see [Install with yum](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-linux#yum-based).
+     </Collapser>
+
+     <Collapser
+       id="windows-install-verify"
+       title="Verify install for Windows Server"
+     >
+       1. Use the Windows command prompt or Powershell to verify that the [agent directory](/docs/agents/manage-apm-agents/troubleshooting/find-agent-root-directory#infra-agent) exists:
+
+          ```
+          dir "C:\Program Files\New Relic\newrelic-infra"
+          ```
+       2. If you receive a `File not found` error, see [Install for Windows Server](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-windows-server).
+     </Collapser>
+   </CollapserGroup>
 2. Use [your init system](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status#init-system) to verify that the agent is running:
 
-   <dl className="clamshell-list">
-     <dt id="systemd-verify-status">Verify status with SystemD</dt><dd><p>Use SystemD commands with CentOS 7, Debian 8, RHEL 7, and Ubuntu 15.04 or higher:</p><ol><li><p>Check that the agent is running:</p><pre>sudo systemctl status newrelic-infra</pre></li><li><p>If the agent isn't running, start the agent manually:</p><pre>sudo systemctl start newrelic-infra</pre></li></ol></dd><dt id="systemv-verify-status">Verify status with System V</dt><dd><p>Use System V commands with Debian 7:</p><ol><li><p>Check that the agent is running:</p><pre>sudo /etc/init.d/newrelic-infra status</pre></li><li><p>If the agent isn't running, start the agent manually:</p><pre>sudo /etc/init.d/newrelic-infra start</pre></li></ol></dd><dt id="upstart-verify-status">Verify status with Upstart</dt><dd><p>Use Upstart commands with Amazon Linux, CentOS 6, RHEL 6, and Ubuntu 14.10 or lower:</p><ol><li><p>Check that the agent is running:</p><pre>sudo initctl status newrelic-infra</pre></li><li><p>If the agent isn't running, start the agent manually:</p><pre>sudo initctl start newrelic-infra</pre></li></ol></dd><dt id="windows-verify-status">Verify status with Windows</dt><dd><p>Use the Windows command prompt:</p><ol><li><p>Check that the agent is running:</p><pre>sc query "newrelic-infra" | find "RUNNING"</pre></li><li><p>If the agent isn't running, start the agent manually with the Windows command prompt:</p><pre>net start newrelic-infra</pre></li></ol><p>If running <code>net start newrelic-infra</code> returns <code>The service name is invalid</code>, the Infrastructure agent may not have been installed correctly and the service was not properly created.</p><p>To test this:</p><ol><li>From Powershell, run the command <code>get-service newrelic-infra</code>, which will return the status of the service.</li><li>If it returns an error <code>Cannot find any service with service name newrelic-infra</code>, then follow standard procedures to reinstall the agent.</li></ol></dd>
-   </dl>
+   <CollapserGroup>
+     <Collapser
+       id="systemd-verify-status"
+       title="Verify status with SystemD"
+     >
+       Use SystemD commands with CentOS 7, Debian 8, RHEL 7, and Ubuntu 15.04 or higher:
+
+       1. Check that the agent is running:
+
+          ```
+          sudo systemctl status newrelic-infra
+          ```
+       2. If the agent isn't running, start the agent manually:
+
+          ```
+          sudo systemctl start newrelic-infra
+          ```
+     </Collapser>
+
+     <Collapser
+       id="systemv-verify-status"
+       title="Verify status with System V"
+     >
+       Use System V commands with Debian 7:
+
+       1. Check that the agent is running:
+
+          ```
+          sudo /etc/init.d/newrelic-infra status
+          ```
+       2. If the agent isn't running, start the agent manually:
+
+          ```
+          sudo /etc/init.d/newrelic-infra start
+          ```
+     </Collapser>
+
+     <Collapser
+       id="upstart-verify-status"
+       title="Verify status with Upstart"
+     >
+       Use Upstart commands with Amazon Linux, CentOS 6, RHEL 6, and Ubuntu 14.10 or lower:
+
+       1. Check that the agent is running:
+
+          ```
+          sudo initctl status newrelic-infra
+          ```
+       2. If the agent isn't running, start the agent manually:
+
+          ```
+          sudo initctl start newrelic-infra
+          ```
+     </Collapser>
+
+     <Collapser
+       id="windows-verify-status"
+       title="Verify status with Windows"
+     >
+       Use the Windows command prompt:
+
+       1. Check that the agent is running:
+
+          ```
+          sc query "newrelic-infra" | find "RUNNING"
+          ```
+       2. If the agent isn't running, start the agent manually with the Windows command prompt:
+
+          ```
+          net start newrelic-infra
+          ```
+
+       If running `net start newrelic-infra` returns `The service name is invalid`, the Infrastructure agent may not have been installed correctly and the service was not properly created.
+
+       To test this:
+
+       1. From Powershell, run the command `get-service newrelic-infra`, which will return the status of the service.
+       2. If it returns an error `Cannot find any service with service name newrelic-infra`, then follow standard procedures to reinstall the agent.
+     </Collapser>
+   </CollapserGroup>
 3. Use [New Relic Diagnostics](/docs/agents/manage-apm-agents/troubleshooting/new-relic-diagnostics) to try to automatically identify the issue.
 4. Verify that your [`newrelic-infra.yml`](/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#config-file) configuration file contains a valid [`license_key`](/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#conf-license_key) setting.
 5. Verify that the host has a [unique hostname](/docs/infrastructure/new-relic-infrastructure/getting-started/compatibility-requirements-new-relic-infrastructure#hostname), and verify that the hostname is not `localhost`. For more information, see this [Explorers Hub post](https://discuss.newrelic.com/t/relic-solution-a-common-reason-for-a-host-failing-to-show-up-in-the-infrastructure-dashboard/53031).

--- a/src/content/docs/mobile-apps/new-relic-mobile-apps/android-app/introduction-new-relic-android-app.mdx
+++ b/src/content/docs/mobile-apps/new-relic-mobile-apps/android-app/introduction-new-relic-android-app.mdx
@@ -28,9 +28,71 @@ Depending on your New Relic account, additional installation or [user authentica
 
 To view details of your apps monitored by New Relic, select a product from the app's main menu. See below for details on how to use specific features of the app:
 
-<dl className="clamshell-list">
-  <dt id="products">New Relic product details</dt><dd><p>The New Relic Android app includes data about these features:</p><ul><li>New Relic APM metrics, both real-time and <a href="#time">historical</a> data, including health maps. Select the transaction <i className="fa fa-exchange"><span>[transaction icon]</span></i> icon to see detailed transaction metrics, or an <b>Overview</b> chart to view summary charts of your top five transactions. Select the <i className="fa fa-filter"><span>filter</span></i> icon to filter by <a href="/docs/data-analysis/user-interface-functions/labels-categories-organize-your-apps-servers">labels and categories</a>.</li><li>New Relic Browser overview metrics, including average page load time, Browser Apdex, average throughput, and more.</li><li>New Relic Infrastructure utilization.</li><li>New Relic Plugins, including a list of their components or instances, and their charts and current values from the plugin's <a href="/docs/plugins/viewing-the-plugin-summary">Summary</a>.</li><li>New Relic Mobile, including <a href="/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-dashboards/mobile-apps-crash-dashboard">crash reports</a>, network errors, API calls, and active user count.</li><li>Event notifications, including <a href="/docs/mobile-apps/new-relic-ios-app/features/ios-alerting">mobile alerts</a> wherever you are, plus <a href="/docs/applications-menu/deployments-dashboard">deployment notifications</a> and <a href="/docs/site/public-and-private-notes">notes</a>.</li></ul><p>New Relic's Android app does not have the full feature set of the New Relic web interface. For more detailed analysis, sign in to your New Relic account with a web browser.</p></dd><dt id="synthetics">New Relic Synthetics data</dt><dd><p>You can use the Android app to view your <a href="/docs/synthetics/new-relic-synthetics/getting-started/new-relic-synthetics">New Relic Synthetics</a> data, including charts of your monitor's availability, load times, and load sizes. To view more detailed charts, select the caret <i className="fa fa-caret-down"><span>caret-down</span></i> icon.</p><p>You can mute or disable your monitor, and view details of any recent errors. For scripted monitors, you can view and search the script log.</p></dd><dt id="alerts">Alerts</dt><dd><p>When you log in to your New Relic account from the Android app, your device is automatically associated with your <a href="/docs/alerts/new-relic-alerts-beta/managing-notification-channels/notification-channels-controlling-where-send-alerts#user">user channel</a>. Then, you can <a href="/docs/alerts/new-relic-alerts-beta/managing-notification-channels/notification-channels-controlling-where-send-alerts#mobile-push">add your user channel to your target policy</a> to receive alerts.</p><p>For Android alerts, notifications appear on your lock screen. To view them, tap the alert event.</p><p>You can select any alert to view error details or acknowledge the alert. New Relic also sends a push notification when a colleague acknowledges an open event. Then, New Relic sends a final, closing notification when all <b>Critical</b> events end.</p></dd><dt id="mobile-apps">Mobile app monitoring</dt><dd><p>If you have a mobile application and have installed <a href="/docs/mobile-apps/new-relic-mobile">New Relic Mobile</a>, you can monitor its performance directly from your Android device. New Relic Mobile monitoring includes network errors, API calls, and number of active users. You can also view detailed individual crash reports for a deeper understanding of a particular crash incident.</p></dd><dt id="time">Details on setting time range</dt><dd><p>When viewing an application or host, you can change the visible time frame with the <a href="/docs/site/timepicker-setting-time-periods-to-view-data">time picker</a>.</p><ul><li>To move back and forth across the timeline, scrub the New Relic charts.</li><li>To change the duration of the visible time slice, select the clock <img alt="icon-ios-apm-clock" className="as-char" src="/sites/default/files/thumbnails/image/icon-ios-clock_0.png" style={{width: 22, height: 20, borderWidth: 0}} title="icon-ios-apm-clock" typeof="foaf:Image"/> icon.</li><li>To specify an end time other than now, slide the toggle from <b>Ending Now</b> to <b>Custom Date</b>.</li><li>To save your changes and refresh the chart data, select the clock icon again.</li></ul></dd>
-</dl>
+<CollapserGroup>
+  <Collapser
+    id="products"
+    title="New Relic product details"
+  >
+    The New Relic Android app includes data about these features:
+
+    * New Relic APM metrics, both real-time and [historical](#time) data, including health maps. Select the transaction <i className="fa fa-exchange">
+      \[transaction icon]
+      </i>
+      icon to see detailed transaction metrics, or an **Overview** chart to view summary charts of your top five transactions. Select the <i className="fa fa-filter">
+      filter
+      </i>
+      icon to filter by [labels and categories](/docs/data-analysis/user-interface-functions/labels-categories-organize-your-apps-servers).
+    * New Relic Browser overview metrics, including average page load time, Browser Apdex, average throughput, and more.
+    * New Relic Infrastructure utilization.
+    * New Relic Plugins, including a list of their components or instances, and their charts and current values from the plugin's [Summary](/docs/plugins/viewing-the-plugin-summary).
+    * New Relic Mobile, including [crash reports](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-dashboards/mobile-apps-crash-dashboard), network errors, API calls, and active user count.
+    * Event notifications, including [mobile alerts](/docs/mobile-apps/new-relic-ios-app/features/ios-alerting) wherever you are, plus [deployment notifications](/docs/applications-menu/deployments-dashboard) and [notes](/docs/site/public-and-private-notes).
+
+    New Relic's Android app does not have the full feature set of the New Relic web interface. For more detailed analysis, sign in to your New Relic account with a web browser.
+  </Collapser>
+
+  <Collapser
+    id="synthetics"
+    title="New Relic Synthetics data"
+  >
+    You can use the Android app to view your [New Relic Synthetics](/docs/synthetics/new-relic-synthetics/getting-started/new-relic-synthetics) data, including charts of your monitor's availability, load times, and load sizes. To view more detailed charts, select the caret <i className="fa fa-caret-down">
+    caret-down
+    </i>
+    icon.
+
+    You can mute or disable your monitor, and view details of any recent errors. For scripted monitors, you can view and search the script log.
+  </Collapser>
+
+  <Collapser
+    id="alerts"
+    title="Alerts"
+  >
+    When you log in to your New Relic account from the Android app, your device is automatically associated with your [user channel](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/notification-channels-controlling-where-send-alerts#user). Then, you can [add your user channel to your target policy](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/notification-channels-controlling-where-send-alerts#mobile-push) to receive alerts.
+
+    For Android alerts, notifications appear on your lock screen. To view them, tap the alert event.
+
+    You can select any alert to view error details or acknowledge the alert. New Relic also sends a push notification when a colleague acknowledges an open event. Then, New Relic sends a final, closing notification when all **Critical** events end.
+  </Collapser>
+
+  <Collapser
+    id="mobile-apps"
+    title="Mobile app monitoring"
+  >
+    If you have a mobile application and have installed [New Relic Mobile](/docs/mobile-apps/new-relic-mobile), you can monitor its performance directly from your Android device. New Relic Mobile monitoring includes network errors, API calls, and number of active users. You can also view detailed individual crash reports for a deeper understanding of a particular crash incident.
+  </Collapser>
+
+  <Collapser
+    id="time"
+    title="Details on setting time range"
+  >
+    When viewing an application or host, you can change the visible time frame with the [time picker](/docs/site/timepicker-setting-time-periods-to-view-data).
+
+    * To move back and forth across the timeline, scrub the New Relic charts.
+    * To change the duration of the visible time slice, select the clock ![icon-ios-apm-clock](/sites/default/files/thumbnails/image/icon-ios-clock_0.png "icon-ios-apm-clock") icon.
+    * To specify an end time other than now, slide the toggle from **Ending Now** to **Custom Date**.
+    * To save your changes and refresh the chart data, select the clock icon again.
+  </Collapser>
+</CollapserGroup>
 
 ## Data privacy
 

--- a/src/content/docs/mobile-apps/new-relic-mobile-apps/authentication-alerts/alerting-new-relic-mobile-apps.mdx
+++ b/src/content/docs/mobile-apps/new-relic-mobile-apps/authentication-alerts/alerting-new-relic-mobile-apps.mdx
@@ -47,8 +47,132 @@ If alerts are not working on your mobile device:
 
 If the notification settings for your mobile device are correct, but you still do not receive notifications, [delete the device from your account](#account-delete), then [uninstall](#uninstall-app) and [reinstall](#reinstall-app) the New Relic application.
 
-<dl className="clamshell-list">
-  <dt id="notification-settings">Check notification settings for your mobile device.</dt><dd><p>Follow the procedure for your mobile device.</p><table><thead><tr><th style={{width: 150}}><b>Device</b></th><th><b>To check notification settings:</b></th></tr></thead><tbody><tr><td>Android</td><td><ol><li>From your Android device's <b>Settings</b>, select <b>Sound and notification</b>.</li><li>Check the settings for sound volume.</li><li>Optional: Enable <b>Also vibrate for calls</b>.</li><li>Check the settings for <b>Interruptions</b>.</li><li>Check the settings for <b>Notification</b>.</li><li>Check the settings for <b>App notifications</b>: Select the New Relic app, then check the settings for <b>Block</b> and <b>Priority</b>.</li></ol></td></tr><tr><td>iOS</td><td><ol><li>Ensure <a href="http://support.apple.com/kb/HT5463">Do Not Disturb</a> is off: From the iOS <b>Settings</b> app, select <b>Do Not Disturb</b>, and check that the <b>Manual</b> switch is off.</li><li>Ensure the New Relic app is allowed to send notifications: From the iOS <b>Settings</b> app, select <b>Notifications</b>, and locate the New Relic app from the app list.</li><li>Ensure that the <b>Allow Notifications</b> switch is on.</li><li>Ensure that the alert style is set to <b>Banners</b> or <b>Alerts</b>.</li><li>Optional: To enable audio alerts, set <b>Sounds</b> to on.</li></ol></td></tr></tbody></table></dd><dt id="account-delete">Delete the Android or iOS device from your New Relic account.</dt><dd><p>To delete the mobile device from your New Relic account:</p><ol><li>From <a href="https://rpm.newrelic.com">rpm.newrelic.com</a> in a web browser, select <b><a href="/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown">(account dropdown)</a> > User preferences</b>.</li><li>From <b>Mobile devices</b>, locate the device you are troubleshooting, then select <b>Delete</b>.</li><li>Continue with the steps to <a href="#uninstall-app">reinstall</a> the New Relic app from your device.</li></ol></dd><dt id="uninstall-app">Uninstall the New Relic mobile app.</dt><dd><p>Follow the procedure to uninstall the New Relic app from your device, then reinstall it.</p><table><thead><tr><th style={{width: 150}}><b>Device</b></th><th><b>To uninstall the New Relic app:</b></th></tr></thead><tbody><tr><td>Android</td><td><ol><li>From your Android device's <b>Settings</b>, select <b>Apps</b>, then select the New Relic app.</li><li>Select <b>Uninstall</b>.</li><li>Continue with the steps to <a href="#reinstall-app">reinstall</a> the New Relic app.</li></ol></td></tr><tr><td>iOS</td><td><ol><li>From your iOS home screen, tap and hold the New Relic icon until it shakes.</li><li>To <a href="http://support.apple.com/kb/TI135">delete the app</a>, select the <b>X</b> icon.</li><li>Continue with the steps to <a href="#reinstall-app">reinstall</a> the New Relic app.</li></ol></td></tr></tbody></table></dd><dt id="reinstall-app">Reinstall the New Relic mobile app.</dt><dd><p>To reinstall the New Relic mobile app:</p><ol><li><p>From your Android device, select <a href="https://play.google.com/store/apps/details?id=com.newrelic.rpm"><b>Google Play Store</b></a>.</p><p>OR</p><p>From your iOS device's home screen, select <a href="https://itunes.apple.com/us/app/new-relic/id594038638?mt=8"><b>App Store</b>.</a></p></li><li>Search for <b>New Relic</b>.</li><li>Download the app.</li><li>When the download finishes, sign in to your New Relic mobile app with your New Relic account.</li></ol></dd>
-</dl>
+<CollapserGroup>
+  <Collapser
+    id="notification-settings"
+    title="Check notification settings for your mobile device."
+  >
+    Follow the procedure for your mobile device.
+
+    <table>
+      <thead>
+        <tr>
+          <th style={{width: 150}}>
+            **Device**
+          </th>
+
+          <th>
+            **To check notification settings:**
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            Android
+          </td>
+
+          <td>
+            1. From your Android device's **Settings**, select **Sound and notification**.
+            2. Check the settings for sound volume.
+            3. Optional: Enable **Also vibrate for calls**.
+            4. Check the settings for **Interruptions**.
+            5. Check the settings for **Notification**.
+            6. Check the settings for **App notifications**: Select the New Relic app, then check the settings for **Block** and **Priority**.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            iOS
+          </td>
+
+          <td>
+            1. Ensure [Do Not Disturb](http://support.apple.com/kb/HT5463) is off: From the iOS **Settings** app, select **Do Not Disturb**, and check that the **Manual** switch is off.
+            2. Ensure the New Relic app is allowed to send notifications: From the iOS **Settings** app, select **Notifications**, and locate the New Relic app from the app list.
+            3. Ensure that the **Allow Notifications** switch is on.
+            4. Ensure that the alert style is set to **Banners** or **Alerts**.
+            5. Optional: To enable audio alerts, set **Sounds** to on.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
+
+  <Collapser
+    id="account-delete"
+    title="Delete the Android or iOS device from your New Relic account."
+  >
+    To delete the mobile device from your New Relic account:
+
+    1. From [rpm.newrelic.com](https://rpm.newrelic.com) in a web browser, select **[(account dropdown)](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown) > User preferences**.
+    2. From **Mobile devices**, locate the device you are troubleshooting, then select **Delete**.
+    3. Continue with the steps to [reinstall](#uninstall-app) the New Relic app from your device.
+  </Collapser>
+
+  <Collapser
+    id="uninstall-app"
+    title="Uninstall the New Relic mobile app."
+  >
+    Follow the procedure to uninstall the New Relic app from your device, then reinstall it.
+
+    <table>
+      <thead>
+        <tr>
+          <th style={{width: 150}}>
+            **Device**
+          </th>
+
+          <th>
+            **To uninstall the New Relic app:**
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            Android
+          </td>
+
+          <td>
+            1. From your Android device's **Settings**, select **Apps**, then select the New Relic app.
+            2. Select **Uninstall**.
+            3. Continue with the steps to [reinstall](#reinstall-app) the New Relic app.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            iOS
+          </td>
+
+          <td>
+            1. From your iOS home screen, tap and hold the New Relic icon until it shakes.
+            2. To [delete the app](http://support.apple.com/kb/TI135), select the **X** icon.
+            3. Continue with the steps to [reinstall](#reinstall-app) the New Relic app.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
+
+  <Collapser
+    id="reinstall-app"
+    title="Reinstall the New Relic mobile app."
+  >
+    To reinstall the New Relic mobile app:
+
+    1. From your Android device, select [**Google Play Store**](https://play.google.com/store/apps/details?id=com.newrelic.rpm).
+
+       OR
+
+       From your iOS device's home screen, select [**App Store**.](https://itunes.apple.com/us/app/new-relic/id594038638?mt=8)
+    2. Search for **New Relic**.
+    3. Download the app.
+    4. When the download finishes, sign in to your New Relic mobile app with your New Relic account.
+  </Collapser>
+</CollapserGroup>
 
 ## For more help

--- a/src/content/docs/mobile-apps/new-relic-mobile-apps/authentication-alerts/user-settings-authentication.mdx
+++ b/src/content/docs/mobile-apps/new-relic-mobile-apps/authentication-alerts/user-settings-authentication.mdx
@@ -88,9 +88,93 @@ Depending on your New Relic account, additional installation or authentication s
 
 After you sign in, all New Relic accounts and applications associated with the user appear automatically.
 
-<dl className="clamshell-list">
-  <dt id="additional-username">Sign in with additional username</dt><dd><p>Follow the procedure for your mobile device.</p><table><thead><tr><th style={{width: 200}}><b>Mobile device</b></th><th><b>To sign in to the app with an additional user name:</b></th></tr></thead><tbody><tr><td>Android</td><td><p>To switch users:</p><ol><li>Log out from the Android device: <b>Main menu > (selected username) > Logout > Confirm</b>.</li><li>Log in with a new account.</li></ol></td></tr><tr><td>iPhone</td><td><ol><li>From the app menu, select your account name, then select the <strong>Users</strong> menu.</li><li>From the <b>Users</b> menu, select the plus <img alt="icon ios plus" className="as-char" src="/sites/default/files/thumbnails/image/icon-ios-plus_0.png" style={{width: 25, height: 20}} title="icon ios plus"/> icon.</li><li>Sign in with the additional username.</li></ol></td></tr><tr><td>iPad</td><td><ol><li>To access the <strong>Users</strong> menu: Select the user icon <img alt="icon-ios-app-user" className="as-char" src="/sites/default/files/thumbnails/image/icon-ios-app-user.png" style={{width: 25, height: 24}} title="icon-ios-app-user"/> or slide right.</li><li>From the <b>Users</b> menu, select the plus <img alt="icon ios plus" className="as-char" src="/sites/default/files/thumbnails/image/icon-ios-plus_0.png" style={{width: 25, height: 20}} title="icon ios plus"/> icon.</li><li>Sign in with the additional username.</li></ol></td></tr></tbody></table></dd><dt id="switch-accounts">Switch between accounts</dt><dd><p>To switch between accounts associated with your username:</p><ol><li>From the <b>Users</b> menu, select the user name.</li><li>Select the account name.</li></ol></dd><dt id="Remove a username">Remove or re-add a user name</dt><dd><p>To remove a specific username from this device:</p><ol><li>From the <b>Users</b> menu, select <b>Logout</b>.</li><li>To remove a user from this device, select the user's red minus <i className="fa fa-minus-circle" style={{color: 'red'}}><span>[minus-circle]</span></i> icon.</li><li>Select the user's <b>Log out</b> icon.</li></ol><p>To add a user again, sign in with that username again.</p></dd>
-</dl>
+<CollapserGroup>
+  <Collapser
+    id="additional-username"
+    title="Sign in with additional username"
+  >
+    Follow the procedure for your mobile device.
+
+    <table>
+      <thead>
+        <tr>
+          <th style={{width: 200}}>
+            **Mobile device**
+          </th>
+
+          <th>
+            **To sign in to the app with an additional user name:**
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            Android
+          </td>
+
+          <td>
+            To switch users:
+
+            1. Log out from the Android device: **Main menu > (selected username) > Logout > Confirm**.
+            2. Log in with a new account.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            iPhone
+          </td>
+
+          <td>
+            1. From the app menu, select your account name, then select the **Users** menu.
+            2. From the **Users** menu, select the plus ![icon ios plus](/sites/default/files/thumbnails/image/icon-ios-plus_0.png "icon ios plus") icon.
+            3. Sign in with the additional username.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            iPad
+          </td>
+
+          <td>
+            1. To access the **Users** menu: Select the user icon ![icon-ios-app-user](/sites/default/files/thumbnails/image/icon-ios-app-user.png "icon-ios-app-user") or slide right.
+            2. From the **Users** menu, select the plus ![icon ios plus](/sites/default/files/thumbnails/image/icon-ios-plus_0.png "icon ios plus") icon.
+            3. Sign in with the additional username.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
+
+  <Collapser
+    id="switch-accounts"
+    title="Switch between accounts"
+  >
+    To switch between accounts associated with your username:
+
+    1. From the **Users** menu, select the user name.
+    2. Select the account name.
+  </Collapser>
+
+  <Collapser
+    id="Remove a username"
+    title="Remove or re-add a user name"
+  >
+    To remove a specific username from this device:
+
+    1. From the **Users** menu, select **Logout**.
+    2. To remove a user from this device, select the user's red minus <i className="fa fa-minus-circle" style={{color: 'red'}}>
+       \[minus-circle]
+       </i>
+       icon.
+    3. Select the user's **Log out** icon.
+
+    To add a user again, sign in with that username again.
+  </Collapser>
+</CollapserGroup>
 
 ![device-ipad-switch-user.png](https://docs-dev.newrelic.com/sites/default/files/styles/inline_660px/public/thumbnails/image/device-ipad-switch-user.png?itok=Seap1zcK "device-ipad-switch-user.png")
 


### PR DESCRIPTION
Closes #81 

## Description

Adds a codemod to migrate clamshells over to the `Collapser` component. 

## Screenshots

<img width="1920" alt="Screen Shot 2020-10-02 at 1 27 39 AM" src="https://user-images.githubusercontent.com/565661/94903330-7c0b2f00-044e-11eb-88e7-936e786b7b35.png">
