### PR TITLE
Release note landing pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -205,6 +205,8 @@ const getTemplate = (node) => {
   switch (true) {
     case Boolean(node.frontmatter.template):
       return node.frontmatter.template;
+    case /docs\/release-notes\/.*\/index.mdx$/.test(fileRelativePath):
+      return 'releaseNoteLandingPage';
     case fileRelativePath.includes('src/content/docs/release-notes'):
       return 'releaseNote';
     case fileRelativePath.includes('src/content/whats-new'):

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "react-spring": "npm:@react-spring/web@9.0.0-rc.3",
     "react-use": "^15.3.4",
     "react-use-measure": "^2.0.2",
-    "turndown": "^6.0.0"
+    "turndown": "^6.0.0",
+    "unist-util-filter": "^2.0.3"
   },
   "devDependencies": {
     "@newrelic/eslint-plugin-newrelic": "^0.3.1",

--- a/plugins/gatsby-source-nav/gatsby-node.js
+++ b/plugins/gatsby-source-nav/gatsby-node.js
@@ -150,7 +150,7 @@ const createReleaseNotesNav = async ({ createNodeId, nodeModel }) => {
     query: {
       filter: {
         fileAbsolutePath: {
-          regex: '/src/content/docs/release-notes/',
+          regex: '/src/content/docs/release-notes/.*(?<!index).mdx/',
         },
       },
       sort: {

--- a/scripts/utils/migrate/get-frontmatter.js
+++ b/scripts/utils/migrate/get-frontmatter.js
@@ -93,7 +93,7 @@ const addCustomFrontmatter = {
     return stripNulls({
       subject: normalizeSubject(subject),
       releaseDate: doc.releasedOn.split(' ')[0],
-      version: doc.releaseVersion,
+      version: doc.releaseVersion.replace(/^v/i, ''),
       downloadLink: doc.downloadLink,
       template: file.path.match(/src\/content\/docs\/release-notes/)
         ? null

--- a/src/@newrelic/gatsby-theme-newrelic/icons/feather.js
+++ b/src/@newrelic/gatsby-theme-newrelic/icons/feather.js
@@ -215,6 +215,13 @@ export default {
       <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
     </>
   ),
+  rss: (
+    <>
+      <path d="M4 11a9 9 0 0 1 9 9" />
+      <path d="M4 4a16 16 0 0 1 16 16" />
+      <circle cx="5" cy="19" r="1" />
+    </>
+  ),
   settings: (
     <>
       <circle cx="12" cy="12" r="3" />

--- a/src/components/Timeline/Item.js
+++ b/src/components/Timeline/Item.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import { MOBILE_BREAKPOINT } from './config';
+
+const TimelineItem = ({ label, children }) => (
+  <>
+    <div
+      css={css`
+        position: relative;
+        padding-right: 2rem;
+        text-align: right;
+
+        &::after {
+          content: '';
+          position: absolute;
+          width: var(--timeline-width);
+          background: var(--timeline-color);
+          right: calc(var(--timeline-width) * -1);
+          z-index: -1;
+          top: 0;
+          bottom: 0;
+        }
+
+        &:first-child:after {
+          top: calc(var(--ring-size) / 2);
+        }
+
+        &:nth-last-child(2):after {
+          bottom: calc(100% - (var(--ring-size) / 2));
+        }
+
+        @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
+          text-align: left;
+          border-right: none;
+          padding-right: 0;
+
+          &::after {
+            display: none;
+          }
+        }
+      `}
+    >
+      <span
+        css={css`
+          display: inline-flex;
+          align-items: center;
+          height: 1.875rem;
+          line-height: 1;
+          font-weight: 600;
+          font-size: 0.875rem;
+          color: var(--color-neutrals-900);
+
+          .dark-mode & {
+            color: var(--color-dark-900);
+          }
+
+          @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
+            display: block;
+            font-size: 1rem;
+            margin-bottom: 1rem;
+            border-top: 1px solid var(--divider-color);
+            border-bottom: 1px solid var(--divider-color);
+            padding: 1rem 0;
+            height: unset;
+          }
+        `}
+      >
+        {label}
+      </span>
+
+      <div
+        css={css`
+          position: absolute;
+          top: 7px;
+          right: calc((var(--timeline-width) * -1) / 2);
+          transform: translateX(50%);
+          width: var(--ring-size);
+          height: var(--ring-size);
+          border-radius: 50%;
+          background: var(--timeline-color);
+
+          &::after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: calc(var(--ring-size) - (var(--ring-border-width) * 2));
+            height: calc(var(--ring-size) - (var(--ring-border-width) * 2));
+            transform: translate(-50%, -50%);
+            background: var(--primary-background-color);
+            border-radius: 50%;
+          }
+
+          @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
+            display: none;
+          }
+        `}
+      />
+    </div>
+    <div>{children}</div>
+  </>
+);
+TimelineItem.propTypes = {
+  children: PropTypes.node,
+  label: PropTypes.string.isRequired,
+};
+
+export default TimelineItem;

--- a/src/components/Timeline/Timeline.js
+++ b/src/components/Timeline/Timeline.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import Item from './Item';
+import { MOBILE_BREAKPOINT } from './config';
+
+const Timeline = ({ children }) => (
+  <div
+    css={css`
+      --timeline-width: 4px;
+      --ring-size: 1rem;
+      --ring-border-width: var(--timeline-width);
+      --timeline-color: var(--color-neutrals-200);
+
+      display: grid;
+      grid-template-columns: auto 1fr;
+      grid-column-gap: 2rem;
+
+      .dark-mode & {
+        --timeline-color: var(--color-dark-200);
+      }
+
+      @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
+        grid-template-columns: auto;
+      }
+    `}
+  >
+    {children}
+  </div>
+);
+
+Timeline.propTypes = {
+  children: PropTypes.node,
+};
+
+Timeline.Item = Item;
+
+export default Timeline;

--- a/src/components/Timeline/config.js
+++ b/src/components/Timeline/config.js
@@ -1,0 +1,1 @@
+export const MOBILE_BREAKPOINT = '960px';

--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -1,0 +1,1 @@
+export { default } from './Timeline';

--- a/src/content/docs/release-notes/agent-release-notes/agent-sdk-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/agent-sdk-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Agent SDK
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/agent-sdk-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/agent-sdk-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Agent SDK
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: C SDK
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: C SDK
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Go agent
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Go agent
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
@@ -1,4 +1,4 @@
 ---
-subject: iOS
+subject: Java agent
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: iOS
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: iOS
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: .NET agent
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: .NET agent
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Node.js agent
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Node.js agent
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: PHP agent
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: PHP agent
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Python agent
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Python agent
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Ruby agent
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Ruby agent
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3171326.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3171326.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2016-11-08'
-version: v3.17.1.326
+version: 3.17.1.326
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-3.17.1.326.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3172327.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3172327.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2016-12-13'
-version: v3.17.2.327
+version: 3.17.2.327
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-3.17.2.327.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3180329.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3180329.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2017-01-23'
-version: v3.18.0.329
+version: 3.18.0.329
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-3.18.0.329.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3181330.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3181330.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2017-02-09'
-version: v3.18.1.330
+version: 3.18.1.330
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-3.18.1.330.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-430335.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-430335.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2017-07-24'
-version: v4.3.0
+version: 4.3.0
 ---
 
 ## v4.3.0

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-460338.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-460338.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2017-11-13'
-version: v4.6.0
+version: 4.6.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-4.6.0.338.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-540347.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-540347.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2018-09-11'
-version: v5.4.0
+version: 5.4.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-5.4.0.347.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-550348.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-550348.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2018-11-08'
-version: v5.5.0.348
+version: 5.5.0.348
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-5.5.0.348.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-600351.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-600351.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2019-01-28'
-version: v6.0.0
+version: 6.0.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-6.0.0.351.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6100364.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6100364.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2020-04-08'
-version: V6.10.0
+version: 6.10.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-6.10.0.364.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-610352.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-610352.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2019-02-26'
-version: v6.1.0
+version: 6.1.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-6.1.0.352.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6110365.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6110365.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2020-06-03'
-version: V6.11.0
+version: 6.11.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-6.10.0.364.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6120367.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6120367.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2020-07-13'
-version: V6.12.0
+version: 6.12.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-6.12.0.367.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6130.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6130.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2020-09-08'
-version: V6.13.0
+version: 6.13.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-6.13.0.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6131.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6131.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2020-09-25'
-version: V6.13.1
+version: 6.13.1
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-6.13.1.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6140.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6140.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2020-11-17'
-version: V6.14.0
+version: 6.14.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-6.13.1.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-620354.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-620354.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2019-03-18'
-version: v6.2.0
+version: 6.2.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-6.2.0.354.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-630355.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-630355.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2019-04-30'
-version: v6.3.0
+version: 6.3.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-6.3.0.355.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-640356.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-640356.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2019-05-28'
-version: v6.4.0
+version: 6.4.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-6.4.0.356.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-650357.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-650357.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2019-06-26'
-version: v6.5.0
+version: 6.5.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-6.5.0.356.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-670359.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-670359.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2019-10-01'
-version: V6.7.0
+version: 6.7.0
 ---
 
 ## v6.7.0

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-680360.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-680360.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2019-12-30'
-version: V6.8.0
+version: 6.8.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-6.8.0.360.gem'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-690363.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-690363.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2020-02-20'
-version: V6.9.0
+version: 6.9.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-6.9.0.363.gem'
 ---
 

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/index.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: New Relic infrastructure agent
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/index.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: New Relic infrastructure agent
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Insights for Android
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Insights for Android
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Insights for iOS
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Insights for iOS
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Insights for tvOS
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Insights for tvOS
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: New Relic for Android
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: New Relic for Android
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: New Relic for iOS
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: New Relic for iOS
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-release-notes/android-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/android-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Android
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-release-notes/android-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/android-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Android
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
@@ -1,4 +1,4 @@
 ---
-subject: iOS
+subject: iOS agent
 ---
 

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: iOS
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: iOS
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: tvOS agent
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: tvOS agent
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: XCFramework agent
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: XCFramework agent
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v998.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v998.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Browser agent
 releaseDate: '2016-11-03'
-version: v998
+version: '998'
 ---
 
 ### Notes

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/index.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Browser agent
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/index.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Browser agent
 ---
 
-<ReleaseTimeline />

--- a/src/content/docs/release-notes/ruby-agent-400332.mdx
+++ b/src/content/docs/release-notes/ruby-agent-400332.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
 releaseDate: '2017-03-16'
-version: v4.0.0.332
+version: 4.0.0.332
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-4.0.0.332.gem'
 ---
 

--- a/src/content/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/index.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Containerized private minion (CPM)
+---
+
+<ReleaseTimeline />

--- a/src/content/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/index.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Containerized private minion (CPM)
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/agent-sdk-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/agent-sdk-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Agent SDK
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/agent-sdk-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/agent-sdk-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Agent SDK
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: C SDK
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: C SDK
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/go-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/go-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Go agent
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/go-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/go-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Go agent
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
@@ -1,4 +1,4 @@
 ---
-subject: iOS
+subject: Java agent
 ---
 

--- a/src/manual-edits/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: iOS
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: iOS
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/net-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/net-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: .NET agent
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/net-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/net-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: .NET agent
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/nodejs-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/nodejs-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Node.js agent
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/nodejs-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/nodejs-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Node.js agent
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/php-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/php-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: PHP agent
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/php-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/php-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: PHP agent
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/python-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/python-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Python agent
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/python-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/python-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Python agent
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/ruby-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/ruby-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Ruby agent
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/agent-release-notes/ruby-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/agent-release-notes/ruby-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Ruby agent
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: New Relic infrastructure agent
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: New Relic infrastructure agent
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Insights for Android
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Insights for Android
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Insights for iOS
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Insights for iOS
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Insights for tvOS
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Insights for tvOS
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: New Relic for Android
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: New Relic for Android
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: New Relic for iOS
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: New Relic for iOS
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-release-notes/android-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-release-notes/android-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Android
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-release-notes/android-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-release-notes/android-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Android
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
@@ -1,4 +1,4 @@
 ---
-subject: iOS
+subject: iOS agent
 ---
 

--- a/src/manual-edits/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: iOS
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: iOS
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-release-notes/tvos-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-release-notes/tvos-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: tvOS agent
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-release-notes/tvos-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-release-notes/tvos-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: tvOS agent
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-release-notes/xcframework-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-release-notes/xcframework-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: XCFramework agent
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/mobile-release-notes/xcframework-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/mobile-release-notes/xcframework-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: XCFramework agent
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Browser agent
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Browser agent
 ---
 
-<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/index.mdx
@@ -1,0 +1,5 @@
+---
+subject: Containerized private minion (CPM)
+---
+
+<ReleaseTimeline />

--- a/src/manual-edits/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/index.mdx
+++ b/src/manual-edits/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/index.mdx
@@ -2,4 +2,3 @@
 subject: Containerized private minion (CPM)
 ---
 
-<ReleaseTimeline />

--- a/src/pages/whats-new.js
+++ b/src/pages/whats-new.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import SEO from '../components/seo';
@@ -6,8 +6,6 @@ import PageTitle from '../components/PageTitle';
 import { graphql } from 'gatsby';
 import { Layout, Link } from '@newrelic/gatsby-theme-newrelic';
 import Timeline from '../components/Timeline';
-
-const MOBILE_BREAKPOINT = '960px';
 
 const WhatsNew = ({ data }) => {
   const now = useMemo(() => new Date(), []);

--- a/src/pages/whats-new.js
+++ b/src/pages/whats-new.js
@@ -5,6 +5,7 @@ import SEO from '../components/seo';
 import PageTitle from '../components/PageTitle';
 import { graphql } from 'gatsby';
 import { Layout, Link } from '@newrelic/gatsby-theme-newrelic';
+import Timeline from '../components/Timeline';
 
 const MOBILE_BREAKPOINT = '960px';
 
@@ -37,159 +38,46 @@ const WhatsNew = ({ data }) => {
           What's new in New Relic
         </PageTitle>
         <Layout.Content>
-          <div
-            css={css`
-              --timeline-width: 4px;
-              --ring-size: 1rem;
-              --ring-border-width: var(--timeline-width);
-              --timeline-color: var(--color-neutrals-200);
-
-              display: grid;
-              grid-template-columns: auto 1fr;
-              grid-column-gap: 2rem;
-
-              .dark-mode & {
-                --timeline-color: var(--color-dark-200);
-              }
-
-              @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
-                grid-template-columns: auto;
-              }
-            `}
-          >
+          <Timeline>
             {postsByDate.map(([date, posts], idx) => {
               const isLast = idx === postsByDate.length - 1;
 
               return (
-                <Fragment key={date}>
-                  <div
-                    css={css`
-                      position: relative;
-                      padding-right: 2rem;
-                      text-align: right;
-
-                      ${css`
-                        &::after {
-                          content: '';
-                          position: absolute;
-                          width: var(--timeline-width);
-                          background: var(--timeline-color);
-                          top: ${idx === 0 ? 'calc(var(--ring-size) / 2)' : 0};
-                          bottom: ${isLast
-                            ? 'calc(100% - (var(--ring-size) / 2))'
-                            : 0};
-                          right: calc(var(--timeline-width) * -1);
-                          z-index: -1;
-                        }
-                      `}
-
-                      @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
-                        text-align: left;
-                        border-right: none;
-                        padding-right: 0;
-
-                        &::after {
-                          display: none;
-                        }
-                      }
-                    `}
-                  >
-                    <span
+                <Timeline.Item label={date} key={date}>
+                  {posts.map((post) => (
+                    <div
+                      key={post.id}
                       css={css`
-                        display: inline-flex;
-                        align-items: center;
-                        height: 1.875rem;
-                        line-height: 1;
-                        font-weight: 600;
-                        font-size: 0.875rem;
-                        color: var(--color-neutrals-900);
+                        margin-bottom: 2rem;
 
-                        .dark-mode & {
-                          color: var(--color-dark-900);
-                        }
-
-                        @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
-                          display: block;
-                          font-size: 1rem;
-                          margin-bottom: 1rem;
-                          border-top: 1px solid var(--divider-color);
-                          border-bottom: 1px solid var(--divider-color);
-                          padding: 1rem 0;
+                        &:last-child {
+                          margin-bottom: ${isLast ? 0 : '4rem'};
                         }
                       `}
                     >
-                      {date}
-                    </span>
-
-                    <div
-                      css={css`
-                        position: absolute;
-                        top: 7px;
-                        right: calc((var(--timeline-width) * -1) / 2);
-                        transform: translateX(50%);
-                        width: var(--ring-size);
-                        height: var(--ring-size);
-                        border-radius: 50%;
-                        background: var(--timeline-color);
-
-                        &::after {
-                          content: '';
-                          position: absolute;
-                          top: 50%;
-                          left: 50%;
-                          width: calc(
-                            var(--ring-size) - (var(--ring-border-width) * 2)
-                          );
-                          height: calc(
-                            var(--ring-size) - (var(--ring-border-width) * 2)
-                          );
-                          transform: translate(-50%, -50%);
-                          background: var(--primary-background-color);
-                          border-radius: 50%;
-                        }
-
-                        @media screen and (max-width: ${MOBILE_BREAKPOINT}) {
-                          display: none;
-                        }
-                      `}
-                    />
-                  </div>
-                  <div>
-                    {posts.map((post) => (
-                      <div
-                        key={post.id}
+                      <Link
+                        to={post.fields.slug}
                         css={css`
-                          margin-bottom: 2rem;
-
-                          &:last-child {
-                            margin-bottom: ${isLast ? 0 : '4rem'};
-                          }
+                          display: inline-block;
+                          font-size: 1.25rem;
+                          margin-bottom: 0.5rem;
                         `}
                       >
-                        <Link
-                          to={post.fields.slug}
-                          css={css`
-                            display: inline-block;
-                            font-size: 1.25rem;
-                            margin-bottom: 0.5rem;
-                          `}
-                        >
-                          {post.frontmatter.title}
-                        </Link>
-                        <p
-                          css={css`
-                            margin-bottom: 0;
-                          `}
-                        >
-                          {post.frontmatter.summary}
-                        </p>
-                      </div>
-                    ))}
-                  </div>
-                </Fragment>
+                        {post.frontmatter.title}
+                      </Link>
+                      <p
+                        css={css`
+                          margin-bottom: 0;
+                        `}
+                      >
+                        {post.frontmatter.summary}
+                      </p>
+                    </div>
+                  ))}
+                </Timeline.Item>
               );
             })}
-          </div>
+          </Timeline>
         </Layout.Content>
       </div>
     </>

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { graphql } from 'gatsby';
+import PageTitle from '../components/PageTitle';
+import SEO from '../components/seo';
+
+const ReleaseNoteLandingPage = ({ data }) => {
+  const {
+    mdx: {
+      frontmatter: { subject },
+    },
+  } = data;
+
+  return (
+    <>
+      <SEO title={subject} />
+      <PageTitle>{subject}</PageTitle>
+    </>
+  );
+};
+
+ReleaseNoteLandingPage.propTypes = {
+  data: PropTypes.object.isRequired,
+};
+
+export const pageQuery = graphql`
+  query($slug: String!) {
+    mdx(fields: { slug: { eq: $slug } }) {
+      frontmatter {
+        subject
+      }
+    }
+
+    ...MainLayout_query
+  }
+`;
+
+export default ReleaseNoteLandingPage;

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -128,7 +128,7 @@ export const pageQuery = graphql`
 `;
 
 const getBestGuessExcerpt = (mdxAST) => {
-  const textTypes = ['paragraph', 'listItem', 'text', 'root', 'link'];
+  const textTypes = ['paragraph', 'list', 'listItem', 'text', 'root', 'link'];
   const ast = filter(mdxAST, (node) => textTypes.includes(node.type));
 
   return toString(

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -51,26 +51,7 @@ const ReleaseNoteLandingPage = ({ data }) => {
             return (
               <Timeline.Item label={date} key={date}>
                 {posts.map((post) => {
-                  const ast = filter(post.mdxAST, (node) =>
-                    [
-                      'paragraph',
-                      'list',
-                      'listItem',
-                      'text',
-                      'root',
-                      'link',
-                    ].includes(node.type)
-                  );
-
-                  const excerpt = toString(
-                    filter(
-                      ast,
-                      (node, idx, parent) =>
-                        node.type === 'root' ||
-                        parent.type !== 'root' ||
-                        idx === 0
-                    )
-                  );
+                  const excerpt = getBestGuessExcerpt(post.mdxAST);
 
                   return (
                     <div
@@ -145,5 +126,18 @@ export const pageQuery = graphql`
     ...MainLayout_query
   }
 `;
+
+const getBestGuessExcerpt = (mdxAST) => {
+  const textTypes = ['paragraph', 'listItem', 'text', 'root', 'link'];
+  const ast = filter(mdxAST, (node) => textTypes.includes(node.type));
+
+  return toString(
+    filter(
+      ast,
+      (node, idx, parent) =>
+        node.type === 'root' || parent.type !== 'root' || idx === 0
+    )
+  );
+};
 
 export default ReleaseNoteLandingPage;

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -5,13 +5,14 @@ import { graphql } from 'gatsby';
 import PageTitle from '../components/PageTitle';
 import SEO from '../components/seo';
 import Timeline from '../components/Timeline';
-import { Layout, Link } from '@newrelic/gatsby-theme-newrelic';
+import { Icon, Layout, Link } from '@newrelic/gatsby-theme-newrelic';
 import filter from 'unist-util-filter';
 import toString from 'mdast-util-to-string';
 
 const EXCERPT_LENGTH = 200;
 
-const ReleaseNoteLandingPage = ({ data }) => {
+const ReleaseNoteLandingPage = ({ data, pageContext }) => {
+  const { slug } = pageContext;
   const {
     allMdx: { nodes: posts },
     mdx: {
@@ -33,15 +34,44 @@ const ReleaseNoteLandingPage = ({ data }) => {
       .entries()
   );
 
+  const title = `${subject} release notes`;
+
   return (
     <>
-      <SEO title={subject} />
+      <SEO title={title} />
       <PageTitle
         css={css`
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
           margin-bottom: 2rem;
+          gap: 0.5rem;
+
+          @supports not (gap: 0.5rem) {
+            > :first-child {
+              margin-right: 0.5rem;
+            }
+          }
         `}
       >
-        {subject}
+        <span>{title}</span>
+
+        <Link
+          to={`${slug}/feed.xml`}
+          css={css`
+            display: flex;
+            align-items: center;
+            font-size: 0.875rem;
+          `}
+        >
+          RSS
+          <Icon
+            name="fe-rss"
+            css={css`
+              margin-left: 0.25rem;
+            `}
+          />
+        </Link>
       </PageTitle>
       <Layout.Content>
         <Timeline>

--- a/yarn.lock
+++ b/yarn.lock
@@ -17779,6 +17779,13 @@ unist-builder@^1.0.1:
   dependencies:
     object-assign "^4.1.0"
 
+unist-util-filter@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/unist-util-filter/-/unist-util-filter-2.0.3.tgz#558cf866016f0e7ade1e30ef190abf253111dd39"
+  integrity sha512-8k6Jl/KLFqIRTHydJlHh6+uFgqYHq66pV75pZgr1JwfyFSjbWb12yfb0yitW/0TbHXjr9U4G9BQpOvMANB+ExA==
+  dependencies:
+    unist-util-is "^4.0.0"
+
 unist-util-generated@^1.0.0, unist-util-generated@^1.1.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.5.tgz#1e903e68467931ebfaea386dae9ea253628acd42"


### PR DESCRIPTION
Closes #386

## Description

Adds a release note landing page for each release note type.

## Screenshot(s)
<img width="1920" alt="Screen Shot 2020-12-21 at 5 42 45 PM" src="https://user-images.githubusercontent.com/565661/102838830-f6937d00-43b3-11eb-8f9a-efa795d86103.png">



