### PR TITLE
chore: update DexGuard configuration for 9.x

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps.mdx
@@ -128,17 +128,43 @@ To add support for **DexGuard**:
    -dontnote com.newrelic.agent.android.NewRelic
    -dontnote com.newrelic.agent.android.harvest.crash.Crash
    ```
-3. After the DexGuard plugin has been configured, verify that your app's `buildTypes` configuration is similar to this:
+3. After the DexGuard plugin has been configured:
 
-   ```
-   buildTypes {
-      release {
-         minifyEnabled true
-         proguardFile getDefaultDexGuardFile('dexguard-release.pro')
-         proguardFile 'proguard-rules.pro'
-         proguardFile 'dexguard-project.txt'
-      } ...
-   ```
+   - DexGuard 9.x: verify that R8 shrinking is disabled and your `dexguard` block configuration is similar to this:
+  
+     ```
+     buildTypes {
+        release {
+           minifyEnabled false
+           shrinkResources false
+        } ...
+        ...
+     }
+  
+     dexguard {
+        ...
+        configurations {
+           release {
+              defaultConfiguration 'dexguard-release.pro'
+              configuration 'proguard-rules.pro'
+              configuration 'dexguard-project.txt
+           }
+        }
+     }
+     ```
+
+   - DexGuard 8.x: verify that your app's `buildTypes` configuration is similar to this:
+   
+     ```
+     buildTypes {
+        release {
+           minifyEnabled true
+           proguardFile getDefaultDexGuardFile('dexguard-release.pro')
+           proguardFile 'proguard-rules.pro'
+           proguardFile 'dexguard-project.txt'
+        } ...
+     ```
+
 4. Clean and rebuild your project.
 5. Run your app in an emulator or device to start seeing data on your mobile app's [**Overview** page](/docs/mobile-apps/mobile-apps-dashboard).
 6. Optional: Use the New Relic Mobile **Settings** page to [customize your mobile app](/docs/mobile-apps/customizing-your-mobile-app-settings).


### PR DESCRIPTION
## Description

The configuration of DexGuard has change in 9.x. DexGuard 8.x is still in use so both are included.