### PR TITLE
Example boxes + complex titles

### DIFF
--- a/codemods/clamshells.js
+++ b/codemods/clamshells.js
@@ -3,6 +3,7 @@ const toString = require('mdast-util-to-string');
 const {
   removeAttribute,
   isMdxBlockElement,
+  isPlainText,
   hasClassName,
   removeChild,
   setAttribute,
@@ -24,14 +25,8 @@ const clamshells = () => (tree, file) => {
         (node, _idx, parent) => isMdxBlockElement('dt', node) && parent === dl,
         (dt, idx) => {
           const dd = dl.children[idx + 1];
-          const isPlainTextTitle =
-            dt.children.length === 1 &&
-            dt.children[0].type === 'paragraph' &&
-            dt.children[0].children.every((node) => node.type === 'text');
 
-          dt.name = 'Collapser';
-
-          if (isPlainTextTitle) {
+          if (isPlainText(dt)) {
             setAttribute('title', toString(dt), dt);
           } else {
             setAttribute(
@@ -41,6 +36,7 @@ const clamshells = () => (tree, file) => {
             );
           }
 
+          dt.name = 'Collapser';
           dt.children = dd.children;
         }
       );

--- a/codemods/clamshells.js
+++ b/codemods/clamshells.js
@@ -25,11 +25,11 @@ const clamshells = () => (tree, file) => {
         (dt, idx) => {
           const dd = dl.children[idx + 1];
 
-          if (isPlainText(dt)) {
-            setAttribute('title', toString(dt), dt);
-          } else {
-            setAttribute('title', toJSXExpression(dt, file), dt);
-          }
+          setAttribute(
+            'title',
+            isPlainText(dt) ? toString(dt) : toJSXExpression(dt, file),
+            dt
+          );
 
           dt.name = 'Collapser';
           dt.children = dd.children;

--- a/codemods/clamshells.js
+++ b/codemods/clamshells.js
@@ -8,7 +8,6 @@ const {
   removeChild,
   setAttribute,
 } = require('./utils/mdxast');
-const { stringify, mdxValueExpression } = require('./utils/mdxast-builder');
 const toJSXExpression = require('./utils/to-jsx-expression');
 
 const clamshells = () => (tree, file) => {
@@ -29,11 +28,7 @@ const clamshells = () => (tree, file) => {
           if (isPlainText(dt)) {
             setAttribute('title', toString(dt), dt);
           } else {
-            setAttribute(
-              'title',
-              mdxValueExpression(stringify(toJSXExpression(dt, file)).trim()),
-              dt
-            );
+            setAttribute('title', toJSXExpression(dt, file), dt);
           }
 
           dt.name = 'Collapser';

--- a/codemods/exampleBoxes.js
+++ b/codemods/exampleBoxes.js
@@ -1,0 +1,48 @@
+const visit = require('unist-util-visit');
+const { select } = require('unist-util-select');
+const {
+  isMdxBlockElement,
+  hasClassName,
+  removeAttribute,
+  removeChild,
+  setAttribute,
+} = require('./utils/mdxast');
+const { last } = require('lodash');
+
+const exampleBoxes = () => (tree, file) => {
+  visit(
+    tree,
+    (node) =>
+      isMdxBlockElement('dl', node) && hasClassName('example-box', node),
+    (dl) => {
+      dl.name = 'CollapserGroup';
+      // removeAttribute('className', dl);
+
+      visit(
+        dl,
+        (node, _idx, parent) => isMdxBlockElement('dt', node) && parent === dl,
+        (dt, idx) => {
+          const dd = dl.children[idx + 1];
+          const isSimpleExample = dd == null || dd.name !== 'dd';
+          const { value: title } = select('text', dt);
+
+          const children = isSimpleExample ? [last(dt.children)] : dd.children;
+
+          dt.name = 'Collapser';
+          dt.children = children;
+          setAttribute('title', title, dt);
+        }
+      );
+
+      visit(
+        dl,
+        (node, _idx, parent) => isMdxBlockElement('dd', node) && parent === dl,
+        (dd) => {
+          removeChild(dd, dl);
+        }
+      );
+    }
+  );
+};
+
+module.exports = exampleBoxes;

--- a/codemods/exampleBoxes.js
+++ b/codemods/exampleBoxes.js
@@ -9,14 +9,14 @@ const {
 } = require('./utils/mdxast');
 const { last } = require('lodash');
 
-const exampleBoxes = () => (tree, file) => {
+const exampleBoxes = () => (tree) => {
   visit(
     tree,
     (node) =>
       isMdxBlockElement('dl', node) && hasClassName('example-box', node),
     (dl) => {
       dl.name = 'CollapserGroup';
-      // removeAttribute('className', dl);
+      removeAttribute('className', dl);
 
       visit(
         dl,

--- a/codemods/exampleBoxes.js
+++ b/codemods/exampleBoxes.js
@@ -9,7 +9,7 @@ const {
   setAttribute,
 } = require('./utils/mdxast');
 const { last } = require('lodash');
-const { stringify, mdxValueExpression } = require('./utils/mdxast-builder');
+const toString = require('mdast-util-to-string');
 const toJSXExpression = require('./utils/to-jsx-expression');
 
 const exampleBoxes = () => (tree, file) => {
@@ -34,11 +34,7 @@ const exampleBoxes = () => (tree, file) => {
           } else if (isPlainText(dt)) {
             setAttribute('title', toString(dt), dt);
           } else {
-            setAttribute(
-              'title',
-              mdxValueExpression(stringify(toJSXExpression(dt, file)).trim()),
-              dt
-            );
+            setAttribute('title', toJSXExpression(dt, file), dt);
           }
 
           dt.name = 'Collapser';

--- a/codemods/index.js
+++ b/codemods/index.js
@@ -1,6 +1,7 @@
 const indentedCodeBlock = require('./indentedCodeBlock');
 const callouts = require('./callouts');
 const clamshells = require('./clamshells');
+const exampleBoxes = require('./exampleBoxes');
 const videos = require('./videos');
 const images = require('./images');
 const tables = require('./tables');
@@ -15,6 +16,7 @@ module.exports = [
   indentedCodeBlock,
   callouts,
   clamshells,
+  exampleBoxes,
   videos,
   images,
   tables,

--- a/codemods/utils/mdxast-builder.js
+++ b/codemods/utils/mdxast-builder.js
@@ -2,6 +2,8 @@ const u = require('unist-builder');
 
 const mdxAttribute = (name, value) => u('mdxAttribute', { name, value });
 const mdxValueExpression = (value) => u('mdxValueExpression', value);
+const mdxBlockExpression = (value) => u('mdxBlockExpression', value);
+const mdxSpanExpression = (value) => u('mdxSpanExpression', value);
 
 const mdxSpanElement = (name, attributes = [], children = []) =>
   u('mdxSpanElement', { attributes, name }, children);
@@ -12,6 +14,8 @@ const mdxBlockElement = (name, attributes = [], children = []) =>
 module.exports = {
   mdxAttribute,
   mdxBlockElement,
+  mdxBlockExpression,
   mdxSpanElement,
+  mdxSpanExpression,
   mdxValueExpression,
 };

--- a/codemods/utils/mdxast-builder.js
+++ b/codemods/utils/mdxast-builder.js
@@ -1,5 +1,4 @@
 const u = require('unist-builder');
-const createProcessor = require('../../scripts/utils/codemod/create-processor');
 
 const mdxAttribute = (name, value) => u('mdxAttribute', { name, value });
 const mdxValueExpression = (value) => u('mdxValueExpression', value);
@@ -10,12 +9,9 @@ const mdxSpanElement = (name, attributes = [], children = []) =>
 const mdxBlockElement = (name, attributes = [], children = []) =>
   u('mdxBlockElement', { attributes, name }, children);
 
-const stringify = (tree) => createProcessor().stringify(tree);
-
 module.exports = {
   mdxAttribute,
   mdxBlockElement,
   mdxSpanElement,
   mdxValueExpression,
-  stringify,
 };

--- a/codemods/utils/mdxast-builder.js
+++ b/codemods/utils/mdxast-builder.js
@@ -1,0 +1,21 @@
+const u = require('unist-builder');
+const createProcessor = require('../../scripts/utils/codemod/create-processor');
+
+const mdxAttribute = (name, value) => u('mdxAttribute', { name, value });
+const mdxValueExpression = (value) => u('mdxValueExpression', value);
+
+const mdxSpanElement = (name, attributes = [], children = []) =>
+  u('mdxSpanElement', { attributes, name }, children);
+
+const mdxBlockElement = (name, attributes = [], children = []) =>
+  u('mdxBlockElement', { attributes, name }, children);
+
+const stringify = (tree) => createProcessor().stringify(tree);
+
+module.exports = {
+  mdxAttribute,
+  mdxBlockElement,
+  mdxSpanElement,
+  mdxValueExpression,
+  stringify,
+};

--- a/codemods/utils/mdxast-stringify.js
+++ b/codemods/utils/mdxast-stringify.js
@@ -1,0 +1,5 @@
+const createProcessor = require('../../scripts/utils/codemod/create-processor');
+
+const stringify = (tree) => createProcessor().stringify(tree);
+
+module.exports = stringify;

--- a/codemods/utils/mdxast.js
+++ b/codemods/utils/mdxast.js
@@ -83,12 +83,22 @@ const removeChild = curry((child, parent) => {
   }
 });
 
+const isPlainText = (node) => {
+  return (
+    node.children.every((node) => node.type === 'text') ||
+    (node.children.length === 1 &&
+      node.children[0].type === 'paragraph' &&
+      isPlainText(node.children[0]))
+  );
+};
+
 module.exports = {
   addAttribute,
   flatten,
   isMdxBlockElement,
   isMdxElement,
   isMdxSpanElement,
+  isPlainText,
   hasAttribute,
   findAttribute,
   hasClassName,

--- a/codemods/utils/to-jsx-expression.js
+++ b/codemods/utils/to-jsx-expression.js
@@ -43,12 +43,12 @@ const escape = (str) => {
       // without a closing '}', so we'll need to handle this differently if we
       // end up having cases where the text contents only include an opening '{'
       // https://github.com/mdx-js/mdx/issues/1081
-      mdxSpanExpression(`'${str.replace("'", "'")}'`);
+      mdxSpanExpression(`'${str.replace("'", "\\'")}'`);
 };
 
 const TRANSFORMERS = {
   paragraph: transformChildren,
-  inlineCode: (node) => mdxSpanElement('code', [], [escape(node.value)]),
+  inlineCode: (node) => mdxSpanElement('InlineCode', [], [escape(node.value)]),
   text: (node) => node,
   strong: (node) => mdxSpanElement('strong', [], transformChildren(node)),
   link: (node) => {

--- a/codemods/utils/to-jsx-expression.js
+++ b/codemods/utils/to-jsx-expression.js
@@ -1,0 +1,46 @@
+const { mdxAttribute, mdxSpanElement } = require('./mdxast-builder');
+const { root, text } = require('mdast-builder');
+
+const toJSXExpression = (node, file) => {
+  const children = transformChildren(node, file);
+
+  return root(
+    children.length === 1 ? children : [mdxSpanElement(null, [], children)]
+  );
+};
+
+const transformChildren = (node, file) => {
+  return node.children
+    .flatMap((child) => {
+      const transformer = TRANSFORMERS[child.type];
+
+      if (!transformer) {
+        file.message(
+          `Converting to JSX expression of unknown type: '${child.type}'`,
+          child.position.start,
+          'clamshells'
+        );
+        return;
+      }
+
+      return transformer(child, file);
+    })
+    .filter(Boolean);
+};
+
+const TRANSFORMERS = {
+  paragraph: transformChildren,
+  inlineCode: (node) => mdxSpanElement('code', [], [text(node.value)]),
+  text: (node) => node,
+  link: (node) => {
+    const isRelative = node.url.startsWith('http');
+
+    return mdxSpanElement(
+      isRelative ? 'Link' : 'a',
+      [mdxAttribute(isRelative ? 'to' : 'href', node.url)],
+      node.children
+    );
+  },
+};
+
+module.exports = toJSXExpression;

--- a/codemods/utils/to-jsx-expression.js
+++ b/codemods/utils/to-jsx-expression.js
@@ -50,14 +50,15 @@ const TRANSFORMERS = {
   paragraph: transformChildren,
   inlineCode: (node) => mdxSpanElement('InlineCode', [], [escape(node.value)]),
   text: (node) => node,
-  strong: (node) => mdxSpanElement('strong', [], transformChildren(node)),
-  link: (node) => {
+  strong: (node, file) =>
+    mdxSpanElement('strong', [], transformChildren(node, file)),
+  link: (node, file) => {
     const isExternal = node.url.startsWith('http');
 
     return mdxSpanElement(
       isExternal ? 'ExternalLink' : 'Link',
       [mdxAttribute(isExternal ? 'href' : 'to', node.url)],
-      transformChildren(node)
+      transformChildren(node, file)
     );
   },
 };

--- a/codemods/utils/to-jsx-expression.js
+++ b/codemods/utils/to-jsx-expression.js
@@ -1,12 +1,18 @@
-const { mdxAttribute, mdxSpanElement } = require('./mdxast-builder');
+const {
+  mdxAttribute,
+  mdxSpanElement,
+  mdxValueExpression,
+} = require('./mdxast-builder');
 const { root, text } = require('mdast-builder');
+const stringify = require('./mdxast-stringify');
 
 const toJSXExpression = (node, file) => {
   const children = transformChildren(node, file);
-
-  return root(
+  const tree = root(
     children.length === 1 ? children : [mdxSpanElement(null, [], children)]
   );
+
+  return mdxValueExpression(stringify(tree).trim());
 };
 
 const transformChildren = (node, file) => {
@@ -32,6 +38,7 @@ const TRANSFORMERS = {
   paragraph: transformChildren,
   inlineCode: (node) => mdxSpanElement('code', [], [text(node.value)]),
   text: (node) => node,
+  strong: (node) => mdxSpanElement('strong', [], [text(node.value)]),
   link: (node) => {
     const isRelative = node.url.startsWith('http');
 

--- a/codemods/utils/to-jsx-expression.js
+++ b/codemods/utils/to-jsx-expression.js
@@ -55,7 +55,7 @@ const TRANSFORMERS = {
     const isExternal = node.url.startsWith('http');
 
     return mdxSpanElement(
-      isExternal ? 'a' : 'Link',
+      isExternal ? 'ExternalLink' : 'Link',
       [mdxAttribute(isExternal ? 'href' : 'to', node.url)],
       transformChildren(node)
     );

--- a/codemods/utils/to-jsx-expression.js
+++ b/codemods/utils/to-jsx-expression.js
@@ -38,14 +38,14 @@ const TRANSFORMERS = {
   paragraph: transformChildren,
   inlineCode: (node) => mdxSpanElement('code', [], [text(node.value)]),
   text: (node) => node,
-  strong: (node) => mdxSpanElement('strong', [], [text(node.value)]),
+  strong: (node) => mdxSpanElement('strong', [], transformChildren(node)),
   link: (node) => {
-    const isRelative = node.url.startsWith('http');
+    const isExternal = node.url.startsWith('http');
 
     return mdxSpanElement(
-      isRelative ? 'Link' : 'a',
-      [mdxAttribute(isRelative ? 'to' : 'href', node.url)],
-      node.children
+      isExternal ? 'a' : 'Link',
+      [mdxAttribute(isExternal ? 'href' : 'to', node.url)],
+      transformChildren(node)
     );
   },
 };

--- a/scripts/utils/codemod/create-processor.js
+++ b/scripts/utils/codemod/create-processor.js
@@ -5,7 +5,7 @@ const frontmatter = require('remark-frontmatter');
 const remarkMdx = require('remark-mdx');
 const remarkMdxjs = require('remark-mdxjs');
 
-const createProcessor = ({ codemods }) => {
+const createProcessor = ({ codemods = [] } = {}) => {
   const processor = unified()
     .use(stringify, {
       bullet: '*',

--- a/scripts/utils/migrate/html-to-markdown.js
+++ b/scripts/utils/migrate/html-to-markdown.js
@@ -12,6 +12,7 @@ const SPECIAL_COMPONENTS = [
   { tag: 'div', className: 'callout-pricing' },
   { tag: 'i', className: 'fa' },
   { tag: 'dl', className: 'clamshell-list' },
+  { tag: 'dl', className: 'example-box' },
 ];
 
 const escapes = [

--- a/src/components/Collapser.js
+++ b/src/components/Collapser.js
@@ -89,7 +89,7 @@ const Collapser = ({ title, id, openByDefault, className, children }) => {
 };
 
 Collapser.propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   id: PropTypes.string,
   openByDefault: PropTypes.bool,
   className: PropTypes.string,

--- a/src/components/MDXContainer.js
+++ b/src/components/MDXContainer.js
@@ -5,6 +5,7 @@ import { MDXRenderer } from 'gatsby-plugin-mdx';
 import { MDXProvider } from '@mdx-js/react';
 import {
   MDXCodeBlock,
+  ExternalLink,
   Callout,
   Button,
   Icon,
@@ -82,6 +83,9 @@ const components = {
   Callout,
   Collapser,
   CollapserGroup,
+  ExternalLink: (props) => (
+    <ExternalLink {...props} onClick={(e) => e.stopPropagation()} />
+  ),
   Icon,
   InlineCode,
   Table,

--- a/src/components/MDXContainer.js
+++ b/src/components/MDXContainer.js
@@ -67,6 +67,12 @@ Wrapper.propTypes = {
   children: PropTypes.node,
 };
 
+const InlineCode = ({ children }) => <code>{children}</code>;
+
+InlineCode.propTypes = {
+  children: PropTypes.node,
+};
+
 const components = {
   Link,
   code: MDXCodeBlock,
@@ -77,6 +83,7 @@ const components = {
   Collapser,
   CollapserGroup,
   Icon,
+  InlineCode,
   Table,
   Video,
 };

--- a/src/content/docs/agents/java-agent/additional-installation/install-java-agent-using-maven.mdx
+++ b/src/content/docs/agents/java-agent/additional-installation/install-java-agent-using-maven.mdx
@@ -74,74 +74,74 @@ This document explains how to install the Java agent using Maven. For informatio
 
        This will unzip all the files into the newly created `newrelic/` within `project.build.directory`
 
-       <dd>
-         Here is an example `pom.xml` that downloads and extracts `newrelic-java.zip`.
+       <CollapserGroup>
+         <Collapser title={<>Here is an example <InlineCode>pom.xml</InlineCode> that downloads and extracts <InlineCode>newrelic-java.zip</InlineCode>.</>}>
+           ```
+           <project xmlns="http://maven.apache.org/POM/4.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+             <modelVersion>4.0.0</modelVersion>
 
-         ```
-         <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-           <modelVersion>4.0.0</modelVersion>
+             <groupId>com.example.application</groupId>
+             <artifactId>my-example-app</artifactId>
+             <packaging>war</packaging>
+             <version>1.0</version>
+             <name>My Example Application</name>
+             <url>http://example.com</url>
 
-           <groupId>com.example.application</groupId>
-           <artifactId>my-example-app</artifactId>
-           <packaging>war</packaging>
-           <version>1.0</version>
-           <name>My Example Application</name>
-           <url>http://example.com</url>
+             <dependencies>
+                 <dependency>
+                   <groupId>com.newrelic.agent.java</groupId>
+                   <artifactId>newrelic-java</artifactId>
+                   <version>3.47.1</version>
+                   <scope>provided</scope>
+                   <type>zip</type>
+                 </dependency>   
+             </dependencies>
 
-           <dependencies>
-               <dependency>
-                 <groupId>com.newrelic.agent.java</groupId>
-                 <artifactId>newrelic-java</artifactId>
-                 <version>3.47.1</version>
-                 <scope>provided</scope>
-                 <type>zip</type>
-               </dependency>   
-           </dependencies>
+             <!-- boilerplate code so Maven can generate a .war archive without requiring a web.xml file -->
+             <build>
+               <finalName>my-example-app</finalName>
+               <plugins>
 
-           <!-- boilerplate code so Maven can generate a .war archive without requiring a web.xml file -->
-           <build>
-             <finalName>my-example-app</finalName>
-             <plugins>
+                 <plugin>
+                   <groupId>org.apache.maven.plugins</groupId>
+                   <artifactId>maven-war-plugin</artifactId>
+                   <version>3.2.2</version>
+                   <configuration>
+                     <failOnMissingWebXml>false</failOnMissingWebXml>
+                   </configuration>
+                 </plugin>
 
-               <plugin>
-                 <groupId>org.apache.maven.plugins</groupId>
-                 <artifactId>maven-war-plugin</artifactId>
-                 <version>3.2.2</version>
-                 <configuration>
-                   <failOnMissingWebXml>false</failOnMissingWebXml>
-                 </configuration>
-               </plugin>
-
-               <!-- Unzip New Relic Java agent into project.build.directory -->
-               <plugin>
-                 <groupId>org.apache.maven.plugins</groupId>
-                 <artifactId>maven-dependency-plugin</artifactId>
-                 <version>3.1.1</version>
-                 <executions>
-                   <execution>
-                     <id>unpack-newrelic</id>
-                     <phase>package</phase>
-                     <goals>
-                       <goal>unpack-dependencies</goal>
-                     </goals>
-                     <configuration>
-                       <includeGroupIds>com.newrelic.agent.java</includeGroupIds>
-                       <includeArtifactIds>newrelic-java</includeArtifactIds>
-                       <overWriteReleases>false</overWriteReleases>
-                       <overWriteSnapshots>false</overWriteSnapshots>
-                       <overWriteIfNewer>true</overWriteIfNewer>
-                       <outputDirectory>${project.build.directory}</outputDirectory>
-                     </configuration>
-                   </execution>
-                 </executions>
-               </plugin>
-             </plugins>
-           </build>
-         </project>
-         ```
-       </dd>
+                 <!-- Unzip New Relic Java agent into project.build.directory -->
+                 <plugin>
+                   <groupId>org.apache.maven.plugins</groupId>
+                   <artifactId>maven-dependency-plugin</artifactId>
+                   <version>3.1.1</version>
+                   <executions>
+                     <execution>
+                       <id>unpack-newrelic</id>
+                       <phase>package</phase>
+                       <goals>
+                         <goal>unpack-dependencies</goal>
+                       </goals>
+                       <configuration>
+                         <includeGroupIds>com.newrelic.agent.java</includeGroupIds>
+                         <includeArtifactIds>newrelic-java</includeArtifactIds>
+                         <overWriteReleases>false</overWriteReleases>
+                         <overWriteSnapshots>false</overWriteSnapshots>
+                         <overWriteIfNewer>true</overWriteIfNewer>
+                         <outputDirectory>${project.build.directory}</outputDirectory>
+                       </configuration>
+                     </execution>
+                   </executions>
+                 </plugin>
+               </plugins>
+             </build>
+           </project>
+           ```
+         </Collapser>
+       </CollapserGroup>
      </Collapser>
 
      <Collapser
@@ -175,43 +175,43 @@ This document explains how to install the Java agent using Maven. For informatio
           Replace JAVA_AGENT_VERSION with the [latest Java agent version](/docs/agents/java-agent/getting-started/java-release-notes).
        2. Locate the `newrelic.yml` file you received when creating your New Relic account or download one for the [version of the agent](https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes) that you are using.
 
-       <dd>
-         Here is an example `pom.xml` for working with the individual components (Java agent and API jars).
+       <CollapserGroup>
+         <Collapser title={<>Here is an example <InlineCode>pom.xml</InlineCode> for working with the individual components (Java agent and API jars).</>}>
+           ```
+           <project xmlns="http://maven.apache.org/POM/4.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+             <modelVersion>4.0.0</modelVersion>
 
-         ```
-         <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-           <modelVersion>4.0.0</modelVersion>
+             <groupId>com.example.application</groupId>
+             <artifactId>my-example-app</artifactId>
+             <packaging>war</packaging>
+             <version>1.0</version>
+             <name>My Example Application</name>
+             <url>http://example.com</url>
 
-           <groupId>com.example.application</groupId>
-           <artifactId>my-example-app</artifactId>
-           <packaging>war</packaging>
-           <version>1.0</version>
-           <name>My Example Application</name>
-           <url>http://example.com</url>
+             <dependencies>
 
-           <dependencies>
-
-             <!-- The newrelic.jar dependency. -->
-             <dependency>
-               <groupId>com.newrelic.agent.java</groupId>
-               <artifactId>newrelic-agent</artifactId>
-               <version>3.47.1</version>
-               <scope>provided</scope>
-             </dependency>
+               <!-- The newrelic.jar dependency. -->
+               <dependency>
+                 <groupId>com.newrelic.agent.java</groupId>
+                 <artifactId>newrelic-agent</artifactId>
+                 <version>3.47.1</version>
+                 <scope>provided</scope>
+               </dependency>
        
-             <!-- The newrelic-api.jar dependency. -->
-             <dependency>
-               <groupId>com.newrelic.agent.java</groupId>
-               <artifactId>newrelic-api</artifactId>
-               <version>3.47.1</version>
-               <scope>compile</scope>
-           </dependency>
+               <!-- The newrelic-api.jar dependency. -->
+               <dependency>
+                 <groupId>com.newrelic.agent.java</groupId>
+                 <artifactId>newrelic-api</artifactId>
+                 <version>3.47.1</version>
+                 <scope>compile</scope>
+             </dependency>
 
-         </project>
-         ```
-       </dd>
+           </project>
+           ```
+         </Collapser>
+       </CollapserGroup>
      </Collapser>
    </CollapserGroup>
 2. Place `newrelic.yml` in the same folder as `newrelic.jar`, unless you specify otherwise in the JVM arg `-Dnewrelic.config.file`.

--- a/src/content/docs/agents/java-agent/api-guides/java-agent-api-custom-instrumentation-annotation-example-app.mdx
+++ b/src/content/docs/agents/java-agent/api-guides/java-agent-api-custom-instrumentation-annotation-example-app.mdx
@@ -23,114 +23,115 @@ Below is an example of an imaginary store app's servlet using the Java agent API
   If you copy and paste example code, be sure to use appropriate spacing on your command lines.
 </Callout>
 
-<dt id="complete-api-example">
-  Complete API call example
-</dt>
+<CollapserGroup>
+  <Collapser
+    id="complete-api-example"
+    title="Complete API call example"
+  >
+    ```
+    package test;
+    
+    import java.io.IOException;
+    import java.io.PrintWriter;
+    import java.util.Random;
+    import javax.servlet.ServletException;
+    import javax.servlet.http.HttpServlet;
+    import javax.servlet.http.HttpServletRequest;
+    import javax.servlet.http.HttpServletResponse;
+    // Java agent API imports
+    import com.newrelic.api.agent.NewRelic;
+    import com.newrelic.api.agent.Trace;
+    
+    public class TestServlet extends HttpServlet {
+        // instrumentation via annotation
+        @Trace(dispatcher = true)
+        protected void
+        processRequest(HttpServletRequest req,
+        HttpServletResponse resp)
+            throws ServletException, IOException {
+    
+            saveNewRelicInfo(req);
+            doRequestWork(req);
+            writeResponse(resp);
+        }
+    
+        private void saveNewRelicInfo(HttpServletRequest req) {
+            String storeId = req.getParameter("storeId");
+            if (storeId != null) {
+            // set the name of the Transaction
+            NewRelic.setTransactionName(null, "/store");
+    
+        if (storeId.equals("betaStore")) {
+            // prevent the method from contributing to the Apdex score
+            NewRelic.ignoreApdex();
+            }
+        }
+    
+        String userId = req.getParameter("userId");
+            if (userId != null) {
+                // set the user name to associate with the RUM JavaScript footer 
+                // for the current web transaction
+                NewRelic.setUserName(userId);
+                // add a key/value pair to the current transaction
+                NewRelic.addCustomParameter("userId", userId);
+            }
+    
+        String promotionId = req.getParameter("promotionId");
+            if (promotionId != null) {
+                // increment the metric counter for the given name
+                NewRelic.incrementCounter("Custom/Promotion");
+            }
+        }
+    
+        protected void
+        doRequestWork(HttpServletRequest req) {
+        try {
+            long millisToSleep  = new Random().nextInt(5000);
+            Thread.sleep(millisToSleep);
+            // record a response time in milliseconds for the given metric name
+            NewRelic.recordResponseTimeMetric("Custom/RandomSleep",
+            millisToSleep);
+            } catch (InterruptedException e) {
+                // report a handled exception
+                NewRelic.noticeError(e, false);
+            }
+        }
+    
+        protected void
+        writeResponse(HttpServletResponse resp)
+            throws IOException {
+    
+        resp.setContentType("text/html;charset=UTF-8");
+        PrintWriter out = resp.getWriter();
+        out.println("<html>");
+        out.println("<head>");
 
-<dd>
-  ```
-  package test;
-    
-  import java.io.IOException;
-  import java.io.PrintWriter;
-  import java.util.Random;
-  import javax.servlet.ServletException;
-  import javax.servlet.http.HttpServlet;
-  import javax.servlet.http.HttpServletRequest;
-  import javax.servlet.http.HttpServletResponse;
-  // Java agent API imports
-  import com.newrelic.api.agent.NewRelic;
-  import com.newrelic.api.agent.Trace;
-    
-  public class TestServlet extends HttpServlet {
-      // instrumentation via annotation
-      @Trace(dispatcher = true)
-      protected void
-      processRequest(HttpServletRequest req,
-      HttpServletResponse resp)
-          throws ServletException, IOException {
-    
-          saveNewRelicInfo(req);
-          doRequestWork(req);
-          writeResponse(resp);
-      }
-    
-      private void saveNewRelicInfo(HttpServletRequest req) {
-          String storeId = req.getParameter("storeId");
-          if (storeId != null) {
-          // set the name of the Transaction
-          NewRelic.setTransactionName(null, "/store");
-    
-      if (storeId.equals("betaStore")) {
-          // prevent the method from contributing to the Apdex score
-          NewRelic.ignoreApdex();
-          }
-      }
-    
-      String userId = req.getParameter("userId");
-          if (userId != null) {
-              // set the user name to associate with the RUM JavaScript footer 
-              // for the current web transaction
-              NewRelic.setUserName(userId);
-              // add a key/value pair to the current transaction
-              NewRelic.addCustomParameter("userId", userId);
-          }
-    
-      String promotionId = req.getParameter("promotionId");
-          if (promotionId != null) {
-              // increment the metric counter for the given name
-              NewRelic.incrementCounter("Custom/Promotion");
-          }
-      }
-    
-      protected void
-      doRequestWork(HttpServletRequest req) {
-      try {
-          long millisToSleep  = new Random().nextInt(5000);
-          Thread.sleep(millisToSleep);
-          // record a response time in milliseconds for the given metric name
-          NewRelic.recordResponseTimeMetric("Custom/RandomSleep",
-          millisToSleep);
-          } catch (InterruptedException e) {
-              // report a handled exception
-              NewRelic.noticeError(e, false);
-          }
-      }
-    
-      protected void
-      writeResponse(HttpServletResponse resp)
-          throws IOException {
-    
-      resp.setContentType("text/html;charset=UTF-8");
-      PrintWriter out = resp.getWriter();
-      out.println("<html>");
-      out.println("<head>");
-
-      // get the RUM JavaScript header for the current web transaction
-      out.println(NewRelic.getBrowserTimingHeader());
-      out.println("<title>NewRelic API example servlet</title>");
-      out.println("</head>");
-      out.println("<body>");
-      out.println("<h1>API example</h1>");
-      // get the RUM JavaScript footer for the current web transaction
-      out.println(NewRelic.getBrowserTimingFooter());
-      out.println("</body>");
-      out.println("</html>");
-      out.close();
-      }
-      protected void doGet(HttpServletRequest req,
-      HttpServletResponse resp)
-          throws ServletException, IOException {
-          processRequest(req, resp);
-          }
-      protected void doPost(HttpServletRequest req,
-      HttpServletResponse resp)
-          throws ServletException, IOException {
-          processRequest(req, resp);
-      }
-  }
-  ```
-</dd>
+        // get the RUM JavaScript header for the current web transaction
+        out.println(NewRelic.getBrowserTimingHeader());
+        out.println("<title>NewRelic API example servlet</title>");
+        out.println("</head>");
+        out.println("<body>");
+        out.println("<h1>API example</h1>");
+        // get the RUM JavaScript footer for the current web transaction
+        out.println(NewRelic.getBrowserTimingFooter());
+        out.println("</body>");
+        out.println("</html>");
+        out.close();
+        }
+        protected void doGet(HttpServletRequest req,
+        HttpServletResponse resp)
+            throws ServletException, IOException {
+            processRequest(req, resp);
+            }
+        protected void doPost(HttpServletRequest req,
+        HttpServletResponse resp)
+            throws ServletException, IOException {
+            processRequest(req, resp);
+        }
+    }
+    ```
+  </Collapser>
+</CollapserGroup>
 
 ## How the example uses the API
 

--- a/src/content/docs/agents/java-agent/api-guides/java-agent-api-instrument-using-annotation.mdx
+++ b/src/content/docs/agents/java-agent/api-guides/java-agent-api-instrument-using-annotation.mdx
@@ -101,7 +101,10 @@ class_transformer:
 The `@Trace` annotation supports the following properties.
 
 <CollapserGroup>
-  <Collapser id="trace-dispatcher">
+  <Collapser
+    id="trace-dispatcher"
+    title={<InlineCode>dispatcher</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -135,7 +138,10 @@ The `@Trace` annotation supports the following properties.
     ```
   </Collapser>
 
-  <Collapser id="trace-async">
+  <Collapser
+    id="trace-async"
+    title={<InlineCode>async</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -169,7 +175,10 @@ The `@Trace` annotation supports the following properties.
     If `false` (default), the method is not marked as asynchronous. If other `@Trace` annotations are present and the method is not executing asynchronously, it will still be traced.
   </Collapser>
 
-  <Collapser id="trace-metric-name">
+  <Collapser
+    id="trace-metric-name"
+    title={<InlineCode>metricName</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -211,7 +220,10 @@ The `@Trace` annotation supports the following properties.
     </Callout>
   </Collapser>
 
-  <Collapser id="trace-exclude-trace">
+  <Collapser
+    id="trace-exclude-trace"
+    title={<InlineCode>excludeFromTransactionTrace</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -243,7 +255,10 @@ The `@Trace` annotation supports the following properties.
     ```
   </Collapser>
 
-  <Collapser id="leaf-tracer">
+  <Collapser
+    id="leaf-tracer"
+    title={<InlineCode>leaf</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>

--- a/src/content/docs/agents/java-agent/attributes/java-agent-attributes.mdx
+++ b/src/content/docs/agents/java-agent/attributes/java-agent-attributes.mdx
@@ -611,31 +611,32 @@ The Java agent follows these rules when determining which attributes to include 
   >
     If you set the main [`attributes.enabled`](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#cfg-attributes-enabled) property to `false`, the agent does not report any attributes at all.
 
-    <dt id="disable-all-example">
-      Disabling all attributes
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="disable-all-example"
+        title="Disabling all attributes"
+      >
+        Agent configuration:
 
-    <dd>
-      Agent configuration:
+        * `attributes.enabled: false`
+        * `attributes.include: request.parameters.*`
+        * `error_collector.attributes.enabled: true`
 
-      * `attributes.enabled: false`
-      * `attributes.include: request.parameters.*`
-      * `error_collector.attributes.enabled: true`
+        Input keys:
 
-      Input keys:
+        * `foo`
+        * `bar`
+        * `request.parameters.foo`
+        * `request.parameters.bar`
 
-      * `foo`
-      * `bar`
-      * `request.parameters.foo`
-      * `request.parameters.bar`
+        Agent output:
 
-      Agent output:
-
-      * Transaction traces: No attributes
-      * Error analytics: No attributes
-      * APM events: No attributes
-      * Browser events: No attributes
-    </dd>
+        * Transaction traces: No attributes
+        * Error analytics: No attributes
+        * APM events: No attributes
+        * Browser events: No attributes
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
@@ -644,31 +645,32 @@ The Java agent follows these rules when determining which attributes to include 
   >
     When you set [enabled](#cfg-attributes-enabled) to `false` for a destination, the agent ignores your include/exclude settings and doesn't report any attributes for that destination.
 
-    <dt id="example-disabling-destination">
-      Disable one destination
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="example-disabling-destination"
+        title="Disable one destination"
+      >
+        Agent configuration:
 
-    <dd>
-      Agent configuration:
+        * `transaction_tracer.attributes.enabled: false`
+        * `attributes.include: one, two*`
+        * `transaction_tracer.attributes.include: three, four`
 
-      * `transaction_tracer.attributes.enabled: false`
-      * `attributes.include: one, two*`
-      * `transaction_tracer.attributes.include: three, four`
+        Input keys:
 
-      Input keys:
+        * `one`
+        * `two`
+        * `three`
+        * `four`
 
-      * `one`
-      * `two`
-      * `three`
-      * `four`
+        Agent output:
 
-      Agent output:
-
-      * Transaction traces: No attributes
-      * Error analytics: `one`, `two`
-      * APM events: `one`, `two`
-      * Browser events: No attributes
-    </dd>
+        * Transaction traces: No attributes
+        * Error analytics: `one`, `two`
+        * APM events: `one`, `two`
+        * Browser events: No attributes
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
@@ -677,30 +679,31 @@ The Java agent follows these rules when determining which attributes to include 
   >
     The `.exclude` properties override the `.include` properties.
 
-    <dt id="example-exclude-overrides">
-      Conflict between include and exclude settings
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="example-exclude-overrides"
+        title="Conflict between include and exclude settings"
+      >
+        Agent configuration:
 
-    <dd>
-      Agent configuration:
+        * `attributes.enabled: true`
+        * `attributes.include: foo, myCustomAtt`
+        * `attributes.exclude: password, myCustomAtt`
 
-      * `attributes.enabled: true`
-      * `attributes.include: foo, myCustomAtt`
-      * `attributes.exclude: password, myCustomAtt`
+        Input keys:
 
-      Input keys:
+        * `foo`
+        * `myCustomAtt`
+        * `password`
 
-      * `foo`
-      * `myCustomAtt`
-      * `password`
+        Agent output:
 
-      Agent output:
-
-      * Transaction traces: `foo`
-      * Error analytics: `foo`
-      * APM events: `foo`
-      * Browser events: `foo`
-    </dd>
+        * Transaction traces: `foo`
+        * Error analytics: `foo`
+        * APM events: `foo`
+        * Browser events: `foo`
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
@@ -709,32 +712,33 @@ The Java agent follows these rules when determining which attributes to include 
   >
     If multiple include or exclude attributes affect the same key, the most specific setting will have priority.
 
-    <dt id="example-most-specific">
-      Conflicting specific settings
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="example-most-specific"
+        title="Conflicting specific settings"
+      >
+        Agent configuration:
 
-    <dd>
-      Agent configuration:
+        * `attributes.enabled: true`
+        * `attributes.include: foo, myCustomAtt`
+        * `attributes.exclude: password, myCustomAtt`
+        * `browser_monitoring.attributes.enabled: true`
 
-      * `attributes.enabled: true`
-      * `attributes.include: foo, myCustomAtt`
-      * `attributes.exclude: password, myCustomAtt`
-      * `browser_monitoring.attributes.enabled: true`
+        Input keys:
 
-      Input keys:
+        * `food`
+        * `food.bread`
+        * `food.fruit.banana`
+        * `food.fruit.apple`
 
-      * `food`
-      * `food.bread`
-      * `food.fruit.banana`
-      * `food.fruit.apple`
+        Agent output:
 
-      Agent output:
-
-      * Transaction traces: `food.fruit.apple`
-      * Error analytics: `food.fruit.banana`, `food.fruit.apple`
-      * APM events: `food.fruit.banana`, `food.fruit.apple`
-      * Browser events: `food.fruit.banana`, `food.fruit.apple`
-    </dd>
+        * Transaction traces: `food.fruit.apple`
+        * Error analytics: `food.fruit.banana`, `food.fruit.apple`
+        * APM events: `food.fruit.banana`, `food.fruit.apple`
+        * Browser events: `food.fruit.banana`, `food.fruit.apple`
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
@@ -743,31 +747,32 @@ The Java agent follows these rules when determining which attributes to include 
   >
     The keys specified in the `.include` and `.exclude` properties are case-sensitive.
 
-    <dt id="example-case-sensitive">
-      Keys which do not match the specified case
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="example-case-sensitive"
+        title="Keys which do not match the specified case"
+      >
+        Agent configuration:
 
-    <dd>
-      Agent configuration:
+        * `attributes.enabled: true`
+        * `attributes.exclude: password, PaSsWoRd`
 
-      * `attributes.enabled: true`
-      * `attributes.exclude: password, PaSsWoRd`
+        Input keys:
 
-      Input keys:
+        * `password`
+        * `Password`
+        * `PASSWORD`
+        * `PaSsWoRd`
+        * `PassWORD`
 
-      * `password`
-      * `Password`
-      * `PASSWORD`
-      * `PaSsWoRd`
-      * `PassWORD`
+        Agent output:
 
-      Agent output:
-
-      * Transaction traces: `Password`, `PASSWORD`, `PassWORD`
-      * Error analytics: `Password`, `PASSWORD`, `PassWORD`
-      * APM events: `Password`, `PASSWORD`, `PassWORD`
-      * Browser events: `Password`, `PASSWORD`, `PassWORD`
-    </dd>
+        * Transaction traces: `Password`, `PASSWORD`, `PassWORD`
+        * Error analytics: `Password`, `PASSWORD`, `PassWORD`
+        * APM events: `Password`, `PASSWORD`, `PassWORD`
+        * Browser events: `Password`, `PASSWORD`, `PassWORD`
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser

--- a/src/content/docs/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -120,9 +120,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 <CollapserGroup>
   <Collapser
     id="cfg-license_key"
-    title="license"
-    title="_"
-    title="key (REQUIRED)"
+    title="license_key (REQUIRED)"
   >
     <Table>
       <tbody>
@@ -153,9 +151,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-app_name"
-    title="app"
-    title="_"
-    title="name (REQUIRED)"
+    title="app_name (REQUIRED)"
   >
     <Table>
       <tbody>
@@ -196,9 +192,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-agent_enabled"
-    title="agent"
-    title="_"
-    title="enabled"
+    title="agent_enabled"
   >
     <Table>
       <tbody>
@@ -229,9 +223,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-apdex_t"
-    title="apdex"
-    title="_"
-    title="t (DEPRECATED)"
+    title="apdex_t (DEPRECATED)"
   >
     <Table>
       <tbody>
@@ -262,9 +254,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-appserver_port"
-    title="appserver"
-    title="_"
-    title="port"
+    title="appserver_port"
   >
     <Table>
       <tbody>
@@ -305,9 +295,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-audit_mode"
-    title="audit"
-    title="_"
-    title="mode"
+    title="audit_mode"
   >
     <Table>
       <tbody>
@@ -338,11 +326,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="ca_config_bundle"
-    title="ca"
-    title="_"
-    title="bundle"
-    title="_"
-    title="path"
+    title="ca_bundle_path"
   >
     <Table>
       <tbody>
@@ -377,13 +361,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-enable_auto_app_naming"
-    title="enable"
-    title="_"
-    title="auto"
-    title="_"
-    title="app"
-    title="_"
-    title="naming"
+    title="enable_auto_app_naming"
   >
     <Table>
       <tbody>
@@ -418,13 +396,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-enable_auto_transaction_naming"
-    title="enable"
-    title="_"
-    title="auto"
-    title="_"
-    title="transaction"
-    title="_"
-    title="naming"
+    title="enable_auto_transaction_naming"
   >
     <Table>
       <tbody>
@@ -459,11 +431,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-enable_custom_tracing"
-    title="enable"
-    title="_"
-    title="custom"
-    title="_"
-    title="tracing"
+    title="enable_custom_tracing"
   >
     <Table>
       <tbody>
@@ -525,9 +493,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-enable_high_security"
-    title="high"
-    title="_"
-    title="security"
+    title="high_security"
   >
     <Table>
       <tbody>
@@ -562,11 +528,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-insert_api_key"
-    title="insert"
-    title="_"
-    title="api"
-    title="_"
-    title="key"
+    title="insert_api_key"
   >
     <Table>
       <tbody>
@@ -628,13 +590,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="max-stack-trace-lines"
-    title="max"
-    title="_"
-    title="stack"
-    title="_"
-    title="trace"
-    title="_"
-    title="lines"
+    title="max_stack_trace_lines"
   >
     <Table>
       <tbody>
@@ -665,9 +621,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-proxy_host"
-    title="proxy"
-    title="_"
-    title="host"
+    title="proxy_host"
   >
     <Table>
       <tbody>
@@ -698,9 +652,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-proxy_password"
-    title="proxy"
-    title="_"
-    title="password"
+    title="proxy_password"
   >
     <Table>
       <tbody>
@@ -735,9 +687,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-proxy_port"
-    title="proxy"
-    title="_"
-    title="port"
+    title="proxy_port"
   >
     <Table>
       <tbody>
@@ -768,9 +718,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-proxy_user"
-    title="proxy"
-    title="_"
-    title="user"
+    title="proxy_user"
   >
     <Table>
       <tbody>
@@ -801,9 +749,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-proxy_scheme"
-    title="proxy"
-    title="_"
-    title="scheme"
+    title="proxy_scheme"
   >
     <Table>
       <tbody>
@@ -834,13 +780,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-send_data_on_exit"
-    title="send"
-    title="_"
-    title="data"
-    title="_"
-    title="on"
-    title="_"
-    title="exit"
+    title="send_data_on_exit"
   >
     <Table>
       <tbody>
@@ -871,15 +811,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="send_data_on_exit_threshold"
-    title="send"
-    title="_"
-    title="data"
-    title="_"
-    title="on"
-    title="_"
-    title="exit"
-    title="_"
-    title="threshold"
+    title="send_data_on_exit_threshold"
   >
     <Table>
       <tbody>
@@ -910,11 +842,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-send_environment_info"
-    title="send"
-    title="_"
-    title="environment"
-    title="_"
-    title="info"
+    title="send_environment_info"
   >
     <Table>
       <tbody>
@@ -945,11 +873,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-send_jvm_props"
-    title="send"
-    title="_"
-    title="jvm"
-    title="_"
-    title="props"
+    title="send_jvm_props"
   >
     <Table>
       <tbody>
@@ -1021,9 +945,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="cfg-sync_startup"
-    title="sync"
-    title="_"
-    title="startup"
+    title="sync_startup"
   >
     <Table>
       <tbody>
@@ -1054,13 +976,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
   <Collapser
     id="scala-futures-segment"
-    title="scala"
-    title="_"
-    title="futures"
-    title="_"
-    title="as"
-    title="_"
-    title="segments"
+    title="scala_futures_as_segments"
   >
     <Callout variant="important">
       This applies to Java agent [version 3.44.0 or higher](/docs/release-notes/agent-release-notes/java-release-notes).
@@ -1118,9 +1034,7 @@ Depending on the growth rate, it is possible for the log file size to exceed the
 <CollapserGroup>
   <Collapser
     id="cfg-log_file_count"
-    title="log"
-    title="_"
-    title="daily"
+    title="log_daily"
   >
     <Table>
       <tbody>
@@ -1151,11 +1065,7 @@ Depending on the growth rate, it is possible for the log file size to exceed the
 
   <Collapser
     id="cfg-log_file_count"
-    title="log"
-    title="_"
-    title="file"
-    title="_"
-    title="count"
+    title="log_file_count"
   >
     <Table>
       <tbody>
@@ -1186,11 +1096,7 @@ Depending on the growth rate, it is possible for the log file size to exceed the
 
   <Collapser
     id="cfg-log_file_name"
-    title="log"
-    title="_"
-    title="file"
-    title="_"
-    title="name"
+    title="log_file_name"
   >
     <Table>
       <tbody>
@@ -1221,11 +1127,7 @@ Depending on the growth rate, it is possible for the log file size to exceed the
 
   <Collapser
     id="cfg-log_file_path"
-    title="log"
-    title="_"
-    title="file"
-    title="_"
-    title="path"
+    title="log_file_path"
   >
     <Table>
       <tbody>
@@ -1260,9 +1162,7 @@ Depending on the growth rate, it is possible for the log file size to exceed the
 
   <Collapser
     id="cfg-log_level"
-    title="log"
-    title="_"
-    title="level"
+    title="log_level"
   >
     <Table>
       <tbody>
@@ -1305,13 +1205,7 @@ Depending on the growth rate, it is possible for the log file size to exceed the
 
   <Collapser
     id="cfg-log_limit_in_kbytes"
-    title="log"
-    title="_"
-    title="limit"
-    title="_"
-    title="in"
-    title="_"
-    title="kbytes"
+    title="log_limit_in_kbytes"
   >
     <Table>
       <tbody>
@@ -1502,9 +1396,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
   <Collapser
     id="tt-explain_enabled"
-    title="explain"
-    title="_"
-    title="enabled"
+    title="explain_enabled"
   >
     <Table>
       <tbody>
@@ -1535,9 +1427,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
   <Collapser
     id="tt-explain_threshold"
-    title="explain"
-    title="_"
-    title="threshold"
+    title="explain_threshold"
   >
     <Table>
       <tbody>
@@ -1568,9 +1458,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
   <Collapser
     id="tt-log_sql"
-    title="log"
-    title="_"
-    title="sql"
+    title="log_sql"
   >
     <Table>
       <tbody>
@@ -1601,9 +1489,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
   <Collapser
     id="tt-record_sql"
-    title="record"
-    title="_"
-    title="sql"
+    title="record_sql"
   >
     <Table>
       <tbody>
@@ -1638,11 +1524,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
   <Collapser
     id="tt-stack_based_naming"
-    title="stack"
-    title="_"
-    title="based"
-    title="_"
-    title="naming (Play 2.x+ only)"
+    title="stack_based_naming (Play 2.x+ only)"
   >
     <Table>
       <tbody>
@@ -1675,11 +1557,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
   <Collapser
     id="tt-stack_trace_threshold"
-    title="stack"
-    title="_"
-    title="trace"
-    title="_"
-    title="threshold"
+    title="stack_trace_threshold"
   >
     <Table>
       <tbody>
@@ -1710,9 +1588,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
   <Collapser
     id="tt-top_n"
-    title="top"
-    title="_"
-    title="n"
+    title="top_n"
   >
     <Table>
       <tbody>
@@ -1750,9 +1626,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
   <Collapser
     id="tt-transaction_threshold"
-    title="transaction"
-    title="_"
-    title="threshold"
+    title="transaction_threshold"
   >
     <Table>
       <tbody>
@@ -1785,11 +1659,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
   <Collapser
     id="tt-slow_query_whitelist"
-    title="slow"
-    title="_"
-    title="query"
-    title="_"
-    title="whitelist (DEPRECATED)"
+    title="slow_query_whitelist (DEPRECATED)"
   >
     <Table>
       <tbody>
@@ -1840,13 +1710,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
   <Collapser
     id="tt-collect_slow_queries_from"
-    title="collect"
-    title="_"
-    title="slow"
-    title="_"
-    title="queries"
-    title="_"
-    title="from"
+    title="collect_slow_queries_from"
   >
     <Table>
       <tbody>
@@ -1986,9 +1850,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
   <Collapser
     id="cfg-tt-token_limit"
-    title="token"
-    title="_"
-    title="limit"
+    title="token_limit"
   >
     <Table>
       <tbody>
@@ -2019,9 +1881,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
   <Collapser
     id="cfg-tt-segment_limit"
-    title="segment"
-    title="_"
-    title="limit"
+    title="segment_limit"
   >
     <Table>
       <tbody>
@@ -2052,11 +1912,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
   <Collapser
     id="tt-gc-time-enabled"
-    title="gc"
-    title="_"
-    title="time"
-    title="_"
-    title="enabled"
+    title="gc_time_enabled"
   >
     <Table>
       <tbody>
@@ -2200,9 +2056,7 @@ Browser monitoring gives you insight into the performance real users are experie
 <CollapserGroup>
   <Collapser
     id="bm-auto_instrument"
-    title="auto"
-    title="_"
-    title="instrument"
+    title="auto_instrument"
   >
     <Table>
       <tbody>
@@ -2233,11 +2087,7 @@ Browser monitoring gives you insight into the performance real users are experie
 
   <Collapser
     id="bm-disabled_auto_pages"
-    title="disabled"
-    title="_"
-    title="auto"
-    title="_"
-    title="pages"
+    title="disabled_auto_pages"
   >
     <Table>
       <tbody>
@@ -2374,11 +2224,7 @@ The external tracing options are set in the `external_tracer` stanza and can be 
 <CollapserGroup>
   <Collapser
     id="cat-enabled"
-    title="exclude"
-    title="_"
-    title="request"
-    title="_"
-    title="uri"
+    title="exclude_request_uri"
   >
     <Table>
       <tbody>
@@ -2489,9 +2335,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
   <Collapser
     id="ec-ignore_classes"
-    title="ignore"
-    title="_"
-    title="classes"
+    title="ignore_classes"
   >
     <Table>
       <tbody>
@@ -2533,9 +2377,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
   <Collapser
     id="ec-ignore_messages"
-    title="ignore"
-    title="_"
-    title="messages"
+    title="ignore_messages"
   >
     <Table>
       <tbody>
@@ -2587,11 +2429,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
   <Collapser
     id="ec-ignore_status_codes"
-    title="ignore"
-    title="_"
-    title="status"
-    title="_"
-    title="codes"
+    title="ignore_status_codes"
   >
     <Table>
       <tbody>
@@ -2633,9 +2471,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
   <Collapser
     id="ec-expected_classes"
-    title="expected"
-    title="_"
-    title="classes"
+    title="expected_classes"
   >
     <Table>
       <tbody>
@@ -2677,9 +2513,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
   <Collapser
     id="ec-expected_messages"
-    title="expected"
-    title="_"
-    title="messages"
+    title="expected_messages"
   >
     <Table>
       <tbody>
@@ -2726,11 +2560,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
   <Collapser
     id="ec-expected_status_codes"
-    title="expected"
-    title="_"
-    title="status"
-    title="_"
-    title="codes"
+    title="expected_status_codes"
   >
     <Table>
       <tbody>
@@ -2863,9 +2693,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
   <Collapser
     id="ec-ignore_errors"
-    title="ignore"
-    title="_"
-    title="errors (DEPRECATED)"
+    title="ignore_errors (DEPRECATED)"
   >
     <Table>
       <tbody>
@@ -2979,9 +2807,7 @@ These options are set in the `strip_exception_messages` stanza and unless noted 
 
   <Collapser
     id="strip_exception_messages_allowed_classes"
-    title="allowed"
-    title="_"
-    title="classes"
+    title="allowed_classes"
   >
     <Table>
       <tbody>
@@ -3094,11 +2920,7 @@ Transaction events provide the data for displaying histograms and percentiles in
 
   <Collapser
     id="ae-max_samples_stored"
-    title="max"
-    title="_"
-    title="samples"
-    title="_"
-    title="stored"
+    title="max_samples_stored"
   >
     <Table>
       <tbody>
@@ -3139,11 +2961,7 @@ Transaction events provide the data for displaying histograms and percentiles in
 
   <Collapser
     id="tt-custom-request-headers"
-    title="custom"
-    title="_"
-    title="request"
-    title="_"
-    title="headers"
+    title="custom_request_headers"
   >
     <Table>
       <tbody>
@@ -3343,11 +3161,7 @@ APM lets you [record custom event data](https://docs.newrelic.com/docs/insights/
 
   <Collapser
     id="cie-max_samples_stored"
-    title="max"
-    title="_"
-    title="samples"
-    title="_"
-    title="stored"
+    title="max_samples_stored"
   >
     <Table>
       <tbody>
@@ -3388,9 +3202,7 @@ These properties are used for configuring the hostname displayed in the UI:
 <CollapserGroup>
   <Collapser
     id="display_name"
-    title="display"
-    title="_"
-    title="name"
+    title="display_name"
   >
     <Table>
       <tbody>
@@ -3421,9 +3233,7 @@ These properties are used for configuring the hostname displayed in the UI:
 
   <Collapser
     id="ae-max_samples_stored"
-    title="ipv"
-    title="_"
-    title="preference"
+    title="ipv_preference"
   >
     <Table>
       <tbody>
@@ -3460,13 +3270,7 @@ These options set in the `class_transformer` stanza and can be [overridden](#Sys
 <CollapserGroup>
   <Collapser
     id="ci-trace_annotation_class_name"
-    title="trace"
-    title="_"
-    title="annotation"
-    title="_"
-    title="class"
-    title="_"
-    title="name"
+    title="trace_annotation_class_name"
   >
     <Table>
       <tbody>
@@ -3538,11 +3342,7 @@ In addition to overriding configuration settings, the following system propertie
 <CollapserGroup>
   <Collapser
     id="newrelic-bootstrap_classpath"
-    title="newrelic.config.process"
-    title="_"
-    title="host.display"
-    title="_"
-    title="name"
+    title="newrelic.config.process_host.display_name"
   >
     <Table>
       <tbody>
@@ -3747,13 +3547,7 @@ For agent versions older than 4.10.0 the following environment variables are ava
 <CollapserGroup>
   <Collapser
     id="ev-NEW_RELIC_APP_NAME"
-    title="NEW"
-    title="_"
-    title="RELIC"
-    title="_"
-    title="APP"
-    title="_"
-    title="NAME (REQUIRED)"
+    title="NEW_RELIC_APP_NAME (REQUIRED)"
   >
     <Table>
       <tbody>
@@ -3794,15 +3588,7 @@ For agent versions older than 4.10.0 the following environment variables are ava
 
   <Collapser
     id="ev-NEW_RELIC_DISTRIBUTED_TRACING_ENABLED"
-    title="NEW"
-    title="_"
-    title="RELIC"
-    title="_"
-    title="DISTRIBUTED"
-    title="_"
-    title="TRACING"
-    title="_"
-    title="ENABLED"
+    title="NEW_RELIC_DISTRIBUTED_TRACING_ENABLED"
   >
     <Table>
       <tbody>
@@ -3833,17 +3619,7 @@ For agent versions older than 4.10.0 the following environment variables are ava
 
   <Collapser
     id="NEW_RELIC_PROCESS_HOST_DISPLAY_NAME"
-    title="NEW"
-    title="_"
-    title="RELIC"
-    title="_"
-    title="PROCESS"
-    title="_"
-    title="HOST"
-    title="_"
-    title="DISPLAY"
-    title="_"
-    title="NAME"
+    title="NEW_RELIC_PROCESS_HOST_DISPLAY_NAME"
   >
     <Table>
       <tbody>
@@ -3874,13 +3650,7 @@ For agent versions older than 4.10.0 the following environment variables are ava
 
   <Collapser
     id="ev-NEW_RELIC_LICENSE_KEY"
-    title="NEW"
-    title="_"
-    title="RELIC"
-    title="_"
-    title="LICENSE"
-    title="_"
-    title="KEY (REQUIRED)"
+    title="NEW_RELIC_LICENSE_KEY (REQUIRED)"
   >
     <Table>
       <tbody>
@@ -3913,11 +3683,7 @@ For agent versions older than 4.10.0 the following environment variables are ava
 
   <Collapser
     id="ev-NEW_RELIC_LOG"
-    title="NEW"
-    title="_"
-    title="RELIC"
-    title="_"
-    title="LOG"
+    title="NEW_RELIC_LOG"
   >
     <Table>
       <tbody>
@@ -3956,9 +3722,7 @@ The agent collects utilization information and sends it to the New Relic service
 <CollapserGroup>
   <Collapser
     id="aws-enabled"
-    title="detect"
-    title="_"
-    title="aws"
+    title="detect_aws"
   >
     <Table>
       <tbody>
@@ -3989,9 +3753,7 @@ The agent collects utilization information and sends it to the New Relic service
 
   <Collapser
     id="docker-enabled"
-    title="detect"
-    title="_"
-    title="docker"
+    title="detect_docker"
   >
     <Table>
       <tbody>
@@ -4028,9 +3790,7 @@ These options are set directly in the `common` stanza and can be [overridden](#S
 <CollapserGroup>
   <Collapser
     id="cfg-token_timeout"
-    title="token"
-    title="_"
-    title="timeout"
+    title="token_timeout"
   >
     <Table>
       <tbody>
@@ -4065,9 +3825,7 @@ These options are set directly in the `common` stanza and can be [overridden](#S
 
   <Collapser
     id="cfg-segment_timeout"
-    title="segment"
-    title="_"
-    title="timeout"
+    title="segment_timeout"
   >
     <Table>
       <tbody>
@@ -4150,9 +3908,7 @@ common: &default_settings​
 
   <Collapser
     id="cfg-circuitbreaker_memory_threshold"
-    title="memory"
-    title="_"
-    title="threshold"
+    title="memory_threshold"
   >
     <Table>
       <tbody>
@@ -4183,11 +3939,7 @@ common: &default_settings​
 
   <Collapser
     id="cfg-circuitbreaker_gc_cpu_threshold"
-    title="gc"
-    title="_"
-    title="cpu"
-    title="_"
-    title="threshold"
+    title="gc_cpu_threshold"
   >
     <Table>
       <tbody>
@@ -4224,9 +3976,7 @@ These options are set in the `message_tracer` stanza and can be [overridden](#Sy
 <CollapserGroup>
   <Collapser
     id="tt-enabled"
-    title="segment"
-    title="_"
-    title="parameters.enabled"
+    title="segment_parameters.enabled"
   >
     <Table>
       <tbody>
@@ -4313,11 +4063,7 @@ These options are set in the `message_tracer` stanza and can be [overridden](#Sy
 
   <Collapser
     id="dt-exclude_newrelic_header"
-    title="exclude"
-    title="_"
-    title="newrelic"
-    title="_"
-    title="header"
+    title="exclude_newrelic_header"
   >
     <Table>
       <tbody>
@@ -4376,9 +4122,7 @@ To turn on Infinite Tracing, enable distributed tracing and add the additional s
 <CollapserGroup>
   <Collapser
     id="infinite-tracing-trace-observer-host"
-    title="trace"
-    title="_"
-    title="observer.host"
+    title="trace_observer.host"
   >
     <Table>
       <tbody>
@@ -4602,9 +4346,7 @@ jfr:
 
   <Collapser
     id="jfr-audit_mode"
-    title="audit"
-    title="_"
-    title="mode"
+    title="audit_mode"
   >
     <Table>
       <tbody>

--- a/src/content/docs/agents/java-agent/frameworks/scala-installation-java.mdx
+++ b/src/content/docs/agents/java-agent/frameworks/scala-installation-java.mdx
@@ -28,8 +28,7 @@ Instrument Scala to use the New Relic API class or [annotations](/docs/agents/ja
    <CollapserGroup>
      <Collapser
        id="build-scala"
-       title="Configure using the project/build.scala"
-       title=" file"
+       title={<><strong>Configure using the project/build.scala</strong> file</>}
      >
        Add the following line (replacing X.Y.Z with the [Java agent version](/docs/agents/java-agent/installation/update-java-agent#procedures) you use) to the appDependencies method in your application's `project/build.scala` file:
 
@@ -40,8 +39,7 @@ Instrument Scala to use the New Relic API class or [annotations](/docs/agents/ja
 
      <Collapser
        id="build.sbt"
-       title="Configure using the project/build.sbt"
-       title=" file"
+       title={<><strong>Configure using the project/build.sbt</strong> file</>}
      >
        Add the following line (replacing X.Y.Z with the [Java agent version](/docs/agents/java-agent/installation/update-java-agent#procedures) you use) to your application's `project/build.sbt` file:
 

--- a/src/content/docs/agents/java-agent/installation/install-java-agent.mdx
+++ b/src/content/docs/agents/java-agent/installation/install-java-agent.mdx
@@ -39,7 +39,7 @@ Download `newrelic-java.zip` using `curl`, `Invoke-WebRequest` (PowerShell), or 
 <CollapserGroup>
   <Collapser
     id="download-from-curl"
-    title="Download using "
+    title={<>Download using <InlineCode>curl</InlineCode></>}
   >
     Complete the following:
 
@@ -55,8 +55,7 @@ Download `newrelic-java.zip` using `curl`, `Invoke-WebRequest` (PowerShell), or 
 
   <Collapser
     id="download-from-powershell"
-    title="Download using "
-    title=" (PowerShell)"
+    title={<>Download using <InlineCode>Invoke-WebRequest</InlineCode> (PowerShell)</>}
   >
     Complete the following:
 

--- a/src/content/docs/agents/java-agent/instrumentation/extension-additional-instrumentation-modules.mdx
+++ b/src/content/docs/agents/java-agent/instrumentation/extension-additional-instrumentation-modules.mdx
@@ -447,10 +447,7 @@ These are the archived modules that are currently available:
   <Collapser
     className="freq-link"
     id="akka-20"
-    title="Akka "
-    title="["
-    title="2.0"
-    title="]"
+    title="Akka [2.0]"
   >
     <Table>
       <tbody>
@@ -492,10 +489,7 @@ These are the archived modules that are currently available:
   <Collapser
     className="freq-link"
     id="akka-21"
-    title="Akka "
-    title="["
-    title="2.1"
-    title="]"
+    title="Akka [2.1]"
   >
     <Table>
       <tbody>
@@ -537,10 +531,7 @@ These are the archived modules that are currently available:
   <Collapser
     className="freq-link"
     id="akka-http-10"
-    title="Akka HTTP "
-    title="["
-    title="1.0"
-    title="]"
+    title="Akka HTTP [1.0]"
   >
     <Table>
       <tbody>
@@ -584,10 +575,7 @@ These are the archived modules that are currently available:
   <Collapser
     className="freq-link"
     id="akka-http-20"
-    title="Akka HTTP "
-    title="["
-    title="2.0 – 2.4.1"
-    title="]"
+    title="Akka HTTP [2.0 – 2.4.1]"
   >
     <Table>
       <tbody>
@@ -631,10 +619,7 @@ These are the archived modules that are currently available:
   <Collapser
     className="freq-link"
     id="akka-http-242"
-    title="Akka HTTP "
-    title="["
-    title="2.4.2 – 2.4.4"
-    title="]"
+    title="Akka HTTP [2.4.2 – 2.4.4]"
   >
     <Table>
       <tbody>
@@ -678,10 +663,7 @@ These are the archived modules that are currently available:
   <Collapser
     className="freq-link"
     id="hystrix-102"
-    title="Hystrix "
-    title="["
-    title="1.0.2 – 1.1.7"
-    title="]"
+    title="Hystrix [1.0.2 – 1.1.7]"
   >
     <Table>
       <tbody>
@@ -723,10 +705,7 @@ These are the archived modules that are currently available:
   <Collapser
     className="freq-link"
     id="hystrix-120"
-    title="Hystrix "
-    title="["
-    title="1.2.0 – 1.2.18"
-    title="]"
+    title="Hystrix [1.2.0 – 1.2.18]"
   >
     <Table>
       <tbody>
@@ -768,10 +747,7 @@ These are the archived modules that are currently available:
   <Collapser
     className="freq-link"
     id="hystrix-130"
-    title="Hystrix "
-    title="["
-    title="1.3.0 – 1.3.13"
-    title="]"
+    title="Hystrix [1.3.0 – 1.3.13]"
   >
     <Table>
       <tbody>
@@ -813,10 +789,7 @@ These are the archived modules that are currently available:
   <Collapser
     className="freq-link"
     id="play-20"
-    title="Play "
-    title="["
-    title="2.0"
-    title="]"
+    title="Play [2.0]"
   >
     <Table>
       <tbody>
@@ -858,10 +831,7 @@ These are the archived modules that are currently available:
   <Collapser
     className="freq-link"
     id="play-21"
-    title="Play "
-    title="["
-    title="2.1"
-    title="]"
+    title="Play [2.1]"
   >
     <Table>
       <tbody>
@@ -903,10 +873,7 @@ These are the archived modules that are currently available:
   <Collapser
     className="freq-link"
     id="play22"
-    title="Play "
-    title="["
-    title="2.2"
-    title="]"
+    title="Play [2.2]"
   >
     <Table>
       <tbody>
@@ -948,10 +915,7 @@ These are the archived modules that are currently available:
   <Collapser
     className="freq-link"
     id="solr-310"
-    title="Solr "
-    title="["
-    title="3.1.0 – 3.4.0"
-    title="]"
+    title="Solr [3.1.0 – 3.4.0]"
   >
     <Table>
       <tbody>
@@ -993,10 +957,7 @@ These are the archived modules that are currently available:
   <Collapser
     className="freq-link"
     id="solr-350"
-    title="Solr "
-    title="["
-    title="3.5.0"
-    title="]"
+    title="Solr [3.5.0]"
   >
     <Table>
       <tbody>
@@ -1038,10 +999,7 @@ These are the archived modules that are currently available:
   <Collapser
     className="freq-link"
     id="solr-360"
-    title="Solr "
-    title="["
-    title="3.6.0 – 3.6.2"
-    title="]"
+    title="Solr [3.6.0 – 3.6.2]"
   >
     <Table>
       <tbody>

--- a/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -2730,9 +2730,7 @@ The `infiniteTracing` element supports the following elements:
 <CollapserGroup>
   <Collapser
     id="trace_observer"
-    title="trace"
-    title="_"
-    title="observer"
+    title="trace_observer"
   >
     The `trace_observer` element identifies an observer host that is independent from the agent. For help getting a valid Infinite Tracing trace observer host entry, see [Find or create a trace observer endpoint](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing#provision-trace-observer "https&#x3A;//docs.newrelic.com/docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing#provision-trace-observer").
 

--- a/src/content/docs/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -49,45 +49,46 @@ The main reason for you to be careful in using these request-naming tools is to 
 
 Define your configuration rules from the most specific to the most general. The first rules listed in your config file or added with the [Node.js transaction naming API](/docs/nodejs/nodejs-transaction-naming-api) will be applied first and should be narrowly targeted. More general "fall-through" rules should be added toward the end of the list, because they will be evaluated in the order they were configured or added using the Node.js transaction naming API.
 
-<dt id="retailer-example">
-  URL pattern matching
-</dt>
+<CollapserGroup>
+  <Collapser
+    id="retailer-example"
+    title="URL pattern matching"
+  >
+    An online retailer has a URL pattern like this:
 
-<dd>
-  An online retailer has a URL pattern like this:
+    ```
+    /user/customers/all/prospects
+    /user/customers/all/current
+    /user/customers/all/returning
+    /user/customers/John
+    /user/customers/Jane
+    ```
 
-  ```
-  /user/customers/all/prospects
-  /user/customers/all/current
-  /user/customers/all/returning
-  /user/customers/John
-  /user/customers/Jane
-  ```
+    The retailer could create rules like this:
 
-  The retailer could create rules like this:
-
-  ```
-  // newrelic.js
-  exports.config={
-    //other configuration
-    rules:{
-      name:[
-        { pattern: "/user/customers/all/prospects/", name: "/user/customers/all/prospects" },
-        { pattern: "/user/customers/all/.*", name: "/user/customers/all" },
-        { pattern: "/user/customers/.*", name: "/user/customers/:customer" }
-      ]
+    ```
+    // newrelic.js
+    exports.config={
+      //other configuration
+      rules:{
+        name:[
+          { pattern: "/user/customers/all/prospects/", name: "/user/customers/all/prospects" },
+          { pattern: "/user/customers/all/.*", name: "/user/customers/all" },
+          { pattern: "/user/customers/.*", name: "/user/customers/:customer" }
+        ]
+      }
     }
-  }
-  ```
+    ```
 
-  With these rules, the retailer would create three transaction names:
+    With these rules, the retailer would create three transaction names:
 
-  * `/user/customers/:customer`
-  * `/user/customers/all`
-  * `/user/customers/all/prospects`
+    * `/user/customers/:customer`
+    * `/user/customers/all`
+    * `/user/customers/all/prospects`
 
-  If the retailer reversed the order, the rules would catch `all` transactions in `:customer`, which would not be as useful.
-</dd>
+    If the retailer reversed the order, the rules would catch `all` transactions in `:customer`, which would not be as useful.
+  </Collapser>
+</CollapserGroup>
 
 ## Load the request naming API
 
@@ -104,13 +105,19 @@ This returns the request naming API. You can safely require the module from mult
 Here is a summary of the Request API calls for New Relic's Node.js agent.
 
 <CollapserGroup>
-  <Collapser id="transaction">
+  <Collapser
+    id="transaction"
+    title={<InlineCode>newrelic.setTransactionName(name)</InlineCode>}
+  >
     Name the current request, following the [request naming requirements](#requirements). You can call this function anywhere within the context of an HTTP request handler, at any time after handling of the request has started, but before the request has finished. In general, if the request and response objects are in scope, you can set the name.
 
     Explicitly calling `newrelic.setTransactionName()` will override any names set by Express or Restify routes. Also, calls to `newrelic.setTransactionName()` and `newrelic.setControllerName()` will overwrite each other. The last one to run before the request ends wins.
   </Collapser>
 
-  <Collapser id="controller">
+  <Collapser
+    id="controller"
+    title={<InlineCode>newrelic.setControllerName(name, \[action])</InlineCode>}
+  >
     Name the current request using a controller-style pattern, optionally including the current controller action. If the action is omitted, New Relic will include the HTTP method (GET, POST, etc.) as the action. The rules for when you can call `newrelic.setControllerName()` are the same as they are for `newrelic.setTransactionName()`, including the [request naming requirements](#requirements).
 
     Explicitly calling `newrelic.setControllerName()` will override any names set by Express or Restify routes. Also, calls to `newrelic.setTransactionName()` and `newrelic.setControllerName()` will overwrite each other. The last one to run before the request ends wins.
@@ -122,7 +129,10 @@ Here is a summary of the Request API calls for New Relic's Node.js agent.
 Use these API calls to [expand your instrumentation with custom instrumentation](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation).
 
 <CollapserGroup>
-  <Collapser id="instrument">
+  <Collapser
+    id="instrument"
+    title={<InlineCode>newrelic.instrument(moduleName, onRequire \[, onError])</InlineCode>}
+  >
     Sets an instrumentation callback for a specific module.
 
     The provided `onRequire` callback will be fired when the given module is loaded with `require`. The `moduleName` parameter should be the string that will be passed to `require`; for example, `'express'` or `'amqplib/callback_api'`. The optional `onError` callback is called if the `onRequire` parameters throws an error. This is useful for debugging your instrumentation.
@@ -136,13 +146,19 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     For more information, see New Relic's [Node.js instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/docs/tutorial-Instrumentation-Basics.html).
   </Collapser>
 
-  <Collapser id="instrumentDatastore">
+  <Collapser
+    id="instrumentDatastore"
+    title={<InlineCode>newrelic.instrumentDatastore(moduleName, onRequire \[, onError])</InlineCode>}
+  >
     Sets an instrumentation callback for a datastore module.
 
     This method is just like [`newrelic.instrument()`](#instrument), except it provides a [datastore-specialized shim](https://newrelic.github.io/node-newrelic/docs/DatastoreShim.html). For more information, see New Relic's [Node.js datastore instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/docs/tutorial-Datastore-Simple.html).
   </Collapser>
 
-  <Collapser id="instrumentLoadedModule">
+  <Collapser
+    id="instrumentLoadedModule"
+    title={<InlineCode>newrelic.instrumentLoadedModule(moduleName, moduleInstance)</InlineCode>}
+  >
     The `instrumentLoadedModule` method allows you to add stock instrumentation to specific modules in situations where it's impossible to have `require('newrelic');` as the first line of your app's main module.
 
     ```
@@ -164,19 +180,28 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     </Callout>
   </Collapser>
 
-  <Collapser id="instrumentMessages">
+  <Collapser
+    id="instrumentMessages"
+    title={<InlineCode>newrelic.instrumentMessages(moduleName, onRequire \[, onError])</InlineCode>}
+  >
     Sets an instrumentation callback for a message service client module.
 
     This method is just like [`newrelic.instrument()`](#instrument), except it provides a [message-service-specialized shim](https://newrelic.github.io/node-newrelic/docs/MessageShim.html). For more information, see New Relic's [Node.js message service instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/docs/tutorial-Messaging-Simple.html).
   </Collapser>
 
-  <Collapser id="instrumentWebframework">
+  <Collapser
+    id="instrumentWebframework"
+    title={<InlineCode>newrelic.instrumentWebframework(moduleName, onRequire \[, onError])</InlineCode>}
+  >
     Sets an instrumentation callback for a web framework module.
 
     This method is just like [`newrelic.instrument()`](#instrument), except it provides a [web-framework-specialized shim](https://newrelic.github.io/node-newrelic/docs/WebFrameworkShim.html). For more information, see New Relic's [Node.js web framework instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/docs/tutorial-Webframework-Simple.html).
   </Collapser>
 
-  <Collapser id="startWebTransaction">
+  <Collapser
+    id="startWebTransaction"
+    title={<InlineCode>newrelic.startWebTransaction(url, handle)</InlineCode>}
+  >
     Instrument the specified web transaction. Using this API call, you can instrument transactions that New Relic [does not automatically detect](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation#web-txn).
 
     * The `url` defines the transaction name and needs to be static. Do not include variable data such as user ID.
@@ -189,7 +214,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     You can also return a promise to indicate the end of the transaction. Please note that if this promise rejects, it does not automatically hook into New Relic’s error tracking. This needs to be done manually with [`noticeError()`](#noticeError).
   </Collapser>
 
-  <Collapser id="startBackgroundTransaction">
+  <Collapser
+    id="startBackgroundTransaction"
+    title={<InlineCode>newrelic.startBackgroundTransaction(name, \[group], handle)</InlineCode>}
+  >
     Instrument the specified background transaction. Using this API call, you can expand New Relic's instrumentation to [capture data from background transactions](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation#background-txn).
 
     * The `name` defines the transaction name and needs to be static. Do not include variable data such as user ID.
@@ -203,17 +231,26 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     You can also return a promise to indicate the end of the transaction. Please note that if this promise rejects, it does not automatically hook into New Relic’s error tracking. This needs to be done manually with [`noticeError()`](#noticeError).
   </Collapser>
 
-  <Collapser id="getTransaction">
+  <Collapser
+    id="getTransaction"
+    title={<InlineCode>newrelic.getTransaction()</InlineCode>}
+  >
     Returns a handle on the currently executing transaction. This handle can then be used to interact with a given transaction safely from any context. It is best used with `newrelic.startWebTransaction()` and `newrelic.startBackgroundTransaction()`.
 
     [Please refer to the transaction handle section for more details.](#transaction-handle-methods)
   </Collapser>
 
-  <Collapser id="endTransaction">
+  <Collapser
+    id="endTransaction"
+    title={<InlineCode>newrelic.endTransaction()</InlineCode>}
+  >
     End the current [web](#createWebTransaction) or [background](#createBackgroundTransaction) custom transaction. This method requires being in the correct transaction context when called. This API call takes no arguments.
   </Collapser>
 
-  <Collapser id="startSegment">
+  <Collapser
+    id="startSegment"
+    title={<InlineCode>newrelic.startSegment(name, record, handler, callback)</InlineCode>}
+  >
     Instrument a particular method to [improve visibility into a transaction](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation#expanding-instrumentation), or optionally turn it into a metric.
 
     * The `name` defines a name for the segment. This name will be visible in transaction traces and as a new metric in the New Relic UI.
@@ -230,14 +267,20 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
 Use these API calls to [record additional arbitrary metrics](/docs/agents/nodejs-agent/supported-features/nodejs-custom-metrics):
 
 <CollapserGroup>
-  <Collapser id="record_metric">
+  <Collapser
+    id="record_metric"
+    title={<InlineCode>newrelic.recordMetric(name, value)</InlineCode>}
+  >
     Use `recordMetric` to record an event-based metric, usually associated with a particular duration. The `name` must be a string following standard metric naming rules. The `value` will usually be a number, but it can also be an object.
 
     * When `value` is a numeric value, it should represent the magnitude of a measurement associated with an event; for example, the duration for a particular method call.
     * When `value` is an object, it must contain `count`, `total`, `min`, `max`, and `sumOfSquares` keys, all with number values. This form is useful to aggregate metrics on your own and report them periodically; for example, from a `setInterval`. These values will be aggregated with any previously collected values for the same metric. The names of these keys match the names of the keys used by the platform API.
   </Collapser>
 
-  <Collapser id="increment_metric">
+  <Collapser
+    id="increment_metric"
+    title={<InlineCode>newrelic.incrementMetric(name, \[amount])</InlineCode>}
+  >
     Use `incrementMetric` to update a metric that acts as a simple counter. The count of the selected metric will be incremented by the specified amount, defaulting to 1.
   </Collapser>
 </CollapserGroup>
@@ -247,28 +290,32 @@ Use these API calls to [record additional arbitrary metrics](/docs/agents/nodejs
 Use these API calls to record additional events:
 
 <CollapserGroup>
-  <Collapser id="record_custom_event">
+  <Collapser
+    id="record_custom_event"
+    title={<InlineCode>newrelic.recordCustomEvent(eventType, attributes)</InlineCode>}
+  >
     Use `recordCustomEvent` to record an event-based metric, usually associated with a particular duration.
 
     * The `eventType` must be an alphanumeric string less than 255 characters.
     * The `attributes` must be an object of key and value pairs. The keys must be shorter than 255 characters, and the values must be string, number, or boolean.
 
-    <dt id="example-link-bg-txn">
-      Recording a custom event
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="example-link-bg-txn"
+        title="Recording a custom event"
+      >
+        The following example demonstrates recording a custom event with multiple attributes.
 
-    <dd>
-      The following example demonstrates recording a custom event with multiple attributes.
+        ```
+        const attributes = {
+          attribute1: 'value1',
+          attribute2: 2
+        }
 
-      ```
-      const attributes = {
-        attribute1: 'value1',
-        attribute2: 2
-      }
-
-      newrelic.recordCustomEvent('MessagingEvent', attributes)
-      ```
-    </dd>
+        newrelic.recordCustomEvent('MessagingEvent', attributes)
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 </CollapserGroup>
 
@@ -279,17 +326,26 @@ This section details the methods provided by the `TransactionHandle` class insta
 Use these methods to interact directly with the current transaction:
 
 <CollapserGroup>
-  <Collapser id="transaction-handle-end">
+  <Collapser
+    id="transaction-handle-end"
+    title={<InlineCode>transactionHandle.end(\[callback])</InlineCode>}
+  >
     Use `transactionHandle.end` to end the transaction referenced by the handle instance.
 
     The `callback` is invoked when the transaction has fully ended. The finished transaction passed to the callback as the first argument.
   </Collapser>
 
-  <Collapser id="transaction-handle-end">
+  <Collapser
+    id="transaction-handle-end"
+    title={<InlineCode>transactionHandle.ignore()</InlineCode>}
+  >
     Use `transactionHandle.ignore` to ignore the transaction referenced by the handle instance.
   </Collapser>
 
-  <Collapser id="transaction-handle-insertDistributedTraceHeaders">
+  <Collapser
+    id="transaction-handle-insertDistributedTraceHeaders"
+    title={<InlineCode>transactionHandle.insertDistributedTraceHeaders(headers)</InlineCode>}
+  >
     <Callout variant="important">
       This API requires [distributed tracing to be enabled](/docs/enable-distributed-tracing).
     </Callout>
@@ -298,29 +354,33 @@ Use these methods to interact directly with the current transaction:
 
     `transactionHandle.insertDistributedTraceHeaders` is used to implement distributed tracing. It modifies the `headers` map that is passed in by adding W3C Trace Context headers and New Relic Distributed Trace headers. The New Relic headers can be disabled with `distributed_tracing.exclude_newrelic_header: true` in the config. This method replaces the deprecated [`createDistributedTracePayload`](#transaction-handle-createDistributedTracePayload) method, which only creates New Relic Distributed Trace payloads.
 
-    <dt id="example-link-bg-txn">
-      Generating distributed trace headers
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="example-link-bg-txn"
+        title="Generating distributed trace headers"
+      >
+        In the following example, by calling insertDistributedTraceHeaders with an empty object, the appropriate Distributed Trace headers and W3C Trace Context headers will be generated for the transaction.
 
-    <dd>
-      In the following example, by calling insertDistributedTraceHeaders with an empty object, the appropriate Distributed Trace headers and W3C Trace Context headers will be generated for the transaction.
+        ```
+        // Call newrelic.getTransaction to retrieve a handle on the current transaction.
+        const transactionHandle = newrelic.getTransaction()
 
-      ```
-      // Call newrelic.getTransaction to retrieve a handle on the current transaction.
-      const transactionHandle = newrelic.getTransaction()
-
-      // This could be a header object from an incoming request as well
-      const headersObject = {}
-      newrelic.startBackgroundTransaction('background task', function executeTransaction() {
-        const transaction = newrelic.getTransaction()
-        // generate the headers
-        transaction.insertDistributedTraceHeaders(headersObject)
-      })
-      ```
-    </dd>
+        // This could be a header object from an incoming request as well
+        const headersObject = {}
+        newrelic.startBackgroundTransaction('background task', function executeTransaction() {
+          const transaction = newrelic.getTransaction()
+          // generate the headers
+          transaction.insertDistributedTraceHeaders(headersObject)
+        })
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
-  <Collapser id="transaction-handle-acceptDistributedTraceHeaders">
+  <Collapser
+    id="transaction-handle-acceptDistributedTraceHeaders"
+    title={<InlineCode>transactionHandle.acceptDistributedTraceHeaders(transportType, headers)</InlineCode>}
+  >
     <Callout variant="important">
       This API requires [distributed tracing to be enabled](/docs/enable-distributed-tracing).
     </Callout>
@@ -343,31 +403,35 @@ Use these methods to interact directly with the current transaction:
 
     `headers` should be an object containing all the headers in the incoming request. The keys must be lowercase.
 
-    <dt id="example-link-bg-txn">
-      Accept incoming distributed trace headers
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="example-link-bg-txn"
+        title="Accept incoming distributed trace headers"
+      >
+        The following example demonstrates adding distributed trace headers retrieved from a Kafka message. In this example, we assume that the incoming Kafka message has Distributed Trace headers inserted.
 
-    <dd>
-      The following example demonstrates adding distributed trace headers retrieved from a Kafka message. In this example, we assume that the incoming Kafka message has Distributed Trace headers inserted.
+        ```
+        // incoming Kafka message headers
+        const headersObject = message.headers
 
-      ```
-      // incoming Kafka message headers
-      const headersObject = message.headers
+        // Call newrelic.getTransaction to retrieve a handle on the current transaction.
+        const transactionHandle = newrelic.getTransaction()
 
-      // Call newrelic.getTransaction to retrieve a handle on the current transaction.
-      const transactionHandle = newrelic.getTransaction()
+        newrelic.startBackgroundTransaction('background task', function executeTransaction() {
+          const transaction = newrelic.getTransaction()
 
-      newrelic.startBackgroundTransaction('background task', function executeTransaction() {
-        const transaction = newrelic.getTransaction()
-
-        // accept the headers
-        transaction.acceptDistributedTraceHeaders('Kafka', headersObject)
-      })
-      ```
-    </dd>
+          // accept the headers
+          transaction.acceptDistributedTraceHeaders('Kafka', headersObject)
+        })
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
-  <Collapser id="transaction-handle-createDistributedTracePayload">
+  <Collapser
+    id="transaction-handle-createDistributedTracePayload"
+    title={<InlineCode>transactionHandle.createDistributedTracePayload()</InlineCode>}
+  >
     <Callout variant="caution">
       This method is deprecated and will be fully removed in the next major release! Please use [`insertDistributedTraceHeaders`](#transaction-handle-insertDistributedTraceHeaders)
     </Callout>
@@ -388,41 +452,46 @@ Use these methods to interact directly with the current transaction:
 
     * `DistributedTracePayload#text`: returns a JSON representation of the payload.
 
-      <dt id="example-link-bg-txn">
-        Link a nested background transaction
-      </dt>
-
-      <dd>
-        ```
-        // Call newrelic.getTransaction to retrieve a handle on the current transaction.
-        var transactionHandle = newrelic.getTransaction()
-        var payload = transactionHandle.createDistributedTracePayload()
-        var jsonPayload = payload.text()
-        newrelic.startBackgroundTransaction('background task', function executeTransaction() {
-          var backgroundHandle = newrelic.getTransaction()
-          // Link the nested transaction by accepting the payload with the background transaction's handle
-          backgroundHandle.acceptDistributedTracePayload(jsonPayload)
-        })
-        ```
-      </dd>
+      <CollapserGroup>
+        <Collapser
+          id="example-link-bg-txn"
+          title="Link a nested background transaction"
+        >
+          ```
+          // Call newrelic.getTransaction to retrieve a handle on the current transaction.
+          var transactionHandle = newrelic.getTransaction()
+          var payload = transactionHandle.createDistributedTracePayload()
+          var jsonPayload = payload.text()
+          newrelic.startBackgroundTransaction('background task', function executeTransaction() {
+            var backgroundHandle = newrelic.getTransaction()
+            // Link the nested transaction by accepting the payload with the background transaction's handle
+            backgroundHandle.acceptDistributedTracePayload(jsonPayload)
+          })
+          ```
+        </Collapser>
+      </CollapserGroup>
     * `DistributedTracePayload#httpSafe`: returns a base64 encoded JSON representation of the payload.
 
-      <dt id="example-payload-outgoing-request">
-        Place payload on an outgoing request
-      </dt>
-
-      <dd>
-        ```
-        // Call newrelic.getTransaction to retrieve a handle on the current transaction.
-        var transactionHandle = newrelic.getTransaction()
-        var payload = transactionHandle.createDistributedTracePayload()
-        // Place the base64 encoded value on an outbound request header.
-        req.headers[myTracingHeader] = payload.httpSafe()
-        ```
-      </dd>
+      <CollapserGroup>
+        <Collapser
+          id="example-payload-outgoing-request"
+          title="Place payload on an outgoing request"
+        >
+          ```
+          // Call newrelic.getTransaction to retrieve a handle on the current transaction.
+          var transactionHandle = newrelic.getTransaction()
+          var payload = transactionHandle.createDistributedTracePayload()
+          // Place the base64 encoded value on an outbound request header.
+          req.headers[myTracingHeader] = payload.httpSafe()
+          ```
+        </Collapser>
+      </CollapserGroup>
   </Collapser>
 
-  <Collapser id="transaction-handle-acceptDistributedTracePayload">
+  <Collapser
+    id="transaction-handle-acceptDistributedTracePayload"
+    title={<InlineCode>transactionHandle.acceptDistributedTracePayload(payload)</InlineCode>}
+  >
     <Callout variant="caution">
       This method is deprecated and will be fully removed in the next major release! Please use [`acceptDistributedTraceHeaders`](#transaction-handle-acceptDistributedTraceHeaders)
     </Callout>
@@ -436,7 +505,10 @@ Use these methods to interact directly with the current transaction:
     `transactionHandle.acceptDistributedTracePayload` is used to instrument the called service for inclusion in a distributed trace. It links the spans in a trace by accepting the payload generated by [`createDistributedTracePayload`](#transaction-handle-createDistributedTracePayload).
   </Collapser>
 
-  <Collapser id="transaction-handle-isSampled">
+  <Collapser
+    id="transaction-handle-isSampled"
+    title={<InlineCode>transactionHandle.isSampled()</InlineCode>}
+  >
     Returns whether this trace is being sampled.
   </Collapser>
 </CollapserGroup>
@@ -446,53 +518,68 @@ Use these methods to interact directly with the current transaction:
 New Relic's Node.js agent includes additional API calls.
 
 <CollapserGroup>
-  <Collapser id="add-custom-attribute">
+  <Collapser
+    id="add-custom-attribute"
+    title={<InlineCode>newrelic.addCustomAttribute(name, value)</InlineCode>}
+  >
     Set a custom attribute value to be displayed along with the transaction trace in the New Relic UI. This must be called within the context of a transaction so it has a place to set the custom attributes. Custom attributes will appear in New Relic APM's transaction trace detail view and in errors for the transaction.
 
-    <dt id="example-link-bg-txn">
-      Add custom attribute
-
-      ```
-      newrelic.addCustomAttribute('attribute1', 'value1')
-      ```
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="example-link-bg-txn"
+        title="Add custom attribute"
+      >
+        ```
+        newrelic.addCustomAttribute('attribute1', 'value1')
+        ```
+      </Collapser>
+    </CollapserGroup>
 
     <Callout variant="caution">
       If you want to use your custom attributes, avoid using any of the [reserved terms used by NRQL](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words) when naming them.
     </Callout>
   </Collapser>
 
-  <Collapser id="add-custom-attributes">
+  <Collapser
+    id="add-custom-attributes"
+    title={<InlineCode>newrelic.addCustomAttributes(attributes)</InlineCode>}
+  >
     Set multiple custom attribute values to be displayed along with the transaction trace in the New Relic UI. The attributes should be passed as a single object. This must be called within the context of a transaction so it has a place to set the custom attributes. Custom attributes will appear in the transaction trace detail view and in errors for the transaction.
 
-    <dt id="example-link-bg-txn">
-      Adding custom attributes
+    <CollapserGroup>
+      <Collapser
+        id="example-link-bg-txn"
+        title="Adding custom attributes"
+      >
+        ```
+        const attributes = {
+          attribute1: 'value1',
+          attribute2: 2
+        }
 
-      ```
-      const attributes = {
-        attribute1: 'value1',
-        attribute2: 2
-      }
-
-      newrelic.addCustomAttributes(attributes)
-      ```
-    </dt>
+        newrelic.addCustomAttributes(attributes)
+        ```
+      </Collapser>
+    </CollapserGroup>
 
     <Callout variant="caution">
       If you want to use your custom attributes, avoid using any of the [reserved terms used by NRQL](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words) when naming them.
     </Callout>
   </Collapser>
 
-  <Collapser>
+  <Collapser title={<InlineCode>newrelic.addCustomSpanAttribute(name, value)</InlineCode>}>
     Set a custom span attribute value to be displayed along with a transaction trace span in the New Relic UI. This must be called within the context of an active segment/span so it has a place to set the custom span attributes. Custom span attributes will appear in the Attributes section of the span detail view.
 
-    <dt id="example-link-bg-txn">
-      Add custom span attribute
-
-      ```
-      newrelic.addCustomSpanAttribute('attribute1', 'value')
-      ```
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="example-link-bg-txn"
+        title="Add custom span attribute"
+      >
+        ```
+        newrelic.addCustomSpanAttribute('attribute1', 'value')
+        ```
+      </Collapser>
+    </CollapserGroup>
 
     <Callout variant="important">
       This API requires [distributed tracing](/docs/enable-distributed-tracing) and [span events](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#span-events) to be enabled.
@@ -503,21 +590,24 @@ New Relic's Node.js agent includes additional API calls.
     </Callout>
   </Collapser>
 
-  <Collapser>
+  <Collapser title={<InlineCode>newrelic.addCustomSpanAttributes(attributes)</InlineCode>}>
     Set multiple custom span attribute values to be displayed along with the transaction trace spans in the New Relic UI. The attributes should be passed as a single object. This must be called within the context of an active segment/span so it has a place to set the custom span attributes. Custom span attributes will appear in the Attributes section of the span detail view.
 
-    <dt id="example-link-bg-txn">
-      Add custom span attributes
+    <CollapserGroup>
+      <Collapser
+        id="example-link-bg-txn"
+        title="Add custom span attributes"
+      >
+        ```
+        const attributes = {
+          attribute1: 'value1',
+          attribute2: 'value2'
+        }
 
-      ```
-      const attributes = {
-        attribute1: 'value1',
-        attribute2: 'value2'
-      }
-
-      newrelic.addCustomSpanAttributes(attributes)
-      ```
-    </dt>
+        newrelic.addCustomSpanAttributes(attributes)
+        ```
+      </Collapser>
+    </CollapserGroup>
 
     <Callout variant="important">
       This API requires [distributed tracing](/docs/enable-distributed-tracing) and [span events](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#span-events) to be enabled.
@@ -528,11 +618,17 @@ New Relic's Node.js agent includes additional API calls.
     </Callout>
   </Collapser>
 
-  <Collapser id="browserTimingHeader">
+  <Collapser
+    id="browserTimingHeader"
+    title={<InlineCode>newrelic.getBrowserTimingHeader()</InlineCode>}
+  >
     Returns the HTML snippet to be inserted into the header of HTML pages to enable [New Relic Browser](/docs/agents/nodejs-agent/supported-features/page-load-timing-nodejs). The HTML will instruct the browser to fetch a small JavaScript file and start the page timer.
   </Collapser>
 
-  <Collapser id="ignore">
+  <Collapser
+    id="ignore"
+    title={<InlineCode>newrelic.setIgnoreTransaction(ignored)</InlineCode>}
+  >
     Tell the module whether or not to ignore a given request. This allows you to explicitly filter long-polling, irrelevant routes or requests you know will be time-consuming. This also allows you to gather metrics for requests that otherwise would be ignored.
 
     * To ignore the transaction, set the parameter to `true` will ignore the transaction.
@@ -540,7 +636,10 @@ New Relic's Node.js agent includes additional API calls.
     * Passing `null` or `undefined` will not change whether the transaction is ignored.
   </Collapser>
 
-  <Collapser id="noticeError">
+  <Collapser
+    id="noticeError"
+    title={<InlineCode>newrelic.noticeError(error, \[customParameters])</InlineCode>}
+  >
     Use this call if your app is doing its own error handling with domains or try/catch clauses, but you want all of the information about how many errors are coming out of the app to be centrally managed. Unlike other Node.js calls, this can be used outside of route handlers, but it will have additional context if called from within transaction scope.
 
     <Callout variant="caution">
@@ -548,7 +647,10 @@ New Relic's Node.js agent includes additional API calls.
     </Callout>
   </Collapser>
 
-  <Collapser id="shutdown">
+  <Collapser
+    id="shutdown"
+    title={<InlineCode>newrelic.shutdown(\[options], callback)</InlineCode>}
+  >
     Use this method to gracefully shut down the agent.
 
     `options`
@@ -565,13 +667,19 @@ New Relic's Node.js agent includes additional API calls.
     ```
   </Collapser>
 
-  <Collapser id="getLinkingMetadata">
+  <Collapser
+    id="getLinkingMetadata"
+    title={<InlineCode>newrelic.getLinkingMetadata()</InlineCode>}
+  >
     Returns key/value pairs which can be used to link traces or entities.
 
     It will only contain items with meaningful values. For instance, if distributed tracing is disabled, `trace.id` will not be included.
   </Collapser>
 
-  <Collapser id="getTraceMetadata">
+  <Collapser
+    id="getTraceMetadata"
+    title={<InlineCode>newrelic.getTraceMetadata()</InlineCode>}
+  >
     Returns and object containing the current trace ID and span ID.
 
     <Callout variant="important">
@@ -587,7 +695,10 @@ If you do not want to put calls to the New Relic module directly into your appli
 Here is the structure for rules in New Relic's Node.js agent.
 
 <CollapserGroup>
-  <Collapser id="rules-name">
+  <Collapser
+    id="rules-name"
+    title={<InlineCode>rules.name</InlineCode>}
+  >
     A list of rules of the format `{pattern : "pattern", name : "name"}` for matching incoming request URLs to `pattern` and naming the matching New Relic transaction's `name`. This acts as a regex replace, where you can set the pattern either as a string, or as a JavaScript regular expression literal, and both pattern and name are required.
 
     When passing a regex as a string, escape backslashes, as the agent does not keep them when given as a string in a pattern. Define your configuration rules from the most specific to the most general, as the patterns will be evaluated in order and are terminal in nature. For more information, see the [naming guidelines](/docs/agents/nodejs-agent/installation-configuration/configuring-nodejs#rules).
@@ -673,83 +784,84 @@ Here is the structure for rules in New Relic's Node.js agent.
 
     Here are some examples of naming rules and the results.
 
-    <dt id="naming-full-url">
-      Match full URL
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="naming-full-url"
+        title="Match full URL"
+      >
+        ```
+        pattern: "^/items/[0-9]+$",
+        name: "/items/:id"
+        ```
 
-    <dd>
-      ```
-      pattern: "^/items/[0-9]+$",
-      name: "/items/:id"
-      ```
+        will result in:
 
-      will result in:
+        ```
+        /items/123  =>  /items/:id
+        /orders/123  =>  /orders/123   (not replaced since the rule is a full match)
+        ```
+      </Collapser>
 
-      ```
-      /items/123  =>  /items/:id
-      /orders/123  =>  /orders/123   (not replaced since the rule is a full match)
-      ```
-    </dd>
+      <Collapser
+        id="first-match-url"
+        title="Replace first match in URL"
+      >
+        ```
+        pattern: "[0-9]+",
+        name: ":id"
+        ```
 
-    <dt id="first-match-url">
-      Replace first match in URL
-    </dt>
+        will result in:
 
-    <dd>
-      ```
-      pattern: "[0-9]+",
-      name: ":id"
-      ```
+        ```
+        /orders/123  =>  /orders/:id
+        /items/123  =>  /items/:id
+        /orders/123/items/123  =>  /orders/:id/items/123
+        ```
+      </Collapser>
 
-      will result in:
+      <Collapser
+        id="replace-urls"
+        title="Replace all matches in any URL"
+      >
+        ```
+        pattern: "[0-9]+",
+        name: ":id",
+        replace_all: true
+        ```
 
-      ```
-      /orders/123  =>  /orders/:id
-      /items/123  =>  /items/:id
-      /orders/123/items/123  =>  /orders/:id/items/123
-      ```
-    </dd>
+        will result in:
 
-    <dt id="replace-urls">
-      Replace all matches in any URL
-    </dt>
+        ```
+        /orders/123/items/123  =>  /orders/:id/items/:id
+        ```
+      </Collapser>
 
-    <dd>
-      ```
-      pattern: "[0-9]+",
-      name: ":id",
-      replace_all: true
-      ```
+      <Collapser
+        id="regular-match-group"
+        title="Match group references"
+      >
+        Using regular expression match group references:
 
-      will result in:
+        ```
+        pattern: '^/(items|orders)/[0-9]+$',
+        name: '/\\1/:id'
+        ```
 
-      ```
-      /orders/123/items/123  =>  /orders/:id/items/:id
-      ```
-    </dd>
+        will result in:
 
-    <dt id="regular-match-group">
-      Match group references
-    </dt>
-
-    <dd>
-      Using regular expression match group references:
-
-      ```
-      pattern: '^/(items|orders)/[0-9]+$',
-      name: '/\\1/:id'
-      ```
-
-      will result in:
-
-      ```
-      /orders/123  =>  /orders/:id
-      /items/123  =>  /items/:id
-      ```
-    </dd>
+        ```
+        /orders/123  =>  /orders/:id
+        /items/123  =>  /items/:id
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
-  <Collapser id="rules-ignore">
+  <Collapser
+    id="rules-ignore"
+    title={<InlineCode>rules.ignore</InlineCode>}
+  >
     This can also be set via the environment variable `NEW_RELIC_IGNORING_RULES`, with multiple rules passed in as a list of comma-delimited patterns. Currently there is no way to escape commas in patterns.
 
     ```
@@ -760,53 +872,59 @@ Here is the structure for rules in New Relic's Node.js agent.
 
 Here are full examples of how rules are included in the configuration file:
 
-<dt id="example-naming-rule">
-  Naming rule example
-</dt>
+<CollapserGroup>
+  <Collapser
+    id="example-naming-rule"
+    title="Naming rule example"
+  >
+    ```
+    // newrelic.js
+      exports.config = {
+        // other configuration
+        rules : {
+          name : [
+            { pattern: "/tables/name-here", name: "/name-hererule1" }
+          ]
+        }
+    ```
+  </Collapser>
 
-<dd>
-  ```
-  // newrelic.js
-    exports.config = {
-      // other configuration
-      rules : {
-        name : [
-          { pattern: "/tables/name-here", name: "/name-hererule1" }
-        ]
-      }
-  ```
-</dd>
+  <Collapser
+    id="example-ignoring-rule"
+    title="Ignoring rule example"
+  >
+    If you are using **socket.io**, you will have a use case for ignoring rules right out of the box. To keep socket.io long-polling from dominating your response-time metrics and affecting the Apdex metrics for your application, add a rule such as:
 
-<dt id="example-ignoring-rule">
-  Ignoring rule example
-</dt>
-
-<dd>
-  If you are using **socket.io**, you will have a use case for ignoring rules right out of the box. To keep socket.io long-polling from dominating your response-time metrics and affecting the Apdex metrics for your application, add a rule such as:
-
-  ```
-  // newrelic.js
-    exports.config = {
-      // other configuration
-      rules : {
-        ignore : [
-          '^\/socket\.io\/.*\/xhr-polling'
-        ]
-      }
-    };
-  ```
-</dd>
+    ```
+    // newrelic.js
+      exports.config = {
+        // other configuration
+        rules : {
+          ignore : [
+            '^\/socket\.io\/.*\/xhr-polling'
+          ]
+        }
+      };
+    ```
+  </Collapser>
+</CollapserGroup>
 
 ## API calls for rules
 
 Here are the API calls for naming and ignoring rules with New Relic's Node.js agent.
 
 <CollapserGroup>
-  <Collapser id="addnamingrule">
+  <Collapser
+    id="addnamingrule"
+    title={<InlineCode>newrelic.addNamingRule(pattern, name)</InlineCode>}
+  >
     Programmatic version of **rules.name**. Once naming rules are added, they cannot be removed until the Node process is restarted. They can also be added via the Node.js agent's configuration. Both parameters are required.
   </Collapser>
 
-  <Collapser id="addignoringrule">
+  <Collapser
+    id="addignoringrule"
+    title={<InlineCode>newrelic.addIgnoringRule(pattern)</InlineCode>}
+  >
     Programmatic version of **rules.ignore**. Once ignoring rules are added, they cannot be removed until the Node process is restarted. They can also be added via the Node.js agent's configuration. This parameter is required.
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -62,9 +62,7 @@ This section defines the Node.js agent variables in the order they typically app
 <CollapserGroup>
   <Collapser
     id="app_name"
-    title="app"
-    title="_"
-    title="name (HIGHLY RECOMMENDED)"
+    title="app_name (HIGHLY RECOMMENDED)"
   >
     <Table>
       <tbody>
@@ -111,9 +109,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="license"
-    title="license"
-    title="_"
-    title="key (REQUIRED)"
+    title="license_key (REQUIRED)"
   >
     <Table>
       <tbody>
@@ -154,9 +150,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="agent-enabled"
-    title="agent"
-    title="_"
-    title="enabled"
+    title="agent_enabled"
   >
     <Table>
       <tbody>
@@ -197,11 +191,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="allow_all_headers"
-    title="allow"
-    title="_"
-    title="all"
-    title="_"
-    title="headers"
+    title="allow_all_headers"
   >
     If `true`, enables capture of all HTTP headers, except for those filtered by `exclude` rules. If `false`, collected headers are limited to those defined in [Node.js agent attributes](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-attributes).
 
@@ -236,9 +226,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="apdex"
-    title="apdex"
-    title="_"
-    title="t (DEPRECATED)"
+    title="apdex_t (DEPRECATED)"
   >
     <Table>
       <tbody>
@@ -318,9 +306,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="high_security"
-    title="high"
-    title="_"
-    title="security"
+    title="high_security"
   >
     <Table>
       <tbody>
@@ -537,9 +523,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="proxy_host"
-    title="proxy"
-    title="_"
-    title="host"
+    title="proxy_host"
   >
     <Table>
       <tbody>
@@ -580,9 +564,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="proxy_pass"
-    title="proxy"
-    title="_"
-    title="pass"
+    title="proxy_pass"
   >
     <Table>
       <tbody>
@@ -623,9 +605,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="proxy_port"
-    title="proxy"
-    title="_"
-    title="port"
+    title="proxy_port"
   >
     <Table>
       <tbody>
@@ -666,9 +646,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="proxy_user"
-    title="proxy"
-    title="_"
-    title="user"
+    title="proxy_user"
   >
     <Table>
       <tbody>
@@ -1003,11 +981,7 @@ This section allows you to choose which API methods are enabled. Each configurat
 <CollapserGroup>
   <Collapser
     id="custom-attributes"
-    title="custom"
-    title="_"
-    title="attributes"
-    title="_"
-    title="enabled"
+    title="custom_attributes_enabled"
   >
     <Table>
       <tbody>
@@ -1048,11 +1022,7 @@ This section allows you to choose which API methods are enabled. Each configurat
 
   <Collapser
     id="custom-events"
-    title="custom"
-    title="_"
-    title="events"
-    title="_"
-    title="enabled"
+    title="custom_events_enabled"
   >
     <Table>
       <tbody>
@@ -1093,11 +1063,7 @@ This section allows you to choose which API methods are enabled. Each configurat
 
   <Collapser
     id="notice-error"
-    title="notice"
-    title="_"
-    title="error"
-    title="_"
-    title="enabled"
+    title="notice_error_enabled"
   >
     <Table>
       <tbody>
@@ -1271,9 +1237,7 @@ This section defines the variables for [Node.js agent attributes](/docs/agents/n
 
   <Collapser
     id="attributes_include_enabled"
-    title="include"
-    title="_"
-    title="enabled"
+    title="include_enabled"
   >
     <Table>
       <tbody>
@@ -1371,11 +1335,7 @@ You can [manage how error are handled](/docs/agents/manage-apm-agents/agent-data
 
   <Collapser
     id="error_ignore"
-    title="ignore"
-    title="_"
-    title="status"
-    title="_"
-    title="codes"
+    title="ignore_status_codes"
   >
     <Table>
       <tbody>
@@ -1430,9 +1390,7 @@ You can [manage how error are handled](/docs/agents/manage-apm-agents/agent-data
 
   <Collapser
     id="error_ignore"
-    title="ignore"
-    title="_"
-    title="classes"
+    title="ignore_classes"
   >
     <Table>
       <tbody>
@@ -1489,9 +1447,7 @@ You can [manage how error are handled](/docs/agents/manage-apm-agents/agent-data
 
   <Collapser
     id="error_ignore"
-    title="ignore"
-    title="_"
-    title="messages"
+    title="ignore_messages"
   >
     <Table>
       <tbody>
@@ -1538,11 +1494,7 @@ You can [manage how error are handled](/docs/agents/manage-apm-agents/agent-data
 
   <Collapser
     id="error_ignore"
-    title="expected"
-    title="_"
-    title="status"
-    title="_"
-    title="codes"
+    title="expected_status_codes"
   >
     <Table>
       <tbody>
@@ -1587,9 +1539,7 @@ You can [manage how error are handled](/docs/agents/manage-apm-agents/agent-data
 
   <Collapser
     id="error_ignore"
-    title="expected"
-    title="_"
-    title="classes"
+    title="expected_classes"
   >
     <Table>
       <tbody>
@@ -1644,9 +1594,7 @@ You can [manage how error are handled](/docs/agents/manage-apm-agents/agent-data
 
   <Collapser
     id="error_ignore"
-    title="expected"
-    title="_"
-    title="messages"
+    title="expected_messages"
   >
     <Table>
       <tbody>
@@ -1888,9 +1836,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="explain_threshold"
-    title="explain"
-    title="_"
-    title="threshold"
+    title="explain_threshold"
   >
     <Table>
       <tbody>
@@ -1931,9 +1877,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="record-sql"
-    title="record"
-    title="_"
-    title="sql"
+    title="record_sql"
   >
     <Table>
       <tbody>
@@ -1976,9 +1920,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="tracer_top"
-    title="top"
-    title="_"
-    title="n"
+    title="top_n"
   >
     <Table>
       <tbody>
@@ -2027,9 +1969,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="tracer_threshold"
-    title="transaction"
-    title="_"
-    title="threshold"
+    title="transaction_threshold"
   >
     <Table>
       <tbody>
@@ -2084,9 +2024,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="hide-internals"
-    title="hide"
-    title="_"
-    title="internals"
+    title="hide_internals"
   >
     <Table>
       <tbody>
@@ -2361,9 +2299,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="enforce_backstop"
-    title="enforce"
-    title="_"
-    title="backstop"
+    title="enforce_backstop"
   >
     <Table>
       <tbody>
@@ -2445,11 +2381,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="tx_events_max_samples_stored"
-    title="max"
-    title="_"
-    title="samples"
-    title="_"
-    title="stored"
+    title="max_samples_stored"
   >
     <Table>
       <tbody>
@@ -2486,11 +2418,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="tx_events_max_samples_stored_legacy"
-    title="max"
-    title="_"
-    title="samples"
-    title="_"
-    title="stored (DEPRECATED)"
+    title="max_samples_stored (DEPRECATED)"
   >
     <Table>
       <tbody>
@@ -2525,13 +2453,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="tx_events_max_samples_per_minute"
-    title="max"
-    title="_"
-    title="samples"
-    title="_"
-    title="per"
-    title="_"
-    title="minute (DEPRECATED)"
+    title="max_samples_per_minute (DEPRECATED)"
   >
     <Table>
       <tbody>
@@ -2955,11 +2877,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="custom_events_max_samples_stored"
-    title="max"
-    title="_"
-    title="samples"
-    title="_"
-    title="stored"
+    title="max_samples_stored"
   >
     <Table>
       <tbody>
@@ -3041,9 +2959,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="slow-sql-max-samples"
-    title="max"
-    title="_"
-    title="samples"
+    title="max_samples"
   >
     <Table>
       <tbody>
@@ -3094,9 +3010,7 @@ This section defines the Node.js agent variables in the order they typically app
 <CollapserGroup>
   <Collapser
     id="custom-hostnames-display"
-    title="display"
-    title="_"
-    title="name"
+    title="display_name"
   >
     <Table>
       <tbody>
@@ -3141,9 +3055,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="custom-hostnames-ipv"
-    title="ipv"
-    title="_"
-    title="preference"
+    title="ipv_preference"
   >
     <Table>
       <tbody>
@@ -3188,11 +3100,7 @@ This section defines two configuration options only available with environment v
 <CollapserGroup>
   <Collapser
     id="home"
-    title="NEW"
-    title="_"
-    title="RELIC"
-    title="_"
-    title="HOME"
+    title="NEW_RELIC_HOME"
   >
     Path to the directory containing `newrelic.js`. This is available only as an environment variable. You cannot set it in your config file.
 
@@ -3223,15 +3131,7 @@ This section defines two configuration options only available with environment v
 
   <Collapser
     id="no_file"
-    title="NEW"
-    title="_"
-    title="RELIC"
-    title="_"
-    title="NO"
-    title="_"
-    title="CONFIG"
-    title="_"
-    title="FILE"
+    title="NEW_RELIC_NO_CONFIG_FILE"
   >
     If used, this prevents the agent from reading configuration settings from `newrelic.js`. Default values and values from environment variables will still be set.
 
@@ -3270,9 +3170,7 @@ This section defines the Node.js agent variables in the order they typically app
 <CollapserGroup>
   <Collapser
     id="datastore-instance-enabled"
-    title="instance"
-    title="_"
-    title="reporting.enabled"
+    title="instance_reporting.enabled"
   >
     <Table>
       <tbody>
@@ -3303,11 +3201,7 @@ This section defines the Node.js agent variables in the order they typically app
 
   <Collapser
     id="datastore-name-enabled"
-    title="database"
-    title="_"
-    title="name"
-    title="_"
-    title="reporting.enabled"
+    title="database_name_reporting.enabled"
   >
     <Table>
       <tbody>
@@ -3483,11 +3377,7 @@ When distributed tracing is enabled, you can collect [span events](/docs/apm/dis
 
   <Collapser
     id="dt-exclude-newrelic-header"
-    title="exclude"
-    title="_"
-    title="newrelic"
-    title="_"
-    title="header"
+    title="exclude_newrelic_header"
   >
     <Table>
       <tbody>
@@ -3703,9 +3593,7 @@ To turn on Infinite Tracing, enable distributed tracing (set `distributed_tracin
 <CollapserGroup>
   <Collapser
     id="infinite-tracing-host"
-    title="trace"
-    title="_"
-    title="observer.host"
+    title="trace_observer.host"
   >
     <Table>
       <tbody>

--- a/src/content/docs/agents/nodejs-agent/supported-features/browser-monitoring-nodejs-agent.mdx
+++ b/src/content/docs/agents/nodejs-agent/supported-features/browser-monitoring-nodejs-agent.mdx
@@ -28,145 +28,144 @@ Generating headers is fast, and it does not require your application to make ext
 
 Here are some examples of how to set up browser monitoring with different frameworks and templates.
 
-<dt id="example-express">
-  Express and jade
-</dt>
+<CollapserGroup>
+  <Collapser
+    id="example-express"
+    title="Express and jade"
+  >
+    This example uses [Express](http://expressjs.com), a web application framework, and [jade](http://jade-lang.com), a template module. Although the specifics are different with other frameworks, this general approach should work in most cases.
 
-<dd>
-  This example uses [Express](http://expressjs.com), a web application framework, and [jade](http://jade-lang.com), a template module. Although the specifics are different with other frameworks, this general approach should work in most cases.
+    The simplest way to insert browser timing headings is to pass the `newrelic` module into your template, and then call `newrelic.getBrowsertimingHeader()` from within the template.
 
-  The simplest way to insert browser timing headings is to pass the `newrelic` module into your template, and then call `newrelic.getBrowsertimingHeader()` from within the template.
+    In your `app.js`:
 
-  In your `app.js`:
+    ```
+    var newrelic = require('newrelic');
+    var app = require('express')();
+    // in express, this lets you call newrelic from within a template
+    app.locals.newrelic = newrelic;
 
-  ```
-  var newrelic = require('newrelic');
-  var app = require('express')();
-  // in express, this lets you call newrelic from within a template
-  app.locals.newrelic = newrelic;
-
-  app.get('/user/:id', function (req, res) {
-    res.render('user');
-  });
-  app.listen(process.env.PORT);
-  ```
-
-  In your **layout.jade**:
-
-  ```
-  doctype html
-  html
-  head
-    != newrelic.getBrowserTimingHeader()
-    title= title
-    link(rel='stylesheet', href='stylesheets/style.css')
-  body
-    block content
-  ```
-</dd>
-
-<dt id="example-express-swig">
-  Express and Swig
-</dt>
-
-<dd>
-  This example uses Express with [Swig](https://github.com/paularmstrong/swig "Link opens in a new window").
-
-  In your `app.js`:
-
-  ```
-  var newrelic = require('newrelic');
-
-  var http = require('http')
-  var path = require('path')
-  var swig = require('swig')
-
-  var app = require('express')();
-
-  app.locals.newrelic = newrelic;
-
-  //taken from http://paularmstrong.github.io/swig/docs/#express
-  app.engine('html', swig.renderFile);
-  app.set('view engine', 'html');
-  app.set('views', __dirname + '/views');
-
-  app.get('/user/:id', function (req, res) {
+    app.get('/user/:id', function (req, res) {
       res.render('user');
-  });
+    });
+    app.listen(process.env.PORT);
+    ```
 
-  app.listen(process.env.PORT);
-  ```
+    In your **layout.jade**:
 
-  In your `views/user.html`:
+    ```
+    doctype html
+    html
+    head
+      != newrelic.getBrowserTimingHeader()
+      title= title
+      link(rel='stylesheet', href='stylesheets/style.css')
+    body
+      block content
+    ```
+  </Collapser>
 
-  ```
-  <!DOCTYPE html>
-  <html>
-      <head>
-          {{ newrelic.getBrowserTimingHeader() }}
-          <title>Hello</title>
-      </head>
-      <body>
-          <h1>Hello World</h1>
-      </body>
-  </html>
-  ```
-</dd>
+  <Collapser
+    id="example-express-swig"
+    title="Express and Swig"
+  >
+    This example uses Express with [Swig](https://github.com/paularmstrong/swig "Link opens in a new window").
 
-<dt id="example-hapijs">
-  Hapi.js and handlebars
-</dt>
+    In your `app.js`:
 
-<dd>
-  This example uses [hapi.js](http://hapijs.com/) and [handlebars](http://handlebarsjs.com). Other similar templating languages typically require triple brackets; for example, using [mustache](https://mustache.github.io/mustache.5.html) with [hogan-express](https://github.com/vol4ok/hogan-express). This helps prevent escaping of the script content.
+    ```
+    var newrelic = require('newrelic');
 
-  Using **hapi**, in your `app.js`:
+    var http = require('http')
+    var path = require('path')
+    var swig = require('swig')
 
-  ```
-  var newrelic = require('newrelic');
-  var Hapi = require('hapi');
-  var server = new Hapi.Server(parseInt(PORT), '0.0.0.0', {
-      views: {
-      engines : {html: 'handlebars' },
-      path : __dirname + '/templates'
-      }
-  });
+    var app = require('express')();
 
-  function homepage(request, reply) {
-      var context = {
+    app.locals.newrelic = newrelic;
 
-      // pass in the header each request
-      nreum : newrelic.getBrowserTimingHeader(),
-      content : ...
-  };
+    //taken from http://paularmstrong.github.io/swig/docs/#express
+    app.engine('html', swig.renderFile);
+    app.set('view engine', 'html');
+    app.set('views', __dirname + '/views');
 
-  reply.view('homepage', context);
-  };
+    app.get('/user/:id', function (req, res) {
+        res.render('user');
+    });
 
-  server.route({
-      method : 'GET',
-      path : '/',
-      handler : homepage
-  });
+    app.listen(process.env.PORT);
+    ```
 
-  server.start();
-  ```
+    In your `views/user.html`:
 
-  In your `templates/homepage.html`:
+    ```
+    <!DOCTYPE html>
+    <html>
+        <head>
+            {{ newrelic.getBrowserTimingHeader() }}
+            <title>Hello</title>
+        </head>
+        <body>
+            <h1>Hello World</h1>
+        </body>
+    </html>
+    ```
+  </Collapser>
 
-  ```
-  <!DOCTYPE html>
-  <html>
-      <head>
-          {{{ nreum }}}
-          <title>Hello</title>
-      </head>
-      <body>
-          {{ content }}
-      </body>
-  </html>
-  ```
-</dd>
+  <Collapser
+    id="example-hapijs"
+    title="Hapi.js and handlebars"
+  >
+    This example uses [hapi.js](http://hapijs.com/) and [handlebars](http://handlebarsjs.com). Other similar templating languages typically require triple brackets; for example, using [mustache](https://mustache.github.io/mustache.5.html) with [hogan-express](https://github.com/vol4ok/hogan-express). This helps prevent escaping of the script content.
+
+    Using **hapi**, in your `app.js`:
+
+    ```
+    var newrelic = require('newrelic');
+    var Hapi = require('hapi');
+    var server = new Hapi.Server(parseInt(PORT), '0.0.0.0', {
+        views: {
+        engines : {html: 'handlebars' },
+        path : __dirname + '/templates'
+        }
+    });
+
+    function homepage(request, reply) {
+        var context = {
+
+        // pass in the header each request
+        nreum : newrelic.getBrowserTimingHeader(),
+        content : ...
+    };
+
+    reply.view('homepage', context);
+    };
+
+    server.route({
+        method : 'GET',
+        path : '/',
+        handler : homepage
+    });
+
+    server.start();
+    ```
+
+    In your `templates/homepage.html`:
+
+    ```
+    <!DOCTYPE html>
+    <html>
+        <head>
+            {{{ nreum }}}
+            <title>Hello</title>
+        </head>
+        <body>
+            {{ content }}
+        </body>
+    </html>
+    ```
+  </Collapser>
+</CollapserGroup>
 
 ## Disable header generation
 

--- a/src/content/docs/agents/php-agent/advanced-installation/php-agent-installation-non-standard-php-advanced.mdx
+++ b/src/content/docs/agents/php-agent/advanced-installation/php-agent-installation-non-standard-php-advanced.mdx
@@ -30,15 +30,14 @@ Use the command line version of PHP (`php -i`) or look at the output of `phpinfo
    <CollapserGroup>
      <Collapser
        id="add-php-to-path"
-       title="Add your PHP location to your "
+       title={<>Add your PHP location to your <InlineCode>PATH</InlineCode></>}
      >
        The install script needs to be able to find your command line `php` or `php-config`. You can add the directory that contains those programs to your current `PATH`.
      </Collapser>
 
      <Collapser
        id="nr-install-path"
-       title="Set the "
-       title=" variable."
+       title={<>Set the <InlineCode>NR_INSTALL_PATH</InlineCode> variable.</>}
      >
        This can be a colon-separated list of directories in which to look for PHP installations in addition to those in your PATH. These directories should contain `php` or `php-config`. For example:
 
@@ -50,8 +49,7 @@ Use the command line version of PHP (`php -i`) or look at the output of `phpinfo
 
      <Collapser
        id="nr-install-phplist"
-       title="Set the "
-       title=" variable"
+       title={<>Set the <InlineCode>NR_INSTALL_PHPLIST</InlineCode> variable</>}
      >
        Optional: Use a colon-separated list to set the exact locations (directories) in which to search. This option will ignore `PATH` and `NR_INSTALL_PATH`. For example:
 
@@ -89,7 +87,7 @@ You can either review and obtain the appropriate values from your `phpinfo()` yo
 
   <Collapser
     id="manual-installation-phpinfo"
-    title="Obtaining installation parameters from "
+    title={<>Obtaining installation parameters from <InlineCode>phpinfo()</InlineCode></>}
   >
     If this does not work you can obtain the correct information from your `phpinfo()` and pass the appropriate settings to your system as environment variables.
 

--- a/src/content/docs/agents/php-agent/advanced-installation/silent-mode-install-script-advanced.mdx
+++ b/src/content/docs/agents/php-agent/advanced-installation/silent-mode-install-script-advanced.mdx
@@ -33,11 +33,7 @@ This is the list of environment variables you can set prior to invoking [`newrel
 <CollapserGroup>
   <Collapser
     id="NR_INSTALL_SILENT"
-    title="NR"
-    title="_"
-    title="INSTALL"
-    title="_"
-    title="SILENT"
+    title="NR_INSTALL_SILENT"
   >
     <Table>
       <tbody>
@@ -82,11 +78,7 @@ This is the list of environment variables you can set prior to invoking [`newrel
 
   <Collapser
     id="NR_INSTALL_NOKSH"
-    title="NR"
-    title="_"
-    title="INSTALL"
-    title="_"
-    title="NOKSH"
+    title="NR_INSTALL_NOKSH"
   >
     <Table>
       <tbody>
@@ -131,11 +123,7 @@ This is the list of environment variables you can set prior to invoking [`newrel
 
   <Collapser
     id="NR_INSTALL_SHELL"
-    title="NR"
-    title="_"
-    title="INSTALL"
-    title="_"
-    title="SHELL"
+    title="NR_INSTALL_SHELL"
   >
     <Table>
       <tbody>
@@ -180,11 +168,7 @@ This is the list of environment variables you can set prior to invoking [`newrel
 
   <Collapser
     id="NR_INSTALL_PATH"
-    title="NR"
-    title="_"
-    title="INSTALL"
-    title="_"
-    title="PATH"
+    title="NR_INSTALL_PATH"
   >
     <Table>
       <tbody>
@@ -227,11 +211,7 @@ This is the list of environment variables you can set prior to invoking [`newrel
 
   <Collapser
     id="NR_INSTALL_PHPLIST"
-    title="NR"
-    title="_"
-    title="INSTALL"
-    title="_"
-    title="PHPLIST"
+    title="NR_INSTALL_PHPLIST"
   >
     <Table>
       <tbody>
@@ -274,11 +254,7 @@ This is the list of environment variables you can set prior to invoking [`newrel
 
   <Collapser
     id="NR_INSTALL_ARCH"
-    title="NR"
-    title="_"
-    title="INSTALL"
-    title="_"
-    title="ARCH"
+    title="NR_INSTALL_ARCH"
   >
     <Table>
       <tbody>
@@ -325,11 +301,7 @@ This is the list of environment variables you can set prior to invoking [`newrel
 
   <Collapser
     id="NR_INSTALL_KEY"
-    title="NR"
-    title="_"
-    title="INSTALL"
-    title="_"
-    title="KEY"
+    title="NR_INSTALL_KEY"
   >
     <Table>
       <tbody>
@@ -370,11 +342,7 @@ This is the list of environment variables you can set prior to invoking [`newrel
 
   <Collapser
     id="NR_INSTALL_INITSCRIPT"
-    title="NR"
-    title="_"
-    title="INSTALL"
-    title="_"
-    title="INITSCRIPT"
+    title="NR_INSTALL_INITSCRIPT"
   >
     <Table>
       <tbody>
@@ -417,11 +385,7 @@ This is the list of environment variables you can set prior to invoking [`newrel
 
   <Collapser
     id="NR_INSTALL_DAEMONPATH"
-    title="NR"
-    title="_"
-    title="INSTALL"
-    title="_"
-    title="DAEMONPATH"
+    title="NR_INSTALL_DAEMONPATH"
   >
     <Table>
       <tbody>
@@ -466,17 +430,7 @@ This is the list of environment variables you can set prior to invoking [`newrel
 
   <Collapser
     id="NR_INSTALL_USE_CP_NOT_LN"
-    title="NR"
-    title="_"
-    title="INSTALL"
-    title="_"
-    title="USE"
-    title="_"
-    title="CP"
-    title="_"
-    title="NOT"
-    title="_"
-    title="LN"
+    title="NR_INSTALL_USE_CP_NOT_LN"
   >
     <Table>
       <tbody>

--- a/src/content/docs/agents/php-agent/advanced-installation/using-newrelic-install-script.mdx
+++ b/src/content/docs/agents/php-agent/advanced-installation/using-newrelic-install-script.mdx
@@ -86,9 +86,7 @@ Follow this process to install New Relic.
 <CollapserGroup>
   <Collapser
     id="invoke"
-    title="1"
-    title="."
-    title=" Invoke install mode."
+    title="1. Invoke install mode."
   >
     Invoke install mode by using **one** of these methods:
 
@@ -98,18 +96,14 @@ Follow this process to install New Relic.
 
   <Collapser
     id="license-key"
-    title="2"
-    title="."
-    title=" Provide your New Relic license key."
+    title="2. Provide your New Relic license key."
   >
     At the prompt, enter your New Relic [license key](/docs/accounts-partnerships/accounts/account-setup/license-key). This key will be inserted into any INI files created during the rest of the installation process.
   </Collapser>
 
   <Collapser
     id="select-version"
-    title="3"
-    title="."
-    title=" Select which PHP version to use if applicable."
+    title="3. Select which PHP version to use if applicable."
   >
     If `newrelic-install` finds more than one version of PHP, select which version of PHP to use. You will not see this screen if the script only found a single version of PHP.
 
@@ -145,9 +139,7 @@ Follow this process to install New Relic.
 
   <Collapser
     id="daemon"
-    title="4"
-    title="."
-    title=" Install the daemon if applicable."
+    title="4. Install the daemon if applicable."
   >
     If the daemon was not installed by the package manager, install the daemon.
 
@@ -162,9 +154,7 @@ Follow this process to install New Relic.
 
   <Collapser
     id="restart-web-server"
-    title="5"
-    title="."
-    title=" Restart your web server."
+    title="5. Restart your web server."
   >
     To activate the PHP agent, restart your web server.
 
@@ -175,18 +165,14 @@ Follow this process to install New Relic.
 
   <Collapser
     id="archive-file"
-    title="6"
-    title="."
-    title=" Note your archive file."
+    title="6. Note your archive file."
   >
     Note the name and location of the install archive file. This file will be located at **/tmp/nrinstall-nnnn.tar** and will contain both the install log and useful system information to help New Relic Technical Support with troubleshooting.
   </Collapser>
 
   <Collapser
     id="configuration"
-    title="7"
-    title="."
-    title=" Fine-tune your configuration."
+    title="7. Fine-tune your configuration."
   >
     After you install New Relic successfully and restart your web server, you can begin gathering data about your applications. After a few minutes, data will begin to appear on your [APM **Summary** page](/docs/apm/applications-menu/monitoring/apm-overview-page).
 

--- a/src/content/docs/agents/php-agent/attributes/enable-or-disable-attributes.mdx
+++ b/src/content/docs/agents/php-agent/attributes/enable-or-disable-attributes.mdx
@@ -16,7 +16,10 @@ Learn about properties to enable or disable attributes, and the rules that New R
 Use the following destination properties to open or close the destination to any attribute collection:
 
 <CollapserGroup>
-  <Collapser id="cfg-attributes-enabled">
+  <Collapser
+    id="cfg-attributes-enabled"
+    title={<InlineCode>newrelic.attributes.enabled</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -44,7 +47,10 @@ Use the following destination properties to open or close the destination to any
     Turns on or turns off all attributes in all destinations.
   </Collapser>
 
-  <Collapser id="cfg-browser-attributes-enabled">
+  <Collapser
+    id="cfg-browser-attributes-enabled"
+    title={<InlineCode>newrelic.browser_monitoring.attributes.enabled</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -72,7 +78,10 @@ Use the following destination properties to open or close the destination to any
     Turns on or turns off all attributes for browser monitoring. This is the data that gets sent to page views in Insights. If `newrelic.attributes.enabled` is `false`, no attributes will be sent to browser monitoring regardless of how this property is set.
   </Collapser>
 
-  <Collapser id="cfg-error-attributes-enabled">
+  <Collapser
+    id="cfg-error-attributes-enabled"
+    title={<InlineCode>newrelic.error_collector.attributes.enabled</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -100,7 +109,10 @@ Use the following destination properties to open or close the destination to any
     Turns on or turns off all attributes for traced errors. If `newrelic.attributes.enabled` is `false`, no attributes will be sent to traced errors regardless of how this property is set.
   </Collapser>
 
-  <Collapser id="cfg-events-attributes-enabled">
+  <Collapser
+    id="cfg-events-attributes-enabled"
+    title={<InlineCode>newrelic.transaction_events.attributes.enabled</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -128,7 +140,10 @@ Use the following destination properties to open or close the destination to any
     Turns on or turns off all attributes for transaction events. If `newrelic.attributes.enabled` is `false`, no attributes will be sent to transaction events regardless of how this property is set.
   </Collapser>
 
-  <Collapser id="cfg-tt-attributes-enabled">
+  <Collapser
+    id="cfg-tt-attributes-enabled"
+    title={<InlineCode>newrelic.transaction_tracer.attributes.enabled</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -156,7 +171,10 @@ Use the following destination properties to open or close the destination to any
     Turns on or off all attributes for transaction traces. If `newrelic.attributes.enabled` is `false`, no attributes will be sent to transaction traces regardless of how this property is set.
   </Collapser>
 
-  <Collapser id="cfg-tt-attributes-enabled">
+  <Collapser
+    id="cfg-tt-attributes-enabled"
+    title={<InlineCode>newrelic.span_events.attributes.enabled</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -188,7 +206,10 @@ Use the following destination properties to open or close the destination to any
 Use the following attribute/destination specific `.include` or `.exclude` properties to add or remove specific attributes in specific destinations:
 
 <CollapserGroup>
-  <Collapser id="cfg-attributes-include">
+  <Collapser
+    id="cfg-attributes-include"
+    title={<InlineCode>newrelic.attributes.include</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -216,7 +237,10 @@ Use the following attribute/destination specific `.include` or `.exclude` proper
     If attributes are enabled, all attribute keys in this list will be sent to New Relic.
   </Collapser>
 
-  <Collapser id="cfg-attributes-exclude">
+  <Collapser
+    id="cfg-attributes-exclude"
+    title={<InlineCode>newrelic.attributes.exclude</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -244,7 +268,10 @@ Use the following attribute/destination specific `.include` or `.exclude` proper
     All attribute keys in this list will **not** be sent to New Relic.
   </Collapser>
 
-  <Collapser id="cfg-bm-attributes-include">
+  <Collapser
+    id="cfg-bm-attributes-include"
+    title={<InlineCode>newrelic.browser_monitoring.attributes.include</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -272,7 +299,10 @@ Use the following attribute/destination specific `.include` or `.exclude` proper
     If attributes are enabled for browser_monitoring, all attribute keys in this list will be sent to New Relic Browser in page views.
   </Collapser>
 
-  <Collapser id="cfg-bm-attributes-exclude">
+  <Collapser
+    id="cfg-bm-attributes-exclude"
+    title={<InlineCode>newrelic.browser_monitoring.attributes.exclude</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -300,7 +330,10 @@ Use the following attribute/destination specific `.include` or `.exclude` proper
     All attribute keys found in this list will **not** be sent to New Relic in page views.
   </Collapser>
 
-  <Collapser id="cfg-ec-attributes-include">
+  <Collapser
+    id="cfg-ec-attributes-include"
+    title={<InlineCode>newrelic.error_collector.attributes.include</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -328,7 +361,10 @@ Use the following attribute/destination specific `.include` or `.exclude` proper
     If attributes are enabled for traced errors, all attribute keys in this list will be sent to New Relic in traced errors.
   </Collapser>
 
-  <Collapser id="cfg-ec-attributes-exclude">
+  <Collapser
+    id="cfg-ec-attributes-exclude"
+    title={<InlineCode>newrelic.error_collector.attributes.exclude</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -356,7 +392,10 @@ Use the following attribute/destination specific `.include` or `.exclude` proper
     All attribute keys in this list will **not** be sent to New Relic in traced errors.
   </Collapser>
 
-  <Collapser id="cfg-te-attributes-include">
+  <Collapser
+    id="cfg-te-attributes-include"
+    title={<InlineCode>newrelic.transaction_events.attributes.include</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -384,7 +423,10 @@ Use the following attribute/destination specific `.include` or `.exclude` proper
     If attributes are enabled for transaction events, all attribute keys in this list will be sent to New Relic in transaction events.
   </Collapser>
 
-  <Collapser id="cfg-te-attributes-exclude">
+  <Collapser
+    id="cfg-te-attributes-exclude"
+    title={<InlineCode>newrelic.transaction_events.attributes.exclude</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -412,7 +454,10 @@ Use the following attribute/destination specific `.include` or `.exclude` proper
     All attribute keys in this list will **not** be sent to New Relic in transaction events.
   </Collapser>
 
-  <Collapser id="cfg-tt-attributes-include">
+  <Collapser
+    id="cfg-tt-attributes-include"
+    title={<InlineCode>newrelic.transaction_tracer.attributes.include</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -440,7 +485,10 @@ Use the following attribute/destination specific `.include` or `.exclude` proper
     If attributes are enabled for transaction traces, all attribute keys in this list will be sent to New Relic in transaction traces.
   </Collapser>
 
-  <Collapser id="cfg-tt-attributes-exclude">
+  <Collapser
+    id="cfg-tt-attributes-exclude"
+    title={<InlineCode>newrelic.transaction_tracer.attributes.exclude</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -468,7 +516,10 @@ Use the following attribute/destination specific `.include` or `.exclude` proper
     All attribute keys in this list will **not** be sent to New Relic in transaction traces.
   </Collapser>
 
-  <Collapser id="cfg-tt-attributes-include">
+  <Collapser
+    id="cfg-tt-attributes-include"
+    title={<InlineCode>newrelic.span_events.attributes.include</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -496,7 +547,10 @@ Use the following attribute/destination specific `.include` or `.exclude` proper
     If attributes are enabled for span events, all attribute keys in this list will be sent to New Relic in span events.
   </Collapser>
 
-  <Collapser id="cfg-tt-attributes-exclude">
+  <Collapser
+    id="cfg-tt-attributes-exclude"
+    title={<InlineCode>newrelic.span_events.attributes.exclude</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -647,8 +701,7 @@ New Relic follows these rules when determining which attributes to include or ex
 
   <Collapser
     id="rule-star-wildcard"
-    title="Use a star ("
-    title=") for wildcards."
+    title={<>Use a star (<InlineCode>\*</InlineCode>) for wildcards.</>}
   >
     You can use an asterisk or star (`*`) at the end of a key as a wildcard. This will match a set of attributes with the same prefix.
 

--- a/src/content/docs/agents/php-agent/attributes/php-agent-attributes.mdx
+++ b/src/content/docs/agents/php-agent/attributes/php-agent-attributes.mdx
@@ -18,7 +18,10 @@ You can customize exactly which attributes will be sent to each of these destina
 In addition to the [default APM attributes](https://docs.newrelic.com/docs/insights/new-relic-insights/decorating-events/apm-default-attributes-insights#transaction-defaults), you can configure the following attributes in the PHP agent. See [PHP agent (`newrelic.ini`) settings](/docs/php/php-agent-phpini-settings) and [Enabling and disabling attributes](/docs/agents/php-agent/attributes/enabling-and-disabling-attributes) for more information.
 
 <CollapserGroup>
-  <Collapser id="httpResponseCode">
+  <Collapser
+    id="httpResponseCode"
+    title={<InlineCode>response.statusCode</InlineCode>}
+  >
     The response status code for a web request.
 
     Defaults:
@@ -31,7 +34,7 @@ In addition to the [default APM attributes](https://docs.newrelic.com/docs/insig
 
   <Collapser
     id="newrelic_add_custom_parameter"
-    title=" API call"
+    title={<><InlineCode>newrelic_add_custom_parameter</InlineCode> API call</>}
   >
     Attributes added to an `newrelic_add_custom_parameter()` call on the New Relic API.
 
@@ -43,7 +46,10 @@ In addition to the [default APM attributes](https://docs.newrelic.com/docs/insig
     * Page views (browser monitoring): Enabled
   </Collapser>
 
-  <Collapser id="requestHeadersAccept">
+  <Collapser
+    id="requestHeadersAccept"
+    title={<InlineCode>request.headers.accept</InlineCode>}
+  >
     The types as read from the HTTP Accept request header.
 
     Defaults:
@@ -54,7 +60,10 @@ In addition to the [default APM attributes](https://docs.newrelic.com/docs/insig
     * Page views (browser monitoring): Unavailable
   </Collapser>
 
-  <Collapser id="requestHeadersContentType">
+  <Collapser
+    id="requestHeadersContentType"
+    title={<InlineCode>request.headers.contentType</InlineCode>}
+  >
     The incoming request content-type as read from the Content-Type request header.
 
     Defaults:
@@ -65,7 +74,10 @@ In addition to the [default APM attributes](https://docs.newrelic.com/docs/insig
     * Page views (browser monitoring): Unavailable
   </Collapser>
 
-  <Collapser id="requestHeadersContentLength">
+  <Collapser
+    id="requestHeadersContentLength"
+    title={<InlineCode>request.headers.contentLength</InlineCode>}
+  >
     The incoming request size in bytes as read from the Content-Length request header.
 
     Defaults:
@@ -76,7 +88,10 @@ In addition to the [default APM attributes](https://docs.newrelic.com/docs/insig
     * Page views (browser monitoring): Unavailable
   </Collapser>
 
-  <Collapser id="requestHeadersHost">
+  <Collapser
+    id="requestHeadersHost"
+    title={<InlineCode>request.headers.host</InlineCode>}
+  >
     The name from the HTTP host request header.
 
     Defaults:
@@ -87,7 +102,10 @@ In addition to the [default APM attributes](https://docs.newrelic.com/docs/insig
     * Page views (browser monitoring): Unavailable
   </Collapser>
 
-  <Collapser id="requestHeadersReferer">
+  <Collapser
+    id="requestHeadersReferer"
+    title={<InlineCode>request.headers.referer</InlineCode>}
+  >
     The incoming request referer as read from the Referer request header.
 
     Defaults:
@@ -98,7 +116,10 @@ In addition to the [default APM attributes](https://docs.newrelic.com/docs/insig
     * Page views (browser monitoring): Unavailable
   </Collapser>
 
-  <Collapser id="userAgent">
+  <Collapser
+    id="userAgent"
+    title={<InlineCode>request.headers.userAgent</InlineCode>}
+  >
     The contents of the `User-Agent` HTTP header.
 
     Defaults:
@@ -109,7 +130,10 @@ In addition to the [default APM attributes](https://docs.newrelic.com/docs/insig
     * Page views (browser monitoring): Unavailable
   </Collapser>
 
-  <Collapser id="requestMethod">
+  <Collapser
+    id="requestMethod"
+    title={<InlineCode>request.method</InlineCode>}
+  >
     The HTTP method of the incoming request.
 
     Defaults:
@@ -120,7 +144,10 @@ In addition to the [default APM attributes](https://docs.newrelic.com/docs/insig
     * Page views (browser monitoring): Unavailable
   </Collapser>
 
-  <Collapser id="requestParameters">
+  <Collapser
+    id="requestParameters"
+    title={<InlineCode>request.parameters.\*</InlineCode>}
+  >
     Request parameters from the transaction.
 
     <Callout variant="tip">
@@ -135,7 +162,10 @@ In addition to the [default APM attributes](https://docs.newrelic.com/docs/insig
     * Page views (browser monitoring): Unavailable
   </Collapser>
 
-  <Collapser id="request_uri">
+  <Collapser
+    id="request_uri"
+    title={<InlineCode>request.uri</InlineCode>}
+  >
     The request URI from the transaction.
 
     Defaults
@@ -146,7 +176,10 @@ In addition to the [default APM attributes](https://docs.newrelic.com/docs/insig
     * Page views (browser monitoring): Unavailable
   </Collapser>
 
-  <Collapser id="responseheadersContentLength">
+  <Collapser
+    id="responseheadersContentLength"
+    title={<InlineCode>response.headers.contentLength</InlineCode>}
+  >
     The outgoing response size in bytes as read from the Content-Length response header.
 
     Defaults:
@@ -157,7 +190,10 @@ In addition to the [default APM attributes](https://docs.newrelic.com/docs/insig
     * Page views (browser monitoring): Unavailable
   </Collapser>
 
-  <Collapser id="requestHeadersContentType">
+  <Collapser
+    id="requestHeadersContentType"
+    title={<InlineCode>response.headers.contentType</InlineCode>}
+  >
     The outgoing response content-type as read from the Content-Type response header.
 
     Defaults:
@@ -168,7 +204,10 @@ In addition to the [default APM attributes](https://docs.newrelic.com/docs/insig
     * Page views (browser monitoring): Unavailable
   </Collapser>
 
-  <Collapser id="server_name">
+  <Collapser
+    id="server_name"
+    title={<InlineCode>SERVER_NAME</InlineCode>}
+  >
     The name of the server host under which the current script is executing.
 
     Defaults

--- a/src/content/docs/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -246,22 +246,21 @@ These settings are available in the `newrelic.ini` file.
 
     The setting's value is a semicolon-separated list of up to three application names. The first name in the list is the **primary** application name. It [must be unique](/docs/apm/new-relic-apm/installation-configuration/name-your-application#app-name) for each account. The application name is used as a key into a cache. When using [multiple names for an app](/docs/agents/manage-apm-agents/app-naming/use-multiple-names-app), New Relic only uses the first name for caching. Therefore, each application name can only appear as the first element **once**.
 
-    <dt id="cache-example">
-      Caching example
-    </dt>
-
-    <dd>
-      If you set `newrelic.appname="App1;App2"` and later in the code set `newrelic.appname="App1;App3"`, the second one will appear not to work. It will report to **App1** and **App2** because of the caching.
-    </dd>
+    <CollapserGroup>
+      <Collapser
+        id="cache-example"
+        title="Caching example"
+      >
+        If you set `newrelic.appname="App1;App2"` and later in the code set `newrelic.appname="App1;App3"`, the second one will appear not to work. It will report to **App1** and **App2** because of the caching.
+      </Collapser>
+    </CollapserGroup>
 
     If you need [overlapping application names](/docs/agents/manage-apm-agents/app-naming/use-multiple-names-app), set the common application name in the second or third positions. For example: `newrelic.appname="App2;App1"` and `newrelic.appname="App3;App1"`. This is useful, for example, when you want to track a superset of applications.
   </Collapser>
 
   <Collapser
     id="inivar-capture_params"
-    title="newrelic.capture"
-    title="_"
-    title="params"
+    title="newrelic.capture_params"
   >
     <Table>
       <tbody>
@@ -377,9 +376,7 @@ These settings are available in the `newrelic.ini` file.
 
   <Collapser
     id="inivar-ignored_params"
-    title="newrelic.ignored"
-    title="_"
-    title="params"
+    title="newrelic.ignored_params"
   >
     <Table>
       <tbody>
@@ -533,9 +530,7 @@ These settings are available in the `newrelic.ini` file.
 
   <Collapser
     id="inivar-tt-detail"
-    title="newrelic.transaction"
-    title="_"
-    title="tracer.detail"
+    title="newrelic.transaction_tracer.detail"
   >
     <Table>
       <tbody>
@@ -593,9 +588,7 @@ These settings are available in the `newrelic.ini` file.
 
   <Collapser
     id="inivar-high-security"
-    title="newrelic.high"
-    title="_"
-    title="security"
+    title="newrelic.high_security"
   >
     <Table>
       <tbody>
@@ -694,11 +687,7 @@ These settings are available in the `newrelic.ini` file.
 
   <Collapser
     id="inivar-process_host-display_name"
-    title="newrelic.process"
-    title="_"
-    title="host.display"
-    title="_"
-    title="name"
+    title="newrelic.process_host.display_name"
   >
     <Table>
       <tbody>
@@ -753,9 +742,7 @@ For more information about ways to start the daemon and when to use an external 
 <CollapserGroup>
   <Collapser
     id="inivar-daemon-app_timeout"
-    title="newrelic.daemon.app"
-    title="_"
-    title="timeout"
+    title="newrelic.daemon.app_timeout"
   >
     <Table>
       <tbody>
@@ -800,11 +787,7 @@ For more information about ways to start the daemon and when to use an external 
 
   <Collapser
     id="inivar-daemon-app_timeout"
-    title="newrelic.daemon.app"
-    title="_"
-    title="connect"
-    title="_"
-    title="timeout"
+    title="newrelic.daemon.app_connect_timeout"
   >
     <Table>
       <tbody>
@@ -896,9 +879,7 @@ For more information about ways to start the daemon and when to use an external 
 
   <Collapser
     id="inivar-daemon-collector"
-    title="newrelic.daemon.collector"
-    title="_"
-    title="host"
+    title="newrelic.daemon.collector_host"
   >
     <Table>
       <tbody>
@@ -945,9 +926,7 @@ For more information about ways to start the daemon and when to use an external 
 
   <Collapser
     id="inivar-daemon-launch"
-    title="newrelic.daemon.dont"
-    title="_"
-    title="launch"
+    title="newrelic.daemon.dont_launch"
   >
     <Table>
       <tbody>
@@ -1344,11 +1323,7 @@ For more information about ways to start the daemon and when to use an external 
 
   <Collapser
     id="inivar-daemon-ssl-ca-bundle"
-    title="newrelic.daemon.ssl"
-    title="_"
-    title="ca"
-    title="_"
-    title="bundle"
+    title="newrelic.daemon.ssl_ca_bundle"
   >
     <Table>
       <tbody>
@@ -1393,11 +1368,7 @@ For more information about ways to start the daemon and when to use an external 
 
   <Collapser
     id="inivar-daemon-ssl-ca-path"
-    title="newrelic.daemon.ssl"
-    title="_"
-    title="ca"
-    title="_"
-    title="path"
+    title="newrelic.daemon.ssl_ca_path"
   >
     <Table>
       <tbody>
@@ -1442,9 +1413,7 @@ For more information about ways to start the daemon and when to use an external 
 
   <Collapser
     id="inivar-daemon-app_timeout"
-    title="newrelic.daemon.start"
-    title="_"
-    title="timeout"
+    title="newrelic.daemon.start_timeout"
   >
     <Table>
       <tbody>
@@ -1497,9 +1466,7 @@ The values of these settings are used to control transaction traces.
 <CollapserGroup>
   <Collapser
     id="inivar-tt-custom"
-    title="newrelic.transaction"
-    title="_"
-    title="tracer.custom"
+    title="newrelic.transaction_tracer.custom"
   >
     <Table>
       <tbody>
@@ -1548,9 +1515,7 @@ The values of these settings are used to control transaction traces.
 
   <Collapser
     id="inivar-tt-enable"
-    title="newrelic.transaction"
-    title="_"
-    title="tracer.enabled"
+    title="newrelic.transaction_tracer.enabled"
   >
     <Table>
       <tbody>
@@ -1597,11 +1562,7 @@ The values of these settings are used to control transaction traces.
 
   <Collapser
     id="inivar-tt-expenable"
-    title="newrelic.transaction"
-    title="_"
-    title="tracer.explain"
-    title="_"
-    title="enabled"
+    title="newrelic.transaction_tracer.explain_enabled"
   >
     <Table>
       <tbody>
@@ -1642,11 +1603,7 @@ The values of these settings are used to control transaction traces.
 
   <Collapser
     id="inivar-tt-epthreshold"
-    title="newrelic.transaction"
-    title="_"
-    title="tracer.explain"
-    title="_"
-    title="threshold"
+    title="newrelic.transaction_tracer.explain_threshold"
   >
     <Table>
       <tbody>
@@ -1694,13 +1651,7 @@ The values of these settings are used to control transaction traces.
 
   <Collapser
     id="inivar-tt-internalfun"
-    title="newrelic.transaction"
-    title="_"
-    title="tracer.internal"
-    title="_"
-    title="functions"
-    title="_"
-    title="enabled"
+    title="newrelic.transaction_tracer.internal_functions_enabled"
   >
     <Table>
       <tbody>
@@ -1743,11 +1694,7 @@ The values of these settings are used to control transaction traces.
 
   <Collapser
     id="inivar-tt-sql"
-    title="newrelic.transaction"
-    title="_"
-    title="tracer.record"
-    title="_"
-    title="sql"
+    title="newrelic.transaction_tracer.record_sql"
   >
     <Table>
       <tbody>
@@ -1797,11 +1744,7 @@ The values of these settings are used to control transaction traces.
 
   <Collapser
     id="inivar-tt-slowsql"
-    title="newrelic.transaction"
-    title="_"
-    title="tracer.slow"
-    title="_"
-    title="sql"
+    title="newrelic.transaction_tracer.slow_sql"
   >
     <Table>
       <tbody>
@@ -1847,13 +1790,7 @@ The values of these settings are used to control transaction traces.
 
   <Collapser
     id="inivar-tt-stthreshold"
-    title="newrelic.transaction"
-    title="_"
-    title="tracer.stack"
-    title="_"
-    title="trace"
-    title="_"
-    title="threshold"
+    title="newrelic.transaction_tracer.stack_trace_threshold"
   >
     <Table>
       <tbody>
@@ -1905,9 +1842,7 @@ The values of these settings are used to control transaction traces.
 
   <Collapser
     id="inivar-tt-threshold"
-    title="newrelic.transaction"
-    title="_"
-    title="tracer.threshold"
+    title="newrelic.transaction_tracer.threshold"
   >
     <Table>
       <tbody>
@@ -1958,13 +1893,7 @@ The values of these settings are used to control transaction traces.
 
   <Collapser
     id="inivar-tt-gather-input-queries"
-    title="newrelic.transaction"
-    title="_"
-    title="tracer.gather"
-    title="_"
-    title="input"
-    title="_"
-    title="queries"
+    title="newrelic.transaction_tracer.gather_input_queries"
   >
     <Table>
       <tbody>
@@ -2005,13 +1934,7 @@ The values of these settings are used to control transaction traces.
 
   <Collapser
     id="inivar-tt-maxsegweb"
-    title="newrelic.transaction"
-    title="_"
-    title="tracer.max"
-    title="_"
-    title="segments"
-    title="_"
-    title="web"
+    title="newrelic.transaction_tracer.max_segments_web"
   >
     <Table>
       <tbody>
@@ -2060,13 +1983,7 @@ The values of these settings are used to control transaction traces.
 
   <Collapser
     id="inivar-tt-maxsegcli"
-    title="newrelic.transaction"
-    title="_"
-    title="tracer.max"
-    title="_"
-    title="segments"
-    title="_"
-    title="cli"
+    title="newrelic.transaction_tracer.max_segments_cli"
   >
     <Table>
       <tbody>
@@ -2121,11 +2038,7 @@ The values of these settings are used to control various tracer features.
 <CollapserGroup>
   <Collapser
     id="inivar-cross-app-tracer-enabled"
-    title="newrelic.cross"
-    title="_"
-    title="application"
-    title="_"
-    title="tracer.enabled"
+    title="newrelic.cross_application_tracer.enabled"
   >
     <Callout variant="important">
       A [distributed tracing](https://docs.newrelic.com/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) feature is available. Distributed tracing improves on [cross application tracing](/docs/traces/cross-application-traces) and is recommended for monitoring activity in complex distributed systems.
@@ -2172,11 +2085,7 @@ The values of these settings are used to control various tracer features.
 
   <Collapser
     id="inivar-distributed-enabled"
-    title="newrelic.distributed"
-    title="_"
-    title="tracing"
-    title="_"
-    title="enabled"
+    title="newrelic.distributed_tracing_enabled"
   >
     <Table>
       <tbody>
@@ -2226,15 +2135,7 @@ The values of these settings are used to control various tracer features.
 
   <Collapser
     id="inivar-dt-exclude-newrelic"
-    title="newrelic.distributed"
-    title="_"
-    title="tracing"
-    title="_"
-    title="exclude"
-    title="_"
-    title="newrelic"
-    title="_"
-    title="header"
+    title="newrelic.distributed_tracing_exclude_newrelic_header"
   >
     <Table>
       <tbody>
@@ -2277,11 +2178,7 @@ The values of these settings are used to control various tracer features.
 
   <Collapser
     id="inivar-span-enabled"
-    title="newrelic.span"
-    title="_"
-    title="events"
-    title="_"
-    title="enabled"
+    title="newrelic.span_events_enabled"
   >
     <Table>
       <tbody>
@@ -2322,11 +2219,7 @@ The values of these settings are used to control various tracer features.
 
   <Collapser
     id="inivar-inftr-host"
-    title="newrelic.infinite"
-    title="_"
-    title="tracing.trace"
-    title="_"
-    title="observer.host"
+    title="newrelic.infinite_tracing.trace_observer.host"
   >
     <Table>
       <tbody>
@@ -2367,11 +2260,7 @@ The values of these settings are used to control various tracer features.
 
   <Collapser
     id="inivar-inftr-port"
-    title="newrelic.infinite"
-    title="_"
-    title="tracing.trace"
-    title="_"
-    title="observer.port"
+    title="newrelic.infinite_tracing.trace_observer.port"
   >
     <Table>
       <tbody>
@@ -2412,13 +2301,7 @@ The values of these settings are used to control various tracer features.
 
   <Collapser
     id="inivar-inftr-queue"
-    title="newrelic.infinite"
-    title="_"
-    title="tracing.span"
-    title="_"
-    title="events.queue"
-    title="_"
-    title="size"
+    title="newrelic.infinite_tracing.span_events.queue_size"
   >
     <Table>
       <tbody>
@@ -2459,9 +2342,7 @@ The values of these settings are used to control various tracer features.
 
   <Collapser
     id="inivar-err-enabled"
-    title="newrelic.error"
-    title="_"
-    title="collector.enabled"
+    title="newrelic.error_collector.enabled"
   >
     <Table>
       <tbody>
@@ -2508,13 +2389,7 @@ The values of these settings are used to control various tracer features.
 
   <Collapser
     id="inivar-err-db"
-    title="newrelic.error"
-    title="_"
-    title="collector.record"
-    title="_"
-    title="database"
-    title="_"
-    title="errors"
+    title="newrelic.error_collector.record_database_errors"
   >
     <Table>
       <tbody>
@@ -2555,13 +2430,7 @@ The values of these settings are used to control various tracer features.
 
   <Collapser
     id="inivar-err-priority"
-    title="newrelic.error"
-    title="_"
-    title="collector.prioritize"
-    title="_"
-    title="api"
-    title="_"
-    title="errors"
+    title="newrelic.error_collector.prioritize_api_errors"
   >
     <Table>
       <tbody>
@@ -2602,11 +2471,7 @@ The values of these settings are used to control various tracer features.
 
   <Collapser
     id="inivar-err-ignore-exceptions"
-    title="newrelic.error"
-    title="_"
-    title="collector.ignore"
-    title="_"
-    title="exceptions"
+    title="newrelic.error_collector.ignore_exceptions"
   >
     <Table>
       <tbody>
@@ -2652,11 +2517,7 @@ The values of these settings are used to control various tracer features.
 
   <Collapser
     id="inivar-err-ignore-errors"
-    title="newrelic.error"
-    title="_"
-    title="collector.ignore"
-    title="_"
-    title="errors"
+    title="newrelic.error_collector.ignore_errors"
   >
     <Table>
       <tbody>
@@ -2897,11 +2758,7 @@ The values of these settings are used to control various tracer features.
 
   <Collapser
     id="inivar-wt-remove-path"
-    title="newrelic.webtransaction.name.remove"
-    title="_"
-    title="trailing"
-    title="_"
-    title="path"
+    title="newrelic.webtransaction.name.remove_trailing_path"
   >
     <Table>
       <tbody>
@@ -2942,11 +2799,7 @@ The values of these settings are used to control various tracer features.
 
   <Collapser
     id="ini-var-dt-instance-reporting"
-    title="newrelic.datastore"
-    title="_"
-    title="tracer.instance"
-    title="_"
-    title="reporting.enabled"
+    title="newrelic.datastore_tracer.instance_reporting.enabled"
   >
     <Table>
       <tbody>
@@ -2987,13 +2840,7 @@ The values of these settings are used to control various tracer features.
 
   <Collapser
     id="ini-var-dt-database-name-reporting"
-    title="newrelic.datastore"
-    title="_"
-    title="tracer.database"
-    title="_"
-    title="name"
-    title="_"
-    title="reporting.enabled"
+    title="newrelic.datastore_tracer.database_name_reporting.enabled"
   >
     <Table>
       <tbody>
@@ -3083,9 +2930,7 @@ This section lists the settings that affect attribute collection and reporting.
 
   <Collapser
     id="inivar-attributes-enabled"
-    title="newrelic."
-    title="{"
-    title="destination}.attributes.enabled"
+    title="newrelic.{destination}.attributes.enabled"
   >
     <Table>
       <tbody>
@@ -3128,9 +2973,7 @@ This section lists the settings that affect attribute collection and reporting.
 
   <Collapser
     id="inivar-attributes-include-exclude"
-    title="newrelic.attributes."
-    title="{"
-    title="include|exclude}"
+    title="newrelic.attributes.{include|exclude}"
   >
     <Table>
       <tbody>
@@ -3275,9 +3118,7 @@ This section lists the remaining newrelic.ini settings.
 
   <Collapser
     id="inivar-analytics-events"
-    title="newrelic.transaction"
-    title="_"
-    title="events.enabled"
+    title="newrelic.transaction_events.enabled"
   >
     <Table>
       <tbody>
@@ -3318,11 +3159,7 @@ This section lists the remaining newrelic.ini settings.
 
   <Collapser
     id="inivar-error-events"
-    title="newrelic.error"
-    title="_"
-    title="collector.capture"
-    title="_"
-    title="events"
+    title="newrelic.error_collector.capture_events"
   >
     <Table>
       <tbody>
@@ -3363,9 +3200,7 @@ This section lists the remaining newrelic.ini settings.
 
   <Collapser
     id="inivar-feature-flag"
-    title="newrelic.feature"
-    title="_"
-    title="flag"
+    title="newrelic.feature_flag"
   >
     <Table>
       <tbody>
@@ -3406,11 +3241,7 @@ This section lists the remaining newrelic.ini settings.
 
   <Collapser
     id="inivar-autorum"
-    title="newrelic.browser"
-    title="_"
-    title="monitoring.auto"
-    title="_"
-    title="instrument"
+    title="newrelic.browser_monitoring.auto_instrument"
   >
     <Table>
       <tbody>
@@ -3494,13 +3325,7 @@ This section lists the remaining newrelic.ini settings.
 
   <Collapser
     id="inivar-autorum"
-    title="newrelic.preload"
-    title="_"
-    title="framework"
-    title="_"
-    title="library"
-    title="_"
-    title="detection"
+    title="newrelic.preload_framework_library_detection"
   >
     <Table>
       <tbody>

--- a/src/content/docs/agents/php-agent/configuration/php-directory-ini-settings.mdx
+++ b/src/content/docs/agents/php-agent/configuration/php-directory-ini-settings.mdx
@@ -32,8 +32,7 @@ When using the PHP module, Apache provides two mechanisms for setting PHP variab
 <CollapserGroup>
   <Collapser
     id="ini-apache"
-    title="Edit the "
-    title=" file or one of the files it includes."
+    title={<>Edit the <InlineCode>httpd.conf</InlineCode> file or one of the files it includes.</>}
   >
     Use the syntax from the INI file examples when your web server serves up multiple domains. To view each of these domains separately in New Relic:
 
@@ -61,35 +60,36 @@ When using the PHP module, Apache provides two mechanisms for setting PHP variab
       ?>
       ```
 
-    <dt id="separating-domains">
-      Setting appname by domain
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="separating-domains"
+        title="Setting appname by domain"
+      >
+        Here is an example of separating domains, where PHP_MODULE is the name of your PHP5 module.
 
-    <dd>
-      Here is an example of separating domains, where PHP_MODULE is the name of your PHP5 module.
+        ```
+        <VirtualHost 192.168.42.43>
+          ServerName www.myvhost1.com
+          DocumentRoot "/path/to/vhost1/"
+          ...
+          <IfModule PHP_MODULE>
+            php_value newrelic.appname "Virtual Host 1"
+          </IfModule>
+        </VirtualHost>
 
-      ```
-      <VirtualHost 192.168.42.43>
-        ServerName www.myvhost1.com
-        DocumentRoot "/path/to/vhost1/"
-        ...
-        <IfModule PHP_MODULE>
-          php_value newrelic.appname "Virtual Host 1"
-        </IfModule>
-      </VirtualHost>
+        <VirtualHost 192.168.123.45>
+          ServerName www.myvhost2.com
+          DocumentRoot "/path/to/vhost2/"
+          ...
+          <IfModule PHP_MODULE>
+            php_value newrelic.appname "Virtual Host 2"
+          </IfModule>
+        </VirtualHost>
+        ```
 
-      <VirtualHost 192.168.123.45>
-        ServerName www.myvhost2.com
-        DocumentRoot "/path/to/vhost2/"
-        ...
-        <IfModule PHP_MODULE>
-          php_value newrelic.appname "Virtual Host 2"
-        </IfModule>
-      </VirtualHost>
-      ```
-
-      In the above example, `newrelic.appname` is set to a different value for each virtual host.
-    </dd>
+        In the above example, `newrelic.appname` is set to a different value for each virtual host.
+      </Collapser>
+    </CollapserGroup>
 
     For string and number values, use `php_value name VALUE`, where:
 
@@ -116,8 +116,7 @@ When using the PHP module, Apache provides two mechanisms for setting PHP variab
 
   <Collapser
     id="htaccess-apache"
-    title="Edit the "
-    title=" file."
+    title={<>Edit the <InlineCode>.htaccess</InlineCode> file.</>}
   >
     Use the syntax from the INI file examples inside an `.htaccess` file. For example:
 
@@ -158,9 +157,7 @@ When using PHP-FPM, there are two mechanisms for setting PHP variables outside t
 <CollapserGroup>
   <Collapser
     id="perdir-fpm"
-    title="Edit the "
-    title="PHP-FPM pool"
-    title=" per-directory settings"
+    title={<>Edit the <strong>PHP-FPM pool</strong> per-directory settings</>}
   >
     <Callout variant="important">
       Changing variables on a per-directory basis can be more difficult if you use **PHP-FPM**. You must use multiple PHP-FPM pools, one for each virtual host or unique application.
@@ -197,8 +194,7 @@ When using PHP-FPM, there are two mechanisms for setting PHP variables outside t
 
   <Collapser
     id="PHP-FPm_user_ini"
-    title="Create a "
-    title=" file."
+    title={<>Create a <InlineCode>.user.ini</InlineCode> file.</>}
   >
     You can use the syntax from the INI file example for CGI/FastCGI in a `.user.ini` file. This is similar to a `.htaccess` file for Apache but is unique to PHP-FPM. The directory that PHP is executed in is scanned for a `.user.ini` file. More information about this feature is available in the [PHP `user.ini` files documentation](http://php.net/manual/en/configuration.file.per-user.php).
 
@@ -221,9 +217,7 @@ When using PHP-FPM, there are two mechanisms for setting PHP variables outside t
 
   <Collapser
     id="PHP-FPM_nginix"
-    title="Edit the "
-    title="NGINX config file"
-    title="."
+    title={<>Edit the <strong>NGINX config file</strong>.</>}
   >
     <Callout variant="important">
       This section applies only to PHP 5.3.3 or higher.

--- a/src/content/docs/agents/php-agent/configuration/proxy-daemon-newreliccfg-settings.mdx
+++ b/src/content/docs/agents/php-agent/configuration/proxy-daemon-newreliccfg-settings.mdx
@@ -26,7 +26,10 @@ A sample daemon configuration file was created during installation. To manually 
 </Callout>
 
 <CollapserGroup>
-  <Collapser id="cfgvar-logfile">
+  <Collapser
+    id="cfgvar-logfile"
+    title={<InlineCode>logfile</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -46,7 +49,10 @@ A sample daemon configuration file was created during installation. To manually 
     Can be set on the command line by the daemon `-l` option. Setting this value on the command line will override the value set in `newrelic.cfg` Although the daemon itself provides no default name for the log file, the daemon startup scripts use the **-l** option to set the default location and name to `/var/log/newrelic/newrelic-daemon.log`.
   </Collapser>
 
-  <Collapser id="cfgvar-loglevel">
+  <Collapser
+    id="cfgvar-loglevel"
+    title={<InlineCode>loglevel</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -73,7 +79,10 @@ A sample daemon configuration file was created during installation. To manually 
     Can be set on the command line using the daemon `--loglevel` option. Setting this value on the command line will override the value set in `newrelic.cfg`
   </Collapser>
 
-  <Collapser id="cfgvar-ssl">
+  <Collapser
+    id="cfgvar-ssl"
+    title={<InlineCode>ssl</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -95,7 +104,10 @@ A sample daemon configuration file was created during installation. To manually 
     Can be enabled or disabled on the command line by the daemon `--tls` option. Setting this value on the command line will override the value set in `newrelic.cfg`
   </Collapser>
 
-  <Collapser id="cfgvar-ssl-ca-bundle">
+  <Collapser
+    id="cfgvar-ssl-ca-bundle"
+    title={<InlineCode>ssl_ca_bundle</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -117,7 +129,10 @@ A sample daemon configuration file was created during installation. To manually 
     This setting has no effect when [`ssl`](#cfgvar-ssl) is set to `false`.
   </Collapser>
 
-  <Collapser id="cfgvar-ssl-ca-path">
+  <Collapser
+    id="cfgvar-ssl-ca-path"
+    title={<InlineCode>ssl_ca_path</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -139,7 +154,10 @@ A sample daemon configuration file was created during installation. To manually 
     This setting has no effect when [`ssl`](#cfgvar-ssl) is set to `false`.
   </Collapser>
 
-  <Collapser id="cfgvar-proxy">
+  <Collapser
+    id="cfgvar-proxy"
+    title={<InlineCode>proxy</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -165,8 +183,7 @@ A sample daemon configuration file was created during installation. To manually 
 
   <Collapser
     id="cfgvar-port"
-    title=" (alias for "
-    title=")"
+    title={<><InlineCode>address</InlineCode> (alias for <InlineCode>port</InlineCode>)</>}
   >
     <Table>
       <tbody>
@@ -192,7 +209,10 @@ A sample daemon configuration file was created during installation. To manually 
     These options may also be set via the command line using the daemon `--address` option. Setting this value on the command line will override the value set in `newrelic.cfg`.
   </Collapser>
 
-  <Collapser id="cfgvar-pidfile">
+  <Collapser
+    id="cfgvar-pidfile"
+    title={<InlineCode>pidfile</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>
@@ -214,7 +234,10 @@ A sample daemon configuration file was created during installation. To manually 
     Can be set on the command line using the daemon `--pidfile` option. Setting this value on the command line will override the value set in `newrelic.cfg`
   </Collapser>
 
-  <Collapser id="cfgvar-auditlog">
+  <Collapser
+    id="cfgvar-auditlog"
+    title={<InlineCode>auditlog</InlineCode>}
+  >
     <Table>
       <tbody>
         <tr>

--- a/src/content/docs/agents/php-agent/features/browser-monitoring-php-agent.mdx
+++ b/src/content/docs/agents/php-agent/features/browser-monitoring-php-agent.mdx
@@ -48,66 +48,66 @@ The [manual instrumentation examples](#manual_examples) show how to add instrume
 
 Here are some basic examples.
 
-<dt id="manual_wp">
-  WordPress
-</dt>
+<CollapserGroup>
+  <Collapser
+    id="manual_wp"
+    title="WordPress"
+  >
+    This example shows how to call the PHP agent API to generate headers and footers for a WordPress installation using the default `twentyten` theme.
 
-<dd>
-  This example shows how to call the PHP agent API to generate headers and footers for a WordPress installation using the default `twentyten` theme.
+    1. Insert a call to generate the JavaScript header in `website home dir/wordpress/wp-content/themes/twentyten/header.php`.
 
-  1. Insert a call to generate the JavaScript header in `website home dir/wordpress/wp-content/themes/twentyten/header.php`.
+       ```
+       <body <?php body_class(); ?>>
+       <div id="wrapper" class="hfeed">
+         <div id="header">
+           <?php if( extension_loaded('newrelic') ) { echo newrelic_get_browser_timing_header(); } ?>
+           <div id="masthead">
+           ...
+       ```
+    2. Insert a call to generate the end user monitoring footer in `website home dir/wordpress/wp-content/themes/twentyten/footer.php`.
 
-     ```
-     <body <?php body_class(); ?>>
-     <div id="wrapper" class="hfeed">
-       <div id="header">
-         <?php if( extension_loaded('newrelic') ) { echo newrelic_get_browser_timing_header(); } ?>
-         <div id="masthead">
-         ...
-     ```
-  2. Insert a call to generate the end user monitoring footer in `website home dir/wordpress/wp-content/themes/twentyten/footer.php`.
+       ```
+       ...
+           </div><!-- #site-generator -->
+         </div><!-- #colophon -->
+         <?php if( extension_loaded('newrelic') ) { echo newrelic_get_browser_timing_footer(); } ?>
+       </div><!-- #footer -->
+       ```
+  </Collapser>
 
-     ```
-     ...
-         </div><!-- #site-generator -->
-       </div><!-- #colophon -->
+  <Collapser
+    id="manual_drupal"
+    title="Drupal"
+  >
+    This example shows how to call the PHP agent API to generate headers and footers for a Drupal installation using the default `garland` theme.
+
+    1. Insert a call to generate the JavaScript header right after the opening header tag in `website home dir/drupal/themes/garland/page.tpl.php`.
+
+       ```
+       <div id="container" class="clear-block">
+         <div id="header">
+           <?php if( extension_loaded('newrelic') ) { echo newrelic_get_browser_timing_header(); } ?>
+           <div id="logo-floater">
+           ...
+       ```
+    2. Insert a call to generate the footer right before the last closing layout tag:
+
+       ```
+       ...
+       </div>
        <?php if( extension_loaded('newrelic') ) { echo newrelic_get_browser_timing_footer(); } ?>
-     </div><!-- #footer -->
-     ```
-</dd>
+       <!-- /layout -->
+         <?php print $closure ?>
+         </body>
+       </html>
+       ```
 
-<dt id="manual_drupal">
-  Drupal
-</dt>
-
-<dd>
-  This example shows how to call the PHP agent API to generate headers and footers for a Drupal installation using the default `garland` theme.
-
-  1. Insert a call to generate the JavaScript header right after the opening header tag in `website home dir/drupal/themes/garland/page.tpl.php`.
-
-     ```
-     <div id="container" class="clear-block">
-       <div id="header">
-         <?php if( extension_loaded('newrelic') ) { echo newrelic_get_browser_timing_header(); } ?>
-         <div id="logo-floater">
-         ...
-     ```
-  2. Insert a call to generate the footer right before the last closing layout tag:
-
-     ```
-     ...
-     </div>
-     <?php if( extension_loaded('newrelic') ) { echo newrelic_get_browser_timing_footer(); } ?>
-     <!-- /layout -->
-       <?php print $closure ?>
-       </body>
-     </html>
-     ```
-
-  <Callout variant="important">
-    In Drupal 7.15, **Compress cached pages** is turned on by default. If you also select **Cache pages for anonymous users**, the JavaScript (newrelic.js) is not inserted into the served pages for anonymous users. This is because Drupal's pages are compressed directly from the database before they are stored in the cache (with gzip), so New Relic's PHP agent does not have a chance to parse any HTML. In this situation, manual instrumentation provides a better opportunity to capture data for anonymous users.
-  </Callout>
-</dd>
+    <Callout variant="important">
+      In Drupal 7.15, **Compress cached pages** is turned on by default. If you also select **Cache pages for anonymous users**, the JavaScript (newrelic.js) is not inserted into the served pages for anonymous users. This is because Drupal's pages are compressed directly from the database before they are stored in the cache (with gzip), so New Relic's PHP agent does not have a chance to parse any HTML. In this situation, manual instrumentation provides a better opportunity to capture data for anonymous users.
+    </Callout>
+  </Collapser>
+</CollapserGroup>
 
 ## View Browser data
 

--- a/src/content/docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos.mdx
+++ b/src/content/docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos.mdx
@@ -27,8 +27,7 @@ Follow this procedure to install New Relic's PHP agent using AWS Linux 2, RedHat
    <CollapserGroup>
      <Collapser
        id="tell-rpm"
-       title="Tell the package manager ("
-       title=") about the New Relic repository"
+       title={<>Tell the package manager (<InlineCode>rpm</InlineCode>) about the New Relic repository</>}
      >
        For **32-bit** systems, run:
 

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_notice_error.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_notice_error.mdx
@@ -57,7 +57,10 @@ newrelic_notice_error(Throwable|Exception $e)
 To use your own handler, use these calls to make sure that the PHP agent notices the errors and exceptions from within your handler.
 
 <CollapserGroup>
-  <Collapser id="set-exception-handler">
+  <Collapser
+    id="set-exception-handler"
+    title={<InlineCode>set_exception_handler()</InlineCode>}
+  >
     To [provide `newrelic_notice_error` as the callback](#custom-exception-handler) for [`set_exception_handler()`](https://secure.php.net/manual/en/function.set-exception-handler.php), use the following:
 
     ```
@@ -65,7 +68,10 @@ To use your own handler, use these calls to make sure that the PHP agent notices
     ```
   </Collapser>
 
-  <Collapser id="set-error-handler">
+  <Collapser
+    id="set-error-handler"
+    title={<InlineCode>set_error_handler()</InlineCode>}
+  >
     To [provide `newrelic_notice_error` as the callback](#custom-error-handler-5) for [`set_error_handler()`](https://secure.php.net/set_error_handler), use the following:
 
     ```

--- a/src/content/docs/agents/python-agent/back-end-services/python-agent-celery.mdx
+++ b/src/content/docs/agents/python-agent/back-end-services/python-agent-celery.mdx
@@ -86,29 +86,30 @@ The `app_name` setting in the Python agent configuration file sets the app name 
 
 By [setting multiple app names in the agent config files](/docs/agents/manage-apm-agents/app-naming/use-multiple-names-app), you can monitor both the combined data and the segregated data. Here's a common way to do this, using a Django application as an example:
 
-<dt id="multiple-app-names">
-  Using multiple application names
-</dt>
+<CollapserGroup>
+  <Collapser
+    id="multiple-app-names"
+    title="Using multiple application names"
+  >
+    For the agent monitoring the Django app, set the following:
 
-<dd>
-  For the agent monitoring the Django app, set the following:
+    ```
+    app_name = Your_app_name (Django); Your_app_name (Combined)
+    ```
 
-  ```
-  app_name = Your_app_name (Django); Your_app_name (Combined)
-  ```
+    For the agent monitoring Celery, set the following:
 
-  For the agent monitoring Celery, set the following:
+    ```
+    app_name = Your_app_name (Celery); Your_app_name (Combined)
+    ```
 
-  ```
-  app_name = Your_app_name (Celery); Your_app_name (Combined)
-  ```
+    This results in three displayed names in the UI:
 
-  This results in three displayed names in the UI:
-
-  * `Your_app_name (Combined)`, which combines data from both Celery and the Django application
-  * `Your_app_name (Django)`, which shows the Django app data
-  * `Your_app_name (Celery)`, which shows the Celery data
-</dd>
+    * `Your_app_name (Combined)`, which combines data from both Celery and the Django application
+    * `Your_app_name (Django)`, which shows the Django app data
+    * `Your_app_name (Celery)`, which shows the Celery data
+  </Collapser>
+</CollapserGroup>
 
 ## Ignore task retry errors
 

--- a/src/content/docs/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -306,66 +306,49 @@ Here are detailed descriptions of each configuration method:
 
     Set these values with the strings `on`, `off`, `true`, `false`, `1` and `0`. If set from a configuration mechanism implemented using Python code, Python objects evaluating to True or False will also be accepted.
 
-    <dt id="example-apache-mod-wsgi">
-      Example: Apache/mod_wsgi app name
-    </dt>
-
-    <dd>
-      In the Apache/mod_wsgi server, you can use the `SetEnv` directive to override config settings (optionally inside a `Location` or `Directory` block). For example, you could override the [app name](#app_name) for a complete virtual host, or for a subset of URLs handled by the WSGI application for that virtual host.
-    </dd>
+    <CollapserGroup>
+      <Collapser
+        id="example-apache-mod-wsgi"
+        title="Example: Apache/mod_wsgi app name"
+      >
+        In the Apache/mod_wsgi server, you can use the `SetEnv` directive to override config settings (optionally inside a `Location` or `Directory` block). For example, you could override the [app name](#app_name) for a complete virtual host, or for a subset of URLs handled by the WSGI application for that virtual host.
+      </Collapser>
+    </CollapserGroup>
 
     In addition to being able to override certain agent configuration settings, you can set other per-request configuration settings with their WSGI environment key:
 
     <CollapserGroup>
       <Collapser
         id="set_background_task"
-        title="newrelic.set"
-        title="_"
-        title="background"
-        title="_"
-        title="task"
+        title="newrelic.set_background_task"
       >
         If set to `true`, this web transaction will instead be reported as a [non-web transaction](/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions).
       </Collapser>
 
       <Collapser
         id="ignore_transaction"
-        title="newrelic.ignore"
-        title="_"
-        title="transaction"
+        title="newrelic.ignore_transaction"
       >
         If set to `true`, this web transaction will not be reported.
       </Collapser>
 
       <Collapser
         id="suppress_apdex_metric"
-        title="newrelic.suppress"
-        title="_"
-        title="apdex"
-        title="_"
-        title="metric"
+        title="newrelic.suppress_apdex_metric"
       >
         If set to `true`, no Apdex metric will be generated for this web transaction.
       </Collapser>
 
       <Collapser
         id="suppress_transaction_trace"
-        title="newrelic.suppress"
-        title="_"
-        title="transaction"
-        title="_"
-        title="trace"
+        title="newrelic.suppress_transaction_trace"
       >
         If set to `true`, this web transaction cannot be recorded in a [transaction trace](/docs/apm/transactions/transaction-traces/transaction-traces).
       </Collapser>
 
       <Collapser
         id="disable_browser_autorum"
-        title="newrelic.disable"
-        title="_"
-        title="browser"
-        title="_"
-        title="autorum"
+        title="newrelic.disable_browser_autorum"
       >
         If set to `true`, this disables automatic insertion of the JavaScript header/footer for page load timing (sometimes referred to as real user monitoring or RUM). Only applicable if auto-insertion is [available for your web framework](/docs/agents/python-agent/supported-features/page-load-timing-python#restrictions_on_instrumentation).
       </Collapser>
@@ -413,9 +396,7 @@ These settings are available in the agent configuration file.
 <CollapserGroup>
   <Collapser
     id="license_key"
-    title="license"
-    title="_"
-    title="key (REQUIRED)"
+    title="license_key (REQUIRED)"
   >
     <Table>
       <tbody>
@@ -466,9 +447,7 @@ These settings are available in the agent configuration file.
 
   <Collapser
     id="app_name"
-    title="app"
-    title="_"
-    title="name (HIGHLY RECOMMENDED)"
+    title="app_name (HIGHLY RECOMMENDED)"
   >
     <Table>
       <tbody>
@@ -529,9 +508,7 @@ These settings are available in the agent configuration file.
 
   <Collapser
     id="monitor_mode"
-    title="monitor"
-    title="_"
-    title="mode"
+    title="monitor_mode"
   >
     <Table>
       <tbody>
@@ -582,9 +559,7 @@ These settings are available in the agent configuration file.
 
   <Collapser
     id="developer_mode"
-    title="developer"
-    title="_"
-    title="mode"
+    title="developer_mode"
   >
     <Table>
       <tbody>
@@ -637,9 +612,7 @@ These settings are available in the agent configuration file.
 
   <Collapser
     id="log_file"
-    title="log"
-    title="_"
-    title="file"
+    title="log_file"
   >
     <Table>
       <tbody>
@@ -696,9 +669,7 @@ These settings are available in the agent configuration file.
 
   <Collapser
     id="log_level"
-    title="log"
-    title="_"
-    title="level"
+    title="log_level"
   >
     <Table>
       <tbody>
@@ -751,9 +722,7 @@ These settings are available in the agent configuration file.
 
   <Collapser
     id="high_security"
-    title="high"
-    title="_"
-    title="security"
+    title="high_security"
   >
     <Table>
       <tbody>
@@ -806,17 +775,7 @@ These settings are available in the agent configuration file.
 
   <Collapser
     id="proxy"
-    title="proxy"
-    title="_"
-    title="scheme, proxy"
-    title="_"
-    title="host, proxy"
-    title="_"
-    title="port, proxy"
-    title="_"
-    title="user, proxy"
-    title="_"
-    title="pass"
+    title="proxy_scheme, proxy_host, proxy_port, proxy_user, proxy_pass"
   >
     <Table>
       <tbody>
@@ -883,11 +842,7 @@ These settings are available in the agent configuration file.
 
   <Collapser
     id="audit-log-file"
-    title="audit"
-    title="_"
-    title="log"
-    title="_"
-    title="file"
+    title="audit_log_file"
   >
     <Table>
       <tbody>
@@ -992,24 +947,21 @@ These settings are available in the agent configuration file.
 
     Attach [labels](/docs/apm/new-relic-apm/maintenance/labels-categories-organize-your-apps-servers) to this app. Specify name:value separated by a colon `:`, and separate additional labels with semicolons `;`.
 
-    <dt id="example-2-labels">
-      Two labels
-    </dt>
-
-    <dd>
-      ```
-      Server:One;Data Center:Primary
-      ```
-    </dd>
+    <CollapserGroup>
+      <Collapser
+        id="example-2-labels"
+        title="Two labels"
+      >
+        ```
+        Server:One;Data Center:Primary
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     id="process_host-display_name"
-    title="process"
-    title="_"
-    title="host.display"
-    title="_"
-    title="name"
+    title="process_host.display_name"
   >
     <Table>
       <tbody>
@@ -1060,9 +1012,7 @@ These settings are available in the agent configuration file.
 
   <Collapser
     id="api-key"
-    title="api"
-    title="_"
-    title="key"
+    title="api_key"
   >
     <Table>
       <tbody>
@@ -1113,11 +1063,7 @@ These settings are available in the agent configuration file.
 
   <Collapser
     id="ca-bundle-path"
-    title="ca"
-    title="_"
-    title="bundle"
-    title="_"
-    title="path"
+    title="ca_bundle_path"
   >
     <Table>
       <tbody>
@@ -1325,9 +1271,7 @@ For more information about transaction traces, see [Transaction traces](/docs/tr
 <CollapserGroup>
   <Collapser
     id="txn-tracer-enabled"
-    title="transaction"
-    title="_"
-    title="tracer.enabled"
+    title="transaction_tracer.enabled"
   >
     <Table>
       <tbody>
@@ -1378,11 +1322,7 @@ For more information about transaction traces, see [Transaction traces](/docs/tr
 
   <Collapser
     id="txn-tracer-threshold"
-    title="transaction"
-    title="_"
-    title="tracer.transaction"
-    title="_"
-    title="threshold"
+    title="transaction_tracer.transaction_threshold"
   >
     <Table>
       <tbody>
@@ -1433,11 +1373,7 @@ For more information about transaction traces, see [Transaction traces](/docs/tr
 
   <Collapser
     id="txn-tracer-sql"
-    title="transaction"
-    title="_"
-    title="tracer.record"
-    title="_"
-    title="sql"
+    title="transaction_tracer.record_sql"
   >
     <Table>
       <tbody>
@@ -1490,13 +1426,7 @@ For more information about transaction traces, see [Transaction traces](/docs/tr
 
   <Collapser
     id="txn-tracer-stack"
-    title="transaction"
-    title="_"
-    title="tracer.stack"
-    title="_"
-    title="trace"
-    title="_"
-    title="threshold"
+    title="transaction_tracer.stack_trace_threshold"
   >
     <Table>
       <tbody>
@@ -1547,11 +1477,7 @@ For more information about transaction traces, see [Transaction traces](/docs/tr
 
   <Collapser
     id="txn-tracer-explain"
-    title="transaction"
-    title="_"
-    title="tracer.explain"
-    title="_"
-    title="enabled"
+    title="transaction_tracer.explain_enabled"
   >
     <Table>
       <tbody>
@@ -1602,11 +1528,7 @@ For more information about transaction traces, see [Transaction traces](/docs/tr
 
   <Collapser
     id="txn-tracer-explain-threshold"
-    title="transaction"
-    title="_"
-    title="tracer.explain"
-    title="_"
-    title="threshold"
+    title="transaction_tracer.explain_threshold"
   >
     <Table>
       <tbody>
@@ -1657,9 +1579,7 @@ For more information about transaction traces, see [Transaction traces](/docs/tr
 
   <Collapser
     id="cfg-tt-attributes-enabled"
-    title="transaction"
-    title="_"
-    title="tracer.attributes.enabled"
+    title="transaction_tracer.attributes.enabled"
   >
     <Table>
       <tbody>
@@ -1700,9 +1620,7 @@ For more information about transaction traces, see [Transaction traces](/docs/tr
 
   <Collapser
     id="cfg-tt-attributes-include"
-    title="transaction"
-    title="_"
-    title="tracer.attributes.include"
+    title="transaction_tracer.attributes.include"
   >
     <Table>
       <tbody>
@@ -1743,9 +1661,7 @@ For more information about transaction traces, see [Transaction traces](/docs/tr
 
   <Collapser
     id="cfg-tt-attributes-exclude"
-    title="transaction"
-    title="_"
-    title="tracer.attributes.exclude"
+    title="transaction_tracer.attributes.exclude"
   >
     <Table>
       <tbody>
@@ -1786,11 +1702,7 @@ For more information about transaction traces, see [Transaction traces](/docs/tr
 
   <Collapser
     id="txn-tracer-function"
-    title="transaction"
-    title="_"
-    title="tracer.function"
-    title="_"
-    title="trace"
+    title="transaction_tracer.function_trace"
   >
     <Table>
       <tbody>
@@ -1837,9 +1749,7 @@ Here are Transaction segment settings available via the agent configuration file
 <CollapserGroup>
   <Collapser
     id="cfg-tt-attributes-enabled"
-    title="transaction"
-    title="_"
-    title="segments.attributes.enabled"
+    title="transaction_segments.attributes.enabled"
   >
     <Table>
       <tbody>
@@ -1880,9 +1790,7 @@ Here are Transaction segment settings available via the agent configuration file
 
   <Collapser
     id="cfg-tt-attributes-include"
-    title="transaction"
-    title="_"
-    title="segments.attributes.include"
+    title="transaction_segments.attributes.include"
   >
     <Table>
       <tbody>
@@ -1923,9 +1831,7 @@ Here are Transaction segment settings available via the agent configuration file
 
   <Collapser
     id="cfg-tt-attributes-exclude"
-    title="transaction"
-    title="_"
-    title="segments.attributes.exclude"
+    title="transaction_segments.attributes.exclude"
   >
     <Table>
       <tbody>
@@ -1976,9 +1882,7 @@ Here are error collector settings available via the agent configuration file.
 <CollapserGroup>
   <Collapser
     id="error-enabled"
-    title="error"
-    title="_"
-    title="collector.enabled"
+    title="error_collector.enabled"
   >
     <Table>
       <tbody>
@@ -2029,11 +1933,7 @@ Here are error collector settings available via the agent configuration file.
 
   <Collapser
     id="error-ignore"
-    title="error"
-    title="_"
-    title="collector.ignore"
-    title="_"
-    title="errors"
+    title="error_collector.ignore_errors"
   >
     <Table>
       <tbody>
@@ -2084,13 +1984,7 @@ Here are error collector settings available via the agent configuration file.
 
   <Collapser
     id="error-ignore-status-codes"
-    title="error"
-    title="_"
-    title="collector.ignore"
-    title="_"
-    title="status"
-    title="_"
-    title="codes"
+    title="error_collector.ignore_status_codes"
   >
     <Table>
       <tbody>
@@ -2133,9 +2027,7 @@ Here are error collector settings available via the agent configuration file.
 
   <Collapser
     id="cfg-error-attributes-enabled"
-    title="error"
-    title="_"
-    title="collector.attributes.enabled"
+    title="error_collector.attributes.enabled"
   >
     <Table>
       <tbody>
@@ -2176,9 +2068,7 @@ Here are error collector settings available via the agent configuration file.
 
   <Collapser
     id="cfg-ec-attributes-include"
-    title="error"
-    title="_"
-    title="collector.attributes.include"
+    title="error_collector.attributes.include"
   >
     <Table>
       <tbody>
@@ -2219,9 +2109,7 @@ Here are error collector settings available via the agent configuration file.
 
   <Collapser
     id="cfg-ec-attributes-exclude"
-    title="error"
-    title="_"
-    title="collector.attributes.exclude"
+    title="error_collector.attributes.exclude"
   >
     <Table>
       <tbody>
@@ -2262,11 +2150,7 @@ Here are error collector settings available via the agent configuration file.
 
   <Collapser
     id="cfg-ec-capture-events"
-    title="error"
-    title="_"
-    title="collector.capture"
-    title="_"
-    title="events"
+    title="error_collector.capture_events"
   >
     <Table>
       <tbody>
@@ -2313,9 +2197,7 @@ Here are browser monitoring settings available via the agent configuration file.
 <CollapserGroup>
   <Collapser
     id="browser-enabled"
-    title="browser"
-    title="_"
-    title="monitoring.enabled"
+    title="browser_monitoring.enabled"
   >
     <Table>
       <tbody>
@@ -2360,11 +2242,7 @@ Here are browser monitoring settings available via the agent configuration file.
 
   <Collapser
     id="browser-auto"
-    title="browser"
-    title="_"
-    title="monitoring.auto"
-    title="_"
-    title="instrument"
+    title="browser_monitoring.auto_instrument"
   >
     <Table>
       <tbody>
@@ -2405,11 +2283,7 @@ Here are browser monitoring settings available via the agent configuration file.
 
   <Collapser
     id="browser-content-type"
-    title="browser"
-    title="_"
-    title="monitoring.content"
-    title="_"
-    title="type"
+    title="browser_monitoring.content_type"
   >
     <Table>
       <tbody>
@@ -2447,28 +2321,27 @@ Here are browser monitoring settings available via the agent configuration file.
 
     Specify the HTML `Content-Type`(s) that our browser monitoring agent should auto-instrument. Add additional entries in a space-separated list.
 
-    <dt id="example-instrument-xhtml-xml">
-      Instrument xhtml+xml page responses
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="example-instrument-xhtml-xml"
+        title="Instrument xhtml+xml page responses"
+      >
+        If you are generating HTML page responses and using the `Content-Type` of `application/xhtml+xml`, you can override the allowed content types to list both this content type and the default `text/html` by using:
 
-    <dd>
-      If you are generating HTML page responses and using the `Content-Type` of `application/xhtml+xml`, you can override the allowed content types to list both this content type and the default `text/html` by using:
+        ```
+        browser_monitoring.content_type = text/html application/xhtml+xml
+        ```
 
-      ```
-      browser_monitoring.content_type = text/html application/xhtml+xml
-      ```
-
-      <Callout variant="important">
-        The browser monitoring JavaScript snippet prevents the page from validating as `application/xhtml+xml`, although the page should load and render in end-user browsers.
-      </Callout>
-    </dd>
+        <Callout variant="important">
+          The browser monitoring JavaScript snippet prevents the page from validating as `application/xhtml+xml`, although the page should load and render in end-user browsers.
+        </Callout>
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     id="cfg-browser-attributes-enabled"
-    title="browser"
-    title="_"
-    title="monitoring.attributes.enabled"
+    title="browser_monitoring.attributes.enabled"
   >
     <Table>
       <tbody>
@@ -2509,9 +2382,7 @@ Here are browser monitoring settings available via the agent configuration file.
 
   <Collapser
     id="cfg-bm-attributes-include"
-    title="browser"
-    title="_"
-    title="monitoring.attributes.include"
+    title="browser_monitoring.attributes.include"
   >
     <Table>
       <tbody>
@@ -2552,9 +2423,7 @@ Here are browser monitoring settings available via the agent configuration file.
 
   <Collapser
     id="cfg-bm-attributes-exclude"
-    title="browser"
-    title="_"
-    title="monitoring.attributes.exclude"
+    title="browser_monitoring.attributes.exclude"
   >
     <Table>
       <tbody>
@@ -2605,9 +2474,7 @@ Here are Transaction events settings available via the agent configuration file.
 <CollapserGroup>
   <Collapser
     id="transaction-events-enabled"
-    title="transaction"
-    title="_"
-    title="events.enabled"
+    title="transaction_events.enabled"
   >
     <Table>
       <tbody>
@@ -2648,9 +2515,7 @@ Here are Transaction events settings available via the agent configuration file.
 
   <Collapser
     id="cfg-events-attributes-enabled"
-    title="transaction"
-    title="_"
-    title="events.attributes.enabled"
+    title="transaction_events.attributes.enabled"
   >
     <Table>
       <tbody>
@@ -2691,9 +2556,7 @@ Here are Transaction events settings available via the agent configuration file.
 
   <Collapser
     id="cfg-events-attributes-include"
-    title="transaction"
-    title="_"
-    title="events.attributes.include"
+    title="transaction_events.attributes.include"
   >
     <Table>
       <tbody>
@@ -2734,9 +2597,7 @@ Here are Transaction events settings available via the agent configuration file.
 
   <Collapser
     id="cfg-events-attributes-exclude"
-    title="transaction"
-    title="_"
-    title="events.attributes.exclude"
+    title="transaction_events.attributes.exclude"
   >
     <Table>
       <tbody>
@@ -2773,11 +2634,7 @@ Here are Custom Insights events settings available via the agent configuration f
 <CollapserGroup>
   <Collapser
     id="custom-insights-events-enabled"
-    title="custom"
-    title="_"
-    title="insights"
-    title="_"
-    title="events.enabled"
+    title="custom_insights_events.enabled"
   >
     <Table>
       <tbody>
@@ -2824,11 +2681,7 @@ These datastore tracer settings are available via the agent configuration file:
 <CollapserGroup>
   <Collapser
     id="datastore-tracer-instance-reporting-enabled"
-    title="datastore"
-    title="_"
-    title="tracer.instance"
-    title="_"
-    title="reporting.enabled"
+    title="datastore_tracer.instance_reporting.enabled"
   >
     <Table>
       <tbody>
@@ -2869,13 +2722,7 @@ These datastore tracer settings are available via the agent configuration file:
 
   <Collapser
     id="datastore-tracer-database-name-reporting-enabled"
-    title="datastore"
-    title="_"
-    title="tracer.database"
-    title="_"
-    title="name"
-    title="_"
-    title="reporting.enabled"
+    title="datastore_tracer.database_name_reporting.enabled"
   >
     <Table>
       <tbody>
@@ -2928,9 +2775,7 @@ Distributed tracing lets you see the path that a request takes as it travels thr
 <CollapserGroup>
   <Collapser
     id="distributed-tracing-enabled"
-    title="distributed"
-    title="_"
-    title="tracing.enabled"
+    title="distributed_tracing.enabled"
   >
     <Table>
       <tbody>
@@ -2987,9 +2832,7 @@ Distributed tracing lets you see the path that a request takes as it travels thr
 <CollapserGroup>
   <Collapser
     id="cfg-tt-attributes-enabled"
-    title="span"
-    title="_"
-    title="events.enabled"
+    title="span_events.enabled"
   >
     <Table>
       <tbody>
@@ -3030,9 +2873,7 @@ Distributed tracing lets you see the path that a request takes as it travels thr
 
   <Collapser
     id="cfg-tt-attributes-enabled"
-    title="span"
-    title="_"
-    title="events.attributes.enabled"
+    title="span_events.attributes.enabled"
   >
     <Table>
       <tbody>
@@ -3073,9 +2914,7 @@ Distributed tracing lets you see the path that a request takes as it travels thr
 
   <Collapser
     id="cfg-tt-attributes-include"
-    title="span"
-    title="_"
-    title="events.attributes.include"
+    title="span_events.attributes.include"
   >
     <Table>
       <tbody>
@@ -3116,9 +2955,7 @@ Distributed tracing lets you see the path that a request takes as it travels thr
 
   <Collapser
     id="cfg-tt-attributes-exclude"
-    title="span"
-    title="_"
-    title="events.attributes.exclude"
+    title="span_events.attributes.exclude"
   >
     <Table>
       <tbody>
@@ -3169,11 +3006,7 @@ Event loop visibility surfaces information about transactions that block the eve
 <CollapserGroup>
   <Collapser
     id="event-loop-visibility-enabled"
-    title="event"
-    title="_"
-    title="loop"
-    title="_"
-    title="visibility.enabled"
+    title="event_loop_visibility.enabled"
   >
     <Table>
       <tbody>
@@ -3214,13 +3047,7 @@ Event loop visibility surfaces information about transactions that block the eve
 
   <Collapser
     id="event-loop-visbility-blocking-threshold"
-    title="event"
-    title="_"
-    title="loop"
-    title="_"
-    title="visibility.blocking"
-    title="_"
-    title="threshold"
+    title="event_loop_visibility.blocking_threshold"
   >
     <Table>
       <tbody>
@@ -3267,9 +3094,7 @@ Here are assorted other settings available via the agent configuration file.
 <CollapserGroup>
   <Collapser
     id="utilization-detect_aws"
-    title="utilization.detect"
-    title="_"
-    title="aws"
+    title="utilization.detect_aws"
   >
     <Table>
       <tbody>
@@ -3300,9 +3125,7 @@ Here are assorted other settings available via the agent configuration file.
 
   <Collapser
     id="utilization-detect_azure"
-    title="utilization.detect"
-    title="_"
-    title="azure"
+    title="utilization.detect_azure"
   >
     <Table>
       <tbody>
@@ -3333,9 +3156,7 @@ Here are assorted other settings available via the agent configuration file.
 
   <Collapser
     id="utilization-detect_gcp"
-    title="utilization.detect"
-    title="_"
-    title="gcp"
+    title="utilization.detect_gcp"
   >
     <Table>
       <tbody>
@@ -3366,9 +3187,7 @@ Here are assorted other settings available via the agent configuration file.
 
   <Collapser
     id="utilization-detect_pcf"
-    title="utilization.detect"
-    title="_"
-    title="pcf"
+    title="utilization.detect_pcf"
   >
     <Table>
       <tbody>
@@ -3399,9 +3218,7 @@ Here are assorted other settings available via the agent configuration file.
 
   <Collapser
     id="utilization-detect_docker"
-    title="utilization.detect"
-    title="_"
-    title="docker"
+    title="utilization.detect_docker"
   >
     <Table>
       <tbody>
@@ -3432,9 +3249,7 @@ Here are assorted other settings available via the agent configuration file.
 
   <Collapser
     id="slow-sql"
-    title="slow"
-    title="_"
-    title="sql.enabled"
+    title="slow_sql.enabled"
   >
     <Table>
       <tbody>
@@ -3485,9 +3300,7 @@ Here are assorted other settings available via the agent configuration file.
 
   <Collapser
     id="thread-profiler"
-    title="thread"
-    title="_"
-    title="profiler.enabled"
+    title="thread_profiler.enabled"
   >
     <Table>
       <tbody>
@@ -3538,11 +3351,7 @@ Here are assorted other settings available via the agent configuration file.
 
   <Collapser
     id="cross-application-tracer"
-    title="cross"
-    title="_"
-    title="application"
-    title="_"
-    title="tracer.enabled"
+    title="cross_application_tracer.enabled"
   >
     <Table>
       <tbody>
@@ -3583,11 +3392,7 @@ Here are assorted other settings available via the agent configuration file.
 
   <Collapser
     id="strip_exception_messages_enabled"
-    title="strip"
-    title="_"
-    title="exception"
-    title="_"
-    title="messages.enabled"
+    title="strip_exception_messages.enabled"
   >
     <Table>
       <tbody>
@@ -3628,11 +3433,7 @@ Here are assorted other settings available via the agent configuration file.
 
   <Collapser
     id="strip_exception_messages_whitelist"
-    title="strip"
-    title="_"
-    title="exception"
-    title="_"
-    title="messages.whitelist"
+    title="strip_exception_messages.whitelist"
   >
     <Table>
       <tbody>
@@ -3679,9 +3480,7 @@ Here are assorted other settings available via the agent configuration file.
 
   <Collapser
     id="startup-timeout"
-    title="startup"
-    title="_"
-    title="timeout"
+    title="startup_timeout"
   >
     <Table>
       <tbody>
@@ -3738,9 +3537,7 @@ Here are assorted other settings available via the agent configuration file.
 
   <Collapser
     id="shutdown-timeout"
-    title="shutdown"
-    title="_"
-    title="timeout"
+    title="shutdown_timeout"
   >
     <Table>
       <tbody>
@@ -3797,11 +3594,7 @@ Here are assorted other settings available via the agent configuration file.
 
   <Collapser
     id="shutdown-timeout"
-    title="compressed"
-    title="_"
-    title="content"
-    title="_"
-    title="encoding"
+    title="compressed_content_encoding"
   >
     <Table>
       <tbody>
@@ -3846,11 +3639,7 @@ Here are assorted other settings available via the agent configuration file.
 <CollapserGroup>
   <Collapser
     id="heroku-use_dyno_names"
-    title="heroku.use"
-    title="_"
-    title="dyno"
-    title="_"
-    title="names"
+    title="heroku.use_dyno_names"
   >
     <Table>
       <tbody>
@@ -3891,15 +3680,7 @@ Here are assorted other settings available via the agent configuration file.
 
   <Collapser
     id="heroku-dyno_name_prefixes_to_shorten"
-    title="heroku.dyno"
-    title="_"
-    title="name"
-    title="_"
-    title="prefixes"
-    title="_"
-    title="to"
-    title="_"
-    title="shorten"
+    title="heroku.dyno_name_prefixes_to_shorten"
   >
     <Table>
       <tbody>
@@ -3945,17 +3726,18 @@ The Python agent instruments a range of Python packages/modules. This instrument
 
 To disable default instrumentation, provide a special `import-hook` section corresponding to the name of the module that triggered instrumentation. Then set the `enabled` setting to `false` to disable instrumentation of that module.
 
-<dt id="example-disable-mysqldb">
-  Example: Disabling MySQLdb database query instrumentation
-</dt>
+<CollapserGroup>
+  <Collapser
+    id="example-disable-mysqldb"
+    title="Example: Disabling MySQLdb database query instrumentation"
+  >
+    Add the following to the configuration file:
 
-<dd>
-  Add the following to the configuration file:
-
-  ```
-  [import-hook:MySQLdb]
-  enabled = false
-  ```
-</dd>
+    ```
+    [import-hook:MySQLdb]
+    enabled = false
+    ```
+  </Collapser>
+</CollapserGroup>
 
 ## For more help

--- a/src/content/docs/agents/python-agent/custom-instrumentation/python-custom-instrumentation-config-file.mdx
+++ b/src/content/docs/agents/python-agent/custom-instrumentation/python-custom-instrumentation-config-file.mdx
@@ -15,18 +15,19 @@ You can extend the Python agent's monitoring to trace time spent in additional f
 
 To extend instrumentation to designated functions and class methods, add them to the `transaction_tracer.function_trace` setting within the `newrelic` section of the agent configuration file. The identifier for a function should have the form `module:function` and that of a class method `module:class.function`.
 
-<dt id="dumdbm-example">
-  Using dumbdbm
-</dt>
+<CollapserGroup>
+  <Collapser
+    id="dumdbm-example"
+    title="Using dumbdbm"
+  >
+    In this example, you use the Python **dumbdbm** module and want to instrument the time it took to open a database, and then to write that database back to a file. In this case you would use:
 
-<dd>
-  In this example, you use the Python **dumbdbm** module and want to instrument the time it took to open a database, and then to write that database back to a file. In this case you would use:
-
-  ```
-  transaction_tracer.function_trace = dumbdbm:open
-                                                 dumbdbm:_Database._commit
-  ```
-</dd>
+    ```
+    transaction_tracer.function_trace = dumbdbm:open
+                                                   dumbdbm:_Database._commit
+    ```
+  </Collapser>
+</CollapserGroup>
 
 To list more than one item, use either of these methods:
 

--- a/src/content/docs/agents/python-agent/getting-started/instrumented-python-packages.mdx
+++ b/src/content/docs/agents/python-agent/getting-started/instrumented-python-packages.mdx
@@ -22,7 +22,7 @@ To request built-in instrumentation for additional packages, get support at [sup
 <CollapserGroup>
   <Collapser
     id="aiohttp"
-    title="aiohttp"
+    title={<ExternalLink href="http://aiohttp.readthedocs.io">aiohttp</ExternalLink>}
   >
     Support for versions 2.2.x or higher.
 
@@ -40,7 +40,7 @@ To request built-in instrumentation for additional packages, get support at [sup
 
   <Collapser
     id="bottle"
-    title="Bottle"
+    title={<ExternalLink href="http://bottlepy.org/">Bottle</ExternalLink>}
   >
     Function timing in transactions traces for slow transactions is provided for:
 
@@ -58,7 +58,7 @@ To request built-in instrumentation for additional packages, get support at [sup
 
   <Collapser
     id="cherrypy"
-    title="CherryPy"
+    title={<ExternalLink href="http://cherrypy.org/">CherryPy</ExternalLink>}
   >
     Function timing in transactions traces for slow transactions is provided for:
 
@@ -75,7 +75,7 @@ To request built-in instrumentation for additional packages, get support at [sup
 
   <Collapser
     id="django"
-    title="Django"
+    title={<ExternalLink href="http://www.djangoproject.com/">Django</ExternalLink>}
   >
     Function timing in transactions traces for slow transactions is provided for:
 
@@ -108,7 +108,7 @@ To request built-in instrumentation for additional packages, get support at [sup
 
   <Collapser
     id="falcon"
-    title="Falcon"
+    title={<ExternalLink href="https://falconframework.org/">Falcon</ExternalLink>}
   >
     Function timing in transactions traces for slow transactions is provided for:
 
@@ -123,7 +123,7 @@ To request built-in instrumentation for additional packages, get support at [sup
 
   <Collapser
     id="flask"
-    title="Flask"
+    title={<ExternalLink href="http://flask.pocoo.org/">Flask</ExternalLink>}
   >
     Function timing in transactions traces for slow transactions is provided for:
 
@@ -141,7 +141,7 @@ To request built-in instrumentation for additional packages, get support at [sup
 
   <Collapser
     id="grpc"
-    title="gRPC"
+    title={<ExternalLink href="https://grpc.github.io/grpc/python/">gRPC</ExternalLink>}
   >
     Supported for versions 1.4 or higher.
 
@@ -157,7 +157,7 @@ To request built-in instrumentation for additional packages, get support at [sup
 
   <Collapser
     id="pylons"
-    title="Pylons"
+    title={<ExternalLink href="http://pylonsproject.org/">Pylons</ExternalLink>}
   >
     Function timing in transactions traces for slow transactions is provided for:
 
@@ -175,7 +175,7 @@ To request built-in instrumentation for additional packages, get support at [sup
 
   <Collapser
     id="pyramid"
-    title="Pyramid"
+    title={<ExternalLink href="http://pylonsproject.org/">Pyramid</ExternalLink>}
   >
     Function timing in transactions traces for slow transactions is provided for:
 
@@ -190,7 +190,7 @@ To request built-in instrumentation for additional packages, get support at [sup
 
   <Collapser
     id="sanic"
-    title="Sanic"
+    title={<ExternalLink href="https://github.com/channelcat/sanic">Sanic</ExternalLink>}
   >
     Function timing in transactions traces for slow transactions is provided for:
 
@@ -210,14 +210,14 @@ To request built-in instrumentation for additional packages, get support at [sup
 
   <Collapser
     id="tornado"
-    title="Tornado"
+    title={<ExternalLink href="http://www.tornadoweb.org/en/stable/">Tornado</ExternalLink>}
   >
     You can use the Python agent with an app that uses [Tornado 6](/docs/agents/python-agent/web-frameworks-servers/python-agent-tornado-6-web-framework).
   </Collapser>
 
   <Collapser
     id="web2py"
-    title="Web2py"
+    title={<ExternalLink href="http://web2py.com/">Web2py</ExternalLink>}
   >
     Function timing in transactions traces for slow transactions is provided for:
 
@@ -239,14 +239,14 @@ To request built-in instrumentation for additional packages, get support at [sup
 <CollapserGroup>
   <Collapser
     id="gearman"
-    title="gearman"
+    title={<ExternalLink href="https://pypi.python.org/pypi/gearman/">gearman</ExternalLink>}
   >
     Timing of task execution performed in a gearman worker recorded as background tasks against designated web application. Timing as a web external any client side calls to a gearman server to queue up or wait for the execution of queued tasks.
   </Collapser>
 
   <Collapser
     id="celery"
-    title="Celery"
+    title={<ExternalLink href="http://celeryproject.org/">Celery</ExternalLink>}
   >
     Timing of task execution recorded as background tasks against designated web application.
   </Collapser>
@@ -257,7 +257,7 @@ To request built-in instrumentation for additional packages, get support at [sup
 <CollapserGroup>
   <Collapser
     id="genshi"
-    title="Genshi"
+    title={<ExternalLink href="http://genshi.edgewall.org/">Genshi</ExternalLink>}
   >
     Function timing in transactions traces for slow transactions is provided for:
 
@@ -266,7 +266,7 @@ To request built-in instrumentation for additional packages, get support at [sup
 
   <Collapser
     id="jinja2"
-    title="Jinja2"
+    title={<ExternalLink href="http://jinja.pocoo.org/">Jinja2</ExternalLink>}
   >
     Function timing in transactions traces for slow transactions is provided for:
 
@@ -276,7 +276,7 @@ To request built-in instrumentation for additional packages, get support at [sup
 
   <Collapser
     id="mako"
-    title="Mako"
+    title={<ExternalLink href="http://www.makotemplates.org/">Mako</ExternalLink>}
   >
     Function timing in transactions traces for slow transactions is provided for:
 

--- a/src/content/docs/agents/python-agent/installation/advanced-install-new-relic-python-agent.mdx
+++ b/src/content/docs/agents/python-agent/installation/advanced-install-new-relic-python-agent.mdx
@@ -47,9 +47,7 @@ Download and install the agent package using your preferred procedure. For examp
 
   <Collapser
     id="easy_install"
-    title="easy"
-    title="_"
-    title="install"
+    title="easy_install"
   >
     Run:
 
@@ -153,9 +151,7 @@ If you use any of the following services, follow these guidelines before continu
 
   <Collapser
     id="mod_wsgi"
-    title="mod"
-    title="_"
-    title="wsgi"
+    title="mod_wsgi"
   >
     If you use `mod_wsgi`, you cannot use the recommended integration method of running the admin script via the command line. Instead, you must [manually integrate](/docs/agents/python-agent/installation-configuration/python-agent-integration#manual-integration) the Python agent in your app code.
 

--- a/src/content/docs/agents/python-agent/installation/python-agent-advanced-integration.mdx
+++ b/src/content/docs/agents/python-agent/installation/python-agent-advanced-integration.mdx
@@ -68,45 +68,44 @@ Here are examples of running the script:
 
 The following examples give instructions for a Bourne-style shell. You may need to adjust these instructions for a different shell.
 
-<dt id="gunicorn">
-  Gunicorn example
-</dt>
+<CollapserGroup>
+  <Collapser
+    id="gunicorn"
+    title="Gunicorn example"
+  >
+    If you're using Gunicorn (a popular Python web server) and your startup command is:
 
-<dd>
-  If you're using Gunicorn (a popular Python web server) and your startup command is:
+    ```
+    gunicorn -w 3 wsgi:application
+    ```
 
-  ```
-  gunicorn -w 3 wsgi:application
-  ```
+    Then your new agent-integrated command would be:
 
-  Then your new agent-integrated command would be:
+    ```
+    NEW_RELIC_CONFIG_FILE=newrelic.ini newrelic-admin run-program gunicorn -w 3 wsgi:application
+    ```
+  </Collapser>
 
-  ```
-  NEW_RELIC_CONFIG_FILE=newrelic.ini newrelic-admin run-program gunicorn -w 3 wsgi:application
-  ```
-</dd>
+  <Collapser
+    id="gunicorn"
+    title="uWSGI run directly on a WSGI application"
+  >
+    ```
+    newrelic-admin run-program uwsgi --socket /tmp/uwsgi.sock --single-interpreter --enable-threads wsgi.py
+    ```
+  </Collapser>
 
-<dt id="gunicorn">
-  uWSGI run directly on a WSGI application
-</dt>
+  <Collapser
+    id="gunicorn"
+    title="Paster serve"
+  >
+    Here's an example of running the admin script using paster serve on a WSGI app specified in a paster ini configuration file:
 
-<dd>
-  ```
-  newrelic-admin run-program uwsgi --socket /tmp/uwsgi.sock --single-interpreter --enable-threads wsgi.py
-  ```
-</dd>
-
-<dt id="gunicorn">
-  Paster serve
-</dt>
-
-<dd>
-  Here's an example of running the admin script using paster serve on a WSGI app specified in a paster ini configuration file:
-
-  ```
-  newrelic-admin run-program paster serve production.ini
-  ```
-</dd>
+    ```
+    newrelic-admin run-program paster serve production.ini
+    ```
+  </Collapser>
+</CollapserGroup>
 
 For framework-specific documentation on using the admin script, see [Web frameworks and servers](/docs/agents/python-agent/web-frameworks-servers).
 

--- a/src/content/docs/agents/python-agent/web-frameworks-servers/python-agent-web2py-web-framework.mdx
+++ b/src/content/docs/agents/python-agent/web-frameworks-servers/python-agent-web2py-web-framework.mdx
@@ -31,9 +31,7 @@ Choose the Web2py set-up you use from the list below for more information:
 
   <Collapser
     id="running-with-mod_wsgi"
-    title="Apache/mod"
-    title="_"
-    title="wsgi"
+    title="Apache/mod_wsgi"
   >
     When using Apache/mod_wsgi, you **must** manually insert code in the WSGI script file you are using in order to initialize the Python agent. For more info, see [our mod_wsgi documentation](/docs/python/python-agent-and-mod_wsgi).
   </Collapser>

--- a/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -89,9 +89,7 @@ These settings are available for agent configuration. Some settings depend on yo
 <CollapserGroup>
   <Collapser
     id="license_key"
-    title="license"
-    title="_"
-    title="key"
+    title="license_key"
   >
     <Table>
       <tbody>
@@ -132,9 +130,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="agent_enabled"
-    title="agent"
-    title="_"
-    title="enabled"
+    title="agent_enabled"
   >
     <Table>
       <tbody>
@@ -175,9 +171,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="app_name"
-    title="app"
-    title="_"
-    title="name"
+    title="app_name"
   >
     <Table>
       <tbody>
@@ -218,9 +212,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="entity_guid"
-    title="entity"
-    title="_"
-    title="guid"
+    title="entity_guid"
   >
     <Table>
       <tbody>
@@ -261,9 +253,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="monitor_mode"
-    title="monitor"
-    title="_"
-    title="mode"
+    title="monitor_mode"
   >
     <Table>
       <tbody>
@@ -304,9 +294,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="log_level"
-    title="log"
-    title="_"
-    title="level"
+    title="log_level"
   >
     <Table>
       <tbody>
@@ -347,9 +335,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="high_security"
-    title="high"
-    title="_"
-    title="security"
+    title="high_security"
   >
     <Table>
       <tbody>
@@ -390,11 +376,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="security_policies_token"
-    title="security"
-    title="_"
-    title="policies"
-    title="_"
-    title="token"
+    title="security_policies_token"
   >
     <Table>
       <tbody>
@@ -435,9 +417,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="proxy_host"
-    title="proxy"
-    title="_"
-    title="host"
+    title="proxy_host"
   >
     <Table>
       <tbody>
@@ -478,9 +458,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="proxy_port"
-    title="proxy"
-    title="_"
-    title="port"
+    title="proxy_port"
   >
     <Table>
       <tbody>
@@ -521,9 +499,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="proxy_user"
-    title="proxy"
-    title="_"
-    title="user"
+    title="proxy_user"
   >
     <Table>
       <tbody>
@@ -564,9 +540,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="proxy_pass"
-    title="proxy"
-    title="_"
-    title="pass"
+    title="proxy_pass"
   >
     <Table>
       <tbody>
@@ -607,9 +581,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="capture_params"
-    title="capture"
-    title="_"
-    title="params"
+    title="capture_params"
   >
     <Table>
       <tbody>
@@ -652,9 +624,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="config_path"
-    title="config"
-    title="_"
-    title="path"
+    title="config_path"
   >
     <Table>
       <tbody>
@@ -695,9 +665,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="apdex_t"
-    title="apdex"
-    title="_"
-    title="t"
+    title="apdex_t"
   >
     <Table>
       <tbody>
@@ -738,9 +706,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="sync_startup"
-    title="sync"
-    title="_"
-    title="startup"
+    title="sync_startup"
   >
     <Table>
       <tbody>
@@ -781,13 +747,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="send_data_on_exit"
-    title="send"
-    title="_"
-    title="data"
-    title="_"
-    title="on"
-    title="_"
-    title="exit"
+    title="send_data_on_exit"
   >
     <Table>
       <tbody>
@@ -869,11 +829,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="log_file_name"
-    title="log"
-    title="_"
-    title="file"
-    title="_"
-    title="name"
+    title="log_file_name"
   >
     <Table>
       <tbody>
@@ -914,11 +870,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="log_file_path"
-    title="log"
-    title="_"
-    title="file"
-    title="_"
-    title="path"
+    title="log_file_path"
   >
     <Table>
       <tbody>
@@ -959,13 +911,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="prepend_active_record_instrumentation"
-    title="prepend"
-    title="_"
-    title="active"
-    title="_"
-    title="record"
-    title="_"
-    title="instrumentation"
+    title="prepend_active_record_instrumentation"
   >
     <Table>
       <tbody>
@@ -1006,11 +952,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="capture_memcache_keys"
-    title="capture"
-    title="_"
-    title="memcache"
-    title="_"
-    title="keys"
+    title="capture_memcache_keys"
   >
     <Table>
       <tbody>
@@ -1051,11 +993,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="message_tracer-segment_parameters-enabled"
-    title="message"
-    title="_"
-    title="tracer.segment"
-    title="_"
-    title="parameters.enabled"
+    title="message_tracer.segment_parameters.enabled"
   >
     <Table>
       <tbody>
@@ -1137,17 +1075,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="backport_fast_active_record_connection_lookup"
-    title="backport"
-    title="_"
-    title="fast"
-    title="_"
-    title="active"
-    title="_"
-    title="record"
-    title="_"
-    title="connection"
-    title="_"
-    title="lookup"
+    title="backport_fast_active_record_connection_lookup"
   >
     <Table>
       <tbody>
@@ -1229,11 +1157,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="ca_bundle_path"
-    title="ca"
-    title="_"
-    title="bundle"
-    title="_"
-    title="path"
+    title="ca_bundle_path"
   >
     <Table>
       <tbody>
@@ -1274,11 +1198,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="datastore_tracer-instance_reporting-enabled"
-    title="datastore"
-    title="_"
-    title="tracer.instance"
-    title="_"
-    title="reporting.enabled"
+    title="datastore_tracer.instance_reporting.enabled"
   >
     <Table>
       <tbody>
@@ -1319,13 +1239,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="datastore_tracer-database_name_reporting-enabled"
-    title="datastore"
-    title="_"
-    title="tracer.database"
-    title="_"
-    title="name"
-    title="_"
-    title="reporting.enabled"
+    title="datastore_tracer.database_name_reporting.enabled"
   >
     <Table>
       <tbody>
@@ -1366,15 +1280,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="clear_transaction_state_after_fork"
-    title="clear"
-    title="_"
-    title="transaction"
-    title="_"
-    title="state"
-    title="_"
-    title="after"
-    title="_"
-    title="fork"
+    title="clear_transaction_state_after_fork"
   >
     <Table>
       <tbody>
@@ -1415,11 +1321,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="infinite_tracing-trace_observer-host"
-    title="infinite"
-    title="_"
-    title="tracing.trace"
-    title="_"
-    title="observer.host"
+    title="infinite_tracing.trace_observer.host"
   >
     <Table>
       <tbody>
@@ -1460,11 +1362,7 @@ These settings are available for agent configuration. Some settings depend on yo
 
   <Collapser
     id="infinite_tracing-trace_observer-port"
-    title="infinite"
-    title="_"
-    title="tracing.trace"
-    title="_"
-    title="observer.port"
+    title="infinite_tracing.trace_observer.port"
   >
     <Table>
       <tbody>
@@ -1511,9 +1409,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
 <CollapserGroup>
   <Collapser
     id="transaction_tracer-enabled"
-    title="transaction"
-    title="_"
-    title="tracer.enabled"
+    title="transaction_tracer.enabled"
   >
     <Table>
       <tbody>
@@ -1554,11 +1450,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
 
   <Collapser
     id="transaction_tracer-transaction_threshold"
-    title="transaction"
-    title="_"
-    title="tracer.transaction"
-    title="_"
-    title="threshold"
+    title="transaction_tracer.transaction_threshold"
   >
     <Table>
       <tbody>
@@ -1599,11 +1491,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
 
   <Collapser
     id="transaction_tracer-record_sql"
-    title="transaction"
-    title="_"
-    title="tracer.record"
-    title="_"
-    title="sql"
+    title="transaction_tracer.record_sql"
   >
     <Table>
       <tbody>
@@ -1650,13 +1538,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
 
   <Collapser
     id="transaction_tracer-record_redis_arguments"
-    title="transaction"
-    title="_"
-    title="tracer.record"
-    title="_"
-    title="redis"
-    title="_"
-    title="arguments"
+    title="transaction_tracer.record_redis_arguments"
   >
     <Table>
       <tbody>
@@ -1697,11 +1579,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
 
   <Collapser
     id="transaction_tracer-capture_attributes"
-    title="transaction"
-    title="_"
-    title="tracer.capture"
-    title="_"
-    title="attributes"
+    title="transaction_tracer.capture_attributes"
   >
     <Table>
       <tbody>
@@ -1742,11 +1620,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
 
   <Collapser
     id="transaction_tracer-explain_threshold"
-    title="transaction"
-    title="_"
-    title="tracer.explain"
-    title="_"
-    title="threshold"
+    title="transaction_tracer.explain_threshold"
   >
     <Table>
       <tbody>
@@ -1787,11 +1661,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
 
   <Collapser
     id="transaction_tracer-explain_enabled"
-    title="transaction"
-    title="_"
-    title="tracer.explain"
-    title="_"
-    title="enabled"
+    title="transaction_tracer.explain_enabled"
   >
     <Table>
       <tbody>
@@ -1832,13 +1702,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
 
   <Collapser
     id="transaction_tracer-stack_trace_threshold"
-    title="transaction"
-    title="_"
-    title="tracer.stack"
-    title="_"
-    title="trace"
-    title="_"
-    title="threshold"
+    title="transaction_tracer.stack_trace_threshold"
   >
     <Table>
       <tbody>
@@ -1879,11 +1743,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
 
   <Collapser
     id="transaction_tracer-limit_segments"
-    title="transaction"
-    title="_"
-    title="tracer.limit"
-    title="_"
-    title="segments"
+    title="transaction_tracer.limit_segments"
   >
     <Table>
       <tbody>
@@ -1930,9 +1790,7 @@ The agent collects and reports all uncaught exceptions by default. These configu
 <CollapserGroup>
   <Collapser
     id="error_collector-enabled"
-    title="error"
-    title="_"
-    title="collector.enabled"
+    title="error_collector.enabled"
   >
     <Table>
       <tbody>
@@ -1973,11 +1831,7 @@ The agent collects and reports all uncaught exceptions by default. These configu
 
   <Collapser
     id="error_collector-capture_attributes"
-    title="error"
-    title="_"
-    title="collector.capture"
-    title="_"
-    title="attributes"
+    title="error_collector.capture_attributes"
   >
     <Table>
       <tbody>
@@ -2018,11 +1872,7 @@ The agent collects and reports all uncaught exceptions by default. These configu
 
   <Collapser
     id="error_collector-ignore_errors"
-    title="error"
-    title="_"
-    title="collector.ignore"
-    title="_"
-    title="errors"
+    title="error_collector.ignore_errors"
   >
     <Table>
       <tbody>
@@ -2063,13 +1913,7 @@ The agent collects and reports all uncaught exceptions by default. These configu
 
   <Collapser
     id="error_collector-max_backtrace_frames"
-    title="error"
-    title="_"
-    title="collector.max"
-    title="_"
-    title="backtrace"
-    title="_"
-    title="frames"
+    title="error_collector.max_backtrace_frames"
   >
     <Table>
       <tbody>
@@ -2110,11 +1954,7 @@ The agent collects and reports all uncaught exceptions by default. These configu
 
   <Collapser
     id="error_collector-capture_events"
-    title="error"
-    title="_"
-    title="collector.capture"
-    title="_"
-    title="events"
+    title="error_collector.capture_events"
   >
     <Table>
       <tbody>
@@ -2155,15 +1995,7 @@ The agent collects and reports all uncaught exceptions by default. These configu
 
   <Collapser
     id="error_collector-max_event_samples_stored"
-    title="error"
-    title="_"
-    title="collector.max"
-    title="_"
-    title="event"
-    title="_"
-    title="samples"
-    title="_"
-    title="stored"
+    title="error_collector.max_event_samples_stored"
   >
     <Table>
       <tbody>
@@ -2210,11 +2042,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 <CollapserGroup>
   <Collapser
     id="browser_monitoring-auto_instrument"
-    title="browser"
-    title="_"
-    title="monitoring.auto"
-    title="_"
-    title="instrument"
+    title="browser_monitoring.auto_instrument"
   >
     <Table>
       <tbody>
@@ -2255,11 +2083,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="browser_monitoring-capture_attributes"
-    title="browser"
-    title="_"
-    title="monitoring.capture"
-    title="_"
-    title="attributes"
+    title="browser_monitoring.capture_attributes"
   >
     <Table>
       <tbody>
@@ -2306,9 +2130,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 <CollapserGroup>
   <Collapser
     id="analytics_events-enabled"
-    title="analytics"
-    title="_"
-    title="events.enabled"
+    title="analytics_events.enabled"
   >
     <Table>
       <tbody>
@@ -2349,13 +2171,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="analytics_events-max_samples_stored"
-    title="analytics"
-    title="_"
-    title="events.max"
-    title="_"
-    title="samples"
-    title="_"
-    title="stored"
+    title="analytics_events.max_samples_stored"
   >
     <Table>
       <tbody>
@@ -2396,11 +2212,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="analytics_events-capture_attributes"
-    title="analytics"
-    title="_"
-    title="events.capture"
-    title="_"
-    title="attributes"
+    title="analytics_events.capture_attributes"
   >
     <Table>
       <tbody>
@@ -2488,9 +2300,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="transaction_tracer-attributes-enabled"
-    title="transaction"
-    title="_"
-    title="tracer.attributes.enabled"
+    title="transaction_tracer.attributes.enabled"
   >
     <Table>
       <tbody>
@@ -2531,9 +2341,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="transaction_events-attributes-enabled"
-    title="transaction"
-    title="_"
-    title="events.attributes.enabled"
+    title="transaction_events.attributes.enabled"
   >
     <Table>
       <tbody>
@@ -2578,9 +2386,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="error_collector-attributes-enabled"
-    title="error"
-    title="_"
-    title="collector.attributes.enabled"
+    title="error_collector.attributes.enabled"
   >
     <Table>
       <tbody>
@@ -2621,9 +2427,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="browser_monitoring-attributes-enabled"
-    title="browser"
-    title="_"
-    title="monitoring.attributes.enabled"
+    title="browser_monitoring.attributes.enabled"
   >
     <Table>
       <tbody>
@@ -2664,9 +2468,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="span_events-attributes-enabled"
-    title="span"
-    title="_"
-    title="events.attributes.enabled"
+    title="span_events.attributes.enabled"
   >
     <Table>
       <tbody>
@@ -2707,9 +2509,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="transaction_segments-attributes-enabled"
-    title="transaction"
-    title="_"
-    title="segments.attributes.enabled"
+    title="transaction_segments.attributes.enabled"
   >
     <Table>
       <tbody>
@@ -2791,9 +2591,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="transaction_tracer-attributes-exclude"
-    title="transaction"
-    title="_"
-    title="tracer.attributes.exclude"
+    title="transaction_tracer.attributes.exclude"
   >
     <Table>
       <tbody>
@@ -2834,9 +2632,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="transaction_events-attributes-exclude"
-    title="transaction"
-    title="_"
-    title="events.attributes.exclude"
+    title="transaction_events.attributes.exclude"
   >
     <Table>
       <tbody>
@@ -2881,9 +2677,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="error_collector-attributes-exclude"
-    title="error"
-    title="_"
-    title="collector.attributes.exclude"
+    title="error_collector.attributes.exclude"
   >
     <Table>
       <tbody>
@@ -2924,9 +2718,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="browser_monitoring-attributes-exclude"
-    title="browser"
-    title="_"
-    title="monitoring.attributes.exclude"
+    title="browser_monitoring.attributes.exclude"
   >
     <Table>
       <tbody>
@@ -2967,9 +2759,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="span_events-attributes-exclude"
-    title="span"
-    title="_"
-    title="events.attributes.exclude"
+    title="span_events.attributes.exclude"
   >
     <Table>
       <tbody>
@@ -3010,9 +2800,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="transaction_segments-attributes-exclude"
-    title="transaction"
-    title="_"
-    title="segments.attributes.exclude"
+    title="transaction_segments.attributes.exclude"
   >
     <Table>
       <tbody>
@@ -3094,9 +2882,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="transaction_tracer-attributes-include"
-    title="transaction"
-    title="_"
-    title="tracer.attributes.include"
+    title="transaction_tracer.attributes.include"
   >
     <Table>
       <tbody>
@@ -3137,9 +2923,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="transaction_events-attributes-include"
-    title="transaction"
-    title="_"
-    title="events.attributes.include"
+    title="transaction_events.attributes.include"
   >
     <Table>
       <tbody>
@@ -3184,9 +2968,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="error_collector-attributes-include"
-    title="error"
-    title="_"
-    title="collector.attributes.include"
+    title="error_collector.attributes.include"
   >
     <Table>
       <tbody>
@@ -3227,9 +3009,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="browser_monitoring-attributes-include"
-    title="browser"
-    title="_"
-    title="monitoring.attributes.include"
+    title="browser_monitoring.attributes.include"
   >
     <Table>
       <tbody>
@@ -3270,9 +3050,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="span_events-attributes-include"
-    title="span"
-    title="_"
-    title="events.attributes.include"
+    title="span_events.attributes.include"
   >
     <Table>
       <tbody>
@@ -3313,9 +3091,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="transaction_segments-attributes-include"
-    title="transaction"
-    title="_"
-    title="segments.attributes.include"
+    title="transaction_segments.attributes.include"
   >
     <Table>
       <tbody>
@@ -3360,9 +3136,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 <CollapserGroup>
   <Collapser
     id="audit_log-enabled"
-    title="audit"
-    title="_"
-    title="log.enabled"
+    title="audit_log.enabled"
   >
     <Table>
       <tbody>
@@ -3403,9 +3177,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="audit_log-path"
-    title="audit"
-    title="_"
-    title="log.path"
+    title="audit_log.path"
   >
     <Table>
       <tbody>
@@ -3446,9 +3218,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="audit_log-endpoints"
-    title="audit"
-    title="_"
-    title="log.endpoints"
+    title="audit_log.endpoints"
   >
     <Table>
       <tbody>
@@ -3493,9 +3263,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 <CollapserGroup>
   <Collapser
     id="autostart-blacklisted_constants"
-    title="autostart.blacklisted"
-    title="_"
-    title="constants"
+    title="autostart.blacklisted_constants"
   >
     <Table>
       <tbody>
@@ -3536,9 +3304,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="autostart-denylisted_constants"
-    title="autostart.denylisted"
-    title="_"
-    title="constants"
+    title="autostart.denylisted_constants"
   >
     <Table>
       <tbody>
@@ -3579,9 +3345,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="autostart-blacklisted_executables"
-    title="autostart.blacklisted"
-    title="_"
-    title="executables"
+    title="autostart.blacklisted_executables"
   >
     <Table>
       <tbody>
@@ -3622,9 +3386,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="autostart-denylisted_executables"
-    title="autostart.denylisted"
-    title="_"
-    title="executables"
+    title="autostart.denylisted_executables"
   >
     <Table>
       <tbody>
@@ -3665,11 +3427,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="autostart-blacklisted_rake_tasks"
-    title="autostart.blacklisted"
-    title="_"
-    title="rake"
-    title="_"
-    title="tasks"
+    title="autostart.blacklisted_rake_tasks"
   >
     <Table>
       <tbody>
@@ -3710,11 +3468,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="autostart-denylisted_rake_tasks"
-    title="autostart.denylisted"
-    title="_"
-    title="rake"
-    title="_"
-    title="tasks"
+    title="autostart.denylisted_rake_tasks"
   >
     <Table>
       <tbody>
@@ -3759,11 +3513,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 <CollapserGroup>
   <Collapser
     id="cross_application_tracer-enabled"
-    title="cross"
-    title="_"
-    title="application"
-    title="_"
-    title="tracer.enabled"
+    title="cross_application_tracer.enabled"
   >
     <Table>
       <tbody>
@@ -3808,9 +3558,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 <CollapserGroup>
   <Collapser
     id="custom_attributes-enabled"
-    title="custom"
-    title="_"
-    title="attributes.enabled"
+    title="custom_attributes.enabled"
   >
     <Table>
       <tbody>
@@ -3855,11 +3603,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 <CollapserGroup>
   <Collapser
     id="custom_insights_events-enabled"
-    title="custom"
-    title="_"
-    title="insights"
-    title="_"
-    title="events.enabled"
+    title="custom_insights_events.enabled"
   >
     <Table>
       <tbody>
@@ -3900,15 +3644,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
   <Collapser
     id="custom_insights_events-max_samples_stored"
-    title="custom"
-    title="_"
-    title="insights"
-    title="_"
-    title="events.max"
-    title="_"
-    title="samples"
-    title="_"
-    title="stored"
+    title="custom_insights_events.max_samples_stored"
   >
     <Table>
       <tbody>
@@ -3955,9 +3691,7 @@ Use these settings to toggle instrumentation types during agent startup.
 <CollapserGroup>
   <Collapser
     id="disable_rake"
-    title="disable"
-    title="_"
-    title="rake"
+    title="disable_rake"
   >
     <Table>
       <tbody>
@@ -3998,9 +3732,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_samplers"
-    title="disable"
-    title="_"
-    title="samplers"
+    title="disable_samplers"
   >
     <Table>
       <tbody>
@@ -4041,9 +3773,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_resque"
-    title="disable"
-    title="_"
-    title="resque"
+    title="disable_resque"
   >
     <Table>
       <tbody>
@@ -4084,9 +3814,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_sidekiq"
-    title="disable"
-    title="_"
-    title="sidekiq"
+    title="disable_sidekiq"
   >
     <Table>
       <tbody>
@@ -4127,9 +3855,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_dj"
-    title="disable"
-    title="_"
-    title="dj"
+    title="disable_dj"
   >
     <Table>
       <tbody>
@@ -4170,9 +3896,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_sinatra"
-    title="disable"
-    title="_"
-    title="sinatra"
+    title="disable_sinatra"
   >
     <Table>
       <tbody>
@@ -4213,13 +3937,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_sinatra_auto_middleware"
-    title="disable"
-    title="_"
-    title="sinatra"
-    title="_"
-    title="auto"
-    title="_"
-    title="middleware"
+    title="disable_sinatra_auto_middleware"
   >
     <Table>
       <tbody>
@@ -4260,11 +3978,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_view_instrumentation"
-    title="disable"
-    title="_"
-    title="view"
-    title="_"
-    title="instrumentation"
+    title="disable_view_instrumentation"
   >
     <Table>
       <tbody>
@@ -4305,11 +4019,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_activerecord_instrumentation"
-    title="disable"
-    title="_"
-    title="activerecord"
-    title="_"
-    title="instrumentation"
+    title="disable_activerecord_instrumentation"
   >
     <Table>
       <tbody>
@@ -4350,11 +4060,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_data_mapper"
-    title="disable"
-    title="_"
-    title="data"
-    title="_"
-    title="mapper"
+    title="disable_data_mapper"
   >
     <Table>
       <tbody>
@@ -4395,9 +4101,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_activejob"
-    title="disable"
-    title="_"
-    title="activejob"
+    title="disable_activejob"
   >
     <Table>
       <tbody>
@@ -4438,13 +4142,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_action_cable_instrumentation"
-    title="disable"
-    title="_"
-    title="action"
-    title="_"
-    title="cable"
-    title="_"
-    title="instrumentation"
+    title="disable_action_cable_instrumentation"
   >
     <Table>
       <tbody>
@@ -4485,11 +4183,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_active_storage"
-    title="disable"
-    title="_"
-    title="active"
-    title="_"
-    title="storage"
+    title="disable_active_storage"
   >
     <Table>
       <tbody>
@@ -4530,9 +4224,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_memcached"
-    title="disable"
-    title="_"
-    title="memcached"
+    title="disable_memcached"
   >
     <Table>
       <tbody>
@@ -4573,11 +4265,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_memcache_client"
-    title="disable"
-    title="_"
-    title="memcache"
-    title="_"
-    title="client"
+    title="disable_memcache_client"
   >
     <Table>
       <tbody>
@@ -4618,9 +4306,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_dalli"
-    title="disable"
-    title="_"
-    title="dalli"
+    title="disable_dalli"
   >
     <Table>
       <tbody>
@@ -4661,13 +4347,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_dalli_cas_client"
-    title="disable"
-    title="_"
-    title="dalli"
-    title="_"
-    title="cas"
-    title="_"
-    title="client"
+    title="disable_dalli_cas_client"
   >
     <Table>
       <tbody>
@@ -4708,11 +4388,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_memcache_instrumentation"
-    title="disable"
-    title="_"
-    title="memcache"
-    title="_"
-    title="instrumentation"
+    title="disable_memcache_instrumentation"
   >
     <Table>
       <tbody>
@@ -4753,11 +4429,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_gc_profiler"
-    title="disable"
-    title="_"
-    title="gc"
-    title="_"
-    title="profiler"
+    title="disable_gc_profiler"
   >
     <Table>
       <tbody>
@@ -4798,11 +4470,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_sequel_instrumentation"
-    title="disable"
-    title="_"
-    title="sequel"
-    title="_"
-    title="instrumentation"
+    title="disable_sequel_instrumentation"
   >
     <Table>
       <tbody>
@@ -4843,11 +4511,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_database_instrumentation"
-    title="disable"
-    title="_"
-    title="database"
-    title="_"
-    title="instrumentation"
+    title="disable_database_instrumentation"
   >
     <Table>
       <tbody>
@@ -4888,9 +4552,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_mongo"
-    title="disable"
-    title="_"
-    title="mongo"
+    title="disable_mongo"
   >
     <Table>
       <tbody>
@@ -4931,9 +4593,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_redis"
-    title="disable"
-    title="_"
-    title="redis"
+    title="disable_redis"
   >
     <Table>
       <tbody>
@@ -4974,11 +4634,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_vm_sampler"
-    title="disable"
-    title="_"
-    title="vm"
-    title="_"
-    title="sampler"
+    title="disable_vm_sampler"
   >
     <Table>
       <tbody>
@@ -5019,11 +4675,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_memory_sampler"
-    title="disable"
-    title="_"
-    title="memory"
-    title="_"
-    title="sampler"
+    title="disable_memory_sampler"
   >
     <Table>
       <tbody>
@@ -5064,11 +4716,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_cpu_sampler"
-    title="disable"
-    title="_"
-    title="cpu"
-    title="_"
-    title="sampler"
+    title="disable_cpu_sampler"
   >
     <Table>
       <tbody>
@@ -5109,13 +4757,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_delayed_job_sampler"
-    title="disable"
-    title="_"
-    title="delayed"
-    title="_"
-    title="job"
-    title="_"
-    title="sampler"
+    title="disable_delayed_job_sampler"
   >
     <Table>
       <tbody>
@@ -5156,13 +4798,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_active_record_4"
-    title="disable"
-    title="_"
-    title="active"
-    title="_"
-    title="record"
-    title="_"
-    title="4"
+    title="disable_active_record_4"
   >
     <Table>
       <tbody>
@@ -5203,13 +4839,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_active_record_5"
-    title="disable"
-    title="_"
-    title="active"
-    title="_"
-    title="record"
-    title="_"
-    title="5"
+    title="disable_active_record_5"
   >
     <Table>
       <tbody>
@@ -5250,13 +4880,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_active_record_notifications"
-    title="disable"
-    title="_"
-    title="active"
-    title="_"
-    title="record"
-    title="_"
-    title="notifications"
+    title="disable_active_record_notifications"
   >
     <Table>
       <tbody>
@@ -5297,9 +4921,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_bunny"
-    title="disable"
-    title="_"
-    title="bunny"
+    title="disable_bunny"
   >
     <Table>
       <tbody>
@@ -5340,9 +4962,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_curb"
-    title="disable"
-    title="_"
-    title="curb"
+    title="disable_curb"
   >
     <Table>
       <tbody>
@@ -5383,9 +5003,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_excon"
-    title="disable"
-    title="_"
-    title="excon"
+    title="disable_excon"
   >
     <Table>
       <tbody>
@@ -5426,9 +5044,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_httpclient"
-    title="disable"
-    title="_"
-    title="httpclient"
+    title="disable_httpclient"
   >
     <Table>
       <tbody>
@@ -5469,11 +5085,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_net_http"
-    title="disable"
-    title="_"
-    title="net"
-    title="_"
-    title="http"
+    title="disable_net_http"
   >
     <Table>
       <tbody>
@@ -5514,9 +5126,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_rack"
-    title="disable"
-    title="_"
-    title="rack"
+    title="disable_rack"
   >
     <Table>
       <tbody>
@@ -5557,11 +5167,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_rack_urlmap"
-    title="disable"
-    title="_"
-    title="rack"
-    title="_"
-    title="urlmap"
+    title="disable_rack_urlmap"
   >
     <Table>
       <tbody>
@@ -5602,11 +5208,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_puma_rack"
-    title="disable"
-    title="_"
-    title="puma"
-    title="_"
-    title="rack"
+    title="disable_puma_rack"
   >
     <Table>
       <tbody>
@@ -5647,13 +5249,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_puma_rack_urlmap"
-    title="disable"
-    title="_"
-    title="puma"
-    title="_"
-    title="rack"
-    title="_"
-    title="urlmap"
+    title="disable_puma_rack_urlmap"
   >
     <Table>
       <tbody>
@@ -5694,9 +5290,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_typhoeus"
-    title="disable"
-    title="_"
-    title="typhoeus"
+    title="disable_typhoeus"
   >
     <Table>
       <tbody>
@@ -5737,9 +5331,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_httprb"
-    title="disable"
-    title="_"
-    title="httprb"
+    title="disable_httprb"
   >
     <Table>
       <tbody>
@@ -5780,11 +5372,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_middleware_instrumentation"
-    title="disable"
-    title="_"
-    title="middleware"
-    title="_"
-    title="instrumentation"
+    title="disable_middleware_instrumentation"
   >
     <Table>
       <tbody>
@@ -5825,9 +5413,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="disable_grape"
-    title="disable"
-    title="_"
-    title="grape"
+    title="disable_grape"
   >
     <Table>
       <tbody>
@@ -5872,9 +5458,7 @@ Use these settings to toggle instrumentation types during agent startup.
 <CollapserGroup>
   <Collapser
     id="distributed_tracing-enabled"
-    title="distributed"
-    title="_"
-    title="tracing.enabled"
+    title="distributed_tracing.enabled"
   >
     <Table>
       <tbody>
@@ -5915,11 +5499,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="exclude_newrelic_header"
-    title="exclude"
-    title="_"
-    title="newrelic"
-    title="_"
-    title="header"
+    title="exclude_newrelic_header"
   >
     <Table>
       <tbody>
@@ -5964,11 +5544,7 @@ Use these settings to toggle instrumentation types during agent startup.
 <CollapserGroup>
   <Collapser
     id="heroku-use_dyno_names"
-    title="heroku.use"
-    title="_"
-    title="dyno"
-    title="_"
-    title="names"
+    title="heroku.use_dyno_names"
   >
     <Table>
       <tbody>
@@ -6009,15 +5585,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="heroku-dyno_name_prefixes_to_shorten"
-    title="heroku.dyno"
-    title="_"
-    title="name"
-    title="_"
-    title="prefixes"
-    title="_"
-    title="to"
-    title="_"
-    title="shorten"
+    title="heroku.dyno_name_prefixes_to_shorten"
   >
     <Table>
       <tbody>
@@ -6062,9 +5630,7 @@ Use these settings to toggle instrumentation types during agent startup.
 <CollapserGroup>
   <Collapser
     id="mongo-capture_queries"
-    title="mongo.capture"
-    title="_"
-    title="queries"
+    title="mongo.capture_queries"
   >
     <Table>
       <tbody>
@@ -6105,9 +5671,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="mongo-obfuscate_queries"
-    title="mongo.obfuscate"
-    title="_"
-    title="queries"
+    title="mongo.obfuscate_queries"
   >
     <Table>
       <tbody>
@@ -6152,11 +5716,7 @@ Use these settings to toggle instrumentation types during agent startup.
 <CollapserGroup>
   <Collapser
     id="process_host-display_name"
-    title="process"
-    title="_"
-    title="host.display"
-    title="_"
-    title="name"
+    title="process_host.display_name"
   >
     <Table>
       <tbody>
@@ -6242,9 +5802,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="rake-connect_timeout"
-    title="rake.connect"
-    title="_"
-    title="timeout"
+    title="rake.connect_timeout"
   >
     <Table>
       <tbody>
@@ -6289,9 +5847,7 @@ Use these settings to toggle instrumentation types during agent startup.
 <CollapserGroup>
   <Collapser
     id="resque-capture_params"
-    title="resque.capture"
-    title="_"
-    title="params"
+    title="resque.capture_params"
   >
     <Table>
       <tbody>
@@ -6336,11 +5892,7 @@ Use these settings to toggle instrumentation types during agent startup.
 <CollapserGroup>
   <Collapser
     id="rules-ignore_url_regexes"
-    title="rules.ignore"
-    title="_"
-    title="url"
-    title="_"
-    title="regexes"
+    title="rules.ignore_url_regexes"
   >
     <Table>
       <tbody>
@@ -6385,9 +5937,7 @@ Use these settings to toggle instrumentation types during agent startup.
 <CollapserGroup>
   <Collapser
     id="sidekiq-capture_params"
-    title="sidekiq.capture"
-    title="_"
-    title="params"
+    title="sidekiq.capture_params"
   >
     <Table>
       <tbody>
@@ -6432,9 +5982,7 @@ Use these settings to toggle instrumentation types during agent startup.
 <CollapserGroup>
   <Collapser
     id="slow_sql-enabled"
-    title="slow"
-    title="_"
-    title="sql.enabled"
+    title="slow_sql.enabled"
   >
     <Table>
       <tbody>
@@ -6475,11 +6023,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="slow_sql-explain_threshold"
-    title="slow"
-    title="_"
-    title="sql.explain"
-    title="_"
-    title="threshold"
+    title="slow_sql.explain_threshold"
   >
     <Table>
       <tbody>
@@ -6520,11 +6064,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="slow_sql-explain_enabled"
-    title="slow"
-    title="_"
-    title="sql.explain"
-    title="_"
-    title="enabled"
+    title="slow_sql.explain_enabled"
   >
     <Table>
       <tbody>
@@ -6565,11 +6105,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="slow_sql-record_sql"
-    title="slow"
-    title="_"
-    title="sql.record"
-    title="_"
-    title="sql"
+    title="slow_sql.record_sql"
   >
     <Table>
       <tbody>
@@ -6610,15 +6146,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="slow_sql-use_longer_sql_id"
-    title="slow"
-    title="_"
-    title="sql.use"
-    title="_"
-    title="longer"
-    title="_"
-    title="sql"
-    title="_"
-    title="id"
+    title="slow_sql.use_longer_sql_id"
   >
     <Table>
       <tbody>
@@ -6663,9 +6191,7 @@ Use these settings to toggle instrumentation types during agent startup.
 <CollapserGroup>
   <Collapser
     id="span_events-enabled"
-    title="span"
-    title="_"
-    title="events.enabled"
+    title="span_events.enabled"
   >
     <Table>
       <tbody>
@@ -6706,11 +6232,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="span_events-queue_size"
-    title="span"
-    title="_"
-    title="events.queue"
-    title="_"
-    title="size"
+    title="span_events.queue_size"
   >
     <Table>
       <tbody>
@@ -6751,13 +6273,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="span_events-max_samples_stored"
-    title="span"
-    title="_"
-    title="events.max"
-    title="_"
-    title="samples"
-    title="_"
-    title="stored"
+    title="span_events.max_samples_stored"
   >
     <Table>
       <tbody>
@@ -6802,11 +6318,7 @@ Use these settings to toggle instrumentation types during agent startup.
 <CollapserGroup>
   <Collapser
     id="strip_exception_messages-enabled"
-    title="strip"
-    title="_"
-    title="exception"
-    title="_"
-    title="messages.enabled"
+    title="strip_exception_messages.enabled"
   >
     <Table>
       <tbody>
@@ -6847,11 +6359,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="strip_exception_messages-whitelist"
-    title="strip"
-    title="_"
-    title="exception"
-    title="_"
-    title="messages.whitelist"
+    title="strip_exception_messages.whitelist"
   >
     <Table>
       <tbody>
@@ -6892,13 +6400,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="strip_exception_messages-allowed_classes"
-    title="strip"
-    title="_"
-    title="exception"
-    title="_"
-    title="messages.allowed"
-    title="_"
-    title="classes"
+    title="strip_exception_messages.allowed_classes"
   >
     <Table>
       <tbody>
@@ -6943,9 +6445,7 @@ Use these settings to toggle instrumentation types during agent startup.
 <CollapserGroup>
   <Collapser
     id="thread_profiler-enabled"
-    title="thread"
-    title="_"
-    title="profiler.enabled"
+    title="thread_profiler.enabled"
   >
     <Table>
       <tbody>
@@ -6990,9 +6490,7 @@ Use these settings to toggle instrumentation types during agent startup.
 <CollapserGroup>
   <Collapser
     id="utilization-detect_aws"
-    title="utilization.detect"
-    title="_"
-    title="aws"
+    title="utilization.detect_aws"
   >
     <Table>
       <tbody>
@@ -7033,9 +6531,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="utilization-detect_azure"
-    title="utilization.detect"
-    title="_"
-    title="azure"
+    title="utilization.detect_azure"
   >
     <Table>
       <tbody>
@@ -7076,9 +6572,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="utilization-detect_gcp"
-    title="utilization.detect"
-    title="_"
-    title="gcp"
+    title="utilization.detect_gcp"
   >
     <Table>
       <tbody>
@@ -7119,9 +6613,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="utilization-detect_pcf"
-    title="utilization.detect"
-    title="_"
-    title="pcf"
+    title="utilization.detect_pcf"
   >
     <Table>
       <tbody>
@@ -7162,9 +6654,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="utilization-detect_docker"
-    title="utilization.detect"
-    title="_"
-    title="docker"
+    title="utilization.detect_docker"
   >
     <Table>
       <tbody>
@@ -7205,9 +6695,7 @@ Use these settings to toggle instrumentation types during agent startup.
 
   <Collapser
     id="utilization-detect_kubernetes"
-    title="utilization.detect"
-    title="_"
-    title="kubernetes"
+    title="utilization.detect_kubernetes"
   >
     <Table>
       <tbody>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,56 +1,94 @@
 ---
-title: Get started with New Relic
+title: New Relic APIs
 contentType: landingPage
 template: basicDoc
 topics:
-  - Using New Relic
-  - Welcome to New Relic
+  - ''
+  - APIs
 ---
 
 import { Link } from 'gatsby'
 
-**Welcome to New Relic!** You just joined thousands of others who are managing applications in increasingly complicated environments. We're your partner. Together, we can help you see what's happening in your application, understand where the problems are, and make sure you never miss an issue that needs attention.
+New Relic offers a variety of APIs and SDKs you can use to:
 
-**Let's get started together.** We're going to take you through the basics to manage your application and services. Follow these steps and you'll be set up for success:
+* Retrieve data from the New Relic platform.
+* Insert data into New Relic.
+* Adjust configuration settings.
 
-1. Get data reporting.
-2. Improve your application's performance.
-3. Organize your applications with labels.
-4. Get notified if something goes wrong (alerts).
+Different New Relic products have their own APIs, so before you start using a specific API, it's a good idea to understand what the various APIs can do. Recommended reading:
 
-![New Relic APM Overview](./images/apm-landing-page.png "New Relic APM Overview")
+* [Introduction to New Relic APIs](/docs/apis/getting-started/intro-apis/introduction-new-relic-apis)
+* [A developer-centric look at our APIs](https://developer.newrelic.com/)
 
-[**rpm.newrelic.com:**](https://rpm.newrelic.com) Starting from the **APM Overview** page, dive into the wealth of tables, charts, and other dashboards showing current and historical trends about your app's performance.
+![New Relic Graph QL API explorer](./images/new-relic-graph-ql-api-explorer.png "new-relic-graph-ql-api-explorer.png")
 
-[<Icon name="list" size="3em"/>](/docs/using-new-relic/welcome-new-relic/getting-started/get-started-data-reporting)
+**[api.newrelic.com/graphiql](https://api.newrelic.com/graphiql):** Our NerdGraph GraphiQL explorer is one of the ways you can query and retrieve New Relic data.
 
-**Get data reporting.** In order to see what's happening in your application, you need to install our agent in your environment. This connection allows your application to send data about its performance. [Learn how.](/docs/using-new-relic/welcome-new-relic/getting-started/get-started-data-reporting)
+<i
+  aria-hidden="true"
+  className="fa fa-map-o fa-3x text-muted"
+>
+  \[map icon]
+</i>
 
-[<i aria-hidden="true" className="fa fa-area-chart fa-3x color_apm">\[search icon\]
-</i>](/docs/using-new-relic/welcome-new-relic/getting-started/get-started-improving-app-performance)
+**[Introduction to APIs.](/docs/apis/getting-started/intro-apis/introduction-new-relic-apis)** See an overview of all APIs, including account admin and subscription usage data APIs.
 
-**Improve app performance.** Now that you can see data from your application, it's time to put that data to work and analyze how you can improve its performance. [Learn how.](/docs/using-new-relic/welcome-new-relic/getting-started/get-started-improving-app-performance)
+<Icon
+  name="terminal"
+  size="3em"
+/>
 
-[<i aria-hidden="true" className="fa fa-tags fa-3x color_apm">\[tags icon\]
-</i>](/docs/using-new-relic/welcome-new-relic/getting-started/get-started-organizing-your-apps)
+**[New Relic's developer site.](https://developer.newrelic.com/)** Learn developer options for extending and customizing New Relic.
 
-**Organize your applications.** Use labels to make it easier to find, view, and compare only the entities that are meaningful to you. [Learn how.](/docs/using-new-relic/welcome-new-relic/getting-started/get-started-organizing-your-apps)
+<i
+  aria-hidden="true"
+  className="fa fa-book fa-3x text-muted"
+>
+  \[book icon]
+</i>
 
-[<Icon name="alert-triangle" size="3em"/>](/docs/using-new-relic/welcome-new-relic/getting-started/get-started-alerts)
+**[NerdGraph GraphiQL explorer.](/docs/apis/graphql-api/getting-started/introduction-new-relic-graphql-api)** Retrieve specified data with a single request, instead of making multiple calls.
 
-**Get notified if something goes wrong.** Diagnosing the problem after the fact is important, but it's more important to know that you have a problem, or are about to have one. [Learn how.](/docs/using-new-relic/welcome-new-relic/getting-started/get-started-alerts)
+<i
+  aria-hidden="true"
+  className="fa fa-area-chart fa-3x text-muted"
+>
+  \[area chart icon]
+</i>
+
+**[APM agent APIs.](/docs/apis/getting-started/intro-apis/introduction-new-relic-apis#apm-api)** Use our language agent APIs to report custom transactions and make other customizations.
+
+<Icon
+  name="alert-triangle"
+  size="3em"
+/>
+
+[**Alerts API.**](/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api/rest-api-calls-new-relic-alerts) Use the Alerts API to set up alerting solutions and to get data about your Alerts settings.
+
+<i
+  aria-hidden="true"
+  className="fa fa-code fa-3x text-muted"
+>
+  \[code icon]
+</i>
+
+**[Synthetics APIs.](/docs/apis/synthetics-rest-api)** Manage Synthetics monitors and return monitor data.
 
 <Button
   role="button"
   as={Link}
-  to="/docs/using-new-relic?toc=true"
+  to="/docs/apis?toc=true"
   variant="primary"
 >
-  View all Using New Relic docs
+  View all APIs docs
 </Button>
+den="true"
+  className="fa fa-check fa-2x"
+>
+  \[check icon]
+</i>
 
-\-- NORMAL --
-t-audit-logs-nrauditevent), and use other [product security options](/docs/using-new-relic/new-relic-security/security/data-privacy-new-relic#product-security).
+**Security: What you can do.** To enhance your own security measures, you can use our [SAML single sign-on (SSO) providers](/docs/accounts/accounts/saml-single-sign/saml-service-providers), adjust [high security mode](/docs/agents/manage-apm-agents/configuration/high-security-mode) settings, review [audit logs](/docs/insights/use-insights-ui/manage-account-data/query-account-audit-logs-nrauditevent), and use other [product security options](/docs/using-new-relic/new-relic-security/security/data-privacy-new-relic#product-security).
 
 <i
   aria-hidden="true"

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,94 +1,56 @@
 ---
-title: New Relic APIs
+title: Get started with New Relic
 contentType: landingPage
 template: basicDoc
 topics:
-  - ''
-  - APIs
+  - Using New Relic
+  - Welcome to New Relic
 ---
 
 import { Link } from 'gatsby'
 
-New Relic offers a variety of APIs and SDKs you can use to:
+**Welcome to New Relic!** You just joined thousands of others who are managing applications in increasingly complicated environments. We're your partner. Together, we can help you see what's happening in your application, understand where the problems are, and make sure you never miss an issue that needs attention.
 
-* Retrieve data from the New Relic platform.
-* Insert data into New Relic.
-* Adjust configuration settings.
+**Let's get started together.** We're going to take you through the basics to manage your application and services. Follow these steps and you'll be set up for success:
 
-Different New Relic products have their own APIs, so before you start using a specific API, it's a good idea to understand what the various APIs can do. Recommended reading:
+1. Get data reporting.
+2. Improve your application's performance.
+3. Organize your applications with labels.
+4. Get notified if something goes wrong (alerts).
 
-* [Introduction to New Relic APIs](/docs/apis/getting-started/intro-apis/introduction-new-relic-apis)
-* [A developer-centric look at our APIs](https://developer.newrelic.com/)
+![New Relic APM Overview](./images/apm-landing-page.png "New Relic APM Overview")
 
-![New Relic Graph QL API explorer](./images/new-relic-graph-ql-api-explorer.png "new-relic-graph-ql-api-explorer.png")
+[**rpm.newrelic.com:**](https://rpm.newrelic.com) Starting from the **APM Overview** page, dive into the wealth of tables, charts, and other dashboards showing current and historical trends about your app's performance.
 
-**[api.newrelic.com/graphiql](https://api.newrelic.com/graphiql):** Our NerdGraph GraphiQL explorer is one of the ways you can query and retrieve New Relic data.
+[<Icon name="list" size="3em"/>](/docs/using-new-relic/welcome-new-relic/getting-started/get-started-data-reporting)
 
-<i
-  aria-hidden="true"
-  className="fa fa-map-o fa-3x text-muted"
->
-  \[map icon]
-</i>
+**Get data reporting.** In order to see what's happening in your application, you need to install our agent in your environment. This connection allows your application to send data about its performance. [Learn how.](/docs/using-new-relic/welcome-new-relic/getting-started/get-started-data-reporting)
 
-**[Introduction to APIs.](/docs/apis/getting-started/intro-apis/introduction-new-relic-apis)** See an overview of all APIs, including account admin and subscription usage data APIs.
+[<i aria-hidden="true" className="fa fa-area-chart fa-3x color_apm">\[search icon\]
+</i>](/docs/using-new-relic/welcome-new-relic/getting-started/get-started-improving-app-performance)
 
-<Icon
-  name="terminal"
-  size="3em"
-/>
+**Improve app performance.** Now that you can see data from your application, it's time to put that data to work and analyze how you can improve its performance. [Learn how.](/docs/using-new-relic/welcome-new-relic/getting-started/get-started-improving-app-performance)
 
-**[New Relic's developer site.](https://developer.newrelic.com/)** Learn developer options for extending and customizing New Relic.
+[<i aria-hidden="true" className="fa fa-tags fa-3x color_apm">\[tags icon\]
+</i>](/docs/using-new-relic/welcome-new-relic/getting-started/get-started-organizing-your-apps)
 
-<i
-  aria-hidden="true"
-  className="fa fa-book fa-3x text-muted"
->
-  \[book icon]
-</i>
+**Organize your applications.** Use labels to make it easier to find, view, and compare only the entities that are meaningful to you. [Learn how.](/docs/using-new-relic/welcome-new-relic/getting-started/get-started-organizing-your-apps)
 
-**[NerdGraph GraphiQL explorer.](/docs/apis/graphql-api/getting-started/introduction-new-relic-graphql-api)** Retrieve specified data with a single request, instead of making multiple calls.
+[<Icon name="alert-triangle" size="3em"/>](/docs/using-new-relic/welcome-new-relic/getting-started/get-started-alerts)
 
-<i
-  aria-hidden="true"
-  className="fa fa-area-chart fa-3x text-muted"
->
-  \[area chart icon]
-</i>
-
-**[APM agent APIs.](/docs/apis/getting-started/intro-apis/introduction-new-relic-apis#apm-api)** Use our language agent APIs to report custom transactions and make other customizations.
-
-<Icon
-  name="alert-triangle"
-  size="3em"
-/>
-
-[**Alerts API.**](/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api/rest-api-calls-new-relic-alerts) Use the Alerts API to set up alerting solutions and to get data about your Alerts settings.
-
-<i
-  aria-hidden="true"
-  className="fa fa-code fa-3x text-muted"
->
-  \[code icon]
-</i>
-
-**[Synthetics APIs.](/docs/apis/synthetics-rest-api)** Manage Synthetics monitors and return monitor data.
+**Get notified if something goes wrong.** Diagnosing the problem after the fact is important, but it's more important to know that you have a problem, or are about to have one. [Learn how.](/docs/using-new-relic/welcome-new-relic/getting-started/get-started-alerts)
 
 <Button
   role="button"
   as={Link}
-  to="/docs/apis?toc=true"
+  to="/docs/using-new-relic?toc=true"
   variant="primary"
 >
-  View all APIs docs
+  View all Using New Relic docs
 </Button>
-den="true"
-  className="fa fa-check fa-2x"
->
-  \[check icon]
-</i>
 
-**Security: What you can do.** To enhance your own security measures, you can use our [SAML single sign-on (SSO) providers](/docs/accounts/accounts/saml-single-sign/saml-service-providers), adjust [high security mode](/docs/agents/manage-apm-agents/configuration/high-security-mode) settings, review [audit logs](/docs/insights/use-insights-ui/manage-account-data/query-account-audit-logs-nrauditevent), and use other [product security options](/docs/using-new-relic/new-relic-security/security/data-privacy-new-relic#product-security).
+\-- NORMAL --
+t-audit-logs-nrauditevent), and use other [product security options](/docs/using-new-relic/new-relic-security/security/data-privacy-new-relic#product-security).
 
 <i
   aria-hidden="true"

--- a/src/content/docs/insights/insights-api/get-data/query-insights-event-data-api.mdx
+++ b/src/content/docs/insights/insights-api/get-data/query-insights-event-data-api.mdx
@@ -70,64 +70,62 @@ The structure of the JSON data depends on the NRQL that you used in the request:
 
 The Insights query API returns JSON data. Here's an example of an Insights query, its query request format, and its returned data:
 
-<dt>
-  Query, query API request, returned data
-</dt>
+<CollapserGroup>
+  <Collapser title="Query, query API request, returned data">
+    **Original NRQL query:**
 
-<dd>
-  **Original NRQL query:**
+    ```
+    SELECT count(appName) FROM PageView SINCE '2014-08-04 00:00:00+0500'
+    ```
 
-  ```
-  SELECT count(appName) FROM PageView SINCE '2014-08-04 00:00:00+0500'
-  ```
+    **Query cURL request (with URL-encoded NRQL query)**:
 
-  **Query cURL request (with URL-encoded NRQL query)**:
+    ```
+    curl -H "Accept: application/json" -H "X-Query-Key: YOUR_QUERY_KEY" "https://insights-api.newrelic.com/v1/accounts/YOUR_ACCOUNT_ID/query?nrql=SELECT+count%28appName%29+FROM+PageView+SINCE+%272014-08-04+00%3A00%3A00%2B0500%27"
+    ```
 
-  ```
-  curl -H "Accept: application/json" -H "X-Query-Key: YOUR_QUERY_KEY" "https://insights-api.newrelic.com/v1/accounts/YOUR_ACCOUNT_ID/query?nrql=SELECT+count%28appName%29+FROM+PageView+SINCE+%272014-08-04+00%3A00%3A00%2B0500%27"
-  ```
+    **Returned JSON data:**
 
-  **Returned JSON data:**
-
-  ```
-  {
-    "results": [
-      {
-        "count": 80275388
-      }
-    ],
-    "metadata": {
-      "eventTypes": [
-        "PageView"
-      ],
-      "eventType": "PageView",
-      "openEnded": true,
-      "beginTime": "2014-08-03T19:00:00Z",
-      "endTime": "2017-01-18T23:18:41Z",
-      "beginTimeMillis=": 1407092400000,
-      "endTimeMillis": 1484781521198,
-      "rawSince": "'2014-08-04 00:00:00+0500'",
-      "rawUntil": "`now`",
-      "rawCompareWith": "",
-      "clippedTimeWindows": {
-        "Browser": {
-          "beginTimeMillis": 1483571921198,
-          "endTimeMillis": 1484781521198,
-          "retentionMillis": 1209600000
-        }
-      },
-      "messages": [],
-      "contents": [
+    ```
+    {
+      "results": [
         {
-          "function": "count",
-          "attribute": "appName",
-          "simple": true
+          "count": 80275388
         }
-      ]
+      ],
+      "metadata": {
+        "eventTypes": [
+          "PageView"
+        ],
+        "eventType": "PageView",
+        "openEnded": true,
+        "beginTime": "2014-08-03T19:00:00Z",
+        "endTime": "2017-01-18T23:18:41Z",
+        "beginTimeMillis=": 1407092400000,
+        "endTimeMillis": 1484781521198,
+        "rawSince": "'2014-08-04 00:00:00+0500'",
+        "rawUntil": "`now`",
+        "rawCompareWith": "",
+        "clippedTimeWindows": {
+          "Browser": {
+            "beginTimeMillis": 1483571921198,
+            "endTimeMillis": 1484781521198,
+            "retentionMillis": 1209600000
+          }
+        },
+        "messages": [],
+        "contents": [
+          {
+            "function": "count",
+            "attribute": "appName",
+            "simple": true
+          }
+        ]
+      }
     }
-  }
-  ```
-</dd>
+    ```
+  </Collapser>
+</CollapserGroup>
 
 ## Rate limiting guidelines
 

--- a/src/content/docs/introduction-new-relic-agent-sdk.mdx
+++ b/src/content/docs/introduction-new-relic-agent-sdk.mdx
@@ -386,57 +386,35 @@ After you install the New Relic Agent SDK, update your configuration so that you
     <CollapserGroup>
       <Collapser
         id="license-key"
-        title="NEWRELIC"
-        title="_"
-        title="LICENSE"
-        title="_"
-        title="KEY (required for daemon-mode)"
+        title="NEWRELIC_LICENSE_KEY (required for daemon-mode)"
       >
         Format: &lt;your license key>
       </Collapser>
 
       <Collapser
         id="app-name"
-        title="NEWRELIC"
-        title="_"
-        title="APP"
-        title="_"
-        title="NAME (required for daemon-mode)"
+        title="NEWRELIC_APP_NAME (required for daemon-mode)"
       >
         Format: "Hello World"
       </Collapser>
 
       <Collapser
         id="app-language"
-        title="NEWRELIC"
-        title="_"
-        title="APP"
-        title="_"
-        title="LANGUAGE (required for daemon-mode)"
+        title="NEWRELIC_APP_LANGUAGE (required for daemon-mode)"
       >
         Format: "Perl"
       </Collapser>
 
       <Collapser
         id="language-version"
-        title="NEWRELIC"
-        title="_"
-        title="APP"
-        title="_"
-        title="LANGUAGE"
-        title="_"
-        title="VERSION (required for daemon-mode)"
+        title="NEWRELIC_APP_LANGUAGE_VERSION (required for daemon-mode)"
       >
         Format: 5.18.2
       </Collapser>
 
       <Collapser
         id="ssl"
-        title="NEWRELIC"
-        title="_"
-        title="ENABLE"
-        title="_"
-        title="SSL"
+        title="NEWRELIC_ENABLE_SSL"
       >
         Format: 0 (disabled) or 1 (enabled, default)
 
@@ -445,13 +423,7 @@ After you install the New Relic Agent SDK, update your configuration so that you
 
       <Collapser
         id="high-security"
-        title="NEWRELIC"
-        title="_"
-        title="ENABLE"
-        title="_"
-        title="HIGH"
-        title="_"
-        title="SECURITY"
+        title="NEWRELIC_ENABLE_HIGH_SECURITY"
       >
         Format: 0 (disabled, default) or 1 (enabled)
 
@@ -460,13 +432,7 @@ After you install the New Relic Agent SDK, update your configuration so that you
 
       <Collapser
         id="properties"
-        title="NEWRELIC"
-        title="_"
-        title="LOG"
-        title="_"
-        title="PROPERTIES"
-        title="_"
-        title="FILE"
+        title="NEWRELIC_LOG_PROPERTIES_FILE"
       >
         Format: &lt;path/to/log4cplus.properties>
 
@@ -480,15 +446,7 @@ After you install the New Relic Agent SDK, update your configuration so that you
 
       <Collapser
         id="apdex-t"
-        title="NEWRELIC"
-        title="_"
-        title="APP"
-        title="_"
-        title="SERVER"
-        title="_"
-        title="APDEX"
-        title="_"
-        title="T"
+        title="NEWRELIC_APP_SERVER_APDEX_T"
       >
         Format: 0.25 (default is 0.5)
 
@@ -497,9 +455,7 @@ After you install the New Relic Agent SDK, update your configuration so that you
 
       <Collapser
         id="proxy"
-        title="http"
-        title="_"
-        title="proxy"
+        title="http_proxy"
       >
         Format: "http&#x3A;//&lt;name>:&lt;passwd>@&lt;proxy>:&lt;port>"
 

--- a/src/content/docs/plugins/plugins-new-relic/install-plugins/install-plugin-central.mdx
+++ b/src/content/docs/plugins/plugins-new-relic/install-plugins/install-plugin-central.mdx
@@ -116,7 +116,7 @@ The New Relic Platform Installer (NPI) is a command line utility that helps you 
 
       <Collapser
         id="no-file-found"
-        title="Error message "
+        title={<>Error message <InlineCode>./npi: line 1: bin/node: No such file or directory</InlineCode></>}
       >
         **Problem**: The architecture script that you selected when you installed the NPI tool does not match your operating system (for example, x86 instead of x64).
 
@@ -125,7 +125,7 @@ The New Relic Platform Installer (NPI) is a command line utility that helps you 
 
       <Collapser
         id="nav-to-npi-dir"
-        title="Error message "
+        title={<>Error message <InlineCode>-bash: ./npi: No such file or directory</InlineCode></>}
       >
         **Problem**: You cannot run NPI commands.
 

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -29,8 +29,7 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
   <Collapser
     className="freq-link"
     id="state-select"
-    title="Required: "
-    title=" statement"
+    title={<>Required: <InlineCode>SELECT</InlineCode> statement</>}
   >
     ```
     SELECT attribute ...
@@ -49,24 +48,24 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
 
     You can also [use `SELECT` with basic math functions](/docs/query-data/nrql-new-relic-query-language/getting-started/nrql-math-using-select).
 
-    <dt id="avg-resp-time-query">
-      Avg response time since last week
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="avg-resp-time-query"
+        title="Avg response time since last week"
+      >
+        This query returns the average response time since last week.
 
-    <dd>
-      This query returns the average response time since last week.
-
-      ```
-      SELECT average(duration) FROM PageView SINCE 1 week ago
-      ```
-    </dd>
+        ```
+        SELECT average(duration) FROM PageView SINCE 1 week ago
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     className="freq-link"
     id="sel-from"
-    title="Required: "
-    title=" clause"
+    title={<>Required: <InlineCode>FROM</InlineCode> clause</>}
   >
     ```
     SELECT ...
@@ -76,35 +75,35 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
 
     Use the `FROM` clause to specify the [data type](/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql#what-you-can-query) you wish to query. You can start your query with `FROM` or with [`SELECT`](#state-select). You can merge values for the same attributes across multiple data types in a [comma separated list](#commas).
 
-    <dt id="one-event">
-      Query one data type
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="one-event"
+        title="Query one data type"
+      >
+        This query returns the count of all [APM transactions](/docs/insights/new-relic-insights/decorating-events/insights-attributes#transaction-defaults) over the last three days:
 
-    <dd>
-      This query returns the count of all [APM transactions](/docs/insights/new-relic-insights/decorating-events/insights-attributes#transaction-defaults) over the last three days:
+        ```
+        SELECT count(*) FROM Transaction SINCE 3 days ago
+        ```
+      </Collapser>
 
-      ```
-      SELECT count(*) FROM Transaction SINCE 3 days ago
-      ```
-    </dd>
+      <Collapser
+        id="multiple-events"
+        title="Query multiple data types"
+      >
+        This query returns the count of all [APM transactions](/docs/insights/new-relic-insights/decorating-events/insights-attributes#transaction-defaults) and [Browser events](/docs/insights/new-relic-insights/decorating-events/browser-default-attributes-insights#browser-attributes-table) over the last three days:
 
-    <dt id="multiple-events">
-      Query multiple data types
-    </dt>
-
-    <dd>
-      This query returns the count of all [APM transactions](/docs/insights/new-relic-insights/decorating-events/insights-attributes#transaction-defaults) and [Browser events](/docs/insights/new-relic-insights/decorating-events/browser-default-attributes-insights#browser-attributes-table) over the last three days:
-
-      ```
-      SELECT count(*) FROM Transaction, PageView SINCE 3 days ago
-      ```
-    </dd>
+        ```
+        SELECT count(*) FROM Transaction, PageView SINCE 3 days ago
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     className="freq-link"
     id="show-event-types"
-    title=" clause"
+    title={<><InlineCode>SHOW EVENT TYPES</InlineCode> clause</>}
   >
     ```
     SHOW EVENT TYPES...
@@ -116,23 +115,24 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
       In this context, "event types" refers to the data types you can access with a NRQL query.
     </Callout>
 
-    <dt id="avg-resp-time-query">
-      Data types in the last day
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="avg-resp-time-query"
+        title="Data types in the last day"
+      >
+        This query will return all the data types present over the past day:
 
-    <dd>
-      This query will return all the data types present over the past day:
-
-      ```
-      SHOW EVENT TYPES SINCE 1 day ago
-      ```
-    </dd>
+        ```
+        SHOW EVENT TYPES SINCE 1 day ago
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     className="freq-link"
     id="sel-where"
-    title=" clause"
+    title={<><InlineCode>WHERE</InlineCode> clause</>}
   >
     Use the `WHERE` clause to filter results. NRQL returns the results that fulfill the condition(s) you specify in the clause.
 
@@ -328,25 +328,26 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
       </tbody>
     </Table>
 
-    <dt id="query-3-conditions">
-      Example query with three conditions
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="query-3-conditions"
+        title="Example query with three conditions"
+      >
+        This query returns the browser response time for pages with `checkout` in the URL for Safari users in the United States and Canada over the past 24 hours.
 
-    <dd>
-      This query returns the browser response time for pages with `checkout` in the URL for Safari users in the United States and Canada over the past 24 hours.
-
-      ```
-      SELECT histogram(duration, 50, 20) FROM PageView
-      WHERE countryCode IN ('CA', 'US') AND userAgentName='Safari' AND pageUrl LIKE '%checkout%'
-      SINCE 1 day ago
-      ```
-    </dd>
+        ```
+        SELECT histogram(duration, 50, 20) FROM PageView
+        WHERE countryCode IN ('CA', 'US') AND userAgentName='Safari' AND pageUrl LIKE '%checkout%'
+        SINCE 1 day ago
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     className="freq-link"
     id="sel-as"
-    title=" clause"
+    title={<><InlineCode>AS</InlineCode> clause</>}
   >
     ```
     SELECT ...
@@ -356,39 +357,39 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
 
     Use the `AS` clause to label an attribute, aggregator, step in a funnel, or the result of a math function with a string delimited by single quotes. The label is used in the resulting chart.
 
-    <dt id="math-as">
-      Query using math function and `AS`
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="math-as"
+        title={<>Query using math function and <InlineCode>AS</InlineCode></>}
+      >
+        This query returns the number of page views per session:
 
-    <dd>
-      This query returns the number of page views per session:
+        ```
+        SELECT count(*)/uniqueCount(session) AS 'Pageviews per Session'
+          FROM PageView
+        ```
+      </Collapser>
 
-      ```
-      SELECT count(*)/uniqueCount(session) AS 'Pageviews per Session'
-        FROM PageView
-      ```
-    </dd>
+      <Collapser
+        id="funnel-as"
+        title={<>Query using funnel and <InlineCode>AS</InlineCode></>}
+      >
+        This query returns a count of people who have visited both the main page and the careers page of a site over the past week:
 
-    <dt id="funnel-as">
-      Query using funnel and `AS`
-    </dt>
-
-    <dd>
-      This query returns a count of people who have visited both the main page and the careers page of a site over the past week:
-
-      ```
-      SELECT funnel(SESSION,
-          WHERE name='Controller/about/main' AS 'Step 1',
-          WHERE name = 'Controller/about/careers' AS 'Step 2')
-          FROM PageView SINCE 1 week ago
-      ```
-    </dd>
+        ```
+        SELECT funnel(SESSION,
+            WHERE name='Controller/about/main' AS 'Step 1',
+            WHERE name = 'Controller/about/careers' AS 'Step 2')
+            FROM PageView SINCE 1 week ago
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     className="freq-link"
     id="sel-facet"
-    title=" clause"
+    title={<><InlineCode>FACET</InlineCode> clause</>}
   >
     ```
     SELECT ...
@@ -406,45 +407,44 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
 
     For more on faceting on multiple attributes, with some real-world examples, see this [New Relic blog post](https://blog.newrelic.com/2017/12/08/facets-nrql-queries-insights/).
 
-    <dt id="faceted-query">
-      Faceted query using `count()`
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="faceted-query"
+        title={<>Faceted query using <InlineCode>count()</InlineCode></>}
+      >
+        This query shows cities with the highest pageview counts. This query uses the total number of pageviews per city to determine how facets are picked and ordered.
 
-    <dd>
-      This query shows cities with the highest pageview counts. This query uses the total number of pageviews per city to determine how facets are picked and ordered.
+        ```
+        SELECT count(*) FROM PageView FACET city
+        ```
+      </Collapser>
 
-      ```
-      SELECT count(*) FROM PageView FACET city
-      ```
-    </dd>
+      <Collapser
+        id="uniquecount"
+        title={<>Faceted query using <InlineCode>uniqueCount()</InlineCode></>}
+      >
+        This query shows the cities that access the highest number of unique URLs. This query uses the total number of times a particular city appears in the results to determine how facets are picked and ordered.
 
-    <dt id="uniquecount">
-      Faceted query using `uniqueCount()`
-    </dt>
+        ```
+        SELECT uniqueCount(pageUrl) FROM PageView FACET city
+        ```
+      </Collapser>
 
-    <dd>
-      This query shows the cities that access the highest number of unique URLs. This query uses the total number of times a particular city appears in the results to determine how facets are picked and ordered.
+      <Collapser
+        id="cohort-analysis"
+        title="Grouping results across time"
+      >
+        [Advanced segmentation](/docs/insights/new-relic-insights/features/advanced-segmentation) and [cohort analysis](/docs/insights/new-relic-insights/features/cohort-analysis-grouping-results-across-time) allow you to facet on bucket functions to more effectively break out your data.
 
-      ```
-      SELECT uniqueCount(pageUrl) FROM PageView FACET city
-      ```
-    </dd>
-
-    <dt id="cohort-analysis">
-      Grouping results across time
-    </dt>
-
-    <dd>
-      [Advanced segmentation](/docs/insights/new-relic-insights/features/advanced-segmentation) and [cohort analysis](/docs/insights/new-relic-insights/features/cohort-analysis-grouping-results-across-time) allow you to facet on bucket functions to more effectively break out your data.
-
-      Cohort analysis is a way to group results together based on timestamps. You can separate them into buckets that cover a specified range of dates and times.
-    </dd>
+        Cohort analysis is a way to group results together based on timestamps. You can separate them into buckets that cover a specified range of dates and times.
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     className="freq-link"
     id="sel-facet-cases"
-    title=" clause"
+    title={<><InlineCode>FACET CASES</InlineCode> clause</>}
   >
     ```
     SELECT ...
@@ -458,45 +458,44 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
 
     You may also use a [time function](/docs/query-data/nrql-new-relic-query-language/nrql-query-examples/group-results-across-time) with your attribute.
 
-    <dt id="facet-cases-basic">
-      Basic usage with `WHERE`
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="facet-cases-basic"
+        title={<>Basic usage with <InlineCode>WHERE</InlineCode></>}
+      >
+        ```
+        SELECT count(*) FROM PageView FACET CASES (WHERE duration < 1, WHERE duration > 1 and duration < 10, WHERE duration > 10)
+        ```
+      </Collapser>
 
-    <dd>
-      ```
-      SELECT count(*) FROM PageView FACET CASES (WHERE duration < 1, WHERE duration > 1 and duration < 10, WHERE duration > 10)
-      ```
-    </dd>
+      <Collapser
+        id="facet-cases-mixnmatch"
+        title="Group based on multiple attributes"
+      >
+        This example groups results into one bucket where the transaction name contains `login`, and another where the URL contains `login` and a custom attribute indicates that the user was a paid user:
 
-    <dt id="facet-cases-mixnmatch">
-      Group based on multiple attributes
-    </dt>
+        ```
+        SELECT count(*) FROM Transaction FACET CASES (WHERE name LIKE '%login%', WHERE name LIKE '%feature%' AND customer_type='Paid')
+        ```
+      </Collapser>
 
-    <dd>
-      This example groups results into one bucket where the transaction name contains `login`, and another where the URL contains `login` and a custom attribute indicates that the user was a paid user:
+      <Collapser
+        id="facet-cases-as-label"
+        title={<>Label groups with <InlineCode>AS</InlineCode></>}
+      >
+        This example uses the [`AS`](#sel-as) selector to give your results a human-readable name:
 
-      ```
-      SELECT count(*) FROM Transaction FACET CASES (WHERE name LIKE '%login%', WHERE name LIKE '%feature%' AND customer_type='Paid')
-      ```
-    </dd>
-
-    <dt id="facet-cases-as-label">
-      Label groups with `AS`
-    </dt>
-
-    <dd>
-      This example uses the [`AS`](#sel-as) selector to give your results a human-readable name:
-
-      ```
-      SELECT count(*) FROM Transaction FACET CASES (WHERE name LIKE '%login%' AS 'Total Logins', WHERE name LIKE '%feature%' AND customer_type='Paid' AS 'Feature Visits from Paid Users')
-      ```
-    </dd>
+        ```
+        SELECT count(*) FROM Transaction FACET CASES (WHERE name LIKE '%login%' AS 'Total Logins', WHERE name LIKE '%feature%' AND customer_type='Paid' AS 'Feature Visits from Paid Users')
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     className="freq-link"
     id="sel-limit"
-    title=" clause"
+    title={<><InlineCode>LIMIT</InlineCode> clause</>}
   >
     ```
     SELECT ...
@@ -508,25 +507,23 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
 
     The maximum allowed value for the `LIMIT` clause is 2,000.
 
-    <dt>
-      Query using `LIMIT`
-    </dt>
+    <CollapserGroup>
+      <Collapser title={<>Query using <InlineCode>LIMIT</InlineCode></>}>
+        This query shows the top 20 countries by session count and provides 95th percentile of response time for each country for Windows users only.
 
-    <dd>
-      This query shows the top 20 countries by session count and provides 95th percentile of response time for each country for Windows users only.
-
-      ```
-      SELECT uniqueCount(session), percentile(duration, 95)
-        FROM PageView WHERE userAgentOS = 'Windows'
-        FACET countryCode LIMIT 20 SINCE YESTERDAY
-      ```
-    </dd>
+        ```
+        SELECT uniqueCount(session), percentile(duration, 95)
+          FROM PageView WHERE userAgentOS = 'Windows'
+          FACET countryCode LIMIT 20 SINCE YESTERDAY
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     className="freq-link"
     id="sel-offset"
-    title=" clause"
+    title={<><InlineCode>OFFSET</InlineCode> clause</>}
   >
     ```
     SELECT ...
@@ -544,7 +541,7 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
   <Collapser
     className="freq-link"
     id="sel-since"
-    title=" clause"
+    title={<><InlineCode>SINCE</InlineCode> clause</>}
   >
     ```
     SELECT ...
@@ -562,7 +559,7 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
   <Collapser
     className="freq-link"
     id="sel-until"
-    title=" clause"
+    title={<><InlineCode>UNTIL</InlineCode> clause</>}
   >
     ```
     SELECT ...
@@ -580,7 +577,7 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
   <Collapser
     className="freq-link"
     id="sel-timezone"
-    title=" clause"
+    title={<><InlineCode>WITH TIMEZONE</InlineCode> clause</>}
   >
     ```
     SELECT ... WITH TIMEZONE (selected zone)
@@ -1025,7 +1022,7 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
   <Collapser
     className="freq-link"
     id="with-metric-format"
-    title=" clause"
+    title={<><InlineCode>WITH METRIC_FORMAT</InlineCode> clause</>}
   >
     For information on querying metric data, see [Query metrics](#query-metrics).
   </Collapser>
@@ -1033,7 +1030,7 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
   <Collapser
     className="freq-link"
     id="sel-compare"
-    title=" clause"
+    title={<><InlineCode>COMPARE WITH</InlineCode> clause</>}
   >
     ```
     SELECT ... (SINCE or UNTIL) (integer units) AGO
@@ -1066,7 +1063,7 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
   <Collapser
     className="freq-link"
     id="sel-timeseries"
-    title=" clause"
+    title={<><InlineCode>TIMESERIES</InlineCode> clause</>}
   >
     ```
     SELECT ...
@@ -1083,46 +1080,45 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
     * `TIMESERIES 1 hour`
     * `TIMESERIES 30 seconds`
 
-    <dt id="set-interval">
-      Use a set interval
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="set-interval"
+        title="Use a set interval"
+      >
+        The value provided indicates the units used to break out the graph. For example, to present a one-day graph showing 30 minute increments:
 
-    <dd>
-      The value provided indicates the units used to break out the graph. For example, to present a one-day graph showing 30 minute increments:
+        ```
+        SELECT ... SINCE 1 day AGO TIMESERIES 30 minutes
+        ```
+      </Collapser>
 
-      ```
-      SELECT ... SINCE 1 day AGO TIMESERIES 30 minutes
-      ```
-    </dd>
+      <Collapser
+        id="timeseries-auto"
+        title="Use automatically set interval"
+      >
+        `TIMESERIES` can also be set to `AUTO`, which will divide your graph into a reasonable number of divisions. For example, a daily chart will be divided into 30 minute intervals and a weekly chart will be divided into 6 hour intervals.
 
-    <dt id="timeseries-auto">
-      Use automatically set interval
-    </dt>
+        This query returns data as a line chart showing the 50th and 90th percentile of client-side transaction time for one week with a data point every 6 hours.
 
-    <dd>
-      `TIMESERIES` can also be set to `AUTO`, which will divide your graph into a reasonable number of divisions. For example, a daily chart will be divided into 30 minute intervals and a weekly chart will be divided into 6 hour intervals.
+        ```
+        SELECT average(duration), percentile(duration, 50, 90)
+          FROM PageView SINCE 1 week AGO TIMESERIES AUTO
+        ```
+      </Collapser>
 
-      This query returns data as a line chart showing the 50th and 90th percentile of client-side transaction time for one week with a data point every 6 hours.
+      <Collapser
+        id="timeseries-max"
+        title="Use max interval"
+      >
+        You can set `TIMESERIES` to `MAX`, which will automatically adjust your time window to the maximum number of intervals allowed for a given time period. This allows you to update your time windows without having to manually update your `TIMESERIES` buckets and ensures your time window is being split into the peak number of intervals allowed. The maximum number of `TIMESERIES` buckets that will be returned is 366.
 
-      ```
-      SELECT average(duration), percentile(duration, 50, 90)
-        FROM PageView SINCE 1 week AGO TIMESERIES AUTO
-      ```
-    </dd>
+        For example, the following query creates 4-minute intervals, which is the ceiling for a daily chart.
 
-    <dt id="timeseries-max">
-      Use max interval
-    </dt>
-
-    <dd>
-      You can set `TIMESERIES` to `MAX`, which will automatically adjust your time window to the maximum number of intervals allowed for a given time period. This allows you to update your time windows without having to manually update your `TIMESERIES` buckets and ensures your time window is being split into the peak number of intervals allowed. The maximum number of `TIMESERIES` buckets that will be returned is 366.
-
-      For example, the following query creates 4-minute intervals, which is the ceiling for a daily chart.
-
-      ```
-      SELECT average(duration) FROM Transaction since 1 day ago TIMESERIES MAX
-      ```
-    </dd>
+        ```
+        SELECT average(duration) FROM Transaction since 1 day ago TIMESERIES MAX
+        ```
+      </Collapser>
+    </CollapserGroup>
 
     <Callout variant="important">
       For functions such as `average( )` or `percentile( )`, a large interval can have a significant smoothing effect on outliers.
@@ -1132,7 +1128,7 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
   <Collapser
     className="freq-link"
     id="extrapolate"
-    title=" clause"
+    title={<><InlineCode>EXTRAPOLATE</InlineCode> clause</>}
   >
     You can use this clause with these data types:
 
@@ -1161,31 +1157,31 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
     * rate (if function it takes as an argument supports `EXTRAPOLATE`)
     * stddev
 
-    <dt id="extrapolate-example-1">
-      Example of extrapolating throughput
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="extrapolate-example-1"
+        title="Example of extrapolating throughput"
+      >
+        A query that will show the extrapolated throughput of a service named `interestingApplication`.
 
-    <dd>
-      A query that will show the extrapolated throughput of a service named `interestingApplication`.
+        ```
+        SELECT count(*) FROM Transaction WHERE appName='interestingApplication' 
+        SINCE 60 minutes ago EXTRAPOLATE
+        ```
+      </Collapser>
 
-      ```
-      SELECT count(*) FROM Transaction WHERE appName='interestingApplication' 
-      SINCE 60 minutes ago EXTRAPOLATE
-      ```
-    </dd>
+      <Collapser
+        id="extrapolate-example-2"
+        title="Example of extrapolating throughput as a time series"
+      >
+        A query that will show the extrapolated throughput of a service named `interestingApplication` by transaction name, displayed as a time series.
 
-    <dt id="extrapolate-example-2">
-      Example of extrapolating throughput as a time series
-    </dt>
-
-    <dd>
-      A query that will show the extrapolated throughput of a service named `interestingApplication` by transaction name, displayed as a time series.
-
-      ```
-      SELECT count(*) FROM Transaction WHERE appName='interestingApplication' 
-      SINCE 60 minutes ago FACET name TIMESERIES 1 minute EXTRAPOLATE
-      ```
-    </dd>
+        ```
+        SELECT count(*) FROM Transaction WHERE appName='interestingApplication' 
+        SINCE 60 minutes ago FACET name TIMESERIES 1 minute EXTRAPOLATE
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 </CollapserGroup>
 
@@ -1218,57 +1214,55 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-apdex"
+    title={<InlineCode>apdex(attribute, t: )</InlineCode>}
   >
     Use the `apdex` function to return an [Apdex score](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction#score) for a single transaction or for all your transactions. The [attribute](/docs/insights/new-relic-insights/decorating-events/insights-attributes) can be any attribute based on response time, such as [`duration`](/docs/insights/insights-data-sources/default-events-attributes/apm-default-event-attributes#txn-duration) or [`backendDuration`](/docs/insights/insights-data-sources/default-events-attributes/browser-default-events-attributes-insights#backend-duration). The `t:` argument defines an [Apdex T](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction) threshold in seconds.
 
     The Apdex score returned by the `apdex( )` function is based only on execution time. It does not account for APM errors. If a transaction includes an error but completes in [Apdex T](/docs/apm/new-relic-apm/getting-started/glossary#apdex_t) or less, that transaction will be rated [satisfying](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction#bullet-satisfied) by the `apdex ( )` function.
 
-    <dt id="apdex-cust-attributes">
-      Get Apdex for specific customers
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="apdex-cust-attributes"
+        title="Get Apdex for specific customers"
+      >
+        If you have [defined custom attributes](/docs/insights/new-relic-insights/decorating-events/insights-custom-attributes), you can filter based on those attributes. For example, you could monitor the Apdex for a particularly important customer:
 
-    <dd>
-      If you have [defined custom attributes](/docs/insights/new-relic-insights/decorating-events/insights-custom-attributes), you can filter based on those attributes. For example, you could monitor the Apdex for a particularly important customer:
+        ```
+        SELECT apdex(duration, t: 0.4) FROM Transaction
+          WHERE customerName='ReallyImportantCustomer' SINCE 1 day ago
+        ```
+      </Collapser>
 
-      ```
-      SELECT apdex(duration, t: 0.4) FROM Transaction
-        WHERE customerName='ReallyImportantCustomer' SINCE 1 day ago
-      ```
-    </dd>
+      <Collapser
+        id="apdex-transaction"
+        title="Get Apdex for specific transaction"
+      >
+        Use the `name` attribute to return a score for a specific transaction, or return an overall Apdex by omitting `name`. This query returns an Apdex score for the **Controller/notes/index** transaction over the last hour:
 
-    <dt id="apdex-transaction">
-      Get Apdex for specific transaction
-    </dt>
+        ```
+        SELECT apdex(duration, t: 0.5) from Transaction
+          WHERE name='Controller/notes/index' SINCE 1 hour ago
+        ```
 
-    <dd>
-      Use the `name` attribute to return a score for a specific transaction, or return an overall Apdex by omitting `name`. This query returns an Apdex score for the **Controller/notes/index** transaction over the last hour:
+        ![crop-apdex-function](./images/screen-apdex-function.png "crop-apdex-function")
 
-      ```
-      SELECT apdex(duration, t: 0.5) from Transaction
-        WHERE name='Controller/notes/index' SINCE 1 hour ago
-      ```
+        The `apdex` function returns an [Apdex score](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction) that measures user satisfaction with your site. Arguments are a response time attribute and an Apdex T threshold in seconds.
+      </Collapser>
 
-      ![crop-apdex-function](./images/screen-apdex-function.png "crop-apdex-function")
+      <Collapser title="Get overall Apdex for your app">
+        This example query returns an overall Apdex for the application over the last three weeks:
 
-      The `apdex` function returns an [Apdex score](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction) that measures user satisfaction with your site. Arguments are a response time attribute and an Apdex T threshold in seconds.
-    </dd>
-
-    <dt>
-      Get overall Apdex for your app
-    </dt>
-
-    <dd>
-      This example query returns an overall Apdex for the application over the last three weeks:
-
-      ```
-      SELECT apdex(duration, t: 0.08) FROM Transaction SINCE 3 week ago
-      ```
-    </dd>
+        ```
+        SELECT apdex(duration, t: 0.08) FROM Transaction SINCE 3 week ago
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     className="freq-link"
     id="func-average"
+    title={<InlineCode>average(attribute)</InlineCode>}
   >
     Use the `average( )` function to return the average value for an attribute. It takes a single attribute name as an argument. If a value of the attribute is not numeric, it will be ignored when aggregating. If data matching the query's conditions is not found, or there are no numeric values returned by the query, it will return a value of null.
   </Collapser>
@@ -1276,6 +1270,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-buckets"
+    title={<InlineCode>buckets(attribute, ceiling \[,number of buckets])</InlineCode>}
   >
     Use the `buckets()` function to aggregate data split up by a `FACET` clause into buckets based on ranges. You can bucket by any attribute that is stored as a numerical value in the New Relic database.
 
@@ -1291,6 +1286,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-bucket-percentile"
+    title={<InlineCode>bucketPercentile(attribute)</InlineCode>}
   >
     The `bucketPercentile( )` function is the NRQL equivalent of the [`histogram_quantile`](https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) function in Prometheus. It is intended to be used with dimensional metric data. Instead of the quantile, New Relic returns the percentile, which is the quantile \* 100.
 
@@ -1318,6 +1314,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-cardinality"
+    title={<InlineCode>cardinality(attribute)</InlineCode>}
   >
     Use the `cardinality( )` function to obtain the number of combinations of all the dimensions (attributes) on a [metric](/docs/using-new-relic/data/understand-data/new-relic-data-types#metrics).
 
@@ -1335,6 +1332,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-count"
+    title={<InlineCode>count(\*)</InlineCode>}
   >
     Use the `count( )` function to return a count of available records. It takes a single argument; either `*`, an attribute, or a constant value. Currently, it follows typical SQL behavior and counts all records that have values for its argument.
 
@@ -1344,6 +1342,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="derivative"
+    title={<InlineCode>derivative(attribute \[,time interval])</InlineCode>}
   >
     `derivative()` finds the rate of change for a given dataset. The rate of change is calculated using a least-squares regression to approximate the derivative.
 
@@ -1353,6 +1352,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-dimensions"
+    title={<InlineCode>{'dimensions(include: {attributes}, exclude: {attributes})'}</InlineCode>}
   >
     Use the `dimensions( )` function to return all the dimensional values on a data type.
 
@@ -1368,27 +1368,31 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
     When used with a `FACET` clause, `dimensions( )` produces a unique timeseries for all facets available on the event type, similar to how Prometheus behaves with non-aggregated queries.
   </Collapser>
 
-  <Collapser className="freq-link">
+  <Collapser
+    className="freq-link"
+    title={<InlineCode>earliest(attribute)</InlineCode>}
+  >
     Use the `earliest( )` function to return the earliest value for an attribute over the specified time range.
 
     It takes a single argument. Arguments after the first will be ignored.
 
     If used in conjunction with a `FACET` it will return the most recent value for an attribute for each of the resulting facets.
 
-    <dt>
-      Get earliest country per user agent from PageView
-    </dt>
+    <CollapserGroup>
+      <Collapser title="Get earliest country per user agent from PageView">
+        This query returns the earliest country code per each user agent from the PageView event.
 
-    <dd>
-      This query returns the earliest country code per each user agent from the PageView event.
-
-      ```
-      SELECT earliest(countryCode) FROM PageView FACET userAgentName
-      ```
-    </dd>
+        ```
+        SELECT earliest(countryCode) FROM PageView FACET userAgentName
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
-  <Collapser className="freq-link">
+  <Collapser
+    className="freq-link"
+    title={<InlineCode>eventType()</InlineCode>}
+  >
     ```
     ...WHERE eventType() = 'EventNameHere'...
     ...FACET eventType()...
@@ -1400,53 +1404,53 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
       In this context, "event type" refers to the types of data you can access with a NRQL query.
     </Callout>
 
-    <dt id="filter-eventtype">
-      Use `eventType()` in `filter()` function
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="filter-eventtype"
+        title={<>Use <InlineCode>eventType()</InlineCode> in <InlineCode>filter()</InlineCode> function</>}
+      >
+        This query returns the percentage of total `TransactionError` results out of the total `Transaction` results. You can use the `eventType()` function to target specific types of data with the filter() function.
 
-    <dd>
-      This query returns the percentage of total `TransactionError` results out of the total `Transaction` results. You can use the `eventType()` function to target specific types of data with the filter() function.
+        ```
+        SELECT 100 * filter(count(*), where eventType() = 'TransactionError') / filter(count(*), where eventType() = 'Transaction') FROM Transaction, TransactionError WHERE appName = 'App.Prod' TIMESERIES 2 Minutes SINCE 6 hours ago
+        ```
+      </Collapser>
 
-      ```
-      SELECT 100 * filter(count(*), where eventType() = 'TransactionError') / filter(count(*), where eventType() = 'Transaction') FROM Transaction, TransactionError WHERE appName = 'App.Prod' TIMESERIES 2 Minutes SINCE 6 hours ago
-      ```
-    </dd>
+      <Collapser
+        id="facet-eventtype"
+        title={<>Use <InlineCode>eventType()</InlineCode> with <InlineCode>FACET</InlineCode></>}
+      >
+        This query displays a count of how many records each data type (`Transaction` and `TransactionError`) returns.
 
-    <dt id="facet-eventtype">
-      Use `eventType()` with `FACET`
-    </dt>
-
-    <dd>
-      This query displays a count of how many records each data type (`Transaction` and `TransactionError`) returns.
-
-      ```
-      SELECT count(*) FROM Transaction, TransactionError FACET eventType() TIMESERIES
-      ```
-    </dd>
+        ```
+        SELECT count(*) FROM Transaction, TransactionError FACET eventType() TIMESERIES
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     className="freq-link"
     id="func-filter"
+    title={<InlineCode>filter(function(attribute), WHERE condition)</InlineCode>}
   >
     Use the `filter( )` function to limit the results for one of the aggregator functions in your SELECT statement. You can use `filter()` in conjunction with `FACET` or `TIMESERIES`.
 
-    <dt>
-      Analyze purchases that used offer codes
-    </dt>
+    <CollapserGroup>
+      <Collapser title="Analyze purchases that used offer codes">
+        You could use `filter()` to compare the items bought in a set of transactions for those using an offer code versus those who aren't:
 
-    <dd>
-      You could use `filter()` to compare the items bought in a set of transactions for those using an offer code versus those who aren't:
+        ![screenshot insights filter](./images/screenshot_insights_filter_0_0.png "screenshot insights filter")
 
-      ![screenshot insights filter](./images/screenshot_insights_filter_0_0.png "screenshot insights filter")
-
-      Use the `filter( )` function to limit the results for one of the aggregator functions in your SELECT statement.
-    </dd>
+        Use the `filter( )` function to limit the results for one of the aggregator functions in your SELECT statement.
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     className="freq-link"
     id="func-funnel"
+    title={<InlineCode>funnel(attribute, steps)</InlineCode>}
   >
     Use the `funnel()` function to generate a funnel chart. It takes an attribute as its first argument. You then specify steps as [`WHERE`](#sel-where) clauses (with optional [`AS`](#sel-as) clauses for labels) separated by commas.
 
@@ -1456,6 +1460,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-get-field"
+    title={<InlineCode>getField(attribute, field)</InlineCode>}
   >
     Use the `getField()` function to extract a field from [complex metrics](/docs/using-new-relic/data/understand-data/new-relic-data-types).
 
@@ -1533,6 +1538,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-histogram"
+    title={<InlineCode>histogram(attribute, ceiling \[,number of buckets])</InlineCode>}
   >
     Use the `histogram( )` function to generate histograms. It takes three arguments:
 
@@ -1540,85 +1546,85 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
     * Maximum value of the sample range
     * Total number of buckets
 
-    <dt id="histogram-response-times">
-      Histogram of response times from PageView events
-    </dt>
+    <CollapserGroup>
+      <Collapser
+        id="histogram-response-times"
+        title="Histogram of response times from PageView events"
+      >
+        This query results in a histogram of response times ranging up to 10 seconds over 20 buckets.
 
-    <dd>
-      This query results in a histogram of response times ranging up to 10 seconds over 20 buckets.
+        ```
+        SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
+        ```
+      </Collapser>
 
-      ```
-      SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
-      ```
-    </dd>
+      <Collapser
+        id="histogram-prometheus"
+        title="Prometheus histogram buckets"
+      >
+        `histogram( )` accepts Prometheus histogram buckets:
 
-    <dt id="histogram-prometheus">
-      Prometheus histogram buckets
-    </dt>
+        ```
+        SELECT histogram(duration_bucket, 10, 20) FROM Metric SINCE 1 week ago
+        ```
+      </Collapser>
 
-    <dd>
-      `histogram( )` accepts Prometheus histogram buckets:
+      <Collapser
+        id="distribution-metric"
+        title="New Relic distribution metric"
+      >
+        `histogram( )` accepts [Distribution metric](/docs/data-ingest-apis/get-data-new-relic/metric-api/events-metrics-service-create-metrics#limits-rules) as an input:
 
-      ```
-      SELECT histogram(duration_bucket, 10, 20) FROM Metric SINCE 1 week ago
-      ```
-    </dd>
-
-    <dt id="distribution-metric">
-      New Relic distribution metric
-    </dt>
-
-    <dd>
-      `histogram( )` accepts [Distribution metric](/docs/data-ingest-apis/get-data-new-relic/metric-api/events-metrics-service-create-metrics#limits-rules) as an input:
-
-      ```
-      SELECT histogram(myDistributionMetric, 10, 20) FROM Metric SINCE 1 week ago
-      ```
-    </dd>
+        ```
+        SELECT histogram(myDistributionMetric, 10, 20) FROM Metric SINCE 1 week ago
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     className="freq-link"
     id="keyset"
+    title={<InlineCode>keyset()</InlineCode>}
   >
     Using `keyset()` will allow you to see all of the attributes for a given data type over a given time range. It takes no arguments. It returns a JSON structure containing groups of string-typed keys, numeric-typed keys, boolean-typed keys, and all keys.
 
-    <dt>
-      See all attributes for a data type
-    </dt>
+    <CollapserGroup>
+      <Collapser title="See all attributes for a data type">
+        This query returns the attributes found for `PageView` events from the last day:
 
-    <dd>
-      This query returns the attributes found for `PageView` events from the last day:
-
-      ```
-      SELECT keyset() FROM PageView SINCE 1 day ago
-      ```
-    </dd>
+        ```
+        SELECT keyset() FROM PageView SINCE 1 day ago
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
-  <Collapser className="freq-link">
+  <Collapser
+    className="freq-link"
+    title={<InlineCode>latest(attribute)</InlineCode>}
+  >
     Use the `latest( )` function to return the most recent value for an attribute over a specified time range.
 
     It takes a single argument. Arguments after the first will be ignored.
 
     If used in conjunction with a `FACET` it will return the most recent value for an attribute for each of the resulting facets.
 
-    <dt>
-      Get most recent country per user agent from PageView
-    </dt>
+    <CollapserGroup>
+      <Collapser title="Get most recent country per user agent from PageView">
+        This query returns the most recent country code per each user agent from the PageView event.
 
-    <dd>
-      This query returns the most recent country code per each user agent from the PageView event.
-
-      ```
-      SELECT latest(countryCode) FROM PageView FACET userAgentName
-      ```
-    </dd>
+        ```
+        SELECT latest(countryCode) FROM PageView FACET userAgentName
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     className="freq-link"
     id="func-max"
+    title={<InlineCode>max(attribute)</InlineCode>}
   >
     Use the `max( )` function to return the maximum recorded value of a numeric attribute over the time range specified. It takes a single attribute name as an argument. If a value of the attribute is not numeric, it will be ignored when aggregating. If data matching the query's conditions is not found, or there are no numeric values returned by the query, it will return a value of null.
   </Collapser>
@@ -1626,6 +1632,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-median"
+    title={<InlineCode>median(attribute)</InlineCode>}
   >
     Use the `median( )` function to return an attribute's median, or 50th percentile. For more information about percentile queries, see [percentile()](#func-percentile).
 
@@ -1633,22 +1640,21 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
       The `median( )` query is only available when using the [query builder](/docs/chart-builder/use-chart-builder/get-started/introduction-chart-builder).
     </Callout>
 
-    <dt>
-      Median query
-    </dt>
+    <CollapserGroup>
+      <Collapser title="Median query">
+        This query will generate a line chart for the median value.
 
-    <dd>
-      This query will generate a line chart for the median value.
-
-      ```
-      SELECT median(duration) FROM PageView TIMESERIES AUTO
-      ```
-    </dd>
+        ```
+        SELECT median(duration) FROM PageView TIMESERIES AUTO
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     className="freq-link"
     id="func-min"
+    title={<InlineCode>min(attribute)</InlineCode>}
   >
     Use the `min( )` function to return the minimum recorded value of a numeric attribute over the time range specified. It takes a single attribute name as an argument. If a value of the attribute is not numeric, it will be ignored when aggregating. If data matching the query's conditions is not found, or there are no numeric values returned by the query, it will return a value of null.
   </Collapser>
@@ -1656,6 +1662,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-percentage"
+    title={<InlineCode>percentage(function(attribute), WHERE condition)</InlineCode>}
   >
     Use the `percentage( )` function to return the percentage of a target data set that matches some condition.
 
@@ -1665,6 +1672,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-percentile"
+    title={<InlineCode>percentile(attribute \[, percentile \[, ...]])</InlineCode>}
   >
     Use the `percentile( )` function to return an attribute's approximate value at a given percentile. It requires an attribute and can take any number of arguments representing percentile points. The `percentile()` function enables percentiles to displays with up to three digits after the decimal point, providing greater precision. Percentile thresholds may be specified as decimal values, but be aware that for most data sets, percentiles closer than 0.1 from each other will not be resolved.
 
@@ -1678,22 +1686,21 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
 
     If no percentiles are listed, the default is the 95th percentile. To return only the 50th percentile value, the median, you can also use [median()](#func-median).
 
-    <dt>
-      Basic percentile query
-    </dt>
+    <CollapserGroup>
+      <Collapser title="Basic percentile query">
+        This query will generate a line chart with lines for the 5th, 50th, and 95th percentile.
 
-    <dd>
-      This query will generate a line chart with lines for the 5th, 50th, and 95th percentile.
-
-      ```
-      SELECT percentile(duration, 5, 50, 95) FROM PageView TIMESERIES AUTO
-      ```
-    </dd>
+        ```
+        SELECT percentile(duration, 5, 50, 95) FROM PageView TIMESERIES AUTO
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     className="freq-link"
     id="predictLinear"
+    title={<InlineCode>predictLinear(attribute, \[,time interval])</InlineCode>}
   >
     `predictLinear()` is an extension of the `derivative()` function. It uses a similar method of least-squares linear regression to predict the future values for a dataset.
 
@@ -1707,29 +1714,29 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-rate"
+    title={<InlineCode>rate(function(attribute) \[,time interval])</InlineCode>}
   >
     Use the `rate( )` function to visualize the frequency or rate of a given query per time interval. For example, you might want to know the number of pageviews per minute over an hour-long period or the count of unique sessions on your site per hour over a day-long period.
 
     * Use [`TIMESERIES`](#sel-timeseries) to generate a line chart with rates mapped over time.
     * Omit [`TIMESERIES`](#sel-timeseries) to generate a billboard showing a single rate value averaged over time.
 
-    <dt>
-      Basic rate query
-    </dt>
+    <CollapserGroup>
+      <Collapser title="Basic rate query">
+        This query will generate a line chart showing the rate of throughput for APM transactions per 10 minutes over the past 6 hours.
 
-    <dd>
-      This query will generate a line chart showing the rate of throughput for APM transactions per 10 minutes over the past 6 hours.
-
-      ```
-      SELECT rate(count(*), 10 minute) FROM Transaction SINCE 6 hours ago 
-      TIMESERIES
-      ```
-    </dd>
+        ```
+        SELECT rate(count(*), 10 minute) FROM Transaction SINCE 6 hours ago 
+        TIMESERIES
+        ```
+      </Collapser>
+    </CollapserGroup>
   </Collapser>
 
   <Collapser
     className="freq-link"
     id="round"
+    title={<InlineCode>round(attribute)</InlineCode>}
   >
     Use the `round( )` function to return the rounded value of an attribute.
 
@@ -1743,6 +1750,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="stddev"
+    title={<InlineCode>stddev(attribute)</InlineCode>}
   >
     Use the `stddev( )` function to return one [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation) for a numeric attribute over the time range specified.  
     It takes a single argument. If the attribute is not numeric, it will return a value of zero.
@@ -1751,6 +1759,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="stdvar"
+    title={<InlineCode>stdvar(attribute)</InlineCode>}
   >
     Use the `stdvar( )` function to return the [standard variance](https://en.wikipedia.org/wiki/Variance) for a numeric attribute over the time range specified.
 
@@ -1760,6 +1769,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-sum"
+    title={<InlineCode>sum(attribute)</InlineCode>}
   >
     Use the `sum( )` function to return the sum recorded values of a numeric attribute over the time range specified.
 
@@ -1769,6 +1779,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-uniqueCount"
+    title={<InlineCode>uniqueCount(attribute)</InlineCode>}
   >
     Use the `uniqueCount( )` function to return the number of unique values recorded for an attribute over the time range specified.
 
@@ -1780,7 +1791,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-uniques"
-    title="​"
+    title={<><InlineCode>uniques(attribute \[,limit]</InlineCode>​<InlineCode>)</InlineCode></>}
   >
     Use the `uniques( )` function to return a list of unique values recorded for an attribute over the time range specified. When used along with the `facet` clause, a list of unique attribute values will be returned per each facet value.
 

--- a/src/content/docs/using-new-relic/welcome-new-relic/get-started/glossary.mdx
+++ b/src/content/docs/using-new-relic/welcome-new-relic/get-started/glossary.mdx
@@ -114,9 +114,7 @@ A glossary of common terminology you may encounter.
 
   <Collapser
     id="apdex_f"
-    title="apdex"
-    title="_"
-    title="f"
+    title="apdex_f"
   >
     The response time above which a transaction are rated **frustrating**. Defaults to four times `apdex_t`.
 
@@ -129,9 +127,7 @@ A glossary of common terminology you may encounter.
 
   <Collapser
     id="apdex_t"
-    title="apdex"
-    title="_"
-    title="t"
+    title="apdex_t"
   >
     The response time above which a transaction is considered **tolerable**. The default value is 0.5 seconds, but you can [change this in your Apdex settings](/docs/site/changing-your-apdex-settings).
 
@@ -244,9 +240,7 @@ A glossary of common terminology you may encounter.
 
   <Collapser
     id="condition_id"
-    title="condition"
-    title="_"
-    title="id"
+    title="condition_id"
   >
     See [alert condition](#alert-condition).
   </Collapser>


### PR DESCRIPTION
Closes #148 

## Description

Adds a codemod to convert `<dl className="example-box">` components over to a `Collapser`. This PR also handles titles on Collapsers that have additional markdown content instead of just a plain string. 