### PR TITLE
Private Editor Workflow Documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,24 +187,9 @@ If you intend on adding an entirely new section to the navigation, create a new 
 
 ## Private edits
 
-There may be times where you would like to work on content and have others review it without making it publicly visible. There are a few steps needed to achieve this:
+If you have access to a private version of this repository, you can contribute and review content without sharing it publicly.
 
 _NOTE: with all of these steps, if you have SSH Keys set up, you will want to use the SSH URL (not the HTTPS URL)._
-
-### Set up a private version of the repository
-1. Make a new repo in the [GitHub UI](https://github.com/new) (ensure it's marked "Private").
-2. Make a temporary copy of the docs repo: `git clone --bare https://github.com/newrelic/docs-website.git`.
-3. Change into the temporary repo: `cd docs-website.git`.
-4. Mirror-push to the new private repo: `git push --mirror https://github.com/yourname/private-repo.git`.
-5. Remove the temporary repo: `cd ../ && rm -rf docs-website.git`.
-6. Clone your, private, version of the repo: `git clone https://github.com/yourname/private-repo.git`.
-
-### Working with your private repository
-Once you have a private copy of the repo, you can do any work you would like and share it with whomever you would like. To pull in any _new_ changes from the public repo, do the following:
-1. Change into the private rep repo: `cd private-repo`.
-2. Connect the public repo: `git remote add public https://github.com/newrelic/docs-website.git`.
-3. Pull the latest from the public repo: `git pull public main`.
-4. Push the new stuff to your private repo: `git push origin main`.
 
 ### Bring your private work back into the public repository
 1. Click the fork button in the GitHub UI for the [docs-website repository](https://github.com/newrelic/docs-website).


### PR DESCRIPTION
## Description
Documentation for how to make _private_ edits to the docs website.

While this process does work, it's incredibly cumbersome and fairly technical. The reason for the extra hoops is because GitHub will not allow you to change the visibility of a fork (see screenshot). If you fork the docs-website repo, you can _not_ make it public.

GitHub's [recommendation](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/duplicating-a-repository) is to duplicate the repository, which is what I have outlined in our guide.

While it's not ideal, this approach works and I am willing to merge these instructions for now. We should brainstorm alternatives to this approach.

## Related Issue(s)
* Closes #196 

## Screenshot(s)
![Screen Shot 2020-11-03 at 10 28 12 AM](https://user-images.githubusercontent.com/1946433/98029866-0c79be00-1dc5-11eb-8033-bfcd00b42040.png)
