### PR TITLE
Add overview link to whats new nav

### DIFF
--- a/plugins/gatsby-source-nav/gatsby-node.js
+++ b/plugins/gatsby-source-nav/gatsby-node.js
@@ -131,13 +131,15 @@ const createWhatsNewNav = async ({ createNodeId, nodeModel }) => {
   return {
     id: createNodeId('whats-new'),
     title: "What's new",
-    pages: formatPosts(recentPosts).concat(
-      [
-        { title: 'This month', pages: formatPosts(thisMonthsPosts) },
-        { title: 'Last month', pages: formatPosts(lastMonthsPosts) },
-        { title: 'Older', pages: formatPosts(olderPosts) },
-      ].filter(({ pages }) => pages.length)
-    ),
+    pages: [{ title: 'Overview', url: '/whats-new' }]
+      .concat(formatPosts(recentPosts))
+      .concat(
+        [
+          { title: 'This month', pages: formatPosts(thisMonthsPosts) },
+          { title: 'Last month', pages: formatPosts(lastMonthsPosts) },
+          { title: 'Older', pages: formatPosts(olderPosts) },
+        ].filter(({ pages }) => pages.length)
+      ),
   };
 };
 


### PR DESCRIPTION
## Description

Adds an overview link to the "What's new" nav so that users can navigate back to the timeline after visiting a post.

## Screenshots

<img width="1919" alt="Screen Shot 2020-12-10 at 4 34 09 PM" src="https://user-images.githubusercontent.com/565661/101846316-8bb98a80-3b05-11eb-9875-854e9381b5fe.png">