### PR TITLE
Release note template

### DIFF
--- a/src/components/MarkdownContainer.js
+++ b/src/components/MarkdownContainer.js
@@ -92,7 +92,6 @@ const MarkdownContainer = ({
 
         ul li ul {
           margin-top: 1rem;
-          line-height: 1;
         }
       `}
     >

--- a/src/templates/releaseNote.js
+++ b/src/templates/releaseNote.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
 import { graphql } from 'gatsby';
-import { Layout } from '@newrelic/gatsby-theme-newrelic';
+import { Icon, Layout } from '@newrelic/gatsby-theme-newrelic';
 import PageTitle from '../components/PageTitle';
 import MDXContainer from '../components/MDXContainer';
 import SEO from '../components/seo';
@@ -10,7 +11,7 @@ const ReleaseNoteTemplate = ({ data }) => {
   const {
     mdx: {
       body,
-      frontmatter: { subject, version },
+      frontmatter: { subject, version, releaseDate },
     },
   } = data;
 
@@ -19,8 +20,44 @@ const ReleaseNoteTemplate = ({ data }) => {
   return (
     <>
       <SEO title={title} />
-      <PageTitle>{title}</PageTitle>
-      <Layout.Content>
+      <PageTitle
+        css={css`
+          max-width: 850px;
+          margin-bottom: 0.5rem;
+          line-height: 1.15;
+        `}
+      >
+        {title}
+      </PageTitle>
+
+      <div
+        css={css`
+          font-size: 0.75rem;
+          color: var(--color-dark-600);
+          display: flex;
+          align-items: baseline;
+          max-width: 850px;
+          border-bottom: 1px solid var(--divider-color);
+          padding-bottom: 1rem;
+          margin-bottom: 1rem;
+        `}
+      >
+        <Icon
+          name="fe-calendar"
+          size="0.75rem"
+          css={css`
+            position: relative;
+            top: 1px;
+            margin-right: 0.25rem;
+          `}
+        />
+        {releaseDate}
+      </div>
+      <Layout.Content
+        css={css`
+          max-width: 850px;
+        `}
+      >
         <MDXContainer body={body} />
       </Layout.Content>
     </>
@@ -38,6 +75,7 @@ export const pageQuery = graphql`
       frontmatter {
         subject
         version
+        releaseDate(formatString: "MMMM D, YYYY")
       }
     }
     ...MainLayout_query

--- a/src/templates/releaseNote.js
+++ b/src/templates/releaseNote.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { graphql } from 'gatsby';
-import { Icon, Layout } from '@newrelic/gatsby-theme-newrelic';
+import { Icon, Layout, Link } from '@newrelic/gatsby-theme-newrelic';
 import PageTitle from '../components/PageTitle';
 import MDXContainer from '../components/MDXContainer';
 import SEO from '../components/seo';
@@ -11,7 +11,7 @@ const ReleaseNoteTemplate = ({ data }) => {
   const {
     mdx: {
       body,
-      frontmatter: { subject, version, releaseDate },
+      frontmatter: { downloadLink, subject, version, releaseDate },
     },
   } = data;
 
@@ -32,6 +32,9 @@ const ReleaseNoteTemplate = ({ data }) => {
 
       <div
         css={css`
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
           font-size: 0.75rem;
           color: var(--color-dark-600);
           display: flex;
@@ -42,16 +45,37 @@ const ReleaseNoteTemplate = ({ data }) => {
           margin-bottom: 1rem;
         `}
       >
-        <Icon
-          name="fe-calendar"
-          size="0.75rem"
-          css={css`
-            position: relative;
-            top: 1px;
-            margin-right: 0.25rem;
-          `}
-        />
-        {releaseDate}
+        <span>
+          <Icon
+            name="fe-calendar"
+            size="0.75rem"
+            css={css`
+              position: relative;
+              top: 1px;
+              margin-right: 0.25rem;
+            `}
+          />
+          {releaseDate}
+        </span>
+        {downloadLink && (
+          <Link
+            to={downloadLink}
+            css={css`
+              display: inline-flex;
+              align-items: center;
+            `}
+          >
+            Download{' '}
+            <Icon
+              name="fe-external-link"
+              css={css`
+                margin-left: 0.25rem;
+                position: relative;
+                top: -1px;
+              `}
+            />
+          </Link>
+        )}
       </div>
       <Layout.Content
         css={css`
@@ -76,6 +100,7 @@ export const pageQuery = graphql`
         subject
         version
         releaseDate(formatString: "MMMM D, YYYY")
+        downloadLink
       }
     }
     ...MainLayout_query


### PR DESCRIPTION
## Description

Update the release note template to match a design similar to the whats new posts.

## Screenshots

<img width="1920" alt="Screen Shot 2020-12-18 at 10 46 34 PM" src="https://user-images.githubusercontent.com/565661/102683063-09733b00-4183-11eb-88b7-002b9057a754.png">
