### PR TITLE
Update page title when clicking on logo

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -17,9 +17,12 @@ const SEO = ({ title }) => {
     }
   `);
 
+  const { defaultTitle, titleTemplate } = siteMetadata;
+  const template = title ? titleTemplate : '%s';
+
   return (
-    <Helmet titleTemplate={siteMetadata.titleTemplate}>
-      <title>{title || siteMetadata.defaultTitle}</title>
+    <Helmet titleTemplate={template}>
+      <title>{title || defaultTitle}</title>
     </Helmet>
   );
 };

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -10,6 +10,7 @@ import { Link, graphql, useStaticQuery } from 'gatsby';
 import { css } from '@emotion/core';
 import MobileHeader from '../components/MobileHeader';
 import { useMedia, usePrevious } from 'react-use';
+import Seo from '../components/seo';
 import RootNavigation from '../components/RootNavigation';
 import SubNavigation from '../components/SubNavigation';
 import { animated, useTransition } from 'react-spring';
@@ -62,6 +63,7 @@ const MainLayout = ({ data = {}, children, pageContext }) => {
 
   return (
     <>
+      <Seo />
       <GlobalHeader />
       {isSmallScreen && (
         <MobileHeader
@@ -97,10 +99,6 @@ const MainLayout = ({ data = {}, children, pageContext }) => {
               top: calc(${layout.contentPadding} + 3rem);
               padding-bottom: ${layout.contentPadding};
             `;
-
-            if (isRoot) {
-              document.title = 'New Relic Documentation';
-            }
 
             return isRoot ? (
               <animated.div style={style} css={containerStyle}>


### PR DESCRIPTION
## Description
When you are viewing a page on the documentation site, and you click on the logo in the sidebar, the layout updates to show the index page. We were not updating the page `<title>` to reflect the navigation (the title was for the previously viewed page). This adds a simple check to update the title if we're navigating back to the root page.

## Related Issue(s)
* Closes #220