### PR TITLE
Update migration script to account for sort order

### DIFF
--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -82,16 +82,19 @@ const run = async () => {
           const bTopic = last(b.data.topics);
           const getStartedRegex = /^Get(ting)? started/i;
           const troubleshootRegex = /^Troubleshoot(ing)?/i;
-          if (aTopic === bTopic) {
-            return 0;
+
+          switch (true) {
+            case aTopic === bTopic:
+              return 0;
+            case getStartedRegex.test(aTopic):
+            case troubleshootRegex.test(bTopic):
+              return -1;
+            case getStartedRegex.test(bTopic):
+            case troubleshootRegex.test(aTopic):
+              return 1;
+            default:
+              return 0;
           }
-          if (getStartedRegex.test(aTopic) || troubleshootRegex.test(bTopic)) {
-            return -1;
-          }
-          if (getStartedRegex.test(bTopic) || troubleshootRegex.test(aTopic)) {
-            return 1;
-          }
-          return 0;
         })
     );
     await fetchDocCount(

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -70,7 +70,11 @@ const run = async () => {
     await saveWhatsNewIds(whatsNewFiles);
     const definitionFiles = attributeDefFiles.concat(eventDefFiles);
     const files = await all(docs, toVFile).then((files) =>
-      files.sort((a, b) => a.path.localeCompare(b.path))
+      files.sort(
+        (a, b) =>
+          parseInt(a.data.doc.order || 0, 10) -
+          parseInt(b.data.doc.order || 0, 10)
+      )
     );
     await fetchDocCount(
       files.concat(definitionFiles).concat(whatsNewFiles).length

--- a/src/nav/accounts.yml
+++ b/src/nav/accounts.yml
@@ -1,111 +1,111 @@
 title: Accounts
 path: /docs/accounts
 pages:
-  - title: Original accounts and billing
-    pages:
-      - title: SAML SSO (original users)
-        pages:
-          - title: Configure SAML with multiple accounts (original user model)
-            path: /docs/accounts-partnerships/accounts/saml-single-sign/configure-saml-multiple-accounts
-          - title: Add users to SAML accounts (original user model)
-            path: /docs/accounts/accounts/saml-single-sign/add-users-saml-accounts
-          - title: Delete the SSO configuration (original user model)
-            path: /docs/accounts/accounts/saml-single-sign/delete-sso-configuration
-          - title: Maintain SSO settings (original user model)
-            path: /docs/accounts/accounts/saml-single-sign/maintain-sso-settings
-          - title: New Relic Partners and SAML SSO (original user model)
-            path: /docs/accounts/accounts/saml-single-sign/new-relic-partners-saml-sso
-          - title: Intro to SAML SSO (original user model)
-            path: /docs/accounts/accounts/saml-single-sign/saml-service-providers
-          - title: Set up SSO (original user model)
-            path: /docs/accounts/accounts/saml-single-sign/set-sso
-      - title: Original product-based pricing
-        pages:
-          - title: Set session timeouts
-            path: /docs/accounts/accounts/account-maintenance/set-session-timeouts
-          - title: Original product-based pricing and billing
-            path: /docs/accounts/original-accounts-billing/product-pricing/product-based-pricing
-      - title: Original users and roles
-        pages:
-          - title: Add/update users (original user model)
-            path: /docs/accounts/accounts/roles-permissions/add-update-users
-          - title: Bulk user actions (original user model)
-            path: /docs/accounts/accounts/roles-permissions/bulk-user-actions-add-delete-or-update-batches-users
-          - title: Users and roles (original user model)
-            path: /docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model
-      - title: Original pricing plan usage
-        pages:
-          - title: APM (CU-based) subscription usage
-            path: /docs/accounts/new-relic-account-usage/getting-started-usage/apm-cu-based-subscription-usage
-          - title: APM (host-based) subscription usage
-            path: /docs/accounts/new-relic-account-usage/getting-started-usage/apm-host-based-subscription-usage
-          - title: Infrastructure subscription usage
-            path: /docs/accounts/new-relic-account-usage/getting-started-usage/infrastructure-subscription-usage
-          - title: Insights subscription usage
-            path: /docs/accounts/new-relic-account-usage/getting-started-usage/insights-subscription-usage
-          - title: Intro to subscription usage (original pricing plan)
-            path: /docs/accounts/new-relic-account-usage/getting-started-usage/introduction-new-relic-subscription-usage-data
-          - title: Mobile subscription usage
-            path: /docs/accounts/new-relic-account-usage/getting-started-usage/mobile-subscription-usage
-          - title: Synthetics subscription usage
-            path: /docs/accounts/new-relic-account-usage/getting-started-usage/synthetics-subscription-usage
-          - title: Browser subscription usage
-            path: /docs/accounts/original-accounts-billing/original-pricing-plan-usage/browser-subscription-usage
-      - title: Original data retention
-        pages:
-          - title: Event data retention (original pricing plan)
-            path: /docs/accounts/original-accounts-billing/original-data-retention/event-data-retention-original-pricing-plan
-          - title: Overview of data retention (original pricing plan)
-            path: /docs/accounts/original-accounts-billing/product-based-pricing/overview-data-retention-components
   - title: Accounts and billing
     pages:
       - title: Account setup
         pages:
-          - title: Install New Relic
-            path: /docs/accounts-partnerships/install-new-relic/install-agent/install-agent
-          - title: Account ID
-            path: /docs/accounts/accounts-billing/account-setup/account-id
           - title: Create your New Relic account
             path: /docs/accounts/accounts-billing/account-setup/create-your-new-relic-account
-          - title: Downgrade/cancel account
-            path: /docs/accounts/accounts-billing/account-setup/downgradecancel-account
+          - title: Install New Relic
+            path: /docs/accounts-partnerships/install-new-relic/install-agent/install-agent
           - title: New Relic license key
             path: /docs/accounts/accounts-billing/account-setup/new-relic-license-key
+          - title: Account ID
+            path: /docs/accounts/accounts-billing/account-setup/account-id
           - title: 'Troubleshoot password, email address, and login issues'
             path: /docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems
-      - title: Account structure
-        pages:
-          - title: Master/sub-account structure
-            path: /docs/accounts/accounts-billing/account-structure/mastersub-account-structure
-          - title: Use multiple accounts
-            path: /docs/accounts/install-new-relic/account-setup/use-multiple-accounts
-      - title: General account settings
-        pages:
-          - title: Email settings
-            path: /docs/accounts/accounts/account-maintenance/account-email-settings
-          - title: Set or change password
-            path: /docs/accounts/accounts/account-maintenance/change-passwords-user-preferences
-          - title: Change account or user name
-            path: /docs/accounts/accounts/account-maintenance/change-your-new-relic-account-name
-          - title: Tax information
-            path: /docs/accounts/accounts/billing/view-or-change-account-tax-information
-          - title: Eligibility guidelines for Observability for Good
-            path: /docs/accounts/accounts/subscription-pricing/eligibility-guidelines-new-relic-nonprofit-program
-          - title: Default time zone setting
-            path: /docs/accounts/install-new-relic/account-setup/change-your-account-time-zone-setting
+          - title: Downgrade/cancel account
+            path: /docs/accounts/accounts-billing/account-setup/downgradecancel-account
       - title: Partner installation
         pages:
-          - title: Google App Engine environment
-            path: /docs/accounts/install-new-relic/partner-based-installation/google-app-engine-environment
-          - title: 'Heroku: Install the New Relic add-on'
-            path: /docs/accounts/install-new-relic/partner-based-installation/heroku-install-new-relic-add
           - title: Log in to and install New Relic via partners
             path: /docs/accounts/install-new-relic/partner-based-installation/log-install-new-relic-partners
           - title: New Relic and AWS (Amazon Web Services)
             path: /docs/accounts/install-new-relic/partner-based-installation/new-relic-aws-amazon-web-services
+          - title: Google App Engine environment
+            path: /docs/accounts/install-new-relic/partner-based-installation/google-app-engine-environment
+          - title: 'Heroku: Install the New Relic add-on'
+            path: /docs/accounts/install-new-relic/partner-based-installation/heroku-install-new-relic-add
           - title: Rackspace Cloud Load Balancer plugin
             path: /docs/accounts/install-new-relic/partner-based-installation/rackspace-cloud-load-balancer-plugin
           - title: RightScale users and New Relic
             path: /docs/accounts/install-new-relic/partner-based-installation/rightscale-users-new-relic
           - title: Windows Azure users and New Relic
             path: /docs/accounts/install-new-relic/partner-based-installation/windows-azure-users-new-relic
+      - title: Account structure
+        pages:
+          - title: Use multiple accounts
+            path: /docs/accounts/install-new-relic/account-setup/use-multiple-accounts
+          - title: Master/sub-account structure
+            path: /docs/accounts/accounts-billing/account-structure/mastersub-account-structure
+      - title: General account settings
+        pages:
+          - title: Email settings
+            path: /docs/accounts/accounts/account-maintenance/account-email-settings
+          - title: Set or change password
+            path: /docs/accounts/accounts/account-maintenance/change-passwords-user-preferences
+          - title: Default time zone setting
+            path: /docs/accounts/install-new-relic/account-setup/change-your-account-time-zone-setting
+          - title: Change account or user name
+            path: /docs/accounts/accounts/account-maintenance/change-your-new-relic-account-name
+          - title: Tax information
+            path: /docs/accounts/accounts/billing/view-or-change-account-tax-information
+          - title: Eligibility guidelines for Observability for Good
+            path: /docs/accounts/accounts/subscription-pricing/eligibility-guidelines-new-relic-nonprofit-program
+  - title: Original accounts and billing
+    pages:
+      - title: SAML SSO (original users)
+        pages:
+          - title: Intro to SAML SSO (original user model)
+            path: /docs/accounts/accounts/saml-single-sign/saml-service-providers
+          - title: New Relic Partners and SAML SSO (original user model)
+            path: /docs/accounts/accounts/saml-single-sign/new-relic-partners-saml-sso
+          - title: Set up SSO (original user model)
+            path: /docs/accounts/accounts/saml-single-sign/set-sso
+          - title: Add users to SAML accounts (original user model)
+            path: /docs/accounts/accounts/saml-single-sign/add-users-saml-accounts
+          - title: Configure SAML with multiple accounts (original user model)
+            path: /docs/accounts-partnerships/accounts/saml-single-sign/configure-saml-multiple-accounts
+          - title: Maintain SSO settings (original user model)
+            path: /docs/accounts/accounts/saml-single-sign/maintain-sso-settings
+          - title: Delete the SSO configuration (original user model)
+            path: /docs/accounts/accounts/saml-single-sign/delete-sso-configuration
+      - title: Original pricing plan usage
+        pages:
+          - title: Intro to subscription usage (original pricing plan)
+            path: /docs/accounts/new-relic-account-usage/getting-started-usage/introduction-new-relic-subscription-usage-data
+          - title: APM (CU-based) subscription usage
+            path: /docs/accounts/new-relic-account-usage/getting-started-usage/apm-cu-based-subscription-usage
+          - title: APM (host-based) subscription usage
+            path: /docs/accounts/new-relic-account-usage/getting-started-usage/apm-host-based-subscription-usage
+          - title: Browser subscription usage
+            path: /docs/accounts/original-accounts-billing/original-pricing-plan-usage/browser-subscription-usage
+          - title: Infrastructure subscription usage
+            path: /docs/accounts/new-relic-account-usage/getting-started-usage/infrastructure-subscription-usage
+          - title: Insights subscription usage
+            path: /docs/accounts/new-relic-account-usage/getting-started-usage/insights-subscription-usage
+          - title: Mobile subscription usage
+            path: /docs/accounts/new-relic-account-usage/getting-started-usage/mobile-subscription-usage
+          - title: Synthetics subscription usage
+            path: /docs/accounts/new-relic-account-usage/getting-started-usage/synthetics-subscription-usage
+      - title: Original users and roles
+        pages:
+          - title: Users and roles (original user model)
+            path: /docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model
+          - title: Add/update users (original user model)
+            path: /docs/accounts/accounts/roles-permissions/add-update-users
+          - title: Bulk user actions (original user model)
+            path: /docs/accounts/accounts/roles-permissions/bulk-user-actions-add-delete-or-update-batches-users
+      - title: Original product-based pricing
+        pages:
+          - title: Original product-based pricing and billing
+            path: /docs/accounts/original-accounts-billing/product-pricing/product-based-pricing
+          - title: Set session timeouts
+            path: /docs/accounts/accounts/account-maintenance/set-session-timeouts
+      - title: Original data retention
+        pages:
+          - title: Overview of data retention (original pricing plan)
+            path: /docs/accounts/original-accounts-billing/product-based-pricing/overview-data-retention-components
+          - title: Event data retention (original pricing plan)
+            path: /docs/accounts/original-accounts-billing/original-data-retention/event-data-retention-original-pricing-plan

--- a/src/nav/agents.yml
+++ b/src/nav/agents.yml
@@ -1,460 +1,409 @@
 title: Agents
 path: /docs/agents
 pages:
-  - title: PHP agent
-    path: /docs/agents/php-agent
-    pages:
-      - title: Advanced installation
-        pages:
-          - title: Using the newrelic-install script
-            path: /docs/agents/php-agent/advanced-installation/using-newrelic-install-script
-          - title: 'Docker and other container environments: Install PHP agent'
-            path: /docs/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent
-          - title: Starting the PHP daemon (advanced)
-            path: /docs/agents/php-agent/advanced-installation/starting-php-daemon-advanced
-          - title: Silent mode for the install script (advanced)
-            path: /docs/agents/php-agent/advanced-installation/silent-mode-install-script-advanced
-          - title: 'PHP agent installation: Non-standard PHP (advanced)'
-            path: /docs/agents/php-agent/advanced-installation/php-agent-installation-non-standard-php-advanced
-          - title: PHP agent and Heroku
-            path: /docs/agents/php-agent/advanced-installation/php-agent-heroku
-          - title: Uninstall the PHP agent
-            path: /docs/agents/php-agent/advanced-installation/uninstalling-php-agent
-      - title: Configuration
-        pages:
-          - title: PHP agent configuration
-            path: /docs/agents/php-agent/configuration/php-agent-configuration
-          - title: PHP per-directory INI settings
-            path: /docs/agents/php-agent/configuration/php-directory-ini-settings
-          - title: Name your PHP application
-            path: /docs/agents/php-agent/configuration/name-your-php-application
-          - title: Proxy daemon (newrelic.cfg) settings
-            path: /docs/agents/php-agent/configuration/proxy-daemon-newreliccfg-settings
-      - title: Attributes
-        pages:
-          - title: PHP agent attributes
-            path: /docs/agents/php-agent/attributes/php-agent-attributes
-          - title: Enable or disable attributes
-            path: /docs/agents/php-agent/attributes/enable-or-disable-attributes
-          - title: Attribute examples
-            path: /docs/agents/php-agent/attributes/attribute-examples
-      - title: Getting started
-        pages:
-          - title: Introduction to New Relic for PHP
-            path: /docs/agents/php-agent/getting-started/introduction-new-relic-php
-          - title: PHP agent compatibility and requirements
-            path: /docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-          - title: New Relic daemon processes
-            path: /docs/agents/php-agent/getting-started/new-relic-daemon-processes
-          - title: 'APM agent security: PHP'
-            path: /docs/agents/php-agent/getting-started/apm-agent-security-php
-          - title: PHP agent release notes
-            path: /docs/agents/php-agent/getting-started/php-agent-release-notes
-      - title: Features
-        pages:
-          - title: Multiple accounts
-            path: /docs/agents/php-agent/features/multiple-accounts
-          - title: Distributed tracing for the PHP agent
-            path: /docs/agents/php-agent/features/distributed-tracing-php-agent
-          - title: Browser monitoring and the PHP agent
-            path: /docs/agents/php-agent/features/browser-monitoring-php-agent
-          - title: PHP custom instrumentation
-            path: /docs/agents/php-agent/features/php-custom-instrumentation
-          - title: Recording deployments using a PHP script
-            path: /docs/agents/php-agent/features/recording-deployments-using-php-script
-      - title: Frameworks and libraries
-        pages:
-          - title: 'PHP frameworks: Integrate support for New Relic'
-            path: /docs/agents/php-agent/frameworks-libraries/php-frameworks-integrate-support-new-relic
-          - title: Analyze PHPUnit test data in New Relic
-            path: /docs/agents/php-agent/frameworks-libraries/analyze-phpunit-test-data-new-relic
-          - title: AWS Elastic Beanstalk installation for PHP
-            path: /docs/agents/php-agent/frameworks-libraries/aws-elastic-beanstalk-installation-php
-          - title: Drupal-specific functionality
-            path: /docs/agents/php-agent/frameworks-libraries/drupal-specific-functionality
-          - title: PHP agent support for Guzzle
-            path: /docs/agents/php-agent/frameworks-libraries/guzzle
-          - title: Magento-specific functionality
-            path: /docs/agents/php-agent/frameworks-libraries/magento-specific-functionality
-          - title: Predis library in PHP
-            path: /docs/agents/php-agent/frameworks-libraries/predis-library-php
-          - title: WordPress specific functionality
-            path: /docs/agents/php-agent/frameworks-libraries/wordpress-specific-functionality
-      - title: Installation
-        pages:
-          - title: PHP agent installation overview
-            path: /docs/agents/php-agent/installation/php-agent-installation-overview
-          - title: 'PHP agent installation: AWS Linux, RedHat, and CentOS'
-            path: /docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos
-          - title: 'PHP agent installation: Ubuntu and Debian'
-            path: /docs/agents/php-agent/installation/php-agent-installation-ubuntu-debian
-          - title: 'PHP agent installation: Tar file'
-            path: /docs/agents/php-agent/installation/php-agent-installation-tar-file
-          - title: Install PHP agent on shared hosting service
-            path: /docs/agents/php-agent/installation/install-php-agent-shared-hosting-service
-          - title: Update the PHP agent
-            path: /docs/agents/php-agent/installation/update-php-agent
-      - title: PHP agent API
-        path: /docs/agents/php-agent/php-agent-api
-        pages:
-          - title: View all methods
-            path: /docs/agents/php-agent/php-agent-api/view-all-methods
-          - title: newrelic_accept_distributed_trace_headers
-            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtraceheaders
-          - title: newrelic_accept_distributed_trace_payload (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtracepayload-php-agent-api
-          - title: newrelic_accept_distributed_trace_payload_httpsafe (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtracepayloadhttpsafe-php-agent-api
-          - title: newrelic_add_custom_parameter (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_add_custom_parameter
-          - title: newrelic_add_custom_span_parameter (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelicaddcustomspanparameter-php-agent-api
-          - title: newrelic_add_custom_tracer (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_add_custom_tracer
-          - title: newrelic_background_job (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_background_job
-          - title: newrelic_capture_params (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_capture_params
-          - title: newrelic_create_distributed_trace_payload (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newreliccreatedistributedtracepayload-php-agent-api
-          - title: newrelic_custom_metric (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newreliccustommetric-php-agent-api
-          - title: newrelic_disable_autorum (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_disable_autorum
-          - title: newrelic_end_of_transaction (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_end_of_transaction
-          - title: newrelic_end_transaction (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_end_transaction
-          - title: newrelic_get_browser_timing_footer (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_get_browser_timing_footer
-          - title: newrelic_get_browser_timing_header (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_get_browser_timing_header
-          - title: newrelic_get_linking_metadata
-            path: /docs/agents/php-agent/php-agent-api/newrelicgetlinkingmetadata
-          - title: newrelic_get_trace_metadata
-            path: /docs/agents/php-agent/php-agent-api/newrelicgettracemetadata
-          - title: newrelic_ignore_apdex (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_ignore_apdex
-          - title: newrelic_ignore_transaction (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_ignore_transaction
-          - title: newrelic_insert_distributed_trace_headers
-            path: /docs/agents/php-agent/php-agent-api/newrelicinsertdistributedtraceheaders
-          - title: newrelic_is_sampled
-            path: /docs/agents/php-agent/php-agent-api/newrelicissampled
-          - title: newrelic_name_transaction (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_name_transaction
-          - title: newrelic_notice_error (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_notice_error
-          - title: newrelic_record_custom_event (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_record_custom_event
-          - title: newrelic_record_datastore_segment (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_record_datastore_segment
-          - title: newrelic_set_appname (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_set_appname
-          - title: newrelic_set_user_attributes (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_set_user_attributes
-          - title: newrelic_start_transaction (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelic_start_transaction
-      - title: API guides
-        pages:
-          - title: Guide to using the PHP agent API
-            path: /docs/agents/php-agent/api-guides/guide-using-php-agent-api
-      - title: Troubleshooting
-        pages:
-          - title: No data appears (PHP)
-            path: /docs/agents/php-agent/troubleshooting/no-data-appears-php
-          - title: PHP agent not reporting errors
-            path: /docs/agents/php-agent/troubleshooting/php-agent-not-reporting-errors
-          - title: Determine permissions requirements (PHP)
-            path: /docs/agents/php-agent/troubleshooting/determine-permissions-requirements-php
-          - title: Generating logs for troubleshooting (PHP)
-            path: /docs/agents/php-agent/troubleshooting/generating-logs-troubleshooting-php
-          - title: Data stops reporting while using SELinux
-            path: /docs/agents/php-agent/troubleshooting/data-stops-reporting-while-using-selinux
-          - title: Agent stops working after updating PHP
-            path: /docs/agents/php-agent/troubleshooting/agent-stops-working-after-updating-php
-          - title: Checking loaded configuration files directory
-            path: /docs/agents/php-agent/troubleshooting/checking-loaded-configuration-files-directory
-          - title: Missing PHP module
-            path: /docs/agents/php-agent/troubleshooting/missing-php-module
-          - title: Protocol mismatch error
-            path: /docs/agents/php-agent/troubleshooting/protocol-mismatch-error
-          - title: INI settings not taking effect immediately
-            path: /docs/agents/php-agent/troubleshooting/ini-settings-not-taking-effect-immediately
-          - title: Submitting troubleshooting results (PHP)
-            path: /docs/agents/php-agent/troubleshooting/submitting-troubleshooting-results-php
-          - title: Threaded Apache worker MPMs
-            path: /docs/agents/php-agent/troubleshooting/threaded-apache-worker-mpms
-          - title: Transactions named /index.php or /unknown
-            path: /docs/agents/php-agent/troubleshooting/transactions-named-indexphp-or-unknown
-          - title: Troubleshoot the PHP agent instance count
-            path: /docs/agents/php-agent/troubleshooting/troubleshoot-php-agent-instance-count
-          - title: Uninstrumented time in traces
-            path: /docs/agents/php-agent/troubleshooting/uninstrumented-time-traces
-          - title: Using phpinfo to verify PHP
-            path: /docs/agents/php-agent/troubleshooting/using-phpinfo-verify-php
-          - title: Verifying the PHP daemon
-            path: /docs/agents/php-agent/troubleshooting/verifying-php-daemon
-          - title: Why and when to restart your web server (PHP)
-            path: /docs/agents/php-agent/troubleshooting/why-when-restart-your-web-server-php
-          - title: PHP installation fails on OS X 10.11 - El Capitan
-            path: /docs/agents/php-agent/troubleshooting/php-installation-fails-os-x-1011-el-capitan
-          - title: Data stops reporting
-            path: /docs/agents/php-agent/troubleshooting/data-stops-reporting
-          - title: First PHP transaction is not reported
-            path: /docs/agents/php-agent/troubleshooting/first-php-transaction-not-reported
-  - title: Node.js agent
-    path: /docs/agents/nodejs-agent
+  - title: Java agent
+    path: /docs/agents/java-agent
     pages:
       - title: Getting started
         pages:
-          - title: Introduction to New Relic for Node.js
-            path: /docs/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs
-          - title: Compatibility and requirements for the Node.js agent
-            path: /docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent
-          - title: 'APM agent security: Node.js'
-            path: /docs/agents/nodejs-agent/getting-started/apm-agent-security-nodejs
-          - title: Node.js release notes
-            path: /docs/agents/nodejs-agent/getting-started/nodejs-release-notes
-      - title: Installation and configuration
+          - title: Java release notes
+            path: /docs/agents/java-agent/getting-started/java-release-notes
+          - title: 'APM agent security: Java'
+            path: /docs/agents/java-agent/getting-started/apm-agent-security-java
+          - title: Introduction to New Relic for Java
+            path: /docs/agents/java-agent/getting-started/introduction-new-relic-java
+          - title: Compatibility and requirements for the Java agent
+            path: /docs/agents/java-agent/getting-started/compatibility-requirements-java-agent
+      - title: Instrumentation
         pages:
-          - title: Install the Node.js agent
-            path: /docs/agents/nodejs-agent/installation-configuration/install-nodejs-agent
-          - title: Node.js agent configuration
-            path: /docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration
-          - title: Update the Node.js agent
-            path: /docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent
-          - title: Uninstall the Node.js agent
-            path: /docs/agents/nodejs-agent/installation-configuration/uninstall-nodejs-agent
-      - title: Extend your instrumentation
-        pages:
-          - title: Node.js custom instrumentation
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation
-          - title: Node.js custom metrics
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-metrics
-          - title: Node.js VMs statistics page
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-vms-statistics-page
-          - title: Enable distributed tracing for Node.js agent
-            path: /docs/agents/nodejs-agent/supported-features/enable-distributed-tracing-nodejs-agent
-          - title: Message queues
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/message-queues
-          - title: Browser monitoring and the Node.js agent
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/browser-monitoring-nodejs-agent
-          - title: Node.js VM measurements
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-vm-measurements
-          - title: Node.js v1 custom instrumentation (legacy)
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-v1-custom-instrumentation-legacy
-      - title: Hosting services
-        pages:
-          - title: Install New Relic Node.js agent in GAE flexible environment
-            path: /docs/agents/nodejs-agent/hosting-services/install-new-relic-nodejs-agent-gae-flexible-environment
-          - title: Node.js agent on Microsoft Azure Web Apps
-            path: /docs/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure
-          - title: Node.js agent and Heroku
-            path: /docs/agents/nodejs-agent/hosting-services/nodejs-agent-heroku
-      - title: API guides
-        pages:
-          - title: Guide to using the Node.js agent API
-            path: /docs/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api
-          - title: Node.js agent API
-            path: /docs/agents/nodejs-agent/api-guides/nodejs-agent-api
-      - title: Troubleshooting
-        pages:
-          - title: Troubleshoot your Node.js installation
-            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-your-nodejs-installation
-          - title: Generate trace log for troubleshooting (Node.js)
-            path: /docs/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs
-          - title: Troubleshoot message consumers
-            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-message-consumers
-          - title: Troubleshooting large memory usage (Node.js)
-            path: /docs/agents/nodejs-agent/troubleshooting/troubleshooting-large-memory-usage-nodejs
-          - title: Troubleshoot browser instrumentation in Node.js
-            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-browser-instrumentation-nodejs
-      - title: Attributes
-        pages:
-          - title: Node.js agent attributes
-            path: /docs/agents/nodejs-agent/attributes/nodejs-agent-attributes
-  - title: .NET agent
-    path: /docs/agents/net-agent
-    pages:
-      - title: Getting started
-        pages:
-          - title: Introduction to New Relic for .NET
-            path: /docs/agents/net-agent/getting-started/introduction-new-relic-net
-          - title: '.NET agent: compatibility and requirements for .NET Framework'
-            path: /docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework
-          - title: '.NET agent: compatibility and requirements for .NET Core'
-            path: /docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core
-          - title: 'APM agent security: .NET'
-            path: /docs/agents/net-agent/getting-started/apm-agent-security-net
-          - title: .NET release notes
-            path: /docs/agents/net-agent/getting-started/net-release-notes
+          - title: Transaction naming protocol
+            path: /docs/agents/java-agent/instrumentation/transaction-naming-protocol
+          - title: Monitor deployments (Java agent)
+            path: /docs/agents/java-agent/instrumentation/monitor-deployments-java-agent
+          - title: Instrument browser monitoring with Java agent API
+            path: /docs/agents/java-agent/instrumentation/instrument-browser-monitoring-java-agent-api
+          - title: Use RabbitMQ or JMS for message queues
+            path: /docs/agents/java-agent/instrumentation/use-rabbitmq-or-jms-message-queues
+          - title: Extension and additional instrumentation modules
+            path: /docs/agents/java-agent/instrumentation/extension-additional-instrumentation-modules
+          - title: Ignore specific transactions
+            path: /docs/agents/java-agent/instrumentation/ignore-transactions-using-api
       - title: Custom instrumentation
         pages:
-          - title: Introduction to .NET custom instrumentation
-            path: /docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation
-          - title: Custom instrumentation via attributes (.NET)
-            path: /docs/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net
-          - title: Create transactions via XML (.NET)
-            path: /docs/agents/net-agent/custom-instrumentation/create-transactions-xml-net
-          - title: Add detail to transactions via XML (.NET)
-            path: /docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net
-      - title: Attributes
-        pages:
-          - title: .NET agent attributes
-            path: /docs/agents/net-agent/attributes/net-agent-attributes
-          - title: .NET attribute examples
-            path: /docs/agents/net-agent/attributes/net-attribute-examples
-          - title: Enable and disable attributes (.NET)
-            path: /docs/agents/net-agent/attributes/enable-disable-attributes-net
-      - title: Azure troubleshooting
-        pages:
-          - title: 'Azure Cloud Services: No data appears'
-            path: /docs/agents/net-agent/azure-troubleshooting/azure-cloud-services-no-data-appears
-          - title: 'Azure Web Apps: Using Always On and no data appears'
-            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-using-always-no-data-appears
-          - title: 'Azure Web Apps: Unable to open log file'
-            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-unable-open-log-file
-          - title: 'Azure Web Apps: Profiler .dll locks during deployment'
-            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-profiler-dll-locks-during-deployment
-          - title: No data reporting with Microsoft Application Insights
-            path: /docs/agents/net-agent/azure-troubleshooting/no-data-reporting-microsoft-application-insights
-      - title: NET agent API
-        path: /docs/agents/net-agent/net-agent-api
-        pages:
-          - title: View all methods
-            path: /docs/agents/net-agent/net-agent-api/view-all-methods
-          - title: AddCustomParameter (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/addcustomparameter-net-agent-api
-          - title: DisableBrowserMonitoring (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/disablebrowsermonitoring-net-agent-api
-          - title: GetAgent
-            path: /docs/agents/net-agent/net-agent-api/getagent
-          - title: GetBrowserTimingHeader (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent-api
-          - title: GetLinkingMetadata (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/getlinkingmetadata-net-agent-api
-          - title: IAgent
-            path: /docs/agents/net-agent/net-agent-api/iagent
-          - title: IDistributedTracePayload (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/idistributedtracepayload-net-agent-api
-          - title: ITransaction
-            path: /docs/agents/net-agent/net-agent-api/itransaction
-          - title: ISpan
-            path: /docs/agents/net-agent/net-agent-api/ispan
-          - title: IgnoreApdex (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/ignore-apdex
-          - title: IgnoreTransaction (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/ignore-transaction
-          - title: NoticeError (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/noticeerror-net-agent-api
-          - title: IncrementCounter (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/incrementcounter-net-agent-api
-          - title: RecordCustomEvent (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/recordcustomevent-net-agent-api
-          - title: RecordMetric (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/recordmetric-net-agent-api
-          - title: RecordResponseTimeMetric (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/recordresponsetimemetric-net-agent-api
-          - title: SetApplicationName (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/set-application-name
-          - title: SetTransactionName (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/settransactionname-net-agent-api
-          - title: SetTransactionUri (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/set-transaction-uri
-          - title: SetUserParameters (.NET agent)
-            path: /docs/agents/net-agent/net-agent-api/set-user-parameters
-          - title: StartAgent (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/start-agent
-          - title: TraceMetadata (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/tracemetadata-net-agent-api-0
-      - title: API guides
-        pages:
-          - title: Guide to using the .NET agent API
-            path: /docs/agents/net-agent/api-guides/guide-using-net-agent-api
+          - title: Java custom instrumentation
+            path: /docs/agents/java-agent/custom-instrumentation/java-custom-instrumentation
+          - title: 'Custom instrumentation editor: Instrument from UI'
+            path: /docs/agents/java-agent/custom-instrumentation/custom-instrumentation-editor-instrument-ui
+          - title: Scala instrumentation
+            path: /docs/agents/java-agent/frameworks/scala-installation-java
+          - title: Java instrumentation by XML
+            path: /docs/agents/java-agent/custom-instrumentation/java-instrumentation-xml
+          - title: Java XML instrumentation examples
+            path: /docs/agents/java-agent/custom-instrumentation/java-xml-instrumentation-examples
+          - title: 'Java agent: Custom JMX instrumentation by YAML'
+            path: /docs/agents/java-agent/custom-instrumentation/java-agent-custom-jmx-instrumentation-yaml
+          - title: Custom JMX YAML examples
+            path: /docs/agents/java-agent/custom-instrumentation/custom-jmx-yaml-examples
+          - title: Troubleshooting Java custom instrumentation
+            path: /docs/agents/java-agent/custom-instrumentation/troubleshooting-java-custom-instrumentation
+          - title: Circuit breaker for Java custom instrumentation
+            path: /docs/agents/java-agent/custom-instrumentation/circuit-breaker-java-custom-instrumentation
       - title: Installation
         pages:
-          - title: Introduction to .NET agent install
-            path: /docs/agents/net-agent/installation/introduction-net-agent-install
-          - title: Update the .NET agent
-            path: /docs/agents/net-agent/installation/update-net-agent
-          - title: Uninstall the .NET agent
-            path: /docs/agents/net-agent/installation/uninstall-net-agent
-      - title: Troubleshooting
-        pages:
-          - title: No data appears (.NET)
-            path: /docs/agents/net-agent/troubleshooting/no-data-appears-net
-          - title: Agent changes Content-Type header for WCF apps (.NET)
-            path: /docs/agents/net-agent/troubleshooting/agent-changes-content-type-header-wcf-apps-net
-          - title: Azure Pipelines wipes out NewRelic.Azure.WebSites.Extension directories
-            path: /docs/agents/net-agent/troubleshooting/azure-pipelines-wipes-out-newrelicazurewebsitesextension-directories
-          - title: Technical support for .NET Framework 4.0 or lower
-            path: /docs/agents/net-agent/troubleshooting/technical-support-net-framework-40-or-lower
-          - title: Generate logs for troubleshooting (.NET)
-            path: /docs/agents/net-agent/troubleshooting/generate-logs-troubleshooting-net
-          - title: No Browser data appears (.NET)
-            path: /docs/agents/net-agent/troubleshooting/no-browser-data-appears-net
-          - title: Profiler conflicts
-            path: /docs/agents/net-agent/troubleshooting/profiler-conflicts
-          - title: .NET agent reports handled errors
-            path: /docs/agents/net-agent/troubleshooting/net-agent-reports-handled-errors
-          - title: No data and registry key permission issues
-            path: /docs/agents/net-agent/troubleshooting/no-data-registry-key-permission-issues
-          - title: High memory usage (.NET)
-            path: /docs/agents/net-agent/troubleshooting/high-memory-usage-net
-          - title: 'CoCreate errors: No event log'
-            path: /docs/agents/net-agent/troubleshooting/cocreate-errors-no-event-log
-          - title: 'Browser injection: Health check conflict'
-            path: /docs/agents/net-agent/troubleshooting/browser-injection-health-check-conflict
-          - title: 'CoCreateInstance errors: No profiler log'
-            path: /docs/agents/net-agent/troubleshooting/cocreateinstance-errors-no-profiler-log
-          - title: Missing .NET async metrics
-            path: /docs/agents/net-agent/troubleshooting/missing-net-async-metrics
-          - title: Missing Couchbase metrics (.NET)
-            path: /docs/agents/net-agent/troubleshooting/missing-couchbase-metrics-net
-          - title: New Relic for .NET status monitor
-            path: /docs/agents/net-agent/troubleshooting/new-relic-net-status-monitor
-          - title: Resolve .NET and SCOM conflicts
-            path: /docs/agents/net-agent/troubleshooting/resolve-net-scom-conflicts
-          - title: No data appears after disabling TLS 1.0
-            path: /docs/agents/net-agent/troubleshooting/no-data-appears-after-disabling-tls-10
-          - title: Monitor short-lived .NET processes
-            path: /docs/agents/net-agent/troubleshooting/monitor-short-lived-net-processes
-      - title: Other installation
-        pages:
-          - title: Install the .NET agent using NuGet
-            path: /docs/agents/net-agent/install-guides/install-net-agent-using-nuget
-          - title: Install on Docker container
-            path: /docs/agents/net-agent/installation/install-docker-container
-          - title: .NET agent install resources
-            path: /docs/net-agent-install-resources
+          - title: Install the Java agent
+            path: /docs/agents/java-agent/installation/install-java-agent
+          - title: Include the Java agent with a JVM argument
+            path: /docs/agents/java-agent/installation/include-java-agent-jvm-argument
+          - title: Update the Java agent
+            path: /docs/agents/java-agent/installation/update-java-agent
+          - title: Uninstall the Java agent
+            path: /docs/agents/java-agent/installation/uninstall-java-agent
       - title: Configuration
         pages:
-          - title: .NET agent configuration
-            path: /docs/agents/net-agent/configuration/net-agent-configuration
-          - title: Name your .NET application
-            path: /docs/agents/net-agent/configuration/name-your-net-application
-      - title: Azure installation
+          - title: 'Java agent configuration: Config file'
+            path: /docs/agents/java-agent/configuration/java-agent-configuration-config-file
+          - title: Java agent config file template
+            path: /docs/agents/java-agent/configuration/java-agent-config-file-template
+          - title: Hostname logic in Java
+            path: /docs/agents/java-agent/configuration/hostname-logic-java
+          - title: Enable distributed tracing for Java agent
+            path: /docs/agents/java-agent/configuration/enable-distributed-tracing-java-agent
+          - title: Automatic application naming
+            path: /docs/agents/java-agent/configuration/automatic-application-naming
+          - title: Java agent error configuration
+            path: /docs/agents/java-agent/configuration/java-agent-error-configuration
+          - title: Configuring your SSL certificates
+            path: /docs/agents/java-agent/configuration/configuring-your-ssl-certificates
+      - title: Features
         pages:
-          - title: Install the .NET agent on Azure Cloud Services
-            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-cloud-services
-          - title: Install .NET agent on Azure Service Fabric
-            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-service-fabric
-          - title: Install the .NET agent on Azure Web Apps
-            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-web-apps
-          - title: Install Azure Marketplace app with New Relic
-            path: /docs/agents/net-agent/azure-installation/install-azure-marketplace-app-new-relic
-          - title: Azure troubleshooting
-            path: /docs/agents/net-agent/azure-installation/azure-troubleshooting
-      - title: Other features
+          - title: 'JVMs page (Java): View app server metrics from JMX'
+            path: /docs/agents/java-agent/features/jvms-page-java-view-app-server-metrics-jmx
+      - title: Heroku
         pages:
-          - title: Async support in .NET
-            path: /docs/agents/net-agent/other-features/async-support-net
-          - title: Browser monitoring and the .NET agent
-            path: /docs/agents/net-agent/other-features/browser-monitoring-net-agent
+          - title: Java agent and Heroku
+            path: /docs/agents/java-agent/heroku/java-agent-heroku
+          - title: Java agent with Scala on Heroku
+            path: /docs/agents/java-agent/heroku/java-agent-scala-heroku
+          - title: No data appears with Heroku (Java)
+            path: /docs/agents/java-agent/heroku/no-data-appears-heroku-java
+      - title: Async instrumentation
+        pages:
+          - title: Introduction to Java async instrumentation
+            path: /docs/agents/java-agent/async-instrumentation/introduction-java-async-instrumentation
+          - title: Java agent API for asynchronous applications
+            path: /docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications
+          - title: Troubleshoot Java asynchronous instrumentation
+            path: /docs/agents/java-agent/async-instrumentation/troubleshoot-java-asynchronous-instrumentation
+          - title: 'Disable Scala, Netty, Akka, and Play 2 Instrumentation'
+            path: /docs/agents/java-agent/async-instrumentation/disable-scala-netty-akka-play-2-instrumentation
+      - title: Additional installation
+        pages:
+          - title: Install New Relic Java agent for Docker
+            path: /docs/agents/java-agent/additional-installation/install-new-relic-java-agent-docker
+          - title: AWS Elastic Beanstalk installation for Java
+            path: /docs/agents/java-agent/additional-installation/aws-elastic-beanstalk-installation-java
+          - title: WildFly installation for Java
+            path: /docs/agents/java-agent/additional-installation/wildfly-installation-java
+          - title: Install New Relic Java agent in GAE flexible environment
+            path: /docs/agents/java-agent/additional-installation/install-new-relic-java-agent-gae-flexible-environment
+          - title: IBM WebSphere Application Server
+            path: /docs/agents/java-agent/additional-installation/ibm-websphere-application-server
+          - title: Java 2 security installation
+            path: /docs/agents/java-agent/installation/install-java-agent-java-2-security
+          - title: Install Java agent using Maven
+            path: /docs/agents/java-agent/additional-installation/install-java-agent-using-maven
+      - title: Attributes
+        pages:
+          - title: Java agent attributes
+            path: /docs/agents/java-agent/attributes/java-agent-attributes
+      - title: API guides
+        pages:
+          - title: Guide to using the Java agent API
+            path: /docs/agents/java-agent/api-guides/guide-using-java-agent-api
+          - title: 'Java agent API: Instrument using annotation'
+            path: /docs/agents/java-agent/api-guides/java-agent-api-instrument-using-annotation
+          - title: 'Java agent API: Instrument external calls, messaging, datastore, web frameworks'
+            path: /docs/agents/java-agent/api-guides/java-agent-api-instrument-external-calls-messaging-datastore-web-frameworks
+          - title: 'Java agent API: Custom instrumentation with annotation of an example app'
+            path: /docs/agents/java-agent/api-guides/java-agent-api-custom-instrumentation-annotation-example-app
+          - title: 'Java agent API: Instrumenting example app for external datastore calls and CAT'
+            path: /docs/agents/java-agent/api-guides/java-agent-api-instrumenting-example-app-external-datastore-calls-cat
+      - title: Troubleshooting
+        pages:
+          - title: No data appears (Java)
+            path: /docs/agents/java-agent/troubleshooting/no-data-appears-java
+          - title: Determine permissions requirements (Java)
+            path: /docs/agents/java-agent/troubleshooting/determine-permissions-requirements-java
+          - title: Gather troubleshooting information (Java)
+            path: /docs/agents/java-agent/troubleshooting/gather-troubleshooting-information-java
+          - title: All hosts appear as localhost
+            path: /docs/agents/java-agent/troubleshooting/all-hosts-appear-localhost
+          - title: Error bootstrapping New Relic Java agent
+            path: /docs/agents/java-agent/troubleshooting/error-bootstrapping-new-relic-java-agent
+          - title: Errors starting Java app server
+            path: /docs/agents/java-agent/troubleshooting/errors-starting-java-app-server
+          - title: Firewall or traffic connectivity failures
+            path: /docs/agents/java-agent/troubleshooting/firewall-or-traffic-connectivity-failures
+          - title: Generate debug logs for troubleshooting (Java)
+            path: /docs/agents/java-agent/troubleshooting/generate-debug-logs-troubleshooting-java
+          - title: Host links missing in Java app's APM Summary
+            path: /docs/agents/java-agent/troubleshooting/host-links-missing-java-apps-apm-summary
+          - title: Java Solr data does not appear
+            path: /docs/agents/java-agent/troubleshooting/java-solr-data-does-not-appear
+          - title: No Browser data appears (Java)
+            path: /docs/agents/java-agent/troubleshooting/no-browser-data-appears-java
+          - title: No log file (Java)
+            path: /docs/agents/java-agent/troubleshooting/no-log-file-java
+          - title: No stack traces (Java)
+            path: /docs/agents/java-agent/troubleshooting/no-stack-traces-java
+          - title: NullPointerException issues (Java)
+            path: /docs/agents/java-agent/troubleshooting/nullpointerexception-issues-java
+          - title: Resolve metric grouping issues with Java apps
+            path: /docs/agents/java-agent/troubleshooting/resolve-metric-grouping-issues-java-apps
+          - title: SSL or connection errors (Java)
+            path: /docs/agents/java-agent/troubleshooting/ssl-or-connection-errors-java
+          - title: Update Java config for legacy agent versions
+            path: /docs/agents/java-agent/troubleshooting/update-java-config-legacy-agent-versions
+          - title: Application server JMX setup
+            path: /docs/agents/java-agent/troubleshooting/application-server-jmx-setup
+          - title: Large number of false positive security vulnerabilities
+            path: /docs/agents/java-agent/troubleshooting/large-number-false-positive-security-vulnerabilities
+  - title: Go agent
+    path: /docs/agents/go-agent
+    pages:
+      - title: Get started
+        pages:
+          - title: Go agent release notes
+            path: /docs/agents/go-agent/get-started/go-agent-release-notes
+          - title: Go agent compatibility and requirements
+            path: /docs/agents/go-agent/get-started/go-agent-compatibility-requirements
+          - title: 'APM agent security: Go'
+            path: /docs/agents/go-agent/get-started/apm-agent-security-go
+          - title: Introduction to New Relic for Go
+            path: /docs/agents/go-agent/get-started/introduction-new-relic-go
+      - title: Instrumentation
+        pages:
+          - title: Instrument Go transactions
+            path: /docs/agents/go-agent/instrumentation/instrument-go-transactions
+          - title: Instrument Go segments
+            path: /docs/agents/go-agent/instrumentation/instrument-go-segments
+          - title: Create custom events (Go)
+            path: /docs/agents/go-agent/features/create-custom-events-go
+          - title: Go agent attributes
+            path: /docs/agents/go-agent/instrumentation/go-agent-attributes
+          - title: Create custom metrics in Go
+            path: /docs/agents/go-agent/instrumentation/create-custom-metrics-go
+      - title: Installation
+        pages:
+          - title: Install New Relic for Go
+            path: /docs/agents/go-agent/installation/install-new-relic-go
+          - title: Install the Go agent in GAE flexible environment
+            path: /docs/agents/go-agent/installation/install-go-agent-gae-flexible-environment
+          - title: Uninstall the Go agent
+            path: /docs/agents/go-agent/installation/uninstall-go-agent
+      - title: Configuration
+        pages:
+          - title: Go agent configuration
+            path: /docs/agents/go-agent/configuration/go-agent-configuration
+          - title: Go agent logging
+            path: /docs/agents/go-agent/configuration/go-agent-logging
+      - title: Features
+        pages:
+          - title: 'Go runtime page: Troubleshoot performance problems'
+            path: /docs/agents/go-agent/features/go-runtime-page-troubleshoot-performance-problems
+          - title: Create custom events (Go)
+            path: /docs/agents/go-agent/features/create-custom-events-go
+          - title: Add browser monitoring to your Go apps
+            path: /docs/agents/go-agent/features/add-browser-monitoring-your-go-apps
+          - title: Enable distributed tracing for your Go applications
+            path: /docs/agents/go-agent/features/enable-distributed-tracing-your-go-applications
+          - title: Cross application tracing with Go
+            path: /docs/agents/go-agent/features/cross-application-tracing-go
+      - title: API guides
+        pages:
+          - title: Guide to using the Go agent API
+            path: /docs/agents/go-agent/api-guides/guide-using-go-agent-api
+      - title: Troubleshooting
+        pages:
+          - title: No data appears (Go)
+            path: /docs/agents/go-agent/troubleshooting/no-data-appears-go
+  - title: C SDK
+    path: /docs/agents/c-sdk
+    pages:
+      - title: Get started
+        pages:
+          - title: 'APM security: C SDK'
+            path: /docs/agents/c-sdk/get-started/apm-security-c-sdk
+          - title: C SDK compatibility and requirements
+            path: /docs/agents/c-sdk/get-started/c-sdk-compatibility-requirements
+          - title: Introduction to the C SDK
+            path: /docs/agents/c-sdk/get-started/introduction-c-sdk
+      - title: Install and configure
+        pages:
+          - title: 'Install the C SDK: Compile and link your code'
+            path: /docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code
+          - title: C SDK configuration
+            path: /docs/agents/c-sdk/install-configure/c-sdk-configuration
+          - title: Update your C SDK library
+            path: /docs/agents/c-sdk/install-configure/update-your-c-sdk-library
+          - title: Uninstall (remove) the C SDK
+            path: /docs/agents/c-sdk/install-configure/uninstall-remove-c-sdk
+      - title: Instrumentation
+        pages:
+          - title: Use default or custom attributes (C SDK)
+            path: /docs/agents/c-sdk/instrumentation/use-default-or-custom-attributes-c-sdk
+      - title: Troubleshooting
+        pages:
+          - title: No data appears (C SDK)
+            path: /docs/agents/c-sdk/troubleshooting/no-data-appears-c-sdk
+          - title: Generate logs for troubleshooting (C SDK)
+            path: /docs/agents/c-sdk/troubleshooting/generate-logs-troubleshooting-c-sdk
+  - title: Ruby agent
+    path: /docs/agents/ruby-agent
+    pages:
+      - title: Getting started
+        pages:
+          - title: New Relic's GitHub repository
+            path: /docs/agents/ruby-agent/getting-started/new-relics-github-repository
+          - title: Ruby release notes
+            path: /docs/agents/ruby-agent/getting-started/ruby-release-notes
+          - title: Introduction to New Relic for Ruby
+            path: /docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby
+          - title: Ruby agent requirements and supported frameworks
+            path: /docs/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks
+          - title: 'APM agent security: Ruby'
+            path: /docs/agents/ruby-agent/getting-started/apm-agent-security-ruby
+      - title: Installation
+        pages:
+          - title: Install the New Relic Ruby agent
+            path: /docs/agents/ruby-agent/installation/install-new-relic-ruby-agent
+          - title: 'Ruby agent installation: Rails plugin'
+            path: /docs/agents/ruby-agent/installation/ruby-agent-installation-rails-plugin
+          - title: Install New Relic Ruby agent in GAE flexible environment
+            path: /docs/agents/ruby-agent/installation/install-new-relic-ruby-agent-gae-flexible-environment
+          - title: Ruby agent and Heroku
+            path: /docs/agents/ruby-agent/installation/ruby-agent-heroku
+          - title: Update the Ruby agent
+            path: /docs/agents/ruby-agent/installation/update-ruby-agent
+          - title: Uninstall the Ruby agent
+            path: /docs/agents/ruby-agent/installation/uninstall-ruby-agent
+      - title: Configuration
+        pages:
+          - title: Ruby agent configuration
+            path: /docs/agents/ruby-agent/configuration/ruby-agent-configuration
+          - title: Custom SSL certificates (Ruby)
+            path: /docs/agents/ruby-agent/configuration/custom-ssl-certificates-ruby
+          - title: Connect hosts to your account
+            path: /docs/agents/ruby-agent/configuration/connect-hosts-your-account
+      - title: API guides
+        pages:
+          - title: Ruby custom instrumentation
+            path: /docs/agents/ruby-agent/api-guides/ruby-custom-instrumentation
+          - title: Guide to using the Ruby agent API
+            path: /docs/agents/ruby-agent/api-guides/guide-using-ruby-agent-api
+          - title: Ruby custom metrics
+            path: /docs/agents/ruby-agent/api-guides/ruby-custom-metrics
+          - title: Ignoring specific transactions
+            path: /docs/agents/ruby-agent/api-guides/ignoring-specific-transactions
+          - title: Sending handled errors to New Relic
+            path: /docs/agents/ruby-agent/api-guides/sending-handled-errors-new-relic
+          - title: Third party instrumentation
+            path: /docs/agents/ruby-agent/api-guides/third-party-instrumentation
+      - title: Features
+        pages:
+          - title: Record deployments with the Ruby agent
+            path: /docs/agents/ruby-agent/features/record-deployments-ruby-agent
+          - title: Message queues
+            path: /docs/agents/ruby-agent/features/message-queues
+          - title: HTTP client tracing in Ruby
+            path: /docs/agents/ruby-agent/features/http-client-tracing-ruby
+          - title: Cross application tracing in Ruby
+            path: /docs/agents/ruby-agent/features/cross-application-tracing-ruby
+          - title: Ruby VM measurements
+            path: /docs/agents/ruby-agent/features/ruby-vm-measurements
+          - title: Garbage collection
+            path: /docs/agents/ruby-agent/features/garbage-collection
+          - title: New Relic Browser and the Ruby agent
+            path: /docs/agents/ruby-agent/features/new-relic-browser-ruby-agent
+          - title: Developer mode
+            path: /docs/agents/ruby-agent/features/developer-mode
+      - title: Background jobs
+        pages:
+          - title: Resque instrumentation
+            path: /docs/agents/ruby-agent/background-jobs/resque-instrumentation
+          - title: Sidekiq instrumentation
+            path: /docs/agents/ruby-agent/background-jobs/sidekiq-instrumentation
+          - title: Rake instrumentation
+            path: /docs/agents/ruby-agent/background-jobs/rake-instrumentation
+          - title: Monitor Ruby background processes
+            path: /docs/agents/ruby-agent/background-jobs/monitor-ruby-background-processes
+          - title: 'Delayed::Job instrumentation'
+            path: /docs/agents/ruby-agent/background-jobs/delayedjob-instrumentation
+      - title: Attributes
+        pages:
+          - title: Enable and disable attributes (Ruby)
+            path: /docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby
+          - title: Ruby agent attributes
+            path: /docs/agents/ruby-agent/attributes/ruby-agent-attributes
+          - title: Ruby attribute examples
+            path: /docs/agents/ruby-agent/attributes/ruby-attribute-examples
+      - title: Instrumented gems
+        pages:
+          - title: Redis instrumentation
+            path: /docs/agents/ruby-agent/instrumented-gems/redis-instrumentation
+          - title: Mongo instrumentation
+            path: /docs/agents/ruby-agent/frameworks/mongo-instrumentation
+          - title: Rack and Metal support
+            path: /docs/agents/ruby-agent/frameworks/rack-metal-support
+          - title: Rack middlewares
+            path: /docs/agents/ruby-agent/instrumented-gems/rack-middlewares
+          - title: Metal controller instrumentation
+            path: /docs/agents/ruby-agent/frameworks/metal-controller-instrumentation
+          - title: Sequel instrumentation
+            path: /docs/agents/ruby-agent/frameworks/sequel-instrumentation
+          - title: Sinatra instrumentation
+            path: /docs/agents/ruby-agent/instrumented-gems/sinatra-instrumentation
+      - title: Troubleshooting
+        pages:
+          - title: Passenger troubleshooting
+            path: /docs/agents/ruby-agent/troubleshooting/passenger-troubleshooting
+          - title: Generating logs for troubleshooting (Ruby)
+            path: /docs/agents/ruby-agent/troubleshooting/generating-logs-troubleshooting-ruby
+          - title: No data appears (Ruby)
+            path: /docs/agents/ruby-agent/troubleshooting/no-data-appears-ruby
+          - title: Incompatible gems
+            path: /docs/agents/ruby-agent/troubleshooting/incompatible-gems
+          - title: No log file (Ruby)
+            path: /docs/agents/ruby-agent/troubleshooting/no-log-file-ruby
+          - title: Control when the Ruby agent starts
+            path: /docs/agents/ruby-agent/troubleshooting/control-when-ruby-agent-starts
+          - title: 'SystemStackError: stack level too deep'
+            path: /docs/agents/ruby-agent/troubleshooting/systemstackerror-stack-level-too-deep
+          - title: Ruby agent audit log
+            path: /docs/agents/ruby-agent/troubleshooting/ruby-agent-audit-log
+          - title: No data with Unicorn
+            path: /docs/agents/ruby-agent/troubleshooting/no-data-unicorn
+          - title: Update deprecated API calls
+            path: /docs/agents/ruby-agent/troubleshooting/update-deprecated-api-calls
+          - title: Update private API calls to public Tracer API
+            path: /docs/agents/ruby-agent/troubleshooting/update-private-api-calls-public-tracer-api
+          - title: Not installing New Relic supported Grape
+            path: /docs/agents/ruby-agent/troubleshooting/not-installing-new-relic-supported-grape
   - title: Python agent
     path: /docs/agents/python-agent
     pages:
+      - title: Getting started
+        pages:
+          - title: 'APM agent security: Python'
+            path: /docs/agents/python-agent/getting-started/apm-agent-security-python
+          - title: Python release notes
+            path: /docs/agents/python-agent/getting-started/python-release-notes
+          - title: Introduction to New Relic for Python
+            path: /docs/agents/python-agent/getting-started/introduction-new-relic-python
+          - title: Compatibility and requirements for the Python agent
+            path: /docs/agents/python-agent/getting-started/compatibility-requirements-python-agent
+          - title: Instrumented Python packages
+            path: /docs/agents/python-agent/getting-started/instrumented-python-packages
       - title: Supported features
         pages:
           - title: Python custom metrics
@@ -511,18 +460,6 @@ pages:
         pages:
           - title: Python agent and Celery
             path: /docs/agents/python-agent/back-end-services/python-agent-celery
-      - title: Getting started
-        pages:
-          - title: Introduction to New Relic for Python
-            path: /docs/agents/python-agent/getting-started/introduction-new-relic-python
-          - title: Compatibility and requirements for the Python agent
-            path: /docs/agents/python-agent/getting-started/compatibility-requirements-python-agent
-          - title: Instrumented Python packages
-            path: /docs/agents/python-agent/getting-started/instrumented-python-packages
-          - title: 'APM agent security: Python'
-            path: /docs/agents/python-agent/getting-started/apm-agent-security-python
-          - title: Python release notes
-            path: /docs/agents/python-agent/getting-started/python-release-notes
       - title: Attributes
         pages:
           - title: Python agent attributes
@@ -636,22 +573,6 @@ pages:
             path: /docs/agents/python-agent/python-agent-api/wsgiapplication-python-agent-api
           - title: asgi_application (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/asgiapplication-python-agent-api
-      - title: Troubleshooting
-        pages:
-          - title: No data appears (Python)
-            path: /docs/agents/python-agent/troubleshooting/no-data-appears-python
-          - title: Troubleshooting Browser instrumentation in Python
-            path: /docs/agents/python-agent/troubleshooting/troubleshooting-browser-instrumentation-python
-          - title: Emulating legacy server-side parameter configuration (Python)
-            path: /docs/agents/python-agent/troubleshooting/emulating-legacy-server-side-parameter-configuration-python
-          - title: Testing the Python agent
-            path: /docs/agents/python-agent/troubleshooting/testing-python-agent
-          - title: Python agent logging
-            path: /docs/agents/python-agent/troubleshooting/python-agent-logging
-          - title: Missing information when using ensure_future (Python)
-            path: /docs/agents/python-agent/troubleshooting/missing-information-when-using-ensurefuture-python
-          - title: Activate application warning (Python)
-            path: /docs/agents/python-agent/troubleshooting/activate-application-warning-python
       - title: Configuration
         pages:
           - title: Python agent configuration
@@ -662,394 +583,473 @@ pages:
             path: /docs/agents/python-agent/custom-instrumentation/python-custom-instrumentation
           - title: Python custom instrumentation via config file
             path: /docs/agents/python-agent/custom-instrumentation/python-custom-instrumentation-config-file
-  - title: Java agent
-    path: /docs/agents/java-agent
+      - title: Troubleshooting
+        pages:
+          - title: Troubleshooting Browser instrumentation in Python
+            path: /docs/agents/python-agent/troubleshooting/troubleshooting-browser-instrumentation-python
+          - title: No data appears (Python)
+            path: /docs/agents/python-agent/troubleshooting/no-data-appears-python
+          - title: Emulating legacy server-side parameter configuration (Python)
+            path: /docs/agents/python-agent/troubleshooting/emulating-legacy-server-side-parameter-configuration-python
+          - title: Testing the Python agent
+            path: /docs/agents/python-agent/troubleshooting/testing-python-agent
+          - title: Python agent logging
+            path: /docs/agents/python-agent/troubleshooting/python-agent-logging
+          - title: Missing information when using ensure_future (Python)
+            path: /docs/agents/python-agent/troubleshooting/missing-information-when-using-ensurefuture-python
+          - title: Activate application warning (Python)
+            path: /docs/agents/python-agent/troubleshooting/activate-application-warning-python
+  - title: PHP agent
+    path: /docs/agents/php-agent
     pages:
       - title: Getting started
         pages:
-          - title: Introduction to New Relic for Java
-            path: /docs/agents/java-agent/getting-started/introduction-new-relic-java
-          - title: Compatibility and requirements for the Java agent
-            path: /docs/agents/java-agent/getting-started/compatibility-requirements-java-agent
-          - title: 'APM agent security: Java'
-            path: /docs/agents/java-agent/getting-started/apm-agent-security-java
-          - title: Java release notes
-            path: /docs/agents/java-agent/getting-started/java-release-notes
-      - title: Instrumentation
+          - title: 'APM agent security: PHP'
+            path: /docs/agents/php-agent/getting-started/apm-agent-security-php
+          - title: PHP agent release notes
+            path: /docs/agents/php-agent/getting-started/php-agent-release-notes
+          - title: Introduction to New Relic for PHP
+            path: /docs/agents/php-agent/getting-started/introduction-new-relic-php
+          - title: PHP agent compatibility and requirements
+            path: /docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
+          - title: New Relic daemon processes
+            path: /docs/agents/php-agent/getting-started/new-relic-daemon-processes
+      - title: Advanced installation
         pages:
-          - title: Transaction naming protocol
-            path: /docs/agents/java-agent/instrumentation/transaction-naming-protocol
-          - title: Monitor deployments (Java agent)
-            path: /docs/agents/java-agent/instrumentation/monitor-deployments-java-agent
-          - title: Instrument browser monitoring with Java agent API
-            path: /docs/agents/java-agent/instrumentation/instrument-browser-monitoring-java-agent-api
-          - title: Use RabbitMQ or JMS for message queues
-            path: /docs/agents/java-agent/instrumentation/use-rabbitmq-or-jms-message-queues
-          - title: Extension and additional instrumentation modules
-            path: /docs/agents/java-agent/instrumentation/extension-additional-instrumentation-modules
-          - title: Ignore specific transactions
-            path: /docs/agents/java-agent/instrumentation/ignore-transactions-using-api
+          - title: Using the newrelic-install script
+            path: /docs/agents/php-agent/advanced-installation/using-newrelic-install-script
+          - title: 'Docker and other container environments: Install PHP agent'
+            path: /docs/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent
+          - title: Starting the PHP daemon (advanced)
+            path: /docs/agents/php-agent/advanced-installation/starting-php-daemon-advanced
+          - title: Silent mode for the install script (advanced)
+            path: /docs/agents/php-agent/advanced-installation/silent-mode-install-script-advanced
+          - title: 'PHP agent installation: Non-standard PHP (advanced)'
+            path: /docs/agents/php-agent/advanced-installation/php-agent-installation-non-standard-php-advanced
+          - title: PHP agent and Heroku
+            path: /docs/agents/php-agent/advanced-installation/php-agent-heroku
+          - title: Uninstall the PHP agent
+            path: /docs/agents/php-agent/advanced-installation/uninstalling-php-agent
+      - title: Configuration
+        pages:
+          - title: PHP agent configuration
+            path: /docs/agents/php-agent/configuration/php-agent-configuration
+          - title: PHP per-directory INI settings
+            path: /docs/agents/php-agent/configuration/php-directory-ini-settings
+          - title: Name your PHP application
+            path: /docs/agents/php-agent/configuration/name-your-php-application
+          - title: Proxy daemon (newrelic.cfg) settings
+            path: /docs/agents/php-agent/configuration/proxy-daemon-newreliccfg-settings
+      - title: Attributes
+        pages:
+          - title: PHP agent attributes
+            path: /docs/agents/php-agent/attributes/php-agent-attributes
+          - title: Enable or disable attributes
+            path: /docs/agents/php-agent/attributes/enable-or-disable-attributes
+          - title: Attribute examples
+            path: /docs/agents/php-agent/attributes/attribute-examples
+      - title: Features
+        pages:
+          - title: Multiple accounts
+            path: /docs/agents/php-agent/features/multiple-accounts
+          - title: Distributed tracing for the PHP agent
+            path: /docs/agents/php-agent/features/distributed-tracing-php-agent
+          - title: Browser monitoring and the PHP agent
+            path: /docs/agents/php-agent/features/browser-monitoring-php-agent
+          - title: PHP custom instrumentation
+            path: /docs/agents/php-agent/features/php-custom-instrumentation
+          - title: Recording deployments using a PHP script
+            path: /docs/agents/php-agent/features/recording-deployments-using-php-script
+      - title: Frameworks and libraries
+        pages:
+          - title: 'PHP frameworks: Integrate support for New Relic'
+            path: /docs/agents/php-agent/frameworks-libraries/php-frameworks-integrate-support-new-relic
+          - title: Analyze PHPUnit test data in New Relic
+            path: /docs/agents/php-agent/frameworks-libraries/analyze-phpunit-test-data-new-relic
+          - title: AWS Elastic Beanstalk installation for PHP
+            path: /docs/agents/php-agent/frameworks-libraries/aws-elastic-beanstalk-installation-php
+          - title: Drupal-specific functionality
+            path: /docs/agents/php-agent/frameworks-libraries/drupal-specific-functionality
+          - title: PHP agent support for Guzzle
+            path: /docs/agents/php-agent/frameworks-libraries/guzzle
+          - title: Magento-specific functionality
+            path: /docs/agents/php-agent/frameworks-libraries/magento-specific-functionality
+          - title: Predis library in PHP
+            path: /docs/agents/php-agent/frameworks-libraries/predis-library-php
+          - title: WordPress specific functionality
+            path: /docs/agents/php-agent/frameworks-libraries/wordpress-specific-functionality
+      - title: Installation
+        pages:
+          - title: PHP agent installation overview
+            path: /docs/agents/php-agent/installation/php-agent-installation-overview
+          - title: 'PHP agent installation: AWS Linux, RedHat, and CentOS'
+            path: /docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos
+          - title: 'PHP agent installation: Ubuntu and Debian'
+            path: /docs/agents/php-agent/installation/php-agent-installation-ubuntu-debian
+          - title: 'PHP agent installation: Tar file'
+            path: /docs/agents/php-agent/installation/php-agent-installation-tar-file
+          - title: Install PHP agent on shared hosting service
+            path: /docs/agents/php-agent/installation/install-php-agent-shared-hosting-service
+          - title: Update the PHP agent
+            path: /docs/agents/php-agent/installation/update-php-agent
+      - title: PHP agent API
+        path: /docs/agents/php-agent/php-agent-api
+        pages:
+          - title: View all methods
+            path: /docs/agents/php-agent/php-agent-api/view-all-methods
+          - title: newrelic_accept_distributed_trace_headers
+            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtraceheaders
+          - title: newrelic_accept_distributed_trace_payload (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtracepayload-php-agent-api
+          - title: newrelic_accept_distributed_trace_payload_httpsafe (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtracepayloadhttpsafe-php-agent-api
+          - title: newrelic_add_custom_parameter (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_add_custom_parameter
+          - title: newrelic_add_custom_span_parameter (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelicaddcustomspanparameter-php-agent-api
+          - title: newrelic_add_custom_tracer (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_add_custom_tracer
+          - title: newrelic_background_job (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_background_job
+          - title: newrelic_capture_params (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_capture_params
+          - title: newrelic_create_distributed_trace_payload (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newreliccreatedistributedtracepayload-php-agent-api
+          - title: newrelic_custom_metric (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newreliccustommetric-php-agent-api
+          - title: newrelic_disable_autorum (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_disable_autorum
+          - title: newrelic_end_of_transaction (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_end_of_transaction
+          - title: newrelic_end_transaction (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_end_transaction
+          - title: newrelic_get_browser_timing_footer (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_get_browser_timing_footer
+          - title: newrelic_get_browser_timing_header (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_get_browser_timing_header
+          - title: newrelic_get_linking_metadata
+            path: /docs/agents/php-agent/php-agent-api/newrelicgetlinkingmetadata
+          - title: newrelic_get_trace_metadata
+            path: /docs/agents/php-agent/php-agent-api/newrelicgettracemetadata
+          - title: newrelic_ignore_apdex (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_ignore_apdex
+          - title: newrelic_ignore_transaction (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_ignore_transaction
+          - title: newrelic_insert_distributed_trace_headers
+            path: /docs/agents/php-agent/php-agent-api/newrelicinsertdistributedtraceheaders
+          - title: newrelic_is_sampled
+            path: /docs/agents/php-agent/php-agent-api/newrelicissampled
+          - title: newrelic_name_transaction (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_name_transaction
+          - title: newrelic_notice_error (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_notice_error
+          - title: newrelic_record_custom_event (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_record_custom_event
+          - title: newrelic_record_datastore_segment (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_record_datastore_segment
+          - title: newrelic_set_appname (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_set_appname
+          - title: newrelic_set_user_attributes (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_set_user_attributes
+          - title: newrelic_start_transaction (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelic_start_transaction
+      - title: API guides
+        pages:
+          - title: Guide to using the PHP agent API
+            path: /docs/agents/php-agent/api-guides/guide-using-php-agent-api
+      - title: Troubleshooting
+        pages:
+          - title: PHP agent not reporting errors
+            path: /docs/agents/php-agent/troubleshooting/php-agent-not-reporting-errors
+          - title: No data appears (PHP)
+            path: /docs/agents/php-agent/troubleshooting/no-data-appears-php
+          - title: Determine permissions requirements (PHP)
+            path: /docs/agents/php-agent/troubleshooting/determine-permissions-requirements-php
+          - title: Generating logs for troubleshooting (PHP)
+            path: /docs/agents/php-agent/troubleshooting/generating-logs-troubleshooting-php
+          - title: Data stops reporting while using SELinux
+            path: /docs/agents/php-agent/troubleshooting/data-stops-reporting-while-using-selinux
+          - title: Agent stops working after updating PHP
+            path: /docs/agents/php-agent/troubleshooting/agent-stops-working-after-updating-php
+          - title: Checking loaded configuration files directory
+            path: /docs/agents/php-agent/troubleshooting/checking-loaded-configuration-files-directory
+          - title: Missing PHP module
+            path: /docs/agents/php-agent/troubleshooting/missing-php-module
+          - title: Protocol mismatch error
+            path: /docs/agents/php-agent/troubleshooting/protocol-mismatch-error
+          - title: INI settings not taking effect immediately
+            path: /docs/agents/php-agent/troubleshooting/ini-settings-not-taking-effect-immediately
+          - title: Submitting troubleshooting results (PHP)
+            path: /docs/agents/php-agent/troubleshooting/submitting-troubleshooting-results-php
+          - title: Threaded Apache worker MPMs
+            path: /docs/agents/php-agent/troubleshooting/threaded-apache-worker-mpms
+          - title: Transactions named /index.php or /unknown
+            path: /docs/agents/php-agent/troubleshooting/transactions-named-indexphp-or-unknown
+          - title: Troubleshoot the PHP agent instance count
+            path: /docs/agents/php-agent/troubleshooting/troubleshoot-php-agent-instance-count
+          - title: Uninstrumented time in traces
+            path: /docs/agents/php-agent/troubleshooting/uninstrumented-time-traces
+          - title: Using phpinfo to verify PHP
+            path: /docs/agents/php-agent/troubleshooting/using-phpinfo-verify-php
+          - title: Verifying the PHP daemon
+            path: /docs/agents/php-agent/troubleshooting/verifying-php-daemon
+          - title: Why and when to restart your web server (PHP)
+            path: /docs/agents/php-agent/troubleshooting/why-when-restart-your-web-server-php
+          - title: PHP installation fails on OS X 10.11 - El Capitan
+            path: /docs/agents/php-agent/troubleshooting/php-installation-fails-os-x-1011-el-capitan
+          - title: Data stops reporting
+            path: /docs/agents/php-agent/troubleshooting/data-stops-reporting
+          - title: First PHP transaction is not reported
+            path: /docs/agents/php-agent/troubleshooting/first-php-transaction-not-reported
+  - title: .NET agent
+    path: /docs/agents/net-agent
+    pages:
+      - title: Getting started
+        pages:
+          - title: 'APM agent security: .NET'
+            path: /docs/agents/net-agent/getting-started/apm-agent-security-net
+          - title: .NET release notes
+            path: /docs/agents/net-agent/getting-started/net-release-notes
+          - title: Introduction to New Relic for .NET
+            path: /docs/agents/net-agent/getting-started/introduction-new-relic-net
+          - title: '.NET agent: compatibility and requirements for .NET Framework'
+            path: /docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework
+          - title: '.NET agent: compatibility and requirements for .NET Core'
+            path: /docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core
       - title: Custom instrumentation
         pages:
-          - title: Java custom instrumentation
-            path: /docs/agents/java-agent/custom-instrumentation/java-custom-instrumentation
-          - title: 'Custom instrumentation editor: Instrument from UI'
-            path: /docs/agents/java-agent/custom-instrumentation/custom-instrumentation-editor-instrument-ui
-          - title: Scala instrumentation
-            path: /docs/agents/java-agent/frameworks/scala-installation-java
-          - title: Java instrumentation by XML
-            path: /docs/agents/java-agent/custom-instrumentation/java-instrumentation-xml
-          - title: Java XML instrumentation examples
-            path: /docs/agents/java-agent/custom-instrumentation/java-xml-instrumentation-examples
-          - title: 'Java agent: Custom JMX instrumentation by YAML'
-            path: /docs/agents/java-agent/custom-instrumentation/java-agent-custom-jmx-instrumentation-yaml
-          - title: Custom JMX YAML examples
-            path: /docs/agents/java-agent/custom-instrumentation/custom-jmx-yaml-examples
-          - title: Troubleshooting Java custom instrumentation
-            path: /docs/agents/java-agent/custom-instrumentation/troubleshooting-java-custom-instrumentation
-          - title: Circuit breaker for Java custom instrumentation
-            path: /docs/agents/java-agent/custom-instrumentation/circuit-breaker-java-custom-instrumentation
-      - title: Installation
-        pages:
-          - title: Install the Java agent
-            path: /docs/agents/java-agent/installation/install-java-agent
-          - title: Include the Java agent with a JVM argument
-            path: /docs/agents/java-agent/installation/include-java-agent-jvm-argument
-          - title: Update the Java agent
-            path: /docs/agents/java-agent/installation/update-java-agent
-          - title: Uninstall the Java agent
-            path: /docs/agents/java-agent/installation/uninstall-java-agent
-      - title: Configuration
-        pages:
-          - title: 'Java agent configuration: Config file'
-            path: /docs/agents/java-agent/configuration/java-agent-configuration-config-file
-          - title: Java agent config file template
-            path: /docs/agents/java-agent/configuration/java-agent-config-file-template
-          - title: Hostname logic in Java
-            path: /docs/agents/java-agent/configuration/hostname-logic-java
-          - title: Enable distributed tracing for Java agent
-            path: /docs/agents/java-agent/configuration/enable-distributed-tracing-java-agent
-          - title: Automatic application naming
-            path: /docs/agents/java-agent/configuration/automatic-application-naming
-          - title: Java agent error configuration
-            path: /docs/agents/java-agent/configuration/java-agent-error-configuration
-          - title: Configuring your SSL certificates
-            path: /docs/agents/java-agent/configuration/configuring-your-ssl-certificates
-      - title: Features
-        pages:
-          - title: 'JVMs page (Java): View app server metrics from JMX'
-            path: /docs/agents/java-agent/features/jvms-page-java-view-app-server-metrics-jmx
-      - title: Heroku
-        pages:
-          - title: Java agent and Heroku
-            path: /docs/agents/java-agent/heroku/java-agent-heroku
-          - title: Java agent with Scala on Heroku
-            path: /docs/agents/java-agent/heroku/java-agent-scala-heroku
-          - title: No data appears with Heroku (Java)
-            path: /docs/agents/java-agent/heroku/no-data-appears-heroku-java
-      - title: Async instrumentation
-        pages:
-          - title: Introduction to Java async instrumentation
-            path: /docs/agents/java-agent/async-instrumentation/introduction-java-async-instrumentation
-          - title: Java agent API for asynchronous applications
-            path: /docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications
-          - title: Troubleshoot Java asynchronous instrumentation
-            path: /docs/agents/java-agent/async-instrumentation/troubleshoot-java-asynchronous-instrumentation
-          - title: 'Disable Scala, Netty, Akka, and Play 2 Instrumentation'
-            path: /docs/agents/java-agent/async-instrumentation/disable-scala-netty-akka-play-2-instrumentation
-      - title: Additional installation
-        pages:
-          - title: Install New Relic Java agent for Docker
-            path: /docs/agents/java-agent/additional-installation/install-new-relic-java-agent-docker
-          - title: AWS Elastic Beanstalk installation for Java
-            path: /docs/agents/java-agent/additional-installation/aws-elastic-beanstalk-installation-java
-          - title: WildFly installation for Java
-            path: /docs/agents/java-agent/additional-installation/wildfly-installation-java
-          - title: Install New Relic Java agent in GAE flexible environment
-            path: /docs/agents/java-agent/additional-installation/install-new-relic-java-agent-gae-flexible-environment
-          - title: IBM WebSphere Application Server
-            path: /docs/agents/java-agent/additional-installation/ibm-websphere-application-server
-          - title: Java 2 security installation
-            path: /docs/agents/java-agent/installation/install-java-agent-java-2-security
-          - title: Install Java agent using Maven
-            path: /docs/agents/java-agent/additional-installation/install-java-agent-using-maven
-      - title: Troubleshooting
-        pages:
-          - title: No data appears (Java)
-            path: /docs/agents/java-agent/troubleshooting/no-data-appears-java
-          - title: Determine permissions requirements (Java)
-            path: /docs/agents/java-agent/troubleshooting/determine-permissions-requirements-java
-          - title: Gather troubleshooting information (Java)
-            path: /docs/agents/java-agent/troubleshooting/gather-troubleshooting-information-java
-          - title: All hosts appear as localhost
-            path: /docs/agents/java-agent/troubleshooting/all-hosts-appear-localhost
-          - title: Error bootstrapping New Relic Java agent
-            path: /docs/agents/java-agent/troubleshooting/error-bootstrapping-new-relic-java-agent
-          - title: Errors starting Java app server
-            path: /docs/agents/java-agent/troubleshooting/errors-starting-java-app-server
-          - title: Firewall or traffic connectivity failures
-            path: /docs/agents/java-agent/troubleshooting/firewall-or-traffic-connectivity-failures
-          - title: Generate debug logs for troubleshooting (Java)
-            path: /docs/agents/java-agent/troubleshooting/generate-debug-logs-troubleshooting-java
-          - title: Host links missing in Java app's APM Summary
-            path: /docs/agents/java-agent/troubleshooting/host-links-missing-java-apps-apm-summary
-          - title: Java Solr data does not appear
-            path: /docs/agents/java-agent/troubleshooting/java-solr-data-does-not-appear
-          - title: No Browser data appears (Java)
-            path: /docs/agents/java-agent/troubleshooting/no-browser-data-appears-java
-          - title: No log file (Java)
-            path: /docs/agents/java-agent/troubleshooting/no-log-file-java
-          - title: No stack traces (Java)
-            path: /docs/agents/java-agent/troubleshooting/no-stack-traces-java
-          - title: NullPointerException issues (Java)
-            path: /docs/agents/java-agent/troubleshooting/nullpointerexception-issues-java
-          - title: Resolve metric grouping issues with Java apps
-            path: /docs/agents/java-agent/troubleshooting/resolve-metric-grouping-issues-java-apps
-          - title: SSL or connection errors (Java)
-            path: /docs/agents/java-agent/troubleshooting/ssl-or-connection-errors-java
-          - title: Update Java config for legacy agent versions
-            path: /docs/agents/java-agent/troubleshooting/update-java-config-legacy-agent-versions
-          - title: Application server JMX setup
-            path: /docs/agents/java-agent/troubleshooting/application-server-jmx-setup
-          - title: Large number of false positive security vulnerabilities
-            path: /docs/agents/java-agent/troubleshooting/large-number-false-positive-security-vulnerabilities
+          - title: Introduction to .NET custom instrumentation
+            path: /docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation
+          - title: Custom instrumentation via attributes (.NET)
+            path: /docs/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net
+          - title: Create transactions via XML (.NET)
+            path: /docs/agents/net-agent/custom-instrumentation/create-transactions-xml-net
+          - title: Add detail to transactions via XML (.NET)
+            path: /docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net
       - title: Attributes
         pages:
-          - title: Java agent attributes
-            path: /docs/agents/java-agent/attributes/java-agent-attributes
+          - title: .NET agent attributes
+            path: /docs/agents/net-agent/attributes/net-agent-attributes
+          - title: .NET attribute examples
+            path: /docs/agents/net-agent/attributes/net-attribute-examples
+          - title: Enable and disable attributes (.NET)
+            path: /docs/agents/net-agent/attributes/enable-disable-attributes-net
+      - title: Azure troubleshooting
+        pages:
+          - title: 'Azure Cloud Services: No data appears'
+            path: /docs/agents/net-agent/azure-troubleshooting/azure-cloud-services-no-data-appears
+          - title: 'Azure Web Apps: Using Always On and no data appears'
+            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-using-always-no-data-appears
+          - title: 'Azure Web Apps: Unable to open log file'
+            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-unable-open-log-file
+          - title: 'Azure Web Apps: Profiler .dll locks during deployment'
+            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-profiler-dll-locks-during-deployment
+          - title: No data reporting with Microsoft Application Insights
+            path: /docs/agents/net-agent/azure-troubleshooting/no-data-reporting-microsoft-application-insights
+      - title: NET agent API
+        path: /docs/agents/net-agent/net-agent-api
+        pages:
+          - title: View all methods
+            path: /docs/agents/net-agent/net-agent-api/view-all-methods
+          - title: AddCustomParameter (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/addcustomparameter-net-agent-api
+          - title: DisableBrowserMonitoring (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/disablebrowsermonitoring-net-agent-api
+          - title: GetAgent
+            path: /docs/agents/net-agent/net-agent-api/getagent
+          - title: GetBrowserTimingHeader (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent-api
+          - title: GetLinkingMetadata (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/getlinkingmetadata-net-agent-api
+          - title: IAgent
+            path: /docs/agents/net-agent/net-agent-api/iagent
+          - title: IDistributedTracePayload (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/idistributedtracepayload-net-agent-api
+          - title: ITransaction
+            path: /docs/agents/net-agent/net-agent-api/itransaction
+          - title: ISpan
+            path: /docs/agents/net-agent/net-agent-api/ispan
+          - title: IgnoreApdex (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/ignore-apdex
+          - title: IgnoreTransaction (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/ignore-transaction
+          - title: NoticeError (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/noticeerror-net-agent-api
+          - title: IncrementCounter (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/incrementcounter-net-agent-api
+          - title: RecordCustomEvent (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/recordcustomevent-net-agent-api
+          - title: RecordMetric (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/recordmetric-net-agent-api
+          - title: RecordResponseTimeMetric (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/recordresponsetimemetric-net-agent-api
+          - title: SetApplicationName (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/set-application-name
+          - title: SetTransactionName (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/settransactionname-net-agent-api
+          - title: SetTransactionUri (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/set-transaction-uri
+          - title: SetUserParameters (.NET agent)
+            path: /docs/agents/net-agent/net-agent-api/set-user-parameters
+          - title: StartAgent (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/start-agent
+          - title: TraceMetadata (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/tracemetadata-net-agent-api-0
       - title: API guides
         pages:
-          - title: Guide to using the Java agent API
-            path: /docs/agents/java-agent/api-guides/guide-using-java-agent-api
-          - title: 'Java agent API: Instrument using annotation'
-            path: /docs/agents/java-agent/api-guides/java-agent-api-instrument-using-annotation
-          - title: 'Java agent API: Instrument external calls, messaging, datastore, web frameworks'
-            path: /docs/agents/java-agent/api-guides/java-agent-api-instrument-external-calls-messaging-datastore-web-frameworks
-          - title: 'Java agent API: Custom instrumentation with annotation of an example app'
-            path: /docs/agents/java-agent/api-guides/java-agent-api-custom-instrumentation-annotation-example-app
-          - title: 'Java agent API: Instrumenting example app for external datastore calls and CAT'
-            path: /docs/agents/java-agent/api-guides/java-agent-api-instrumenting-example-app-external-datastore-calls-cat
-  - title: Ruby agent
-    path: /docs/agents/ruby-agent
+          - title: Guide to using the .NET agent API
+            path: /docs/agents/net-agent/api-guides/guide-using-net-agent-api
+      - title: Installation
+        pages:
+          - title: Introduction to .NET agent install
+            path: /docs/agents/net-agent/installation/introduction-net-agent-install
+          - title: Update the .NET agent
+            path: /docs/agents/net-agent/installation/update-net-agent
+          - title: Uninstall the .NET agent
+            path: /docs/agents/net-agent/installation/uninstall-net-agent
+      - title: Other installation
+        pages:
+          - title: Install the .NET agent using NuGet
+            path: /docs/agents/net-agent/install-guides/install-net-agent-using-nuget
+          - title: Install on Docker container
+            path: /docs/agents/net-agent/installation/install-docker-container
+          - title: .NET agent install resources
+            path: /docs/net-agent-install-resources
+      - title: Configuration
+        pages:
+          - title: .NET agent configuration
+            path: /docs/agents/net-agent/configuration/net-agent-configuration
+          - title: Name your .NET application
+            path: /docs/agents/net-agent/configuration/name-your-net-application
+      - title: Azure installation
+        pages:
+          - title: Install the .NET agent on Azure Cloud Services
+            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-cloud-services
+          - title: Install .NET agent on Azure Service Fabric
+            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-service-fabric
+          - title: Install the .NET agent on Azure Web Apps
+            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-web-apps
+          - title: Install Azure Marketplace app with New Relic
+            path: /docs/agents/net-agent/azure-installation/install-azure-marketplace-app-new-relic
+          - title: Azure troubleshooting
+            path: /docs/agents/net-agent/azure-installation/azure-troubleshooting
+      - title: Other features
+        pages:
+          - title: Async support in .NET
+            path: /docs/agents/net-agent/other-features/async-support-net
+          - title: Browser monitoring and the .NET agent
+            path: /docs/agents/net-agent/other-features/browser-monitoring-net-agent
+      - title: Troubleshooting
+        pages:
+          - title: Agent changes Content-Type header for WCF apps (.NET)
+            path: /docs/agents/net-agent/troubleshooting/agent-changes-content-type-header-wcf-apps-net
+          - title: Azure Pipelines wipes out NewRelic.Azure.WebSites.Extension directories
+            path: /docs/agents/net-agent/troubleshooting/azure-pipelines-wipes-out-newrelicazurewebsitesextension-directories
+          - title: No data appears (.NET)
+            path: /docs/agents/net-agent/troubleshooting/no-data-appears-net
+          - title: Technical support for .NET Framework 4.0 or lower
+            path: /docs/agents/net-agent/troubleshooting/technical-support-net-framework-40-or-lower
+          - title: Generate logs for troubleshooting (.NET)
+            path: /docs/agents/net-agent/troubleshooting/generate-logs-troubleshooting-net
+          - title: No Browser data appears (.NET)
+            path: /docs/agents/net-agent/troubleshooting/no-browser-data-appears-net
+          - title: Profiler conflicts
+            path: /docs/agents/net-agent/troubleshooting/profiler-conflicts
+          - title: .NET agent reports handled errors
+            path: /docs/agents/net-agent/troubleshooting/net-agent-reports-handled-errors
+          - title: No data and registry key permission issues
+            path: /docs/agents/net-agent/troubleshooting/no-data-registry-key-permission-issues
+          - title: High memory usage (.NET)
+            path: /docs/agents/net-agent/troubleshooting/high-memory-usage-net
+          - title: 'CoCreate errors: No event log'
+            path: /docs/agents/net-agent/troubleshooting/cocreate-errors-no-event-log
+          - title: 'Browser injection: Health check conflict'
+            path: /docs/agents/net-agent/troubleshooting/browser-injection-health-check-conflict
+          - title: 'CoCreateInstance errors: No profiler log'
+            path: /docs/agents/net-agent/troubleshooting/cocreateinstance-errors-no-profiler-log
+          - title: Missing .NET async metrics
+            path: /docs/agents/net-agent/troubleshooting/missing-net-async-metrics
+          - title: Missing Couchbase metrics (.NET)
+            path: /docs/agents/net-agent/troubleshooting/missing-couchbase-metrics-net
+          - title: New Relic for .NET status monitor
+            path: /docs/agents/net-agent/troubleshooting/new-relic-net-status-monitor
+          - title: Resolve .NET and SCOM conflicts
+            path: /docs/agents/net-agent/troubleshooting/resolve-net-scom-conflicts
+          - title: No data appears after disabling TLS 1.0
+            path: /docs/agents/net-agent/troubleshooting/no-data-appears-after-disabling-tls-10
+          - title: Monitor short-lived .NET processes
+            path: /docs/agents/net-agent/troubleshooting/monitor-short-lived-net-processes
+  - title: Node.js agent
+    path: /docs/agents/nodejs-agent
     pages:
       - title: Getting started
         pages:
-          - title: Introduction to New Relic for Ruby
-            path: /docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby
-          - title: Ruby agent requirements and supported frameworks
-            path: /docs/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks
-          - title: 'APM agent security: Ruby'
-            path: /docs/agents/ruby-agent/getting-started/apm-agent-security-ruby
-          - title: New Relic's GitHub repository
-            path: /docs/agents/ruby-agent/getting-started/new-relics-github-repository
-          - title: Ruby release notes
-            path: /docs/agents/ruby-agent/getting-started/ruby-release-notes
-      - title: Installation
+          - title: Node.js release notes
+            path: /docs/agents/nodejs-agent/getting-started/nodejs-release-notes
+          - title: Introduction to New Relic for Node.js
+            path: /docs/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs
+          - title: Compatibility and requirements for the Node.js agent
+            path: /docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent
+          - title: 'APM agent security: Node.js'
+            path: /docs/agents/nodejs-agent/getting-started/apm-agent-security-nodejs
+      - title: Installation and configuration
         pages:
-          - title: Install the New Relic Ruby agent
-            path: /docs/agents/ruby-agent/installation/install-new-relic-ruby-agent
-          - title: 'Ruby agent installation: Rails plugin'
-            path: /docs/agents/ruby-agent/installation/ruby-agent-installation-rails-plugin
-          - title: Install New Relic Ruby agent in GAE flexible environment
-            path: /docs/agents/ruby-agent/installation/install-new-relic-ruby-agent-gae-flexible-environment
-          - title: Ruby agent and Heroku
-            path: /docs/agents/ruby-agent/installation/ruby-agent-heroku
-          - title: Update the Ruby agent
-            path: /docs/agents/ruby-agent/installation/update-ruby-agent
-          - title: Uninstall the Ruby agent
-            path: /docs/agents/ruby-agent/installation/uninstall-ruby-agent
-      - title: Configuration
+          - title: Install the Node.js agent
+            path: /docs/agents/nodejs-agent/installation-configuration/install-nodejs-agent
+          - title: Node.js agent configuration
+            path: /docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration
+          - title: Update the Node.js agent
+            path: /docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent
+          - title: Uninstall the Node.js agent
+            path: /docs/agents/nodejs-agent/installation-configuration/uninstall-nodejs-agent
+      - title: Extend your instrumentation
         pages:
-          - title: Ruby agent configuration
-            path: /docs/agents/ruby-agent/configuration/ruby-agent-configuration
-          - title: Custom SSL certificates (Ruby)
-            path: /docs/agents/ruby-agent/configuration/custom-ssl-certificates-ruby
-          - title: Connect hosts to your account
-            path: /docs/agents/ruby-agent/configuration/connect-hosts-your-account
+          - title: Node.js custom instrumentation
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation
+          - title: Node.js custom metrics
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-metrics
+          - title: Node.js VMs statistics page
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-vms-statistics-page
+          - title: Enable distributed tracing for Node.js agent
+            path: /docs/agents/nodejs-agent/supported-features/enable-distributed-tracing-nodejs-agent
+          - title: Message queues
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/message-queues
+          - title: Browser monitoring and the Node.js agent
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/browser-monitoring-nodejs-agent
+          - title: Node.js VM measurements
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-vm-measurements
+          - title: Node.js v1 custom instrumentation (legacy)
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-v1-custom-instrumentation-legacy
+      - title: Hosting services
+        pages:
+          - title: Install New Relic Node.js agent in GAE flexible environment
+            path: /docs/agents/nodejs-agent/hosting-services/install-new-relic-nodejs-agent-gae-flexible-environment
+          - title: Node.js agent on Microsoft Azure Web Apps
+            path: /docs/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure
+          - title: Node.js agent and Heroku
+            path: /docs/agents/nodejs-agent/hosting-services/nodejs-agent-heroku
       - title: API guides
         pages:
-          - title: Ruby custom instrumentation
-            path: /docs/agents/ruby-agent/api-guides/ruby-custom-instrumentation
-          - title: Guide to using the Ruby agent API
-            path: /docs/agents/ruby-agent/api-guides/guide-using-ruby-agent-api
-          - title: Ruby custom metrics
-            path: /docs/agents/ruby-agent/api-guides/ruby-custom-metrics
-          - title: Ignoring specific transactions
-            path: /docs/agents/ruby-agent/api-guides/ignoring-specific-transactions
-          - title: Sending handled errors to New Relic
-            path: /docs/agents/ruby-agent/api-guides/sending-handled-errors-new-relic
-          - title: Third party instrumentation
-            path: /docs/agents/ruby-agent/api-guides/third-party-instrumentation
-      - title: Features
-        pages:
-          - title: Record deployments with the Ruby agent
-            path: /docs/agents/ruby-agent/features/record-deployments-ruby-agent
-          - title: Message queues
-            path: /docs/agents/ruby-agent/features/message-queues
-          - title: HTTP client tracing in Ruby
-            path: /docs/agents/ruby-agent/features/http-client-tracing-ruby
-          - title: Cross application tracing in Ruby
-            path: /docs/agents/ruby-agent/features/cross-application-tracing-ruby
-          - title: Ruby VM measurements
-            path: /docs/agents/ruby-agent/features/ruby-vm-measurements
-          - title: Garbage collection
-            path: /docs/agents/ruby-agent/features/garbage-collection
-          - title: New Relic Browser and the Ruby agent
-            path: /docs/agents/ruby-agent/features/new-relic-browser-ruby-agent
-          - title: Developer mode
-            path: /docs/agents/ruby-agent/features/developer-mode
-      - title: Background jobs
-        pages:
-          - title: Resque instrumentation
-            path: /docs/agents/ruby-agent/background-jobs/resque-instrumentation
-          - title: Sidekiq instrumentation
-            path: /docs/agents/ruby-agent/background-jobs/sidekiq-instrumentation
-          - title: Rake instrumentation
-            path: /docs/agents/ruby-agent/background-jobs/rake-instrumentation
-          - title: Monitor Ruby background processes
-            path: /docs/agents/ruby-agent/background-jobs/monitor-ruby-background-processes
-          - title: 'Delayed::Job instrumentation'
-            path: /docs/agents/ruby-agent/background-jobs/delayedjob-instrumentation
+          - title: Guide to using the Node.js agent API
+            path: /docs/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api
+          - title: Node.js agent API
+            path: /docs/agents/nodejs-agent/api-guides/nodejs-agent-api
       - title: Attributes
         pages:
-          - title: Enable and disable attributes (Ruby)
-            path: /docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby
-          - title: Ruby agent attributes
-            path: /docs/agents/ruby-agent/attributes/ruby-agent-attributes
-          - title: Ruby attribute examples
-            path: /docs/agents/ruby-agent/attributes/ruby-attribute-examples
+          - title: Node.js agent attributes
+            path: /docs/agents/nodejs-agent/attributes/nodejs-agent-attributes
       - title: Troubleshooting
         pages:
-          - title: No data appears (Ruby)
-            path: /docs/agents/ruby-agent/troubleshooting/no-data-appears-ruby
-          - title: Generating logs for troubleshooting (Ruby)
-            path: /docs/agents/ruby-agent/troubleshooting/generating-logs-troubleshooting-ruby
-          - title: Incompatible gems
-            path: /docs/agents/ruby-agent/troubleshooting/incompatible-gems
-          - title: No log file (Ruby)
-            path: /docs/agents/ruby-agent/troubleshooting/no-log-file-ruby
-          - title: Control when the Ruby agent starts
-            path: /docs/agents/ruby-agent/troubleshooting/control-when-ruby-agent-starts
-          - title: 'SystemStackError: stack level too deep'
-            path: /docs/agents/ruby-agent/troubleshooting/systemstackerror-stack-level-too-deep
-          - title: Ruby agent audit log
-            path: /docs/agents/ruby-agent/troubleshooting/ruby-agent-audit-log
-          - title: Passenger troubleshooting
-            path: /docs/agents/ruby-agent/troubleshooting/passenger-troubleshooting
-          - title: No data with Unicorn
-            path: /docs/agents/ruby-agent/troubleshooting/no-data-unicorn
-          - title: Update deprecated API calls
-            path: /docs/agents/ruby-agent/troubleshooting/update-deprecated-api-calls
-          - title: Update private API calls to public Tracer API
-            path: /docs/agents/ruby-agent/troubleshooting/update-private-api-calls-public-tracer-api
-          - title: Not installing New Relic supported Grape
-            path: /docs/agents/ruby-agent/troubleshooting/not-installing-new-relic-supported-grape
-      - title: Instrumented gems
-        pages:
-          - title: Redis instrumentation
-            path: /docs/agents/ruby-agent/instrumented-gems/redis-instrumentation
-          - title: Mongo instrumentation
-            path: /docs/agents/ruby-agent/frameworks/mongo-instrumentation
-          - title: Rack and Metal support
-            path: /docs/agents/ruby-agent/frameworks/rack-metal-support
-          - title: Rack middlewares
-            path: /docs/agents/ruby-agent/instrumented-gems/rack-middlewares
-          - title: Metal controller instrumentation
-            path: /docs/agents/ruby-agent/frameworks/metal-controller-instrumentation
-          - title: Sequel instrumentation
-            path: /docs/agents/ruby-agent/frameworks/sequel-instrumentation
-          - title: Sinatra instrumentation
-            path: /docs/agents/ruby-agent/instrumented-gems/sinatra-instrumentation
-  - title: Go agent
-    path: /docs/agents/go-agent
-    pages:
-      - title: Get started
-        pages:
-          - title: Introduction to New Relic for Go
-            path: /docs/agents/go-agent/get-started/introduction-new-relic-go
-          - title: Go agent compatibility and requirements
-            path: /docs/agents/go-agent/get-started/go-agent-compatibility-requirements
-          - title: 'APM agent security: Go'
-            path: /docs/agents/go-agent/get-started/apm-agent-security-go
-          - title: Go agent release notes
-            path: /docs/agents/go-agent/get-started/go-agent-release-notes
-      - title: Instrumentation
-        pages:
-          - title: Instrument Go transactions
-            path: /docs/agents/go-agent/instrumentation/instrument-go-transactions
-          - title: Instrument Go segments
-            path: /docs/agents/go-agent/instrumentation/instrument-go-segments
-          - title: Create custom events (Go)
-            path: /docs/agents/go-agent/features/create-custom-events-go
-          - title: Go agent attributes
-            path: /docs/agents/go-agent/instrumentation/go-agent-attributes
-          - title: Create custom metrics in Go
-            path: /docs/agents/go-agent/instrumentation/create-custom-metrics-go
-      - title: Installation
-        pages:
-          - title: Install New Relic for Go
-            path: /docs/agents/go-agent/installation/install-new-relic-go
-          - title: Install the Go agent in GAE flexible environment
-            path: /docs/agents/go-agent/installation/install-go-agent-gae-flexible-environment
-          - title: Uninstall the Go agent
-            path: /docs/agents/go-agent/installation/uninstall-go-agent
-      - title: Configuration
-        pages:
-          - title: Go agent configuration
-            path: /docs/agents/go-agent/configuration/go-agent-configuration
-          - title: Go agent logging
-            path: /docs/agents/go-agent/configuration/go-agent-logging
-      - title: Features
-        pages:
-          - title: 'Go runtime page: Troubleshoot performance problems'
-            path: /docs/agents/go-agent/features/go-runtime-page-troubleshoot-performance-problems
-          - title: Create custom events (Go)
-            path: /docs/agents/go-agent/features/create-custom-events-go
-          - title: Add browser monitoring to your Go apps
-            path: /docs/agents/go-agent/features/add-browser-monitoring-your-go-apps
-          - title: Enable distributed tracing for your Go applications
-            path: /docs/agents/go-agent/features/enable-distributed-tracing-your-go-applications
-          - title: Cross application tracing with Go
-            path: /docs/agents/go-agent/features/cross-application-tracing-go
-      - title: API guides
-        pages:
-          - title: Guide to using the Go agent API
-            path: /docs/agents/go-agent/api-guides/guide-using-go-agent-api
-      - title: Troubleshooting
-        pages:
-          - title: No data appears (Go)
-            path: /docs/agents/go-agent/troubleshooting/no-data-appears-go
-  - title: C SDK
-    path: /docs/agents/c-sdk
-    pages:
-      - title: Install and configure
-        pages:
-          - title: 'Install the C SDK: Compile and link your code'
-            path: /docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code
-          - title: C SDK configuration
-            path: /docs/agents/c-sdk/install-configure/c-sdk-configuration
-          - title: Update your C SDK library
-            path: /docs/agents/c-sdk/install-configure/update-your-c-sdk-library
-          - title: Uninstall (remove) the C SDK
-            path: /docs/agents/c-sdk/install-configure/uninstall-remove-c-sdk
-      - title: Get started
-        pages:
-          - title: Introduction to the C SDK
-            path: /docs/agents/c-sdk/get-started/introduction-c-sdk
-          - title: C SDK compatibility and requirements
-            path: /docs/agents/c-sdk/get-started/c-sdk-compatibility-requirements
-          - title: 'APM security: C SDK'
-            path: /docs/agents/c-sdk/get-started/apm-security-c-sdk
-      - title: Instrumentation
-        pages:
-          - title: Use default or custom attributes (C SDK)
-            path: /docs/agents/c-sdk/instrumentation/use-default-or-custom-attributes-c-sdk
-      - title: Troubleshooting
-        pages:
-          - title: No data appears (C SDK)
-            path: /docs/agents/c-sdk/troubleshooting/no-data-appears-c-sdk
-          - title: Generate logs for troubleshooting (C SDK)
-            path: /docs/agents/c-sdk/troubleshooting/generate-logs-troubleshooting-c-sdk
+          - title: Generate trace log for troubleshooting (Node.js)
+            path: /docs/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs
+          - title: Troubleshoot your Node.js installation
+            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-your-nodejs-installation
+          - title: Troubleshoot message consumers
+            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-message-consumers
+          - title: Troubleshooting large memory usage (Node.js)
+            path: /docs/agents/nodejs-agent/troubleshooting/troubleshooting-large-memory-usage-nodejs
+          - title: Troubleshoot browser instrumentation in Node.js
+            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-browser-instrumentation-nodejs
   - title: Open-source licensed agents
     pages:
       - title: Open-source licensed agents

--- a/src/nav/agents.yml
+++ b/src/nav/agents.yml
@@ -1,613 +1,71 @@
 title: Agents
 path: /docs/agents
 pages:
-  - title: C SDK
-    path: /docs/agents/c-sdk
-    pages:
-      - title: Get started
-        pages:
-          - title: 'APM security: C SDK'
-            path: /docs/agents/c-sdk/get-started/apm-security-c-sdk
-          - title: C SDK compatibility and requirements
-            path: /docs/agents/c-sdk/get-started/c-sdk-compatibility-requirements
-          - title: Introduction to the C SDK
-            path: /docs/agents/c-sdk/get-started/introduction-c-sdk
-      - title: Install and configure
-        pages:
-          - title: C SDK configuration
-            path: /docs/agents/c-sdk/install-configure/c-sdk-configuration
-          - title: 'Install the C SDK: Compile and link your code'
-            path: /docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code
-          - title: Uninstall (remove) the C SDK
-            path: /docs/agents/c-sdk/install-configure/uninstall-remove-c-sdk
-          - title: Update your C SDK library
-            path: /docs/agents/c-sdk/install-configure/update-your-c-sdk-library
-      - title: Instrumentation
-        pages:
-          - title: Use default or custom attributes (C SDK)
-            path: /docs/agents/c-sdk/instrumentation/use-default-or-custom-attributes-c-sdk
-      - title: Troubleshooting
-        pages:
-          - title: Generate logs for troubleshooting (C SDK)
-            path: /docs/agents/c-sdk/troubleshooting/generate-logs-troubleshooting-c-sdk
-          - title: No data appears (C SDK)
-            path: /docs/agents/c-sdk/troubleshooting/no-data-appears-c-sdk
-  - title: Go agent
-    path: /docs/agents/go-agent
-    pages:
-      - title: API guides
-        pages:
-          - title: Guide to using the Go agent API
-            path: /docs/agents/go-agent/api-guides/guide-using-go-agent-api
-      - title: Configuration
-        pages:
-          - title: Go agent configuration
-            path: /docs/agents/go-agent/configuration/go-agent-configuration
-          - title: Go agent logging
-            path: /docs/agents/go-agent/configuration/go-agent-logging
-      - title: Features
-        pages:
-          - title: Add browser monitoring to your Go apps
-            path: /docs/agents/go-agent/features/add-browser-monitoring-your-go-apps
-          - title: Create custom events (Go)
-            path: /docs/agents/go-agent/features/create-custom-events-go
-          - title: Cross application tracing with Go
-            path: /docs/agents/go-agent/features/cross-application-tracing-go
-          - title: Enable distributed tracing for your Go applications
-            path: /docs/agents/go-agent/features/enable-distributed-tracing-your-go-applications
-          - title: 'Go runtime page: Troubleshoot performance problems'
-            path: /docs/agents/go-agent/features/go-runtime-page-troubleshoot-performance-problems
-      - title: Instrumentation
-        pages:
-          - title: Create custom events (Go)
-            path: /docs/agents/go-agent/features/create-custom-events-go
-          - title: Create custom metrics in Go
-            path: /docs/agents/go-agent/instrumentation/create-custom-metrics-go
-          - title: Go agent attributes
-            path: /docs/agents/go-agent/instrumentation/go-agent-attributes
-          - title: Instrument Go segments
-            path: /docs/agents/go-agent/instrumentation/instrument-go-segments
-          - title: Instrument Go transactions
-            path: /docs/agents/go-agent/instrumentation/instrument-go-transactions
-      - title: Get started
-        pages:
-          - title: 'APM agent security: Go'
-            path: /docs/agents/go-agent/get-started/apm-agent-security-go
-          - title: Go agent compatibility and requirements
-            path: /docs/agents/go-agent/get-started/go-agent-compatibility-requirements
-          - title: Go agent release notes
-            path: /docs/agents/go-agent/get-started/go-agent-release-notes
-          - title: Introduction to New Relic for Go
-            path: /docs/agents/go-agent/get-started/introduction-new-relic-go
-      - title: Installation
-        pages:
-          - title: Install the Go agent in GAE flexible environment
-            path: /docs/agents/go-agent/installation/install-go-agent-gae-flexible-environment
-          - title: Install New Relic for Go
-            path: /docs/agents/go-agent/installation/install-new-relic-go
-          - title: Uninstall the Go agent
-            path: /docs/agents/go-agent/installation/uninstall-go-agent
-      - title: Troubleshooting
-        pages:
-          - title: No data appears (Go)
-            path: /docs/agents/go-agent/troubleshooting/no-data-appears-go
-  - title: Java agent
-    path: /docs/agents/java-agent
-    pages:
-      - title: Additional installation
-        pages:
-          - title: AWS Elastic Beanstalk installation for Java
-            path: /docs/agents/java-agent/additional-installation/aws-elastic-beanstalk-installation-java
-          - title: IBM WebSphere Application Server
-            path: /docs/agents/java-agent/additional-installation/ibm-websphere-application-server
-          - title: Install Java agent using Maven
-            path: /docs/agents/java-agent/additional-installation/install-java-agent-using-maven
-          - title: Install New Relic Java agent for Docker
-            path: /docs/agents/java-agent/additional-installation/install-new-relic-java-agent-docker
-          - title: Install New Relic Java agent in GAE flexible environment
-            path: /docs/agents/java-agent/additional-installation/install-new-relic-java-agent-gae-flexible-environment
-          - title: WildFly installation for Java
-            path: /docs/agents/java-agent/additional-installation/wildfly-installation-java
-          - title: Java 2 security installation
-            path: /docs/agents/java-agent/installation/install-java-agent-java-2-security
-      - title: API guides
-        pages:
-          - title: Guide to using the Java agent API
-            path: /docs/agents/java-agent/api-guides/guide-using-java-agent-api
-          - title: 'Java agent API: Custom instrumentation with annotation of an example app'
-            path: /docs/agents/java-agent/api-guides/java-agent-api-custom-instrumentation-annotation-example-app
-          - title: 'Java agent API: Instrument external calls, messaging, datastore, web frameworks'
-            path: /docs/agents/java-agent/api-guides/java-agent-api-instrument-external-calls-messaging-datastore-web-frameworks
-          - title: 'Java agent API: Instrument using annotation'
-            path: /docs/agents/java-agent/api-guides/java-agent-api-instrument-using-annotation
-          - title: 'Java agent API: Instrumenting example app for external datastore calls and CAT'
-            path: /docs/agents/java-agent/api-guides/java-agent-api-instrumenting-example-app-external-datastore-calls-cat
-      - title: Async instrumentation
-        pages:
-          - title: 'Disable Scala, Netty, Akka, and Play 2 Instrumentation'
-            path: /docs/agents/java-agent/async-instrumentation/disable-scala-netty-akka-play-2-instrumentation
-          - title: Introduction to Java async instrumentation
-            path: /docs/agents/java-agent/async-instrumentation/introduction-java-async-instrumentation
-          - title: Java agent API for asynchronous applications
-            path: /docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications
-          - title: Troubleshoot Java asynchronous instrumentation
-            path: /docs/agents/java-agent/async-instrumentation/troubleshoot-java-asynchronous-instrumentation
-      - title: Attributes
-        pages:
-          - title: Java agent attributes
-            path: /docs/agents/java-agent/attributes/java-agent-attributes
-      - title: Configuration
-        pages:
-          - title: Automatic application naming
-            path: /docs/agents/java-agent/configuration/automatic-application-naming
-          - title: Configuring your SSL certificates
-            path: /docs/agents/java-agent/configuration/configuring-your-ssl-certificates
-          - title: Enable distributed tracing for Java agent
-            path: /docs/agents/java-agent/configuration/enable-distributed-tracing-java-agent
-          - title: Hostname logic in Java
-            path: /docs/agents/java-agent/configuration/hostname-logic-java
-          - title: Java agent config file template
-            path: /docs/agents/java-agent/configuration/java-agent-config-file-template
-          - title: 'Java agent configuration: Config file'
-            path: /docs/agents/java-agent/configuration/java-agent-configuration-config-file
-          - title: Java agent error configuration
-            path: /docs/agents/java-agent/configuration/java-agent-error-configuration
-      - title: Custom instrumentation
-        pages:
-          - title: Circuit breaker for Java custom instrumentation
-            path: /docs/agents/java-agent/custom-instrumentation/circuit-breaker-java-custom-instrumentation
-          - title: 'Custom instrumentation editor: Instrument from UI'
-            path: /docs/agents/java-agent/custom-instrumentation/custom-instrumentation-editor-instrument-ui
-          - title: Custom JMX YAML examples
-            path: /docs/agents/java-agent/custom-instrumentation/custom-jmx-yaml-examples
-          - title: 'Java agent: Custom JMX instrumentation by YAML'
-            path: /docs/agents/java-agent/custom-instrumentation/java-agent-custom-jmx-instrumentation-yaml
-          - title: Java custom instrumentation
-            path: /docs/agents/java-agent/custom-instrumentation/java-custom-instrumentation
-          - title: Java instrumentation by XML
-            path: /docs/agents/java-agent/custom-instrumentation/java-instrumentation-xml
-          - title: Java XML instrumentation examples
-            path: /docs/agents/java-agent/custom-instrumentation/java-xml-instrumentation-examples
-          - title: Troubleshooting Java custom instrumentation
-            path: /docs/agents/java-agent/custom-instrumentation/troubleshooting-java-custom-instrumentation
-          - title: Scala instrumentation
-            path: /docs/agents/java-agent/frameworks/scala-installation-java
-      - title: Features
-        pages:
-          - title: 'JVMs page (Java): View app server metrics from JMX'
-            path: /docs/agents/java-agent/features/jvms-page-java-view-app-server-metrics-jmx
-      - title: Getting started
-        pages:
-          - title: 'APM agent security: Java'
-            path: /docs/agents/java-agent/getting-started/apm-agent-security-java
-          - title: Compatibility and requirements for the Java agent
-            path: /docs/agents/java-agent/getting-started/compatibility-requirements-java-agent
-          - title: Introduction to New Relic for Java
-            path: /docs/agents/java-agent/getting-started/introduction-new-relic-java
-          - title: Java release notes
-            path: /docs/agents/java-agent/getting-started/java-release-notes
-      - title: Heroku
-        pages:
-          - title: Java agent and Heroku
-            path: /docs/agents/java-agent/heroku/java-agent-heroku
-          - title: Java agent with Scala on Heroku
-            path: /docs/agents/java-agent/heroku/java-agent-scala-heroku
-          - title: No data appears with Heroku (Java)
-            path: /docs/agents/java-agent/heroku/no-data-appears-heroku-java
-      - title: Installation
-        pages:
-          - title: Include the Java agent with a JVM argument
-            path: /docs/agents/java-agent/installation/include-java-agent-jvm-argument
-          - title: Install the Java agent
-            path: /docs/agents/java-agent/installation/install-java-agent
-          - title: Uninstall the Java agent
-            path: /docs/agents/java-agent/installation/uninstall-java-agent
-          - title: Update the Java agent
-            path: /docs/agents/java-agent/installation/update-java-agent
-      - title: Instrumentation
-        pages:
-          - title: Extension and additional instrumentation modules
-            path: /docs/agents/java-agent/instrumentation/extension-additional-instrumentation-modules
-          - title: Ignore specific transactions
-            path: /docs/agents/java-agent/instrumentation/ignore-transactions-using-api
-          - title: Instrument browser monitoring with Java agent API
-            path: /docs/agents/java-agent/instrumentation/instrument-browser-monitoring-java-agent-api
-          - title: Monitor deployments (Java agent)
-            path: /docs/agents/java-agent/instrumentation/monitor-deployments-java-agent
-          - title: Transaction naming protocol
-            path: /docs/agents/java-agent/instrumentation/transaction-naming-protocol
-          - title: Use RabbitMQ or JMS for message queues
-            path: /docs/agents/java-agent/instrumentation/use-rabbitmq-or-jms-message-queues
-      - title: Troubleshooting
-        pages:
-          - title: All hosts appear as localhost
-            path: /docs/agents/java-agent/troubleshooting/all-hosts-appear-localhost
-          - title: Application server JMX setup
-            path: /docs/agents/java-agent/troubleshooting/application-server-jmx-setup
-          - title: Determine permissions requirements (Java)
-            path: /docs/agents/java-agent/troubleshooting/determine-permissions-requirements-java
-          - title: Error bootstrapping New Relic Java agent
-            path: /docs/agents/java-agent/troubleshooting/error-bootstrapping-new-relic-java-agent
-          - title: Errors starting Java app server
-            path: /docs/agents/java-agent/troubleshooting/errors-starting-java-app-server
-          - title: Firewall or traffic connectivity failures
-            path: /docs/agents/java-agent/troubleshooting/firewall-or-traffic-connectivity-failures
-          - title: Gather troubleshooting information (Java)
-            path: /docs/agents/java-agent/troubleshooting/gather-troubleshooting-information-java
-          - title: Generate debug logs for troubleshooting (Java)
-            path: /docs/agents/java-agent/troubleshooting/generate-debug-logs-troubleshooting-java
-          - title: Host links missing in Java app's APM Summary
-            path: /docs/agents/java-agent/troubleshooting/host-links-missing-java-apps-apm-summary
-          - title: Java Solr data does not appear
-            path: /docs/agents/java-agent/troubleshooting/java-solr-data-does-not-appear
-          - title: Large number of false positive security vulnerabilities
-            path: /docs/agents/java-agent/troubleshooting/large-number-false-positive-security-vulnerabilities
-          - title: No Browser data appears (Java)
-            path: /docs/agents/java-agent/troubleshooting/no-browser-data-appears-java
-          - title: No data appears (Java)
-            path: /docs/agents/java-agent/troubleshooting/no-data-appears-java
-          - title: No log file (Java)
-            path: /docs/agents/java-agent/troubleshooting/no-log-file-java
-          - title: No stack traces (Java)
-            path: /docs/agents/java-agent/troubleshooting/no-stack-traces-java
-          - title: NullPointerException issues (Java)
-            path: /docs/agents/java-agent/troubleshooting/nullpointerexception-issues-java
-          - title: Resolve metric grouping issues with Java apps
-            path: /docs/agents/java-agent/troubleshooting/resolve-metric-grouping-issues-java-apps
-          - title: SSL or connection errors (Java)
-            path: /docs/agents/java-agent/troubleshooting/ssl-or-connection-errors-java
-          - title: Update Java config for legacy agent versions
-            path: /docs/agents/java-agent/troubleshooting/update-java-config-legacy-agent-versions
-  - title: Manage APM agents
-    pages:
-      - title: Agent data
-        pages:
-          - title: Agent attributes
-            path: /docs/agents/manage-apm-agents/agent-data/agent-attributes
-          - title: Collect custom events
-            path: /docs/agents/manage-apm-agents/agent-data/collect-custom-events
-          - title: Collect custom metrics
-            path: /docs/agents/manage-apm-agents/agent-data/collect-custom-metrics
-          - title: Custom instrumentation
-            path: /docs/agents/manage-apm-agents/agent-data/custom-instrumentation
-          - title: 'Manage errors in APM: Collect, ignore, or mark as expected'
-            path: /docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected
-      - title: App naming
-        pages:
-          - title: Name your application
-            path: /docs/agents/manage-apm-agents/app-naming/name-your-application
-          - title: Use multiple names for an app
-            path: /docs/agents/manage-apm-agents/app-naming/use-multiple-names-app
-      - title: Configuration
-        pages:
-          - title: 'Add, rename, and remove hosts'
-            path: /docs/agents/manage-apm-agents/configuration/add-rename-remove-hosts
-          - title: Enable configurable security policies
-            path: /docs/agents/manage-apm-agents/configuration/enable-configurable-security-policies
-          - title: High security mode
-            path: /docs/agents/manage-apm-agents/configuration/high-security-mode
-          - title: Monitor background processes
-            path: /docs/agents/manage-apm-agents/configuration/monitor-background-processes
-          - title: Server-side agent configuration
-            path: /docs/agents/manage-apm-agents/configuration/server-side-agent-configuration
-          - title: View config values for your app
-            path: /docs/agents/manage-apm-agents/configuration/view-config-values-your-app
-      - title: Troubleshooting
-        pages:
-          - title: Agent NRIntegrationErrors appear in Insights
-            path: /docs/agents/manage-apm-agents/troubleshooting/agent-nrintegrationerrors-appear-insights
-          - title: Get environment data about your APM app
-            path: /docs/agents/manage-apm-agents/troubleshooting/get-environment-data-about-your-apm-app
-  - title: .NET agent
-    path: /docs/agents/net-agent
-    pages:
-      - title: API guides
-        pages:
-          - title: Guide to using the .NET agent API
-            path: /docs/agents/net-agent/api-guides/guide-using-net-agent-api
-      - title: Attributes
-        pages:
-          - title: Enable and disable attributes (.NET)
-            path: /docs/agents/net-agent/attributes/enable-disable-attributes-net
-          - title: .NET agent attributes
-            path: /docs/agents/net-agent/attributes/net-agent-attributes
-          - title: .NET attribute examples
-            path: /docs/agents/net-agent/attributes/net-attribute-examples
-      - title: Azure installation
-        pages:
-          - title: Azure troubleshooting
-            path: /docs/agents/net-agent/azure-installation/azure-troubleshooting
-          - title: Install Azure Marketplace app with New Relic
-            path: /docs/agents/net-agent/azure-installation/install-azure-marketplace-app-new-relic
-          - title: Install the .NET agent on Azure Cloud Services
-            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-cloud-services
-          - title: Install .NET agent on Azure Service Fabric
-            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-service-fabric
-          - title: Install the .NET agent on Azure Web Apps
-            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-web-apps
-      - title: Azure troubleshooting
-        pages:
-          - title: 'Azure Cloud Services: No data appears'
-            path: /docs/agents/net-agent/azure-troubleshooting/azure-cloud-services-no-data-appears
-          - title: 'Azure Web Apps: Profiler .dll locks during deployment'
-            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-profiler-dll-locks-during-deployment
-          - title: 'Azure Web Apps: Unable to open log file'
-            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-unable-open-log-file
-          - title: 'Azure Web Apps: Using Always On and no data appears'
-            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-using-always-no-data-appears
-          - title: No data reporting with Microsoft Application Insights
-            path: /docs/agents/net-agent/azure-troubleshooting/no-data-reporting-microsoft-application-insights
-      - title: Configuration
-        pages:
-          - title: Name your .NET application
-            path: /docs/agents/net-agent/configuration/name-your-net-application
-          - title: .NET agent configuration
-            path: /docs/agents/net-agent/configuration/net-agent-configuration
-      - title: Custom instrumentation
-        pages:
-          - title: Add detail to transactions via XML (.NET)
-            path: /docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net
-          - title: Create transactions via XML (.NET)
-            path: /docs/agents/net-agent/custom-instrumentation/create-transactions-xml-net
-          - title: Custom instrumentation via attributes (.NET)
-            path: /docs/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net
-          - title: Introduction to .NET custom instrumentation
-            path: /docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation
-      - title: Getting started
-        pages:
-          - title: 'APM agent security: .NET'
-            path: /docs/agents/net-agent/getting-started/apm-agent-security-net
-          - title: Introduction to New Relic for .NET
-            path: /docs/agents/net-agent/getting-started/introduction-new-relic-net
-          - title: '.NET agent: compatibility and requirements for .NET Core'
-            path: /docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core
-          - title: '.NET agent: compatibility and requirements for .NET Framework'
-            path: /docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework
-          - title: .NET release notes
-            path: /docs/agents/net-agent/getting-started/net-release-notes
-      - title: Other installation
-        pages:
-          - title: Install the .NET agent using NuGet
-            path: /docs/agents/net-agent/install-guides/install-net-agent-using-nuget
-          - title: Install on Docker container
-            path: /docs/agents/net-agent/installation/install-docker-container
-          - title: .NET agent install resources
-            path: /docs/net-agent-install-resources
-      - title: Installation
-        pages:
-          - title: Introduction to .NET agent install
-            path: /docs/agents/net-agent/installation/introduction-net-agent-install
-          - title: Uninstall the .NET agent
-            path: /docs/agents/net-agent/installation/uninstall-net-agent
-          - title: Update the .NET agent
-            path: /docs/agents/net-agent/installation/update-net-agent
-      - title: NET agent API
-        path: /docs/agents/net-agent/net-agent-api
-        pages:
-          - title: AddCustomParameter (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/addcustomparameter-net-agent-api
-          - title: DisableBrowserMonitoring (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/disablebrowsermonitoring-net-agent-api
-          - title: GetAgent
-            path: /docs/agents/net-agent/net-agent-api/getagent
-          - title: GetBrowserTimingHeader (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent-api
-          - title: GetLinkingMetadata (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/getlinkingmetadata-net-agent-api
-          - title: IAgent
-            path: /docs/agents/net-agent/net-agent-api/iagent
-          - title: IDistributedTracePayload (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/idistributedtracepayload-net-agent-api
-          - title: IgnoreApdex (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/ignore-apdex
-          - title: IgnoreTransaction (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/ignore-transaction
-          - title: IncrementCounter (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/incrementcounter-net-agent-api
-          - title: ISpan
-            path: /docs/agents/net-agent/net-agent-api/ispan
-          - title: ITransaction
-            path: /docs/agents/net-agent/net-agent-api/itransaction
-          - title: NoticeError (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/noticeerror-net-agent-api
-          - title: RecordCustomEvent (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/recordcustomevent-net-agent-api
-          - title: RecordMetric (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/recordmetric-net-agent-api
-          - title: RecordResponseTimeMetric (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/recordresponsetimemetric-net-agent-api
-          - title: SetApplicationName (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/set-application-name
-          - title: SetTransactionUri (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/set-transaction-uri
-          - title: SetUserParameters (.NET agent)
-            path: /docs/agents/net-agent/net-agent-api/set-user-parameters
-          - title: SetTransactionName (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/settransactionname-net-agent-api
-          - title: StartAgent (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/start-agent
-          - title: TraceMetadata (.NET agent API)
-            path: /docs/agents/net-agent/net-agent-api/tracemetadata-net-agent-api-0
-          - title: View all methods
-            path: /docs/agents/net-agent/net-agent-api/view-all-methods
-      - title: Other features
-        pages:
-          - title: Async support in .NET
-            path: /docs/agents/net-agent/other-features/async-support-net
-          - title: Browser monitoring and the .NET agent
-            path: /docs/agents/net-agent/other-features/browser-monitoring-net-agent
-      - title: Troubleshooting
-        pages:
-          - title: Agent changes Content-Type header for WCF apps (.NET)
-            path: /docs/agents/net-agent/troubleshooting/agent-changes-content-type-header-wcf-apps-net
-          - title: Azure Pipelines wipes out NewRelic.Azure.WebSites.Extension directories
-            path: /docs/agents/net-agent/troubleshooting/azure-pipelines-wipes-out-newrelicazurewebsitesextension-directories
-          - title: 'Browser injection: Health check conflict'
-            path: /docs/agents/net-agent/troubleshooting/browser-injection-health-check-conflict
-          - title: 'CoCreate errors: No event log'
-            path: /docs/agents/net-agent/troubleshooting/cocreate-errors-no-event-log
-          - title: 'CoCreateInstance errors: No profiler log'
-            path: /docs/agents/net-agent/troubleshooting/cocreateinstance-errors-no-profiler-log
-          - title: Generate logs for troubleshooting (.NET)
-            path: /docs/agents/net-agent/troubleshooting/generate-logs-troubleshooting-net
-          - title: High memory usage (.NET)
-            path: /docs/agents/net-agent/troubleshooting/high-memory-usage-net
-          - title: Missing Couchbase metrics (.NET)
-            path: /docs/agents/net-agent/troubleshooting/missing-couchbase-metrics-net
-          - title: Missing .NET async metrics
-            path: /docs/agents/net-agent/troubleshooting/missing-net-async-metrics
-          - title: Monitor short-lived .NET processes
-            path: /docs/agents/net-agent/troubleshooting/monitor-short-lived-net-processes
-          - title: .NET agent reports handled errors
-            path: /docs/agents/net-agent/troubleshooting/net-agent-reports-handled-errors
-          - title: New Relic for .NET status monitor
-            path: /docs/agents/net-agent/troubleshooting/new-relic-net-status-monitor
-          - title: No Browser data appears (.NET)
-            path: /docs/agents/net-agent/troubleshooting/no-browser-data-appears-net
-          - title: No data appears after disabling TLS 1.0
-            path: /docs/agents/net-agent/troubleshooting/no-data-appears-after-disabling-tls-10
-          - title: No data appears (.NET)
-            path: /docs/agents/net-agent/troubleshooting/no-data-appears-net
-          - title: No data and registry key permission issues
-            path: /docs/agents/net-agent/troubleshooting/no-data-registry-key-permission-issues
-          - title: Profiler conflicts
-            path: /docs/agents/net-agent/troubleshooting/profiler-conflicts
-          - title: Resolve .NET and SCOM conflicts
-            path: /docs/agents/net-agent/troubleshooting/resolve-net-scom-conflicts
-          - title: Technical support for .NET Framework 4.0 or lower
-            path: /docs/agents/net-agent/troubleshooting/technical-support-net-framework-40-or-lower
-  - title: Node.js agent
-    path: /docs/agents/nodejs-agent
-    pages:
-      - title: API guides
-        pages:
-          - title: Guide to using the Node.js agent API
-            path: /docs/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api
-          - title: Node.js agent API
-            path: /docs/agents/nodejs-agent/api-guides/nodejs-agent-api
-      - title: Attributes
-        pages:
-          - title: Node.js agent attributes
-            path: /docs/agents/nodejs-agent/attributes/nodejs-agent-attributes
-      - title: Extend your instrumentation
-        pages:
-          - title: Browser monitoring and the Node.js agent
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/browser-monitoring-nodejs-agent
-          - title: Message queues
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/message-queues
-          - title: Node.js custom instrumentation
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation
-          - title: Node.js custom metrics
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-metrics
-          - title: Node.js v1 custom instrumentation (legacy)
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-v1-custom-instrumentation-legacy
-          - title: Node.js VM measurements
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-vm-measurements
-          - title: Node.js VMs statistics page
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-vms-statistics-page
-          - title: Enable distributed tracing for Node.js agent
-            path: /docs/agents/nodejs-agent/supported-features/enable-distributed-tracing-nodejs-agent
-      - title: Getting started
-        pages:
-          - title: 'APM agent security: Node.js'
-            path: /docs/agents/nodejs-agent/getting-started/apm-agent-security-nodejs
-          - title: Compatibility and requirements for the Node.js agent
-            path: /docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent
-          - title: Introduction to New Relic for Node.js
-            path: /docs/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs
-          - title: Node.js release notes
-            path: /docs/agents/nodejs-agent/getting-started/nodejs-release-notes
-      - title: Hosting services
-        pages:
-          - title: Install New Relic Node.js agent in GAE flexible environment
-            path: /docs/agents/nodejs-agent/hosting-services/install-new-relic-nodejs-agent-gae-flexible-environment
-          - title: Node.js agent and Heroku
-            path: /docs/agents/nodejs-agent/hosting-services/nodejs-agent-heroku
-          - title: Node.js agent on Microsoft Azure Web Apps
-            path: /docs/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure
-      - title: Installation and configuration
-        pages:
-          - title: Install the Node.js agent
-            path: /docs/agents/nodejs-agent/installation-configuration/install-nodejs-agent
-          - title: Node.js agent configuration
-            path: /docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration
-          - title: Uninstall the Node.js agent
-            path: /docs/agents/nodejs-agent/installation-configuration/uninstall-nodejs-agent
-          - title: Update the Node.js agent
-            path: /docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent
-      - title: Troubleshooting
-        pages:
-          - title: Generate trace log for troubleshooting (Node.js)
-            path: /docs/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs
-          - title: Troubleshoot browser instrumentation in Node.js
-            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-browser-instrumentation-nodejs
-          - title: Troubleshoot message consumers
-            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-message-consumers
-          - title: Troubleshoot your Node.js installation
-            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-your-nodejs-installation
-          - title: Troubleshooting large memory usage (Node.js)
-            path: /docs/agents/nodejs-agent/troubleshooting/troubleshooting-large-memory-usage-nodejs
-  - title: Open-source licensed agents
-    pages:
-      - title: Open-source licensed agents
-        pages:
-          - title: Elixir open-source agent
-            path: /docs/agents/open-source-licensed-agents/elixir-open-source-agent
   - title: PHP agent
     path: /docs/agents/php-agent
     pages:
       - title: Advanced installation
         pages:
-          - title: 'Docker and other container environments: Install PHP agent'
-            path: /docs/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent
-          - title: PHP agent and Heroku
-            path: /docs/agents/php-agent/advanced-installation/php-agent-heroku
-          - title: 'PHP agent installation: Non-standard PHP (advanced)'
-            path: /docs/agents/php-agent/advanced-installation/php-agent-installation-non-standard-php-advanced
-          - title: Silent mode for the install script (advanced)
-            path: /docs/agents/php-agent/advanced-installation/silent-mode-install-script-advanced
-          - title: Starting the PHP daemon (advanced)
-            path: /docs/agents/php-agent/advanced-installation/starting-php-daemon-advanced
-          - title: Uninstall the PHP agent
-            path: /docs/agents/php-agent/advanced-installation/uninstalling-php-agent
           - title: Using the newrelic-install script
             path: /docs/agents/php-agent/advanced-installation/using-newrelic-install-script
-      - title: API guides
-        pages:
-          - title: Guide to using the PHP agent API
-            path: /docs/agents/php-agent/api-guides/guide-using-php-agent-api
-      - title: Attributes
-        pages:
-          - title: Attribute examples
-            path: /docs/agents/php-agent/attributes/attribute-examples
-          - title: Enable or disable attributes
-            path: /docs/agents/php-agent/attributes/enable-or-disable-attributes
-          - title: PHP agent attributes
-            path: /docs/agents/php-agent/attributes/php-agent-attributes
+          - title: 'Docker and other container environments: Install PHP agent'
+            path: /docs/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent
+          - title: Starting the PHP daemon (advanced)
+            path: /docs/agents/php-agent/advanced-installation/starting-php-daemon-advanced
+          - title: Silent mode for the install script (advanced)
+            path: /docs/agents/php-agent/advanced-installation/silent-mode-install-script-advanced
+          - title: 'PHP agent installation: Non-standard PHP (advanced)'
+            path: /docs/agents/php-agent/advanced-installation/php-agent-installation-non-standard-php-advanced
+          - title: PHP agent and Heroku
+            path: /docs/agents/php-agent/advanced-installation/php-agent-heroku
+          - title: Uninstall the PHP agent
+            path: /docs/agents/php-agent/advanced-installation/uninstalling-php-agent
       - title: Configuration
         pages:
-          - title: Name your PHP application
-            path: /docs/agents/php-agent/configuration/name-your-php-application
           - title: PHP agent configuration
             path: /docs/agents/php-agent/configuration/php-agent-configuration
           - title: PHP per-directory INI settings
             path: /docs/agents/php-agent/configuration/php-directory-ini-settings
+          - title: Name your PHP application
+            path: /docs/agents/php-agent/configuration/name-your-php-application
           - title: Proxy daemon (newrelic.cfg) settings
             path: /docs/agents/php-agent/configuration/proxy-daemon-newreliccfg-settings
+      - title: Attributes
+        pages:
+          - title: PHP agent attributes
+            path: /docs/agents/php-agent/attributes/php-agent-attributes
+          - title: Enable or disable attributes
+            path: /docs/agents/php-agent/attributes/enable-or-disable-attributes
+          - title: Attribute examples
+            path: /docs/agents/php-agent/attributes/attribute-examples
+      - title: Getting started
+        pages:
+          - title: Introduction to New Relic for PHP
+            path: /docs/agents/php-agent/getting-started/introduction-new-relic-php
+          - title: PHP agent compatibility and requirements
+            path: /docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
+          - title: New Relic daemon processes
+            path: /docs/agents/php-agent/getting-started/new-relic-daemon-processes
+          - title: 'APM agent security: PHP'
+            path: /docs/agents/php-agent/getting-started/apm-agent-security-php
+          - title: PHP agent release notes
+            path: /docs/agents/php-agent/getting-started/php-agent-release-notes
       - title: Features
         pages:
-          - title: Browser monitoring and the PHP agent
-            path: /docs/agents/php-agent/features/browser-monitoring-php-agent
-          - title: Distributed tracing for the PHP agent
-            path: /docs/agents/php-agent/features/distributed-tracing-php-agent
           - title: Multiple accounts
             path: /docs/agents/php-agent/features/multiple-accounts
+          - title: Distributed tracing for the PHP agent
+            path: /docs/agents/php-agent/features/distributed-tracing-php-agent
+          - title: Browser monitoring and the PHP agent
+            path: /docs/agents/php-agent/features/browser-monitoring-php-agent
           - title: PHP custom instrumentation
             path: /docs/agents/php-agent/features/php-custom-instrumentation
           - title: Recording deployments using a PHP script
             path: /docs/agents/php-agent/features/recording-deployments-using-php-script
       - title: Frameworks and libraries
         pages:
+          - title: 'PHP frameworks: Integrate support for New Relic'
+            path: /docs/agents/php-agent/frameworks-libraries/php-frameworks-integrate-support-new-relic
           - title: Analyze PHPUnit test data in New Relic
             path: /docs/agents/php-agent/frameworks-libraries/analyze-phpunit-test-data-new-relic
           - title: AWS Elastic Beanstalk installation for PHP
@@ -618,49 +76,49 @@ pages:
             path: /docs/agents/php-agent/frameworks-libraries/guzzle
           - title: Magento-specific functionality
             path: /docs/agents/php-agent/frameworks-libraries/magento-specific-functionality
-          - title: 'PHP frameworks: Integrate support for New Relic'
-            path: /docs/agents/php-agent/frameworks-libraries/php-frameworks-integrate-support-new-relic
           - title: Predis library in PHP
             path: /docs/agents/php-agent/frameworks-libraries/predis-library-php
           - title: WordPress specific functionality
             path: /docs/agents/php-agent/frameworks-libraries/wordpress-specific-functionality
-      - title: Getting started
-        pages:
-          - title: 'APM agent security: PHP'
-            path: /docs/agents/php-agent/getting-started/apm-agent-security-php
-          - title: Introduction to New Relic for PHP
-            path: /docs/agents/php-agent/getting-started/introduction-new-relic-php
-          - title: New Relic daemon processes
-            path: /docs/agents/php-agent/getting-started/new-relic-daemon-processes
-          - title: PHP agent compatibility and requirements
-            path: /docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-          - title: PHP agent release notes
-            path: /docs/agents/php-agent/getting-started/php-agent-release-notes
       - title: Installation
         pages:
-          - title: Install PHP agent on shared hosting service
-            path: /docs/agents/php-agent/installation/install-php-agent-shared-hosting-service
-          - title: 'PHP agent installation: AWS Linux, RedHat, and CentOS'
-            path: /docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos
           - title: PHP agent installation overview
             path: /docs/agents/php-agent/installation/php-agent-installation-overview
-          - title: 'PHP agent installation: Tar file'
-            path: /docs/agents/php-agent/installation/php-agent-installation-tar-file
+          - title: 'PHP agent installation: AWS Linux, RedHat, and CentOS'
+            path: /docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos
           - title: 'PHP agent installation: Ubuntu and Debian'
             path: /docs/agents/php-agent/installation/php-agent-installation-ubuntu-debian
+          - title: 'PHP agent installation: Tar file'
+            path: /docs/agents/php-agent/installation/php-agent-installation-tar-file
+          - title: Install PHP agent on shared hosting service
+            path: /docs/agents/php-agent/installation/install-php-agent-shared-hosting-service
           - title: Update the PHP agent
             path: /docs/agents/php-agent/installation/update-php-agent
       - title: PHP agent API
         path: /docs/agents/php-agent/php-agent-api
         pages:
+          - title: View all methods
+            path: /docs/agents/php-agent/php-agent-api/view-all-methods
+          - title: newrelic_accept_distributed_trace_headers
+            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtraceheaders
+          - title: newrelic_accept_distributed_trace_payload (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtracepayload-php-agent-api
+          - title: newrelic_accept_distributed_trace_payload_httpsafe (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtracepayloadhttpsafe-php-agent-api
           - title: newrelic_add_custom_parameter (PHP agent API)
             path: /docs/agents/php-agent/php-agent-api/newrelic_add_custom_parameter
+          - title: newrelic_add_custom_span_parameter (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newrelicaddcustomspanparameter-php-agent-api
           - title: newrelic_add_custom_tracer (PHP agent API)
             path: /docs/agents/php-agent/php-agent-api/newrelic_add_custom_tracer
           - title: newrelic_background_job (PHP agent API)
             path: /docs/agents/php-agent/php-agent-api/newrelic_background_job
           - title: newrelic_capture_params (PHP agent API)
             path: /docs/agents/php-agent/php-agent-api/newrelic_capture_params
+          - title: newrelic_create_distributed_trace_payload (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newreliccreatedistributedtracepayload-php-agent-api
+          - title: newrelic_custom_metric (PHP agent API)
+            path: /docs/agents/php-agent/php-agent-api/newreliccustommetric-php-agent-api
           - title: newrelic_disable_autorum (PHP agent API)
             path: /docs/agents/php-agent/php-agent-api/newrelic_disable_autorum
           - title: newrelic_end_of_transaction (PHP agent API)
@@ -671,10 +129,18 @@ pages:
             path: /docs/agents/php-agent/php-agent-api/newrelic_get_browser_timing_footer
           - title: newrelic_get_browser_timing_header (PHP agent API)
             path: /docs/agents/php-agent/php-agent-api/newrelic_get_browser_timing_header
+          - title: newrelic_get_linking_metadata
+            path: /docs/agents/php-agent/php-agent-api/newrelicgetlinkingmetadata
+          - title: newrelic_get_trace_metadata
+            path: /docs/agents/php-agent/php-agent-api/newrelicgettracemetadata
           - title: newrelic_ignore_apdex (PHP agent API)
             path: /docs/agents/php-agent/php-agent-api/newrelic_ignore_apdex
           - title: newrelic_ignore_transaction (PHP agent API)
             path: /docs/agents/php-agent/php-agent-api/newrelic_ignore_transaction
+          - title: newrelic_insert_distributed_trace_headers
+            path: /docs/agents/php-agent/php-agent-api/newrelicinsertdistributedtraceheaders
+          - title: newrelic_is_sampled
+            path: /docs/agents/php-agent/php-agent-api/newrelicissampled
           - title: newrelic_name_transaction (PHP agent API)
             path: /docs/agents/php-agent/php-agent-api/newrelic_name_transaction
           - title: newrelic_notice_error (PHP agent API)
@@ -689,56 +155,32 @@ pages:
             path: /docs/agents/php-agent/php-agent-api/newrelic_set_user_attributes
           - title: newrelic_start_transaction (PHP agent API)
             path: /docs/agents/php-agent/php-agent-api/newrelic_start_transaction
-          - title: newrelic_accept_distributed_trace_headers
-            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtraceheaders
-          - title: newrelic_accept_distributed_trace_payload (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtracepayload-php-agent-api
-          - title: newrelic_accept_distributed_trace_payload_httpsafe (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtracepayloadhttpsafe-php-agent-api
-          - title: newrelic_add_custom_span_parameter (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newrelicaddcustomspanparameter-php-agent-api
-          - title: newrelic_create_distributed_trace_payload (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newreliccreatedistributedtracepayload-php-agent-api
-          - title: newrelic_custom_metric (PHP agent API)
-            path: /docs/agents/php-agent/php-agent-api/newreliccustommetric-php-agent-api
-          - title: newrelic_get_linking_metadata
-            path: /docs/agents/php-agent/php-agent-api/newrelicgetlinkingmetadata
-          - title: newrelic_get_trace_metadata
-            path: /docs/agents/php-agent/php-agent-api/newrelicgettracemetadata
-          - title: newrelic_insert_distributed_trace_headers
-            path: /docs/agents/php-agent/php-agent-api/newrelicinsertdistributedtraceheaders
-          - title: newrelic_is_sampled
-            path: /docs/agents/php-agent/php-agent-api/newrelicissampled
-          - title: View all methods
-            path: /docs/agents/php-agent/php-agent-api/view-all-methods
+      - title: API guides
+        pages:
+          - title: Guide to using the PHP agent API
+            path: /docs/agents/php-agent/api-guides/guide-using-php-agent-api
       - title: Troubleshooting
         pages:
-          - title: Agent stops working after updating PHP
-            path: /docs/agents/php-agent/troubleshooting/agent-stops-working-after-updating-php
-          - title: Checking loaded configuration files directory
-            path: /docs/agents/php-agent/troubleshooting/checking-loaded-configuration-files-directory
-          - title: Data stops reporting while using SELinux
-            path: /docs/agents/php-agent/troubleshooting/data-stops-reporting-while-using-selinux
-          - title: Data stops reporting
-            path: /docs/agents/php-agent/troubleshooting/data-stops-reporting
-          - title: Determine permissions requirements (PHP)
-            path: /docs/agents/php-agent/troubleshooting/determine-permissions-requirements-php
-          - title: First PHP transaction is not reported
-            path: /docs/agents/php-agent/troubleshooting/first-php-transaction-not-reported
-          - title: Generating logs for troubleshooting (PHP)
-            path: /docs/agents/php-agent/troubleshooting/generating-logs-troubleshooting-php
-          - title: INI settings not taking effect immediately
-            path: /docs/agents/php-agent/troubleshooting/ini-settings-not-taking-effect-immediately
-          - title: Missing PHP module
-            path: /docs/agents/php-agent/troubleshooting/missing-php-module
           - title: No data appears (PHP)
             path: /docs/agents/php-agent/troubleshooting/no-data-appears-php
           - title: PHP agent not reporting errors
             path: /docs/agents/php-agent/troubleshooting/php-agent-not-reporting-errors
-          - title: PHP installation fails on OS X 10.11 - El Capitan
-            path: /docs/agents/php-agent/troubleshooting/php-installation-fails-os-x-1011-el-capitan
+          - title: Determine permissions requirements (PHP)
+            path: /docs/agents/php-agent/troubleshooting/determine-permissions-requirements-php
+          - title: Generating logs for troubleshooting (PHP)
+            path: /docs/agents/php-agent/troubleshooting/generating-logs-troubleshooting-php
+          - title: Data stops reporting while using SELinux
+            path: /docs/agents/php-agent/troubleshooting/data-stops-reporting-while-using-selinux
+          - title: Agent stops working after updating PHP
+            path: /docs/agents/php-agent/troubleshooting/agent-stops-working-after-updating-php
+          - title: Checking loaded configuration files directory
+            path: /docs/agents/php-agent/troubleshooting/checking-loaded-configuration-files-directory
+          - title: Missing PHP module
+            path: /docs/agents/php-agent/troubleshooting/missing-php-module
           - title: Protocol mismatch error
             path: /docs/agents/php-agent/troubleshooting/protocol-mismatch-error
+          - title: INI settings not taking effect immediately
+            path: /docs/agents/php-agent/troubleshooting/ini-settings-not-taking-effect-immediately
           - title: Submitting troubleshooting results (PHP)
             path: /docs/agents/php-agent/troubleshooting/submitting-troubleshooting-results-php
           - title: Threaded Apache worker MPMs
@@ -755,47 +197,344 @@ pages:
             path: /docs/agents/php-agent/troubleshooting/verifying-php-daemon
           - title: Why and when to restart your web server (PHP)
             path: /docs/agents/php-agent/troubleshooting/why-when-restart-your-web-server-php
+          - title: PHP installation fails on OS X 10.11 - El Capitan
+            path: /docs/agents/php-agent/troubleshooting/php-installation-fails-os-x-1011-el-capitan
+          - title: Data stops reporting
+            path: /docs/agents/php-agent/troubleshooting/data-stops-reporting
+          - title: First PHP transaction is not reported
+            path: /docs/agents/php-agent/troubleshooting/first-php-transaction-not-reported
+  - title: Node.js agent
+    path: /docs/agents/nodejs-agent
+    pages:
+      - title: Getting started
+        pages:
+          - title: Introduction to New Relic for Node.js
+            path: /docs/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs
+          - title: Compatibility and requirements for the Node.js agent
+            path: /docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent
+          - title: 'APM agent security: Node.js'
+            path: /docs/agents/nodejs-agent/getting-started/apm-agent-security-nodejs
+          - title: Node.js release notes
+            path: /docs/agents/nodejs-agent/getting-started/nodejs-release-notes
+      - title: Installation and configuration
+        pages:
+          - title: Install the Node.js agent
+            path: /docs/agents/nodejs-agent/installation-configuration/install-nodejs-agent
+          - title: Node.js agent configuration
+            path: /docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration
+          - title: Update the Node.js agent
+            path: /docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent
+          - title: Uninstall the Node.js agent
+            path: /docs/agents/nodejs-agent/installation-configuration/uninstall-nodejs-agent
+      - title: Extend your instrumentation
+        pages:
+          - title: Node.js custom instrumentation
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation
+          - title: Node.js custom metrics
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-metrics
+          - title: Node.js VMs statistics page
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-vms-statistics-page
+          - title: Enable distributed tracing for Node.js agent
+            path: /docs/agents/nodejs-agent/supported-features/enable-distributed-tracing-nodejs-agent
+          - title: Message queues
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/message-queues
+          - title: Browser monitoring and the Node.js agent
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/browser-monitoring-nodejs-agent
+          - title: Node.js VM measurements
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-vm-measurements
+          - title: Node.js v1 custom instrumentation (legacy)
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-v1-custom-instrumentation-legacy
+      - title: Hosting services
+        pages:
+          - title: Install New Relic Node.js agent in GAE flexible environment
+            path: /docs/agents/nodejs-agent/hosting-services/install-new-relic-nodejs-agent-gae-flexible-environment
+          - title: Node.js agent on Microsoft Azure Web Apps
+            path: /docs/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure
+          - title: Node.js agent and Heroku
+            path: /docs/agents/nodejs-agent/hosting-services/nodejs-agent-heroku
+      - title: API guides
+        pages:
+          - title: Guide to using the Node.js agent API
+            path: /docs/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api
+          - title: Node.js agent API
+            path: /docs/agents/nodejs-agent/api-guides/nodejs-agent-api
+      - title: Troubleshooting
+        pages:
+          - title: Troubleshoot your Node.js installation
+            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-your-nodejs-installation
+          - title: Generate trace log for troubleshooting (Node.js)
+            path: /docs/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs
+          - title: Troubleshoot message consumers
+            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-message-consumers
+          - title: Troubleshooting large memory usage (Node.js)
+            path: /docs/agents/nodejs-agent/troubleshooting/troubleshooting-large-memory-usage-nodejs
+          - title: Troubleshoot browser instrumentation in Node.js
+            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-browser-instrumentation-nodejs
+      - title: Attributes
+        pages:
+          - title: Node.js agent attributes
+            path: /docs/agents/nodejs-agent/attributes/nodejs-agent-attributes
+  - title: .NET agent
+    path: /docs/agents/net-agent
+    pages:
+      - title: Getting started
+        pages:
+          - title: Introduction to New Relic for .NET
+            path: /docs/agents/net-agent/getting-started/introduction-new-relic-net
+          - title: '.NET agent: compatibility and requirements for .NET Framework'
+            path: /docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework
+          - title: '.NET agent: compatibility and requirements for .NET Core'
+            path: /docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core
+          - title: 'APM agent security: .NET'
+            path: /docs/agents/net-agent/getting-started/apm-agent-security-net
+          - title: .NET release notes
+            path: /docs/agents/net-agent/getting-started/net-release-notes
+      - title: Custom instrumentation
+        pages:
+          - title: Introduction to .NET custom instrumentation
+            path: /docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation
+          - title: Custom instrumentation via attributes (.NET)
+            path: /docs/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net
+          - title: Create transactions via XML (.NET)
+            path: /docs/agents/net-agent/custom-instrumentation/create-transactions-xml-net
+          - title: Add detail to transactions via XML (.NET)
+            path: /docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net
+      - title: Attributes
+        pages:
+          - title: .NET agent attributes
+            path: /docs/agents/net-agent/attributes/net-agent-attributes
+          - title: .NET attribute examples
+            path: /docs/agents/net-agent/attributes/net-attribute-examples
+          - title: Enable and disable attributes (.NET)
+            path: /docs/agents/net-agent/attributes/enable-disable-attributes-net
+      - title: Azure troubleshooting
+        pages:
+          - title: 'Azure Cloud Services: No data appears'
+            path: /docs/agents/net-agent/azure-troubleshooting/azure-cloud-services-no-data-appears
+          - title: 'Azure Web Apps: Using Always On and no data appears'
+            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-using-always-no-data-appears
+          - title: 'Azure Web Apps: Unable to open log file'
+            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-unable-open-log-file
+          - title: 'Azure Web Apps: Profiler .dll locks during deployment'
+            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-profiler-dll-locks-during-deployment
+          - title: No data reporting with Microsoft Application Insights
+            path: /docs/agents/net-agent/azure-troubleshooting/no-data-reporting-microsoft-application-insights
+      - title: NET agent API
+        path: /docs/agents/net-agent/net-agent-api
+        pages:
+          - title: View all methods
+            path: /docs/agents/net-agent/net-agent-api/view-all-methods
+          - title: AddCustomParameter (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/addcustomparameter-net-agent-api
+          - title: DisableBrowserMonitoring (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/disablebrowsermonitoring-net-agent-api
+          - title: GetAgent
+            path: /docs/agents/net-agent/net-agent-api/getagent
+          - title: GetBrowserTimingHeader (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent-api
+          - title: GetLinkingMetadata (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/getlinkingmetadata-net-agent-api
+          - title: IAgent
+            path: /docs/agents/net-agent/net-agent-api/iagent
+          - title: IDistributedTracePayload (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/idistributedtracepayload-net-agent-api
+          - title: ITransaction
+            path: /docs/agents/net-agent/net-agent-api/itransaction
+          - title: ISpan
+            path: /docs/agents/net-agent/net-agent-api/ispan
+          - title: IgnoreApdex (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/ignore-apdex
+          - title: IgnoreTransaction (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/ignore-transaction
+          - title: NoticeError (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/noticeerror-net-agent-api
+          - title: IncrementCounter (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/incrementcounter-net-agent-api
+          - title: RecordCustomEvent (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/recordcustomevent-net-agent-api
+          - title: RecordMetric (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/recordmetric-net-agent-api
+          - title: RecordResponseTimeMetric (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/recordresponsetimemetric-net-agent-api
+          - title: SetApplicationName (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/set-application-name
+          - title: SetTransactionName (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/settransactionname-net-agent-api
+          - title: SetTransactionUri (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/set-transaction-uri
+          - title: SetUserParameters (.NET agent)
+            path: /docs/agents/net-agent/net-agent-api/set-user-parameters
+          - title: StartAgent (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/start-agent
+          - title: TraceMetadata (.NET agent API)
+            path: /docs/agents/net-agent/net-agent-api/tracemetadata-net-agent-api-0
+      - title: API guides
+        pages:
+          - title: Guide to using the .NET agent API
+            path: /docs/agents/net-agent/api-guides/guide-using-net-agent-api
+      - title: Installation
+        pages:
+          - title: Introduction to .NET agent install
+            path: /docs/agents/net-agent/installation/introduction-net-agent-install
+          - title: Update the .NET agent
+            path: /docs/agents/net-agent/installation/update-net-agent
+          - title: Uninstall the .NET agent
+            path: /docs/agents/net-agent/installation/uninstall-net-agent
+      - title: Troubleshooting
+        pages:
+          - title: No data appears (.NET)
+            path: /docs/agents/net-agent/troubleshooting/no-data-appears-net
+          - title: Agent changes Content-Type header for WCF apps (.NET)
+            path: /docs/agents/net-agent/troubleshooting/agent-changes-content-type-header-wcf-apps-net
+          - title: Azure Pipelines wipes out NewRelic.Azure.WebSites.Extension directories
+            path: /docs/agents/net-agent/troubleshooting/azure-pipelines-wipes-out-newrelicazurewebsitesextension-directories
+          - title: Technical support for .NET Framework 4.0 or lower
+            path: /docs/agents/net-agent/troubleshooting/technical-support-net-framework-40-or-lower
+          - title: Generate logs for troubleshooting (.NET)
+            path: /docs/agents/net-agent/troubleshooting/generate-logs-troubleshooting-net
+          - title: No Browser data appears (.NET)
+            path: /docs/agents/net-agent/troubleshooting/no-browser-data-appears-net
+          - title: Profiler conflicts
+            path: /docs/agents/net-agent/troubleshooting/profiler-conflicts
+          - title: .NET agent reports handled errors
+            path: /docs/agents/net-agent/troubleshooting/net-agent-reports-handled-errors
+          - title: No data and registry key permission issues
+            path: /docs/agents/net-agent/troubleshooting/no-data-registry-key-permission-issues
+          - title: High memory usage (.NET)
+            path: /docs/agents/net-agent/troubleshooting/high-memory-usage-net
+          - title: 'CoCreate errors: No event log'
+            path: /docs/agents/net-agent/troubleshooting/cocreate-errors-no-event-log
+          - title: 'Browser injection: Health check conflict'
+            path: /docs/agents/net-agent/troubleshooting/browser-injection-health-check-conflict
+          - title: 'CoCreateInstance errors: No profiler log'
+            path: /docs/agents/net-agent/troubleshooting/cocreateinstance-errors-no-profiler-log
+          - title: Missing .NET async metrics
+            path: /docs/agents/net-agent/troubleshooting/missing-net-async-metrics
+          - title: Missing Couchbase metrics (.NET)
+            path: /docs/agents/net-agent/troubleshooting/missing-couchbase-metrics-net
+          - title: New Relic for .NET status monitor
+            path: /docs/agents/net-agent/troubleshooting/new-relic-net-status-monitor
+          - title: Resolve .NET and SCOM conflicts
+            path: /docs/agents/net-agent/troubleshooting/resolve-net-scom-conflicts
+          - title: No data appears after disabling TLS 1.0
+            path: /docs/agents/net-agent/troubleshooting/no-data-appears-after-disabling-tls-10
+          - title: Monitor short-lived .NET processes
+            path: /docs/agents/net-agent/troubleshooting/monitor-short-lived-net-processes
+      - title: Other installation
+        pages:
+          - title: Install the .NET agent using NuGet
+            path: /docs/agents/net-agent/install-guides/install-net-agent-using-nuget
+          - title: Install on Docker container
+            path: /docs/agents/net-agent/installation/install-docker-container
+          - title: .NET agent install resources
+            path: /docs/net-agent-install-resources
+      - title: Configuration
+        pages:
+          - title: .NET agent configuration
+            path: /docs/agents/net-agent/configuration/net-agent-configuration
+          - title: Name your .NET application
+            path: /docs/agents/net-agent/configuration/name-your-net-application
+      - title: Azure installation
+        pages:
+          - title: Install the .NET agent on Azure Cloud Services
+            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-cloud-services
+          - title: Install .NET agent on Azure Service Fabric
+            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-service-fabric
+          - title: Install the .NET agent on Azure Web Apps
+            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-web-apps
+          - title: Install Azure Marketplace app with New Relic
+            path: /docs/agents/net-agent/azure-installation/install-azure-marketplace-app-new-relic
+          - title: Azure troubleshooting
+            path: /docs/agents/net-agent/azure-installation/azure-troubleshooting
+      - title: Other features
+        pages:
+          - title: Async support in .NET
+            path: /docs/agents/net-agent/other-features/async-support-net
+          - title: Browser monitoring and the .NET agent
+            path: /docs/agents/net-agent/other-features/browser-monitoring-net-agent
   - title: Python agent
     path: /docs/agents/python-agent
     pages:
-      - title: API guides
+      - title: Supported features
         pages:
-          - title: Guide to using the Python agent API
-            path: /docs/agents/python-agent/api-guides/guide-using-python-agent-api
-      - title: Attributes
+          - title: Python custom metrics
+            path: /docs/agents/python-agent/supported-features/python-custom-metrics
+          - title: Python message queues
+            path: /docs/agents/python-agent/supported-features/python-message-queues
+          - title: Browser monitoring and the Python agent
+            path: /docs/agents/python-agent/supported-features/browser-monitoring-python-agent
+          - title: 'Monitor non-web scripts, worker processes, tasks, and functions'
+            path: /docs/agents/python-agent/supported-features/monitor-non-web-scripts-worker-processes-tasks-functions
+          - title: Python tips and tricks
+            path: /docs/agents/python-agent/supported-features/python-tips-tricks
+          - title: Cross application tracing
+            path: /docs/agents/python-agent/supported-features/cross-application-tracing
+          - title: Optional manual Browser instrumentation with Django templates
+            path: /docs/agents/python-agent/supported-features/optional-manual-browser-instrumentation-django-templates
+      - title: Installation
         pages:
-          - title: Enabling and disabling attributes (Python)
-            path: /docs/agents/python-agent/attributes/enabling-disabling-attributes-python
-          - title: Python agent attributes
-            path: /docs/agents/python-agent/attributes/python-agent-attributes
-          - title: Python attribute examples
-            path: /docs/agents/python-agent/attributes/python-attribute-examples
+          - title: Standard Python agent install
+            path: /docs/agents/python-agent/installation/standard-python-agent-install
+          - title: Advanced install of New Relic Python agent
+            path: /docs/agents/python-agent/installation/advanced-install-new-relic-python-agent
+          - title: 'Python agent: Advanced integration'
+            path: /docs/agents/python-agent/installation/python-agent-advanced-integration
+          - title: Update the Python agent
+            path: /docs/agents/python-agent/installation/update-python-agent
+          - title: 'Python agent admin script: Advanced usage'
+            path: /docs/agents/python-agent/installation/python-agent-admin-script-advanced-usage
+          - title: Uninstall the Python agent
+            path: /docs/agents/python-agent/installation/uninstall-python-agent
+      - title: Web frameworks and servers
+        pages:
+          - title: Python agent and uWSGI web server
+            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-uwsgi-web-server
+          - title: Python agent and Gunicorn WSGI web server
+            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-gunicorn-wsgi-web-server
+          - title: Python agent and mod_wsgi web server
+            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-modwsgi-web-server
+          - title: Python agent and CherryPy web framework
+            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-cherrypy-web-framework
+          - title: Python agent and Web2py web framework
+            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-web2py-web-framework
+          - title: Python agent and AJP WSGI server
+            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-ajp-wsgi-server
+          - title: Python agent and FastCGI web server
+            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-fastcgi-web-server
+          - title: Python agent and Paste
+            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-paste
+          - title: Python agent and SCGI web server
+            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-scgi-web-server
+          - title: Python agent and Waitress web server
+            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-waitress-web-server
       - title: Back-end services
         pages:
           - title: Python agent and Celery
             path: /docs/agents/python-agent/back-end-services/python-agent-celery
-      - title: Configuration
-        pages:
-          - title: Python agent configuration
-            path: /docs/agents/python-agent/configuration/python-agent-configuration
-      - title: Custom instrumentation
-        pages:
-          - title: Python custom instrumentation via config file
-            path: /docs/agents/python-agent/custom-instrumentation/python-custom-instrumentation-config-file
-          - title: Python custom instrumentation
-            path: /docs/agents/python-agent/custom-instrumentation/python-custom-instrumentation
       - title: Getting started
         pages:
-          - title: 'APM agent security: Python'
-            path: /docs/agents/python-agent/getting-started/apm-agent-security-python
+          - title: Introduction to New Relic for Python
+            path: /docs/agents/python-agent/getting-started/introduction-new-relic-python
           - title: Compatibility and requirements for the Python agent
             path: /docs/agents/python-agent/getting-started/compatibility-requirements-python-agent
           - title: Instrumented Python packages
             path: /docs/agents/python-agent/getting-started/instrumented-python-packages
-          - title: Introduction to New Relic for Python
-            path: /docs/agents/python-agent/getting-started/introduction-new-relic-python
+          - title: 'APM agent security: Python'
+            path: /docs/agents/python-agent/getting-started/apm-agent-security-python
           - title: Python release notes
             path: /docs/agents/python-agent/getting-started/python-release-notes
+      - title: Attributes
+        pages:
+          - title: Python agent attributes
+            path: /docs/agents/python-agent/attributes/python-agent-attributes
+          - title: Enabling and disabling attributes (Python)
+            path: /docs/agents/python-agent/attributes/enabling-disabling-attributes-python
+          - title: Python attribute examples
+            path: /docs/agents/python-agent/attributes/python-attribute-examples
+      - title: API guides
+        pages:
+          - title: Guide to using the Python agent API
+            path: /docs/agents/python-agent/api-guides/guide-using-python-agent-api
       - title: Hosting services
         pages:
           - title: Install the Python agent in GAE flexible environment
@@ -808,27 +547,11 @@ pages:
             path: /docs/agents/python-agent/hosting-services/python-agent-stackato
           - title: Python agent and WebFaction
             path: /docs/agents/python-agent/hosting-services/python-agent-webfaction
-      - title: Installation
-        pages:
-          - title: Advanced install of New Relic Python agent
-            path: /docs/agents/python-agent/installation/advanced-install-new-relic-python-agent
-          - title: 'Python agent admin script: Advanced usage'
-            path: /docs/agents/python-agent/installation/python-agent-admin-script-advanced-usage
-          - title: 'Python agent: Advanced integration'
-            path: /docs/agents/python-agent/installation/python-agent-advanced-integration
-          - title: Standard Python agent install
-            path: /docs/agents/python-agent/installation/standard-python-agent-install
-          - title: Uninstall the Python agent
-            path: /docs/agents/python-agent/installation/uninstall-python-agent
-          - title: Update the Python agent
-            path: /docs/agents/python-agent/installation/update-python-agent
       - title: Python agent API
         path: /docs/agents/python-agent/python-agent-api
         pages:
-          - title: accept_distributed_trace_headers (Python agent API)
-            path: /docs/agents/python-agent/python-agent-api/acceptdistributedtraceheaders-python-agent-api
-          - title: accept_distributed_trace_payload (Python agent API)
-            path: /docs/agents/python-agent/python-agent-api/acceptdistributedtracepayload-python-agent-api
+          - title: View all Python agent API calls
+            path: /docs/agents/python-agent/python-agent-api/view-all-python-agent-api-calls
           - title: add_custom_parameter (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/addcustomparameter-python-agent-api
           - title: add_custom_parameters (Python agent API)
@@ -839,24 +562,30 @@ pages:
             path: /docs/agents/python-agent/python-agent-api/application-python-agent-api
           - title: application_settings (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/applicationsettings-python-agent-api
-          - title: asgi_application (Python agent API)
-            path: /docs/agents/python-agent/python-agent-api/asgiapplication-python-agent-api
           - title: background_task (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/backgroundtask-python-agent-api
+          - title: web_transaction
+            path: /docs/agents/python-agent/python-agent-api/webtransaction
           - title: callable_name (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/callablename-python-agent-api
           - title: capture_request_params (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/capturerequestparams-python-agent-api
-          - title: create_distributed_trace_payload (Python agent API)
-            path: /docs/agents/python-agent/python-agent-api/createdistributedtracepayload-python-agent-api
           - title: current_transaction (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/currenttransaction-python-agent-api
+          - title: create_distributed_trace_payload (Python agent API)
+            path: /docs/agents/python-agent/python-agent-api/createdistributedtracepayload-python-agent-api
+          - title: accept_distributed_trace_payload (Python agent API)
+            path: /docs/agents/python-agent/python-agent-api/acceptdistributedtracepayload-python-agent-api
+          - title: insert_distributed_trace_headers (Python agent API)
+            path: /docs/agents/python-agent/python-agent-api/insertdistributedtraceheaders-python-agent-api
+          - title: accept_distributed_trace_headers (Python agent API)
+            path: /docs/agents/python-agent/python-agent-api/acceptdistributedtraceheaders-python-agent-api
+          - title: datastore_trace (Python agent API)
+            path: /docs/agents/python-agent/python-agent-api/datastoretrace-python-agent-api
           - title: data_source_factory (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/datasourcefactory-python-agent-api
           - title: data_source_generator (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/datasourcegenerator-python-agent-api
-          - title: datastore_trace (Python agent API)
-            path: /docs/agents/python-agent/python-agent-api/datastoretrace-python-agent-api
           - title: disable_browser_autorum (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/disablebrowserautorum-python-agent-api
           - title: end_of_transaction (Python agent API)
@@ -877,20 +606,18 @@ pages:
             path: /docs/agents/python-agent/python-agent-api/ignoretransaction-python-agent-api
           - title: initialize (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/initialize-python-agent-api
-          - title: insert_distributed_trace_headers (Python agent API)
-            path: /docs/agents/python-agent/python-agent-api/insertdistributedtraceheaders-python-agent-api
           - title: message_trace (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/messagetrace-python-agent-api
           - title: message_transaction (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/messagetransaction-python-agent-api
           - title: record_custom_event (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/recordcustomevent-python-agent-api
+          - title: record_exception (Python agent API)
+            path: /docs/agents/python-agent/python-agent-api/recordexception-python-agent-api
           - title: record_custom_metric (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/recordcustommetric-python-agent-api
           - title: record_custom_metrics (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/recordcustommetrics-python-agent-api
-          - title: record_exception (Python agent API)
-            path: /docs/agents/python-agent/python-agent-api/recordexception-python-agent-api
           - title: register_application (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/registerapplication-python-agent-api
           - title: register_data_source (Python agent API)
@@ -905,83 +632,284 @@ pages:
             path: /docs/agents/python-agent/python-agent-api/suppressapdexmetric-python-agent-api
           - title: suppress_transaction_trace (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/suppresstransactiontrace-python-agent-api
-          - title: View all Python agent API calls
-            path: /docs/agents/python-agent/python-agent-api/view-all-python-agent-api-calls
-          - title: web_transaction
-            path: /docs/agents/python-agent/python-agent-api/webtransaction
           - title: wsgi_application (Python agent API)
             path: /docs/agents/python-agent/python-agent-api/wsgiapplication-python-agent-api
-      - title: Supported features
-        pages:
-          - title: Browser monitoring and the Python agent
-            path: /docs/agents/python-agent/supported-features/browser-monitoring-python-agent
-          - title: Cross application tracing
-            path: /docs/agents/python-agent/supported-features/cross-application-tracing
-          - title: 'Monitor non-web scripts, worker processes, tasks, and functions'
-            path: /docs/agents/python-agent/supported-features/monitor-non-web-scripts-worker-processes-tasks-functions
-          - title: Optional manual Browser instrumentation with Django templates
-            path: /docs/agents/python-agent/supported-features/optional-manual-browser-instrumentation-django-templates
-          - title: Python custom metrics
-            path: /docs/agents/python-agent/supported-features/python-custom-metrics
-          - title: Python message queues
-            path: /docs/agents/python-agent/supported-features/python-message-queues
-          - title: Python tips and tricks
-            path: /docs/agents/python-agent/supported-features/python-tips-tricks
+          - title: asgi_application (Python agent API)
+            path: /docs/agents/python-agent/python-agent-api/asgiapplication-python-agent-api
       - title: Troubleshooting
         pages:
-          - title: Activate application warning (Python)
-            path: /docs/agents/python-agent/troubleshooting/activate-application-warning-python
-          - title: Emulating legacy server-side parameter configuration (Python)
-            path: /docs/agents/python-agent/troubleshooting/emulating-legacy-server-side-parameter-configuration-python
-          - title: Missing information when using ensure_future (Python)
-            path: /docs/agents/python-agent/troubleshooting/missing-information-when-using-ensurefuture-python
           - title: No data appears (Python)
             path: /docs/agents/python-agent/troubleshooting/no-data-appears-python
-          - title: Python agent logging
-            path: /docs/agents/python-agent/troubleshooting/python-agent-logging
-          - title: Testing the Python agent
-            path: /docs/agents/python-agent/troubleshooting/testing-python-agent
           - title: Troubleshooting Browser instrumentation in Python
             path: /docs/agents/python-agent/troubleshooting/troubleshooting-browser-instrumentation-python
-      - title: Web frameworks and servers
+          - title: Emulating legacy server-side parameter configuration (Python)
+            path: /docs/agents/python-agent/troubleshooting/emulating-legacy-server-side-parameter-configuration-python
+          - title: Testing the Python agent
+            path: /docs/agents/python-agent/troubleshooting/testing-python-agent
+          - title: Python agent logging
+            path: /docs/agents/python-agent/troubleshooting/python-agent-logging
+          - title: Missing information when using ensure_future (Python)
+            path: /docs/agents/python-agent/troubleshooting/missing-information-when-using-ensurefuture-python
+          - title: Activate application warning (Python)
+            path: /docs/agents/python-agent/troubleshooting/activate-application-warning-python
+      - title: Configuration
         pages:
-          - title: Python agent and AJP WSGI server
-            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-ajp-wsgi-server
-          - title: Python agent and CherryPy web framework
-            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-cherrypy-web-framework
-          - title: Python agent and FastCGI web server
-            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-fastcgi-web-server
-          - title: Python agent and Gunicorn WSGI web server
-            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-gunicorn-wsgi-web-server
-          - title: Python agent and mod_wsgi web server
-            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-modwsgi-web-server
-          - title: Python agent and Paste
-            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-paste
-          - title: Python agent and SCGI web server
-            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-scgi-web-server
-          - title: Python agent and uWSGI web server
-            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-uwsgi-web-server
-          - title: Python agent and Waitress web server
-            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-waitress-web-server
-          - title: Python agent and Web2py web framework
-            path: /docs/agents/python-agent/web-frameworks-servers/python-agent-web2py-web-framework
+          - title: Python agent configuration
+            path: /docs/agents/python-agent/configuration/python-agent-configuration
+      - title: Custom instrumentation
+        pages:
+          - title: Python custom instrumentation
+            path: /docs/agents/python-agent/custom-instrumentation/python-custom-instrumentation
+          - title: Python custom instrumentation via config file
+            path: /docs/agents/python-agent/custom-instrumentation/python-custom-instrumentation-config-file
+  - title: Java agent
+    path: /docs/agents/java-agent
+    pages:
+      - title: Getting started
+        pages:
+          - title: Introduction to New Relic for Java
+            path: /docs/agents/java-agent/getting-started/introduction-new-relic-java
+          - title: Compatibility and requirements for the Java agent
+            path: /docs/agents/java-agent/getting-started/compatibility-requirements-java-agent
+          - title: 'APM agent security: Java'
+            path: /docs/agents/java-agent/getting-started/apm-agent-security-java
+          - title: Java release notes
+            path: /docs/agents/java-agent/getting-started/java-release-notes
+      - title: Instrumentation
+        pages:
+          - title: Transaction naming protocol
+            path: /docs/agents/java-agent/instrumentation/transaction-naming-protocol
+          - title: Monitor deployments (Java agent)
+            path: /docs/agents/java-agent/instrumentation/monitor-deployments-java-agent
+          - title: Instrument browser monitoring with Java agent API
+            path: /docs/agents/java-agent/instrumentation/instrument-browser-monitoring-java-agent-api
+          - title: Use RabbitMQ or JMS for message queues
+            path: /docs/agents/java-agent/instrumentation/use-rabbitmq-or-jms-message-queues
+          - title: Extension and additional instrumentation modules
+            path: /docs/agents/java-agent/instrumentation/extension-additional-instrumentation-modules
+          - title: Ignore specific transactions
+            path: /docs/agents/java-agent/instrumentation/ignore-transactions-using-api
+      - title: Custom instrumentation
+        pages:
+          - title: Java custom instrumentation
+            path: /docs/agents/java-agent/custom-instrumentation/java-custom-instrumentation
+          - title: 'Custom instrumentation editor: Instrument from UI'
+            path: /docs/agents/java-agent/custom-instrumentation/custom-instrumentation-editor-instrument-ui
+          - title: Scala instrumentation
+            path: /docs/agents/java-agent/frameworks/scala-installation-java
+          - title: Java instrumentation by XML
+            path: /docs/agents/java-agent/custom-instrumentation/java-instrumentation-xml
+          - title: Java XML instrumentation examples
+            path: /docs/agents/java-agent/custom-instrumentation/java-xml-instrumentation-examples
+          - title: 'Java agent: Custom JMX instrumentation by YAML'
+            path: /docs/agents/java-agent/custom-instrumentation/java-agent-custom-jmx-instrumentation-yaml
+          - title: Custom JMX YAML examples
+            path: /docs/agents/java-agent/custom-instrumentation/custom-jmx-yaml-examples
+          - title: Troubleshooting Java custom instrumentation
+            path: /docs/agents/java-agent/custom-instrumentation/troubleshooting-java-custom-instrumentation
+          - title: Circuit breaker for Java custom instrumentation
+            path: /docs/agents/java-agent/custom-instrumentation/circuit-breaker-java-custom-instrumentation
+      - title: Installation
+        pages:
+          - title: Install the Java agent
+            path: /docs/agents/java-agent/installation/install-java-agent
+          - title: Include the Java agent with a JVM argument
+            path: /docs/agents/java-agent/installation/include-java-agent-jvm-argument
+          - title: Update the Java agent
+            path: /docs/agents/java-agent/installation/update-java-agent
+          - title: Uninstall the Java agent
+            path: /docs/agents/java-agent/installation/uninstall-java-agent
+      - title: Configuration
+        pages:
+          - title: 'Java agent configuration: Config file'
+            path: /docs/agents/java-agent/configuration/java-agent-configuration-config-file
+          - title: Java agent config file template
+            path: /docs/agents/java-agent/configuration/java-agent-config-file-template
+          - title: Hostname logic in Java
+            path: /docs/agents/java-agent/configuration/hostname-logic-java
+          - title: Enable distributed tracing for Java agent
+            path: /docs/agents/java-agent/configuration/enable-distributed-tracing-java-agent
+          - title: Automatic application naming
+            path: /docs/agents/java-agent/configuration/automatic-application-naming
+          - title: Java agent error configuration
+            path: /docs/agents/java-agent/configuration/java-agent-error-configuration
+          - title: Configuring your SSL certificates
+            path: /docs/agents/java-agent/configuration/configuring-your-ssl-certificates
+      - title: Features
+        pages:
+          - title: 'JVMs page (Java): View app server metrics from JMX'
+            path: /docs/agents/java-agent/features/jvms-page-java-view-app-server-metrics-jmx
+      - title: Heroku
+        pages:
+          - title: Java agent and Heroku
+            path: /docs/agents/java-agent/heroku/java-agent-heroku
+          - title: Java agent with Scala on Heroku
+            path: /docs/agents/java-agent/heroku/java-agent-scala-heroku
+          - title: No data appears with Heroku (Java)
+            path: /docs/agents/java-agent/heroku/no-data-appears-heroku-java
+      - title: Async instrumentation
+        pages:
+          - title: Introduction to Java async instrumentation
+            path: /docs/agents/java-agent/async-instrumentation/introduction-java-async-instrumentation
+          - title: Java agent API for asynchronous applications
+            path: /docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications
+          - title: Troubleshoot Java asynchronous instrumentation
+            path: /docs/agents/java-agent/async-instrumentation/troubleshoot-java-asynchronous-instrumentation
+          - title: 'Disable Scala, Netty, Akka, and Play 2 Instrumentation'
+            path: /docs/agents/java-agent/async-instrumentation/disable-scala-netty-akka-play-2-instrumentation
+      - title: Additional installation
+        pages:
+          - title: Install New Relic Java agent for Docker
+            path: /docs/agents/java-agent/additional-installation/install-new-relic-java-agent-docker
+          - title: AWS Elastic Beanstalk installation for Java
+            path: /docs/agents/java-agent/additional-installation/aws-elastic-beanstalk-installation-java
+          - title: WildFly installation for Java
+            path: /docs/agents/java-agent/additional-installation/wildfly-installation-java
+          - title: Install New Relic Java agent in GAE flexible environment
+            path: /docs/agents/java-agent/additional-installation/install-new-relic-java-agent-gae-flexible-environment
+          - title: IBM WebSphere Application Server
+            path: /docs/agents/java-agent/additional-installation/ibm-websphere-application-server
+          - title: Java 2 security installation
+            path: /docs/agents/java-agent/installation/install-java-agent-java-2-security
+          - title: Install Java agent using Maven
+            path: /docs/agents/java-agent/additional-installation/install-java-agent-using-maven
+      - title: Troubleshooting
+        pages:
+          - title: No data appears (Java)
+            path: /docs/agents/java-agent/troubleshooting/no-data-appears-java
+          - title: Determine permissions requirements (Java)
+            path: /docs/agents/java-agent/troubleshooting/determine-permissions-requirements-java
+          - title: Gather troubleshooting information (Java)
+            path: /docs/agents/java-agent/troubleshooting/gather-troubleshooting-information-java
+          - title: All hosts appear as localhost
+            path: /docs/agents/java-agent/troubleshooting/all-hosts-appear-localhost
+          - title: Error bootstrapping New Relic Java agent
+            path: /docs/agents/java-agent/troubleshooting/error-bootstrapping-new-relic-java-agent
+          - title: Errors starting Java app server
+            path: /docs/agents/java-agent/troubleshooting/errors-starting-java-app-server
+          - title: Firewall or traffic connectivity failures
+            path: /docs/agents/java-agent/troubleshooting/firewall-or-traffic-connectivity-failures
+          - title: Generate debug logs for troubleshooting (Java)
+            path: /docs/agents/java-agent/troubleshooting/generate-debug-logs-troubleshooting-java
+          - title: Host links missing in Java app's APM Summary
+            path: /docs/agents/java-agent/troubleshooting/host-links-missing-java-apps-apm-summary
+          - title: Java Solr data does not appear
+            path: /docs/agents/java-agent/troubleshooting/java-solr-data-does-not-appear
+          - title: No Browser data appears (Java)
+            path: /docs/agents/java-agent/troubleshooting/no-browser-data-appears-java
+          - title: No log file (Java)
+            path: /docs/agents/java-agent/troubleshooting/no-log-file-java
+          - title: No stack traces (Java)
+            path: /docs/agents/java-agent/troubleshooting/no-stack-traces-java
+          - title: NullPointerException issues (Java)
+            path: /docs/agents/java-agent/troubleshooting/nullpointerexception-issues-java
+          - title: Resolve metric grouping issues with Java apps
+            path: /docs/agents/java-agent/troubleshooting/resolve-metric-grouping-issues-java-apps
+          - title: SSL or connection errors (Java)
+            path: /docs/agents/java-agent/troubleshooting/ssl-or-connection-errors-java
+          - title: Update Java config for legacy agent versions
+            path: /docs/agents/java-agent/troubleshooting/update-java-config-legacy-agent-versions
+          - title: Application server JMX setup
+            path: /docs/agents/java-agent/troubleshooting/application-server-jmx-setup
+          - title: Large number of false positive security vulnerabilities
+            path: /docs/agents/java-agent/troubleshooting/large-number-false-positive-security-vulnerabilities
+      - title: Attributes
+        pages:
+          - title: Java agent attributes
+            path: /docs/agents/java-agent/attributes/java-agent-attributes
+      - title: API guides
+        pages:
+          - title: Guide to using the Java agent API
+            path: /docs/agents/java-agent/api-guides/guide-using-java-agent-api
+          - title: 'Java agent API: Instrument using annotation'
+            path: /docs/agents/java-agent/api-guides/java-agent-api-instrument-using-annotation
+          - title: 'Java agent API: Instrument external calls, messaging, datastore, web frameworks'
+            path: /docs/agents/java-agent/api-guides/java-agent-api-instrument-external-calls-messaging-datastore-web-frameworks
+          - title: 'Java agent API: Custom instrumentation with annotation of an example app'
+            path: /docs/agents/java-agent/api-guides/java-agent-api-custom-instrumentation-annotation-example-app
+          - title: 'Java agent API: Instrumenting example app for external datastore calls and CAT'
+            path: /docs/agents/java-agent/api-guides/java-agent-api-instrumenting-example-app-external-datastore-calls-cat
   - title: Ruby agent
     path: /docs/agents/ruby-agent
     pages:
+      - title: Getting started
+        pages:
+          - title: Introduction to New Relic for Ruby
+            path: /docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby
+          - title: Ruby agent requirements and supported frameworks
+            path: /docs/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks
+          - title: 'APM agent security: Ruby'
+            path: /docs/agents/ruby-agent/getting-started/apm-agent-security-ruby
+          - title: New Relic's GitHub repository
+            path: /docs/agents/ruby-agent/getting-started/new-relics-github-repository
+          - title: Ruby release notes
+            path: /docs/agents/ruby-agent/getting-started/ruby-release-notes
+      - title: Installation
+        pages:
+          - title: Install the New Relic Ruby agent
+            path: /docs/agents/ruby-agent/installation/install-new-relic-ruby-agent
+          - title: 'Ruby agent installation: Rails plugin'
+            path: /docs/agents/ruby-agent/installation/ruby-agent-installation-rails-plugin
+          - title: Install New Relic Ruby agent in GAE flexible environment
+            path: /docs/agents/ruby-agent/installation/install-new-relic-ruby-agent-gae-flexible-environment
+          - title: Ruby agent and Heroku
+            path: /docs/agents/ruby-agent/installation/ruby-agent-heroku
+          - title: Update the Ruby agent
+            path: /docs/agents/ruby-agent/installation/update-ruby-agent
+          - title: Uninstall the Ruby agent
+            path: /docs/agents/ruby-agent/installation/uninstall-ruby-agent
+      - title: Configuration
+        pages:
+          - title: Ruby agent configuration
+            path: /docs/agents/ruby-agent/configuration/ruby-agent-configuration
+          - title: Custom SSL certificates (Ruby)
+            path: /docs/agents/ruby-agent/configuration/custom-ssl-certificates-ruby
+          - title: Connect hosts to your account
+            path: /docs/agents/ruby-agent/configuration/connect-hosts-your-account
       - title: API guides
         pages:
-          - title: Guide to using the Ruby agent API
-            path: /docs/agents/ruby-agent/api-guides/guide-using-ruby-agent-api
-          - title: Ignoring specific transactions
-            path: /docs/agents/ruby-agent/api-guides/ignoring-specific-transactions
           - title: Ruby custom instrumentation
             path: /docs/agents/ruby-agent/api-guides/ruby-custom-instrumentation
+          - title: Guide to using the Ruby agent API
+            path: /docs/agents/ruby-agent/api-guides/guide-using-ruby-agent-api
           - title: Ruby custom metrics
             path: /docs/agents/ruby-agent/api-guides/ruby-custom-metrics
+          - title: Ignoring specific transactions
+            path: /docs/agents/ruby-agent/api-guides/ignoring-specific-transactions
           - title: Sending handled errors to New Relic
             path: /docs/agents/ruby-agent/api-guides/sending-handled-errors-new-relic
           - title: Third party instrumentation
             path: /docs/agents/ruby-agent/api-guides/third-party-instrumentation
+      - title: Features
+        pages:
+          - title: Record deployments with the Ruby agent
+            path: /docs/agents/ruby-agent/features/record-deployments-ruby-agent
+          - title: Message queues
+            path: /docs/agents/ruby-agent/features/message-queues
+          - title: HTTP client tracing in Ruby
+            path: /docs/agents/ruby-agent/features/http-client-tracing-ruby
+          - title: Cross application tracing in Ruby
+            path: /docs/agents/ruby-agent/features/cross-application-tracing-ruby
+          - title: Ruby VM measurements
+            path: /docs/agents/ruby-agent/features/ruby-vm-measurements
+          - title: Garbage collection
+            path: /docs/agents/ruby-agent/features/garbage-collection
+          - title: New Relic Browser and the Ruby agent
+            path: /docs/agents/ruby-agent/features/new-relic-browser-ruby-agent
+          - title: Developer mode
+            path: /docs/agents/ruby-agent/features/developer-mode
+      - title: Background jobs
+        pages:
+          - title: Resque instrumentation
+            path: /docs/agents/ruby-agent/background-jobs/resque-instrumentation
+          - title: Sidekiq instrumentation
+            path: /docs/agents/ruby-agent/background-jobs/sidekiq-instrumentation
+          - title: Rake instrumentation
+            path: /docs/agents/ruby-agent/background-jobs/rake-instrumentation
+          - title: Monitor Ruby background processes
+            path: /docs/agents/ruby-agent/background-jobs/monitor-ruby-background-processes
+          - title: 'Delayed::Job instrumentation'
+            path: /docs/agents/ruby-agent/background-jobs/delayedjob-instrumentation
       - title: Attributes
         pages:
           - title: Enable and disable attributes (Ruby)
@@ -990,109 +918,181 @@ pages:
             path: /docs/agents/ruby-agent/attributes/ruby-agent-attributes
           - title: Ruby attribute examples
             path: /docs/agents/ruby-agent/attributes/ruby-attribute-examples
-      - title: Background jobs
-        pages:
-          - title: 'Delayed::Job instrumentation'
-            path: /docs/agents/ruby-agent/background-jobs/delayedjob-instrumentation
-          - title: Monitor Ruby background processes
-            path: /docs/agents/ruby-agent/background-jobs/monitor-ruby-background-processes
-          - title: Rake instrumentation
-            path: /docs/agents/ruby-agent/background-jobs/rake-instrumentation
-          - title: Resque instrumentation
-            path: /docs/agents/ruby-agent/background-jobs/resque-instrumentation
-          - title: Sidekiq instrumentation
-            path: /docs/agents/ruby-agent/background-jobs/sidekiq-instrumentation
-      - title: Configuration
-        pages:
-          - title: Connect hosts to your account
-            path: /docs/agents/ruby-agent/configuration/connect-hosts-your-account
-          - title: Custom SSL certificates (Ruby)
-            path: /docs/agents/ruby-agent/configuration/custom-ssl-certificates-ruby
-          - title: Ruby agent configuration
-            path: /docs/agents/ruby-agent/configuration/ruby-agent-configuration
-      - title: Features
-        pages:
-          - title: Cross application tracing in Ruby
-            path: /docs/agents/ruby-agent/features/cross-application-tracing-ruby
-          - title: Developer mode
-            path: /docs/agents/ruby-agent/features/developer-mode
-          - title: Garbage collection
-            path: /docs/agents/ruby-agent/features/garbage-collection
-          - title: HTTP client tracing in Ruby
-            path: /docs/agents/ruby-agent/features/http-client-tracing-ruby
-          - title: Message queues
-            path: /docs/agents/ruby-agent/features/message-queues
-          - title: New Relic Browser and the Ruby agent
-            path: /docs/agents/ruby-agent/features/new-relic-browser-ruby-agent
-          - title: Record deployments with the Ruby agent
-            path: /docs/agents/ruby-agent/features/record-deployments-ruby-agent
-          - title: Ruby VM measurements
-            path: /docs/agents/ruby-agent/features/ruby-vm-measurements
-      - title: Instrumented gems
-        pages:
-          - title: Metal controller instrumentation
-            path: /docs/agents/ruby-agent/frameworks/metal-controller-instrumentation
-          - title: Mongo instrumentation
-            path: /docs/agents/ruby-agent/frameworks/mongo-instrumentation
-          - title: Rack and Metal support
-            path: /docs/agents/ruby-agent/frameworks/rack-metal-support
-          - title: Sequel instrumentation
-            path: /docs/agents/ruby-agent/frameworks/sequel-instrumentation
-          - title: Rack middlewares
-            path: /docs/agents/ruby-agent/instrumented-gems/rack-middlewares
-          - title: Redis instrumentation
-            path: /docs/agents/ruby-agent/instrumented-gems/redis-instrumentation
-          - title: Sinatra instrumentation
-            path: /docs/agents/ruby-agent/instrumented-gems/sinatra-instrumentation
-      - title: Getting started
-        pages:
-          - title: 'APM agent security: Ruby'
-            path: /docs/agents/ruby-agent/getting-started/apm-agent-security-ruby
-          - title: Introduction to New Relic for Ruby
-            path: /docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby
-          - title: New Relic's GitHub repository
-            path: /docs/agents/ruby-agent/getting-started/new-relics-github-repository
-          - title: Ruby agent requirements and supported frameworks
-            path: /docs/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks
-          - title: Ruby release notes
-            path: /docs/agents/ruby-agent/getting-started/ruby-release-notes
-      - title: Installation
-        pages:
-          - title: Install New Relic Ruby agent in GAE flexible environment
-            path: /docs/agents/ruby-agent/installation/install-new-relic-ruby-agent-gae-flexible-environment
-          - title: Install the New Relic Ruby agent
-            path: /docs/agents/ruby-agent/installation/install-new-relic-ruby-agent
-          - title: Ruby agent and Heroku
-            path: /docs/agents/ruby-agent/installation/ruby-agent-heroku
-          - title: 'Ruby agent installation: Rails plugin'
-            path: /docs/agents/ruby-agent/installation/ruby-agent-installation-rails-plugin
-          - title: Uninstall the Ruby agent
-            path: /docs/agents/ruby-agent/installation/uninstall-ruby-agent
-          - title: Update the Ruby agent
-            path: /docs/agents/ruby-agent/installation/update-ruby-agent
       - title: Troubleshooting
         pages:
-          - title: Control when the Ruby agent starts
-            path: /docs/agents/ruby-agent/troubleshooting/control-when-ruby-agent-starts
+          - title: No data appears (Ruby)
+            path: /docs/agents/ruby-agent/troubleshooting/no-data-appears-ruby
           - title: Generating logs for troubleshooting (Ruby)
             path: /docs/agents/ruby-agent/troubleshooting/generating-logs-troubleshooting-ruby
           - title: Incompatible gems
             path: /docs/agents/ruby-agent/troubleshooting/incompatible-gems
-          - title: No data appears (Ruby)
-            path: /docs/agents/ruby-agent/troubleshooting/no-data-appears-ruby
-          - title: No data with Unicorn
-            path: /docs/agents/ruby-agent/troubleshooting/no-data-unicorn
           - title: No log file (Ruby)
             path: /docs/agents/ruby-agent/troubleshooting/no-log-file-ruby
-          - title: Not installing New Relic supported Grape
-            path: /docs/agents/ruby-agent/troubleshooting/not-installing-new-relic-supported-grape
-          - title: Passenger troubleshooting
-            path: /docs/agents/ruby-agent/troubleshooting/passenger-troubleshooting
-          - title: Ruby agent audit log
-            path: /docs/agents/ruby-agent/troubleshooting/ruby-agent-audit-log
+          - title: Control when the Ruby agent starts
+            path: /docs/agents/ruby-agent/troubleshooting/control-when-ruby-agent-starts
           - title: 'SystemStackError: stack level too deep'
             path: /docs/agents/ruby-agent/troubleshooting/systemstackerror-stack-level-too-deep
+          - title: Ruby agent audit log
+            path: /docs/agents/ruby-agent/troubleshooting/ruby-agent-audit-log
+          - title: Passenger troubleshooting
+            path: /docs/agents/ruby-agent/troubleshooting/passenger-troubleshooting
+          - title: No data with Unicorn
+            path: /docs/agents/ruby-agent/troubleshooting/no-data-unicorn
           - title: Update deprecated API calls
             path: /docs/agents/ruby-agent/troubleshooting/update-deprecated-api-calls
           - title: Update private API calls to public Tracer API
             path: /docs/agents/ruby-agent/troubleshooting/update-private-api-calls-public-tracer-api
+          - title: Not installing New Relic supported Grape
+            path: /docs/agents/ruby-agent/troubleshooting/not-installing-new-relic-supported-grape
+      - title: Instrumented gems
+        pages:
+          - title: Redis instrumentation
+            path: /docs/agents/ruby-agent/instrumented-gems/redis-instrumentation
+          - title: Mongo instrumentation
+            path: /docs/agents/ruby-agent/frameworks/mongo-instrumentation
+          - title: Rack and Metal support
+            path: /docs/agents/ruby-agent/frameworks/rack-metal-support
+          - title: Rack middlewares
+            path: /docs/agents/ruby-agent/instrumented-gems/rack-middlewares
+          - title: Metal controller instrumentation
+            path: /docs/agents/ruby-agent/frameworks/metal-controller-instrumentation
+          - title: Sequel instrumentation
+            path: /docs/agents/ruby-agent/frameworks/sequel-instrumentation
+          - title: Sinatra instrumentation
+            path: /docs/agents/ruby-agent/instrumented-gems/sinatra-instrumentation
+  - title: Go agent
+    path: /docs/agents/go-agent
+    pages:
+      - title: Get started
+        pages:
+          - title: Introduction to New Relic for Go
+            path: /docs/agents/go-agent/get-started/introduction-new-relic-go
+          - title: Go agent compatibility and requirements
+            path: /docs/agents/go-agent/get-started/go-agent-compatibility-requirements
+          - title: 'APM agent security: Go'
+            path: /docs/agents/go-agent/get-started/apm-agent-security-go
+          - title: Go agent release notes
+            path: /docs/agents/go-agent/get-started/go-agent-release-notes
+      - title: Instrumentation
+        pages:
+          - title: Instrument Go transactions
+            path: /docs/agents/go-agent/instrumentation/instrument-go-transactions
+          - title: Instrument Go segments
+            path: /docs/agents/go-agent/instrumentation/instrument-go-segments
+          - title: Create custom events (Go)
+            path: /docs/agents/go-agent/features/create-custom-events-go
+          - title: Go agent attributes
+            path: /docs/agents/go-agent/instrumentation/go-agent-attributes
+          - title: Create custom metrics in Go
+            path: /docs/agents/go-agent/instrumentation/create-custom-metrics-go
+      - title: Installation
+        pages:
+          - title: Install New Relic for Go
+            path: /docs/agents/go-agent/installation/install-new-relic-go
+          - title: Install the Go agent in GAE flexible environment
+            path: /docs/agents/go-agent/installation/install-go-agent-gae-flexible-environment
+          - title: Uninstall the Go agent
+            path: /docs/agents/go-agent/installation/uninstall-go-agent
+      - title: Configuration
+        pages:
+          - title: Go agent configuration
+            path: /docs/agents/go-agent/configuration/go-agent-configuration
+          - title: Go agent logging
+            path: /docs/agents/go-agent/configuration/go-agent-logging
+      - title: Features
+        pages:
+          - title: 'Go runtime page: Troubleshoot performance problems'
+            path: /docs/agents/go-agent/features/go-runtime-page-troubleshoot-performance-problems
+          - title: Create custom events (Go)
+            path: /docs/agents/go-agent/features/create-custom-events-go
+          - title: Add browser monitoring to your Go apps
+            path: /docs/agents/go-agent/features/add-browser-monitoring-your-go-apps
+          - title: Enable distributed tracing for your Go applications
+            path: /docs/agents/go-agent/features/enable-distributed-tracing-your-go-applications
+          - title: Cross application tracing with Go
+            path: /docs/agents/go-agent/features/cross-application-tracing-go
+      - title: API guides
+        pages:
+          - title: Guide to using the Go agent API
+            path: /docs/agents/go-agent/api-guides/guide-using-go-agent-api
+      - title: Troubleshooting
+        pages:
+          - title: No data appears (Go)
+            path: /docs/agents/go-agent/troubleshooting/no-data-appears-go
+  - title: C SDK
+    path: /docs/agents/c-sdk
+    pages:
+      - title: Install and configure
+        pages:
+          - title: 'Install the C SDK: Compile and link your code'
+            path: /docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code
+          - title: C SDK configuration
+            path: /docs/agents/c-sdk/install-configure/c-sdk-configuration
+          - title: Update your C SDK library
+            path: /docs/agents/c-sdk/install-configure/update-your-c-sdk-library
+          - title: Uninstall (remove) the C SDK
+            path: /docs/agents/c-sdk/install-configure/uninstall-remove-c-sdk
+      - title: Get started
+        pages:
+          - title: Introduction to the C SDK
+            path: /docs/agents/c-sdk/get-started/introduction-c-sdk
+          - title: C SDK compatibility and requirements
+            path: /docs/agents/c-sdk/get-started/c-sdk-compatibility-requirements
+          - title: 'APM security: C SDK'
+            path: /docs/agents/c-sdk/get-started/apm-security-c-sdk
+      - title: Instrumentation
+        pages:
+          - title: Use default or custom attributes (C SDK)
+            path: /docs/agents/c-sdk/instrumentation/use-default-or-custom-attributes-c-sdk
+      - title: Troubleshooting
+        pages:
+          - title: No data appears (C SDK)
+            path: /docs/agents/c-sdk/troubleshooting/no-data-appears-c-sdk
+          - title: Generate logs for troubleshooting (C SDK)
+            path: /docs/agents/c-sdk/troubleshooting/generate-logs-troubleshooting-c-sdk
+  - title: Open-source licensed agents
+    pages:
+      - title: Open-source licensed agents
+        pages:
+          - title: Elixir open-source agent
+            path: /docs/agents/open-source-licensed-agents/elixir-open-source-agent
+  - title: Manage APM agents
+    pages:
+      - title: App naming
+        pages:
+          - title: Name your application
+            path: /docs/agents/manage-apm-agents/app-naming/name-your-application
+          - title: Use multiple names for an app
+            path: /docs/agents/manage-apm-agents/app-naming/use-multiple-names-app
+      - title: Configuration
+        pages:
+          - title: Server-side agent configuration
+            path: /docs/agents/manage-apm-agents/configuration/server-side-agent-configuration
+          - title: View config values for your app
+            path: /docs/agents/manage-apm-agents/configuration/view-config-values-your-app
+          - title: High security mode
+            path: /docs/agents/manage-apm-agents/configuration/high-security-mode
+          - title: Enable configurable security policies
+            path: /docs/agents/manage-apm-agents/configuration/enable-configurable-security-policies
+          - title: 'Add, rename, and remove hosts'
+            path: /docs/agents/manage-apm-agents/configuration/add-rename-remove-hosts
+          - title: Monitor background processes
+            path: /docs/agents/manage-apm-agents/configuration/monitor-background-processes
+      - title: Agent data
+        pages:
+          - title: Custom instrumentation
+            path: /docs/agents/manage-apm-agents/agent-data/custom-instrumentation
+          - title: Agent attributes
+            path: /docs/agents/manage-apm-agents/agent-data/agent-attributes
+          - title: Collect custom events
+            path: /docs/agents/manage-apm-agents/agent-data/collect-custom-events
+          - title: Collect custom metrics
+            path: /docs/agents/manage-apm-agents/agent-data/collect-custom-metrics
+          - title: 'Manage errors in APM: Collect, ignore, or mark as expected'
+            path: /docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected
+      - title: Troubleshooting
+        pages:
+          - title: Agent NRIntegrationErrors appear in Insights
+            path: /docs/agents/manage-apm-agents/troubleshooting/agent-nrintegrationerrors-appear-insights
+          - title: Get environment data about your APM app
+            path: /docs/agents/manage-apm-agents/troubleshooting/get-environment-data-about-your-apm-app

--- a/src/nav/alerts-and-applied-intelligence.yml
+++ b/src/nav/alerts-and-applied-intelligence.yml
@@ -2,97 +2,97 @@ title: Alerts and Applied Intelligence
 path: /docs/alerts-and-applied-intelligence
 icon: nr-ai
 pages:
-  - title: Alerts and Applied Intelligence
-    path: /docs/alerts-applied-intelligence
   - title: New Relic Alerts
     pages:
-      - title: Alert conditions
+      - title: Get started
         pages:
-          - title: Create alert conditions
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions
-          - title: Create baseline alert conditions
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-baseline-alert-conditions
-          - title: Create NRQL alert conditions
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions
-          - title: Define custom metrics for an alert condition
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/define-custom-metrics-alert-condition
-          - title: Outlier detection (NRQL alert)
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/outlier-detection-nrql-alert
-          - title: Provide runbook instructions for alert activity
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/provide-runbook-instructions-alert-activity
-          - title: Scope alert thresholds to specific instances
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/scope-alert-thresholds-specific-instances
-          - title: Select product targets for the alert condition
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/select-product-targets-alert-condition
-          - title: Set thresholds for an alert condition
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/set-thresholds-alert-condition
-          - title: View entity health status and find entities without alert conditions
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/view-entity-health-status-find-entities-without-alert-conditions
-          - title: Create Infrastructure "host not reporting" condition
-            path: /docs/alerts/new-relic-alerts/defining-conditions/create-infrastructure-host-not-reporting-condition
-      - title: Alert incidents
+          - title: Introduction to Alerts
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-alerts
+          - title: Alerts concepts and workflow
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/get-started/alerts-concepts-workflow
+      - title: REST API alerts
         pages:
-          - title: Acknowledge alert incidents
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-incidents/acknowledge-alert-incidents
-          - title: View events from their products
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-incidents/view-events-their-products
-          - title: View violation and event details for incidents
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-incidents/view-violation-event-details-incidents
+          - title: REST API calls for alerts
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/rest-api-calls-alerts
+          - title: Disable and enable alerts conditions using the API
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/disable-enable-alerts-conditions-using-api
+          - title: Alerts conditions API field names
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names
+          - title: Manage entities in alerts conditions
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/manage-entities-alerts-conditions
       - title: Alert notifications
         pages:
-          - title: Customize your webhook payload
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/customize-your-webhook-payload
-          - title: Delete alert notification channels
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/delete-alert-notification-channels
           - title: 'Notification channels: Control where to send alerts'
             path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts
+          - title: View or update user email channels
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/view-or-update-user-email-channels
+          - title: Customize your webhook payload
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/customize-your-webhook-payload
           - title: Test alert notification channels
             path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/test-alert-notification-channels
           - title: Update alert notification channels
             path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/update-alert-notification-channels
-          - title: View or update user email channels
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/view-or-update-user-email-channels
+          - title: Delete alert notification channels
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/delete-alert-notification-channels
+      - title: Alert incidents
+        pages:
+          - title: Acknowledge alert incidents
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-incidents/acknowledge-alert-incidents
+          - title: View violation and event details for incidents
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-incidents/view-violation-event-details-incidents
+          - title: View events from their products
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-incidents/view-events-their-products
       - title: Alert policies
         pages:
           - title: 'Create, edit, or find an alert policy'
             path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/create-edit-or-find-alert-policy
           - title: Specify when alerts create incidents
             path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/specify-when-alerts-create-incidents
-          - title: Update or disable policies and conditions
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/update-or-disable-policies-conditions
           - title: View policies and conditions from our products
             path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/view-policies-conditions-our-products
-      - title: Alert violations
+          - title: Update or disable policies and conditions
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/update-or-disable-policies-conditions
+      - title: Alert conditions
         pages:
-          - title: How alert condition violations are closed
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-violations/how-alert-condition-violations-are-closed
-          - title: View alert violations from our products
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-violations/view-alert-violations-our-products
-      - title: Get started
-        pages:
-          - title: Alerts concepts and workflow
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/get-started/alerts-concepts-workflow
-          - title: Introduction to Alerts
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-alerts
-      - title: REST API alerts
-        pages:
-          - title: Alerts conditions API field names
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names
-          - title: Disable and enable alerts conditions using the API
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/disable-enable-alerts-conditions-using-api
-          - title: Manage entities in alerts conditions
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/manage-entities-alerts-conditions
-          - title: REST API calls for alerts
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/rest-api-calls-alerts
+          - title: Create alert conditions
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions
+          - title: View entity health status and find entities without alert conditions
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/view-entity-health-status-find-entities-without-alert-conditions
+          - title: Select product targets for the alert condition
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/select-product-targets-alert-condition
+          - title: Set thresholds for an alert condition
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/set-thresholds-alert-condition
+          - title: Scope alert thresholds to specific instances
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/scope-alert-thresholds-specific-instances
+          - title: Define custom metrics for an alert condition
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/define-custom-metrics-alert-condition
+          - title: Provide runbook instructions for alert activity
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/provide-runbook-instructions-alert-activity
+          - title: Create baseline alert conditions
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-baseline-alert-conditions
+          - title: Create NRQL alert conditions
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions
+          - title: Create Infrastructure "host not reporting" condition
+            path: /docs/alerts/new-relic-alerts/defining-conditions/create-infrastructure-host-not-reporting-condition
+          - title: Outlier detection (NRQL alert)
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/outlier-detection-nrql-alert
       - title: 'Rules, limits, and glossary'
         pages:
-          - title: Rules and limits for alerts
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/rules-limits-glossary/rules-limits-alerts
           - title: Alerts glossary
             path: /docs/alerts/new-relic-alerts/rules-limits-glossary/alerts-glossary
+          - title: Rules and limits for alerts
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/rules-limits-glossary/rules-limits-alerts
+      - title: Alert violations
+        pages:
+          - title: View alert violations from our products
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-violations/view-alert-violations-our-products
+          - title: How alert condition violations are closed
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-violations/how-alert-condition-violations-are-closed
       - title: Troubleshooting
         pages:
           - title: Missing alert notifications
             path: /docs/alerts-applied-intelligence/new-relic-alerts/troubleshooting/missing-alert-notifications
           - title: Tag information not showing up for entity in Infra alert condition
             path: /docs/alerts-applied-intelligence/new-relic-alerts/troubleshooting/tag-information-not-showing-entity-infra-alert-condition
+  - title: Alerts and Applied Intelligence
+    path: /docs/alerts-applied-intelligence

--- a/src/nav/create-integrations.yml
+++ b/src/nav/create-integrations.yml
@@ -5,14 +5,14 @@ pages:
     pages:
       - title: Get started
         pages:
-          - title: Introduction to Infrastructure Integrations SDK
-            path: /docs/create-integrations/infrastructure-integrations-sdk/get-started/introduction-infrastructure-integrations-sdk
           - title: Compatibility and requirements for Infrastructure Integrations SDK
             path: /docs/create-integrations/infrastructure-integrations-sdk/get-started/compatibility-requirements-infrastructure-integrations-sdk
           - title: Understand and use integration data
             path: /docs/infrastructure/integrations-sdk/understand-use-data/understand-use-integration-data
           - title: Go language integration tutorial and build tools
             path: /docs/create-integrations/infrastructure-integrations-sdk/get-started/go-language-integration-tutorial-build-tools
+          - title: Introduction to Infrastructure Integrations SDK
+            path: /docs/create-integrations/infrastructure-integrations-sdk/get-started/introduction-infrastructure-integrations-sdk
       - title: Specifications
         pages:
           - title: On-host integration files

--- a/src/nav/create-integrations.yml
+++ b/src/nav/create-integrations.yml
@@ -5,20 +5,20 @@ pages:
     pages:
       - title: Get started
         pages:
-          - title: Compatibility and requirements for Infrastructure Integrations SDK
-            path: /docs/create-integrations/infrastructure-integrations-sdk/get-started/compatibility-requirements-infrastructure-integrations-sdk
-          - title: Go language integration tutorial and build tools
-            path: /docs/create-integrations/infrastructure-integrations-sdk/get-started/go-language-integration-tutorial-build-tools
           - title: Introduction to Infrastructure Integrations SDK
             path: /docs/create-integrations/infrastructure-integrations-sdk/get-started/introduction-infrastructure-integrations-sdk
+          - title: Compatibility and requirements for Infrastructure Integrations SDK
+            path: /docs/create-integrations/infrastructure-integrations-sdk/get-started/compatibility-requirements-infrastructure-integrations-sdk
           - title: Understand and use integration data
             path: /docs/infrastructure/integrations-sdk/understand-use-data/understand-use-integration-data
+          - title: Go language integration tutorial and build tools
+            path: /docs/create-integrations/infrastructure-integrations-sdk/get-started/go-language-integration-tutorial-build-tools
       - title: Specifications
         pages:
-          - title: 'On-host integration executable file: JSON specifications'
-            path: /docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integration-executable-file-json-specifications
           - title: On-host integration files
             path: /docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integration-files
+          - title: 'On-host integration executable file: JSON specifications'
+            path: /docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integration-executable-file-json-specifications
           - title: Integration logging recommendations
             path: /docs/create-integrations/infrastructure-integrations-sdk/specifications/integration-logging-recommendations
       - title: Troubleshooting

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -12,33 +12,89 @@ pages:
         pages:
           - title: Troubleshooting
             pages:
-              - title: Log message is truncated
-                path: /docs/logs/log-management/troubleshooting/log-message-truncated
               - title: No log data appears in the UI
                 path: /docs/logs/log-management/troubleshooting/no-log-data-appears-ui
+              - title: Log message is truncated
+                path: /docs/logs/log-management/troubleshooting/log-message-truncated
               - title: JSON message is not parsed
                 path: /docs/logs/new-relic-logs/troubleshooting/json-message-not-parsed
   - title: APM
     path: /docs/apm
     pages:
+      - title: Transactions
+        pages:
+          - title: Key transactions
+            pages:
+              - title: Introduction to key transactions
+                path: /docs/apm/transactions/key-transactions/introduction-key-transactions
+              - title: Key transaction charts and data
+                path: /docs/apm/transactions/key-transactions/key-transaction-charts-data
+              - title: Create and update key transactions
+                path: /docs/apm/transactions/key-transactions/create-update-key-transactions
+              - title: Tag key transactions
+                path: /docs/apm/transactions/key-transactions/tag-key-transactions
+              - title: Key transaction alerts
+                path: /docs/apm/transactions/key-transactions/key-transaction-alerts
+          - title: Transaction traces
+            pages:
+              - title: Introduction to transaction traces
+                path: /docs/apm/transactions/transaction-traces/introduction-transaction-traces
+              - title: Configure transaction traces
+                path: /docs/apm/transactions/transaction-traces/configure-transaction-traces
+              - title: 'Transaction traces: Summary page'
+                path: /docs/apm/transactions/transaction-traces/transaction-traces-summary-page
+              - title: 'Transaction traces: Trace details page'
+                path: /docs/apm/transactions/transaction-traces/transaction-traces-trace-details-page
+              - title: 'Transaction traces: Database queries page'
+                path: /docs/apm/transactions/transaction-traces/transaction-traces-database-queries-page
+              - title: Security and transaction traces
+                path: /docs/apm/transactions/transaction-traces/security-transaction-traces
+              - title: 'Troubleshooting: Not seeing transaction traces'
+                path: /docs/apm/transactions/transaction-traces/troubleshooting-not-seeing-transaction-traces
+          - title: Cross application traces
+            pages:
+              - title: Introduction to cross application traces
+                path: /docs/apm/transactions/cross-application-traces/introduction-cross-application-traces
+              - title: Troubleshoot cross application tracing
+                path: /docs/apm/transactions/cross-application-traces/troubleshoot-cross-application-tracing
+          - title: Intro to transactions
+            pages:
+              - title: Transactions in New Relic APM
+                path: /docs/apm/transactions/intro-transactions/transactions-new-relic-apm
+              - title: Monitor background processes and other non-web transactions
+                path: /docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions
       - title: APM UI pages
         pages:
-          - title: Error analytics
-            pages:
-              - title: 'APM Error profiles: Troubleshoot trends'
-                path: /docs/apm/apm-ui-pages/error-analytics/apm-error-profiles-troubleshoot-trends
-              - title: 'Errors page: Find, fix, and verify problems'
-                path: /docs/apm/apm-ui-pages/error-analytics/errors-page-find-fix-verify-problems
-              - title: Manage error data
-                path: /docs/apm/apm-ui-pages/error-analytics/manage-error-data
           - title: Events
             pages:
               - title: 'Deployments page: View impact on your app and users'
                 path: /docs/apm/apm-ui-pages/events/deployments-page-view-impact-your-app-users
-              - title: Thread profiler tool
-                path: /docs/apm/apm-ui-pages/events/thread-profiler-tool
               - title: View alert history
                 path: /docs/apm/applications-menu/events/view-alert-history
+              - title: Thread profiler tool
+                path: /docs/apm/apm-ui-pages/events/thread-profiler-tool
+          - title: Monitoring
+            pages:
+              - title: 'APM Summary page: View transaction, Apdex, usage data'
+                path: /docs/apm/apm-ui-pages/monitoring/apm-summary-page-view-transaction-apdex-usage-data
+              - title: Response time chart types (APM and browser)
+                path: /docs/apm/apm-ui-pages/monitoring/response-time-chart-types-apm-browser
+              - title: Distributed tracing page
+                path: /docs/apm/applications-menu/monitoring/distributed-tracing-page
+              - title: 'Transactions page: Find specific performance problems'
+                path: /docs/apm/apm-ui-pages/monitoring/transactions-page-find-specific-performance-problems
+              - title: 'Databases page: View operations, throughput, response time'
+                path: /docs/apm/apm-ui-pages/monitoring/databases-page-view-operations-throughput-response-time
+              - title: View slow query details
+                path: /docs/apm/apm-ui-pages/monitoring/view-slow-query-details
+              - title: 'External services page: View web, cloud, network data'
+                path: /docs/apm/apm-ui-pages/monitoring/external-services-page-view-web-cloud-network-data
+              - title: APM data in Infrastructure
+                path: /docs/apm/apm-ui-pages/monitoring/apm-data-infrastructure
+              - title: View your applications index
+                path: /docs/apm/apm-ui-pages/monitoring/view-your-applications-index
+              - title: Agent-specific UI pages
+                path: /docs/apm/apm-ui-pages/monitoring/agent-specific-ui-pages
           - title: Features
             pages:
               - title: Analyze database and instance-level performance issues
@@ -51,30 +107,22 @@ pages:
                 path: /docs/apm/applications-menu/features/request-queue-server-configuration-examples
               - title: Ticketing integrations
                 path: /docs/using-new-relic/user-interface-functions/share-your-data/ticketing-integrations
-          - title: Monitoring
+          - title: Error analytics
             pages:
-              - title: Agent-specific UI pages
-                path: /docs/apm/apm-ui-pages/monitoring/agent-specific-ui-pages
-              - title: APM data in Infrastructure
-                path: /docs/apm/apm-ui-pages/monitoring/apm-data-infrastructure
-              - title: 'APM Summary page: View transaction, Apdex, usage data'
-                path: /docs/apm/apm-ui-pages/monitoring/apm-summary-page-view-transaction-apdex-usage-data
-              - title: 'Databases page: View operations, throughput, response time'
-                path: /docs/apm/apm-ui-pages/monitoring/databases-page-view-operations-throughput-response-time
-              - title: 'External services page: View web, cloud, network data'
-                path: /docs/apm/apm-ui-pages/monitoring/external-services-page-view-web-cloud-network-data
-              - title: Response time chart types (APM and browser)
-                path: /docs/apm/apm-ui-pages/monitoring/response-time-chart-types-apm-browser
-              - title: 'Transactions page: Find specific performance problems'
-                path: /docs/apm/apm-ui-pages/monitoring/transactions-page-find-specific-performance-problems
-              - title: View slow query details
-                path: /docs/apm/apm-ui-pages/monitoring/view-slow-query-details
-              - title: View your applications index
-                path: /docs/apm/apm-ui-pages/monitoring/view-your-applications-index
-              - title: Distributed tracing page
-                path: /docs/apm/applications-menu/monitoring/distributed-tracing-page
+              - title: 'Errors page: Find, fix, and verify problems'
+                path: /docs/apm/apm-ui-pages/error-analytics/errors-page-find-fix-verify-problems
+              - title: 'APM Error profiles: Troubleshoot trends'
+                path: /docs/apm/apm-ui-pages/error-analytics/apm-error-profiles-troubleshoot-trends
+              - title: Manage error data
+                path: /docs/apm/apm-ui-pages/error-analytics/manage-error-data
       - title: Reports
         pages:
+          - title: Service level agreements
+            pages:
+              - title: APM SLA reports
+                path: /docs/apm/reports/service-level-agreements/apm-sla-reports
+              - title: API examples for SLA reports
+                path: /docs/apm/reports/service-level-agreements/api-examples-sla-reports
           - title: Other performance analysis
             pages:
               - title: Background jobs analysis report
@@ -89,281 +137,203 @@ pages:
                 path: /docs/apm/reports/other-performance-analysis/web-transactions-analysis-report
               - title: Weekly performance report
                 path: /docs/apm/reports/other-performance-analysis/weekly-performance-report
-          - title: Service level agreements
-            pages:
-              - title: API examples for SLA reports
-                path: /docs/apm/reports/service-level-agreements/api-examples-sla-reports
-              - title: APM SLA reports
-                path: /docs/apm/reports/service-level-agreements/apm-sla-reports
-      - title: Transactions
-        pages:
-          - title: Cross application traces
-            pages:
-              - title: Introduction to cross application traces
-                path: /docs/apm/transactions/cross-application-traces/introduction-cross-application-traces
-              - title: Troubleshoot cross application tracing
-                path: /docs/apm/transactions/cross-application-traces/troubleshoot-cross-application-tracing
-          - title: Intro to transactions
-            pages:
-              - title: Monitor background processes and other non-web transactions
-                path: /docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions
-              - title: Transactions in New Relic APM
-                path: /docs/apm/transactions/intro-transactions/transactions-new-relic-apm
-          - title: Key transactions
-            pages:
-              - title: Create and update key transactions
-                path: /docs/apm/transactions/key-transactions/create-update-key-transactions
-              - title: Introduction to key transactions
-                path: /docs/apm/transactions/key-transactions/introduction-key-transactions
-              - title: Key transaction alerts
-                path: /docs/apm/transactions/key-transactions/key-transaction-alerts
-              - title: Key transaction charts and data
-                path: /docs/apm/transactions/key-transactions/key-transaction-charts-data
-              - title: Tag key transactions
-                path: /docs/apm/transactions/key-transactions/tag-key-transactions
-          - title: Transaction traces
-            pages:
-              - title: Configure transaction traces
-                path: /docs/apm/transactions/transaction-traces/configure-transaction-traces
-              - title: Introduction to transaction traces
-                path: /docs/apm/transactions/transaction-traces/introduction-transaction-traces
-              - title: Security and transaction traces
-                path: /docs/apm/transactions/transaction-traces/security-transaction-traces
-              - title: 'Transaction traces: Database queries page'
-                path: /docs/apm/transactions/transaction-traces/transaction-traces-database-queries-page
-              - title: 'Transaction traces: Summary page'
-                path: /docs/apm/transactions/transaction-traces/transaction-traces-summary-page
-              - title: 'Transaction traces: Trace details page'
-                path: /docs/apm/transactions/transaction-traces/transaction-traces-trace-details-page
-              - title: 'Troubleshooting: Not seeing transaction traces'
-                path: /docs/apm/transactions/transaction-traces/troubleshooting-not-seeing-transaction-traces
       - title: Apdex
         pages:
           - title: 'Apdex: Measure user satisfaction'
             path: /docs/apm/new-relic-apm/apdex/apdex-measure-user-satisfaction
-          - title: Change your Apdex settings
-            path: /docs/apm/new-relic-apm/apdex/change-your-apdex-settings
           - title: View your Apdex score
             path: /docs/apm/new-relic-apm/apdex/view-your-apdex-score
+          - title: Change your Apdex settings
+            path: /docs/apm/new-relic-apm/apdex/change-your-apdex-settings
       - title: Getting started
         pages:
-          - title: APM agent data security
-            path: /docs/apm/new-relic-apm/getting-started/apm-agent-data-security
           - title: Introduction to APM
             path: /docs/apm/new-relic-apm/getting-started/introduction-apm
           - title: View app alert information in APM
             path: /docs/apm/new-relic-apm/getting-started/view-app-alert-information-apm
+          - title: APM agent data security
+            path: /docs/apm/new-relic-apm/getting-started/apm-agent-data-security
+      - title: Troubleshooting
+        pages:
+          - title: CPU usage mismatch or usage over 100%
+            path: /docs/apm/new-relic-apm/troubleshooting/cpu-usage-mismatch-or-usage-over-100
+          - title: Charts missing or do not render
+            path: /docs/apm/new-relic-apm/troubleshooting/charts-missing-or-do-not-render
+          - title: Errors while using other APM software
+            path: /docs/apm/new-relic-apm/troubleshooting/errors-while-using-other-apm-software
       - title: Maintenance
         pages:
           - title: Disable the APM agent
             path: /docs/apm/new-relic-apm/maintenance/disable-apm-agent
-          - title: Record and monitor deployments
-            path: /docs/apm/new-relic-apm/maintenance/record-monitor-deployments
           - title: Remove applications from New Relic
             path: /docs/apm/new-relic-apm/maintenance/remove-applications-new-relic
-      - title: Troubleshooting
-        pages:
-          - title: Charts missing or do not render
-            path: /docs/apm/new-relic-apm/troubleshooting/charts-missing-or-do-not-render
-          - title: CPU usage mismatch or usage over 100%
-            path: /docs/apm/new-relic-apm/troubleshooting/cpu-usage-mismatch-or-usage-over-100
-          - title: Errors while using other APM software
-            path: /docs/apm/new-relic-apm/troubleshooting/errors-while-using-other-apm-software
+          - title: Record and monitor deployments
+            path: /docs/apm/new-relic-apm/maintenance/record-monitor-deployments
   - title: Browser monitoring
     path: /docs/browser
     pages:
-      - title: Browser Pro features
-        pages:
-          - title: 'AJAX page: Identify time-consuming calls'
-            path: /docs/browser/browser-monitoring/browser-pro-features/ajax-page-identify-time-consuming-calls
-          - title: 'Session traces: Explore a webpage''s life cycle'
-            path: /docs/browser/browser-monitoring/browser-pro-features/session-traces-explore-webpages-life-cycle
-          - title: 'Browser error profiles: Find error causes'
-            path: /docs/browser/new-relic-browser/browser-pro-features/browser-error-profiles-find-error-causes
-          - title: 'Filterable Geography: Webpage metrics by location'
-            path: /docs/browser/new-relic-browser/browser-pro-features/filterable-geography-webpage-metrics-location
-          - title: 'JavaScript errors page: Detect and analyze errors'
-            path: /docs/browser/new-relic-browser/browser-pro-features/javascript-errors-page-detect-analyze-errors
-          - title: SPA monitoring
-            path: /docs/browser/new-relic-browser/browser-pro-features/spa-monitoring
-          - title: Upload source maps via API
-            path: /docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-api
-          - title: Upload source maps to un-minify JS errors
-            path: /docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-un-minify-js-errors
-      - title: Configuration
-        pages:
-          - title: Browser license key and app ID
-            path: /docs/browser/browser-monitoring/configuration/browser-license-key-app-id
-          - title: 'Browser settings: UI options for Apdex and geography'
-            path: /docs/browser/new-relic-browser/configuration/browser-settings-ui-options-apdex-geography
-          - title: Group browser metrics by URLs
-            path: /docs/browser/new-relic-browser/configuration/group-browser-metrics-urls
-          - title: Monitor or block specific domains and subdomains
-            path: /docs/browser/new-relic-browser/configuration/monitor-or-block-specific-domains-subdomains
-          - title: Rename Browser apps
-            path: /docs/browser/new-relic-browser/configuration/rename-browser-apps
-          - title: View a browser app's alert information
-            path: /docs/browser/new-relic-browser/configuration/view-browser-apps-alert-information
       - title: Getting started
         pages:
-          - title: Browser Summary page
-            path: /docs/browser/browser-monitoring/getting-started/browser-summary-page
+          - title: Introduction to Browser monitoring
+            path: /docs/browser/new-relic-browser/getting-started/introduction-browser-monitoring
+          - title: Compatibility and requirements for Browser Monitoring
+            path: /docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring
           - title: Browser agent release notes
             path: /docs/browser/new-relic-browser/getting-started/browser-agent-release-notes
           - title: Browser apps index
             path: /docs/browser/new-relic-browser/getting-started/browser-apps-index
-          - title: Compatibility and requirements for Browser Monitoring
-            path: /docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring
-          - title: Introduction to Browser monitoring
-            path: /docs/browser/new-relic-browser/getting-started/introduction-browser-monitoring
+          - title: Browser Summary page
+            path: /docs/browser/browser-monitoring/getting-started/browser-summary-page
+      - title: Performance quality
+        pages:
+          - title: Security for Browser monitoring
+            path: /docs/browser/new-relic-browser/performance-quality/security-browser-monitoring
+          - title: Browser monitoring and performance impact
+            path: /docs/browser/new-relic-browser/performance-quality/browser-monitoring-performance-impact
+          - title: Browser monitoring and search engine optimization
+            path: /docs/browser/new-relic-browser/performance-quality/browser-monitoring-search-engine-optimization
+      - title: Configuration
+        pages:
+          - title: 'Browser settings: UI options for Apdex and geography'
+            path: /docs/browser/new-relic-browser/configuration/browser-settings-ui-options-apdex-geography
+          - title: Rename Browser apps
+            path: /docs/browser/new-relic-browser/configuration/rename-browser-apps
+          - title: Monitor or block specific domains and subdomains
+            path: /docs/browser/new-relic-browser/configuration/monitor-or-block-specific-domains-subdomains
+          - title: Group browser metrics by URLs
+            path: /docs/browser/new-relic-browser/configuration/group-browser-metrics-urls
+          - title: Browser license key and app ID
+            path: /docs/browser/browser-monitoring/configuration/browser-license-key-app-id
+          - title: View a browser app's alert information
+            path: /docs/browser/new-relic-browser/configuration/view-browser-apps-alert-information
+      - title: Additional standard features
+        pages:
+          - title: 'Page views: Examine page performance'
+            path: /docs/browser/new-relic-browser/additional-standard-features/page-views-examine-page-performance
+          - title: 'Browsers: Problem patterns by type or platform'
+            path: /docs/browser/new-relic-browser/additional-standard-features/browsers-problem-patterns-type-or-platform
+          - title: 'Browser Geography: Webpage performance by location'
+            path: /docs/browser/new-relic-browser/additional-standard-features/browser-geography-webpage-performance-location
+      - title: Page load timing resources
+        pages:
+          - title: Page load timing process
+            path: /docs/browser/new-relic-browser/page-load-timing-resources/page-load-timing-process
+          - title: Instrumentation for browser monitoring
+            path: /docs/browser/new-relic-browser/page-load-timing-resources/instrumentation-browser-monitoring
+          - title: Compare page load performance in Browser and Synthetics
+            path: /docs/browser/new-relic-browser/page-load-timing-resources/compare-page-load-performance-browser-synthetics
+          - title: New Relic cookies used by Browser
+            path: /docs/browser/browser-monitoring/page-load-timing-resources/new-relic-cookies-used-browser
+          - title: Navigation start time unknown
+            path: /docs/browser/new-relic-browser/page-load-timing-resources/navigation-start-time-unknown
+          - title: Cookie collection and session tracking
+            path: /docs/browser/browser-monitoring/page-load-timing-resources/cookie-collection-session-tracking
+          - title: Cached pages
+            path: /docs/browser/new-relic-browser/page-load-timing-resources/cached-pages
       - title: Installation
         pages:
           - title: Install the Browser monitoring agent
             path: /docs/browser/browser-monitoring/installation/install-browser-monitoring-agent
-          - title: Delete apps from New Relic Browser
-            path: /docs/browser/new-relic-browser/installation/delete-apps-new-relic-browser
-          - title: Disable Browser monitoring
-            path: /docs/browser/new-relic-browser/installation/disable-browser-monitoring
-          - title: Monitor AMP pages with New Relic Browser
-            path: /docs/browser/new-relic-browser/installation/monitor-amp-pages-new-relic-browser
           - title: Update the Browser agent
             path: /docs/browser/new-relic-browser/installation/update-browser-agent
-      - title: Page load timing resources
+          - title: Disable Browser monitoring
+            path: /docs/browser/new-relic-browser/installation/disable-browser-monitoring
+          - title: Delete apps from New Relic Browser
+            path: /docs/browser/new-relic-browser/installation/delete-apps-new-relic-browser
+          - title: Monitor AMP pages with New Relic Browser
+            path: /docs/browser/new-relic-browser/installation/monitor-amp-pages-new-relic-browser
+      - title: Browser Pro features
         pages:
-          - title: Cookie collection and session tracking
-            path: /docs/browser/browser-monitoring/page-load-timing-resources/cookie-collection-session-tracking
-          - title: New Relic cookies used by Browser
-            path: /docs/browser/browser-monitoring/page-load-timing-resources/new-relic-cookies-used-browser
-          - title: Cached pages
-            path: /docs/browser/new-relic-browser/page-load-timing-resources/cached-pages
-          - title: Compare page load performance in Browser and Synthetics
-            path: /docs/browser/new-relic-browser/page-load-timing-resources/compare-page-load-performance-browser-synthetics
-          - title: Instrumentation for browser monitoring
-            path: /docs/browser/new-relic-browser/page-load-timing-resources/instrumentation-browser-monitoring
-          - title: Navigation start time unknown
-            path: /docs/browser/new-relic-browser/page-load-timing-resources/navigation-start-time-unknown
-          - title: Page load timing process
-            path: /docs/browser/new-relic-browser/page-load-timing-resources/page-load-timing-process
-      - title: Additional standard features
-        pages:
-          - title: 'Browser Geography: Webpage performance by location'
-            path: /docs/browser/new-relic-browser/additional-standard-features/browser-geography-webpage-performance-location
-          - title: 'Browsers: Problem patterns by type or platform'
-            path: /docs/browser/new-relic-browser/additional-standard-features/browsers-problem-patterns-type-or-platform
-          - title: 'Page views: Examine page performance'
-            path: /docs/browser/new-relic-browser/additional-standard-features/page-views-examine-page-performance
+          - title: SPA monitoring
+            path: /docs/browser/new-relic-browser/browser-pro-features/spa-monitoring
+          - title: 'AJAX page: Identify time-consuming calls'
+            path: /docs/browser/browser-monitoring/browser-pro-features/ajax-page-identify-time-consuming-calls
+          - title: 'JavaScript errors page: Detect and analyze errors'
+            path: /docs/browser/new-relic-browser/browser-pro-features/javascript-errors-page-detect-analyze-errors
+          - title: 'Browser error profiles: Find error causes'
+            path: /docs/browser/new-relic-browser/browser-pro-features/browser-error-profiles-find-error-causes
+          - title: 'Session traces: Explore a webpage''s life cycle'
+            path: /docs/browser/browser-monitoring/browser-pro-features/session-traces-explore-webpages-life-cycle
+          - title: 'Filterable Geography: Webpage metrics by location'
+            path: /docs/browser/new-relic-browser/browser-pro-features/filterable-geography-webpage-metrics-location
+          - title: Upload source maps to un-minify JS errors
+            path: /docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-un-minify-js-errors
+          - title: Upload source maps via API
+            path: /docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-api
       - title: Browser agent and SPA API
         path: /docs/browser/new-relic-browser/browser-agent-spa-api
         pages:
-          - title: actionText (Browser SPA API)
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/actiontext-browser-spa-api
+          - title: View all methods
+            path: /docs/browser/new-relic-browser/browser-agent-spa-api/view-all-methods
           - title: addPageAction (Browser agent API)
             path: /docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action
           - title: addRelease (Browser agent API)
             path: /docs/browser/new-relic-browser/browser-agent-spa-api/add-release
           - title: addToTrace (Browser agent API)
             path: /docs/browser/new-relic-browser/browser-agent-spa-api/addtotrace-browser-agent-api
+          - title: finished (Browser agent API)
+            path: /docs/browser/new-relic-browser/browser-agent-spa-api/finished
+          - title: noticeError (Browser agent API)
+            path: /docs/browser/new-relic-browser/browser-agent-spa-api/noticeerror-browser-agent-api
+          - title: setCustomAttribute (Browser agent API)
+            path: /docs/browser/new-relic-browser/browser-agent-spa-api/setcustomattribute-browser-agent-api
+          - title: setErrorHandler (Browser agent API)
+            path: /docs/browser/new-relic-browser/browser-agent-spa-api/set-error-handler
+          - title: setPageViewName (Browser agent API)
+            path: /docs/browser/new-relic-browser/browser-agent-spa-api/setpageviewname-browser-agent-api
+          - title: actionText (Browser SPA API)
+            path: /docs/browser/new-relic-browser/browser-agent-spa-api/actiontext-browser-spa-api
+          - title: interaction (Browser SPA API)
+            path: /docs/browser/new-relic-browser/browser-agent-spa-api/interaction-browser-spa-api
           - title: createTracer (Browser SPA API)
             path: /docs/browser/new-relic-browser/browser-agent-spa-api/createtracer-browser-spa-api
           - title: end (Browser SPA API)
             path: /docs/browser/new-relic-browser/browser-agent-spa-api/end-browser-spa-api
-          - title: finished (Browser agent API)
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/finished
           - title: getContext (Browser SPA API)
             path: /docs/browser/new-relic-browser/browser-agent-spa-api/getcontext-browser-spa-api
           - title: ignore (Browser SPA API)
             path: /docs/browser/new-relic-browser/browser-agent-spa-api/ignore-browser-spa-api
-          - title: interaction (Browser SPA API)
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/interaction-browser-spa-api
-          - title: noticeError (Browser agent API)
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/noticeerror-browser-agent-api
+          - title: onEnd (Browser SPA API)
+            path: /docs/browser/new-relic-browser/browser-agent-spa-api/spa-on-end
           - title: save (Browser SPA API)
             path: /docs/browser/new-relic-browser/browser-agent-spa-api/save-browser-spa-api
-          - title: setErrorHandler (Browser agent API)
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/set-error-handler
           - title: setAttribute (Browser SPA API)
             path: /docs/browser/new-relic-browser/browser-agent-spa-api/setattribute-browser-spa-api
           - title: setCurrentRouteName (Browser SPA API)
             path: /docs/browser/new-relic-browser/browser-agent-spa-api/setcurrentroutename-browser-spa-api
-          - title: setCustomAttribute (Browser agent API)
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/setcustomattribute-browser-agent-api
           - title: setName (Browser SPA API)
             path: /docs/browser/new-relic-browser/browser-agent-spa-api/setname-browser-spa-api
-          - title: setPageViewName (Browser agent API)
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/setpageviewname-browser-agent-api
-          - title: onEnd (Browser SPA API)
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/spa-on-end
-          - title: View all methods
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/view-all-methods
-      - title: Performance quality
-        pages:
-          - title: Browser monitoring and performance impact
-            path: /docs/browser/new-relic-browser/performance-quality/browser-monitoring-performance-impact
-          - title: Browser monitoring and search engine optimization
-            path: /docs/browser/new-relic-browser/performance-quality/browser-monitoring-search-engine-optimization
-          - title: Security for Browser monitoring
-            path: /docs/browser/new-relic-browser/performance-quality/security-browser-monitoring
       - title: Troubleshooting
         pages:
-          - title: AJAX call fails with a CORS redirect error message
-            path: /docs/browser/new-relic-browser/troubleshooting/ajax-call-fails-cors-redirect-error-message
-          - title: AngularJS errors do not appear
-            path: /docs/browser/new-relic-browser/troubleshooting/angularjs-errors-do-not-appear
-          - title: App server requests greatly outnumber Browser PageView transactions
-            path: /docs/browser/new-relic-browser/troubleshooting/app-server-requests-greatly-outnumber-browser-pageview-transactions
-          - title: Browser data doesn't match other analytics tools
-            path: /docs/browser/new-relic-browser/troubleshooting/browser-data-doesnt-match-other-analytics-tools
-          - title: Browser JavaScript injection causes problems with a page
-            path: /docs/browser/new-relic-browser/troubleshooting/browser-javascript-injection-causes-problems-page
-          - title: Get browser-side troubleshooting details in a HAR file
-            path: /docs/browser/new-relic-browser/troubleshooting/get-browser-side-troubleshooting-details-har-file
-          - title: Google AMP validator fails due to 3rd-party script
-            path: /docs/browser/new-relic-browser/troubleshooting/google-amp-validator-fails-due-3rd-party-script
-          - title: Not seeing specific page or endpoint names in Browser data
-            path: /docs/browser/new-relic-browser/troubleshooting/not-seeing-specific-page-or-endpoint-names-browser-data
-          - title: Third-party JS errors missing stack traces
-            path: /docs/browser/new-relic-browser/troubleshooting/third-party-js-errors-missing-stack-traces
-          - title: Troubleshoot AJAX data collection
-            path: /docs/browser/new-relic-browser/troubleshooting/troubleshoot-ajax-data-collection
           - title: Troubleshooting browser monitoring installation
             path: /docs/browser/new-relic-browser/troubleshooting/troubleshooting-browser-monitoring-installation
-          - title: Troubleshooting session trace collection
-            path: /docs/browser/new-relic-browser/troubleshooting/troubleshooting-session-trace-collection
+          - title: Browser data doesn't match other analytics tools
+            path: /docs/browser/new-relic-browser/troubleshooting/browser-data-doesnt-match-other-analytics-tools
           - title: View detailed error logs in the browser
             path: /docs/browser/new-relic-browser/troubleshooting/view-detailed-error-logs-browser
+          - title: Troubleshoot AJAX data collection
+            path: /docs/browser/new-relic-browser/troubleshooting/troubleshoot-ajax-data-collection
+          - title: Troubleshooting session trace collection
+            path: /docs/browser/new-relic-browser/troubleshooting/troubleshooting-session-trace-collection
+          - title: AngularJS errors do not appear
+            path: /docs/browser/new-relic-browser/troubleshooting/angularjs-errors-do-not-appear
+          - title: Google AMP validator fails due to 3rd-party script
+            path: /docs/browser/new-relic-browser/troubleshooting/google-amp-validator-fails-due-3rd-party-script
+          - title: Get browser-side troubleshooting details in a HAR file
+            path: /docs/browser/new-relic-browser/troubleshooting/get-browser-side-troubleshooting-details-har-file
+          - title: Not seeing specific page or endpoint names in Browser data
+            path: /docs/browser/new-relic-browser/troubleshooting/not-seeing-specific-page-or-endpoint-names-browser-data
+          - title: Browser JavaScript injection causes problems with a page
+            path: /docs/browser/new-relic-browser/troubleshooting/browser-javascript-injection-causes-problems-page
+          - title: Third-party JS errors missing stack traces
+            path: /docs/browser/new-relic-browser/troubleshooting/third-party-js-errors-missing-stack-traces
+          - title: App server requests greatly outnumber Browser PageView transactions
+            path: /docs/browser/new-relic-browser/troubleshooting/app-server-requests-greatly-outnumber-browser-pageview-transactions
+          - title: AJAX call fails with a CORS redirect error message
+            path: /docs/browser/new-relic-browser/troubleshooting/ajax-call-fails-cors-redirect-error-message
   - title: Understand dependencies
     path: /docs/understand-dependencies
     pages:
-      - title: Distributed tracing
-        pages:
-          - title: Trace API
-            pages:
-              - title: Troubleshooting missing Trace API data
-                path: /docs/apm/distributed-tracing/trace-api/troubleshooting-missing-trace-api-data
-          - title: Enable and configure
-            pages:
-              - title: 'Language agents: Enable distributed tracing'
-                path: /docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing
-          - title: Get started
-            pages:
-              - title: 'Distributed tracing: Planning guide'
-                path: /docs/understand-dependencies/distributed-tracing/get-started/distributed-tracing-planning-guide
-              - title: How New Relic distributed tracing works
-                path: /docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works
-              - title: Introduction to distributed tracing
-                path: /docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing
-          - title: Troubleshooting
-            pages:
-              - title: Missing trace data
-                path: /docs/understand-dependencies/distributed-tracing/troubleshooting/missing-trace-data
-          - title: UI and data
-            pages:
-              - title: Query distributed trace data
-                path: /docs/understand-dependencies/distributed-tracing/ui-data/query-distributed-trace-data
-              - title: Span attributes
-                path: /docs/understand-dependencies/distributed-tracing/ui-data/span-attributes
-              - title: Understand and use the distributed tracing UI
-                path: /docs/understand-dependencies/distributed-tracing/ui-data/understand-use-distributed-tracing-ui
       - title: Understand system dependencies
         pages:
           - title: Service maps
@@ -374,9 +344,117 @@ pages:
                 path: /docs/understand-dependencies/understand-system-dependencies/service-maps/service-maps-apm
               - title: 'Troubleshooting: Missing entities in service maps'
                 path: /docs/understand-dependencies/understand-system-dependencies/service-maps/troubleshooting-missing-entities-service-maps
+      - title: Distributed tracing
+        pages:
+          - title: Get started
+            pages:
+              - title: Introduction to distributed tracing
+                path: /docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing
+              - title: 'Distributed tracing: Planning guide'
+                path: /docs/understand-dependencies/distributed-tracing/get-started/distributed-tracing-planning-guide
+              - title: How New Relic distributed tracing works
+                path: /docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works
+          - title: UI and data
+            pages:
+              - title: Understand and use the distributed tracing UI
+                path: /docs/understand-dependencies/distributed-tracing/ui-data/understand-use-distributed-tracing-ui
+              - title: Query distributed trace data
+                path: /docs/understand-dependencies/distributed-tracing/ui-data/query-distributed-trace-data
+              - title: Span attributes
+                path: /docs/understand-dependencies/distributed-tracing/ui-data/span-attributes
+          - title: Enable and configure
+            pages:
+              - title: 'Language agents: Enable distributed tracing'
+                path: /docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing
+          - title: Troubleshooting
+            pages:
+              - title: Missing trace data
+                path: /docs/understand-dependencies/distributed-tracing/troubleshooting/missing-trace-data
+          - title: Trace API
+            pages:
+              - title: Troubleshooting missing Trace API data
+                path: /docs/apm/distributed-tracing/trace-api/troubleshooting-missing-trace-api-data
   - title: Infrastructure monitoring
     path: /docs/infrastructure
     pages:
+      - title: Install the infrastructure agent
+        pages:
+          - title: Linux installation
+            pages:
+              - title: Install the infrastructure agent for Linux
+                path: /docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-agent-linux
+              - title: Docker instrumentation for Infrastructure
+                path: /docs/infrastructure/install-infrastructure-agent/linux-installation/docker-instrumentation-infrastructure
+              - title: Docker container for infrastructure monitoring
+                path: /docs/infrastructure/install-infrastructure-agent/linux-installation/docker-container-infrastructure-monitoring
+          - title: Windows installation
+            pages:
+              - title: Install the infrastructure agent for Windows
+                path: /docs/infrastructure/install-infrastructure-agent/windows-installation/install-infrastructure-agent-windows-server-using-msi-installer
+          - title: Config management tools
+            pages:
+              - title: Configure the infrastructure agent using Chef
+                path: /docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-using-chef
+              - title: Configure the infrastructure agent using Ansible
+                path: /docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-using-ansible
+              - title: Configure the infrastructure agent on AWS Elastic Beanstalk
+                path: /docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-aws-elastic-beanstalk
+              - title: Configure the infrastructure agent with Puppet
+                path: /docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-puppet
+          - title: Manage your agent
+            pages:
+              - title: Infrastructure agent behavior
+                path: /docs/infrastructure/install-infrastructure-agent/manage-your-agent/infrastructure-agent-behavior
+              - title: 'Start, stop, and restart the infrastructure agent'
+                path: /docs/infrastructure/install-infrastructure-agent/manage-your-agent/start-stop-restart-infrastructure-agent
+              - title: Infrastructure agent performance overhead
+                path: /docs/infrastructure/install-infrastructure-agent/manage-your-agent/infrastructure-agent-performance-overhead
+              - title: Agent message size
+                path: /docs/infrastructure/install-infrastructure-agent/manage-your-agent/agent-message-size
+          - title: Configuration
+            pages:
+              - title: Configure the infrastructure agent
+                path: /docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent
+              - title: Config file template (newrelic-infra.yml)
+                path: /docs/infrastructure/install-infrastructure-agent/configuration/config-file-template-newrelic-infrayml
+          - title: Update or uninstall
+            pages:
+              - title: Update the infrastructure agent
+                path: /docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent
+              - title: Uninstall the infrastructure agent
+                path: /docs/infrastructure/install-infrastructure-agent/update-or-uninstall/uninstall-infrastructure-agent
+          - title: Get started
+            pages:
+              - title: Requirements for the infrastructure agent
+                path: /docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent
+      - title: Manage your data
+        pages:
+          - title: Data and instrumentation
+            pages:
+              - title: Default infrastructure events
+                path: /docs/infrastructure/manage-your-data/data-instrumentation/default-infrastructure-events
+              - title: Integration data
+                path: /docs/infrastructure/new-relic-infrastructure/data-instrumentation/integration-data
+              - title: APM data in infrastructure monitoring
+                path: /docs/infrastructure/manage-your-data/data-instrumentation/apm-data-infrastructure-monitoring
+          - title: Filter and group
+            pages:
+              - title: 'Filter sets: Organize your hosts'
+                path: /docs/infrastructure/new-relic-infrastructure/filter-group/filter-sets-organize-your-infrastructure-hosts
+              - title: Group infrastructure results by specific attributes
+                path: /docs/infrastructure/new-relic-infrastructure/filter-group/group-infrastructure-results-specific-attributes
+      - title: Infrastructure monitoring UI
+        pages:
+          - title: Infrastructure UI
+            pages:
+              - title: Infrastructure monitoring Hosts page
+                path: /docs/infrastructure/infrastructure-ui-pages/infrastructure-ui/infrastructure-hosts-page
+              - title: 'Infrastructure Inventory page: Search your entire infrastructure'
+                path: /docs/infrastructure/infrastructure-ui-pages/infra-ui-pages/infrastructure-inventory-page-search-your-entire-infrastructure
+              - title: 'Infrastructure Events page: Live feed of config changes'
+                path: /docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-events-page-live-feed-every-config-change
+              - title: 'Events heatmap: Examine patterns in time range'
+                path: /docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/events-heatmap-examine-patterns-time-range
       - title: Infrastructure monitoring troubleshooting
         pages:
           - title: Troubleshoot infrastructure
@@ -385,182 +463,169 @@ pages:
                 path: /docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/no-data-appears-infrastructure
               - title: APM data missing from infrastructure monitoring
                 path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/apm-data-missing-infrastructure
-              - title: HTTPS proxy configuration not working
-                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/https-proxy-configuration-missing
-              - title: Incorrect host name reported
-                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/incorrect-host-name-reported
               - title: Reduce the infrastructure agent's CPU footprint
                 path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/reduce-infrastructure-agents-cpu-footprint
+              - title: Incorrect host name reported
+                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/incorrect-host-name-reported
+              - title: HTTPS proxy configuration not working
+                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/https-proxy-configuration-missing
               - title: Time gaps with missing data
                 path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/time-gaps-missing-data
           - title: Troubleshoot logs
             pages:
-              - title: Generate logs for troubleshooting the infrastructure agent
-                path: /docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs/generate-logs-troubleshooting-infrastructure
               - title: The agent is not starting and there are no logs
                 path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/agent-not-starting-there-are-no-logs
-      - title: Infrastructure monitoring UI
-        pages:
-          - title: Infrastructure UI
-            pages:
-              - title: 'Infrastructure Inventory page: Search your entire infrastructure'
-                path: /docs/infrastructure/infrastructure-ui-pages/infra-ui-pages/infrastructure-inventory-page-search-your-entire-infrastructure
-              - title: Infrastructure monitoring Hosts page
-                path: /docs/infrastructure/infrastructure-ui-pages/infrastructure-ui/infrastructure-hosts-page
-              - title: 'Events heatmap: Examine patterns in time range'
-                path: /docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/events-heatmap-examine-patterns-time-range
-              - title: 'Infrastructure Events page: Live feed of config changes'
-                path: /docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-events-page-live-feed-every-config-change
-      - title: Install the infrastructure agent
-        pages:
-          - title: Config management tools
-            pages:
-              - title: Configure the infrastructure agent on AWS Elastic Beanstalk
-                path: /docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-aws-elastic-beanstalk
-              - title: Configure the infrastructure agent with Puppet
-                path: /docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-puppet
-              - title: Configure the infrastructure agent using Ansible
-                path: /docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-using-ansible
-              - title: Configure the infrastructure agent using Chef
-                path: /docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-using-chef
-          - title: Configuration
-            pages:
-              - title: Config file template (newrelic-infra.yml)
-                path: /docs/infrastructure/install-infrastructure-agent/configuration/config-file-template-newrelic-infrayml
-              - title: Configure the infrastructure agent
-                path: /docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent
-          - title: Get started
-            pages:
-              - title: Requirements for the infrastructure agent
-                path: /docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent
-          - title: Linux installation
-            pages:
-              - title: Docker container for infrastructure monitoring
-                path: /docs/infrastructure/install-infrastructure-agent/linux-installation/docker-container-infrastructure-monitoring
-              - title: Docker instrumentation for Infrastructure
-                path: /docs/infrastructure/install-infrastructure-agent/linux-installation/docker-instrumentation-infrastructure
-              - title: Install the infrastructure agent for Linux
-                path: /docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-agent-linux
-          - title: Manage your agent
-            pages:
-              - title: Agent message size
-                path: /docs/infrastructure/install-infrastructure-agent/manage-your-agent/agent-message-size
-              - title: Infrastructure agent behavior
-                path: /docs/infrastructure/install-infrastructure-agent/manage-your-agent/infrastructure-agent-behavior
-              - title: Infrastructure agent performance overhead
-                path: /docs/infrastructure/install-infrastructure-agent/manage-your-agent/infrastructure-agent-performance-overhead
-              - title: 'Start, stop, and restart the infrastructure agent'
-                path: /docs/infrastructure/install-infrastructure-agent/manage-your-agent/start-stop-restart-infrastructure-agent
-          - title: Update or uninstall
-            pages:
-              - title: Uninstall the infrastructure agent
-                path: /docs/infrastructure/install-infrastructure-agent/update-or-uninstall/uninstall-infrastructure-agent
-              - title: Update the infrastructure agent
-                path: /docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent
-          - title: Windows installation
-            pages:
-              - title: Install the infrastructure agent for Windows
-                path: /docs/infrastructure/install-infrastructure-agent/windows-installation/install-infrastructure-agent-windows-server-using-msi-installer
-      - title: Manage your data
-        pages:
-          - title: Data and instrumentation
-            pages:
-              - title: APM data in infrastructure monitoring
-                path: /docs/infrastructure/manage-your-data/data-instrumentation/apm-data-infrastructure-monitoring
-              - title: Default infrastructure events
-                path: /docs/infrastructure/manage-your-data/data-instrumentation/default-infrastructure-events
-              - title: Integration data
-                path: /docs/infrastructure/new-relic-infrastructure/data-instrumentation/integration-data
-          - title: Filter and group
-            pages:
-              - title: 'Filter sets: Organize your hosts'
-                path: /docs/infrastructure/new-relic-infrastructure/filter-group/filter-sets-organize-your-infrastructure-hosts
-              - title: Group infrastructure results by specific attributes
-                path: /docs/infrastructure/new-relic-infrastructure/filter-group/group-infrastructure-results-specific-attributes
+              - title: Generate logs for troubleshooting the infrastructure agent
+                path: /docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs/generate-logs-troubleshooting-infrastructure
       - title: Types of integrations
         pages:
-          - title: On-host integrations
-            path: /docs/infrastructure/integrations-getting-started/integrations/host-integrations
           - title: Amazon/AWS integrations
             path: /docs/infrastructure/integrations/integrations/amazonaws-integrations-0
           - title: Azure integrations
             path: /docs/infrastructure/integrations/integrations/azure-integrations
           - title: Google Cloud integrations
             path: /docs/infrastructure/integrations/types-integrations/google-cloud-integrations
+          - title: On-host integrations
+            path: /docs/infrastructure/integrations-getting-started/integrations/host-integrations
   - title: Mobile monitoring
     path: /docs/mobile-monitoring
     pages:
-      - title: Mobile monitoring UI
+      - title: New Relic Mobile
         pages:
-          - title: Crashes
+          - title: Get started
             pages:
-              - title: 'Crash analysis: Group and filter your crashes'
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes
-              - title: Find Build UUIDs for unsymbolicated crashes
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/find-build-uuids-unsymbolicated-crashes
-              - title: 'Handled exceptions: Analyze trends, prevent crashes'
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/handled-exceptions-analyze-trends-prevent-crashes
-              - title: 'Handled exceptions: Occurrences'
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/handled-exceptions-occurrences
-              - title: Introduction to Mobile handled exceptions
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/introduction-mobile-handled-exceptions
-              - title: Investigate a mobile app crash report
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report
-              - title: Mobile crash event trail
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/mobile-crash-event-trail
-              - title: Receive email notifications for unique crashes
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/receive-crash-notifications-email
-          - title: Network pages
+              - title: Introduction to mobile monitoring
+                path: /docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring
+              - title: Mobile monitoring alert information
+                path: /docs/mobile-monitoring/new-relic-mobile/get-started/mobile-monitoring-alert-information
+              - title: Security for mobile apps
+                path: /docs/mobile-monitoring/new-relic-mobile/get-started/security-mobile-apps
+          - title: Maintenance
             pages:
-              - title: MobileRequestError events in Insights
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/mobile-request-failures-query-examples-mobilerequesterror
-              - title: Analyze network requests using MobileRequest event data
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/analyze-network-requests-using-mobilerequest-event-data
-              - title: Carriers page
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/carriers-page
-              - title: Connection types page
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/connection-types-page
-              - title: Geography page for mobile apps
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/geography-page-mobile-apps
-              - title: 'HTTP errors: Network failure analysis'
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-errors-network-failure-analysis
-              - title: HTTP requests page
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-requests-page
-              - title: Map page for mobile apps (deprecated)
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/map-page-mobile-apps-deprecated
-              - title: 'Mobile HTTP error profiles: Find error causes'
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/mobile-http-error-profiles-find-error-causes
-              - title: MobileRequest events in Insights
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/mobilerequest-events
-          - title: Mobile App pages
+              - title: Customize mobile app settings
+                path: /docs/mobile-monitoring/new-relic-mobile/maintenance/customizing-your-mobile-app-settings
+              - title: Add custom data to mobile monitoring
+                path: /docs/mobile-monitoring/new-relic-mobile/maintenance/add-custom-data-new-relic-mobile
+              - title: Application token for New Relic mobile monitoring
+                path: /docs/mobile-monitoring/new-relic-mobile/maintenance/viewing-your-application-token
+              - title: Deleting a mobile app
+                path: /docs/mobile-monitoring/new-relic-mobile/maintenance/deleting-mobile-app
+      - title: New Relic Mobile iOS
+        pages:
+          - title: API guides
             pages:
-              - title: Alerts page for mobile apps
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/alerts-page-mobile-apps
-              - title: Devices page
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/devices-page
-              - title: Interactions page
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/interactions-page
-              - title: Mobile apps index
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/mobile-apps-index
-              - title: Mobile Apps Overview page
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/mobile-apps-overview-page
-              - title: OS versions page
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/os-versions-page
-              - title: Review version trends email reports
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/review-version-trends-email-reports
-              - title: 'Version trends: Compare user adoption metrics and performance'
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/version-trends-compare-user-adoption-metrics-performance
-          - title: Usage pages
+              - title: iOS SDK API guide
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-sdk-api-guide
+              - title: Add custom data
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/api-guides/add-custom-data
+          - title: Installation
             pages:
-              - title: Monthly uniques report
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/usage-pages/monthly-uniques-report
-              - title: Versions analysis
-                path: /docs/mobile-monitoring/mobile-monitoring-ui/usage-pages/versions-analysis
+              - title: CocoaPods installation
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/cocoapods-installation
+              - title: iOS manual installation
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/ios-manual-installation
+              - title: Upgrade New Relic Mobile's iOS SDK
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk
+              - title: Upgrade New Relic Mobile's iOS SDK to v4
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk-v4
+          - title: Get started
+            pages:
+              - title: New Relic for iOS compatibility and requirements
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-compatibility-requirements
+              - title: Introduction to New Relic Mobile for iOS
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/introduction-new-relic-mobile-ios
+              - title: iOS release notes
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/ios-release-notes
+          - title: tvOS
+            pages:
+              - title: tvOS installation and configuration
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/tvos/tvos-installation-configuration
+              - title: New Relic for tvOS compatibility and requirements
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/tvos/new-relic-tvos-compatibility-requirements
+              - title: Upgrading New Relic Mobile's tvOS SDK
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/tvos/upgrading-new-relic-mobiles-tvos-sdk
+              - title: CocoaPods for tvOS installation and configuration
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/tvos/cocoapods-tvos-installation-configuration
+              - title: tvOS crash reporting
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/tvos/tvos-crash-reporting
+          - title: Configuration
+            pages:
+              - title: iOS agent configuration and feature flags
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-agent-configuration-feature-flags
+              - title: iOS and tvOS crash reporting
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-tvos-crash-reporting
+              - title: Enable Swift interaction traces
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/configuration/enable-swift-interaction-traces
+              - title: Adding a prefix header to an iOS project
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/configuration/adding-prefix-header-ios-project
+              - title: Retrieve dSYMs for Bitcode apps
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/configuration/retrieve-dsyms-bitcode-apps
+              - title: Upload dSYM files
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/configuration/upload-dsyms-bitcode-apps
+          - title: iOS SDK API
+            path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api
+            pages:
+              - title: View all methods
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/view-all-methods
+              - title: currentSessionId (iOS SDK API)
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/current-session-id
+              - title: incrementAttribute (iOS SDK API)
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/increment-attribute
+              - title: recordBreadcrumb (iOS SDK API)
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/record-breadcrumb
+              - title: recordCustomEvent (iOS SDK API)
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recordcustomevent-ios-sdk-api
+              - title: recordHandledException (iOS SDK API)
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/record-handled-exception
+              - title: recordError (iOS SDK API)
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recorderror-ios-sdk-api
+              - title: recordMetric (iOS SDK API)
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recordmetric-ios-sdk-api
+              - title: crashNow (iOS SDK API)
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/crashnow-ios-sdk-api
+              - title: removeAllAttributes (iOS SDK API)
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/remove-all-attributes
+              - title: removeAttribute (iOS SDK API)
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/remove-attribute
+              - title: setAttribute (iOS SDK API)
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/set-attribute
+              - title: setMaxEventBufferTime (iOS SDK API)
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/set-max-event-buffer-time
+              - title: setMaxEventPoolSize (iOS SDK API)
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/set-max-event-pool-size
+              - title: setUserId (iOS SDK API)
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/set-user-id
+          - title: Troubleshoot
+            pages:
+              - title: No data appears (iOS)
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/troubleshoot/no-data-appears-ios
       - title: New Relic Mobile Android
         pages:
+          - title: Install configure
+            pages:
+              - title: Install Android apps with Gradle and Android Studio
+                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-apps-gradle-android-studio
+              - title: Configure ProGuard or DexGuard for Android Apps
+                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps
+              - title: Android agent crash reporting
+                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/android-agent-crash-reporting
+              - title: Install the New Relic plugin for Android Instant Apps
+                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-new-relic-plugin-android-instant-apps
+              - title: Upgrade New Relic Mobile's Android SDK
+                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/upgrade-new-relic-mobiles-android-sdk
+          - title: Get started
+            pages:
+              - title: New Relic for Android compatibility and requirements
+                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements
+              - title: Introduction to New Relic Mobile for Android
+                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/introduction-new-relic-mobile-android
+              - title: Android release notes
+                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/android-release-notes
           - title: Android SDK API
             path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api
             pages:
+              - title: View all methods
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/view-all-methods
               - title: crashNow (Android SDK API)
                 path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/crashnow-android-sdk-api
               - title: currentSessionId (Android SDK API)
@@ -597,167 +662,102 @@ pages:
                 path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-user-id
               - title: startInteraction (Android SDK API)
                 path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/start-interaction
-              - title: View all methods
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/view-all-methods
               - title: withApplicationBuild (Android SDK API)
                 path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/with-application-build
               - title: withApplicationVersion (Android SDK API)
                 path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/with-application-version
               - title: withInteractionTracing (Android SDK API)
                 path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/with-interaction-tracing
+          - title: Troubleshoot
+            pages:
+              - title: No data appears (Android)
+                path: /docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/no-data-appears-android
+              - title: Android app exceeds 64k multidex limit
+                path: /docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/android-app-exceeds-64k-multidex-limit
           - title: API guides
             pages:
-              - title: Add custom data
-                path: /docs/mobile-monitoring/new-relic-mobile-android/api-guides/add-custom-data
               - title: Android agent configuration and feature flags
                 path: /docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-agent-configuration-feature-flags
+              - title: Add custom data
+                path: /docs/mobile-monitoring/new-relic-mobile-android/api-guides/add-custom-data
               - title: Android SDK API guide
                 path: /docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-sdk-api-guide
-          - title: Get started
-            pages:
-              - title: Android release notes
-                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/android-release-notes
-              - title: Introduction to New Relic Mobile for Android
-                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/introduction-new-relic-mobile-android
-              - title: New Relic for Android compatibility and requirements
-                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements
-          - title: Install configure
-            pages:
-              - title: Android agent crash reporting
-                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/android-agent-crash-reporting
-              - title: Configure ProGuard or DexGuard for Android Apps
-                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps
-              - title: Install Android apps with Gradle and Android Studio
-                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-apps-gradle-android-studio
-              - title: Install the New Relic plugin for Android Instant Apps
-                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-new-relic-plugin-android-instant-apps
-              - title: Upgrade New Relic Mobile's Android SDK
-                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/upgrade-new-relic-mobiles-android-sdk
           - title: Legacy
             pages:
               - title: Install Android apps with support for legacy Android versions
                 path: /docs/mobile-monitoring/new-relic-mobile-android/legacy/install-android-apps-android-22-support
-          - title: Troubleshoot
+      - title: Mobile monitoring UI
+        pages:
+          - title: Usage pages
             pages:
-              - title: Android app exceeds 64k multidex limit
-                path: /docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/android-app-exceeds-64k-multidex-limit
-              - title: No data appears (Android)
-                path: /docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/no-data-appears-android
+              - title: Versions analysis
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/usage-pages/versions-analysis
+              - title: Monthly uniques report
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/usage-pages/monthly-uniques-report
+          - title: Mobile App pages
+            pages:
+              - title: Mobile apps index
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/mobile-apps-index
+              - title: Mobile Apps Overview page
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/mobile-apps-overview-page
+              - title: Interactions page
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/interactions-page
+              - title: Devices page
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/devices-page
+              - title: OS versions page
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/os-versions-page
+              - title: 'Version trends: Compare user adoption metrics and performance'
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/version-trends-compare-user-adoption-metrics-performance
+              - title: Review version trends email reports
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/review-version-trends-email-reports
+              - title: Alerts page for mobile apps
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/alerts-page-mobile-apps
+          - title: Crashes
+            pages:
+              - title: 'Crash analysis: Group and filter your crashes'
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes
+              - title: Investigate a mobile app crash report
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report
+              - title: Mobile crash event trail
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/mobile-crash-event-trail
+              - title: Receive email notifications for unique crashes
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/receive-crash-notifications-email
+              - title: Find Build UUIDs for unsymbolicated crashes
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/find-build-uuids-unsymbolicated-crashes
+              - title: Introduction to Mobile handled exceptions
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/introduction-mobile-handled-exceptions
+              - title: 'Handled exceptions: Analyze trends, prevent crashes'
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/handled-exceptions-analyze-trends-prevent-crashes
+              - title: 'Handled exceptions: Occurrences'
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/handled-exceptions-occurrences
+          - title: Network pages
+            pages:
+              - title: Analyze network requests using MobileRequest event data
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/analyze-network-requests-using-mobilerequest-event-data
+              - title: 'HTTP errors: Network failure analysis'
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-errors-network-failure-analysis
+              - title: HTTP requests page
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-requests-page
+              - title: Carriers page
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/carriers-page
+              - title: Connection types page
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/connection-types-page
+              - title: 'Mobile HTTP error profiles: Find error causes'
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/mobile-http-error-profiles-find-error-causes
+              - title: Map page for mobile apps (deprecated)
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/map-page-mobile-apps-deprecated
+              - title: Geography page for mobile apps
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/geography-page-mobile-apps
+              - title: MobileRequest events in Insights
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/mobilerequest-events
+              - title: MobileRequestError events in Insights
+                path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/mobile-request-failures-query-examples-mobilerequesterror
       - title: New Relic Mobile Cordova
         pages:
           - title: Get started
             pages:
               - title: Introduction to New Relic for Cordova
                 path: /docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/get-started/introduction-new-relic-cordova
-      - title: New Relic Mobile iOS
-        pages:
-          - title: API guides
-            pages:
-              - title: Add custom data
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/api-guides/add-custom-data
-              - title: iOS SDK API guide
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-sdk-api-guide
-          - title: Configuration
-            pages:
-              - title: iOS agent configuration and feature flags
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-agent-configuration-feature-flags
-              - title: Adding a prefix header to an iOS project
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/configuration/adding-prefix-header-ios-project
-              - title: Enable Swift interaction traces
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/configuration/enable-swift-interaction-traces
-              - title: iOS and tvOS crash reporting
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-tvos-crash-reporting
-              - title: Retrieve dSYMs for Bitcode apps
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/configuration/retrieve-dsyms-bitcode-apps
-              - title: Upload dSYM files
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/configuration/upload-dsyms-bitcode-apps
-          - title: Get started
-            pages:
-              - title: Introduction to New Relic Mobile for iOS
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/introduction-new-relic-mobile-ios
-              - title: iOS release notes
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/ios-release-notes
-              - title: New Relic for iOS compatibility and requirements
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-compatibility-requirements
-          - title: Installation
-            pages:
-              - title: CocoaPods installation
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/cocoapods-installation
-              - title: iOS manual installation
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/ios-manual-installation
-              - title: Upgrade New Relic Mobile's iOS SDK to v4
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk-v4
-              - title: Upgrade New Relic Mobile's iOS SDK
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk
-          - title: iOS SDK API
-            path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api
-            pages:
-              - title: crashNow (iOS SDK API)
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/crashnow-ios-sdk-api
-              - title: currentSessionId (iOS SDK API)
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/current-session-id
-              - title: incrementAttribute (iOS SDK API)
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/increment-attribute
-              - title: recordBreadcrumb (iOS SDK API)
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/record-breadcrumb
-              - title: recordHandledException (iOS SDK API)
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/record-handled-exception
-              - title: recordCustomEvent (iOS SDK API)
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recordcustomevent-ios-sdk-api
-              - title: recordError (iOS SDK API)
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recorderror-ios-sdk-api
-              - title: recordMetric (iOS SDK API)
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recordmetric-ios-sdk-api
-              - title: removeAllAttributes (iOS SDK API)
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/remove-all-attributes
-              - title: removeAttribute (iOS SDK API)
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/remove-attribute
-              - title: setAttribute (iOS SDK API)
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/set-attribute
-              - title: setMaxEventBufferTime (iOS SDK API)
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/set-max-event-buffer-time
-              - title: setMaxEventPoolSize (iOS SDK API)
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/set-max-event-pool-size
-              - title: setUserId (iOS SDK API)
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/set-user-id
-              - title: View all methods
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/view-all-methods
-          - title: Troubleshoot
-            pages:
-              - title: No data appears (iOS)
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/troubleshoot/no-data-appears-ios
-          - title: tvOS
-            pages:
-              - title: CocoaPods for tvOS installation and configuration
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/tvos/cocoapods-tvos-installation-configuration
-              - title: New Relic for tvOS compatibility and requirements
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/tvos/new-relic-tvos-compatibility-requirements
-              - title: tvOS crash reporting
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/tvos/tvos-crash-reporting
-              - title: tvOS installation and configuration
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/tvos/tvos-installation-configuration
-              - title: Upgrading New Relic Mobile's tvOS SDK
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/tvos/upgrading-new-relic-mobiles-tvos-sdk
-      - title: New Relic Mobile
-        pages:
-          - title: Get started
-            pages:
-              - title: Introduction to mobile monitoring
-                path: /docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring
-              - title: Mobile monitoring alert information
-                path: /docs/mobile-monitoring/new-relic-mobile/get-started/mobile-monitoring-alert-information
-              - title: Security for mobile apps
-                path: /docs/mobile-monitoring/new-relic-mobile/get-started/security-mobile-apps
-          - title: Maintenance
-            pages:
-              - title: Add custom data to mobile monitoring
-                path: /docs/mobile-monitoring/new-relic-mobile/maintenance/add-custom-data-new-relic-mobile
-              - title: Customize mobile app settings
-                path: /docs/mobile-monitoring/new-relic-mobile/maintenance/customizing-your-mobile-app-settings
-              - title: Deleting a mobile app
-                path: /docs/mobile-monitoring/new-relic-mobile/maintenance/deleting-mobile-app
-              - title: Application token for New Relic mobile monitoring
-                path: /docs/mobile-monitoring/new-relic-mobile/maintenance/viewing-your-application-token
   - title: Serverless function monitoring
     path: /docs/serverless-function-monitoring
     pages:

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -12,10 +12,10 @@ pages:
         pages:
           - title: Troubleshooting
             pages:
-              - title: No log data appears in the UI
-                path: /docs/logs/log-management/troubleshooting/no-log-data-appears-ui
               - title: Log message is truncated
                 path: /docs/logs/log-management/troubleshooting/log-message-truncated
+              - title: No log data appears in the UI
+                path: /docs/logs/log-management/troubleshooting/no-log-data-appears-ui
               - title: JSON message is not parsed
                 path: /docs/logs/new-relic-logs/troubleshooting/json-message-not-parsed
   - title: APM
@@ -137,6 +137,14 @@ pages:
                 path: /docs/apm/reports/other-performance-analysis/web-transactions-analysis-report
               - title: Weekly performance report
                 path: /docs/apm/reports/other-performance-analysis/weekly-performance-report
+      - title: Getting started
+        pages:
+          - title: APM agent data security
+            path: /docs/apm/new-relic-apm/getting-started/apm-agent-data-security
+          - title: Introduction to APM
+            path: /docs/apm/new-relic-apm/getting-started/introduction-apm
+          - title: View app alert information in APM
+            path: /docs/apm/new-relic-apm/getting-started/view-app-alert-information-apm
       - title: Apdex
         pages:
           - title: 'Apdex: Measure user satisfaction'
@@ -145,22 +153,6 @@ pages:
             path: /docs/apm/new-relic-apm/apdex/view-your-apdex-score
           - title: Change your Apdex settings
             path: /docs/apm/new-relic-apm/apdex/change-your-apdex-settings
-      - title: Getting started
-        pages:
-          - title: Introduction to APM
-            path: /docs/apm/new-relic-apm/getting-started/introduction-apm
-          - title: View app alert information in APM
-            path: /docs/apm/new-relic-apm/getting-started/view-app-alert-information-apm
-          - title: APM agent data security
-            path: /docs/apm/new-relic-apm/getting-started/apm-agent-data-security
-      - title: Troubleshooting
-        pages:
-          - title: CPU usage mismatch or usage over 100%
-            path: /docs/apm/new-relic-apm/troubleshooting/cpu-usage-mismatch-or-usage-over-100
-          - title: Charts missing or do not render
-            path: /docs/apm/new-relic-apm/troubleshooting/charts-missing-or-do-not-render
-          - title: Errors while using other APM software
-            path: /docs/apm/new-relic-apm/troubleshooting/errors-while-using-other-apm-software
       - title: Maintenance
         pages:
           - title: Disable the APM agent
@@ -169,6 +161,14 @@ pages:
             path: /docs/apm/new-relic-apm/maintenance/remove-applications-new-relic
           - title: Record and monitor deployments
             path: /docs/apm/new-relic-apm/maintenance/record-monitor-deployments
+      - title: Troubleshooting
+        pages:
+          - title: CPU usage mismatch or usage over 100%
+            path: /docs/apm/new-relic-apm/troubleshooting/cpu-usage-mismatch-or-usage-over-100
+          - title: Charts missing or do not render
+            path: /docs/apm/new-relic-apm/troubleshooting/charts-missing-or-do-not-render
+          - title: Errors while using other APM software
+            path: /docs/apm/new-relic-apm/troubleshooting/errors-while-using-other-apm-software
   - title: Browser monitoring
     path: /docs/browser
     pages:
@@ -334,26 +334,16 @@ pages:
   - title: Understand dependencies
     path: /docs/understand-dependencies
     pages:
-      - title: Understand system dependencies
-        pages:
-          - title: Service maps
-            pages:
-              - title: Introduction to service maps
-                path: /docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps
-              - title: Legacy APM service maps
-                path: /docs/understand-dependencies/understand-system-dependencies/service-maps/service-maps-apm
-              - title: 'Troubleshooting: Missing entities in service maps'
-                path: /docs/understand-dependencies/understand-system-dependencies/service-maps/troubleshooting-missing-entities-service-maps
       - title: Distributed tracing
         pages:
           - title: Get started
             pages:
-              - title: Introduction to distributed tracing
-                path: /docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing
               - title: 'Distributed tracing: Planning guide'
                 path: /docs/understand-dependencies/distributed-tracing/get-started/distributed-tracing-planning-guide
               - title: How New Relic distributed tracing works
                 path: /docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works
+              - title: Introduction to distributed tracing
+                path: /docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing
           - title: UI and data
             pages:
               - title: Understand and use the distributed tracing UI
@@ -366,19 +356,33 @@ pages:
             pages:
               - title: 'Language agents: Enable distributed tracing'
                 path: /docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing
-          - title: Troubleshooting
-            pages:
-              - title: Missing trace data
-                path: /docs/understand-dependencies/distributed-tracing/troubleshooting/missing-trace-data
           - title: Trace API
             pages:
               - title: Troubleshooting missing Trace API data
                 path: /docs/apm/distributed-tracing/trace-api/troubleshooting-missing-trace-api-data
+          - title: Troubleshooting
+            pages:
+              - title: Missing trace data
+                path: /docs/understand-dependencies/distributed-tracing/troubleshooting/missing-trace-data
+      - title: Understand system dependencies
+        pages:
+          - title: Service maps
+            pages:
+              - title: Introduction to service maps
+                path: /docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps
+              - title: Legacy APM service maps
+                path: /docs/understand-dependencies/understand-system-dependencies/service-maps/service-maps-apm
+              - title: 'Troubleshooting: Missing entities in service maps'
+                path: /docs/understand-dependencies/understand-system-dependencies/service-maps/troubleshooting-missing-entities-service-maps
   - title: Infrastructure monitoring
     path: /docs/infrastructure
     pages:
       - title: Install the infrastructure agent
         pages:
+          - title: Get started
+            pages:
+              - title: Requirements for the infrastructure agent
+                path: /docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent
           - title: Linux installation
             pages:
               - title: Install the infrastructure agent for Linux
@@ -423,10 +427,6 @@ pages:
                 path: /docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent
               - title: Uninstall the infrastructure agent
                 path: /docs/infrastructure/install-infrastructure-agent/update-or-uninstall/uninstall-infrastructure-agent
-          - title: Get started
-            pages:
-              - title: Requirements for the infrastructure agent
-                path: /docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent
       - title: Manage your data
         pages:
           - title: Data and instrumentation
@@ -457,26 +457,26 @@ pages:
                 path: /docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/events-heatmap-examine-patterns-time-range
       - title: Infrastructure monitoring troubleshooting
         pages:
+          - title: Troubleshoot logs
+            pages:
+              - title: Generate logs for troubleshooting the infrastructure agent
+                path: /docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs/generate-logs-troubleshooting-infrastructure
+              - title: The agent is not starting and there are no logs
+                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/agent-not-starting-there-are-no-logs
           - title: Troubleshoot infrastructure
             pages:
-              - title: No data appears (Infrastructure)
-                path: /docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/no-data-appears-infrastructure
-              - title: APM data missing from infrastructure monitoring
-                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/apm-data-missing-infrastructure
-              - title: Reduce the infrastructure agent's CPU footprint
-                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/reduce-infrastructure-agents-cpu-footprint
               - title: Incorrect host name reported
                 path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/incorrect-host-name-reported
               - title: HTTPS proxy configuration not working
                 path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/https-proxy-configuration-missing
               - title: Time gaps with missing data
                 path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/time-gaps-missing-data
-          - title: Troubleshoot logs
-            pages:
-              - title: The agent is not starting and there are no logs
-                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/agent-not-starting-there-are-no-logs
-              - title: Generate logs for troubleshooting the infrastructure agent
-                path: /docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs/generate-logs-troubleshooting-infrastructure
+              - title: No data appears (Infrastructure)
+                path: /docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/no-data-appears-infrastructure
+              - title: APM data missing from infrastructure monitoring
+                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/apm-data-missing-infrastructure
+              - title: Reduce the infrastructure agent's CPU footprint
+                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/reduce-infrastructure-agents-cpu-footprint
       - title: Types of integrations
         pages:
           - title: Amazon/AWS integrations
@@ -490,28 +490,16 @@ pages:
   - title: Mobile monitoring
     path: /docs/mobile-monitoring
     pages:
-      - title: New Relic Mobile
+      - title: New Relic Mobile iOS
         pages:
           - title: Get started
             pages:
-              - title: Introduction to mobile monitoring
-                path: /docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring
-              - title: Mobile monitoring alert information
-                path: /docs/mobile-monitoring/new-relic-mobile/get-started/mobile-monitoring-alert-information
-              - title: Security for mobile apps
-                path: /docs/mobile-monitoring/new-relic-mobile/get-started/security-mobile-apps
-          - title: Maintenance
-            pages:
-              - title: Customize mobile app settings
-                path: /docs/mobile-monitoring/new-relic-mobile/maintenance/customizing-your-mobile-app-settings
-              - title: Add custom data to mobile monitoring
-                path: /docs/mobile-monitoring/new-relic-mobile/maintenance/add-custom-data-new-relic-mobile
-              - title: Application token for New Relic mobile monitoring
-                path: /docs/mobile-monitoring/new-relic-mobile/maintenance/viewing-your-application-token
-              - title: Deleting a mobile app
-                path: /docs/mobile-monitoring/new-relic-mobile/maintenance/deleting-mobile-app
-      - title: New Relic Mobile iOS
-        pages:
+              - title: iOS release notes
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/ios-release-notes
+              - title: New Relic for iOS compatibility and requirements
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-compatibility-requirements
+              - title: Introduction to New Relic Mobile for iOS
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/introduction-new-relic-mobile-ios
           - title: API guides
             pages:
               - title: iOS SDK API guide
@@ -528,14 +516,6 @@ pages:
                 path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk
               - title: Upgrade New Relic Mobile's iOS SDK to v4
                 path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk-v4
-          - title: Get started
-            pages:
-              - title: New Relic for iOS compatibility and requirements
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-compatibility-requirements
-              - title: Introduction to New Relic Mobile for iOS
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/introduction-new-relic-mobile-ios
-              - title: iOS release notes
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/ios-release-notes
           - title: tvOS
             pages:
               - title: tvOS installation and configuration
@@ -599,8 +579,36 @@ pages:
             pages:
               - title: No data appears (iOS)
                 path: /docs/mobile-monitoring/new-relic-mobile-ios/troubleshoot/no-data-appears-ios
+      - title: New Relic Mobile
+        pages:
+          - title: Get started
+            pages:
+              - title: Security for mobile apps
+                path: /docs/mobile-monitoring/new-relic-mobile/get-started/security-mobile-apps
+              - title: Introduction to mobile monitoring
+                path: /docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring
+              - title: Mobile monitoring alert information
+                path: /docs/mobile-monitoring/new-relic-mobile/get-started/mobile-monitoring-alert-information
+          - title: Maintenance
+            pages:
+              - title: Customize mobile app settings
+                path: /docs/mobile-monitoring/new-relic-mobile/maintenance/customizing-your-mobile-app-settings
+              - title: Add custom data to mobile monitoring
+                path: /docs/mobile-monitoring/new-relic-mobile/maintenance/add-custom-data-new-relic-mobile
+              - title: Application token for New Relic mobile monitoring
+                path: /docs/mobile-monitoring/new-relic-mobile/maintenance/viewing-your-application-token
+              - title: Deleting a mobile app
+                path: /docs/mobile-monitoring/new-relic-mobile/maintenance/deleting-mobile-app
       - title: New Relic Mobile Android
         pages:
+          - title: Get started
+            pages:
+              - title: Android release notes
+                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/android-release-notes
+              - title: New Relic for Android compatibility and requirements
+                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements
+              - title: Introduction to New Relic Mobile for Android
+                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/introduction-new-relic-mobile-android
           - title: Install configure
             pages:
               - title: Install Android apps with Gradle and Android Studio
@@ -613,14 +621,6 @@ pages:
                 path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-new-relic-plugin-android-instant-apps
               - title: Upgrade New Relic Mobile's Android SDK
                 path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/upgrade-new-relic-mobiles-android-sdk
-          - title: Get started
-            pages:
-              - title: New Relic for Android compatibility and requirements
-                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements
-              - title: Introduction to New Relic Mobile for Android
-                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/introduction-new-relic-mobile-android
-              - title: Android release notes
-                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/android-release-notes
           - title: Android SDK API
             path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api
             pages:
@@ -668,12 +668,6 @@ pages:
                 path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/with-application-version
               - title: withInteractionTracing (Android SDK API)
                 path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/with-interaction-tracing
-          - title: Troubleshoot
-            pages:
-              - title: No data appears (Android)
-                path: /docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/no-data-appears-android
-              - title: Android app exceeds 64k multidex limit
-                path: /docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/android-app-exceeds-64k-multidex-limit
           - title: API guides
             pages:
               - title: Android agent configuration and feature flags
@@ -686,6 +680,18 @@ pages:
             pages:
               - title: Install Android apps with support for legacy Android versions
                 path: /docs/mobile-monitoring/new-relic-mobile-android/legacy/install-android-apps-android-22-support
+          - title: Troubleshoot
+            pages:
+              - title: Android app exceeds 64k multidex limit
+                path: /docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/android-app-exceeds-64k-multidex-limit
+              - title: No data appears (Android)
+                path: /docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/no-data-appears-android
+      - title: New Relic Mobile Cordova
+        pages:
+          - title: Get started
+            pages:
+              - title: Introduction to New Relic for Cordova
+                path: /docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/get-started/introduction-new-relic-cordova
       - title: Mobile monitoring UI
         pages:
           - title: Usage pages
@@ -752,12 +758,6 @@ pages:
                 path: /docs/mobile-monitoring/mobile-monitoring-ui/network-pages/mobilerequest-events
               - title: MobileRequestError events in Insights
                 path: /docs/mobile-monitoring/mobile-monitoring-ui/crashes/mobile-request-failures-query-examples-mobilerequesterror
-      - title: New Relic Mobile Cordova
-        pages:
-          - title: Get started
-            pages:
-              - title: Introduction to New Relic for Cordova
-                path: /docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/get-started/introduction-new-relic-cordova
   - title: Serverless function monitoring
     path: /docs/serverless-function-monitoring
     pages:

--- a/src/nav/insights.yml
+++ b/src/nav/insights.yml
@@ -3,30 +3,84 @@ path: /docs/insights
 pages:
   - title: Overview
     path: /docs/insights
+  - title: Use Insights UI
+    pages:
+      - title: Explore data
+        pages:
+          - title: 'Query page: Create and edit NRQL queries'
+            path: /docs/insights/use-insights-ui/manage-account-data/query-page-create-edit-nrql-queries
+          - title: 'Data explorer: Query and chart event data'
+            path: /docs/insights/use-insights-ui/explore-data/event-explorer-query-chart-your-event-data
+          - title: 'Metric explorer: Search and chart metric timeslice data'
+            path: /docs/insights/use-insights-ui/explore-data/metric-explorer-search-chart-metrics-sent-new-relic-agents
+      - title: Getting started
+        pages:
+          - title: Introduction to New Relic Insights
+            path: /docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights
+      - title: Guides
+        pages:
+          - title: New Relic Insights best practices guide
+            path: /docs/insights/use-insights-ui/guides/new-relic-insights-best-practices-guide
+      - title: Manage dashboards
+        pages:
+          - title: 'View, organize, share Insights dashboards'
+            path: /docs/insights/use-insights-ui/manage-dashboards/view-organize-share-insights-dashboards
+          - title: Copy Insights dashboards and charts
+            path: /docs/insights/use-insights-ui/manage-dashboards/copy-insights-dashboards-charts
+          - title: Filter Insights dashboards
+            path: /docs/insights/use-insights-ui/manage-dashboards/filter-insights-dashboards
+          - title: Copy chart to another Insights account's dashboard
+            path: /docs/insights/use-insights-ui/manage-dashboards/copy-chart-another-insights-accounts-dashboard
+          - title: 'Data apps: Build collections of linked dashboards'
+            path: /docs/insights/use-insights-ui/manage-dashboards/data-apps-build-collections-linked-dashboards
+          - title: Insights dashboard permissions
+            path: /docs/insights/use-insights-ui/manage-dashboards/insights-dashboard-permissions
+          - title: Add and customize NRQL charts
+            path: /docs/insights/use-insights-ui/manage-dashboards/add-customize-nrql-charts
+          - title: Add and customize metric charts
+            path: /docs/insights/use-insights-ui/manage-dashboards/add-customize-metric-charts
+          - title: Chart types
+            path: /docs/insights/use-insights-ui/manage-dashboards/chart-types
+          - title: Chart refresh intervals
+            path: /docs/insights/use-insights-ui/manage-dashboards/insights-chart-refresh-intervals
+          - title: Delete dashboards and charts
+            path: /docs/insights/use-insights-ui/manage-dashboards/delete-dashboards-charts
+      - title: Export data
+        pages:
+          - title: Export Insights data to CSV file
+            path: /docs/insights/use-insights-ui/export-data/export-insights-data-csv-file
+      - title: Time settings
+        pages:
+          - title: Set time range on Insights dashboards and charts
+            path: /docs/insights/use-insights-ui/time-settings/set-time-range-insights-dashboards-charts
+      - title: Manage account data
+        pages:
+          - title: 'Data formatter: Set default formats for numeric values'
+            path: /docs/insights/use-insights-ui/manage-account-data/data-formatter-set-default-formats-numeric-values
+      - title: Troubleshooting
+        pages:
+          - title: Pie chart with uniqueCount adds up to more than 100%
+            path: /docs/insights/use-insights-ui/troubleshooting/pie-chart-uniquecount-adds-more-100
+  - title: Insights API
+    pages:
+      - title: Insert data
+        pages:
+          - title: Insert data via Insights API
+            path: /docs/insights/insights-api/insert-data/insert-data-insights-api
+      - title: Get data
+        pages:
+          - title: Query Insights event data via API
+            path: /docs/insights/insights-api/get-data/query-insights-event-data-api
+      - title: Manage dashboards
+        pages:
+          - title: Insights Dashboard API
+            path: /docs/insights/insights-api/manage-dashboards/insights-dashboard-api
   - title: Event data sources
     pages:
-      - title: Custom events
-        pages:
-          - title: 'APM: Report custom events'
-            path: /docs/insights/event-data-sources/custom-events/apm-report-custom-events
-          - title: 'New Relic APM: Report custom attributes'
-            path: /docs/insights/event-data-sources/custom-events/new-relic-apm-report-custom-attributes
-          - title: Add custom attributes to New Relic Synthetics data
-            path: /docs/insights/insights-data-sources/custom-data/add-custom-attributes-synthetics-events
-          - title: 'New Relic Browser: Report custom events and attributes'
-            path: /docs/insights/insights-data-sources/custom-data/insert-custom-data-new-relic-browser-agent
-          - title: 'New Relic Mobile: Report custom events and attributes'
-            path: /docs/insights/insights-data-sources/custom-data/insert-custom-events-attributes-new-relic-mobile-data
-          - title: Data requirements and limits for custom event data
-            path: /docs/insights/insights-data-sources/custom-data/insights-custom-data-requirements-limits
-          - title: Report custom event data
-            path: /docs/insights/insights-data-sources/custom-data/report-custom-event-data
       - title: Default events
         pages:
           - title: Default events reported by New Relic products
             path: /docs/insights/event-data-sources/default-data/events-reported-new-relic-products
-          - title: NrAuditEvent event data and query examples
-            path: /docs/insights/event-data-sources/default-events/nrauditevent-event-data-query-examples
           - title: Events reported by New Relic APM
             path: /docs/insights/insights-data-sources/default-data/apm-default-events-insights
           - title: Events reported by New Relic Browser
@@ -39,75 +93,21 @@ pages:
             path: /docs/insights/use-insights-ui/manage-account-data/customized-security-settings-insights
           - title: Query account audit logs (NrAuditEvent)
             path: /docs/insights/use-insights-ui/manage-account-data/query-account-audit-logs-nrauditevent
-  - title: Insights API
-    pages:
-      - title: Get data
+          - title: NrAuditEvent event data and query examples
+            path: /docs/insights/event-data-sources/default-events/nrauditevent-event-data-query-examples
+      - title: Custom events
         pages:
-          - title: Query Insights event data via API
-            path: /docs/insights/insights-api/get-data/query-insights-event-data-api
-      - title: Insert data
-        pages:
-          - title: Insert data via Insights API
-            path: /docs/insights/insights-api/insert-data/insert-data-insights-api
-      - title: Manage dashboards
-        pages:
-          - title: Insights Dashboard API
-            path: /docs/insights/insights-api/manage-dashboards/insights-dashboard-api
-  - title: Use Insights UI
-    pages:
-      - title: Explore data
-        pages:
-          - title: 'Data explorer: Query and chart event data'
-            path: /docs/insights/use-insights-ui/explore-data/event-explorer-query-chart-your-event-data
-          - title: 'Metric explorer: Search and chart metric timeslice data'
-            path: /docs/insights/use-insights-ui/explore-data/metric-explorer-search-chart-metrics-sent-new-relic-agents
-          - title: 'Query page: Create and edit NRQL queries'
-            path: /docs/insights/use-insights-ui/manage-account-data/query-page-create-edit-nrql-queries
-      - title: Export data
-        pages:
-          - title: Export Insights data to CSV file
-            path: /docs/insights/use-insights-ui/export-data/export-insights-data-csv-file
-      - title: Getting started
-        pages:
-          - title: Introduction to New Relic Insights
-            path: /docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights
-      - title: Guides
-        pages:
-          - title: New Relic Insights best practices guide
-            path: /docs/insights/use-insights-ui/guides/new-relic-insights-best-practices-guide
-      - title: Manage account data
-        pages:
-          - title: 'Data formatter: Set default formats for numeric values'
-            path: /docs/insights/use-insights-ui/manage-account-data/data-formatter-set-default-formats-numeric-values
-      - title: Manage dashboards
-        pages:
-          - title: Add and customize metric charts
-            path: /docs/insights/use-insights-ui/manage-dashboards/add-customize-metric-charts
-          - title: Add and customize NRQL charts
-            path: /docs/insights/use-insights-ui/manage-dashboards/add-customize-nrql-charts
-          - title: Chart types
-            path: /docs/insights/use-insights-ui/manage-dashboards/chart-types
-          - title: Copy chart to another Insights account's dashboard
-            path: /docs/insights/use-insights-ui/manage-dashboards/copy-chart-another-insights-accounts-dashboard
-          - title: Copy Insights dashboards and charts
-            path: /docs/insights/use-insights-ui/manage-dashboards/copy-insights-dashboards-charts
-          - title: 'Data apps: Build collections of linked dashboards'
-            path: /docs/insights/use-insights-ui/manage-dashboards/data-apps-build-collections-linked-dashboards
-          - title: Delete dashboards and charts
-            path: /docs/insights/use-insights-ui/manage-dashboards/delete-dashboards-charts
-          - title: Filter Insights dashboards
-            path: /docs/insights/use-insights-ui/manage-dashboards/filter-insights-dashboards
-          - title: Chart refresh intervals
-            path: /docs/insights/use-insights-ui/manage-dashboards/insights-chart-refresh-intervals
-          - title: Insights dashboard permissions
-            path: /docs/insights/use-insights-ui/manage-dashboards/insights-dashboard-permissions
-          - title: 'View, organize, share Insights dashboards'
-            path: /docs/insights/use-insights-ui/manage-dashboards/view-organize-share-insights-dashboards
-      - title: Time settings
-        pages:
-          - title: Set time range on Insights dashboards and charts
-            path: /docs/insights/use-insights-ui/time-settings/set-time-range-insights-dashboards-charts
-      - title: Troubleshooting
-        pages:
-          - title: Pie chart with uniqueCount adds up to more than 100%
-            path: /docs/insights/use-insights-ui/troubleshooting/pie-chart-uniquecount-adds-more-100
+          - title: Report custom event data
+            path: /docs/insights/insights-data-sources/custom-data/report-custom-event-data
+          - title: Data requirements and limits for custom event data
+            path: /docs/insights/insights-data-sources/custom-data/insights-custom-data-requirements-limits
+          - title: 'APM: Report custom events'
+            path: /docs/insights/event-data-sources/custom-events/apm-report-custom-events
+          - title: 'New Relic APM: Report custom attributes'
+            path: /docs/insights/event-data-sources/custom-events/new-relic-apm-report-custom-attributes
+          - title: 'New Relic Browser: Report custom events and attributes'
+            path: /docs/insights/insights-data-sources/custom-data/insert-custom-data-new-relic-browser-agent
+          - title: 'New Relic Mobile: Report custom events and attributes'
+            path: /docs/insights/insights-data-sources/custom-data/insert-custom-events-attributes-new-relic-mobile-data
+          - title: Add custom attributes to New Relic Synthetics data
+            path: /docs/insights/insights-data-sources/custom-data/add-custom-attributes-synthetics-events

--- a/src/nav/insights.yml
+++ b/src/nav/insights.yml
@@ -5,6 +5,10 @@ pages:
     path: /docs/insights
   - title: Use Insights UI
     pages:
+      - title: Getting started
+        pages:
+          - title: Introduction to New Relic Insights
+            path: /docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights
       - title: Explore data
         pages:
           - title: 'Query page: Create and edit NRQL queries'
@@ -13,10 +17,6 @@ pages:
             path: /docs/insights/use-insights-ui/explore-data/event-explorer-query-chart-your-event-data
           - title: 'Metric explorer: Search and chart metric timeslice data'
             path: /docs/insights/use-insights-ui/explore-data/metric-explorer-search-chart-metrics-sent-new-relic-agents
-      - title: Getting started
-        pages:
-          - title: Introduction to New Relic Insights
-            path: /docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights
       - title: Guides
         pages:
           - title: New Relic Insights best practices guide

--- a/src/nav/integrations.yml
+++ b/src/nav/integrations.yml
@@ -1,20 +1,50 @@
 title: Integrations
 path: /docs/integrations
 pages:
+  - title: Kubernetes integration
+    pages:
+      - title: Get started
+        pages:
+          - title: Introduction to the Kubernetes integration
+            path: /docs/integrations/kubernetes-integration/get-started/introduction-kubernetes-integration
+      - title: Understand and use data
+        pages:
+          - title: Navigate the Kubernetes cluster explorer
+            path: /docs/integrations/kubernetes-integration/understand-use-data/kubernetes-cluster-explorer
+          - title: Find and use your Kubernetes data
+            path: /docs/integrations/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data
+      - title: Installation
+        pages:
+          - title: 'Kubernetes integration: install and configure'
+            path: /docs/integrations/kubernetes-integration/installation/kubernetes-integration-install-configure
+      - title: Troubleshooting
+        pages:
+          - title: 'Kubernetes integration troubleshooting: Not seeing data'
+            path: /docs/integrations/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-not-seeing-data
+          - title: 'Kubernetes integration troubleshooting: Error messages'
+            path: /docs/integrations/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-error-messages
+          - title: Get logs and version
+            path: /docs/integrations/kubernetes-integration/troubleshooting/get-logs-version
+          - title: Certificate signed by unknown authority
+            path: /docs/integrations/kubernetes-integration/troubleshooting/certificate-signed-unknown-authority
+          - title: Missing nodes
+            path: /docs/integrations/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-missing-nodes
+          - title: Not seeing control plane data
+            path: /docs/integrations/kubernetes-integration/troubleshooting/not-seeing-control-plane-data
   - title: Infrastructure integrations
     pages:
       - title: Get started
         pages:
-          - title: Introduction to infrastructure integrations
-            path: /docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations
+          - title: Integrations release notes
+            path: /docs/integrations/new-relic-integrations/getting-started/integrations-release-notes
           - title: Understand and use data from infrastructure integrations
             path: /docs/integrations/infrastructure-integrations/get-started/understand-use-data-infrastructure-integrations
           - title: Infrastructure integration dashboards and charts
             path: /docs/integrations/infrastructure-integrations/get-started/infrastructure-integration-dashboards-charts
           - title: Use integration data in New Relic dashboards
             path: /docs/integrations/infrastructure-integrations/get-started/use-integration-data-new-relic-dashboards
-          - title: Integrations release notes
-            path: /docs/integrations/new-relic-integrations/getting-started/integrations-release-notes
+          - title: Introduction to infrastructure integrations
+            path: /docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations
       - title: Cloud integrations
         pages:
           - title: Configure polling frequency and data collection for cloud integrations
@@ -23,6 +53,18 @@ pages:
             path: /docs/integrations/infrastructure-integrations/cloud-integrations/metric-data-gaps-cloud-integrations
   - title: Amazon integrations
     pages:
+      - title: Get started
+        pages:
+          - title: Connect AWS to New Relic infrastructure monitoring
+            path: /docs/integrations/amazon-integrations/get-started/connect-aws-infrastructure
+          - title: Understand and use integration data
+            path: /docs/infrastructure/amazon-integrations/find-use-data/understand-use-integration-data
+          - title: Polling intervals for AWS integrations
+            path: /docs/integrations/amazon-integrations/get-started/polling-intervals-aws-integrations
+          - title: Introduction to AWS integrations
+            path: /docs/integrations/amazon-integrations/get-started/introduction-aws-integrations
+          - title: Integrations and managed policies
+            path: /docs/integrations/amazon-integrations/get-started/integrations-managed-policies
       - title: AWS integrations list
         pages:
           - title: AWS ALB/NLB monitoring integration
@@ -89,18 +131,6 @@ pages:
             path: /docs/integrations/amazon-integrations/aws-integrations-list/aws-vpc-flow-logs-monitoring-integration
           - title: Amazon VPC monitoring integration
             path: /docs/integrations/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration
-      - title: Get started
-        pages:
-          - title: Introduction to AWS integrations
-            path: /docs/integrations/amazon-integrations/get-started/introduction-aws-integrations
-          - title: Connect AWS to New Relic infrastructure monitoring
-            path: /docs/integrations/amazon-integrations/get-started/connect-aws-infrastructure
-          - title: Integrations and managed policies
-            path: /docs/integrations/amazon-integrations/get-started/integrations-managed-policies
-          - title: Understand and use integration data
-            path: /docs/infrastructure/amazon-integrations/find-use-data/understand-use-integration-data
-          - title: Polling intervals for AWS integrations
-            path: /docs/integrations/amazon-integrations/get-started/polling-intervals-aws-integrations
       - title: Troubleshooting
         pages:
           - title: AWS service specific API rate limiting
@@ -119,30 +149,98 @@ pages:
             path: /docs/integrations/amazon-integrations/troubleshooting/invalid-principal-error-unsupported-aws-regions
           - title: 'Partial or missing logs for RDS, VPC, AWS Lambda'
             path: /docs/integrations/amazon-integrations/troubleshooting/partial-or-missing-logs-rds-vpc-aws-lambda
+  - title: Microsoft Azure integrations
+    pages:
+      - title: Get started
+        pages:
+          - title: Activate Azure integrations
+            path: /docs/integrations/microsoft-azure-integrations/getting-started/activate-azure-integrations
+          - title: Understand and use integration data
+            path: /docs/infrastructure/microsoft-azure-integrations/find-use-data/understand-use-integration-data
+          - title: Polling intervals for Azure integrations
+            path: /docs/integrations/microsoft-azure-integrations/getting-started/polling-intervals-azure-integrations
+          - title: Introduction to Azure monitoring integrations
+            path: /docs/integrations/microsoft-azure-integrations/getting-started/introduction-azure-monitoring-integrations
+      - title: Azure integrations list
+        pages:
+          - title: Azure App Service monitoring integration
+            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-app-service-monitoring-integration
+          - title: Azure Cosmos DB (Document DB) monitoring integration
+            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-cosmos-db-document-db-monitoring-integration
+          - title: Azure Functions monitoring integration
+            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-functions-monitoring-integration
+          - title: Azure Load Balancer monitoring integration
+            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-load-balancer-monitoring-integration
+          - title: Azure Redis Cache monitoring integration
+            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-redis-cache-monitoring-integration
+          - title: Azure Service Bus monitoring integration
+            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-service-bus-monitoring-integration
+          - title: Azure SQL Database monitoring integration
+            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-sql-database-monitoring-integration
+          - title: Azure Storage monitoring integration
+            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-storage-monitoring-integration
+          - title: Azure Virtual Network monitoring integration
+            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-virtual-network-monitoring-integration
+          - title: Azure VMs monitoring integration
+            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-vms-monitoring-integration
+          - title: Azure Data Factory monitoring integration
+            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-data-factory-integration
+          - title: Azure Firewalls monitoring integration
+            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-firewalls-monitoring-integration
+  - title: Google Cloud Platform integrations
+    pages:
+      - title: Get started
+        pages:
+          - title: Connect Google Cloud Platform services to New Relic
+            path: /docs/integrations/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic
+          - title: Polling intervals for GCP integrations
+            path: /docs/integrations/google-cloud-platform-integrations/getting-started/polling-intervals-gcp-integrations
+          - title: Introduction to Google Cloud Platform integrations
+            path: /docs/integrations/google-cloud-platform-integrations/getting-started/introduction-google-cloud-platform-integrations
+      - title: GCP integrations list
+        pages:
+          - title: Google App Engine monitoring integration
+            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-app-engine-monitoring-integration
+          - title: Google BigQuery monitoring integration
+            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration
+          - title: Google Cloud Functions monitoring integration
+            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-functions-monitoring-integration
+          - title: Google Cloud Load Balancing monitoring integration
+            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-load-balancing-monitoring-integration
+          - title: Google Cloud Pub/Sub monitoring integration
+            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration
+          - title: Google Cloud Spanner monitoring integration
+            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-spanner-monitoring-integration
+          - title: Google Cloud SQL monitoring integration
+            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-sql-monitoring-integration
+          - title: Google Cloud Storage monitoring integration
+            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-storage-monitoring-integration
+          - title: Google Kubernetes Engine monitoring integration
+            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-kubernetes-engine-monitoring-integration
+          - title: Google Cloud Firestore monitoring integration
+            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firestore-monitoring-integration
+      - title: Troubleshooting
+        pages:
+          - title: 'GCP integration: API authentication errors'
+            path: /docs/integrations/google-cloud-platform-integrations/troubleshooting/gcp-integration-api-authentication-errors
   - title: On-host integrations
     pages:
+      - title: Get started
+        pages:
+          - title: Introduction to on-host integrations
+            path: /docs/integrations/host-integrations/getting-started/introduction-host-integrations
       - title: Installation
         pages:
           - title: Install infrastructure on-host integrations
             path: /docs/integrations/host-integrations/installation/install-infrastructure-host-integrations
           - title: Update infrastructure on-host integrations
             path: /docs/integrations/host-integrations/installation/update-infrastructure-host-integration-package
-      - title: Get started
-        pages:
-          - title: Introduction to on-host integrations
-            path: /docs/integrations/host-integrations/getting-started/introduction-host-integrations
       - title: Understand and use data
         pages:
           - title: Understand and use data
             path: /docs/infrastructure/host-integrations/find-use-data/understand-use-data
           - title: On-host integration data collection and reporting
             path: /docs/integrations/host-integrations/understand-use-data/host-integration-data-collection-reporting
-      - title: Troubleshooting
-        pages:
-          - title: Not seeing on-host integration data
-            path: /docs/integrations/host-integrations/troubleshooting/not-seeing-host-integration-data
-          - title: Pass Infrastructure agent parameters to an on-host integration
-            path: /docs/integrations/host-integrations/troubleshooting/pass-infrastructure-agent-parameters-host-integration
       - title: On-host integrations list
         pages:
           - title: Apache monitoring integration
@@ -205,112 +303,18 @@ pages:
             path: /docs/integrations/host-integrations/host-integrations-list/windows-event-log-integration
           - title: Zookeeper monitoring integration
             path: /docs/integrations/host-integrations/host-integrations-list/zookeeper-monitoring-integration
-  - title: Microsoft Azure integrations
-    pages:
-      - title: Get started
-        pages:
-          - title: Introduction to Azure monitoring integrations
-            path: /docs/integrations/microsoft-azure-integrations/getting-started/introduction-azure-monitoring-integrations
-          - title: Activate Azure integrations
-            path: /docs/integrations/microsoft-azure-integrations/getting-started/activate-azure-integrations
-          - title: Understand and use integration data
-            path: /docs/infrastructure/microsoft-azure-integrations/find-use-data/understand-use-integration-data
-          - title: Polling intervals for Azure integrations
-            path: /docs/integrations/microsoft-azure-integrations/getting-started/polling-intervals-azure-integrations
-      - title: Azure integrations list
-        pages:
-          - title: Azure App Service monitoring integration
-            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-app-service-monitoring-integration
-          - title: Azure Cosmos DB (Document DB) monitoring integration
-            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-cosmos-db-document-db-monitoring-integration
-          - title: Azure Functions monitoring integration
-            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-functions-monitoring-integration
-          - title: Azure Load Balancer monitoring integration
-            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-load-balancer-monitoring-integration
-          - title: Azure Redis Cache monitoring integration
-            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-redis-cache-monitoring-integration
-          - title: Azure Service Bus monitoring integration
-            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-service-bus-monitoring-integration
-          - title: Azure SQL Database monitoring integration
-            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-sql-database-monitoring-integration
-          - title: Azure Storage monitoring integration
-            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-storage-monitoring-integration
-          - title: Azure Virtual Network monitoring integration
-            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-virtual-network-monitoring-integration
-          - title: Azure VMs monitoring integration
-            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-vms-monitoring-integration
-          - title: Azure Data Factory monitoring integration
-            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-data-factory-integration
-          - title: Azure Firewalls monitoring integration
-            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-firewalls-monitoring-integration
-  - title: Google Cloud Platform integrations
-    pages:
-      - title: Get started
-        pages:
-          - title: Introduction to Google Cloud Platform integrations
-            path: /docs/integrations/google-cloud-platform-integrations/getting-started/introduction-google-cloud-platform-integrations
-          - title: Connect Google Cloud Platform services to New Relic
-            path: /docs/integrations/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic
-          - title: Polling intervals for GCP integrations
-            path: /docs/integrations/google-cloud-platform-integrations/getting-started/polling-intervals-gcp-integrations
-      - title: GCP integrations list
-        pages:
-          - title: Google App Engine monitoring integration
-            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-app-engine-monitoring-integration
-          - title: Google BigQuery monitoring integration
-            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration
-          - title: Google Cloud Functions monitoring integration
-            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-functions-monitoring-integration
-          - title: Google Cloud Load Balancing monitoring integration
-            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-load-balancing-monitoring-integration
-          - title: Google Cloud Pub/Sub monitoring integration
-            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration
-          - title: Google Cloud Spanner monitoring integration
-            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-spanner-monitoring-integration
-          - title: Google Cloud SQL monitoring integration
-            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-sql-monitoring-integration
-          - title: Google Cloud Storage monitoring integration
-            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-storage-monitoring-integration
-          - title: Google Kubernetes Engine monitoring integration
-            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-kubernetes-engine-monitoring-integration
-          - title: Google Cloud Firestore monitoring integration
-            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firestore-monitoring-integration
       - title: Troubleshooting
         pages:
-          - title: 'GCP integration: API authentication errors'
-            path: /docs/integrations/google-cloud-platform-integrations/troubleshooting/gcp-integration-api-authentication-errors
-  - title: Kubernetes integration
-    pages:
-      - title: Understand and use data
-        pages:
-          - title: Navigate the Kubernetes cluster explorer
-            path: /docs/integrations/kubernetes-integration/understand-use-data/kubernetes-cluster-explorer
-          - title: Find and use your Kubernetes data
-            path: /docs/integrations/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data
-      - title: Get started
-        pages:
-          - title: Introduction to the Kubernetes integration
-            path: /docs/integrations/kubernetes-integration/get-started/introduction-kubernetes-integration
-      - title: Troubleshooting
-        pages:
-          - title: 'Kubernetes integration troubleshooting: Not seeing data'
-            path: /docs/integrations/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-not-seeing-data
-          - title: 'Kubernetes integration troubleshooting: Error messages'
-            path: /docs/integrations/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-error-messages
-          - title: Get logs and version
-            path: /docs/integrations/kubernetes-integration/troubleshooting/get-logs-version
-          - title: Certificate signed by unknown authority
-            path: /docs/integrations/kubernetes-integration/troubleshooting/certificate-signed-unknown-authority
-          - title: Missing nodes
-            path: /docs/integrations/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-missing-nodes
-          - title: Not seeing control plane data
-            path: /docs/integrations/kubernetes-integration/troubleshooting/not-seeing-control-plane-data
-      - title: Installation
-        pages:
-          - title: 'Kubernetes integration: install and configure'
-            path: /docs/integrations/kubernetes-integration/installation/kubernetes-integration-install-configure
+          - title: Pass Infrastructure agent parameters to an on-host integration
+            path: /docs/integrations/host-integrations/troubleshooting/pass-infrastructure-agent-parameters-host-integration
+          - title: Not seeing on-host integration data
+            path: /docs/integrations/host-integrations/troubleshooting/not-seeing-host-integration-data
   - title: Prometheus integrations
     pages:
+      - title: Install and configure OpenMetrics
+        pages:
+          - title: Configure Prometheus OpenMetrics integrations
+            path: /docs/integrations/prometheus-integrations/install-configure-openmetrics/configure-prometheus-openmetrics-integrations
       - title: Troubleshooting
         pages:
           - title: No data appears (Prometheus integration)
@@ -325,10 +329,12 @@ pages:
             path: /docs/integrations/prometheus-integrations/troubleshooting/rate-limit-errors-prometheus-integration
           - title: Restarts and gaps in data (Kubernetes)
             path: /docs/integrations/prometheus-integrations/troubleshooting/restarts-gaps-data-kubernetes
-      - title: Install and configure OpenMetrics
+  - title: Grafana integrations
+    pages:
+      - title: Set up and configure
         pages:
-          - title: Configure Prometheus OpenMetrics integrations
-            path: /docs/integrations/prometheus-integrations/install-configure-openmetrics/configure-prometheus-openmetrics-integrations
+          - title: Configure New Relic as a Prometheus data source for Grafana
+            path: /docs/integrations/grafana-integrations/set-configure/configure-new-relic-prometheus-data-source-grafana
   - title: Elastic Container Service integration
     pages:
       - title: Troubleshooting
@@ -337,9 +343,3 @@ pages:
             path: /docs/integrations/elastic-container-service-integration/troubleshooting/ecs-integration-troubleshooting-no-data-appears
           - title: 'ECS integration troubleshooting: Generate verbose logs'
             path: /docs/integrations/elastic-container-service-integration/troubleshooting/ecs-integration-troubleshooting-generate-verbose-logs
-  - title: Grafana integrations
-    pages:
-      - title: Set up and configure
-        pages:
-          - title: Configure New Relic as a Prometheus data source for Grafana
-            path: /docs/integrations/grafana-integrations/set-configure/configure-new-relic-prometheus-data-source-grafana

--- a/src/nav/integrations.yml
+++ b/src/nav/integrations.yml
@@ -1,24 +1,30 @@
 title: Integrations
 path: /docs/integrations
 pages:
-  - title: Amazon integrations
+  - title: Infrastructure integrations
     pages:
       - title: Get started
         pages:
-          - title: Understand and use integration data
-            path: /docs/infrastructure/amazon-integrations/find-use-data/understand-use-integration-data
-          - title: Connect AWS to New Relic infrastructure monitoring
-            path: /docs/integrations/amazon-integrations/get-started/connect-aws-infrastructure
-          - title: Integrations and managed policies
-            path: /docs/integrations/amazon-integrations/get-started/integrations-managed-policies
-          - title: Introduction to AWS integrations
-            path: /docs/integrations/amazon-integrations/get-started/introduction-aws-integrations
-          - title: Polling intervals for AWS integrations
-            path: /docs/integrations/amazon-integrations/get-started/polling-intervals-aws-integrations
+          - title: Introduction to infrastructure integrations
+            path: /docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations
+          - title: Understand and use data from infrastructure integrations
+            path: /docs/integrations/infrastructure-integrations/get-started/understand-use-data-infrastructure-integrations
+          - title: Infrastructure integration dashboards and charts
+            path: /docs/integrations/infrastructure-integrations/get-started/infrastructure-integration-dashboards-charts
+          - title: Use integration data in New Relic dashboards
+            path: /docs/integrations/infrastructure-integrations/get-started/use-integration-data-new-relic-dashboards
+          - title: Integrations release notes
+            path: /docs/integrations/new-relic-integrations/getting-started/integrations-release-notes
+      - title: Cloud integrations
+        pages:
+          - title: Configure polling frequency and data collection for cloud integrations
+            path: /docs/integrations/infrastructure-integrations/cloud-integrations/configure-polling-frequency-data-collection-cloud-integrations
+          - title: Metric data gaps with cloud integrations
+            path: /docs/integrations/infrastructure-integrations/cloud-integrations/metric-data-gaps-cloud-integrations
+  - title: Amazon integrations
+    pages:
       - title: AWS integrations list
         pages:
-          - title: Amazon SQS monitoring integration
-            path: /docs/integrations/amazon-integrations/aws-integrations-list/amazon-sqs-monitoring-integration
           - title: AWS ALB/NLB monitoring integration
             path: /docs/integrations/amazon-integrations/aws-integrations-list/aws-albnlb-monitoring-integration
           - title: Amazon API Gateway monitoring integration
@@ -77,50 +83,76 @@ pages:
             path: /docs/integrations/amazon-integrations/aws-integrations-list/aws-simple-email-service-ses-monitoring-integration
           - title: Amazon SNS monitoring integration
             path: /docs/integrations/amazon-integrations/aws-integrations-list/aws-sns-monitoring-integration
+          - title: Amazon SQS monitoring integration
+            path: /docs/integrations/amazon-integrations/aws-integrations-list/amazon-sqs-monitoring-integration
           - title: Amazon VPC Flow Logs monitoring integration
             path: /docs/integrations/amazon-integrations/aws-integrations-list/aws-vpc-flow-logs-monitoring-integration
           - title: Amazon VPC monitoring integration
             path: /docs/integrations/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration
+      - title: Get started
+        pages:
+          - title: Introduction to AWS integrations
+            path: /docs/integrations/amazon-integrations/get-started/introduction-aws-integrations
+          - title: Connect AWS to New Relic infrastructure monitoring
+            path: /docs/integrations/amazon-integrations/get-started/connect-aws-infrastructure
+          - title: Integrations and managed policies
+            path: /docs/integrations/amazon-integrations/get-started/integrations-managed-policies
+          - title: Understand and use integration data
+            path: /docs/infrastructure/amazon-integrations/find-use-data/understand-use-integration-data
+          - title: Polling intervals for AWS integrations
+            path: /docs/integrations/amazon-integrations/get-started/polling-intervals-aws-integrations
       - title: Troubleshooting
         pages:
-          - title: Rate limit alerts from Amazon
-            path: /docs/integrations/amazon-integrations/aws-integrations-list/rate-limit-alerts-amazon
           - title: AWS service specific API rate limiting
             path: /docs/integrations/amazon-integrations/troubleshooting/aws-service-specific-api-rate-limiting
           - title: Cannot create alert condition for infrastructure integration
             path: /docs/integrations/amazon-integrations/troubleshooting/cannot-create-alert-condition-infrastructure-integration
           - title: CloudWatch billing increase
             path: /docs/integrations/amazon-integrations/troubleshooting/cloudwatch-billing-increase
-          - title: '"Invalid principal" error for unsupported AWS regions'
-            path: /docs/integrations/amazon-integrations/troubleshooting/invalid-principal-error-unsupported-aws-regions
           - title: Metric data delays in Amazon AWS integrations
             path: /docs/integrations/amazon-integrations/troubleshooting/metric-data-delays-amazon-aws-integrations
           - title: No data appears (AWS integrations)
             path: /docs/integrations/amazon-integrations/troubleshooting/no-data-appears-aws-integrations
+          - title: Rate limit alerts from Amazon
+            path: /docs/integrations/amazon-integrations/aws-integrations-list/rate-limit-alerts-amazon
+          - title: '"Invalid principal" error for unsupported AWS regions'
+            path: /docs/integrations/amazon-integrations/troubleshooting/invalid-principal-error-unsupported-aws-regions
           - title: 'Partial or missing logs for RDS, VPC, AWS Lambda'
             path: /docs/integrations/amazon-integrations/troubleshooting/partial-or-missing-logs-rds-vpc-aws-lambda
   - title: On-host integrations
     pages:
+      - title: Installation
+        pages:
+          - title: Install infrastructure on-host integrations
+            path: /docs/integrations/host-integrations/installation/install-infrastructure-host-integrations
+          - title: Update infrastructure on-host integrations
+            path: /docs/integrations/host-integrations/installation/update-infrastructure-host-integration-package
+      - title: Get started
+        pages:
+          - title: Introduction to on-host integrations
+            path: /docs/integrations/host-integrations/getting-started/introduction-host-integrations
       - title: Understand and use data
         pages:
           - title: Understand and use data
             path: /docs/infrastructure/host-integrations/find-use-data/understand-use-data
           - title: On-host integration data collection and reporting
             path: /docs/integrations/host-integrations/understand-use-data/host-integration-data-collection-reporting
-      - title: Get started
+      - title: Troubleshooting
         pages:
-          - title: Introduction to on-host integrations
-            path: /docs/integrations/host-integrations/getting-started/introduction-host-integrations
+          - title: Not seeing on-host integration data
+            path: /docs/integrations/host-integrations/troubleshooting/not-seeing-host-integration-data
+          - title: Pass Infrastructure agent parameters to an on-host integration
+            path: /docs/integrations/host-integrations/troubleshooting/pass-infrastructure-agent-parameters-host-integration
       - title: On-host integrations list
         pages:
           - title: Apache monitoring integration
             path: /docs/integrations/host-integrations/host-integrations-list/apache-monitoring-integration
           - title: Cassandra monitoring integration
             path: /docs/integrations/host-integrations/host-integrations-list/cassandra-monitoring-integration
-          - title: Collectd monitoring integration
-            path: /docs/integrations/host-integrations/host-integrations-list/collectd-integration
           - title: Couchbase monitoring integration
             path: /docs/integrations/host-integrations/host-integrations-list/couchbase-monitoring-integration
+          - title: Collectd monitoring integration
+            path: /docs/integrations/host-integrations/host-integrations-list/collectd-integration
           - title: Elasticsearch monitoring integration
             path: /docs/integrations/host-integrations/host-integrations-list/elasticsearch-monitoring-integration
           - title: F5 monitoring integration
@@ -137,10 +169,10 @@ pages:
             path: /docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration
           - title: Memcached monitoring integration
             path: /docs/integrations/host-integrations/host-integrations-list/memcached-monitoring-integration
-          - title: Microsoft SQL Server monitoring integration
-            path: /docs/integrations/host-integrations/host-integrations-list/microsoft-sql-server-monitoring-integration
           - title: MongoDB monitoring integration
             path: /docs/integrations/host-integrations/host-integrations-list/mongodb-monitoring-integration
+          - title: Microsoft SQL Server monitoring integration
+            path: /docs/integrations/host-integrations/host-integrations-list/microsoft-sql-server-monitoring-integration
           - title: MySQL monitoring integration
             path: /docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration
           - title: Nagios monitoring integration
@@ -151,10 +183,10 @@ pages:
             path: /docs/integrations/host-integrations/host-integrations-list/oracledatabase-monitoring-integration
           - title: PerfMon monitoring integration
             path: /docs/integrations/host-integrations/host-integrations-list/perfmon-integration
-          - title: Port monitoring integration
-            path: /docs/integrations/host-integrations/host-integrations-list/port-monitoring-integration
           - title: PostgreSQL monitoring integration
             path: /docs/integrations/host-integrations/host-integrations-list/postgresql-monitoring-integration
+          - title: Port monitoring integration
+            path: /docs/integrations/host-integrations/host-integrations-list/port-monitoring-integration
           - title: RabbitMQ monitoring integration
             path: /docs/integrations/host-integrations/host-integrations-list/rabbitmq-monitoring-integration
           - title: Redis monitoring integration
@@ -173,28 +205,16 @@ pages:
             path: /docs/integrations/host-integrations/host-integrations-list/windows-event-log-integration
           - title: Zookeeper monitoring integration
             path: /docs/integrations/host-integrations/host-integrations-list/zookeeper-monitoring-integration
-      - title: Installation
-        pages:
-          - title: Install infrastructure on-host integrations
-            path: /docs/integrations/host-integrations/installation/install-infrastructure-host-integrations
-          - title: Update infrastructure on-host integrations
-            path: /docs/integrations/host-integrations/installation/update-infrastructure-host-integration-package
-      - title: Troubleshooting
-        pages:
-          - title: Not seeing on-host integration data
-            path: /docs/integrations/host-integrations/troubleshooting/not-seeing-host-integration-data
-          - title: Pass Infrastructure agent parameters to an on-host integration
-            path: /docs/integrations/host-integrations/troubleshooting/pass-infrastructure-agent-parameters-host-integration
   - title: Microsoft Azure integrations
     pages:
       - title: Get started
         pages:
-          - title: Understand and use integration data
-            path: /docs/infrastructure/microsoft-azure-integrations/find-use-data/understand-use-integration-data
-          - title: Activate Azure integrations
-            path: /docs/integrations/microsoft-azure-integrations/getting-started/activate-azure-integrations
           - title: Introduction to Azure monitoring integrations
             path: /docs/integrations/microsoft-azure-integrations/getting-started/introduction-azure-monitoring-integrations
+          - title: Activate Azure integrations
+            path: /docs/integrations/microsoft-azure-integrations/getting-started/activate-azure-integrations
+          - title: Understand and use integration data
+            path: /docs/infrastructure/microsoft-azure-integrations/find-use-data/understand-use-integration-data
           - title: Polling intervals for Azure integrations
             path: /docs/integrations/microsoft-azure-integrations/getting-started/polling-intervals-azure-integrations
       - title: Azure integrations list
@@ -203,10 +223,6 @@ pages:
             path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-app-service-monitoring-integration
           - title: Azure Cosmos DB (Document DB) monitoring integration
             path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-cosmos-db-document-db-monitoring-integration
-          - title: Azure Data Factory monitoring integration
-            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-data-factory-integration
-          - title: Azure Firewalls monitoring integration
-            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-firewalls-monitoring-integration
           - title: Azure Functions monitoring integration
             path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-functions-monitoring-integration
           - title: Azure Load Balancer monitoring integration
@@ -223,24 +239,26 @@ pages:
             path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-virtual-network-monitoring-integration
           - title: Azure VMs monitoring integration
             path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-vms-monitoring-integration
-  - title: Elastic Container Service integration
-    pages:
-      - title: Troubleshooting
-        pages:
-          - title: 'ECS integration troubleshooting: Generate verbose logs'
-            path: /docs/integrations/elastic-container-service-integration/troubleshooting/ecs-integration-troubleshooting-generate-verbose-logs
-          - title: 'ECS integration troubleshooting: No data appears'
-            path: /docs/integrations/elastic-container-service-integration/troubleshooting/ecs-integration-troubleshooting-no-data-appears
+          - title: Azure Data Factory monitoring integration
+            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-data-factory-integration
+          - title: Azure Firewalls monitoring integration
+            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-firewalls-monitoring-integration
   - title: Google Cloud Platform integrations
     pages:
+      - title: Get started
+        pages:
+          - title: Introduction to Google Cloud Platform integrations
+            path: /docs/integrations/google-cloud-platform-integrations/getting-started/introduction-google-cloud-platform-integrations
+          - title: Connect Google Cloud Platform services to New Relic
+            path: /docs/integrations/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic
+          - title: Polling intervals for GCP integrations
+            path: /docs/integrations/google-cloud-platform-integrations/getting-started/polling-intervals-gcp-integrations
       - title: GCP integrations list
         pages:
           - title: Google App Engine monitoring integration
             path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-app-engine-monitoring-integration
           - title: Google BigQuery monitoring integration
             path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration
-          - title: Google Cloud Firestore monitoring integration
-            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firestore-monitoring-integration
           - title: Google Cloud Functions monitoring integration
             path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-functions-monitoring-integration
           - title: Google Cloud Load Balancing monitoring integration
@@ -255,89 +273,73 @@ pages:
             path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-storage-monitoring-integration
           - title: Google Kubernetes Engine monitoring integration
             path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-kubernetes-engine-monitoring-integration
-      - title: Get started
-        pages:
-          - title: Connect Google Cloud Platform services to New Relic
-            path: /docs/integrations/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic
-          - title: Introduction to Google Cloud Platform integrations
-            path: /docs/integrations/google-cloud-platform-integrations/getting-started/introduction-google-cloud-platform-integrations
-          - title: Polling intervals for GCP integrations
-            path: /docs/integrations/google-cloud-platform-integrations/getting-started/polling-intervals-gcp-integrations
+          - title: Google Cloud Firestore monitoring integration
+            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firestore-monitoring-integration
       - title: Troubleshooting
         pages:
           - title: 'GCP integration: API authentication errors'
             path: /docs/integrations/google-cloud-platform-integrations/troubleshooting/gcp-integration-api-authentication-errors
-  - title: Grafana integrations
-    pages:
-      - title: Set up and configure
-        pages:
-          - title: Configure New Relic as a Prometheus data source for Grafana
-            path: /docs/integrations/grafana-integrations/set-configure/configure-new-relic-prometheus-data-source-grafana
-  - title: Infrastructure integrations
-    pages:
-      - title: Cloud integrations
-        pages:
-          - title: Configure polling frequency and data collection for cloud integrations
-            path: /docs/integrations/infrastructure-integrations/cloud-integrations/configure-polling-frequency-data-collection-cloud-integrations
-          - title: Metric data gaps with cloud integrations
-            path: /docs/integrations/infrastructure-integrations/cloud-integrations/metric-data-gaps-cloud-integrations
-      - title: Get started
-        pages:
-          - title: Infrastructure integration dashboards and charts
-            path: /docs/integrations/infrastructure-integrations/get-started/infrastructure-integration-dashboards-charts
-          - title: Introduction to infrastructure integrations
-            path: /docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations
-          - title: Understand and use data from infrastructure integrations
-            path: /docs/integrations/infrastructure-integrations/get-started/understand-use-data-infrastructure-integrations
-          - title: Use integration data in New Relic dashboards
-            path: /docs/integrations/infrastructure-integrations/get-started/use-integration-data-new-relic-dashboards
-          - title: Integrations release notes
-            path: /docs/integrations/new-relic-integrations/getting-started/integrations-release-notes
   - title: Kubernetes integration
     pages:
+      - title: Understand and use data
+        pages:
+          - title: Navigate the Kubernetes cluster explorer
+            path: /docs/integrations/kubernetes-integration/understand-use-data/kubernetes-cluster-explorer
+          - title: Find and use your Kubernetes data
+            path: /docs/integrations/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data
       - title: Get started
         pages:
           - title: Introduction to the Kubernetes integration
             path: /docs/integrations/kubernetes-integration/get-started/introduction-kubernetes-integration
+      - title: Troubleshooting
+        pages:
+          - title: 'Kubernetes integration troubleshooting: Not seeing data'
+            path: /docs/integrations/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-not-seeing-data
+          - title: 'Kubernetes integration troubleshooting: Error messages'
+            path: /docs/integrations/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-error-messages
+          - title: Get logs and version
+            path: /docs/integrations/kubernetes-integration/troubleshooting/get-logs-version
+          - title: Certificate signed by unknown authority
+            path: /docs/integrations/kubernetes-integration/troubleshooting/certificate-signed-unknown-authority
+          - title: Missing nodes
+            path: /docs/integrations/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-missing-nodes
+          - title: Not seeing control plane data
+            path: /docs/integrations/kubernetes-integration/troubleshooting/not-seeing-control-plane-data
       - title: Installation
         pages:
           - title: 'Kubernetes integration: install and configure'
             path: /docs/integrations/kubernetes-integration/installation/kubernetes-integration-install-configure
-      - title: Troubleshooting
-        pages:
-          - title: Get logs and version
-            path: /docs/integrations/kubernetes-integration/troubleshooting/get-logs-version
-          - title: 'Kubernetes integration troubleshooting: Error messages'
-            path: /docs/integrations/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-error-messages
-          - title: Missing nodes
-            path: /docs/integrations/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-missing-nodes
-          - title: 'Kubernetes integration troubleshooting: Not seeing data'
-            path: /docs/integrations/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-not-seeing-data
-          - title: Not seeing control plane data
-            path: /docs/integrations/kubernetes-integration/troubleshooting/not-seeing-control-plane-data
-      - title: Understand and use data
-        pages:
-          - title: Find and use your Kubernetes data
-            path: /docs/integrations/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data
-          - title: Navigate the Kubernetes cluster explorer
-            path: /docs/integrations/kubernetes-integration/understand-use-data/kubernetes-cluster-explorer
   - title: Prometheus integrations
     pages:
-      - title: Install and configure OpenMetrics
-        pages:
-          - title: Configure Prometheus OpenMetrics integrations
-            path: /docs/integrations/prometheus-integrations/install-configure-openmetrics/configure-prometheus-openmetrics-integrations
       - title: Troubleshooting
         pages:
+          - title: No data appears (Prometheus integration)
+            path: /docs/integrations/prometheus-integrations/troubleshooting/no-data-appears-prometheus-integration
           - title: Debug issues with data sent to Metric API (Prometheus integration)
             path: /docs/integrations/prometheus-integrations/troubleshooting/debug-issues-data-sent-metric-api-prometheus-integration
           - title: Get logs (Prometheus integration)
             path: /docs/integrations/prometheus-integrations/troubleshooting/get-logs-prometheus-integration
           - title: Get scraper metrics (Prometheus integration)
             path: /docs/integrations/prometheus-integrations/troubleshooting/get-scraper-metrics-prometheus-integration
-          - title: No data appears (Prometheus integration)
-            path: /docs/integrations/prometheus-integrations/troubleshooting/no-data-appears-prometheus-integration
           - title: Rate limit errors (Prometheus integration)
             path: /docs/integrations/prometheus-integrations/troubleshooting/rate-limit-errors-prometheus-integration
           - title: Restarts and gaps in data (Kubernetes)
             path: /docs/integrations/prometheus-integrations/troubleshooting/restarts-gaps-data-kubernetes
+      - title: Install and configure OpenMetrics
+        pages:
+          - title: Configure Prometheus OpenMetrics integrations
+            path: /docs/integrations/prometheus-integrations/install-configure-openmetrics/configure-prometheus-openmetrics-integrations
+  - title: Elastic Container Service integration
+    pages:
+      - title: Troubleshooting
+        pages:
+          - title: 'ECS integration troubleshooting: No data appears'
+            path: /docs/integrations/elastic-container-service-integration/troubleshooting/ecs-integration-troubleshooting-no-data-appears
+          - title: 'ECS integration troubleshooting: Generate verbose logs'
+            path: /docs/integrations/elastic-container-service-integration/troubleshooting/ecs-integration-troubleshooting-generate-verbose-logs
+  - title: Grafana integrations
+    pages:
+      - title: Set up and configure
+        pages:
+          - title: Configure New Relic as a Prometheus data source for Grafana
+            path: /docs/integrations/grafana-integrations/set-configure/configure-new-relic-prometheus-data-source-grafana

--- a/src/nav/licenses.yml
+++ b/src/nav/licenses.yml
@@ -1,44 +1,12 @@
 title: Licenses
 path: /docs/licenses
 pages:
-  - title: Overview
-    path: /docs/licenses
-  - title: License information
-    pages:
-      - title: Distributed licenses
-        pages:
-          - title: FIT instrumentation end user license agreement
-            path: /docs/licenses/license-information/distributed-licenses/fit-instrumentation-end-user-license-agreement
-          - title: New Relic Agent Software Notice
-            path: /docs/licenses/license-information/distributed-licenses/new-relic-agent-software-notice
-          - title: Services licenses
-            path: /docs/licenses/license-information/other-licenses/services-licenses
-      - title: Special services licenses
-        pages:
-          - title: Data collector licenses
-            path: /docs/licenses/license-information/special-services-licenses/data-collector-licenses
-          - title: New Relic Diagnostics licenses
-            path: /docs/licenses/license-information/special-services-licenses/new-relic-diagnostics-licenses
   - title: Product or service licenses
     pages:
-      - title: Mobile app licenses
-        pages:
-          - title: Insights Android application licenses
-            path: /docs/licenses/license-information/mobile-app-licenses/insights-android-application-licenses
-          - title: Android application licenses
-            path: /docs/licenses/product-or-service-licenses/mobile-app-licenses/android-application-licenses
-          - title: Insights iOS/tvOS application licenses
-            path: /docs/licenses/product-or-service-licenses/mobile-app-licenses/insights-iostvos-application-licenses
-          - title: iOS application licenses
-            path: /docs/licenses/product-or-service-licenses/mobile-app-licenses/ios-application-licenses
-      - title: Miscellaneous
-        pages:
-          - title: Help Center and documentation licenses
-            path: /docs/licenses/product-or-service-licenses/miscellaneous/help-center-documentation-licenses
       - title: New Relic APM
         pages:
-          - title: APM Agent SDK licenses
-            path: /docs/licenses/product-or-service-licenses/new-relic-apm/apm-agent-sdk-licenses
+          - title: New Relic APM licenses
+            path: /docs/licenses/product-or-service-licenses/new-relic-apm/new-relic-apm-licenses
           - title: Java agent licenses
             path: /docs/licenses/product-or-service-licenses/new-relic-apm/java-agent-licenses
           - title: .NET agent licenses
@@ -47,8 +15,6 @@ pages:
             path: /docs/licenses/product-or-service-licenses/new-relic-apm/net-agent-microsoft-azure-portal-extension-licenses
           - title: '.NET agent: Microsoft Azure Portal Resource Provider licenses'
             path: /docs/licenses/product-or-service-licenses/new-relic-apm/net-agent-microsoft-azure-portal-resource-provider-licenses
-          - title: New Relic APM licenses
-            path: /docs/licenses/product-or-service-licenses/new-relic-apm/new-relic-apm-licenses
           - title: Node.js agent licenses
             path: /docs/licenses/product-or-service-licenses/new-relic-apm/nodejs-agent-licenses
           - title: PHP agent licenses
@@ -57,31 +23,65 @@ pages:
             path: /docs/licenses/product-or-service-licenses/new-relic-apm/python-agent-licenses
           - title: Ruby agent licenses
             path: /docs/licenses/product-or-service-licenses/new-relic-apm/ruby-agent-licenses
-      - title: New Relic Browser
+          - title: APM Agent SDK licenses
+            path: /docs/licenses/product-or-service-licenses/new-relic-apm/apm-agent-sdk-licenses
+      - title: Mobile app licenses
         pages:
-          - title: Browser agent licenses
-            path: /docs/licenses/product-or-service-licenses/new-relic-browser/browser-agent-licenses
-          - title: New Relic Browser licenses
-            path: /docs/licenses/product-or-service-licenses/new-relic-browser/new-relic-browser-licenses
-      - title: New Relic Infrastructure
-        pages:
-          - title: New Relic Infrastructure licenses
-            path: /docs/licenses/product-or-service-licenses/new-relic-infrastructure/new-relic-infrastructure-licenses
-      - title: New Relic Insights
-        pages:
-          - title: New Relic Insights licenses
-            path: /docs/licenses/product-or-service-licenses/new-relic-insights/new-relic-insights-licenses
+          - title: Android application licenses
+            path: /docs/licenses/product-or-service-licenses/mobile-app-licenses/android-application-licenses
+          - title: iOS application licenses
+            path: /docs/licenses/product-or-service-licenses/mobile-app-licenses/ios-application-licenses
+          - title: Insights Android application licenses
+            path: /docs/licenses/license-information/mobile-app-licenses/insights-android-application-licenses
+          - title: Insights iOS/tvOS application licenses
+            path: /docs/licenses/product-or-service-licenses/mobile-app-licenses/insights-iostvos-application-licenses
       - title: New Relic Mobile
         pages:
           - title: Android SDK for New Relic Mobile licenses
             path: /docs/licenses/product-or-service-licenses/new-relic-mobile/android-sdk-new-relic-mobile-licenses
           - title: iOS SDK for New Relic Mobile licenses
             path: /docs/licenses/product-or-service-licenses/new-relic-mobile/ios-sdk-new-relic-mobile-licenses
-      - title: New Relic plugins
+      - title: New Relic Browser
         pages:
-          - title: Plugins licenses
-            path: /docs/licenses/product-or-service-licenses/new-relic-plugins/plugins-licenses
+          - title: New Relic Browser licenses
+            path: /docs/licenses/product-or-service-licenses/new-relic-browser/new-relic-browser-licenses
+          - title: Browser agent licenses
+            path: /docs/licenses/product-or-service-licenses/new-relic-browser/browser-agent-licenses
       - title: New Relic Synthetics
         pages:
           - title: New Relic Synthetics licenses
             path: /docs/licenses/product-or-service-licenses/new-relic-synthetics/new-relic-synthetics-licenses
+      - title: New Relic Insights
+        pages:
+          - title: New Relic Insights licenses
+            path: /docs/licenses/product-or-service-licenses/new-relic-insights/new-relic-insights-licenses
+      - title: New Relic plugins
+        pages:
+          - title: Plugins licenses
+            path: /docs/licenses/product-or-service-licenses/new-relic-plugins/plugins-licenses
+      - title: New Relic Infrastructure
+        pages:
+          - title: New Relic Infrastructure licenses
+            path: /docs/licenses/product-or-service-licenses/new-relic-infrastructure/new-relic-infrastructure-licenses
+      - title: Miscellaneous
+        pages:
+          - title: Help Center and documentation licenses
+            path: /docs/licenses/product-or-service-licenses/miscellaneous/help-center-documentation-licenses
+  - title: License information
+    pages:
+      - title: Special services licenses
+        pages:
+          - title: Data collector licenses
+            path: /docs/licenses/license-information/special-services-licenses/data-collector-licenses
+          - title: New Relic Diagnostics licenses
+            path: /docs/licenses/license-information/special-services-licenses/new-relic-diagnostics-licenses
+      - title: Distributed licenses
+        pages:
+          - title: FIT instrumentation end user license agreement
+            path: /docs/licenses/license-information/distributed-licenses/fit-instrumentation-end-user-license-agreement
+          - title: New Relic Agent Software Notice
+            path: /docs/licenses/license-information/distributed-licenses/new-relic-agent-software-notice
+          - title: Services licenses
+            path: /docs/licenses/license-information/other-licenses/services-licenses
+  - title: Overview
+    path: /docs/licenses

--- a/src/nav/new-relic-in-practice.yml
+++ b/src/nav/new-relic-in-practice.yml
@@ -4,6 +4,24 @@ pages:
   - title: Using New Relic
     path: /docs/using-new-relic
     pages:
+      - title: Welcome to New Relic
+        pages:
+          - title: Get started
+            pages:
+              - title: Our EU and US region data centers
+                path: /docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers
+              - title: Introduction to New Relic
+                path: /docs/using-new-relic/welcome-new-relic/get-started/introduction-new-relic
+              - title: Find help and use the Support portal
+                path: /docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal
+              - title: Glossary
+                path: /docs/using-new-relic/welcome-new-relic/get-started/glossary
+          - title: New Relic University
+            pages:
+              - title: New Relic University
+                path: /nru
+          - title: Get started with New Relic
+            path: /docs/using-new-relic/welcome-new-relic
       - title: Cross-product functions
         pages:
           - title: Install and configure
@@ -38,24 +56,6 @@ pages:
                 path: /docs/using-new-relic/cross-product-functions/troubleshooting/metric-grouping-issues
               - title: Log (audit) all data your New Relic agent transmits
                 path: /docs/using-new-relic/cross-product-functions/troubleshooting/log-audit-all-data-your-new-relic-agent-transmits
-      - title: Welcome to New Relic
-        pages:
-          - title: New Relic University
-            pages:
-              - title: New Relic University
-                path: /nru
-          - title: Get started
-            pages:
-              - title: Introduction to New Relic
-                path: /docs/using-new-relic/welcome-new-relic/get-started/introduction-new-relic
-              - title: Find help and use the Support portal
-                path: /docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal
-              - title: Glossary
-                path: /docs/using-new-relic/welcome-new-relic/get-started/glossary
-              - title: Our EU and US region data centers
-                path: /docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers
-          - title: Get started with New Relic
-            path: /docs/using-new-relic/welcome-new-relic
   - title: New Relic One
     path: /docs/new-relic-one
     pages:
@@ -72,14 +72,14 @@ pages:
         pages:
           - title: Get started
             pages:
+              - title: Rate limits for NRQL queries
+                path: /docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries
               - title: 'Introduction to NRQL, New Relic''s query language'
                 path: /docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language
               - title: 'NRQL syntax, clauses, and functions'
                 path: /docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions
               - title: NRQL math using SELECT
                 path: /docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-math-using-select
-              - title: Rate limits for NRQL queries
-                path: /docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries
           - title: NRQL query tutorials
             pages:
               - title: 'Funnels: Evaluate data from a series of related events'

--- a/src/nav/new-relic-in-practice.yml
+++ b/src/nav/new-relic-in-practice.yml
@@ -14,48 +14,48 @@ pages:
                 path: /docs/using-new-relic/cross-product-functions/install-configure/compatibility-requirements-new-relic-agents-products
               - title: Configure New Relic agents
                 path: /docs/using-new-relic/cross-product-functions/install-configure/configure-agent
-              - title: Networks
-                path: /docs/using-new-relic/cross-product-functions/install-configure/networks
-              - title: Notification of changes to New Relic SaaS features and distributed software
-                path: /docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software
-              - title: Uninstall New Relic agents
-                path: /docs/using-new-relic/cross-product-functions/install-configure/uninstall-agent
               - title: Update the New Relic agent
                 path: /docs/using-new-relic/cross-product-functions/install-configure/update-new-relic-agent
               - title: Collect custom attributes
                 path: /docs/using-new-relic/data/customize-data/collect-custom-attributes
+              - title: Uninstall New Relic agents
+                path: /docs/using-new-relic/cross-product-functions/install-configure/uninstall-agent
+              - title: Networks
+                path: /docs/using-new-relic/cross-product-functions/install-configure/networks
+              - title: Notification of changes to New Relic SaaS features and distributed software
+                path: /docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software
           - title: Troubleshooting
             pages:
-              - title: Find root directory of New Relic agents
-                path: /docs/using-new-relic/cross-product-functions/troubleshooting/find-agent-root-directory
-              - title: Generate New Relic agent logs for troubleshooting
-                path: /docs/using-new-relic/cross-product-functions/troubleshooting/generate-new-relic-agent-logs-troubleshooting
-              - title: Log (audit) all data your New Relic agent transmits
-                path: /docs/using-new-relic/cross-product-functions/troubleshooting/log-audit-all-data-your-new-relic-agent-transmits
-              - title: 'Metric grouping issues (APM, browser, mobile)'
-                path: /docs/using-new-relic/cross-product-functions/troubleshooting/metric-grouping-issues
               - title: Diagnostics CLI (nrdiag)
                 path: /docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics
               - title: Not seeing data
                 path: /docs/using-new-relic/cross-product-functions/troubleshooting/not-seeing-data
+              - title: Find root directory of New Relic agents
+                path: /docs/using-new-relic/cross-product-functions/troubleshooting/find-agent-root-directory
+              - title: Generate New Relic agent logs for troubleshooting
+                path: /docs/using-new-relic/cross-product-functions/troubleshooting/generate-new-relic-agent-logs-troubleshooting
+              - title: 'Metric grouping issues (APM, browser, mobile)'
+                path: /docs/using-new-relic/cross-product-functions/troubleshooting/metric-grouping-issues
+              - title: Log (audit) all data your New Relic agent transmits
+                path: /docs/using-new-relic/cross-product-functions/troubleshooting/log-audit-all-data-your-new-relic-agent-transmits
       - title: Welcome to New Relic
         pages:
-          - title: Get started
-            pages:
-              - title: Find help and use the Support portal
-                path: /docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal
-              - title: Glossary
-                path: /docs/using-new-relic/welcome-new-relic/get-started/glossary
-              - title: Introduction to New Relic
-                path: /docs/using-new-relic/welcome-new-relic/get-started/introduction-new-relic
-              - title: Our EU and US region data centers
-                path: /docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers
-          - title: Get started with New Relic
-            path: /docs/using-new-relic/welcome-new-relic
           - title: New Relic University
             pages:
               - title: New Relic University
                 path: /nru
+          - title: Get started
+            pages:
+              - title: Introduction to New Relic
+                path: /docs/using-new-relic/welcome-new-relic/get-started/introduction-new-relic
+              - title: Find help and use the Support portal
+                path: /docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal
+              - title: Glossary
+                path: /docs/using-new-relic/welcome-new-relic/get-started/glossary
+              - title: Our EU and US region data centers
+                path: /docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers
+          - title: Get started with New Relic
+            path: /docs/using-new-relic/welcome-new-relic
   - title: New Relic One
     path: /docs/new-relic-one
     pages:
@@ -74,64 +74,64 @@ pages:
             pages:
               - title: 'Introduction to NRQL, New Relic''s query language'
                 path: /docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language
-              - title: NRQL math using SELECT
-                path: /docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-math-using-select
               - title: 'NRQL syntax, clauses, and functions'
                 path: /docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions
+              - title: NRQL math using SELECT
+                path: /docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-math-using-select
               - title: Rate limits for NRQL queries
                 path: /docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries
           - title: NRQL query tutorials
             pages:
-              - title: App data NRQL query examples
-                path: /docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/app-data-nrql-query-examples
-              - title: Browser/SPA NRQL query examples
-                path: /docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/browserspa-nrql-query-examples
               - title: 'Funnels: Evaluate data from a series of related events'
                 path: /docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/funnels-evaluate-data-series-related-events
+              - title: Simulate SQL JOIN functions in Insights
+                path: /docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/simulate-sql-join-functions-insights
+              - title: 'NRQL: Segment your data into buckets'
+                path: /docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/nrql-segment-your-data-buckets
               - title: 'NRQL: Group results across time'
                 path: /docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/nrql-group-results-across-time
               - title: NRQL query examples for Mobile monitoring
                 path: /docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/nrql-query-examples-mobile-monitoring
-              - title: 'NRQL: Segment your data into buckets'
-                path: /docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/nrql-segment-your-data-buckets
-              - title: Simulate SQL JOIN functions in Insights
-                path: /docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/simulate-sql-join-functions-insights
+              - title: App data NRQL query examples
+                path: /docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/app-data-nrql-query-examples
+              - title: Browser/SPA NRQL query examples
+                path: /docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/browserspa-nrql-query-examples
   - title: Mobile apps
     path: /docs/mobile-apps
     pages:
       - title: New Relic Mobile apps
         pages:
+          - title: iOS app
+            pages:
+              - title: Introduction to iOS mobile app
+                path: /docs/mobile-apps/new-relic-mobile-apps/ios-app/introduction-ios-mobile-app
+              - title: Install the New Relic iOS mobile app
+                path: /docs/mobile-apps/new-relic-mobile-apps/ios-app/install-new-relic-ios-mobile-app
           - title: Android app
             pages:
-              - title: Android app UI
-                path: /docs/mobile-apps/new-relic-mobile-apps/android-app/android-app-ui
               - title: Introduction to New Relic Android app
                 path: /docs/mobile-apps/new-relic-mobile-apps/android-app/introduction-new-relic-android-app
+              - title: Android app UI
+                path: /docs/mobile-apps/new-relic-mobile-apps/android-app/android-app-ui
           - title: Authentication and alerts
             pages:
               - title: Alerting with New Relic mobile apps
                 path: /docs/mobile-apps/new-relic-mobile-apps/authentication-alerts/alerting-new-relic-mobile-apps
-              - title: Troubleshoot SSO accounts using mobile devices
-                path: /docs/mobile-apps/new-relic-mobile-apps/authentication-alerts/troubleshoot-sso-accounts-using-mobile-devices
               - title: User settings and authentication
                 path: /docs/mobile-apps/new-relic-mobile-apps/authentication-alerts/user-settings-authentication
               - title: Authentication with partner and SAML-SSO accounts
                 path: /docs/mobile-monitoring/new-relic-mobile-apps/mobile-app-features/authentication-partner-saml-sso-accounts
+              - title: Troubleshoot SSO accounts using mobile devices
+                path: /docs/mobile-apps/new-relic-mobile-apps/authentication-alerts/troubleshoot-sso-accounts-using-mobile-devices
           - title: Insights app
             pages:
-              - title: Insights for Android release notes
-                path: /docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-android-release-notes
               - title: Insights app for Android and iOS
                 path: /docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-app-android-ios
               - title: Insights app for Apple TV
                 path: /docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-app-apple-tv
               - title: Insights for iOS release notes
                 path: /docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-ios-release-notes
+              - title: Insights for Android release notes
+                path: /docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-android-release-notes
               - title: Insights for tvOS release notes
                 path: /docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-tvos-release-notes
-          - title: iOS app
-            pages:
-              - title: Install the New Relic iOS mobile app
-                path: /docs/mobile-apps/new-relic-mobile-apps/ios-app/install-new-relic-ios-mobile-app
-              - title: Introduction to iOS mobile app
-                path: /docs/mobile-apps/new-relic-mobile-apps/ios-app/introduction-ios-mobile-app

--- a/src/nav/new-relic-only.yml
+++ b/src/nav/new-relic-only.yml
@@ -2,10 +2,104 @@ title: New Relic only
 path: /docs/new-relic-only
 rootNav: false
 pages:
+  - title: Tech writer style guide
+    pages:
+      - title: API writing guidelines
+        pages:
+          - title: API tutorial template
+            path: /docs/new-relic-only/tech-writer-style-guide/writing-guidelines/api-tutorial-template
+          - title: apiStyleGuidelines (Example agent API)
+            path: /docs/new-relic-only/tech-writer-style-guide/writing-guidelines/apistyleguidelines-example-agent-api
+      - title: Processes and procedures
+        pages:
+          - title: Use content types and text formats
+            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/use-content-types-text-formats
+          - title: Docs site edit checklist
+            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/docs-site-edit-checklist
+          - title: Embed images
+            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/embed-images
+          - title: Edit images
+            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/edit-images
+          - title: Rename or redirect a document
+            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/rename-or-redirect-document
+          - title: Translation process
+            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/translation-process
+          - title: Hide or restrict content
+            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/hide-or-restrict-content
+          - title: Checklist for public beta or GA
+            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/checklist-public-beta-or-ga
+          - title: Delete a document
+            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/delete-document
+          - title: Publication checklist
+            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/publication-checklist
+          - title: Embed videos
+            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/embed-videos
+          - title: Clear the cache
+            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/clear-cache
+      - title: Design specifications
+        pages:
+          - title: Supported languages for syntax highlighting
+            path: /docs/new-relic-only/tech-writer-style-guide/design-specifications/supported-languages-syntax-highlighting
+          - title: Classes and styles
+            path: /docs/new-relic-only/tech-writer-style-guide/design-specifications/classes-styles
+          - title: Color and design specs
+            path: /docs/new-relic-only/tech-writer-style-guide/design-specifications/color-design-specs
+      - title: Article templates
+        pages:
+          - title: Agent API guide template
+            path: /docs/new-relic-only/tech-writer-style-guide/article-templates/agent-api-guide-template
+          - title: Attribute definition template
+            path: /docs/new-relic-only/tech-writer-style-guide/article-templates/attribute-definition-template
+          - title: HTML template
+            path: /docs/new-relic-only/tech-writer-style-guide/article-templates/html-template
+          - title: GraphQL API tutorial template
+            path: /docs/new-relic-only/tech-writer-style-guide/article-templates/graphql-api-tutorial-template
+          - title: Landing page template
+            path: /docs/new-relic-only/tech-writer-style-guide/article-templates/landing-page-template
+          - title: Integration doc template
+            path: /docs/new-relic-only/tech-writer-style-guide/article-templates/integration-doc-template-simple
+          - title: Troubleshooting docs guide
+            path: /docs/new-relic-only/tech-writer-style-guide/article-templates/troubleshooting-docs-guide
+          - title: Agent release notes template 1.2.3
+            path: /docs/new-relic-only/tech-writer-style-guide/article-templates/agent-release-notes-template-123
   - title: Basic style guide
     pages:
+      - title: Writing guidelines
+        pages:
+          - title: Introduction to the style guide
+            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/introduction-style-guide
+          - title: Five questions to help write docs
+            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/five-questions-help-write-docs
+          - title: Voice strategies for docs that sound like New Relic
+            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/voice-strategies-docs-sound-new-relic
+          - title: Create and edit content
+            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/create-edit-content
+          - title: Create release notes
+            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/create-release-notes
+          - title: View a doc's revision history (diff)
+            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/view-docs-revision-history-diff
+          - title: Levels of headings
+            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/levels-headings
+          - title: Docs translation
+            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/docs-translation
+          - title: For more help section
+            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/more-help-section
+          - title: 'Code formatting guidelines: var and mark'
+            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/code-formatting-guidelines-var-mark
+          - title: Hyperlinks
+            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/hyperlinks
+          - title: Screenshots and images
+            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/screenshots-images
+          - title: What's new? style guidelines
+            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/whats-new-style-guidelines
+          - title: Event data dictionary style guidelines
+            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/event-data-dictionary-style-guidelines
+          - title: Formatting terminal commands
+            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/formatting-terminal-commands
       - title: Style guide quick reference
         pages:
+          - title: Usage dictionary
+            path: /docs/new-relic-only/basic-style-guide/style-guide-quick-reference/usage-dictionary
           - title: 'Bold or code, not italics'
             path: /docs/new-relic-only/basic-style-guide/style-guide-quick-reference/bold-or-code-not-italics
           - title: Callouts
@@ -16,113 +110,19 @@ pages:
             path: /docs/new-relic-only/basic-style-guide/style-guide-quick-reference/clamshells
           - title: Code examples
             path: /docs/new-relic-only/basic-style-guide/style-guide-quick-reference/code-examples
-          - title: Docs styles quick reference
-            path: /docs/new-relic-only/basic-style-guide/style-guide-quick-reference/docs-styles-quick-reference
           - title: Example box and clamshell
             path: /docs/new-relic-only/basic-style-guide/style-guide-quick-reference/example-box-clamshell
           - title: HTML cheat sheet
             path: /docs/new-relic-only/basic-style-guide/style-guide-quick-reference/html-cheat-sheet
           - title: Lists
             path: /docs/new-relic-only/basic-style-guide/style-guide-quick-reference/lists
-          - title: Pricing-related language
-            path: /docs/new-relic-only/basic-style-guide/style-guide-quick-reference/pricing-related-language
           - title: Tables
             path: /docs/new-relic-only/basic-style-guide/style-guide-quick-reference/tables
-          - title: UI paths
-            path: /docs/new-relic-only/basic-style-guide/style-guide-quick-reference/ui-paths
-          - title: Usage dictionary
-            path: /docs/new-relic-only/basic-style-guide/style-guide-quick-reference/usage-dictionary
+          - title: Pricing-related language
+            path: /docs/new-relic-only/basic-style-guide/style-guide-quick-reference/pricing-related-language
           - title: 'User-related language: styles and recommended phrasings'
             path: /docs/new-relic-only/basic-style-guide/style-guide-quick-reference/user-related-language-styles-recommended-phrasings
-      - title: Writing guidelines
-        pages:
-          - title: 'Code formatting guidelines: var and mark'
-            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/code-formatting-guidelines-var-mark
-          - title: Create and edit content
-            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/create-edit-content
-          - title: Create release notes
-            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/create-release-notes
-          - title: Docs translation
-            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/docs-translation
-          - title: Event data dictionary style guidelines
-            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/event-data-dictionary-style-guidelines
-          - title: Five questions to help write docs
-            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/five-questions-help-write-docs
-          - title: Formatting terminal commands
-            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/formatting-terminal-commands
-          - title: Hyperlinks
-            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/hyperlinks
-          - title: Introduction to the style guide
-            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/introduction-style-guide
-          - title: Levels of headings
-            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/levels-headings
-          - title: For more help section
-            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/more-help-section
-          - title: Screenshots and images
-            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/screenshots-images
-          - title: View a doc's revision history (diff)
-            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/view-docs-revision-history-diff
-          - title: Voice strategies for docs that sound like New Relic
-            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/voice-strategies-docs-sound-new-relic
-          - title: What's new? style guidelines
-            path: /docs/new-relic-only/basic-style-guide/writing-guidelines/whats-new-style-guidelines
-  - title: Tech writer style guide
-    pages:
-      - title: Article templates
-        pages:
-          - title: Agent API guide template
-            path: /docs/new-relic-only/tech-writer-style-guide/article-templates/agent-api-guide-template
-          - title: Agent release notes template 1.2.3
-            path: /docs/new-relic-only/tech-writer-style-guide/article-templates/agent-release-notes-template-123
-          - title: Attribute definition template
-            path: /docs/new-relic-only/tech-writer-style-guide/article-templates/attribute-definition-template
-          - title: GraphQL API tutorial template
-            path: /docs/new-relic-only/tech-writer-style-guide/article-templates/graphql-api-tutorial-template
-          - title: HTML template
-            path: /docs/new-relic-only/tech-writer-style-guide/article-templates/html-template
-          - title: Integration doc template
-            path: /docs/new-relic-only/tech-writer-style-guide/article-templates/integration-doc-template-simple
-          - title: Landing page template
-            path: /docs/new-relic-only/tech-writer-style-guide/article-templates/landing-page-template
-          - title: Troubleshooting docs guide
-            path: /docs/new-relic-only/tech-writer-style-guide/article-templates/troubleshooting-docs-guide
-      - title: Design specifications
-        pages:
-          - title: Classes and styles
-            path: /docs/new-relic-only/tech-writer-style-guide/design-specifications/classes-styles
-          - title: Color and design specs
-            path: /docs/new-relic-only/tech-writer-style-guide/design-specifications/color-design-specs
-          - title: Supported languages for syntax highlighting
-            path: /docs/new-relic-only/tech-writer-style-guide/design-specifications/supported-languages-syntax-highlighting
-      - title: Processes and procedures
-        pages:
-          - title: Checklist for public beta or GA
-            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/checklist-public-beta-or-ga
-          - title: Clear the cache
-            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/clear-cache
-          - title: Delete a document
-            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/delete-document
-          - title: Docs site edit checklist
-            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/docs-site-edit-checklist
-          - title: Edit images
-            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/edit-images
-          - title: Embed images
-            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/embed-images
-          - title: Embed videos
-            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/embed-videos
-          - title: Hide or restrict content
-            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/hide-or-restrict-content
-          - title: Publication checklist
-            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/publication-checklist
-          - title: Rename or redirect a document
-            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/rename-or-redirect-document
-          - title: Translation process
-            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/translation-process
-          - title: Use content types and text formats
-            path: /docs/new-relic-only/tech-writer-style-guide/processes-procedures/use-content-types-text-formats
-      - title: API writing guidelines
-        pages:
-          - title: API tutorial template
-            path: /docs/new-relic-only/tech-writer-style-guide/writing-guidelines/api-tutorial-template
-          - title: apiStyleGuidelines (Example agent API)
-            path: /docs/new-relic-only/tech-writer-style-guide/writing-guidelines/apistyleguidelines-example-agent-api
+          - title: UI paths
+            path: /docs/new-relic-only/basic-style-guide/style-guide-quick-reference/ui-paths
+          - title: Docs styles quick reference
+            path: /docs/new-relic-only/basic-style-guide/style-guide-quick-reference/docs-styles-quick-reference

--- a/src/nav/new-relic-partnerships.yml
+++ b/src/nav/new-relic-partnerships.yml
@@ -1,34 +1,22 @@
 title: New Relic partnerships
 path: /docs/new-relic-partnerships
 pages:
-  - title: Partnerships
-    pages:
-      - title: Partner API
-        pages:
-          - title: Partner API reference
-            path: /docs/new-relic-partnerships/partnerships/partner-api/partner-api-reference
-          - title: Partnership API keys
-            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-keys
-          - title: Typical Partnership integration example
-            path: /docs/new-relic-partnerships/partnerships/partner-api/typical-integration-example
-          - title: Partnership API account object
-            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object
-          - title: Partnership API user object
-            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object
-          - title: Partnership API subscription object
-            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object
-          - title: Partnership billing integration API
-            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-billing-integration-api
-          - title: Product buckets
-            path: /docs/new-relic-partnerships/partnerships/partner-api/product-buckets
-      - title: Getting started
-        pages:
-          - title: Using the Partner Portal
-            path: /docs/new-relic-partnerships/partnerships/getting-started/using-partner-portal
-          - title: Partner marketing
-            path: /docs/new-relic-partnerships/partnerships/getting-started/partner-marketing
   - title: Partner integration guide
     pages:
+      - title: Getting started
+        pages:
+          - title: Walkthrough and signoff
+            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/walkthrough-signoff
+          - title: Partner integration requirements
+            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/partner-integration-requirements
+          - title: 'Partners: Contact New Relic'
+            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/partners-contact-new-relic
+          - title: Co-branding for New Relic partners
+            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/co-branding-new-relic-partners
+          - title: Partnership admin console
+            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/partnership-admin-console
+          - title: Support resources for New Relic partners
+            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/support-resources-new-relic-partners
       - title: Partner account maintenance
         pages:
           - title: 'Partnership accounts, users, and subscriptions'
@@ -53,21 +41,33 @@ pages:
             path: /docs/new-relic-partnerships/partner-integration-guide/new-relic-products-features/single-sign-access-control
           - title: Other partnership settings
             path: /docs/new-relic-partnerships/partner-integration-guide/new-relic-products-features/other-partnership-settings
-      - title: Getting started
-        pages:
-          - title: Partner integration requirements
-            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/partner-integration-requirements
-          - title: 'Partners: Contact New Relic'
-            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/partners-contact-new-relic
-          - title: Co-branding for New Relic partners
-            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/co-branding-new-relic-partners
-          - title: Partnership admin console
-            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/partnership-admin-console
-          - title: Support resources for New Relic partners
-            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/support-resources-new-relic-partners
-          - title: Walkthrough and signoff
-            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/walkthrough-signoff
       - title: Appendix
         pages:
           - title: Version history
             path: /docs/new-relic-partnerships/partner-integration-guide/appendix/version-history
+  - title: Partnerships
+    pages:
+      - title: Getting started
+        pages:
+          - title: Using the Partner Portal
+            path: /docs/new-relic-partnerships/partnerships/getting-started/using-partner-portal
+          - title: Partner marketing
+            path: /docs/new-relic-partnerships/partnerships/getting-started/partner-marketing
+      - title: Partner API
+        pages:
+          - title: Partner API reference
+            path: /docs/new-relic-partnerships/partnerships/partner-api/partner-api-reference
+          - title: Partnership API keys
+            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-keys
+          - title: Typical Partnership integration example
+            path: /docs/new-relic-partnerships/partnerships/partner-api/typical-integration-example
+          - title: Partnership API account object
+            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object
+          - title: Partnership API user object
+            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object
+          - title: Partnership API subscription object
+            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object
+          - title: Partnership billing integration API
+            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-billing-integration-api
+          - title: Product buckets
+            path: /docs/new-relic-partnerships/partnerships/partner-api/product-buckets

--- a/src/nav/new-relic-partnerships.yml
+++ b/src/nav/new-relic-partnerships.yml
@@ -1,73 +1,73 @@
 title: New Relic partnerships
 path: /docs/new-relic-partnerships
 pages:
-  - title: Partner integration guide
+  - title: Partnerships
     pages:
-      - title: Appendix
+      - title: Partner API
         pages:
-          - title: Version history
-            path: /docs/new-relic-partnerships/partner-integration-guide/appendix/version-history
+          - title: Partner API reference
+            path: /docs/new-relic-partnerships/partnerships/partner-api/partner-api-reference
+          - title: Partnership API keys
+            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-keys
+          - title: Typical Partnership integration example
+            path: /docs/new-relic-partnerships/partnerships/partner-api/typical-integration-example
+          - title: Partnership API account object
+            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object
+          - title: Partnership API user object
+            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object
+          - title: Partnership API subscription object
+            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object
+          - title: Partnership billing integration API
+            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-billing-integration-api
+          - title: Product buckets
+            path: /docs/new-relic-partnerships/partnerships/partner-api/product-buckets
       - title: Getting started
         pages:
-          - title: Co-branding for New Relic partners
-            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/co-branding-new-relic-partners
+          - title: Using the Partner Portal
+            path: /docs/new-relic-partnerships/partnerships/getting-started/using-partner-portal
+          - title: Partner marketing
+            path: /docs/new-relic-partnerships/partnerships/getting-started/partner-marketing
+  - title: Partner integration guide
+    pages:
+      - title: Partner account maintenance
+        pages:
+          - title: 'Partnership accounts, users, and subscriptions'
+            path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions
+          - title: Partner API
+            path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api
+          - title: Partner account access for administrators
+            path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-account-access-administrators
+          - title: Restricted access partnerships
+            path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/restricted-access-partnerships
+          - title: Welcome messages for partnerships
+            path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/welcome-messages-partnerships
+          - title: Staging and production
+            path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/staging-production
+          - title: Tips and tricks
+            path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/tips-tricks
+      - title: New Relic products features
+        pages:
+          - title: 'Partner products, pricing, and billing'
+            path: /docs/new-relic-partnerships/partner-integration-guide/new-relic-products-features/partner-products-pricing-billing
+          - title: 'Partnership accounts: Single sign on and access control'
+            path: /docs/new-relic-partnerships/partner-integration-guide/new-relic-products-features/single-sign-access-control
+          - title: Other partnership settings
+            path: /docs/new-relic-partnerships/partner-integration-guide/new-relic-products-features/other-partnership-settings
+      - title: Getting started
+        pages:
           - title: Partner integration requirements
             path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/partner-integration-requirements
           - title: 'Partners: Contact New Relic'
             path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/partners-contact-new-relic
+          - title: Co-branding for New Relic partners
+            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/co-branding-new-relic-partners
           - title: Partnership admin console
             path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/partnership-admin-console
           - title: Support resources for New Relic partners
             path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/support-resources-new-relic-partners
           - title: Walkthrough and signoff
             path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/walkthrough-signoff
-      - title: New Relic products features
+      - title: Appendix
         pages:
-          - title: Other partnership settings
-            path: /docs/new-relic-partnerships/partner-integration-guide/new-relic-products-features/other-partnership-settings
-          - title: 'Partner products, pricing, and billing'
-            path: /docs/new-relic-partnerships/partner-integration-guide/new-relic-products-features/partner-products-pricing-billing
-          - title: 'Partnership accounts: Single sign on and access control'
-            path: /docs/new-relic-partnerships/partner-integration-guide/new-relic-products-features/single-sign-access-control
-      - title: Partner account maintenance
-        pages:
-          - title: Partner account access for administrators
-            path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-account-access-administrators
-          - title: Partner API
-            path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api
-          - title: 'Partnership accounts, users, and subscriptions'
-            path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions
-          - title: Restricted access partnerships
-            path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/restricted-access-partnerships
-          - title: Staging and production
-            path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/staging-production
-          - title: Tips and tricks
-            path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/tips-tricks
-          - title: Welcome messages for partnerships
-            path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/welcome-messages-partnerships
-  - title: Partnerships
-    pages:
-      - title: Getting started
-        pages:
-          - title: Partner marketing
-            path: /docs/new-relic-partnerships/partnerships/getting-started/partner-marketing
-          - title: Using the Partner Portal
-            path: /docs/new-relic-partnerships/partnerships/getting-started/using-partner-portal
-      - title: Partner API
-        pages:
-          - title: Partner API reference
-            path: /docs/new-relic-partnerships/partnerships/partner-api/partner-api-reference
-          - title: Partnership API account object
-            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object
-          - title: Partnership API keys
-            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-keys
-          - title: Partnership API subscription object
-            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object
-          - title: Partnership API user object
-            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object
-          - title: Partnership billing integration API
-            path: /docs/new-relic-partnerships/partnerships/partner-api/partnership-billing-integration-api
-          - title: Product buckets
-            path: /docs/new-relic-partnerships/partnerships/partner-api/product-buckets
-          - title: Typical Partnership integration example
-            path: /docs/new-relic-partnerships/partnerships/partner-api/typical-integration-example
+          - title: Version history
+            path: /docs/new-relic-partnerships/partner-integration-guide/appendix/version-history

--- a/src/nav/new-relic-security.yml
+++ b/src/nav/new-relic-security.yml
@@ -3,48 +3,6 @@ path: /docs/security
 pages:
   - title: Security and Privacy
     pages:
-      - title: Security bulletins
-        pages:
-          - title: Notification of Apollo.io security incident
-            path: /docs/security/new-relic-security/security-bulletins/notification-apolloio-security-incident
-          - title: Security Bulletin NR17-01
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-01
-          - title: Security Bulletin NR17-02
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-02
-          - title: Security Bulletin NR17-03
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-03
-          - title: Security Bulletin NR17-04
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-04
-          - title: Security Bulletin NR17-05
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-05
-          - title: Security Bulletin NR17-06
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-06
-          - title: Security Bulletin NR18-01
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-01
-          - title: Security Bulletin NR18-02
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-02
-          - title: Security Bulletin NR18-03
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-03
-          - title: Security Bulletin NR18-04
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-04
-          - title: Security Bulletin NR18-05
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-05
-          - title: Security Bulletin NR18-06
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-06
-          - title: Security Bulletin NR18-07
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-07
-          - title: Security Bulletin NR18-08
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-08
-          - title: Security Bulletin NR18-09
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-09
-          - title: Security Bulletin NR18-10
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-10
-          - title: Security Bulletin NR18-11
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-11
-          - title: Security Bulletin NR18-12
-            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-12
-          - title: Security for Heartbleed vulnerability
-            path: /docs/security/new-relic-security/security-bulletins/security-heartbleed-vulnerability
       - title: Data privacy
         pages:
           - title: New Relic personal data requests
@@ -55,5 +13,47 @@ pages:
         pages:
           - title: Security bulletins
             path: /docs/security/security-privacy/information-security/security-bulletins
+      - title: Security bulletins
+        pages:
+          - title: Security Bulletin NR18-12
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-12
+          - title: Security Bulletin NR18-11
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-11
+          - title: Security Bulletin NR18-10
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-10
+          - title: Security Bulletin NR18-09
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-09
+          - title: Security Bulletin NR18-08
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-08
+          - title: Security Bulletin NR18-07
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-07
+          - title: Security Bulletin NR18-06
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-06
+          - title: Security Bulletin NR18-05
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-05
+          - title: Security Bulletin NR18-04
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-04
+          - title: Security Bulletin NR18-03
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-03
+          - title: Security Bulletin NR18-02
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-02
+          - title: Security Bulletin NR18-01
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-01
+          - title: Security Bulletin NR17-06
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-06
+          - title: Security Bulletin NR17-05
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-05
+          - title: Security Bulletin NR17-04
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-04
+          - title: Security Bulletin NR17-03
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-03
+          - title: Security Bulletin NR17-02
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-02
+          - title: Security Bulletin NR17-01
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-01
+          - title: Notification of Apollo.io security incident
+            path: /docs/security/new-relic-security/security-bulletins/notification-apolloio-security-incident
+          - title: Security for Heartbleed vulnerability
+            path: /docs/security/new-relic-security/security-bulletins/security-heartbleed-vulnerability
   - title: Overview
     path: /docs/security

--- a/src/nav/new-relic-solutions.yml
+++ b/src/nav/new-relic-solutions.yml
@@ -1,14 +1,8 @@
 title: New Relic solutions
 path: /docs/new-relic-solutions
 pages:
-  - title: Solutions and best practices
-    path: /docs
   - title: Best practices guides
     pages:
-      - title: Alerts and Applied Intelligence
-        pages:
-          - title: Alerts best practices
-            path: /docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices
       - title: Full-stack observability
         pages:
           - title: APM best practices guide
@@ -17,61 +11,67 @@ pages:
             path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-guide
           - title: Browser monitoring best practices in Java
             path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-java
+          - title: Monitor apps and hosts with health maps
+            path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/monitor-apps-hosts-health-maps
           - title: Infrastructure monitoring best practices guide
             path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/infrastructure-monitoring-best-practices-guide
           - title: Mobile monitoring best practices guide
             path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/mobile-monitoring-best-practices-guide
-          - title: Monitor apps and hosts with health maps
-            path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/monitor-apps-hosts-health-maps
           - title: Synthetic monitoring best practices guide
             path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/synthetic-monitoring-best-practices-guide
+      - title: Alerts and Applied Intelligence
+        pages:
+          - title: Alerts best practices
+            path: /docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices
   - title: New Relic solutions
     pages:
       - title: Cloud adoption
         pages:
-          - title: Modern and cloud services
-            path: /docs/new-relic-solutions/new-relic-solutions/cloud-adoption/modern-cloud-services
-          - title: Create application baselines
-            path: /docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/create-application-baselines
           - title: Guide to planning your cloud adoption strategy
             path: /docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/guide-planning-your-cloud-adoption-strategy
+          - title: Create application baselines
+            path: /docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/create-application-baselines
           - title: Identify application dependencies and inventory
             path: /docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/identify-application-dependencies-inventory
-          - title: Identify issues and roadblocks
-            path: /docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/identify-issues-roadblocks
-          - title: Optimize customer experience
-            path: /docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/optimize-customer-experience
-          - title: Optimize your cloud spend
-            path: /docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/optimize-your-cloud-spend
-          - title: Perform migration acceptance testing
-            path: /docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/perform-migration-acceptance-testing
           - title: Prioritize migration order
             path: /docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/prioritize-migration-order
-          - title: Refactor your applications
-            path: /docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/refactor-your-applications
+          - title: Identify issues and roadblocks
+            path: /docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/identify-issues-roadblocks
           - title: Validate cloud improvements
             path: /docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/validate-cloud-improvements
+          - title: Perform migration acceptance testing
+            path: /docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/perform-migration-acceptance-testing
+          - title: Modern and cloud services
+            path: /docs/new-relic-solutions/new-relic-solutions/cloud-adoption/modern-cloud-services
+          - title: Optimize your cloud spend
+            path: /docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/optimize-your-cloud-spend
+          - title: Refactor your applications
+            path: /docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/refactor-your-applications
+          - title: Optimize customer experience
+            path: /docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/optimize-customer-experience
       - title: Measure DevOps success
         pages:
-          - title: 'App remediation: Gather performance statistics'
-            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/app-remediation-gather-performance-statistics
-          - title: 'Customer experience improvement: track experience indicators'
-            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/customer-experience-improvement-track-experience-indicators
-          - title: 'Establish objectives and baselines: define team SLOs'
-            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/establish-objectives-baselines-define-team-slos
-          - title: 'Establish team dashboards: gather and visualize key metrics'
-            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/establish-team-dashboards-gather-visualize-key-metrics
           - title: Guide to measuring DevOps success
             path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/guide-measuring-devops-success
-          - title: 'Incident orchestration: Align teams, tools, processes'
-            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/incident-orchestration-align-teams-tools-processes
-          - title: 'Infrastructure resource sizing: analyze operation metrics'
-            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/infrastructure-resource-sizing-analyze-operation-metrics
-          - title: 'Iterate and measure impact: track metrics before and after deployments'
-            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/iterate-measure-impact-track-metrics-after-deployments
-          - title: 'Operations review: assess and optimize team progress'
-            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/operations-review-assess-optimize-team-progress
-          - title: 'Resolve dependency risk: identify and analyze potential issues'
-            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/resolve-dependency-risk-identify-analyze-potential-issues
+          - title: 'App remediation: Gather performance statistics'
+            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/app-remediation-gather-performance-statistics
+          - title: 'Establish objectives and baselines: define team SLOs'
+            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/establish-objectives-baselines-define-team-slos
           - title: 'Set proactive alerting: understand and respond to performance issues'
             path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/set-proactive-alerting-understand-respond-performance-issues
+          - title: 'Establish team dashboards: gather and visualize key metrics'
+            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/establish-team-dashboards-gather-visualize-key-metrics
+          - title: 'Iterate and measure impact: track metrics before and after deployments'
+            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/iterate-measure-impact-track-metrics-after-deployments
+          - title: 'Incident orchestration: Align teams, tools, processes'
+            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/incident-orchestration-align-teams-tools-processes
+          - title: 'Resolve dependency risk: identify and analyze potential issues'
+            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/resolve-dependency-risk-identify-analyze-potential-issues
+          - title: 'Customer experience improvement: track experience indicators'
+            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/customer-experience-improvement-track-experience-indicators
+          - title: 'Infrastructure resource sizing: analyze operation metrics'
+            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/infrastructure-resource-sizing-analyze-operation-metrics
+          - title: 'Operations review: assess and optimize team progress'
+            path: /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/operations-review-assess-optimize-team-progress
+  - title: Solutions and best practices
+    path: /docs

--- a/src/nav/release-notes.yml
+++ b/src/nav/release-notes.yml
@@ -3,1716 +3,6 @@ path: /docs/release-notes
 pages:
   - title: Agent release notes
     pages:
-      - title: C SDK release notes
-        pages:
-          - title: C SDK 1.0.0
-            path: /docs/release-notes/agent-release-notes/c-sdk-release-notes/c-sdk-100
-          - title: C SDK 1.1.0
-            path: /docs/release-notes/agent-release-notes/c-sdk-release-notes/c-sdk-110
-          - title: C SDK 1.2.0
-            path: /docs/release-notes/agent-release-notes/c-sdk-release-notes/c-sdk-120
-          - title: C SDK 1.3.0
-            path: /docs/release-notes/agent-release-notes/c-sdk-release-notes/c-sdk-130
-      - title: Go release notes
-        pages:
-          - title: Go Agent 1.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-10
-          - title: Go Agent 1.1
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-11
-          - title: Go Agent 1.10
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-110
-          - title: Go Agent 1.11
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-111
-          - title: Go Agent 1.2
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-12
-          - title: Go Agent 1.3
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-13
-          - title: Go Agent 1.4
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-14
-          - title: Go Agent 1.6
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-16
-          - title: Go Agent 1.7
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-17
-          - title: Go Agent 1.8
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-18
-          - title: Go Agent 1.9
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-19
-          - title: Go Agent 2.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-20
-          - title: Go Agent 2.1
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-21
-          - title: Go Agent 2.10.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2100
-          - title: Go Agent 2.11.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2110
-          - title: Go Agent 2.12.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2120
-          - title: Go Agent 2.13.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2130
-          - title: Go Agent 2.14.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2140
-          - title: Go Agent 2.14.1
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2141
-          - title: Go Agent 2.15.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2150
-          - title: Go Agent 2.16.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2160
-          - title: Go Agent 2.16.1
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2161
-          - title: Go Agent 2.16.2
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2162
-          - title: Go Agent 2.16.3
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2163
-          - title: Go Agent 2.2
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-22
-          - title: Go Agent 2.3
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-23
-          - title: Go Agent 2.4
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-24
-          - title: Go Agent 2.5
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-25
-          - title: Go Agent 2.6
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-26
-          - title: Go Agent 2.7
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-27
-          - title: Go Agent 2.8
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-28
-          - title: Go Agent 2.8.1
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-281
-          - title: Go Agent 2.9.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-290
-          - title: Go Agent 3.0.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-300
-          - title: Go Agent 3.1.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-310
-          - title: Go Agent 3.2.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-320
-          - title: Go Agent 3.3.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-330
-          - title: Go Agent 3.4.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-340
-          - title: Go Agent 3.5.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-350
-          - title: Go Agent 3.6.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-360
-          - title: Go Agent 3.7.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-370
-          - title: Go Agent 3.8.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-380
-          - title: Go Agent 3.8.1
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-381
-          - title: Go Agent 3.9.0
-            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-390
-      - title: Java release notes
-        pages:
-          - title: Java Agent 1.3.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-130
-          - title: Java Agent 1.4.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-140
-          - title: Java Agent 2.0.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-200
-          - title: Java Agent 2.0.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-201
-          - title: Java Agent 2.0.2
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-202
-          - title: Java Agent 2.0.3
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-203
-          - title: Java Agent 2.0.4
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-204
-          - title: Java Agent 2.1.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-210
-          - title: Java Agent 2.10.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2100
-          - title: Java Agent 2.10.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2101
-          - title: Java Agent 2.11.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2110
-          - title: Java Agent 2.1.2
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-212
-          - title: Java Agent 2.12.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2120
-          - title: Java Agent 2.13.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2130
-          - title: Java Agent 2.14.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2140
-          - title: Java Agent 2.14.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2141
-          - title: java Agent 2.15.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2150
-          - title: Java Agent 2.15.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2151
-          - title: Java Agent 2.16.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2160
-          - title: Java Agent 2.17.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2170
-          - title: Java Agent 2.17.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2171
-          - title: Java Agent 2.17.2
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2172
-          - title: Java Agent 2.18.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2180
-          - title: Java Agent 2.19.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2190
-          - title: Java Agent 2.19.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2191
-          - title: Java Agent 2.2.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-220
-          - title: Java Agent 2.20.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2200
-          - title: Java Agent 2.2.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-221
-          - title: Java Agent 2.21.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2210
-          - title: Java Agent 2.21.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2211
-          - title: Java Agent 2.21.2
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2212
-          - title: Java Agent 2.21.3
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2213
-          - title: Java Agent 2.21.4
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2214
-          - title: Java Agent 2.21.5
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2215
-          - title: Java Agent 2.21.6
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2216
-          - title: Java Agent 2.21.7
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2217
-          - title: Java Agent 2.3.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-230
-          - title: Java Agent 2.3.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-231
-          - title: Java Agent 2.4.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-240
-          - title: Java Agent 2.4.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-241
-          - title: Java Agent 2.4.2
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-242
-          - title: Java Agent 2.5.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-250
-          - title: Java Agent 2.6.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-260
-          - title: Java Agent 2.7.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-270
-          - title: Java Agent 2.8.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-280
-          - title: Java Agent 2.9.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-290
-          - title: Java Agent 3.0.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-300
-          - title: Java Agent 3.0.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-301
-          - title: Java Agent 3.1.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-310
-          - title: Java Agent 3.10.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3100
-          - title: Java Agent 3.1.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-311
-          - title: Java Agent 3.11.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3110
-          - title: Java Agent 3.12.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3120
-          - title: Java Agent 3.12.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3121
-          - title: Java Agent 3.13.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3130
-          - title: Java Agent 3.14.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3140
-          - title: Java Agent 3.15.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3150
-          - title: Java Agent 3.16.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3161
-          - title: Java Agent 3.17.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3170
-          - title: Java Agent 3.17.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3171
-          - title: Java Agent 3.18.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3180
-          - title: Java Agent 3.19.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3190
-          - title: Java Agent 3.19.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3191
-          - title: Java Agent 3.19.2
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3192
-          - title: Java Agent 3.2.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-320
-          - title: Java Agent 3.20.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3200
-          - title: Java Agent 3.2.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-321
-          - title: Java Agent 3.21.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3210
-          - title: Java Agent 3.2.2
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-322
-          - title: Java Agent 3.22.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3220
-          - title: Java Agent 3.22.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3221
-          - title: Java Agent 3.2.3
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-323
-          - title: Java Agent 3.23.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3230
-          - title: Java Agent 3.24.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3240
-          - title: Java Agent 3.24.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3241
-          - title: Java Agent 3.25.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3250
-          - title: Java Agent 3.26.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3260
-          - title: Java Agent 3.26.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3261
-          - title: Java Agent 3.27.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3270
-          - title: Java Agent 3.28.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3280
-          - title: Java Agent 3.29.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3290
-          - title: Java Agent 3.30.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3300
-          - title: Java Agent 3.30.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3301-1
-          - title: Java Agent 3.3.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-331
-          - title: Java Agent 3.31.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3310
-          - title: Java Agent 3.31.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3311
-          - title: Java Agent 3.3.2
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-332
-          - title: Java Agent 3.32.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3320
-          - title: Java Agent 3.33.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3330
-          - title: Java Agent 3.34.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3340
-          - title: Java Agent 3.35.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3350
-          - title: Java Agent 3.35.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3351
-          - title: Java Agent 3.35.2
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3352
-          - title: Java Agent 3.36.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3360
-          - title: Java Agent 3.37.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3370
-          - title: Java Agent 3.38.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3380
-          - title: Java Agent 3.39.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3390
-          - title: Java agent 3.39.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3391
-          - title: Java Agent 3.4.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-340
-          - title: Java Agent 3.40.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3400-0
-          - title: Java Agent 3.4.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-341
-          - title: Java Agent 3.41.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3410
-          - title: Java Agent 3.4.2
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-342
-          - title: Java Agent 3.42.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3420
-          - title: Java Agent 3.43.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3430
-          - title: Java Agent 3.44.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3440
-          - title: Java Agent 3.44.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3441
-          - title: Java agent 3.45.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3450
-          - title: Java Agent 3.46.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3460
-          - title: Java agent 3.47.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3470
-          - title: Java agent 3.47.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3471
-          - title: Java Agent 3.48.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3480
-          - title: Java Agent 3.5.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-350
-          - title: Java Agent 3.5.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-351
-          - title: Java Agent 3.6.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-360
-          - title: Java Agent 3.7.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-370
-          - title: Java Agent 3.7.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-371
-          - title: Java Agent 3.8.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-380
-          - title: Java Agent 3.8.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-381
-          - title: Java Agent 3.8.2
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-382
-          - title: Java Agent 3.9.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-390
-          - title: Java agent 4.0.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-400
-          - title: Java Agent 4.0.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-401
-          - title: Java Agent 4.1.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-410
-          - title: Java Agent 4.10.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-4100
-          - title: Java agent 4.11.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-4110
-          - title: Java agent 4.12.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-4120
-          - title: Java Agent 4.12.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-4121
-          - title: Java Agent 4.2.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-420
-          - title: Java Agent 4.3.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-430
-          - title: Java Agent 4.4.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-440
-          - title: Java agent 4.5.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-450
-          - title: Java agent 4.6.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-460
-          - title: Java Agent 4.7.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-470
-          - title: Java Agent 4.8.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-480
-          - title: Java Agent 4.9.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-490
-          - title: Java Agent 5.0.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-500
-          - title: Java Agent 5.1.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-510
-          - title: Java Agent 5.10.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-5100
-          - title: Java Agent 5.1.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-511
-          - title: Java Agent 5.11.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-5110
-          - title: Java Agent 5.12.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-5120
-          - title: Java Agent 5.12.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-5121
-          - title: Java Agent 5.13.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-5130
-          - title: Java Agent 5.14.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-5140
-          - title: Java Agent 5.2.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-520
-          - title: Java Agent 5.3.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-530
-          - title: Java Agent 5.4.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-540
-          - title: Java Agent 5.5.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-550
-          - title: Java Agent 5.6.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-560
-          - title: Java Agent 5.7.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-570
-          - title: Java Agent 5.8.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-580
-          - title: Java Agent 5.9.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-590
-          - title: Java Agent 6.0.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-600
-          - title: Java Agent 6.1.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-610
-          - title: Java Agent 6.2.0
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-620
-          - title: Java Agent 6.2.1
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-621
-          - title: Java Agent 3.7.2
-            path: /docs/release-notes/agent-release-notes/java-release-notes/java-ageny-372
-      - title: NET release notes
-        pages:
-          - title: .NET Agent 8.20.262.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/agent-8202620
-          - title: .NET Agent 2.0.10.3
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-20103
-          - title: .NET Agent 2.0.11.1
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-20111
-          - title: .NET Agent 2.0.12.4
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-20124
-          - title: .NET Agent 2.0.5
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-205
-          - title: .NET Agent 2.0.6
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-206
-          - title: .NET Agent 2.0.7
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-207
-          - title: .NET Agent 2.0.8.4
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2084
-          - title: .NET Agent 2.0.9.15
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-20915
-          - title: .NET Agent 2.10.40.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-210400
-          - title: .NET Agent 2.1.0.5
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2105
-          - title: .NET Agent 2.1.1.13
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-21113
-          - title: .NET Agent 2.12.146.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2121460
-          - title: .NET Agent 2.1.2.472
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-212472
-          - title: .NET Agent 2.13.38.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-213380
-          - title: .NET Agent 2.1.3.494
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-213494
-          - title: .NET Agent 2.14.53.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-214530
-          - title: .NET Agent 2.15.180.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2151800
-          - title: .NET Agent  2.15.186.1
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2151861
-          - title: .NET Agent 2.16.164.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2161640
-          - title: .NET Agent 2.17.266.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2172660
-          - title: .NET Agent 2.17.268.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2172680
-          - title: .NET Agent 2.18.35.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-218350
-          - title: .NET Agent 2.19.3.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-21930
-          - title: .NET Agent 2.20.24.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-220240
-          - title: .NET Agent 2.20.25.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-220250
-          - title: .NET Agent 2.21.84.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-221840
-          - title: .NET Agent 2.22.79.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-222790
-          - title: .NET Agent 2.23.2.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-22320
-          - title: .NET Agent 2.24.218.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2242180
-          - title: .NET Agent 2.25.208.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2252080
-          - title: .NET Agent 2.2.83.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-22830
-          - title: .NET Agent 2.3.126.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-231260
-          - title: .NET Agent 2.4.57.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-24570
-          - title: .NET Agent 2.5.112.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-251120
-          - title: .NET Agent 2.6.54.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-26540
-          - title: .NET Agent 2.7.60.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-27600
-          - title: .NET Agent 2.8.1.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2810
-          - title: .NET Agent 2.8.134.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-281340
-          - title: .NET Agent 2.9.135.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-291350
-          - title: .NET Agent 3.0.79.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-30790
-          - title: .NET Agent 3.10.43.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-310430
-          - title: .NET Agent 3.11.296.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-3112960
-          - title: .NET Agent 3.12.140.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-3121400
-          - title: .NET Agent 3.1.65.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-31650
-          - title: .NET Agent 3.2.113.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-321130
-          - title: .NET Agent 3.3.38.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-33380
-          - title: .NET Agent 3.4.24.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-34240
-          - title: .NET Agent 3.5.107.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-351070
-          - title: .NET Agent 3.6.177.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-361770
-          - title: .NET Agent 3.7.135.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-371350
-          - title: .NET Agent 3.8.1.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-3810
-          - title: .NET Agent 3.9.146.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-391460
-          - title: .NET Agent 4.0.146.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-401460
-          - title: .NET Agent 4.1.134.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-411340
-          - title: .NET Agent 4.1.136.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-411360
-          - title: .NET agent 4.2.185.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-421850
-          - title: .NET agent 4.3.123.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-431230
-          - title: .NET agent 4.4.60.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-44600
-          - title: .NET agent 4.5.90.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-45900
-          - title: .NET agent 4.6.29.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-46290
-          - title: .NET agent 5.0.136.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-501360
-          - title: .NET agent 5.10.59.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-510590
-          - title: .NET agent 5.11.53.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-511530
-          - title: .NET agent 5.12.13.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-512130
-          - title: .NET agent 5.13.30.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-513300
-          - title: .NET agent 5.14.43.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-514430
-          - title: .NET agent 5.15.64.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-515640
-          - title: .NET agent 5.16.71.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-516710
-          - title: .NET agent 5.1.72.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-51720
-          - title: .NET agent 5.17.59.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-517590
-          - title: .NET agent 5.18.36.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-518360
-          - title: .NET agent 5.19.47.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-519470
-          - title: .NET agent 5.20.61.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-520610
-          - title: .NET agent 5.21.74.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-521740
-          - title: .NET agent 5.22.6.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-52260
-          - title: .NET agent 5.2.87.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-52870
-          - title: .NET agent 5.3.90.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-53900
-          - title: .NET agent 5.4.16.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-54160
-          - title: .NET agent 5.5.52.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-55520
-          - title: .NET agent 5.6.53.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-56530
-          - title: .NET agent 5.7.17.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-57170
-          - title: .NET agent 5.8.28.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-58280
-          - title: .NET agent 5.9.74.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-59740
-          - title: .NET agent 6.0.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6000
-          - title: .NET agent 6.10.1.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-61010
-          - title: .NET agent 6.11.613.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6116130
-          - title: .NET agent 6.12.61.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-612610
-          - title: .NET agent 6.12.64.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-612640
-          - title: .NET agent 6.12.71.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-612710
-          - title: .NET agent 6.13.366.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6133660
-          - title: .NET agent 6.14.209.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6142090
-          - title: .NET agent 6.1.48.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-61480
-          - title: .NET agent 6.15.202.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6152020
-          - title: .NET agent 6.16.178.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6161780
-          - title: .NET agent 6.17.387.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6173870
-          - title: .NET agent 6.18.139.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6181390
-          - title: .NET agent 6.19.330.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6193300
-          - title: .NET agent 6.20.166.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6201660
-          - title: .NET agent 6.21.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-62100
-          - title: .NET Agent 6.22.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-62200
-          - title: .NET agent 6.2.26.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-62260
-          - title: .NET Agent 6.23.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-62300
-          - title: .NET Agent 6.24.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-62400
-          - title: .NET Agent 6.25.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-62500
-          - title: NET Agent 6.26.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-62600
-          - title: .NET agent 6.3.123.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-631230
-          - title: .NET agent 6.4.21.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-64210
-          - title: .NET agent 6.5.29.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-65290
-          - title: .NET Agent 6.6.5.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6650
-          - title: .NET agent 6.7.67.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-67670
-          - title: .NET agent 6.8.172.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-681720
-          - title: .NET agent 6.9.62.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-69620
-          - title: .NET agent 7.0.2.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-7020
-          - title: .NET agent 7.1.229.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-712290
-          - title: .NET Agent 8.0.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8000
-          - title: .NET Agent 8.10.51.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-810510
-          - title: .NET Agent 8.11.157.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8111570
-          - title: .NET Agent 8.12.216.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8122160
-          - title: .NET Agent 8.13.798.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8137980
-          - title: .NET Agent 8.14.222.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8142220
-          - title: .NET Agent 8.15.455.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8154550
-          - title: .NET Agent 8.16.567.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8165670
-          - title: .NET Agent 8.1.709.0 - Superseded
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-817090
-          - title: .NET Agent 8.1.712.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-817120
-          - title: .NET Agent 8.17.438.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8174380
-          - title: .NET Agent 8.18.241.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8182410
-          - title: .NET Agent 8.19.353.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8193530
-          - title: .NET Agent 8.21.34.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-821340
-          - title: .NET Agent 8.2.216.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-822160
-          - title: .NET Agent 8.22.181.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8221810
-          - title: .NET Agent 8.23.107.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8231070
-          - title: .NET Agent 8.24.244.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8242440
-          - title: .NET Agent 8.25.214.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8252140
-          - title: .NET Agent 8.26.630.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8266300
-          - title: .NET Agent 8.27.139.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8271390
-          - title: .NET Agent 8.28.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8280
-          - title: .NET Agent 8.29.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-82900
-          - title: .NET Agent 8.30.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-83000
-          - title: .NET Agent 8.31.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-83100
-          - title: .NET Agent 8.32.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-83200
-          - title: .NET Agent 8.33.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-83300
-          - title: .NET Agent 8.3.360.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-833600
-          - title: .NET Agent 8.34.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-83400
-          - title: .NET Agent 8.35.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-83500
-          - title: NET Agent 8.36.0.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-83600
-          - title: .NET Agent 8.4.880.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-848800
-          - title: .NET Agent 8.5.186.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-851860
-          - title: .NET Agent 8.6.45.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-86450
-          - title: .NET Agent 8.7.75.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8775
-          - title: .NET Agent 8.8.83.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-88830
-          - title: .NET Agent 8.9.130.0
-            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-891300
-      - title: Node.js release notes
-        pages:
-          - title: Node Agent 1.18.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/clone-node-agent-1181
-          - title: Node Agent 1.0.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-100
-          - title: Node Agent 1.0.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-101
-          - title: Node Agent 1.1.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-110
-          - title: Node Agent 1.10.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1100
-          - title: Node Agent 1.10.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1101
-          - title: Node Agent 1.10.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1102
-          - title: Node Agent 1.10.3
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1103
-          - title: Node Agent 1.1.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-111
-          - title: Node Agent 1.11.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1110
-          - title: Node Agent 1.11.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1111
-          - title: Node Agent 1.11.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1112
-          - title: Node Agent 1.11.3
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1113
-          - title: Node Agent 1.11.4
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1114
-          - title: Node Agent 1.11.5
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1115
-          - title: Node Agent 1.12.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1120
-          - title: Node Agent 1.12.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1121
-          - title: Node Agent 1.12.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1122
-          - title: Node Agent 1.13.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1131
-          - title: Node Agent 1.13.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1132
-          - title: Node Agent 1.13.3
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1133
-          - title: Node Agent 1.13.4
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1134
-          - title: Node Agent 1.14.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1140
-          - title: Node Agent 1.14.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1141
-          - title: Node Agent 1.14.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1142
-          - title: Node Agent 1.14.3
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1143
-          - title: Node Agent 1.14.4
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1144
-          - title: Node Agent 1.14.5
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1145
-          - title: Node Agent 1.14.6
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1146
-          - title: Node Agent 1.14.7
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1147
-          - title: Node Agent 1.15.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1150
-          - title: Node Agent 1.15.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1151
-          - title: Node Agent 1.16.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1160
-          - title: Node Agent 1.16.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1161
-          - title: Node Agent 1.16.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1162
-          - title: Node Agent 1.16.3
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1163
-          - title: Node Agent 1.16.4
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1164
-          - title: Node Agent 1.17.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1171
-          - title: Node Agent 1.17.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1172
-          - title: Node Agent 1.17.3
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1173
-          - title: Node Agent 1.18.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1180
-          - title: Node Agent 1.18.4
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1184
-          - title: Node Agent 1.18.5
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1185
-          - title: Node Agent 1.19.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1190
-          - title: Node Agent 1.2.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-120
-          - title: Node Agent 1.20.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1201
-          - title: Node Agent 1.20.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1202
-          - title: Node Agent 1.21.0 - Superseded
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1210-superseded
-          - title: Node Agent 1.21.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1211
-          - title: Node Agent 1.21.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1212
-          - title: Node Agent 1.22.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1220
-          - title: Node Agent 1.22.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1221
-          - title: Node Agent 1.22.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1222
-          - title: Node Agent 1.23.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1230
-          - title: Node Agent 1.23.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1231
-          - title: Node Agent 1.24.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1240
-          - title: Node Agent 1.24.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1241
-          - title: Node Agent 1.25.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1250
-          - title: Node Agent 1.25.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1251
-          - title: Node Agent 1.25.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1252
-          - title: Node Agent 1.25.3
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1253
-          - title: Node Agent 1.25.4
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1254
-          - title: Node Agent 1.25.5
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1255
-          - title: Node Agent 1.26.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1260
-          - title: Node Agent 1.26.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1261
-          - title: Node Agent 1.26.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1262
-          - title: Node Agent 1.27.0 - Superseded
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1270
-          - title: Node Agent 1.27.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1271
-          - title: Node Agent 1.27.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1272
-          - title: Node Agent 1.28.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1280
-          - title: Node Agent 1.28.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1281
-          - title: Node Agent 1.28.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1282
-          - title: Node Agent 1.28.3
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1283
-          - title: Node Agent 1.29.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1290
-          - title: Node Agent 1.3.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-130
-          - title: Node Agent 1.30.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1300
-          - title: Node Agent 1.30.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1301
-          - title: Node Agent 1.30.2 - Superseded
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1302
-          - title: Node Agent 1.30.3
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1303
-          - title: Node Agent 1.30.4
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1304
-          - title: Node Agent 1.30.5
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1305
-          - title: Node Agent 1.3.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-131
-          - title: Node Agent 1.31.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1310
-          - title: Node Agent 1.3.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-132
-          - title: Node Agent 1.32.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1320
-          - title: Node Agent 1.33.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1330
-          - title: Node Agent 1.34.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1340
-          - title: Node Agent 1.35.0 - Superseded
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1350-superseded
-          - title: Node Agent 1.35.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1351
-          - title: Node Agent 1.36.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1360
-          - title: Node Agent 1.36.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1361
-          - title: Node Agent 1.36.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1362
-          - title: Node Agent 1.37.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1370
-          - title: Node Agent 1.37.1 - Superseded
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1371
-          - title: Node Agent 1.37.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1372
-          - title: Node Agent 1.38.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1380
-          - title: Node Agent 1.38.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1381
-          - title: Node Agent 1.38.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1382
-          - title: Node Agent 1.39.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1390
-          - title: Node Agent 1.39.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1391
-          - title: Node Agent 1.4.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-140
-          - title: Node Agent 1.40.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1400
-          - title: Node Agent 1.5.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-150
-          - title: Node Agent 1.5.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-151
-          - title: Node Agent 1.5.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-152
-          - title: Node Agent 1.5.3
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-153
-          - title: Node Agent 1.5.4
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-154
-          - title: Node Agent 1.5.5
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-155
-          - title: Node Agent 1.6.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-160
-          - title: Node Agent 1.7.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-170
-          - title: Node Agent 1.7.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-171
-          - title: Node Agent 1.7.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-172
-          - title: Node Agent 1.7.3
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-173
-          - title: Node Agent 1.7.4
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-174
-          - title: Node Agent 1.7.5
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-175
-          - title: Node Agent 1.8.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-180
-          - title: Node Agent 1.8.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-181
-          - title: Node Agent 1.9.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-190
-          - title: Node Agent 1.9.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-191
-          - title: Node Agent 1.9.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-192
-          - title: Node Agent 2.0.0-beta
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-200-beta
-          - title: Node Agent 2.0.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-200
-          - title: Node Agent 2.0.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-201
-          - title: Node Agent 2.0.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-202
-          - title: Node Agent 2.1.0-beta
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-210-beta
-          - title: Node Agent 2.1.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-210
-          - title: Node Agent 2.1.1-beta
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-211-beta
-          - title: Node Agent 2.2.0-beta
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-220-beta
-          - title: Node Agent 2.2.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-220
-          - title: Node Agent 2.2.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-221
-          - title: Node Agent 2.2.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-222
-          - title: Node Agent 2.3.0-beta
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-230-beta
-          - title: Node Agent 2.3.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-230
-          - title: Node Agent 2.3.1-beta
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-231-beta
-          - title: Node Agent 2.3.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-231
-          - title: Node Agent 2.3.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-232
-          - title: Node Agent 2.4.0-beta
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-240-beta
-          - title: Node Agent 2.4.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-240
-          - title: Node Agent 2.4.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-241
-          - title: Node Agent 2.4.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-242
-          - title: Node Agent 2.5.0-beta
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-250-beta
-          - title: Node Agent 2.5.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-250
-          - title: Node Agent 2.6.0-beta
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-260-beta
-          - title: Node Agent 2.6.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-260
-          - title: Node Agent 2.6.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-261
-          - title: Node Agent 2.7.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-270
-          - title: Node Agent 2.7.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-271
-          - title: Node Agent 2.8.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-280
-          - title: Node Agent 2.9.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-290
-          - title: Node Agent 2.9.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-291
-          - title: Node Agent 3.0.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-300
-          - title: Node Agent 3.1.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-310
-          - title: Node Agent 3.2.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-320
-          - title: Node Agent 3.3.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-330
-          - title: Node Agent 3.3.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-331
-          - title: Node Agent 4.0.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-400
-          - title: Node Agent 4.1.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-410
-          - title: Node Agent 4.10.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-4100
-          - title: Node Agent 4.1.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-411
-          - title: Node Agent 4.11.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-4110
-          - title: Node Agent 4.1.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-412
-          - title: Node Agent 4.12.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-4120
-          - title: Node Agent 4.1.3
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-413
-          - title: Node Agent 4.13.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-4130
-          - title: Node Agent 4.13.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-4131
-          - title: Node agent 4.1.5
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-415
-          - title: Node Agent 4.2.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-420
-          - title: Node Agent 4.2.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-421
-          - title: Node Agent 4.3.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-430
-          - title: Node Agent 4.4.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-440
-          - title: Node Agent 4.5.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-450
-          - title: Node Agent 4.5.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-451
-          - title: Node Agent 4.6.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-460
-          - title: Node Agent 4.7.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-470
-          - title: Node Agent 4.8.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-480
-          - title: Node Agent 4.8.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-481
-          - title: Node Agent 4.9.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-490
-          - title: Node Agent 5.0.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-500
-          - title: Node Agent 5.1.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-510
-          - title: Node Agent 5.10.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-5100
-          - title: Node Agent 5.11.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-5110
-          - title: Node Agent 5.13.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-5130
-          - title: Node Agent 5.13.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-5131
-          - title: Node Agent 5.2.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-520
-          - title: Node Agent 5.2.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-521
-          - title: Node Agent 5.3.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-530
-          - title: Node Agent 5.5.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-550
-          - title: Node Agent 5.6.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-560
-          - title: Node Agent 5.6.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-561
-          - title: Node Agent 5.6.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-562
-          - title: Node Agent 5.6.3
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-563
-          - title: Node Agent 5.6.4
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-564
-          - title: Node Agent 5.7.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-570
-          - title: Node Agent 5.8.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-580
-          - title: Node Agent 5.9.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-590
-          - title: Node Agent 5.9.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-591
-          - title: Node Agent 6.0.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-600
-          - title: Node Agent 6.1.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-610
-          - title: Node Agent 6.10.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6100
-          - title: Node Agent 6.11.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6110
-          - title: Node Agent 6.12.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6120
-          - title: Node Agent 6.12.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6121
-          - title: Node Agent 6.13.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6130
-          - title: Node Agent 6.13.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6131
-          - title: Node Agent 6.13.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6132
-          - title: Node Agent 6.14.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6140
-          - title: Node Agent 6.2.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-620
-          - title: Node Agent 6.3.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-630
-          - title: Node Agent 6.4.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-640
-          - title: Node Agent 6.4.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-641
-          - title: Node Agent 6.4.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-642
-          - title: Node Agent 6.5.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-650
-          - title: Node Agent 6.6.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-660
-          - title: Node Agent 6.7.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-670
-          - title: Node Agent 6.7.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-671
-          - title: Node Agent 6.8.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-680
-          - title: Node Agent 6.9.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-690
-          - title: Node Agent 7.0.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-700
-          - title: Node Agent 7.0.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-701
-          - title: Node Agent 7.0.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-702
-          - title: Node.js Agent 1.17.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/nodejs-agent-1170
-          - title: Node.js Agent 1.18.3
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/nodejs-agent-1183
-          - title: Node.js Agent 1.19.1
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/nodejs-agent-1191
-          - title: Node.js Agent 1.19.2
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/nodejs-agent-1192
-          - title: Node.js Agent 1.20.0
-            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/nodejs-agent-1200
-          - title: Node Agent 1.13.0
-            path: /docs/release-notes/node-agent-1130
-      - title: PHP Release Notes
-        pages:
-          - title: PHP Agent 2.0.2.65
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-20265
-          - title: PHP Agent 2.0.3.89
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-20389
-          - title: PHP Agent 2.0.5.98
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-20598
-          - title: PHP Agent 2.1.1.134
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-211134
-          - title: PHP Agent 2.1.3.164
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-213164
-          - title: PHP Agent 2.2.1.181
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-221181
-          - title: PHP Agent 2.2.1.185
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-221185
-          - title: PHP Agent 2.2.2.193
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-222193
-          - title: PHP Agent 2.2.3.196
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-223196
-          - title: PHP Agent 2.3.5.21
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-23521
-          - title: PHP Agent 2.4.5.24
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-24524
-          - title: PHP Agent 2.4.5.25
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-24525
-          - title: PHP Agent 2.4.5.26
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-24526
-          - title: PHP Agent 2.5.5.29
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-25529
-          - title: PHP Agent 2.6.5.41
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-26541
-          - title: PHP Agent 2.6.5.44
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-26544
-          - title: PHP Agent 2.6.5.55
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-26555
-          - title: PHP Agent 2.6.5.57
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-26557
-          - title: PHP Agent 2.7.5.64
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-27564
-          - title: PHP Agent 2.7.5.69
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-27569
-          - title: PHP Agent 2.8.5.73
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-28573
-          - title: PHP Agent 2.9.5.76
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-29576
-          - title: PHP Agent 2.9.5.78
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-29578
-          - title: PHP Agent 3.1.5.111
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-315111
-          - title: PHP Agent 3.1.5.120
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-315120
-          - title: PHP Agent 3.1.5.136
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-315136
-          - title: PHP Agent 3.1.5.137
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-315137
-          - title: PHP Agent 3.1.5.141
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-315141
-          - title: PHP Agent 3.2.5.143
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-325143
-          - title: PHP Agent 3.2.5.147
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-325147
-          - title: PHP Agent 3.3.5.154
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-335154
-          - title: PHP Agent 3.3.5.160
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-335160
-          - title: PHP Agent 3.3.5.161
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-335161
-          - title: PHP Agent 3.4.5.167
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-345167
-          - title: PHP Agent 3.5.5.170
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-355170
-          - title: PHP Agent 3.5.5.172
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-355172
-          - title: PHP Agent 3.6.5.178
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-365178
-          - title: PHP Agent 3.7.5.7
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-3757
-          - title: PHP Agent 3.8.5.11
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-38511
-          - title: PHP Agent 3.9.5.13
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-39513
-          - title: PHP Agent 4.0.5.18
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-40518
-          - title: PHP Agent 4.10.0.60
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-410060
-          - title: PHP Agent 4.10.1.62
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-410162
-          - title: PHP Agent 4.11.0
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4110
-          - title: PHP Agent 4.11.1
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4111
-          - title: PHP Agent 4.12.0
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4120
-          - title: PHP Agent 4.13.0
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4130
-          - title: PHP Agent 4.13.1
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4131
-          - title: PHP Agent 4.14.0
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4140
-          - title: PHP Agent 4.15.0.74
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-415074
-          - title: PHP Agent 4.1.5.24
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-41524
-          - title: PHP Agent 4.17.0.79
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-417079
-          - title: PHP Agent 4.17.0.83
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-417083
-          - title: PHP Agent 4.18.0.89
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-418089
-          - title: PHP Agent 4.19.0.90
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-419090
-          - title: PHP Agent 4.20.0.92
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-420092
-          - title: PHP Agent 4.20.1.93
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-420193
-          - title: PHP Agent 4.20.2.95
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-420295
-          - title: PHP Agent 4.21.0.97
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-421097
-          - title: PHP Agent 4.22.0.99
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-422099
-          - title: PHP Agent 4.23.0.102
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-423
-          - title: PHP Agent 4.23.1.107
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4231107
-          - title: PHP Agent 4.23.3.111
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4233111
-          - title: PHP Agent 4.23.4.113
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4234113
-          - title: PHP Agent 4.2.5.26
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-42526
-          - title: PHP Agent 4.2.5.27
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-42527
-          - title: PHP Agent 4.3.5.33
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-43533
-          - title: PHP Agent 4.4.5.35
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-44535
-          - title: PHP Agent 4.5.5.38
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-45538
-          - title: PHP Agent 4.6.5.40
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-46540
-          - title: PHP Agent 4.7.5.43
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-47543
-          - title: PHP Agent 4.8.0.47
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-48047
-          - title: PHP Agent 4.9.0.54
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-49054
-          - title: PHP Agent 5.0.0.115
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-500115
-          - title: PHP Agent 5.1.0.129
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-510129
-          - title: PHP Agent 5.1.1.130
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-511130
-          - title: PHP Agent 5.2.0.141
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-520141
-          - title: PHP Agent 5.3.0.148
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-530148
-          - title: PHP Agent 5.4.0.150
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-540150
-          - title: PHP Agent 5.5.0.154
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-550154
-          - title: PHP Agent 6.0.0.155
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-600155
-          - title: PHP Agent 6.0.1.156
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-601156
-          - title: PHP Agent 6.1.0.157
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-610157
-          - title: PHP Agent 6.2.0.158
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-620158
-          - title: PHP Agent 6.2.1.0
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-6210
-          - title: PHP Agent 6.3.0.161
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-630161
-          - title: PHP Agent 6.4.0.163
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-640163
-          - title: PHP Agent 6.5.0.166
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-650166
-          - title: PHP Agent 6.6.0.169
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-660169
-          - title: PHP Agent 6.6.1.172
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-661172
-          - title: PHP Agent 6.7.0.174
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-670174
-          - title: PHP Agent 6.8.0.177
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-680177
-          - title: PHP Agent 6.9.0.182
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-690182
-          - title: PHP Agent 7.0.0.186
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-700186
-          - title: PHP Agent 7.1.0.187
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-710187
-          - title: PHP Agent 7.2.0.191
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-720191
-          - title: PHP Agent 7.3.0.193
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-730193
-          - title: PHP Agent 7.3.1.197
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-731197
-          - title: PHP Agent 7.4.0.198
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-740198
-          - title: PHP Agent 7.5.0.199
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-750199
-          - title: PHP Agent 7.6.0.201
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-760201
-          - title: PHP Agent 7.7.0.203
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-770203
-          - title: PHP Agent 8.0.0.204
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-800204
-          - title: PHP Agent 8.1.0.209
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-810209
-          - title: PHP Agent 8.2.0.221
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-820221
-          - title: PHP Agent 8.3.0.226
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-830226
-          - title: PHP Agent 8.4.0.231
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-840231
-          - title: PHP Agent 8.5.0.235
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-850235
-          - title: PHP Agent 8.6.0.238
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-860238
-          - title: PHP Agent 8.7.0.242
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-870242
-          - title: PHP Agent 9.0.0.242
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-900242
-          - title: PHP Agent 9.0.2.245
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-902245
-          - title: PHP Agent 9.10.0.262
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-9100262
-          - title: PHP Agent 9.10.1.263
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-9101263
-          - title: PHP Agent 9.1.0.246
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-910246
-          - title: PHP Agent 9.11.0.267
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-9110267
-          - title: PHP Agent 9.12.0.268
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-9120268
-          - title: PHP Agent 9.13.0.270
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-9130270
-          - title: PHP Agent 9.14.0.290
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-9140290
-          - title: PHP Agent 9.15.0.293
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293
-          - title: PHP Agent 9.2.0.247
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-920247
-          - title: PHP Agent 9.3.0.248
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-930248
-          - title: PHP Agent 9.4.0.249
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-940249
-          - title: PHP Agent 9.4.1.250
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-941250
-          - title: PHP Agent 9.5.0.252
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-950252
-          - title: PHP Agent 9.6.0.255
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-960255
-          - title: PHP Agent 9.6.1.256
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-961256
-          - title: PHP Agent 9.7.0.258
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-970258
-          - title: PHP Agent 9.8.0.259
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-980259
-          - title: PHP Agent 9.9.0.260
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-990260
-          - title: PHP Agent 3.0.5.95
-            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent
-      - title: Python release notes
-        pages:
-          - title: Python Agent 1.0.2.130
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-102130
-          - title: Python Agent 1.0.3.138
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-103138
-          - title: Python Agent 1.0.5.156
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-105156
-          - title: Python Agent 1.10.0.28
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-110028
-          - title: Python Agent 1.10.1.36
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-110136
-          - title: Python Agent 1.1.0.192
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-110192
-          - title: Python Agent 1.10.2.38
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-110238
-          - title: Python Agent 1.11.0.55
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-111055
-          - title: Python Agent 1.12.0.56
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-112056
-          - title: Python Agent 1.13.0.30
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-113030
-          - title: Python Agent 1.13.1.31
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-113131
-          - title: Python Agent 1.2.0.246
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-120246
-          - title: Python Agent 1.2.1.265
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-121265
-          - title: Python Agent 1.3.0.289
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-130289
-          - title: Python Agent 1.4.0.137
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-140137
-          - title: Python Agent 1.5.0.103
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-150103
-          - title: Python Agent 1.6.0.13
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-16013
-          - title: Python Agent 1.7.0.31
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-17031
-          - title: Python Agent 1.8.0.13
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-18013
-          - title: Python Agent 1.9.0.21
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-19021
-          - title: Python Agent 2.0.0.1
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2001
-          - title: Python Agent 2.100.0.84
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2100084
-          - title: Python Agent 2.10.0.8
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-21008
-          - title: Python Agent 2.10.1.9
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-21019
-          - title: Python Agent 2.102.0.85
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2102085
-          - title: Python Agent 2.104.0.86
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2104086
-          - title: Python Agent 2.106.0.87
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2106087
-          - title: Python Agent 2.106.1.88
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2106188
-          - title: Python Agent 2.12.0.10
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-212010
-          - title: Python Agent 2.14.0.11
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-214011
-          - title: Python Agent 2.16.0.12
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-216012
-          - title: Python Agent 2.18.1.15
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-218115
-          - title: Python Agent 2.20.0.17
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-220017
-          - title: Python Agent 2.20.1.18
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-220118
-          - title: Python Agent 2.2.0.2
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2202
-          - title: Python Agent 2.2.1.3
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2213
-          - title: Python Agent 2.22.0.19
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-222019
-          - title: Python Agent 2.22.1.20
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-222120
-          - title: Python Agent 2.24.0.21
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-224021
-          - title: Python Agent 2.26.0.22
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-226022
-          - title: Python Agent 2.26.2.24
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-226224
-          - title: Python Agent 2.28.0.26
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-228026
-          - title: Python Agent 2.30.0.27
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-230027
-          - title: Python Agent 2.32.0.28
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-232028
-          - title: Python Agent 2.34.0.29
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-234029
-          - title: Python Agent 2.36.0.30
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-236030
-          - title: Python Agent 2.38.0.31
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-238031
-          - title: Python Agent 2.38.2.33
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-238233
-          - title: Python Agent 2.40.0.34
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-240034
-          - title: Python Agent 2.4.0.4
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2404
-          - title: Python Agent 2.42.0.35
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-242035
-          - title: Python Agent 2.44.0.36
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-244036
-          - title: Python Agent 2.46.0.37
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-246037
-          - title: Python Agent 2.48.0.38
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-248038
-          - title: Python Agent 2.50.0.39
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-250039
-          - title: Python Agent 2.52.0.40
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-252040
-          - title: Python Agent 2.54.0.41
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-254041
-          - title: Python Agent 2.56.0.42
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-256042
-          - title: Python Agent 2.58.0.43
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-258043
-          - title: Python Agent 2.58.1.44
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-258144
-          - title: Python Agent 2.58.2.45
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-258245
-          - title: Python Agent 2.60.0.46
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-260046
-          - title: Python Agent 2.6.0.5
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2605
-          - title: Python Agent 2.62.0.47
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-262047
-          - title: Python Agent 2.64.0.48
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-264048
-          - title: Python Agent 2.66.0.49
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-266049
-          - title: Python Agent 2.68.0.50
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-268050
-          - title: Python Agent 2.70.0.51
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-270051
-          - title: Python Agent 2.72.0.52
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-272052
-          - title: Python Agent 2.72.1.53
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-272153
-          - title: Python Agent 2.74.0.54
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-274054
-          - title: Python Agent 2.76.0.55
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-276055
-          - title: Python Agent 2.78.0.57
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-278057
-          - title: Python Agent 2.80.0.60
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-280060
-          - title: Python Agent 2.80.1.61
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-280161
-          - title: Python Agent 2.8.0.7
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2807
-          - title: Python Agent 2.82.0.62
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-282062
-          - title: Python Agent 2.82.1.63
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-282163
-          - title: Python Agent 2.84.0.64
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-284064
-          - title: Python Agent 2.86.0.65
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-286065
-          - title: Python Agent 2.86.1.66 - Superseded
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-286166
-          - title: Python Agent 2.86.2.68
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-286268
-          - title: Python Agent 2.86.3.70
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-286370
-          - title: Python Agent 2.88.0.72
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-288072
-          - title: Python Agent 2.88.1.73
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-288173
-          - title: Python Agent 2.90.0.75
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-290075
-          - title: Python Agent 2.92.0.78
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-292078
-          - title: Python Agent 2.94.0.79
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-294079
-          - title: Python Agent 2.96.0.80
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-296080
-          - title: Python Agent 2.98.0.81
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-298081
-          - title: Python Agent 3.0.0.89
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-30089
-          - title: Python Agent 3.2.0.91
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-32091
-          - title: Python Agent 3.2.1.93
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-32193
-          - title: Python Agent 3.2.2.94
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-32294
-          - title: Python Agent 3.4.0.95
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-34095
-          - title: Python Agent 4.0.0.99
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-40099
-          - title: Python Agent 4.10.0.112
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-4100112
-          - title: Python Agent 4.12.0.113
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-4120113
-          - title: Python Agent 4.14.0.115
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-4140115
-          - title: Python Agent 4.16.0.116
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-4160116
-          - title: Python Agent 4.16.1.117
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-4161117
-          - title: Python Agent 4.18.0.118
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-4180118
-          - title: Python Agent 4.20.0.120
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-4200120
-          - title: Python Agent 4.2.0.100
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-420100
-          - title: Python Agent 4.20.1.121
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-4201121
-          - title: Python Agent 4.4.0.103
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-440103
-          - title: Python Agent 4.4.1.104
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-441104
-          - title: Python Agent 4.6.0.106
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-460106
-          - title: Python Agent 4.8.0.110
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-480110
-          - title: Python Agent 5.0.0.124
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-500124
-          - title: Python Agent 5.0.1.125
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-501125
-          - title: Python Agent 5.0.2.126
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-502126
-          - title: Python Agent 5.10.0.138
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5100138
-          - title: Python Agent 5.12.0.140
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5120140
-          - title: Python Agent 5.12.1.141
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5121141
-          - title: Python Agent 5.14.0.142
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5140142
-          - title: Python Agent 5.14.1.144
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5141144
-          - title: Python Agent 5.16.0.145
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5160145
-          - title: Python Agent 5.16.1.146
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5161146
-          - title: Python Agent 5.16.2.147
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5162147
-          - title: Python Agent 5.18.0.148
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5180148
-          - title: Python Agent 5.20.0.149
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5200149
-          - title: Python Agent 5.20.1.150
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5201150
-          - title: Python Agent 5.2.0.127
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-520127
-          - title: Python Agent 5.2.1.129
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-521129
-          - title: Python Agent 5.22.0.151
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5220151
-          - title: Python Agent 5.22.1.152
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5221152
-          - title: Python Agent 5.2.2.130
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-522130
-          - title: Python Agent 5.2.3.131
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-523131
-          - title: Python Agent 5.4.0.132
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-540132
-          - title: Python Agent 5.4.1.134
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-541134
-          - title: Python Agent 5.6.0.135
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-560135
-          - title: Python Agent 5.8.0.136
-            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-580136
       - title: Ruby release notes
         pages:
           - title: Ruby Agent 3.0.0
@@ -1721,58 +11,8 @@ pages:
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-301
           - title: Ruby Agent 3.1.0
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-310
-          - title: Ruby Agent 3.10.0.279
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3100279
           - title: Ruby Agent 3.1.1
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-311
-          - title: Ruby Agent 3.11.0.283
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3110283
-          - title: Ruby Agent 3.11.1.284
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3111284
-          - title: Ruby Agent 3.11.2.286
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3112286
-          - title: Ruby Agent 3.12.0.288
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3120288
-          - title: Ruby Agent 3.12.1.298
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3121298
-          - title: Ruby Agent 3.13.0.299
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3130
-          - title: Ruby Agent 3.13.1.300
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3131300
-          - title: Ruby Agent 3.13.2.302
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3132302
-          - title: Ruby Agent 3.14.0.305
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3140305
-          - title: Ruby Agent 3.14.1.311
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3141311
-          - title: Ruby Agent 3.14.2.312
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3142312
-          - title: Ruby Agent 3.14.3.313
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3143313
-          - title: Ruby Agent 3.15.0.314
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3150314
-          - title: Ruby Agent 3.15.1.316
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3151316
-          - title: Ruby Agent 3.15.2.317
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3152317
-          - title: Ruby Agent 3.16.0.318
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3160
-          - title: Ruby Agent 3.16.1.320
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3161320
-          - title: Ruby Agent 3.16.2.321
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3162321
-          - title: Ruby Agent 3.16.3.323
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3163323
-          - title: Ruby Agent 3.17.0.325
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3170325
-          - title: Ruby Agent 3.17.1.326
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3171326
-          - title: Ruby Agent 3.17.2.327
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3172327
-          - title: Ruby Agent 3.18.0.329
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3180329
-          - title: Ruby Agent 3.18.1.330
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3181330
           - title: Ruby Agent 3.2.0
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-320
           - title: Ruby Agent 3.3.0
@@ -1869,6 +109,8 @@ pages:
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-381221
           - title: Ruby Agent 3.9.0.229
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-390229
+          - title: Ruby Agent 3.9.1.236
+            path: /docs/release-notes/ruby-agent-391236
           - title: Ruby Agent 3.9.2.239
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-392239
           - title: Ruby Agent 3.9.3.241
@@ -1885,6 +127,58 @@ pages:
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-398273
           - title: Ruby Agent 3.9.9.275
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-399275
+          - title: Ruby Agent 3.10.0.279
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3100279
+          - title: Ruby Agent 3.11.0.283
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3110283
+          - title: Ruby Agent 3.11.1.284
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3111284
+          - title: Ruby Agent 3.11.2.286
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3112286
+          - title: Ruby Agent 3.12.0.288
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3120288
+          - title: Ruby Agent 3.12.1.298
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3121298
+          - title: Ruby Agent 3.13.0.299
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3130
+          - title: Ruby Agent 3.13.1.300
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3131300
+          - title: Ruby Agent 3.13.2.302
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3132302
+          - title: Ruby Agent 3.14.0.305
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3140305
+          - title: Ruby Agent 3.14.1.311
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3141311
+          - title: Ruby Agent 3.14.2.312
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3142312
+          - title: Ruby Agent 3.14.3.313
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3143313
+          - title: Ruby Agent 3.15.0.314
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3150314
+          - title: Ruby Agent 3.15.1.316
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3151316
+          - title: Ruby Agent 3.15.2.317
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3152317
+          - title: Ruby Agent 3.16.0.318
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3160
+          - title: Ruby Agent 3.16.1.320
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3161320
+          - title: Ruby Agent 3.16.2.321
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3162321
+          - title: Ruby Agent 3.16.3.323
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3163323
+          - title: Ruby Agent 3.17.0.325
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3170325
+          - title: Ruby Agent 3.17.1.326
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3171326
+          - title: Ruby Agent 3.17.2.327
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3172327
+          - title: Ruby Agent 3.18.0.329
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3180329
+          - title: Ruby Agent 3.18.1.330
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3181330
+          - title: Ruby Agent 4.0.0.332
+            path: /docs/release-notes/ruby-agent-400332
           - title: Ruby Agent 4.1.0.333
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-410333
           - title: Ruby Agent 4.2.0.334
@@ -1921,20 +215,8 @@ pages:
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-570350
           - title: Ruby Agent 6.0.0.351
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-600351
-          - title: Ruby Agent 6.10.0.364
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6100364
           - title: Ruby Agent 6.1.0.352
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-610352
-          - title: Ruby Agent 6.11.0.365
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6110365
-          - title: Ruby Agent 6.12.0.367
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6120367
-          - title: Ruby Agent 6.13.0
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6130
-          - title: Ruby Agent 6.13.1
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6131
-          - title: Ruby Agent 6.14.0
-            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6140
           - title: Ruby Agent 6.2.0.354
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-620354
           - title: Ruby Agent 6.3.0.355
@@ -1951,192 +233,1730 @@ pages:
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-680360
           - title: Ruby Agent 6.9.0.363
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-690363
-          - title: Ruby Agent 3.9.1.236
-            path: /docs/release-notes/ruby-agent-391236
-          - title: Ruby Agent 4.0.0.332
-            path: /docs/release-notes/ruby-agent-400332
+          - title: Ruby Agent 6.10.0.364
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6100364
+          - title: Ruby Agent 6.11.0.365
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6110365
+          - title: Ruby Agent 6.12.0.367
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6120367
+          - title: Ruby Agent 6.13.0
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6130
+          - title: Ruby Agent 6.13.1
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6131
+          - title: Ruby Agent 6.14.0
+            path: /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-6140
+      - title: Python release notes
+        pages:
+          - title: Python Agent 1.0.2.130
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-102130
+          - title: Python Agent 1.0.3.138
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-103138
+          - title: Python Agent 1.0.5.156
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-105156
+          - title: Python Agent 1.1.0.192
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-110192
+          - title: Python Agent 1.2.0.246
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-120246
+          - title: Python Agent 1.2.1.265
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-121265
+          - title: Python Agent 1.3.0.289
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-130289
+          - title: Python Agent 1.4.0.137
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-140137
+          - title: Python Agent 1.5.0.103
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-150103
+          - title: Python Agent 1.6.0.13
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-16013
+          - title: Python Agent 1.7.0.31
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-17031
+          - title: Python Agent 1.8.0.13
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-18013
+          - title: Python Agent 1.9.0.21
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-19021
+          - title: Python Agent 1.10.0.28
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-110028
+          - title: Python Agent 1.10.1.36
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-110136
+          - title: Python Agent 1.10.2.38
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-110238
+          - title: Python Agent 1.11.0.55
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-111055
+          - title: Python Agent 1.12.0.56
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-112056
+          - title: Python Agent 1.13.0.30
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-113030
+          - title: Python Agent 1.13.1.31
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-113131
+          - title: Python Agent 2.0.0.1
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2001
+          - title: Python Agent 2.2.0.2
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2202
+          - title: Python Agent 2.2.1.3
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2213
+          - title: Python Agent 2.4.0.4
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2404
+          - title: Python Agent 2.6.0.5
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2605
+          - title: Python Agent 2.8.0.7
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2807
+          - title: Python Agent 2.10.0.8
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-21008
+          - title: Python Agent 2.10.1.9
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-21019
+          - title: Python Agent 2.12.0.10
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-212010
+          - title: Python Agent 2.14.0.11
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-214011
+          - title: Python Agent 2.16.0.12
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-216012
+          - title: Python Agent 2.18.1.15
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-218115
+          - title: Python Agent 2.20.0.17
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-220017
+          - title: Python Agent 2.20.1.18
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-220118
+          - title: Python Agent 2.22.0.19
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-222019
+          - title: Python Agent 2.22.1.20
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-222120
+          - title: Python Agent 2.24.0.21
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-224021
+          - title: Python Agent 2.26.0.22
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-226022
+          - title: Python Agent 2.26.2.24
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-226224
+          - title: Python Agent 2.28.0.26
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-228026
+          - title: Python Agent 2.30.0.27
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-230027
+          - title: Python Agent 2.32.0.28
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-232028
+          - title: Python Agent 2.34.0.29
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-234029
+          - title: Python Agent 2.36.0.30
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-236030
+          - title: Python Agent 2.38.0.31
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-238031
+          - title: Python Agent 2.38.2.33
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-238233
+          - title: Python Agent 2.40.0.34
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-240034
+          - title: Python Agent 2.42.0.35
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-242035
+          - title: Python Agent 2.44.0.36
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-244036
+          - title: Python Agent 2.46.0.37
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-246037
+          - title: Python Agent 2.48.0.38
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-248038
+          - title: Python Agent 2.50.0.39
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-250039
+          - title: Python Agent 2.52.0.40
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-252040
+          - title: Python Agent 2.54.0.41
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-254041
+          - title: Python Agent 2.56.0.42
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-256042
+          - title: Python Agent 2.58.0.43
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-258043
+          - title: Python Agent 2.58.1.44
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-258144
+          - title: Python Agent 2.58.2.45
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-258245
+          - title: Python Agent 2.60.0.46
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-260046
+          - title: Python Agent 2.62.0.47
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-262047
+          - title: Python Agent 2.64.0.48
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-264048
+          - title: Python Agent 2.66.0.49
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-266049
+          - title: Python Agent 2.68.0.50
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-268050
+          - title: Python Agent 2.70.0.51
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-270051
+          - title: Python Agent 2.72.0.52
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-272052
+          - title: Python Agent 2.72.1.53
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-272153
+          - title: Python Agent 2.74.0.54
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-274054
+          - title: Python Agent 2.76.0.55
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-276055
+          - title: Python Agent 2.78.0.57
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-278057
+          - title: Python Agent 2.80.0.60
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-280060
+          - title: Python Agent 2.80.1.61
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-280161
+          - title: Python Agent 2.82.0.62
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-282062
+          - title: Python Agent 2.82.1.63
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-282163
+          - title: Python Agent 2.84.0.64
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-284064
+          - title: Python Agent 2.86.0.65
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-286065
+          - title: Python Agent 2.86.1.66 - Superseded
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-286166
+          - title: Python Agent 2.86.2.68
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-286268
+          - title: Python Agent 2.86.3.70
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-286370
+          - title: Python Agent 2.88.0.72
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-288072
+          - title: Python Agent 2.88.1.73
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-288173
+          - title: Python Agent 2.90.0.75
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-290075
+          - title: Python Agent 2.92.0.78
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-292078
+          - title: Python Agent 2.94.0.79
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-294079
+          - title: Python Agent 2.96.0.80
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-296080
+          - title: Python Agent 2.98.0.81
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-298081
+          - title: Python Agent 2.100.0.84
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2100084
+          - title: Python Agent 2.102.0.85
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2102085
+          - title: Python Agent 2.104.0.86
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2104086
+          - title: Python Agent 2.106.0.87
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2106087
+          - title: Python Agent 2.106.1.88
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2106188
+          - title: Python Agent 3.0.0.89
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-30089
+          - title: Python Agent 3.2.0.91
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-32091
+          - title: Python Agent 3.2.1.93
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-32193
+          - title: Python Agent 3.2.2.94
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-32294
+          - title: Python Agent 3.4.0.95
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-34095
+          - title: Python Agent 4.0.0.99
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-40099
+          - title: Python Agent 4.2.0.100
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-420100
+          - title: Python Agent 4.4.0.103
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-440103
+          - title: Python Agent 4.4.1.104
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-441104
+          - title: Python Agent 4.6.0.106
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-460106
+          - title: Python Agent 4.8.0.110
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-480110
+          - title: Python Agent 4.10.0.112
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-4100112
+          - title: Python Agent 4.12.0.113
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-4120113
+          - title: Python Agent 4.14.0.115
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-4140115
+          - title: Python Agent 4.16.0.116
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-4160116
+          - title: Python Agent 4.16.1.117
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-4161117
+          - title: Python Agent 4.18.0.118
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-4180118
+          - title: Python Agent 4.20.0.120
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-4200120
+          - title: Python Agent 4.20.1.121
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-4201121
+          - title: Python Agent 5.0.0.124
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-500124
+          - title: Python Agent 5.0.1.125
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-501125
+          - title: Python Agent 5.0.2.126
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-502126
+          - title: Python Agent 5.2.0.127
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-520127
+          - title: Python Agent 5.2.1.129
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-521129
+          - title: Python Agent 5.2.2.130
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-522130
+          - title: Python Agent 5.2.3.131
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-523131
+          - title: Python Agent 5.4.0.132
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-540132
+          - title: Python Agent 5.4.1.134
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-541134
+          - title: Python Agent 5.6.0.135
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-560135
+          - title: Python Agent 5.8.0.136
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-580136
+          - title: Python Agent 5.10.0.138
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5100138
+          - title: Python Agent 5.12.0.140
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5120140
+          - title: Python Agent 5.12.1.141
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5121141
+          - title: Python Agent 5.14.0.142
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5140142
+          - title: Python Agent 5.14.1.144
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5141144
+          - title: Python Agent 5.16.0.145
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5160145
+          - title: Python Agent 5.16.1.146
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5161146
+          - title: Python Agent 5.16.2.147
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5162147
+          - title: Python Agent 5.18.0.148
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5180148
+          - title: Python Agent 5.20.0.149
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5200149
+          - title: Python Agent 5.20.1.150
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5201150
+          - title: Python Agent 5.22.0.151
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5220151
+          - title: Python Agent 5.22.1.152
+            path: /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5221152
+      - title: PHP Release Notes
+        pages:
+          - title: PHP Agent 2.0.2.65
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-20265
+          - title: PHP Agent 2.0.3.89
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-20389
+          - title: PHP Agent 2.0.5.98
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-20598
+          - title: PHP Agent 2.1.1.134
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-211134
+          - title: PHP Agent 2.1.3.164
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-213164
+          - title: PHP Agent 2.2.1.181
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-221181
+          - title: PHP Agent 2.2.1.185
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-221185
+          - title: PHP Agent 2.2.2.193
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-222193
+          - title: PHP Agent 2.2.3.196
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-223196
+          - title: PHP Agent 2.3.5.21
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-23521
+          - title: PHP Agent 2.4.5.24
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-24524
+          - title: PHP Agent 2.4.5.25
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-24525
+          - title: PHP Agent 2.4.5.26
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-24526
+          - title: PHP Agent 2.5.5.29
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-25529
+          - title: PHP Agent 2.6.5.41
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-26541
+          - title: PHP Agent 2.6.5.44
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-26544
+          - title: PHP Agent 2.6.5.55
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-26555
+          - title: PHP Agent 2.6.5.57
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-26557
+          - title: PHP Agent 2.7.5.64
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-27564
+          - title: PHP Agent 2.7.5.69
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-27569
+          - title: PHP Agent 2.8.5.73
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-28573
+          - title: PHP Agent 2.9.5.76
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-29576
+          - title: PHP Agent 2.9.5.78
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-29578
+          - title: PHP Agent 3.0.5.95
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent
+          - title: PHP Agent 3.1.5.111
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-315111
+          - title: PHP Agent 3.1.5.120
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-315120
+          - title: PHP Agent 3.1.5.136
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-315136
+          - title: PHP Agent 3.1.5.137
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-315137
+          - title: PHP Agent 3.1.5.141
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-315141
+          - title: PHP Agent 3.2.5.143
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-325143
+          - title: PHP Agent 3.2.5.147
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-325147
+          - title: PHP Agent 3.3.5.154
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-335154
+          - title: PHP Agent 3.3.5.160
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-335160
+          - title: PHP Agent 3.3.5.161
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-335161
+          - title: PHP Agent 3.4.5.167
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-345167
+          - title: PHP Agent 3.5.5.170
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-355170
+          - title: PHP Agent 3.5.5.172
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-355172
+          - title: PHP Agent 3.6.5.178
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-365178
+          - title: PHP Agent 3.7.5.7
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-3757
+          - title: PHP Agent 3.8.5.11
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-38511
+          - title: PHP Agent 3.9.5.13
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-39513
+          - title: PHP Agent 4.0.5.18
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-40518
+          - title: PHP Agent 4.1.5.24
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-41524
+          - title: PHP Agent 4.2.5.26
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-42526
+          - title: PHP Agent 4.2.5.27
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-42527
+          - title: PHP Agent 4.3.5.33
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-43533
+          - title: PHP Agent 4.4.5.35
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-44535
+          - title: PHP Agent 4.5.5.38
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-45538
+          - title: PHP Agent 4.6.5.40
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-46540
+          - title: PHP Agent 4.7.5.43
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-47543
+          - title: PHP Agent 4.8.0.47
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-48047
+          - title: PHP Agent 4.9.0.54
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-49054
+          - title: PHP Agent 4.10.0.60
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-410060
+          - title: PHP Agent 4.10.1.62
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-410162
+          - title: PHP Agent 4.11.0
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4110
+          - title: PHP Agent 4.11.1
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4111
+          - title: PHP Agent 4.12.0
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4120
+          - title: PHP Agent 4.13.0
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4130
+          - title: PHP Agent 4.13.1
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4131
+          - title: PHP Agent 4.14.0
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4140
+          - title: PHP Agent 4.15.0.74
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-415074
+          - title: PHP Agent 4.17.0.79
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-417079
+          - title: PHP Agent 4.17.0.83
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-417083
+          - title: PHP Agent 4.18.0.89
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-418089
+          - title: PHP Agent 4.19.0.90
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-419090
+          - title: PHP Agent 4.20.0.92
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-420092
+          - title: PHP Agent 4.20.1.93
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-420193
+          - title: PHP Agent 4.20.2.95
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-420295
+          - title: PHP Agent 4.21.0.97
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-421097
+          - title: PHP Agent 4.22.0.99
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-422099
+          - title: PHP Agent 4.23.0.102
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-423
+          - title: PHP Agent 4.23.1.107
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4231107
+          - title: PHP Agent 4.23.3.111
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4233111
+          - title: PHP Agent 4.23.4.113
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-4234113
+          - title: PHP Agent 5.0.0.115
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-500115
+          - title: PHP Agent 5.1.0.129
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-510129
+          - title: PHP Agent 5.1.1.130
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-511130
+          - title: PHP Agent 5.2.0.141
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-520141
+          - title: PHP Agent 5.3.0.148
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-530148
+          - title: PHP Agent 5.4.0.150
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-540150
+          - title: PHP Agent 5.5.0.154
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-550154
+          - title: PHP Agent 6.0.0.155
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-600155
+          - title: PHP Agent 6.0.1.156
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-601156
+          - title: PHP Agent 6.1.0.157
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-610157
+          - title: PHP Agent 6.2.0.158
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-620158
+          - title: PHP Agent 6.2.1.0
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-6210
+          - title: PHP Agent 6.3.0.161
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-630161
+          - title: PHP Agent 6.4.0.163
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-640163
+          - title: PHP Agent 6.5.0.166
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-650166
+          - title: PHP Agent 6.6.0.169
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-660169
+          - title: PHP Agent 6.6.1.172
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-661172
+          - title: PHP Agent 6.7.0.174
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-670174
+          - title: PHP Agent 6.8.0.177
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-680177
+          - title: PHP Agent 6.9.0.182
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-690182
+          - title: PHP Agent 7.0.0.186
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-700186
+          - title: PHP Agent 7.1.0.187
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-710187
+          - title: PHP Agent 7.2.0.191
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-720191
+          - title: PHP Agent 7.3.0.193
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-730193
+          - title: PHP Agent 7.3.1.197
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-731197
+          - title: PHP Agent 7.4.0.198
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-740198
+          - title: PHP Agent 7.5.0.199
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-750199
+          - title: PHP Agent 7.6.0.201
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-760201
+          - title: PHP Agent 7.7.0.203
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-770203
+          - title: PHP Agent 8.0.0.204
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-800204
+          - title: PHP Agent 8.1.0.209
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-810209
+          - title: PHP Agent 8.2.0.221
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-820221
+          - title: PHP Agent 8.3.0.226
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-830226
+          - title: PHP Agent 8.4.0.231
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-840231
+          - title: PHP Agent 8.5.0.235
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-850235
+          - title: PHP Agent 8.6.0.238
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-860238
+          - title: PHP Agent 8.7.0.242
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-870242
+          - title: PHP Agent 9.0.2.245
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-902245
+          - title: PHP Agent 9.0.0.242
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-900242
+          - title: PHP Agent 9.1.0.246
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-910246
+          - title: PHP Agent 9.2.0.247
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-920247
+          - title: PHP Agent 9.3.0.248
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-930248
+          - title: PHP Agent 9.4.0.249
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-940249
+          - title: PHP Agent 9.4.1.250
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-941250
+          - title: PHP Agent 9.5.0.252
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-950252
+          - title: PHP Agent 9.6.0.255
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-960255
+          - title: PHP Agent 9.6.1.256
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-961256
+          - title: PHP Agent 9.7.0.258
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-970258
+          - title: PHP Agent 9.8.0.259
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-980259
+          - title: PHP Agent 9.9.0.260
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-990260
+          - title: PHP Agent 9.10.0.262
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-9100262
+          - title: PHP Agent 9.10.1.263
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-9101263
+          - title: PHP Agent 9.11.0.267
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-9110267
+          - title: PHP Agent 9.12.0.268
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-9120268
+          - title: PHP Agent 9.13.0.270
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-9130270
+          - title: PHP Agent 9.14.0.290
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-9140290
+          - title: PHP Agent 9.15.0.293
+            path: /docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293
+      - title: Node.js release notes
+        pages:
+          - title: Node Agent 1.0.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-100
+          - title: Node Agent 1.0.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-101
+          - title: Node Agent 1.1.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-110
+          - title: Node Agent 1.1.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-111
+          - title: Node Agent 1.2.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-120
+          - title: Node Agent 1.3.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-130
+          - title: Node Agent 1.3.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-131
+          - title: Node Agent 1.3.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-132
+          - title: Node Agent 1.4.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-140
+          - title: Node Agent 1.5.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-150
+          - title: Node Agent 1.5.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-151
+          - title: Node Agent 1.5.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-152
+          - title: Node Agent 1.5.3
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-153
+          - title: Node Agent 1.5.4
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-154
+          - title: Node Agent 1.5.5
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-155
+          - title: Node Agent 1.6.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-160
+          - title: Node Agent 1.7.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-170
+          - title: Node Agent 1.7.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-171
+          - title: Node Agent 1.7.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-172
+          - title: Node Agent 1.7.3
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-173
+          - title: Node Agent 1.7.4
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-174
+          - title: Node Agent 1.7.5
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-175
+          - title: Node Agent 1.8.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-180
+          - title: Node Agent 1.8.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-181
+          - title: Node Agent 1.9.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-190
+          - title: Node Agent 1.9.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-191
+          - title: Node Agent 1.9.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-192
+          - title: Node Agent 1.10.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1100
+          - title: Node Agent 1.10.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1101
+          - title: Node Agent 1.10.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1102
+          - title: Node Agent 1.10.3
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1103
+          - title: Node Agent 1.11.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1110
+          - title: Node Agent 1.11.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1111
+          - title: Node Agent 1.11.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1112
+          - title: Node Agent 1.11.3
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1113
+          - title: Node Agent 1.11.4
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1114
+          - title: Node Agent 1.11.5
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1115
+          - title: Node Agent 1.12.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1120
+          - title: Node Agent 1.12.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1121
+          - title: Node Agent 1.12.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1122
+          - title: Node Agent 1.13.0
+            path: /docs/release-notes/node-agent-1130
+          - title: Node Agent 1.13.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1131
+          - title: Node Agent 1.13.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1132
+          - title: Node Agent 1.13.3
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1133
+          - title: Node Agent 1.13.4
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1134
+          - title: Node Agent 1.14.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1140
+          - title: Node Agent 1.14.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1141
+          - title: Node Agent 1.14.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1142
+          - title: Node Agent 1.14.3
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1143
+          - title: Node Agent 1.14.4
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1144
+          - title: Node Agent 1.14.5
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1145
+          - title: Node Agent 1.14.6
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1146
+          - title: Node Agent 1.14.7
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1147
+          - title: Node Agent 1.15.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1150
+          - title: Node Agent 1.15.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1151
+          - title: Node Agent 1.16.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1160
+          - title: Node Agent 1.16.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1161
+          - title: Node Agent 1.16.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1162
+          - title: Node Agent 1.16.3
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1163
+          - title: Node Agent 1.16.4
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1164
+          - title: Node.js Agent 1.17.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/nodejs-agent-1170
+          - title: Node Agent 1.17.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1171
+          - title: Node Agent 1.17.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1172
+          - title: Node Agent 1.17.3
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1173
+          - title: Node Agent 1.18.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1180
+          - title: Node Agent 1.18.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/clone-node-agent-1181
+          - title: Node.js Agent 1.18.3
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/nodejs-agent-1183
+          - title: Node Agent 1.18.4
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1184
+          - title: Node Agent 1.18.5
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1185
+          - title: Node Agent 1.19.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1190
+          - title: Node.js Agent 1.19.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/nodejs-agent-1191
+          - title: Node.js Agent 1.19.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/nodejs-agent-1192
+          - title: Node.js Agent 1.20.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/nodejs-agent-1200
+          - title: Node Agent 1.20.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1201
+          - title: Node Agent 1.20.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1202
+          - title: Node Agent 1.21.0 - Superseded
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1210-superseded
+          - title: Node Agent 1.21.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1211
+          - title: Node Agent 1.21.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1212
+          - title: Node Agent 1.22.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1220
+          - title: Node Agent 1.22.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1221
+          - title: Node Agent 1.22.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1222
+          - title: Node Agent 1.23.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1230
+          - title: Node Agent 1.23.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1231
+          - title: Node Agent 1.24.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1240
+          - title: Node Agent 1.24.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1241
+          - title: Node Agent 1.25.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1250
+          - title: Node Agent 1.25.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1251
+          - title: Node Agent 1.25.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1252
+          - title: Node Agent 1.25.3
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1253
+          - title: Node Agent 1.25.4
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1254
+          - title: Node Agent 1.25.5
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1255
+          - title: Node Agent 1.26.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1260
+          - title: Node Agent 1.26.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1261
+          - title: Node Agent 1.26.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1262
+          - title: Node Agent 1.27.0 - Superseded
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1270
+          - title: Node Agent 1.27.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1271
+          - title: Node Agent 1.27.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1272
+          - title: Node Agent 1.28.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1280
+          - title: Node Agent 1.28.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1281
+          - title: Node Agent 1.28.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1282
+          - title: Node Agent 1.28.3
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1283
+          - title: Node Agent 1.29.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1290
+          - title: Node Agent 2.0.0-beta
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-200-beta
+          - title: Node Agent 1.30.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1300
+          - title: Node Agent 2.1.0-beta
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-210-beta
+          - title: Node Agent 1.30.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1301
+          - title: Node Agent 1.30.2 - Superseded
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1302
+          - title: Node Agent 1.30.3
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1303
+          - title: Node Agent 2.1.1-beta
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-211-beta
+          - title: Node Agent 1.30.4
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1304
+          - title: Node Agent 1.30.5
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1305
+          - title: Node Agent 1.31.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1310
+          - title: Node Agent 1.32.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1320
+          - title: Node Agent 1.33.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1330
+          - title: Node Agent 2.2.0-beta
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-220-beta
+          - title: Node Agent 1.34.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1340
+          - title: Node Agent 1.35.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1351
+          - title: Node Agent 1.35.0 - Superseded
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1350-superseded
+          - title: Node Agent 1.36.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1360
+          - title: Node Agent 2.3.0-beta
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-230-beta
+          - title: Node Agent 1.36.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1361
+          - title: Node Agent 2.3.1-beta
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-231-beta
+          - title: Node Agent 2.4.0-beta
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-240-beta
+          - title: Node Agent 1.36.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1362
+          - title: Node Agent 1.37.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1370
+          - title: Node Agent 1.37.1 - Superseded
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1371
+          - title: Node Agent 1.37.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1372
+          - title: Node Agent 2.5.0-beta
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-250-beta
+          - title: Node Agent 1.38.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1380
+          - title: Node Agent 1.38.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1381
+          - title: Node Agent 1.38.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1382
+          - title: Node Agent 1.39.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1390
+          - title: Node Agent 2.6.0-beta
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-260-beta
+          - title: Node Agent 1.39.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1391
+          - title: Node Agent 1.40.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1400
+          - title: Node Agent 2.0.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-200
+          - title: Node Agent 2.0.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-201
+          - title: Node Agent 2.0.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-202
+          - title: Node Agent 2.1.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-210
+          - title: Node Agent 2.2.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-220
+          - title: Node Agent 2.2.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-221
+          - title: Node Agent 2.2.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-222
+          - title: Node Agent 2.3.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-230
+          - title: Node Agent 2.3.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-231
+          - title: Node Agent 2.3.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-232
+          - title: Node Agent 2.4.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-240
+          - title: Node Agent 2.4.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-241
+          - title: Node Agent 2.4.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-242
+          - title: Node Agent 2.5.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-250
+          - title: Node Agent 2.6.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-260
+          - title: Node Agent 2.6.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-261
+          - title: Node Agent 2.7.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-270
+          - title: Node Agent 2.7.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-271
+          - title: Node Agent 2.8.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-280
+          - title: Node Agent 2.9.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-290
+          - title: Node Agent 2.9.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-291
+          - title: Node Agent 3.0.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-300
+          - title: Node Agent 3.1.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-310
+          - title: Node Agent 3.2.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-320
+          - title: Node Agent 3.3.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-330
+          - title: Node Agent 3.3.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-331
+          - title: Node Agent 4.0.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-400
+          - title: Node Agent 4.1.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-410
+          - title: Node Agent 4.1.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-411
+          - title: Node Agent 4.1.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-412
+          - title: Node Agent 4.1.3
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-413
+          - title: Node agent 4.1.5
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-415
+          - title: Node Agent 4.2.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-420
+          - title: Node Agent 4.2.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-421
+          - title: Node Agent 4.3.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-430
+          - title: Node Agent 4.4.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-440
+          - title: Node Agent 4.5.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-450
+          - title: Node Agent 4.5.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-451
+          - title: Node Agent 4.6.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-460
+          - title: Node Agent 4.7.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-470
+          - title: Node Agent 4.8.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-480
+          - title: Node Agent 4.8.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-481
+          - title: Node Agent 4.9.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-490
+          - title: Node Agent 4.10.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-4100
+          - title: Node Agent 4.11.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-4110
+          - title: Node Agent 4.12.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-4120
+          - title: Node Agent 4.13.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-4130
+          - title: Node Agent 5.0.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-500
+          - title: Node Agent 5.1.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-510
+          - title: Node Agent 5.2.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-520
+          - title: Node Agent 5.2.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-521
+          - title: Node Agent 5.3.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-530
+          - title: Node Agent 5.5.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-550
+          - title: Node Agent 5.6.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-560
+          - title: Node Agent 5.6.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-561
+          - title: Node Agent 5.6.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-562
+          - title: Node Agent 5.6.3
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-563
+          - title: Node Agent 5.6.4
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-564
+          - title: Node Agent 4.13.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-4131
+          - title: Node Agent 5.7.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-570
+          - title: Node Agent 5.8.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-580
+          - title: Node Agent 5.9.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-590
+          - title: Node Agent 5.9.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-591
+          - title: Node Agent 5.10.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-5100
+          - title: Node Agent 5.11.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-5110
+          - title: Node Agent 5.13.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-5130
+          - title: Node Agent 5.13.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-5131
+          - title: Node Agent 6.0.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-600
+          - title: Node Agent 6.1.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-610
+          - title: Node Agent 6.2.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-620
+          - title: Node Agent 6.3.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-630
+          - title: Node Agent 6.4.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-640
+          - title: Node Agent 6.4.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-641
+          - title: Node Agent 6.4.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-642
+          - title: Node Agent 6.5.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-650
+          - title: Node Agent 6.6.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-660
+          - title: Node Agent 6.7.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-670
+          - title: Node Agent 6.7.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-671
+          - title: Node Agent 6.8.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-680
+          - title: Node Agent 6.9.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-690
+          - title: Node Agent 6.10.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6100
+          - title: Node Agent 6.11.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6110
+          - title: Node Agent 6.12.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6120
+          - title: Node Agent 6.12.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6121
+          - title: Node Agent 6.13.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6130
+          - title: Node Agent 6.13.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6131
+          - title: Node Agent 6.13.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6132
+          - title: Node Agent 6.14.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6140
+          - title: Node Agent 7.0.0
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-700
+          - title: Node Agent 7.0.1
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-701
+          - title: Node Agent 7.0.2
+            path: /docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-702
+      - title: Java release notes
+        pages:
+          - title: Java Agent 1.3.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-130
+          - title: Java Agent 1.4.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-140
+          - title: Java Agent 2.0.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-200
+          - title: Java Agent 2.0.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-201
+          - title: Java Agent 2.0.2
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-202
+          - title: Java Agent 2.0.3
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-203
+          - title: Java Agent 2.0.4
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-204
+          - title: Java Agent 2.1.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-210
+          - title: Java Agent 2.1.2
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-212
+          - title: Java Agent 2.2.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-220
+          - title: Java Agent 2.2.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-221
+          - title: Java Agent 2.3.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-230
+          - title: Java Agent 2.3.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-231
+          - title: Java Agent 2.4.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-240
+          - title: Java Agent 2.4.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-241
+          - title: Java Agent 2.4.2
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-242
+          - title: Java Agent 2.5.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-250
+          - title: Java Agent 2.6.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-260
+          - title: Java Agent 2.7.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-270
+          - title: Java Agent 2.8.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-280
+          - title: Java Agent 2.9.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-290
+          - title: Java Agent 2.10.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2100
+          - title: Java Agent 2.10.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2101
+          - title: Java Agent 2.11.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2110
+          - title: Java Agent 2.12.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2120
+          - title: Java Agent 2.13.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2130
+          - title: Java Agent 2.14.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2140
+          - title: Java Agent 2.14.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2141
+          - title: java Agent 2.15.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2150
+          - title: Java Agent 2.15.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2151
+          - title: Java Agent 2.16.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2160
+          - title: Java Agent 2.17.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2170
+          - title: Java Agent 2.17.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2171
+          - title: Java Agent 2.17.2
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2172
+          - title: Java Agent 2.18.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2180
+          - title: Java Agent 2.19.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2190
+          - title: Java Agent 2.19.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2191
+          - title: Java Agent 2.20.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2200
+          - title: Java Agent 2.21.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2210
+          - title: Java Agent 2.21.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2211
+          - title: Java Agent 2.21.2
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2212
+          - title: Java Agent 2.21.3
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2213
+          - title: Java Agent 2.21.4
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2214
+          - title: Java Agent 3.0.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-300
+          - title: Java Agent 3.0.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-301
+          - title: Java Agent 3.1.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-310
+          - title: Java Agent 3.1.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-311
+          - title: Java Agent 3.2.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-320
+          - title: Java Agent 3.2.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-321
+          - title: Java Agent 3.2.2
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-322
+          - title: Java Agent 3.2.3
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-323
+          - title: Java Agent 3.3.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-331
+          - title: Java Agent 3.3.2
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-332
+          - title: Java Agent 3.4.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-340
+          - title: Java Agent 3.4.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-341
+          - title: Java Agent 3.4.2
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-342
+          - title: Java Agent 2.21.5
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2215
+          - title: Java Agent 3.5.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-350
+          - title: Java Agent 3.5.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-351
+          - title: Java Agent 2.21.6
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2216
+          - title: Java Agent 3.6.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-360
+          - title: Java Agent 3.7.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-370
+          - title: Java Agent 3.7.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-371
+          - title: Java Agent 3.7.2
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-ageny-372
+          - title: Java Agent 3.8.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-380
+          - title: Java Agent 3.8.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-381
+          - title: Java Agent 3.8.2
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-382
+          - title: Java Agent 3.9.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-390
+          - title: Java Agent 3.10.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3100
+          - title: Java Agent 3.11.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3110
+          - title: Java Agent 3.12.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3120
+          - title: Java Agent 3.12.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3121
+          - title: Java Agent 2.21.7
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-2217
+          - title: Java Agent 3.13.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3130
+          - title: Java Agent 3.14.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3140
+          - title: Java Agent 3.15.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3150
+          - title: Java Agent 3.16.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3161
+          - title: Java Agent 3.17.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3170
+          - title: Java Agent 3.17.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3171
+          - title: Java Agent 3.18.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3180
+          - title: Java Agent 3.19.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3190
+          - title: Java Agent 3.19.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3191
+          - title: Java Agent 3.19.2
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3192
+          - title: Java Agent 3.20.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3200
+          - title: Java Agent 3.21.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3210
+          - title: Java Agent 3.22.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3220
+          - title: Java Agent 3.22.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3221
+          - title: Java Agent 3.23.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3230
+          - title: Java Agent 3.24.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3240
+          - title: Java Agent 3.24.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3241
+          - title: Java Agent 3.25.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3250
+          - title: Java Agent 3.26.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3260
+          - title: Java Agent 3.26.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3261
+          - title: Java Agent 3.27.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3270
+          - title: Java Agent 3.28.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3280
+          - title: Java Agent 3.29.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3290
+          - title: Java Agent 3.30.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3300
+          - title: Java Agent 3.30.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3301-1
+          - title: Java Agent 3.31.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3310
+          - title: Java Agent 3.31.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3311
+          - title: Java Agent 3.32.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3320
+          - title: Java Agent 3.33.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3330
+          - title: Java Agent 3.34.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3340
+          - title: Java Agent 3.35.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3350
+          - title: Java Agent 3.35.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3351
+          - title: Java Agent 3.35.2
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3352
+          - title: Java Agent 3.36.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3360
+          - title: Java Agent 3.37.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3370
+          - title: Java Agent 3.38.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3380
+          - title: Java Agent 3.39.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3390
+          - title: Java agent 3.39.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3391
+          - title: Java Agent 3.40.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3400-0
+          - title: Java Agent 3.41.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3410
+          - title: Java Agent 3.42.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3420
+          - title: Java Agent 3.43.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3430
+          - title: Java Agent 3.44.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3440
+          - title: Java Agent 3.44.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3441
+          - title: Java agent 3.45.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3450
+          - title: Java Agent 3.46.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3460
+          - title: Java agent 3.47.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3470
+          - title: Java agent 3.47.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3471
+          - title: Java Agent 3.48.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-3480
+          - title: Java agent 4.0.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-400
+          - title: Java Agent 4.0.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-401
+          - title: Java Agent 4.1.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-410
+          - title: Java Agent 4.2.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-420
+          - title: Java Agent 4.3.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-430
+          - title: Java Agent 4.4.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-440
+          - title: Java agent 4.5.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-450
+          - title: Java agent 4.6.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-460
+          - title: Java Agent 4.7.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-470
+          - title: Java Agent 4.8.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-480
+          - title: Java Agent 4.9.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-490
+          - title: Java Agent 4.10.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-4100
+          - title: Java agent 4.11.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-4110
+          - title: Java agent 4.12.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-4120
+          - title: Java Agent 4.12.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-4121
+          - title: Java Agent 5.0.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-500
+          - title: Java Agent 5.1.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-510
+          - title: Java Agent 5.1.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-511
+          - title: Java Agent 5.2.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-520
+          - title: Java Agent 5.3.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-530
+          - title: Java Agent 5.4.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-540
+          - title: Java Agent 5.5.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-550
+          - title: Java Agent 5.6.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-560
+          - title: Java Agent 5.7.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-570
+          - title: Java Agent 5.8.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-580
+          - title: Java Agent 5.9.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-590
+          - title: Java Agent 5.10.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-5100
+          - title: Java Agent 5.11.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-5110
+          - title: Java Agent 5.12.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-5120
+          - title: Java Agent 5.12.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-5121
+          - title: Java Agent 5.13.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-5130
+          - title: Java Agent 5.14.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-5140
+          - title: Java Agent 6.0.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-600
+          - title: Java Agent 6.1.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-610
+          - title: Java Agent 6.2.0
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-620
+          - title: Java Agent 6.2.1
+            path: /docs/release-notes/agent-release-notes/java-release-notes/java-agent-621
+      - title: NET release notes
+        pages:
+          - title: .NET Agent 2.0.5
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-205
+          - title: .NET Agent 2.0.6
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-206
+          - title: .NET Agent 2.0.7
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-207
+          - title: .NET Agent 2.0.8.4
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2084
+          - title: .NET Agent 2.0.9.15
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-20915
+          - title: .NET Agent 2.0.10.3
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-20103
+          - title: .NET Agent 2.0.11.1
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-20111
+          - title: .NET Agent 2.0.12.4
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-20124
+          - title: .NET Agent 2.1.0.5
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2105
+          - title: .NET Agent 2.1.1.13
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-21113
+          - title: .NET Agent 2.1.2.472
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-212472
+          - title: .NET Agent 2.1.3.494
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-213494
+          - title: .NET Agent 2.2.83.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-22830
+          - title: .NET Agent 2.3.126.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-231260
+          - title: .NET Agent 2.4.57.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-24570
+          - title: .NET Agent 2.5.112.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-251120
+          - title: .NET Agent 2.6.54.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-26540
+          - title: .NET Agent 2.7.60.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-27600
+          - title: .NET Agent 2.8.134.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-281340
+          - title: .NET Agent 2.8.1.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2810
+          - title: .NET Agent 2.9.135.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-291350
+          - title: .NET Agent 2.10.40.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-210400
+          - title: .NET Agent 2.12.146.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2121460
+          - title: .NET Agent 2.13.38.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-213380
+          - title: .NET Agent 2.14.53.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-214530
+          - title: .NET Agent 2.15.180.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2151800
+          - title: .NET Agent  2.15.186.1
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2151861
+          - title: .NET Agent 2.16.164.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2161640
+          - title: .NET Agent 2.17.266.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2172660
+          - title: .NET Agent 2.17.268.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2172680
+          - title: .NET Agent 2.18.35.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-218350
+          - title: .NET Agent 2.19.3.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-21930
+          - title: .NET Agent 2.20.24.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-220240
+          - title: .NET Agent 2.20.25.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-220250
+          - title: .NET Agent 2.21.84.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-221840
+          - title: .NET Agent 2.22.79.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-222790
+          - title: .NET Agent 2.23.2.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-22320
+          - title: .NET Agent 2.24.218.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2242180
+          - title: .NET Agent 2.25.208.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2252080
+          - title: .NET Agent 3.0.79.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-30790
+          - title: .NET Agent 3.1.65.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-31650
+          - title: .NET Agent 3.2.113.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-321130
+          - title: .NET Agent 3.3.38.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-33380
+          - title: .NET Agent 3.4.24.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-34240
+          - title: .NET Agent 3.5.107.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-351070
+          - title: .NET Agent 3.6.177.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-361770
+          - title: .NET Agent 3.7.135.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-371350
+          - title: .NET Agent 3.8.1.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-3810
+          - title: .NET Agent 3.9.146.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-391460
+          - title: .NET Agent 3.10.43.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-310430
+          - title: .NET Agent 3.11.296.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-3112960
+          - title: .NET Agent 3.12.140.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-3121400
+          - title: .NET Agent 4.0.146.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-401460
+          - title: .NET Agent 4.1.134.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-411340
+          - title: .NET Agent 4.1.136.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-411360
+          - title: .NET agent 4.2.185.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-421850
+          - title: .NET agent 4.3.123.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-431230
+          - title: .NET agent 4.4.60.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-44600
+          - title: .NET agent 4.5.90.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-45900
+          - title: .NET agent 4.6.29.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-46290
+          - title: .NET agent 5.0.136.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-501360
+          - title: .NET agent 5.1.72.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-51720
+          - title: .NET agent 5.2.87.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-52870
+          - title: .NET agent 5.3.90.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-53900
+          - title: .NET agent 5.4.16.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-54160
+          - title: .NET agent 5.5.52.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-55520
+          - title: .NET agent 5.6.53.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-56530
+          - title: .NET agent 5.7.17.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-57170
+          - title: .NET agent 5.8.28.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-58280
+          - title: .NET agent 5.9.74.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-59740
+          - title: .NET agent 5.10.59.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-510590
+          - title: .NET agent 5.11.53.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-511530
+          - title: .NET agent 5.12.13.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-512130
+          - title: .NET agent 5.13.30.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-513300
+          - title: .NET agent 5.14.43.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-514430
+          - title: .NET agent 5.15.64.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-515640
+          - title: .NET agent 5.16.71.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-516710
+          - title: .NET agent 5.17.59.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-517590
+          - title: .NET agent 5.18.36.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-518360
+          - title: .NET agent 5.19.47.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-519470
+          - title: .NET agent 5.20.61.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-520610
+          - title: .NET agent 5.21.74.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-521740
+          - title: .NET agent 5.22.6.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-52260
+          - title: .NET agent 6.0.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6000
+          - title: .NET agent 6.1.48.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-61480
+          - title: .NET agent 6.2.26.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-62260
+          - title: .NET agent 6.3.123.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-631230
+          - title: .NET agent 6.4.21.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-64210
+          - title: .NET agent 6.5.29.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-65290
+          - title: .NET Agent 6.6.5.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6650
+          - title: .NET agent 6.7.67.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-67670
+          - title: .NET agent 6.8.172.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-681720
+          - title: .NET agent 6.9.62.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-69620
+          - title: .NET agent 6.10.1.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-61010
+          - title: .NET agent 6.11.613.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6116130
+          - title: .NET agent 6.12.61.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-612610
+          - title: .NET agent 6.12.64.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-612640
+          - title: .NET agent 6.12.71.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-612710
+          - title: .NET agent 6.13.366.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6133660
+          - title: .NET agent 6.14.209.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6142090
+          - title: .NET agent 6.15.202.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6152020
+          - title: .NET agent 6.16.178.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6161780
+          - title: .NET agent 6.17.387.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6173870
+          - title: .NET agent 6.18.139.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6181390
+          - title: .NET agent 6.19.330.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6193300
+          - title: .NET agent 6.20.166.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-6201660
+          - title: .NET agent 7.0.2.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-7020
+          - title: .NET agent 6.21.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-62100
+          - title: .NET agent 7.1.229.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-712290
+          - title: .NET Agent 8.0.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8000
+          - title: .NET Agent 6.22.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-62200
+          - title: .NET Agent 8.1.709.0 - Superseded
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-817090
+          - title: .NET Agent 8.1.712.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-817120
+          - title: .NET Agent 8.2.216.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-822160
+          - title: .NET Agent 8.3.360.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-833600
+          - title: .NET Agent 8.4.880.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-848800
+          - title: .NET Agent 8.5.186.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-851860
+          - title: .NET Agent 8.6.45.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-86450
+          - title: .NET Agent 8.7.75.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8775
+          - title: .NET Agent 8.8.83.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-88830
+          - title: .NET Agent 8.9.130.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-891300
+          - title: .NET Agent 8.10.51.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-810510
+          - title: .NET Agent 8.11.157.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8111570
+          - title: .NET Agent 8.12.216.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8122160
+          - title: .NET Agent 8.13.798.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8137980
+          - title: .NET Agent 8.14.222.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8142220
+          - title: .NET Agent 8.15.455.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8154550
+          - title: .NET Agent 6.23.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-62300
+          - title: .NET Agent 8.16.567.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8165670
+          - title: .NET Agent 8.17.438.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8174380
+          - title: .NET Agent 6.24.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-62400
+          - title: .NET Agent 8.18.241.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8182410
+          - title: .NET Agent 8.19.353.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8193530
+          - title: .NET Agent 8.20.262.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/agent-8202620
+          - title: .NET Agent 8.21.34.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-821340
+          - title: .NET Agent 8.22.181.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8221810
+          - title: .NET Agent 6.25.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-62500
+          - title: .NET Agent 8.23.107.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8231070
+          - title: .NET Agent 8.24.244.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8242440
+          - title: .NET Agent 8.25.214.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8252140
+          - title: .NET Agent 8.26.630.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8266300
+          - title: .NET Agent 8.27.139.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8271390
+          - title: .NET Agent 8.28.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8280
+          - title: .NET Agent 8.29.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-82900
+          - title: .NET Agent 8.30.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-83000
+          - title: .NET Agent 8.31.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-83100
+          - title: NET Agent 6.26.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-62600
+          - title: .NET Agent 8.32.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-83200
+          - title: .NET Agent 8.33.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-83300
+          - title: .NET Agent 8.34.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-83400
+          - title: .NET Agent 8.35.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-83500
+          - title: NET Agent 8.36.0.0
+            path: /docs/release-notes/agent-release-notes/net-release-notes/net-agent-83600
+      - title: Go release notes
+        pages:
+          - title: Go Agent 1.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-10
+          - title: Go Agent 1.1
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-11
+          - title: Go Agent 1.2
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-12
+          - title: Go Agent 1.3
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-13
+          - title: Go Agent 1.4
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-14
+          - title: Go Agent 1.6
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-16
+          - title: Go Agent 1.7
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-17
+          - title: Go Agent 1.8
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-18
+          - title: Go Agent 1.9
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-19
+          - title: Go Agent 1.10
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-110
+          - title: Go Agent 1.11
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-111
+          - title: Go Agent 2.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-20
+          - title: Go Agent 2.1
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-21
+          - title: Go Agent 2.2
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-22
+          - title: Go Agent 2.3
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-23
+          - title: Go Agent 2.4
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-24
+          - title: Go Agent 2.5
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-25
+          - title: Go Agent 2.6
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-26
+          - title: Go Agent 2.7
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-27
+          - title: Go Agent 2.8
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-28
+          - title: Go Agent 2.8.1
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-281
+          - title: Go Agent 2.9.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-290
+          - title: Go Agent 2.10.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2100
+          - title: Go Agent 2.11.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2110
+          - title: Go Agent 2.12.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2120
+          - title: Go Agent 2.13.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2130
+          - title: Go Agent 2.14.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2140
+          - title: Go Agent 2.14.1
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2141
+          - title: Go Agent 2.15.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2150
+          - title: Go Agent 2.16.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2160
+          - title: Go Agent 2.16.1
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2161
+          - title: Go Agent 2.16.2
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2162
+          - title: Go Agent 2.16.3
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-2163
+          - title: Go Agent 3.0.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-300
+          - title: Go Agent 3.1.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-310
+          - title: Go Agent 3.2.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-320
+          - title: Go Agent 3.3.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-330
+          - title: Go Agent 3.4.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-340
+          - title: Go Agent 3.5.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-350
+          - title: Go Agent 3.6.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-360
+          - title: Go Agent 3.7.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-370
+          - title: Go Agent 3.8.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-380
+          - title: Go Agent 3.8.1
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-381
+          - title: Go Agent 3.9.0
+            path: /docs/release-notes/agent-release-notes/go-release-notes/go-agent-390
+      - title: C SDK release notes
+        pages:
+          - title: C SDK 1.0.0
+            path: /docs/release-notes/agent-release-notes/c-sdk-release-notes/c-sdk-100
+          - title: C SDK 1.1.0
+            path: /docs/release-notes/agent-release-notes/c-sdk-release-notes/c-sdk-110
+          - title: C SDK 1.2.0
+            path: /docs/release-notes/agent-release-notes/c-sdk-release-notes/c-sdk-120
+          - title: C SDK 1.3.0
+            path: /docs/release-notes/agent-release-notes/c-sdk-release-notes/c-sdk-130
   - title: Mobile release notes
     pages:
-      - title: iOS release notes
-        pages:
-          - title: iOS 3.130
-            path: /docs/release-notes/agent-release-notes/java-release-notes/ios-3130
-          - title: iOS 1.300
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-1300
-          - title: iOS 1.328
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-1328
-          - title: iOS 1.342
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-1342
-          - title: iOS 1.354
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-1354
-          - title: iOS 1.376
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-1376
-          - title: iOS 1.396
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-1396
-          - title: iOS 3.154
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3154
-          - title: iOS 3.174
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3174
-          - title: iOS 3.184
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3184
-          - title: iOS 3.196
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3196
-          - title: iOS 3.252
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3252
-          - title: iOS 3.256
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3256
-          - title: iOS 3.257
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3257
-          - title: iOS 3.289
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3289
-          - title: iOS 3.311
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3311
-          - title: iOS 3.324
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3324
-          - title: iOS 3.343
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3343
-          - title: iOS 3.378
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3378
-          - title: iOS 3.380
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3380
-          - title: iOS 3.396
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3396
-          - title: iOS 3.398
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3398
-          - title: iOS 3.406
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3406-0
-          - title: iOS 3.412
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3412
-          - title: iOS 4.139
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-4139
-          - title: iOS 4.152
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-4152-0
-          - title: iOS 4.155
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-4155
-          - title: iOS 4.174
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-4174
-          - title: iOS 4.186
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-4186
-          - title: iOS 4.186.1
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-41861
-          - title: iOS 4.83
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-483
-          - title: iOS 5.0.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-500
-          - title: iOS 5.0.1
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-501
-          - title: iOS 5.0.2
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-502
-          - title: iOS 5.0.3
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-503
-          - title: iOS 5.1.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-510
-          - title: iOS 5.1.2
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-512
-          - title: iOS 5.2.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-520
-          - title: iOS 5.2.1
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-521
-          - title: iOS 5.3.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-530
-          - title: iOS 5.3.1
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-531
-          - title: iOS 5.3.2
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-532
-          - title: iOS 1.309
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-1309
-          - title: iOS Agent 5.10.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5100
-          - title: iOS Agent 5.10.1
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5101
-          - title: iOS Agent 5.11.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5110
-          - title: iOS Agent 5.12.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5120
-          - title: iOS Agent 5.12.2
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5122
-          - title: iOS Agent 5.12.3
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5123
-          - title: iOS Agent 5.13.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5130
-          - title: iOS Agent 5.14.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5140
-          - title: iOS Agent 5.14.1
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5141
-          - title: iOS Agent 5.14.2
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5142
-          - title: iOS Agent 5.15.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5150
-          - title: iOS 5.2.2
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-522
-          - title: iOS Agent 5.3.4
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-534
-          - title: iOS Agent 5.3.5
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-535
-          - title: iOS Agent 5.3.6
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-536
-          - title: iOS Agent 5.4.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-540
-          - title: iOS Agent 5.4.1
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-541
-          - title: iOS Agent 5.5.0 (removed)
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-550
-          - title: iOS Agent 5.5.1
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-551
-          - title: iOS Agent 5.5.2
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-552
-          - title: iOS Agent 5.6.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-560
-          - title: iOS Agent 5.7.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-570
-          - title: IOS Agent 5.7.1
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-571
-          - title: iOS Agent 5.8.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-580
-          - title: iOS Agent 5.8.1
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-581
-          - title: iOS Agent 5.8.2
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-582
-          - title: iOS Agent 5.8.3
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-583
-          - title: iOS Agent 5.9.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-590
-          - title: iOS Agent 6.0.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-600
-          - title: iOS Agent 6.1.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-610
-          - title: iOS Agent 6.10.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-6100
-          - title: iOS Agent 6.1.1
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-611
-          - title: iOS Agent 6.11.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-6110
-          - title: iOS Agent 6.13.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-6130
-          - title: iOS Agent 6.14.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-6140
-          - title: iOS Agent 6.2.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-620-0
-          - title: iOS Agent 6.3.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-630
-          - title: iOS Agent 6.3.2
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-632
-          - title: iOS Agent 6.4.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-640
-          - title: iOS Agent 6.4.1
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-641
-          - title: iOS Agent 6.5.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-650
-          - title: iOS Agent 6.6.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-660
-          - title: iOS Agent 6.7.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-670
-          - title: iOS Agent 6.8.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-680
-          - title: iOS Agent 6.9.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-690
-          - title: iOS Agent 7.0.0
-            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-700
       - title: Android release notes
         pages:
           - title: Android 1.338
@@ -2177,6 +1997,12 @@ pages:
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-34190
           - title: Android 3.429.0
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-34290
+          - title: Android 4.87.0
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-4870
+          - title: Android 4.95.0
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/clone-android-4950
+          - title: Android 4.98.0
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-4980
           - title: Android 4.120.0
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-41200
           - title: Android 4.178.0
@@ -2189,10 +2015,6 @@ pages:
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-42650-0
           - title: Android 4.273.4
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-42734
-          - title: Android 4.87.0
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-4870
-          - title: Android 4.98.0
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-4980
           - title: Android 5.0.0
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-500
           - title: Android 5.0.1
@@ -2201,14 +2023,50 @@ pages:
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-503
           - title: Android 5.1.0
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-510
-          - title: Android 5.10.0
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-5100
           - title: Android 5.1.1
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-511
-          - title: Android 5.11.0
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-5110
           - title: Android 5.1.2
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-512
+          - title: Android 5.2.0
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-520
+          - title: Android 5.2.1
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-521
+          - title: Android 5.3.0
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-530
+          - title: Android 5.3.1
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-531
+          - title: Android 5.3.2
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-532
+          - title: Android 5.3.3
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-533
+          - title: Android 5.4.0
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-540
+          - title: Android 5.4.1
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-541
+          - title: Android 5.5.0
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-550
+          - title: Android 5.6.0
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-560
+          - title: Android 5.6.1
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-561
+          - title: Android 5.7.0
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-570
+          - title: Android 5.7.1
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-571
+          - title: Android 5.8.0
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-580
+          - title: Android 5.8.2
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-581
+          - title: Android 5.8.3
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-583
+          - title: Android 5.8.4
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-584-0
+          - title: Android 5.9.0
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-590
+          - title: Android 5.10.0
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-5100
+          - title: Android 5.11.0
+            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-5110
           - title: Android 5.12.0
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-5120
           - title: Android 5.12.1
@@ -2243,12 +2101,8 @@ pages:
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-5190
           - title: Android 5.19.1
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-5191-0
-          - title: Android 5.2.0
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-520
           - title: Android 5.20.0
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-5200-0
-          - title: Android 5.2.1
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-521
           - title: Android 5.21.0
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-5210
           - title: Android 5.21.1
@@ -2285,52 +2139,188 @@ pages:
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-5271
           - title: Android 5.28.0
             path: /docs/release-notes/mobile-release-notes/android-release-notes/android-5280
-          - title: Android 5.3.0
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-530
-          - title: Android 5.3.1
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-531
-          - title: Android 5.3.2
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-532
-          - title: Android 5.3.3
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-533
-          - title: Android 5.4.0
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-540
-          - title: Android 5.4.1
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-541
-          - title: Android 5.5.0
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-550
-          - title: Android 5.6.0
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-560
-          - title: Android 5.6.1
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-561
-          - title: Android 5.7.0
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-570
-          - title: Android 5.7.1
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-571
-          - title: Android 5.8.0
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-580
-          - title: Android 5.8.2
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-581
-          - title: Android 5.8.3
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-583
-          - title: Android 5.8.4
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-584-0
-          - title: Android 5.9.0
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/android-590
-          - title: Android 4.95.0
-            path: /docs/release-notes/mobile-release-notes/android-release-notes/clone-android-4950
+      - title: iOS release notes
+        pages:
+          - title: iOS 1.300
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-1300
+          - title: iOS 1.309
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-1309
+          - title: iOS 1.328
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-1328
+          - title: iOS 1.342
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-1342
+          - title: iOS 1.354
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-1354
+          - title: iOS 1.376
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-1376
+          - title: iOS 1.396
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-1396
+          - title: iOS 3.130
+            path: /docs/release-notes/agent-release-notes/java-release-notes/ios-3130
+          - title: iOS 3.154
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3154
+          - title: iOS 3.174
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3174
+          - title: iOS 3.184
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3184
+          - title: iOS 3.196
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3196
+          - title: iOS 3.252
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3252
+          - title: iOS 3.256
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3256
+          - title: iOS 3.257
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3257
+          - title: iOS 3.289
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3289
+          - title: iOS 3.311
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3311
+          - title: iOS 3.324
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3324
+          - title: iOS 3.343
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3343
+          - title: iOS 3.378
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3378
+          - title: iOS 3.380
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3380
+          - title: iOS 3.396
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3396
+          - title: iOS 3.398
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3398
+          - title: iOS 3.406
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3406-0
+          - title: iOS 3.412
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-3412
+          - title: iOS 4.83
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-483
+          - title: iOS 4.139
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-4139
+          - title: iOS 4.152
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-4152-0
+          - title: iOS 4.155
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-4155
+          - title: iOS 4.174
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-4174
+          - title: iOS 4.186
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-4186
+          - title: iOS 4.186.1
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-41861
+          - title: iOS 5.0.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-500
+          - title: iOS 5.0.1
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-501
+          - title: iOS 5.0.2
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-502
+          - title: iOS 5.0.3
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-503
+          - title: iOS 5.1.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-510
+          - title: iOS 5.1.2
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-512
+          - title: iOS 5.2.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-520
+          - title: iOS 5.2.1
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-521
+          - title: iOS 5.2.2
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-522
+          - title: iOS 5.3.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-530
+          - title: iOS 5.3.1
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-531
+          - title: iOS 5.3.2
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-532
+          - title: iOS Agent 5.3.4
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-534
+          - title: iOS Agent 5.3.5
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-535
+          - title: iOS Agent 5.3.6
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-536
+          - title: iOS Agent 5.4.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-540
+          - title: iOS Agent 5.4.1
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-541
+          - title: iOS Agent 5.5.0 (removed)
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-550
+          - title: iOS Agent 5.5.1
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-551
+          - title: iOS Agent 5.5.2
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-552
+          - title: iOS Agent 5.6.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-560
+          - title: iOS Agent 5.7.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-570
+          - title: IOS Agent 5.7.1
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-571
+          - title: iOS Agent 5.8.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-580
+          - title: iOS Agent 5.8.1
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-581
+          - title: iOS Agent 5.8.2
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-582
+          - title: iOS Agent 5.8.3
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-583
+          - title: iOS Agent 5.9.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-590
+          - title: iOS Agent 5.10.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5100
+          - title: iOS Agent 5.10.1
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5101
+          - title: iOS Agent 5.11.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5110
+          - title: iOS Agent 5.12.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5120
+          - title: iOS Agent 5.12.2
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5122
+          - title: iOS Agent 5.12.3
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5123
+          - title: iOS Agent 5.13.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5130
+          - title: iOS Agent 5.14.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5140
+          - title: iOS Agent 5.14.1
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5141
+          - title: iOS Agent 5.14.2
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5142
+          - title: iOS Agent 5.15.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5150
+          - title: iOS Agent 6.0.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-600
+          - title: iOS Agent 6.1.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-610
+          - title: iOS Agent 6.1.1
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-611
+          - title: iOS Agent 6.2.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-620-0
+          - title: iOS Agent 6.3.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-630
+          - title: iOS Agent 6.3.2
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-632
+          - title: iOS Agent 6.4.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-640
+          - title: iOS Agent 6.4.1
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-641
+          - title: iOS Agent 6.5.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-650
+          - title: iOS Agent 6.6.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-660
+          - title: iOS Agent 6.7.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-670
+          - title: iOS Agent 6.8.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-680
+          - title: iOS Agent 6.9.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-690
+          - title: iOS Agent 6.10.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-6100
+          - title: iOS Agent 6.11.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-6110
+          - title: iOS Agent 6.13.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-6130
+          - title: iOS Agent 6.14.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-6140
+          - title: iOS Agent 7.0.0
+            path: /docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-700
       - title: tvOS release notes
         pages:
-          - title: tvOS Agent 5.12.1
-            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5121
-          - title: tvOS Agent 5.13.0
-            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5130
-          - title: tvOS Agent 5.14.0
-            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5140
-          - title: tvOS Agent 5.14.1
-            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5141-0
-          - title: tvOS Agent 5.15.0
-            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5150
           - title: tvOS Agent 5.6.0
             path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-560
           - title: tvOS Agent 5.7.0
@@ -2341,20 +2331,20 @@ pages:
             path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-580
           - title: tvOS Agent 5.8.2
             path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-582-0
+          - title: tvOS Agent 5.12.1
+            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5121
+          - title: tvOS Agent 5.13.0
+            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5130
+          - title: tvOS Agent 5.14.0
+            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5140
+          - title: tvOS Agent 5.14.1
+            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5141-0
+          - title: tvOS Agent 5.15.0
+            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5150
           - title: tvOS Agent 6.0.0
             path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-600
           - title: tvOS Agent 6.1.0
             path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-610
-          - title: tvOS Agent 6.10.0
-            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6100
-          - title: tvOS Agent 6.11.0
-            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6110
-          - title: tvOS Agent 6.12.0
-            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6120
-          - title: tvOS Agent 6.13.0
-            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6130
-          - title: tvOS Agent 6.14.0
-            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6140
           - title: tvOS Agent 6.2.0
             path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-620
           - title: tvOS Agent 6.3.0
@@ -2377,6 +2367,16 @@ pages:
             path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-680
           - title: tvOS Agent 6.9.0
             path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-690
+          - title: tvOS Agent 6.10.0
+            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6100
+          - title: tvOS Agent 6.11.0
+            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6110
+          - title: tvOS Agent 6.12.0
+            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6120
+          - title: tvOS Agent 6.13.0
+            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6130
+          - title: tvOS Agent 6.14.0
+            path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6140
           - title: tvOS Agent 7.0.0
             path: /docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-700
       - title: XCFramework release notes
@@ -2387,416 +2387,8 @@ pages:
             path: /docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-710
           - title: XCFramework Agent 7.2.0
             path: /docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-720
-  - title: Infrastructure release notes
-    pages:
-      - title: Infrastructure agent release notes
-        pages:
-          - title: New Relic Infrastructure Agent 1.0.1052
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/clone-new-relic-infrastructure-agent-101052
-          - title: New Relic Infrastructure Agent 1.5.62
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/clone-new-relic-infrastructure-agent-1559
-          - title: New Relic Infrastructure Agent 1.0.1002
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-101002
-          - title: New Relic Infrastructure Agent 1.0.1015
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-101015
-          - title: New Relic Infrastructure Agent 1.0.1017
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-101017
-          - title: New Relic Infrastructure Agent 1.0.1019
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-101019
-          - title: New Relic Infrastructure Agent 1.0.1033
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-101033
-          - title: New Relic Infrastructure Agent 1.0.1051
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-101051
-          - title: New Relic Infrastructure Agent 1.0.296
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10296
-          - title: New Relic Infrastructure Agent 1.0.301
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10301
-          - title: New Relic Infrastructure Agent 1.0.308
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10308
-          - title: New Relic Infrastructure Agent 1.0.311
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10311
-          - title: New Relic Infrastructure Agent 1.0.316
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10316
-          - title: New Relic Infrastructure Agent 1.0.323
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10323
-          - title: New Relic Infrastructure Agent 1.0.336
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10336
-          - title: New Relic Infrastructure Agent 1.0.338
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10338
-          - title: New Relic Infrastructure Agent 1.0.341
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10341
-          - title: New Relic Infrastructure Agent 1.0.673
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10673
-          - title: New Relic Infrastructure Agent 1.0.677
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10677
-          - title: New Relic Infrastructure Agent 1.0.682
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10682
-          - title: New Relic Infrastructure Agent 1.0.690
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10690
-          - title: New Relic Infrastructure Agent 1.0.703
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10703
-          - title: New Relic Infrastructure Agent 1.0.719
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10719
-          - title: New Relic Infrastructure Agent 1.0.724
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10724
-          - title: New Relic Infrastructure Agent 1.0.726
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10726
-          - title: New Relic Infrastructure Agent 1.0.752
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10752
-          - title: New Relic Infrastructure Agent 1.0.775
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10775
-          - title: New Relic Infrastructure Agent 1.0.783
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10783
-          - title: New Relic Infrastructure Agent 1.0.785
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10785
-          - title: New Relic Infrastructure Agent 1.0.790
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10790
-          - title: New Relic Infrastructure Agent 1.0.799
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10799
-          - title: New Relic Infrastructure Agent 1.0.804
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10804
-          - title: New Relic Infrastructure Agent 1.0.808
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10808
-          - title: New Relic Infrastructure Agent 1.0.818
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10818
-          - title: New Relic Infrastructure Agent 1.0.822
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10822
-          - title: New Relic Infrastructure Agent 1.0.834
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10834
-          - title: New Relic Infrastructure Agent 1.0.840
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10840
-          - title: New Relic Infrastructure Agent 1.0.848
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10848
-          - title: New Relic Infrastructure Agent 1.0.859
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10859
-          - title: New Relic Infrastructure Agent 1.0.872
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10872
-          - title: New Relic Infrastructure Agent 1.0.888
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10888
-          - title: New Relic Infrastructure Agent 1.0.898
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10898
-          - title: New Relic Infrastructure Agent 1.0.909
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10909
-          - title: New Relic Infrastructure Agent 1.0.912
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10912
-          - title: New Relic Infrastructure Agent 1.0.944
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10944
-          - title: New Relic Infrastructure Agent 1.0.976
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10976
-          - title: New Relic Infrastructure Agent 1.0.989
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10989
-          - title: New Relic Infrastructure Agent 1.10.26
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11026
-          - title: New Relic Infrastructure Agent 1.10.30
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11030
-          - title: New Relic Infrastructure Agent 1.10.35
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11035
-          - title: New Relic Infrastructure Agent 1.10.41
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11041
-          - title: New Relic Infrastructure Agent 1.10.7
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1107
-          - title: New Relic Infrastructure Agent 1.11.20
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11120
-          - title: New Relic Infrastructure Agent 1.11.21
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11121
-          - title: New Relic Infrastructure Agent 1.11.22
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11122
-          - title: New Relic Infrastructure Agent 1.11.24
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11124
-          - title: New Relic Infrastructure Agent 1.11.26
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11126
-          - title: New Relic Infrastructure Agent 1.11.35
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11135
-          - title: New Relic Infrastructure Agent 1.11.37
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11137-0
-          - title: New Relic Infrastructure Agent 1.11.4
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1114-0
-          - title: New Relic Infrastructure Agent 1.1.14
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1114
-          - title: New Relic Infrastructure Agent 1.11.40
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11140
-          - title: New Relic Infrastructure Agent 1.11.42
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11142
-          - title: New Relic Infrastructure Agent 1.11.45
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11145
-          - title: New Relic Infrastructure Agent 1.1.19
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1119
-          - title: New Relic Infrastructure Agent 1.12.0
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1120
-          - title: New Relic Infrastructure Agent 1.12.1
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1121
-          - title: New Relic Infrastructure Agent 1.12.2
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1122
-          - title: New Relic Infrastructure Agent 1.12.3
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1123
-          - title: New Relic Infrastructure Agent 1.12.4
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1124
-          - title: New Relic Infrastructure Agent 1.12.5
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1125
-          - title: New Relic Infrastructure Agent 1.12.6
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1126
-          - title: New Relic Infrastructure Agent 1.12.7
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1127
-          - title: New Relic Infrastructure Agent 1.13.0
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1130
-          - title: New Relic Infrastructure Agent 1.13.1
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1131
-          - title: New Relic Infrastructure Agent 1.13.2
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1132
-          - title: New Relic Infrastructure Agent 1.1.4
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-114
-          - title: New Relic Infrastructure Agent 1.1.7
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-117
-          - title: New Relic Infrastructure Agent 1.1.9
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-119
-          - title: New Relic Infrastructure Agent 1.2.1
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-121
-          - title: New Relic Infrastructure Agent 1.2.13
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1213
-          - title: New Relic Infrastructure Agent 1.2.15
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1215
-          - title: New Relic Infrastructure Agent 1.2.25
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1225
-          - title: New Relic Infrastructure Agent 1.2.6
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-126
-          - title: New Relic Infrastructure Agent 1.3.1
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-131
-          - title: New Relic Infrastructure Agent 1.3.18
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1318
-          - title: New Relic Infrastructure Agent 1.3.27
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1327
-          - title: New Relic Infrastructure Agent 1.3.3
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-133
-          - title: New Relic Infrastructure Agent 1.3.30
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1330
-          - title: New Relic Infrastructure Agent 1.3.33
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1333
-          - title: New Relic Infrastructure Agent 1.3.5
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-135
-          - title: New Relic Infrastructure Agent 1.4.0
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-140
-          - title: New Relic Infrastructure Agent 1.4.11
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1411
-          - title: New Relic Infrastructure Agent 1.4.14
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1414
-          - title: New Relic Infrastructure Agent 1.4.5
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-145
-          - title: New Relic Infrastructure Agent 1.4.9
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-149
-          - title: New Relic Infrastructure Agent 1.5.0
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-150
-          - title: New Relic Infrastructure Agent 1.5.1
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-151
-          - title: New Relic Infrastructure Agent 1.5.26
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1526
-          - title: New Relic Infrastructure Agent 1.5.29
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1529
-          - title: New Relic Infrastructure Agent 1.5.31
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1531
-          - title: New Relic Infrastructure Agent 1.5.37
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1537
-          - title: New Relic Infrastructure Agent 1.5.40
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1540
-          - title: New Relic Infrastructure Agent 1.5.45
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1545
-          - title: New Relic Infrastructure Agent 1.5.51
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1551
-          - title: New Relic Infrastructure Agent 1.5.59
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1559
-          - title: New Relic Infrastructure Agent 1.5.66
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1566
-          - title: New Relic Infrastructure Agent 1.5.75
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1575
-          - title: New Relic Infrastructure Agent 1.6.0
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-160
-          - title: New Relic Infrastructure Agent 1.7.0
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-170-0
-          - title: New Relic Infrastructure Agent 1.7.1
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-171
-          - title: New Relic Infrastructure Agent 1.7.5
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-175
-          - title: New Relic Infrastructure Agent 1.7.6
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-176
-          - title: New Relic Infrastructure Agent 1.8.0
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-180
-          - title: New Relic Infrastructure Agent 1.8.14
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1814
-          - title: New Relic Infrastructure Agent 1.8.19
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1819
-          - title: New Relic Infrastructure Agent 1.8.2
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-182
-          - title: New Relic Infrastructure Agent 1.8.23
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1823
-          - title: New Relic Infrastructure Agent 1.8.32
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1832
-          - title: New Relic Infrastructure Agent 1.8.4
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-184
-          - title: New Relic Infrastructure Agent 1.8.8
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-188
-          - title: New Relic Infrastructure Agent 1.9.0
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-190
-          - title: New Relic Infrastructure Agent 1.9.7
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-197
-          - title: New Relic Infrastructure Windows Agent 1.0.934
-            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-windows-agent-10934
-  - title: Insights for Android 3.0.3
-    path: /docs/release-notes/insights-android-303
   - title: Mobile apps release notes
     pages:
-      - title: Insights for iOS release notes
-        pages:
-          - title: Insights for iOS 1.4.2
-            path: /docs/release-notes/insights-ios-142
-          - title: Insights for iOS 1.6.9
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-169
-          - title: Insights for iOS 1.0.0
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-100
-          - title: Insights for iOS 1.0.1
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-101
-          - title: Insights for iOS 1.0.2
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-102
-          - title: Insights for iOS 1.0.3
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-103
-          - title: Insights for iOS 1.10.0
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1100
-          - title: Insights for iOS 1.11.2
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1111
-          - title: Insights for iOS 1.11.3
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1113
-          - title: Insights for iOS 1.1.2
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-112
-          - title: Insights for iOS 1.12.1
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1120
-          - title: Insights for iOS 1.12.4
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1124
-          - title: Insights for iOS 1.12.7
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1127
-          - title: Insights for iOS 1.13.0
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1130
-          - title: Insights for iOS 1.13.1
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1131
-          - title: Insights for iOS 1.13.2
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1132
-          - title: Insights for iOS 1.1.4
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-114
-          - title: Insights for iOS 1.1.5
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-115
-          - title: Insights for iOS 1.2.1
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-121
-          - title: Insights for iOS 1.3.1
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-131
-          - title: Insights for iOS 1.3.5
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-135
-          - title: Insights for iOS 1.3.9
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-139
-          - title: Insights for iOS 1.5.0
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-150
-          - title: Insights for iOS 1.5.3
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-153
-          - title: Insights for iOS 1.6
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-16
-          - title: Insights for iOS 1.6.2
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-162
-          - title: Insights for iOS 1.7.1
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-171
-          - title: Insights for iOS 1.8.2
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-182
-          - title: Insights for iOS 1.9.0
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-190
-          - title: Insights for iOS 1.9.1
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-191
-          - title: Insights for iOS 1.9.2
-            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-192
-      - title: Insights Android release notes
-        pages:
-          - title: Insights for Android 1.0.2
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-102
-          - title: Insights for Android 3.1.5
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-315
-          - title: Insights for Android 3.1.6
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-316
-          - title: Insights for Android 3.1.8
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-318
-          - title: Insights for Android 1.0
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-10
-          - title: Insights for Android 2.0
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-20
-          - title: Insights for Android 2.1
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-21
-          - title: Insights for Android 2.2.2
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-222
-          - title: Insights for Android 2.2.4
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-224
-          - title: Insights for Android 2.3.0
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-230
-          - title: Insights for Android 2.3.2
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-232
-          - title: Insights for Android 2.4.0
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-240
-          - title: Insights for Android 3.0
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-30
-          - title: Insights for Android 3.0.1
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-301
-          - title: Insights for Android 3.0.11
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-3011
-          - title: Insights for Android 3.0.13
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-3013
-          - title: Insights for Android 3.0.15
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-3014
-          - title: Insights for Android 3.0.5
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-305
-          - title: Insights for Android 3.0.6
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-306
-          - title: Insights for Android 3.0.7
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-307
-          - title: Insights for Android 3.0.8
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-308
-          - title: Insights for Android 3.0.10
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-309
-          - title: Insights for Android 3.1.10
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-3110
-          - title: Insights for Android 3.1.11
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-3111
-          - title: Insights for Android 3.1.2
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-312
-          - title: Insights for Android 3.1.3
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-313
-          - title: Insights for Android 3.1.9
-            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-319
-      - title: Insights tvOS release notes
-        pages:
-          - title: Insights for tvOS 1.11.5
-            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-1115
-          - title: Insights for tvOS 1.12.4
-            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-1124
-          - title: Insights for tvOS 1.12.7
-            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-1127
-          - title: Insights for tvOS 1.13.0
-            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-1130
-          - title: Insights for tvOS 1.13.1
-            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-1131
-          - title: Insights for tvOS 1.13.2
-            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-1132
-          - title: Insights for tvOS 1.14.1
-            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-1141
-          - title: Insights for tvOS 1.5
-            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-15
-          - title: Insights for tvOS 1.5.3
-            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-153
-          - title: Insights for tvOS 1.6.3
-            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-163
-          - title: Insights for tvOS 1.7.2
-            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-172
-          - title: Insights for tvOS 1.8.2
-            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-182
-          - title: Insights for tvOS 1.9.0
-            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-190
-          - title: Insights for tvOS 1.9.1
-            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-191
-          - title: Insights for tvOS 1.9.2
-            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-192
-          - title: Insights for tvOS 1.3.6
-            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos
       - title: New Relic for Android release notes
         pages:
           - title: New Relic for Android 1.0.0
@@ -2819,6 +2411,12 @@ pages:
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-190
           - title: New Relic for Android 1.9.1
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-191
+          - title: New Relic for Android 1.9.2
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-192
+          - title: New Relic for Android 1.9.8
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-198
+          - title: New Relic for Android 1.9.9
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-199
           - title: New Relic for Android 1.9.10
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-1910
           - title: New Relic for Android 1.9.11
@@ -2827,16 +2425,10 @@ pages:
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-1912
           - title: New Relic for Android 1.9.13
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-1913
-          - title: New Relic for Android 1.9.14
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-1914
-          - title: New Relic for Android 1.9.2
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-192
-          - title: New Relic for Android 1.9.8
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-198
-          - title: New Relic for Android 1.9.9
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-199
           - title: New Relic for Android 2.0.2
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-201
+          - title: New Relic for Android 1.9.14
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-1914
           - title: New Relic for Android 2.0.3
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-203
           - title: New Relic for Android 2.0.4
@@ -2845,48 +2437,20 @@ pages:
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-207
           - title: New Relic for Android 2.1.0
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-210
-          - title: New Relic for Android 2.10.1
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2100
-          - title: New Relic for Android 2.10.2
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2102
-          - title: New Relic for Android 2.10.3
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2103
-          - title: New Relic for Android 2.10.4
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2104
-          - title: New Relic for Android 2.10.5
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2105
-          - title: New Relic for Android 2.10.6
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2106
-          - title: New Relic for Android 2.11.0
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2110
           - title: New Relic for Android 2.1.2
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-212
-          - title: New Relic for Android 2.12.0
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2120
-          - title: New Relic for Android 2.13.0
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2130
-          - title: New Relic for Android 2.13.1
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2131
-          - title: New Relic for Android 2.13.2
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2132
-          - title: New Relic for Android 2.14.0
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2140
-          - title: New Relic for Android 2.14.1
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2141
           - title: New Relic for Android 2.1.5
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-215
-          - title: New Relic for Android 2.15.0
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2150
-          - title: New Relic for Android 2.18.8
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2188-0
           - title: New Relic for Android 2.2.0
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-220
-          - title: New Relic for Android 2.2.11
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2211
           - title: New Relic for Android 2.2.2
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-222
           - title: New Relic for Android 2.2.4
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-224
+          - title: New Relic for Android 2.2.11
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2211
+          - title: New Relic for Android 2.2.16
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android
           - title: New Relic for Android 2.3.0
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-230
           - title: New Relic for Android 2.3.2
@@ -2911,8 +2475,24 @@ pages:
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-272
           - title: New Relic for Android 2.7.5
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-275
+          - title: New Relic for Android 2.7.6
+            path: /docs/release-notes/new-relic-android-276
           - title: New Relic for Android 2.8.0
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-280
+          - title: New Relic for Android 2.8.2
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-282
+          - title: New Relic for Android 2.8.3
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-283
+          - title: New Relic for Android 2.8.4
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-284
+          - title: New Relic for Android 2.8.5
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-285
+          - title: New Relic for Android 2.8.6
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-286
+          - title: New Relic for Android 2.8.8
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-288
+          - title: New Relic for Android 2.8.9
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-289
           - title: New Relic for Android 2.8.11
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2811
           - title: New Relic for Android 2.8.12
@@ -2923,10 +2503,10 @@ pages:
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2814
           - title: New Relic for Android 2.8.17
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2817-0
+          - title: New Relic for Android 2.18.8
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2188
           - title: New Relic for Android 2.8.19
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2819
-          - title: New Relic for Android 2.8.2
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-282
           - title: New Relic for Android 2.8.20
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2820
           - title: New Relic for Android 2.8.21
@@ -2941,38 +2521,10 @@ pages:
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2827
           - title: New Relic for Android 2.8.29
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2829
-          - title: New Relic for Android 2.8.3
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-283
-          - title: New Relic for Android 2.8.4
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-284
-          - title: New Relic for Android 2.8.5
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-285
-          - title: New Relic for Android 2.8.6
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-286
-          - title: New Relic for Android 2.8.8
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-288
-          - title: New Relic for Android 2.8.9
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-289
           - title: New Relic for Android 2.9.0
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-290
-          - title: New Relic for Android 2.9.10
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2910
-          - title: New Relic for Android 2.9.13
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2913
-          - title: New Relic for Android 2.9.15
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2915
-          - title: New Relic for Android 2.9.16
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2916
-          - title: New Relic for Android 2.9.18
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2918
-          - title: New Relic for Android 2.9.19
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2919
           - title: New Relic for Android 2.9.2
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-292
-          - title: New Relic for Android 2.9.22
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2922
-          - title: New Relic for Android 2.9.23
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2923
           - title: New Relic for Android 2.9.3
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-293
           - title: New Relic for Android 2.9.4
@@ -2981,18 +2533,56 @@ pages:
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-295
           - title: New Relic for Android 2.9.6
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-296
-          - title: New Relic for Android 2.2.16
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android
-          - title: New Relic for Android 2.7.6
-            path: /docs/release-notes/new-relic-android-276
-          - title: New Relic for Android 2.9.17
-            path: /docs/release-notes/new-relic-android-2917
           - title: New Relic for Android 2.9.8
             path: /docs/release-notes/new-relic-android-298
+          - title: New Relic for Android 2.9.10
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2910
+          - title: New Relic for Android 2.9.13
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2913
+          - title: New Relic for Android 2.9.15
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2915
+          - title: New Relic for Android 2.9.16
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2916
+          - title: New Relic for Android 2.9.17
+            path: /docs/release-notes/new-relic-android-2917
+          - title: New Relic for Android 2.9.18
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2918
+          - title: New Relic for Android 2.9.19
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2919
+          - title: New Relic for Android 2.9.22
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2922
+          - title: New Relic for Android 2.9.23
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2923
+          - title: New Relic for Android 2.10.1
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2100
+          - title: New Relic for Android 2.10.2
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2102
+          - title: New Relic for Android 2.10.3
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2103
+          - title: New Relic for Android 2.10.4
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2104
+          - title: New Relic for Android 2.10.5
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2105
+          - title: New Relic for Android 2.10.6
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2106
+          - title: New Relic for Android 2.11.0
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2110
+          - title: New Relic for Android 2.12.0
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2120
+          - title: New Relic for Android 2.13.0
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2130
+          - title: New Relic for Android 2.13.1
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2131
+          - title: New Relic for Android 2.14.0
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2140
+          - title: New Relic for Android 2.13.2
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2132
+          - title: New Relic for Android 2.14.1
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2141
+          - title: New Relic for Android 2.15.0
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-2150
       - title: New Relic iOS release notes
         pages:
-          - title: New Relic for iOS 3.20.3
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-3203
           - title: New Relic for iOS 1.02
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-102
           - title: New Relic for iOS 1.1
@@ -3043,6 +2633,8 @@ pages:
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-320
           - title: New Relic for iOS 3.20.2
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3202
+          - title: New Relic for iOS 3.20.3
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-3203
           - title: New Relic for iOS 3.22
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-322
           - title: New Relic for iOS 3.22.1
@@ -3059,10 +2651,10 @@ pages:
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3242
           - title: New Relic for iOS 3.25
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-325
-          - title: New Relic for iOS 3.25.1
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3251
           - title: New Relic for iOS 3.26
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-326
+          - title: New Relic for iOS 3.25.1
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3251
           - title: New Relic for iOS 3.28.2
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3282
           - title: New Relic for iOS 3.30
@@ -3124,7 +2716,7 @@ pages:
           - title: New Relic for iOS 3.47.0
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3470
           - title: New Relic for iOS 3.48.0
-            path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3480-0
+            path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3480
           - title: New Relic for iOS 3.49.0
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3490
           - title: New Relic for iOS 3.50.0
@@ -3161,16 +2753,170 @@ pages:
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3650
           - title: New Relic for iOS 3.66.0
             path: /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3660
-  - title: New Relic for Android 2.6.2
-    path: /docs/release-notes/new-relic-android-262
-  - title: New Relic for Android 2.7.3
-    path: /docs/release-notes/new-relic-android-273
-  - title: New Relic for Android 2.9.21
-    path: /docs/release-notes/new-relic-android-2921
+      - title: Insights for iOS release notes
+        pages:
+          - title: Insights for iOS 1.0.0
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-100
+          - title: Insights for iOS 1.0.1
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-101
+          - title: Insights for iOS 1.0.2
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-102
+          - title: Insights for iOS 1.0.3
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-103
+          - title: Insights for iOS 1.1.2
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-112
+          - title: Insights for iOS 1.1.4
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-114
+          - title: Insights for iOS 1.1.5
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-115
+          - title: Insights for iOS 1.2.1
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-121
+          - title: Insights for iOS 1.3.1
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-131
+          - title: Insights for iOS 1.3.5
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-135
+          - title: Insights for iOS 1.3.9
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-139
+          - title: Insights for iOS 1.4.2
+            path: /docs/release-notes/insights-ios-142
+          - title: Insights for iOS 1.5.0
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-150
+          - title: Insights for iOS 1.5.3
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-153
+          - title: Insights for iOS 1.6
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-16
+          - title: Insights for iOS 1.6.2
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-162
+          - title: Insights for iOS 1.6.9
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-169
+          - title: Insights for iOS 1.7.1
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-171
+          - title: Insights for iOS 1.8.2
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-182
+          - title: Insights for iOS 1.9.0
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-190
+          - title: Insights for iOS 1.9.1
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-191
+          - title: Insights for iOS 1.9.2
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-192
+          - title: Insights for iOS 1.10.0
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1100
+          - title: Insights for iOS 1.11.2
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1111
+          - title: Insights for iOS 1.11.3
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1113
+          - title: Insights for iOS 1.12.1
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1120
+          - title: Insights for iOS 1.12.4
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1124
+          - title: Insights for iOS 1.12.7
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1127
+          - title: Insights for iOS 1.13.0
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1130
+          - title: Insights for iOS 1.13.1
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1131
+          - title: Insights for iOS 1.13.2
+            path: /docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/insights-ios-1132
+      - title: Insights Android release notes
+        pages:
+          - title: Insights for Android 1.0
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-10
+          - title: Insights for Android 1.0.2
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-102
+          - title: Insights for Android 2.0
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-20
+          - title: Insights for Android 2.1
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-21
+          - title: Insights for Android 2.2.2
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-222
+          - title: Insights for Android 2.2.4
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-224
+          - title: Insights for Android 2.3.0
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-230
+          - title: Insights for Android 2.3.2
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-232
+          - title: Insights for Android 2.4.0
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-240
+          - title: Insights for Android 3.0
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-30
+          - title: Insights for Android 3.0.1
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-301
+          - title: Insights for Android 3.0.5
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-305
+          - title: Insights for Android 3.0.6
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-306
+          - title: Insights for Android 3.0.7
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-307
+          - title: Insights for Android 3.0.8
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-308
+          - title: Insights for Android 3.0.10
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-309
+          - title: Insights for Android 3.0.11
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-3011
+          - title: Insights for Android 3.0.13
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-3013
+          - title: Insights for Android 3.0.15
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-3014
+          - title: Insights for Android 3.1.2
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-312
+          - title: Insights for Android 3.1.3
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-313
+          - title: Insights for Android 3.1.5
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-315
+          - title: Insights for Android 3.1.6
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-316
+          - title: Insights for Android 3.1.8
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-318
+          - title: Insights for Android 3.1.9
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-319
+          - title: Insights for Android 3.1.10
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-3110
+          - title: Insights for Android 3.1.11
+            path: /docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/insights-android-3111
+      - title: Insights tvOS release notes
+        pages:
+          - title: Insights for tvOS 1.3.6
+            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos
+          - title: Insights for tvOS 1.5
+            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-15
+          - title: Insights for tvOS 1.5.3
+            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-153
+          - title: Insights for tvOS 1.6.3
+            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-163
+          - title: Insights for tvOS 1.7.2
+            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-172
+          - title: Insights for tvOS 1.8.2
+            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-182
+          - title: Insights for tvOS 1.9.0
+            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-190
+          - title: Insights for tvOS 1.9.1
+            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-191
+          - title: Insights for tvOS 1.9.2
+            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-192
+          - title: Insights for tvOS 1.11.5
+            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-1115
+          - title: Insights for tvOS 1.12.4
+            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-1124
+          - title: Insights for tvOS 1.12.7
+            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-1127
+          - title: Insights for tvOS 1.13.0
+            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-1130
+          - title: Insights for tvOS 1.13.1
+            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-1131
+          - title: Insights for tvOS 1.13.2
+            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-1132
+          - title: Insights for tvOS 1.14.1
+            path: /docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/insights-tvos-1141
   - title: New Relic Browser release notes
     pages:
       - title: Browser agent release notes
         pages:
+          - title: Browser Agent v974
+            path: /docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v974
+          - title: Browser Agent v971
+            path: /docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v971
+          - title: Browser Agent v998
+            path: /docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v998
           - title: Browser Agent v1016
             path: /docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1016
           - title: Browser Agent v1026
@@ -3207,14 +2953,264 @@ pages:
             path: /docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1177
           - title: Browser Agent v1184
             path: /docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1184
-          - title: Browser Agent v971
-            path: /docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v971
-          - title: Browser Agent v974
-            path: /docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v974
-          - title: Browser Agent v998
-            path: /docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v998
-  - title: Browser Agent v1158
-    path: /docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1158
+  - title: New Relic for Android 2.6.2
+    path: /docs/release-notes/new-relic-android-262
+  - title: Infrastructure release notes
+    pages:
+      - title: Infrastructure agent release notes
+        pages:
+          - title: New Relic Infrastructure Agent 1.0.296
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10296
+          - title: New Relic Infrastructure Agent 1.0.301
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10301
+          - title: New Relic Infrastructure Agent 1.0.308
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10308
+          - title: New Relic Infrastructure Agent 1.0.311
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10311
+          - title: New Relic Infrastructure Agent 1.0.316
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10316
+          - title: New Relic Infrastructure Agent 1.0.323
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10323
+          - title: New Relic Infrastructure Agent 1.0.338
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10338
+          - title: New Relic Infrastructure Agent 1.0.336
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10336
+          - title: New Relic Infrastructure Agent 1.0.341
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10341
+          - title: New Relic Infrastructure Agent 1.0.673
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10673
+          - title: New Relic Infrastructure Agent 1.0.677
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10677
+          - title: New Relic Infrastructure Agent 1.0.682
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10682
+          - title: New Relic Infrastructure Agent 1.0.690
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10690
+          - title: New Relic Infrastructure Agent 1.0.703
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10703
+          - title: New Relic Infrastructure Agent 1.0.719
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10719
+          - title: New Relic Infrastructure Agent 1.0.724
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10724
+          - title: New Relic Infrastructure Agent 1.0.726
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10726
+          - title: New Relic Infrastructure Agent 1.0.752
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10752
+          - title: New Relic Infrastructure Agent 1.0.775
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10775
+          - title: New Relic Infrastructure Agent 1.0.783
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10783
+          - title: New Relic Infrastructure Agent 1.0.785
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10785
+          - title: New Relic Infrastructure Agent 1.0.790
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10790
+          - title: New Relic Infrastructure Agent 1.0.799
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10799
+          - title: New Relic Infrastructure Agent 1.0.804
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10804
+          - title: New Relic Infrastructure Agent 1.0.808
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10808
+          - title: New Relic Infrastructure Agent 1.0.818
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10818
+          - title: New Relic Infrastructure Agent 1.0.822
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10822
+          - title: New Relic Infrastructure Agent 1.0.834
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10834
+          - title: New Relic Infrastructure Agent 1.0.840
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10840
+          - title: New Relic Infrastructure Agent 1.0.848
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10848
+          - title: New Relic Infrastructure Agent 1.0.859
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10859
+          - title: New Relic Infrastructure Agent 1.0.872
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10872
+          - title: New Relic Infrastructure Agent 1.0.888
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10888
+          - title: New Relic Infrastructure Agent 1.0.898
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10898
+          - title: New Relic Infrastructure Agent 1.0.909
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10909
+          - title: New Relic Infrastructure Agent 1.0.912
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10912
+          - title: New Relic Infrastructure Windows Agent 1.0.934
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-windows-agent-10934
+          - title: New Relic Infrastructure Agent 1.0.944
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10944
+          - title: New Relic Infrastructure Agent 1.0.976
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10976
+          - title: New Relic Infrastructure Agent 1.0.989
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-10989
+          - title: New Relic Infrastructure Agent 1.0.1002
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-101002
+          - title: New Relic Infrastructure Agent 1.0.1015
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-101015
+          - title: New Relic Infrastructure Agent 1.0.1017
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-101017
+          - title: New Relic Infrastructure Agent 1.0.1019
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-101019
+          - title: New Relic Infrastructure Agent 1.0.1033
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-101033
+          - title: New Relic Infrastructure Agent 1.0.1051
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-101051
+          - title: New Relic Infrastructure Agent 1.0.1052
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/clone-new-relic-infrastructure-agent-101052
+          - title: New Relic Infrastructure Agent 1.1.4
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-114
+          - title: New Relic Infrastructure Agent 1.1.7
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-117
+          - title: New Relic Infrastructure Agent 1.1.9
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-119
+          - title: New Relic Infrastructure Agent 1.1.14
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1114
+          - title: New Relic Infrastructure Agent 1.1.19
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1119
+          - title: New Relic Infrastructure Agent 1.2.1
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-121
+          - title: New Relic Infrastructure Agent 1.2.6
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-126
+          - title: New Relic Infrastructure Agent 1.2.13
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1213
+          - title: New Relic Infrastructure Agent 1.2.15
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1215
+          - title: New Relic Infrastructure Agent 1.2.25
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1225
+          - title: New Relic Infrastructure Agent 1.3.1
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-131
+          - title: New Relic Infrastructure Agent 1.3.3
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-133
+          - title: New Relic Infrastructure Agent 1.3.5
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-135
+          - title: New Relic Infrastructure Agent 1.3.18
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1318
+          - title: New Relic Infrastructure Agent 1.3.27
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1327
+          - title: New Relic Infrastructure Agent 1.3.30
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1330
+          - title: New Relic Infrastructure Agent 1.3.33
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1333
+          - title: New Relic Infrastructure Agent 1.4.0
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-140
+          - title: New Relic Infrastructure Agent 1.4.5
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-145
+          - title: New Relic Infrastructure Agent 1.4.9
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-149
+          - title: New Relic Infrastructure Agent 1.4.11
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1411
+          - title: New Relic Infrastructure Agent 1.4.14
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1414
+          - title: New Relic Infrastructure Agent 1.5.0
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-150
+          - title: New Relic Infrastructure Agent 1.5.1
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-151
+          - title: New Relic Infrastructure Agent 1.5.26
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1526
+          - title: New Relic Infrastructure Agent 1.5.29
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1529
+          - title: New Relic Infrastructure Agent 1.5.31
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1531
+          - title: New Relic Infrastructure Agent 1.5.37
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1537
+          - title: New Relic Infrastructure Agent 1.5.40
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1540
+          - title: New Relic Infrastructure Agent 1.5.45
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1545
+          - title: New Relic Infrastructure Agent 1.5.51
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1551
+          - title: New Relic Infrastructure Agent 1.5.59
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1559
+          - title: New Relic Infrastructure Agent 1.5.62
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/clone-new-relic-infrastructure-agent-1559
+          - title: New Relic Infrastructure Agent 1.5.66
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1566
+          - title: New Relic Infrastructure Agent 1.5.75
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1575
+          - title: New Relic Infrastructure Agent 1.6.0
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-160
+          - title: New Relic Infrastructure Agent 1.7.0
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-170
+          - title: New Relic Infrastructure Agent 1.7.1
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-171
+          - title: New Relic Infrastructure Agent 1.7.5
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-175
+          - title: New Relic Infrastructure Agent 1.7.6
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-176
+          - title: New Relic Infrastructure Agent 1.8.0
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-180
+          - title: New Relic Infrastructure Agent 1.8.2
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-182
+          - title: New Relic Infrastructure Agent 1.8.4
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-184
+          - title: New Relic Infrastructure Agent 1.8.8
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-188
+          - title: New Relic Infrastructure Agent 1.8.14
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1814
+          - title: New Relic Infrastructure Agent 1.8.19
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1819
+          - title: New Relic Infrastructure Agent 1.8.23
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1823
+          - title: New Relic Infrastructure Agent 1.8.32
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1832
+          - title: New Relic Infrastructure Agent 1.9.0
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-190
+          - title: New Relic Infrastructure Agent 1.9.7
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-197
+          - title: New Relic Infrastructure Agent 1.10.7
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1107
+          - title: New Relic Infrastructure Agent 1.10.26
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11026
+          - title: New Relic Infrastructure Agent 1.10.30
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11030
+          - title: New Relic Infrastructure Agent 1.10.35
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11035
+          - title: New Relic Infrastructure Agent 1.10.41
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11041
+          - title: New Relic Infrastructure Agent 1.11.4
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1114-0
+          - title: New Relic Infrastructure Agent 1.11.20
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11120
+          - title: New Relic Infrastructure Agent 1.11.21
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11121
+          - title: New Relic Infrastructure Agent 1.11.22
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11122
+          - title: New Relic Infrastructure Agent 1.11.24
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11124
+          - title: New Relic Infrastructure Agent 1.11.26
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11126
+          - title: New Relic Infrastructure Agent 1.11.35
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11135
+          - title: New Relic Infrastructure Agent 1.11.37
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11137-0
+          - title: New Relic Infrastructure Agent 1.11.40
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11140
+          - title: New Relic Infrastructure Agent 1.11.42
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11142
+          - title: New Relic Infrastructure Agent 1.11.45
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-11145
+          - title: New Relic Infrastructure Agent 1.12.0
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1120
+          - title: New Relic Infrastructure Agent 1.12.1
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1121
+          - title: New Relic Infrastructure Agent 1.12.2
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1122
+          - title: New Relic Infrastructure Agent 1.12.3
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1123
+          - title: New Relic Infrastructure Agent 1.12.4
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1124
+          - title: New Relic Infrastructure Agent 1.12.5
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1125
+          - title: New Relic Infrastructure Agent 1.12.6
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1126
+          - title: New Relic Infrastructure Agent 1.12.7
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1127
+          - title: New Relic Infrastructure Agent 1.13.0
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1130
+          - title: New Relic Infrastructure Agent 1.13.1
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1131
+          - title: New Relic Infrastructure Agent 1.13.2
+            path: /docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1132
+  - title: New Relic for Android 2.7.3
+    path: /docs/release-notes/new-relic-android-273
+  - title: Insights for Android 3.0.3
+    path: /docs/release-notes/insights-android-303
   - title: Synthetics release notes
     pages:
       - title: Containerized private minions release notes
@@ -3255,6 +3251,16 @@ pages:
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-220
           - title: Containerized Private Minion (CPM) 2.2.1
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-221
+          - title: Containerized Private Minion (CPM) 2.2.2
+            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-222
+          - title: Containerized Private Minion (CPM) 2.2.3
+            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-223
+          - title: Containerized Private Minion (CPM) 2.2.5
+            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-225
+          - title: Containerized Private Minion (CPM) 2.2.6
+            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-226
+          - title: Containerized Private Minion (CPM) 2.2.8
+            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-228
           - title: Containerized Private Minion (CPM) 2.2.11
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-2211
           - title: Containerized Private Minion (CPM) 2.2.13
@@ -3265,8 +3271,6 @@ pages:
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-2216
           - title: Containerized Private Minion (CPM) 2.2.17
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-2217
-          - title: Containerized Private Minion (CPM) 2.2.2
-            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-222
           - title: Containerized Private Minion (CPM) 2.2.21
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-2221
           - title: Containerized Private Minion (CPM) 2.2.23
@@ -3277,20 +3281,24 @@ pages:
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-2228
           - title: Containerized Private Minion (CPM) 2.2.29
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-2229
-          - title: Containerized Private Minion (CPM) 2.2.3
-            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-223
           - title: Containerized Private Minion (CPM) 2.2.30
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-2230
-          - title: Containerized Private Minion (CPM) 2.2.5
-            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-225
-          - title: Containerized Private Minion (CPM) 2.2.6
-            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-226
-          - title: Containerized Private Minion (CPM) 2.2.8
-            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-228
           - title: Containerized Private Minion (CPM) 3.0.0
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-300
           - title: Containerized Private Minion (CPM) 3.0.1
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-301
+          - title: Containerized Private Minion (CPM) 3.0.2
+            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-302
+          - title: Containerized Private Minion (CPM) 3.0.3
+            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-303
+          - title: Containerized Private Minion (CPM) 3.0.5
+            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-305
+          - title: Containerized Private Minion (CPM) 3.0.7
+            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-307
+          - title: Containerized Private Minion (CPM) 3.0.8
+            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-308
+          - title: Containerized Private Minion (CPM) 3.0.9
+            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-309
           - title: Containerized Private Minion (CPM) 3.0.10
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3010
           - title: Containerized Private Minion (CPM) 3.0.11
@@ -3299,8 +3307,6 @@ pages:
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3012
           - title: Containerized Private Minion (CPM) 3.0.16
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3016
-          - title: Containerized Private Minion (CPM) 3.0.2
-            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-302
           - title: Containerized Private Minion (CPM) 3.0.20
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3020
           - title: Containerized Private Minion (CPM) 3.0.21
@@ -3315,17 +3321,11 @@ pages:
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3027
           - title: Containerized Private Minion (CPM) 3.0.28
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3028
-          - title: Containerized Private Minion (CPM) 3.0.3
-            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-303
           - title: Containerized Private Minion (CPM) 3.0.30
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3030
           - title: Containerized Private Minion (CPM) 3.0.31
             path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3031
-          - title: Containerized Private Minion (CPM) 3.0.5
-            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-305
-          - title: Containerized Private Minion (CPM) 3.0.7
-            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-307
-          - title: Containerized Private Minion (CPM) 3.0.8
-            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-308
-          - title: Containerized Private Minion (CPM) 3.0.9
-            path: /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-309
+  - title: New Relic for Android 2.9.21
+    path: /docs/release-notes/new-relic-android-2921
+  - title: Browser Agent v1158
+    path: /docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1158

--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -16,7 +16,7 @@ pages:
         path: /docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types
   - title: Ingest APIs
     pages:
-      - title: Troubleshoot Metric API with NRIntegrationError events
-        path: /docs/telemetry-data-platform/get-data/apis/troubleshoot-nrintegrationerror-events
       - title: Use the Event API to report custom events
         path: /docs/telemetry-data-platform/ingest-manage-data/ingest-apis/use-event-api-report-custom-events
+      - title: Troubleshoot Metric API with NRIntegrationError events
+        path: /docs/telemetry-data-platform/get-data/apis/troubleshoot-nrintegrationerror-events


### PR DESCRIPTION
Partially closes #349 

## Description
This PR updates the migration script to sort Drupal nodes (authored content) by the `order` field which is read from Drupal's weight in term field. This applies to basic pages, troubleshooting, and api docs.

It also updates the migration script to update the sort of common subdirectories (get started to the top and troubleshooting to the bottom). Ordering the remaining directories is likely best handled either via instruction sets on migration OR by directly editing the nav .yml files to the proper order.

There looks to be some slight ordering issues in .mdx content links. Moving the `.sort()` for directories first fixes that, but mis-orders troubleshooting directories. ¯\_(ツ)_/¯

## Screenshot
<img width="1404" alt="2020-12-22_12-04-30" src="https://user-images.githubusercontent.com/2952843/102928677-0069be80-444e-11eb-8a7a-f1339a7088eb.png">
