### PR TITLE
Updates due to whats new pages as regular markdown pages

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -115,6 +115,12 @@ module.exports = {
               linkImagesToOriginal: false,
             },
           },
+          // Gifs are not supported via gatsby-remark-images (https://github.com/gatsbyjs/gatsby/issues/7317).
+          // It is recommended to therefore use this plugin to copy files with a
+          // .gif extension to the public folder.
+          //
+          // Source: https://github.com/gatsbyjs/gatsby/issues/7317#issuecomment-412984851
+          'gatsby-remark-copy-linked-files',
         ],
       },
     },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -148,22 +148,22 @@ module.exports = {
       options: {
         query: `
         {
-					allMdx(filter: {frontmatter: {contentType: {eq: "nr1Announcement"}}}) {
-						nodes {
-							frontmatter {
+          allMarkdownRemark(filter: {fields: {slug: {regex: "/whats-new/"}}}) {
+            nodes {
+              frontmatter {
                 title
                 id
-								releaseDate
-								getStartedLink
-								learnMoreLink
-								summary
-							}
-							fields {
-								slug
-							}
-							html
-						}
-					}
+                releaseDate
+                getStartedLink
+                learnMoreLink
+                summary
+              }
+              fields {
+                slug
+              }
+              html
+            }
+          }
         }
         `,
         path: '/api/nr1/content/nr1-announcements.json',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -104,8 +104,20 @@ module.exports = {
         path: dataDictionaryPath,
       },
     },
-    'gatsby-remark-images',
-    'gatsby-transformer-remark',
+    {
+      resolve: 'gatsby-transformer-remark',
+      options: {
+        plugins: [
+          {
+            resolve: 'gatsby-remark-images',
+            options: {
+              fit: 'inside',
+              linkImagesToOriginal: false,
+            },
+          },
+        ],
+      },
+    },
     {
       resolve: 'gatsby-plugin-mdx',
       options: {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gatsby-plugin-react-helmet": "^3.3.10",
     "gatsby-plugin-sharp": "^2.6.27",
     "gatsby-remark-autolink-headers": "^2.3.12",
+    "gatsby-remark-copy-linked-files": "^2.6.0",
     "gatsby-remark-images": "^3.3.29",
     "gatsby-source-filesystem": "^2.3.24",
     "gatsby-transformer-remark": "^2.8.34",

--- a/src/templates/whatsNew.js
+++ b/src/templates/whatsNew.js
@@ -3,38 +3,40 @@ import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
 import { Layout } from '@newrelic/gatsby-theme-newrelic';
 import PageTitle from '../components/PageTitle';
-import MDXContainer from '../components/MDXContainer';
 import SEO from '../components/seo';
 
-const whatsNewTemplate = ({ data }) => {
-  const { mdx } = data;
-  const { frontmatter, body } = mdx;
-  const { title } = frontmatter;
+const WhatsNewTemplate = ({ data }) => {
+  const {
+    markdownRemark: {
+      html,
+      frontmatter: { title },
+    },
+  } = data;
+
   return (
     <>
       <SEO title={title} />
       <PageTitle>{title}</PageTitle>
       <Layout.Content>
-        <MDXContainer body={body} />
+        <div dangerouslySetInnerHTML={{ __html: html }} />
       </Layout.Content>
     </>
   );
 };
 
-whatsNewTemplate.propTypes = {
+WhatsNewTemplate.propTypes = {
   data: PropTypes.object.isRequired,
 };
 
 export const pageQuery = graphql`
-  query($slug: String!, $nav: String) {
-    mdx(fields: { slug: { eq: $slug } }) {
-      body
+  query($slug: String!) {
+    markdownRemark(fields: { slug: { eq: $slug } }) {
+      html
       frontmatter {
         title
       }
     }
-    ...MainLayout_query
   }
 `;
 
-export default whatsNewTemplate;
+export default WhatsNewTemplate;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1664,6 +1664,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/standalone@^7.11.6":
   version "7.12.4"
   resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.12.4.tgz#1493960e765308cc06e9a75ba1affbe65a11124b"
@@ -9064,6 +9071,20 @@ gatsby-remark-autolink-headers@^2.3.12:
     mdast-util-to-string "^1.1.0"
     unist-util-visit "^1.4.1"
 
+gatsby-remark-copy-linked-files@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-2.6.0.tgz#6444fc2bc9956ff1559a988f0693809cce10fd14"
+  integrity sha512-MDTrATgfhycpZ6tMfxCPF7Tiypg+skXQrWAehHQdK89sIveUNPCQ+ttihYOwxvg0JZXyQ6QvaPifPqZ1qljvEw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    cheerio "^1.0.0-rc.3"
+    fs-extra "^8.1.0"
+    is-relative-url "^3.0.0"
+    lodash "^4.17.20"
+    path-is-inside "^1.0.2"
+    probe-image-size "^5.0.0"
+    unist-util-visit "^1.4.1"
+
 gatsby-remark-images@^3.3.29:
   version "3.3.29"
   resolved "https://registry.yarnpkg.com/gatsby-remark-images/-/gatsby-remark-images-3.3.29.tgz#bfff99bd3f2304c4dce579076eab226754324c4d"
@@ -14894,6 +14915,17 @@ probe-image-size@^4.1.1:
   integrity sha512-42LqKZqTLxH/UvAZ2/cKhAsR4G/Y6B7i7fI2qtQu9hRBK4YjS6gqO+QRtwTjvojUx4+/+JuOMzLoFyRecT9qRw==
   dependencies:
     any-promise "^1.3.0"
+    deepmerge "^4.0.0"
+    inherits "^2.0.3"
+    next-tick "^1.0.0"
+    request "^2.83.0"
+    stream-parser "~0.3.1"
+
+probe-image-size@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/probe-image-size/-/probe-image-size-5.0.0.tgz#1b87d20340ab8fcdb4324ec77fbc8a5f53419878"
+  integrity sha512-V6uBYw5eBc5UVIE7MUZD6Nxg0RYuGDWLDenEn0B1WC6PcTvn1xdQ6HLDDuznefsiExC6rNrCz7mFRBo0f3Xekg==
+  dependencies:
     deepmerge "^4.0.0"
     inherits "^2.0.3"
     next-tick "^1.0.0"


### PR DESCRIPTION
Partially addresses #289

## Description

Updates GraphQL queries for whats new pages to use markdown remark. Ensures images are rendered on the whats new pages. Ensures pages are created via the createPages API for each whats new page.
