### PR TITLE
fix: updating column width without right rail

### DIFF
--- a/src/templates/basicDoc.js
+++ b/src/templates/basicDoc.js
@@ -42,7 +42,7 @@ const BasicDoc = ({ data }) => {
             grid-template-areas:
               'page-title'
               'content';
-            grid-template-columns: 1fr;
+            grid-template-columns: minmax(0, 1fr);
           }
         `}
       >


### PR DESCRIPTION
## Description
When viewing a page that has a right rail, we reduce to one column on medium breakpoints (1300ish px). This working, but the column was too wide causing the page to scroll (see screenshot).

## Related Issue(s)
* Closes #222

## Screenshot(s)
**Before**
![Screen Shot 2020-11-09 at 3 20 33 PM](https://user-images.githubusercontent.com/1946433/98608312-bc589b00-229f-11eb-910a-50de0a62d0d6.png)

**After**
![Screen Shot 2020-11-09 at 3 21 40 PM](https://user-images.githubusercontent.com/1946433/98608327-c4183f80-229f-11eb-8d83-1ce6ed8bdf32.png)
