### PR TITLE
Fix edit link on What's New pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -142,14 +142,13 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       frontmatter: { template },
       fields: { slug },
     } = node;
-    const fileRelativePath = fileAbsolutePath.match(/src\/.*/g)[0];
 
     createPage({
       path: slug,
       component: path.resolve(`${TEMPLATE_DIR}${template}.js`),
       context: {
         slug,
-        fileRelativePath,
+        fileRelativePath: getFileRelativePath(fileAbsolutePath),
       },
     });
   });

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -74,6 +74,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       ) {
         edges {
           node {
+            fileAbsolutePath
             frontmatter {
               template
             }
@@ -137,15 +138,18 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
 
   allMarkdownRemark.edges.forEach(({ node }) => {
     const {
+      fileAbsolutePath,
       frontmatter: { template },
       fields: { slug },
     } = node;
+    const fileRelativePath = fileAbsolutePath.match(/src\/.*/g)[0];
 
     createPage({
       path: slug,
       component: path.resolve(`${TEMPLATE_DIR}${template}.js`),
       context: {
         slug,
+        fileRelativePath,
       },
     });
   });


### PR DESCRIPTION
Closes #401 

Generates `fileRelativePath` from `fileAbsolutePath` in `markdownRemark` nodes and adds it to the context which is then used in the footer to populate the Edit this page link.

## Screenshot
<img width="1920" alt="2020-12-14_12-21-05" src="https://user-images.githubusercontent.com/2952843/102131381-fbca5800-3e06-11eb-84ac-4032762af57b.png">
