### PR TITLE
Remove code that removes node_modules during build

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,7 +4,6 @@ frontend:
     preBuild:
       commands:
         - nvm use $VERSION_NODE_12
-        - rm -rf node_modules
         - yarn install --frozen-lockfile
     build:
       commands:


### PR DESCRIPTION
## Description

Remove code that removes `node_modules` before a build. This was put in place temporarily to fix a hyrdation issue when upgrading the version of Gatsby. We should have enough time for this to propagate everywhere, so we should be safe to remove this.
