### PR TITLE
Handle events without event definitions

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,19 +3,20 @@ frontend:
   phases:
     preBuild:
       commands:
+        - nvm use $VERSION_NODE_12
         - yarn install --frozen-lockfile
     build:
       commands:
         - |
-          if [ "${AWS_BRANCH}" = "main" ]; then 
-            yarn run build:production; 
-          else 
-            yarn run build:staging; 
+          if [ "${AWS_BRANCH}" = "main" ]; then
+            yarn run build:production;
+          else
+            yarn run build:staging;
           fi
   artifacts:
     baseDirectory: public
     files:
-      - "**/*"
+      - '**/*'
   cache:
     paths:
       - node_modules/**/*

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -148,14 +148,19 @@ module.exports = {
         siteUrl,
         graphQLQuery: `
         {
-          allMarkdownRemark(filter: {frontmatter: {type: {eq: "attribute"}}}) {
+          allDataDictionaryEvent {
             edges {
               node {
-                rawMarkdownBody
-                frontmatter {
-                  type
-                  events
+                name
+                definition {
+                  rawMarkdownBody
+                }
+                dataSources
+                childrenDataDictionaryAttribute {
                   name
+                  definition {
+                    rawMarkdownBody
+                  }
                   units
                 }
               }
@@ -163,43 +168,21 @@ module.exports = {
           }
         }
       `,
-        serializeFeed: (results) =>
-          results.data.allMarkdownRemark.edges.map(({ node }) => ({
-            name: node.frontmatter.name,
-            events: node.frontmatter.events,
-            units: node.frontmatter.units,
-            definition: node.rawMarkdownBody.trim(),
+        serializeFeed: ({ data }) =>
+          data.allDataDictionaryEvent.edges.map(({ node }) => ({
+            name: node.name,
+            definition:
+              node.definition && node.definition.rawMarkdownBody.trim(),
+            dataSources: node.dataSources,
+            attributes: node.childrenDataDictionaryAttribute.map(
+              (attribute) => ({
+                name: attribute.name,
+                definition: attribute.definition.rawMarkdownBody.trim(),
+                units: attribute.units,
+              })
+            ),
           })),
-        feedFilename: 'attribute-definitions',
-        nodesPerFeedFile: Infinity,
-      },
-    },
-    {
-      resolve: `gatsby-plugin-json-output`,
-      options: {
-        siteUrl,
-        graphQLQuery: `
-        {
-          allMarkdownRemark(filter: {frontmatter: {type: {eq: "event"}}}) {
-            edges {
-              node {
-                rawMarkdownBody
-                frontmatter {
-                  name
-                  dataSources
-                }
-              }
-            }
-          }
-        }
-      `,
-        serializeFeed: (results) =>
-          results.data.allMarkdownRemark.edges.map(({ node }) => ({
-            name: node.frontmatter.name,
-            dataSources: node.frontmatter.dataSources,
-            definition: node.rawMarkdownBody.trim(),
-          })),
-        feedFilename: 'event-definitions',
+        feedFilename: 'data-dictionary',
         nodesPerFeedFile: Infinity,
       },
     },

--- a/plugins/gatsby-source-data-dictionary/gatsby-node.js
+++ b/plugins/gatsby-source-data-dictionary/gatsby-node.js
@@ -11,7 +11,7 @@ exports.createSchemaCustomization = ({ actions }) => {
   createTypes(`
     type DataDictionaryEvent implements Node {
       name: String!
-      definition: MarkdownRemark! @link
+      definition: MarkdownRemark @link
       dataSources: [String!]!
     }
 

--- a/plugins/gatsby-source-data-dictionary/gatsby-node.js
+++ b/plugins/gatsby-source-data-dictionary/gatsby-node.js
@@ -1,6 +1,7 @@
+const { difference } = require('lodash');
+
 const uniq = (arr) => [...new Set(arr)];
 const prop = (key) => (obj) => obj[key];
-const { difference } = require('lodash');
 
 const getFileRelativePath = (absolutePath) =>
   absolutePath.replace(`${process.cwd()}/`, '');

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -191,7 +191,7 @@ const EventDefinition = memo(({ event, filteredAttribute }) => {
           ))}
         </TagList>
       </div>
-      <div dangerouslySetInnerHTML={{ __html: event.definition.html }} />
+      <div dangerouslySetInnerHTML={{ __html: event.definition?.html }} />
       <Table>
         <thead>
           <tr>


### PR DESCRIPTION
Related to #248

## Description

When creating data dictionary event nodes, some data was skipped if there was no
event definition for an event. This PR ensures that an event definition is
created for events listed from attributes that have no associated definition.
This PR also consolidates the JSON endpoint that lists data dictionary
definitions.
