### PR TITLE
cache builds to speed them up

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -21,3 +21,5 @@ frontend:
   cache:
     paths:
       - node_modules/**/*
+      - gatsby/.cache/**/*
+      - gatsby/public/static/**/*


### PR DESCRIPTION
## Description

Add `public/static` and `.cache` directories to Amplify's cache on build in an attempt to speed them up.