### PR TITLE
Add "Right Rail" to Mobile View

### DIFF
--- a/src/components/TableOfContents.js
+++ b/src/components/TableOfContents.js
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { graphql } from 'gatsby';
+import { useMedia } from 'react-use';
 import { Icon, PageTools } from '@newrelic/gatsby-theme-newrelic';
 import useActiveHash from '../hooks/useActiveHash';
 import { usePrevious } from 'react-use';
@@ -32,6 +33,8 @@ const TableOfContents = ({ page }) => {
   const activeHash = useActiveHash(headingIds);
   const previousActiveHash = usePrevious(activeHash);
   const changedActiveHash = activeHash !== previousActiveHash;
+
+  const isMobileScreen = useMedia('(max-width: 1240px)');
 
   useEffect(() => {
     if (!activeRef.current) {
@@ -83,7 +86,7 @@ const TableOfContents = ({ page }) => {
                 <a
                   ref={isActive ? activeRef : null}
                   href={`#${id}`}
-                  className={isActive ? 'active' : null}
+                  className={isActive && !isMobileScreen ? 'active' : null}
                   css={css`
                     display: flex;
                     align-items: center;
@@ -107,7 +110,9 @@ const TableOfContents = ({ page }) => {
                   <Icon
                     name={Icon.TYPE.ARROW_LEFT}
                     css={css`
-                      display: ${isActive ? 'inline-block' : 'none'};
+                      display: ${isActive && !isMobileScreen
+                        ? 'inline-block'
+                        : 'none'};
                       margin-right: 0.5rem;
                     `}
                   />

--- a/src/templates/basicDoc.js
+++ b/src/templates/basicDoc.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { graphql } from 'gatsby';
+import { useMedia } from 'react-use';
 import PageTitle from '../components/PageTitle';
 import MDXContainer from '../components/MDXContainer';
 import SEO from '../components/seo';
@@ -27,6 +28,8 @@ const BasicDoc = ({ data }) => {
     (node) => node.type === 'heading' && toString(node) === 'For more help'
   );
 
+  const isMobileScreen = useMedia('(max-width: 1240px)');
+
   return (
     <>
       <SEO title={frontmatter.title} />
@@ -42,7 +45,8 @@ const BasicDoc = ({ data }) => {
           @media screen and (max-width: 1240px) {
             grid-template-areas:
               'page-title'
-              'content';
+              'content'
+              'page-tools';
             grid-template-columns: minmax(0, 1fr);
           }
         `}
@@ -56,11 +60,14 @@ const BasicDoc = ({ data }) => {
         <Layout.PageTools
           css={css`
             @media screen and (max-width: 1240px) {
-              display: none;
+              margin-top: 1rem;
+              position: static;
             }
           `}
         >
-          <ContributingGuidelines fileRelativePath={fileRelativePath} />
+          {!isMobileScreen && (
+            <ContributingGuidelines fileRelativePath={fileRelativePath} />
+          )}
           <TableOfContents page={mdx} />
           <SimpleFeedback
             title={frontmatter.title}


### PR DESCRIPTION
## Description
Adds the right rail to pages using the `basicDoc` template. This requires adjustments to the template and our table of contents component.

## Related Issue(s)
* Closes #270 

## Screenshot(s)
![Screen Shot 2020-12-23 at 3 15 57 PM](https://user-images.githubusercontent.com/1946433/103043774-f1107100-4532-11eb-9c67-614c216f5a1f.png)