### PR TITLE
Update table of contents template to use updated MDXContainer API

### DIFF
--- a/src/templates/tableOfContents.js
+++ b/src/templates/tableOfContents.js
@@ -13,7 +13,7 @@ const TableOfContentsPage = ({ data }) => {
     <>
       <SEO title={frontmatter.title} />
       <h1>{frontmatter.title}</h1>
-      <MDXContainer>{body}</MDXContainer>
+      <MDXContainer body={body} />
     </>
   );
 };


### PR DESCRIPTION
## Description

Builds are currently failing due to a change in the API for `<MDXContainer />`. This fixes the build issue for the table of contents template by updating to use the new API.
