### PR TITLE
Deep Link Specific Attributes and Events

### DIFF
--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -179,29 +179,45 @@ const EventDefinition = memo(({ event, filteredAttribute }) => {
         }
       `}
     >
-      <h2
-        css={css`
-          position: sticky;
-          top: var(--global-header-height);
-          background: var(--primary-background-color);
-          padding: 1rem 0;
-
-          // cover up the right table border
-          margin-right: -1px;
-
-          @media (max-width: 1240px) {
-            position: static;
-          }
-        `}
-      >
-        <code
+      <Link to={`?event=${event.name}`}>
+        <h2
+          as={Link}
           css={css`
-            background: none !important;
+            position: sticky;
+            top: var(--global-header-height);
+            background: var(--primary-background-color);
+            padding: 1rem 0;
+
+            // cover up the right table border
+            margin-right: -1px;
+
+            &:hover svg {
+              opacity: 1;
+            }
+
+            @media (max-width: 1240px) {
+              position: static;
+            }
           `}
         >
-          {event.name}
-        </code>
-      </h2>
+          <code
+            css={css`
+              background: none !important;
+            `}
+          >
+            {event.name}
+          </code>
+          <Icon
+            name="fe-link-2"
+            focusable={false}
+            css={css`
+              margin-left: 0.5rem;
+              opacity: 0;
+              transition: opacity 0.2s ease-out;
+            `}
+          />
+        </h2>
+      </Link>
       <div
         css={css`
           margin-bottom: 1rem;
@@ -253,7 +269,7 @@ const EventDefinition = memo(({ event, filteredAttribute }) => {
                   `}
                 >
                   <Link
-                    to={`/attribute-dictionary?${params.toString()}`}
+                    to={`?${params.toString()}`}
                     css={css`
                       color: var(--color-text-primary);
 

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -10,6 +10,7 @@ import {
   Tag,
   TagList,
   useQueryParams,
+  Icon,
 } from '@newrelic/gatsby-theme-newrelic';
 
 import SEO from '../components/seo';
@@ -238,67 +239,95 @@ const EventDefinition = memo(({ event, filteredAttribute }) => {
           </tr>
         </thead>
         <tbody>
-          {filteredAttributes.map((attribute) => (
-            <tr key={attribute.name}>
-              <td
-                css={css`
-                  width: 1px;
-                `}
-              >
-                <code
+          {filteredAttributes.map((attribute) => {
+            const params = new URLSearchParams();
+            params.set('dataSource', event.dataSources[0]);
+            params.set('event', event.name);
+            params.set('attribute', attribute.name);
+
+            return (
+              <tr>
+                <td
                   css={css`
-                    display: block;
-                    background: none !important;
+                    width: 1px;
                   `}
                 >
-                  {attribute.name}
-                </code>
-                {attribute.units && (
-                  <span
+                  <Link
+                    to={`/attribute-dictionary?${params.toString()}`}
                     css={css`
-                      font-size: 0.75rem;
+                      color: var(--color-text-primary);
 
-                      .dark-mode & {
-                        color: var(--color-dark-600);
+                      &:hover svg {
+                        opacity: 1;
                       }
                     `}
                   >
-                    {attribute.units}
-                  </span>
-                )}
-              </td>
-              <td
-                css={css`
-                  p:last-child {
-                    margin-bottom: 0;
-                  }
-                `}
-                dangerouslySetInnerHTML={{
-                  __html: attribute.definition.html,
-                }}
-              />
-              <td
-                css={css`
-                  width: 1px;
-                `}
-              >
-                <ul
+                    <code
+                      css={css`
+                        display: inline-block;
+                        background: none !important;
+                      `}
+                    >
+                      {attribute.name}
+                    </code>
+                    <Icon
+                      name="fe-link-2"
+                      size="1rem"
+                      focusable={false}
+                      css={css`
+                        margin-left: 0.5rem;
+                        opacity: 0;
+                        transition: opacity 0.2s ease-out;
+                      `}
+                    />
+                  </Link>
+                  {attribute.units && (
+                    <div
+                      css={css`
+                        font-size: 0.75rem;
+
+                        .dark-mode & {
+                          color: var(--color-dark-600);
+                        }
+                      `}
+                    >
+                      {attribute.units}
+                    </div>
+                  )}
+                </td>
+                <td
                   css={css`
-                    margin: 0;
-                    list-style: none;
-                    padding-left: 0;
-                    font-size: 0.875rem;
+                    p:last-child {
+                      margin-bottom: 0;
+                    }
+                  `}
+                  dangerouslySetInnerHTML={{
+                    __html: attribute.definition.html,
+                  }}
+                />
+                <td
+                  css={css`
+                    width: 1px;
                   `}
                 >
-                  {attribute.events.map((event) => (
-                    <li key={event.name}>
-                      <Link to={`?event=${event.name}`}>{event.name}</Link>
-                    </li>
-                  ))}
-                </ul>
-              </td>
-            </tr>
-          ))}
+                  <ul
+                    css={css`
+                      margin: 0;
+                      list-style: none;
+                      padding-left: 0;
+                      font-size: 0.875rem;
+                    `}
+                  >
+                    {attribute.events.map((event) => (
+                      <li key={event.name}>
+                        <Link to={`?event=${event.name}`}>{event.name}</Link>
+                      </li>
+                    ))}
+                  </ul>
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </Table>
     </div>

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
+import React, { memo, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { graphql, Link } from 'gatsby';


### PR DESCRIPTION
## Description

Adds the ability to deep link to specific events and individual attributes on the [attribute dictionary page](https://docs-preview.newrelic.com/attribute-dictionary/). The "link" icon (🔗 ) appears on hover [like we have for section headers](https://github.com/newrelic/docs-website/pull/464).

## Reviewer Notes
Most of the line changes are indentation, might want to turn off whitespace when reviewing this PR.

## Related Issue(s) / Ticket(s)
* Closes #343

## Screenshot(s)
**Event (hover)**
![Screen Shot 2020-12-28 at 2 07 26 PM](https://user-images.githubusercontent.com/1946433/103245936-8edeb400-4916-11eb-96a4-9d31483805fb.png)

**Attribute (hover)**
![Screen Shot 2020-12-28 at 2 07 30 PM](https://user-images.githubusercontent.com/1946433/103245944-94d49500-4916-11eb-973e-f39dd956c6f2.png)
