### PR TITLE
Add ability to pull in paginated data

### DIFF
--- a/scripts/utils/constants.js
+++ b/scripts/utils/constants.js
@@ -60,6 +60,6 @@ module.exports = {
     release_notes: 1,
     release_notes_platform: 1,
     troubleshooting_doc: 1,
-    nr1_announcement: 1,
+    nr1_announcement: Infinity,
   },
 };

--- a/scripts/utils/constants.js
+++ b/scripts/utils/constants.js
@@ -52,4 +52,14 @@ module.exports = {
     nr1_announcement: '20',
     attribute_definition: '100',
   },
+
+  MAX_PAGES_PER_TYPE: {
+    page: 1,
+    landing_page: 1,
+    api_doc: 1,
+    release_notes: 1,
+    release_notes_platform: 1,
+    troubleshooting_doc: 1,
+    nr1_announcement: 1,
+  },
 };

--- a/scripts/utils/migrate/docs-api.js
+++ b/scripts/utils/migrate/docs-api.js
@@ -39,7 +39,8 @@ const paginate = async (
 ) => {
   const { pages, docs } = await get(pathname, { page, perPage });
 
-  if (page < pages.total && page < maxPages) {
+  // account for the 0 based offset on pages when comparing with max pages
+  if (page < pages.total && page + 1 < maxPages) {
     return docs.concat(
       await paginate(pathname, { page: page + 1, perPage, maxPages })
     );

--- a/scripts/utils/migrate/fetch-docs.js
+++ b/scripts/utils/migrate/fetch-docs.js
@@ -1,7 +1,12 @@
 const path = require('path');
 const docsApi = require('./docs-api');
 const { prop } = require('../functional');
-const { TYPES, ITEMS_PER_TYPE, DIRECT_IDS } = require('../constants');
+const {
+  TYPES,
+  ITEMS_PER_TYPE,
+  DIRECT_IDS,
+  MAX_PAGES_PER_TYPE,
+} = require('../constants');
 
 const IGNORED_TYPES = [TYPES.ATTRIBUTE_DEFINITION, TYPES.EVENT_DEFINITION];
 
@@ -9,22 +14,24 @@ const fetchDocs = async () => {
   const requests = Object.values(TYPES)
     .filter((type) => !IGNORED_TYPES.includes(type))
     .map((type) =>
-      docsApi.get(path.join('/api/migration/content', type, 'list'), {
+      docsApi.paginate(path.join('/api/migration/content', type, 'list'), {
         perPage: ITEMS_PER_TYPE[type],
+        maxPages: MAX_PAGES_PER_TYPE[type] || Infinity,
       })
-    );
+    )
+    .concat(docsApi.paginate('/api/migration/content/page/nr-only/list'));
 
   const hardCodedRequests = DIRECT_IDS.map((id) =>
     docsApi.get(`/api/migration/content/page/${id}`)
   );
 
-  const nrOnly = await docsApi.paginate(
-    '/api/migration/content/page/nr-only/list'
-  );
+  const docs = await Promise.all(requests);
+  const hardCodedDocs = await Promise.all(hardCodedRequests);
 
-  const docs = await Promise.all([...requests, ...hardCodedRequests]);
-
-  return docs.flatMap(prop('docs')).concat(nrOnly).map(prop('doc'));
+  return docs
+    .concat(hardCodedDocs.map(prop('docs')))
+    .flat()
+    .map(prop('doc'));
 };
 
 module.exports = fetchDocs;


### PR DESCRIPTION
Partially addresses #301 and #256 

## Description

Paginates the docs results from the API so that we can pull in more than 1 page of data. Also specifies to pull in all whats new content. Note that this PR does not pull in additional content yet as that will be addressed in a separate PR.

