### PR TITLE
Sort api doc list alphabetically on index pages

### DIFF
--- a/src/templates/apiIndexPage.js
+++ b/src/templates/apiIndexPage.js
@@ -40,7 +40,10 @@ export const pageQuery = graphql`
         title
       }
     }
-    allMdx(filter: { fields: { slug: { regex: $slugRegex } } }) {
+    allMdx(
+      filter: { fields: { slug: { regex: $slugRegex } } }
+      sort: { fields: frontmatter___title, order: ASC }
+    ) {
       nodes {
         fields {
           slug


### PR DESCRIPTION
## Description

Small change to sort api doc list on api index pages alphabetically by title (which for api docs is their method name) so it's easier to scan.

## Related Issue(s) / Ticket(s)
* #390 

## Screenshot(s)

<img width="1189" alt="2020-12-22_14-20-32" src="https://user-images.githubusercontent.com/2952843/102938295-e5ed1080-4460-11eb-972b-a18d2cd2efd0.png">

