### PR TITLE
Update Theme Version

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -61,14 +61,6 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
       value: createFilePath({ node, getNode, trailingSlash: false }),
     });
   }
-
-  if (node.internal.type === 'MarkdownRemark') {
-    createNodeField({
-      node,
-      name: 'fileRelativePath',
-      value: getFileRelativePath(node.fileAbsolutePath),
-    });
-  }
 };
 
 exports.createPages = async ({ actions, graphql, reporter }) => {
@@ -163,7 +155,6 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     const landingPage = landingPagesReleaseNotes.nodes.find(
       (node) => node.frontmatter.subject === fieldValue
     );
-
 
     landingPage &&
       createRedirect({

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "^2.0.0-next.8",
     "@mdx-js/react": "^2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "^1.17.1",
+    "@newrelic/gatsby-theme-newrelic": "^1.18.1",
     "@splitsoftware/splitio-react": "^1.2.0",
     "babel-jest": "^26.3.0",
     "date-fns": "^2.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2222,15 +2222,16 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^1.17.1":
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.17.1.tgz#1fa5d3abe8bc41b4aae39dc08f34e6ef8a86bbbd"
-  integrity sha512-kmvRZELEZHVqu2mj5eblFnp1Zvs8ugWx4n2ifGfznjdZm2Ht/EgnPBzxVHwQzl+R6WEIEBz5i49c/EP3l2+dag==
+"@newrelic/gatsby-theme-newrelic@^1.18.1":
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.18.1.tgz#beb0376b2abc663f040376c3cac2ce4cce141773"
+  integrity sha512-TG633+UxjEWWAeRNjxacthJaQgxu6WNCISX/ZKjzoJjGwYoKwe3rNifnwghJJ7J1D49mCHrvkiYY/494wRN0fg==
   dependencies:
     "@elastic/react-search-ui" "^1.4.1"
     "@elastic/react-search-ui-views" "^1.4.1"
     "@elastic/search-ui-site-search-connector" "^1.4.1"
     "@wry/equality" "^0.3.0"
+    "@xstate/react" "^1.1.0"
     babel-plugin-prismjs "^2.0.1"
     date-fns "^2.16.1"
     gatsby-plugin-emotion "^4.3.10"
@@ -2252,10 +2253,13 @@
     react-middle-ellipsis "^1.1.0"
     react-simple-code-editor "^0.11.0"
     react-spring "^8.0.27"
+    react-typist "^2.0.5"
+    react-use "^15.3.4"
     use-dark-mode "^2.3.1"
     use-media "^1.4.0"
     use-persisted-state "^0.3.0"
     warning "^4.0.3"
+    xstate "^4.15.1"
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -3040,6 +3044,14 @@
   version "1.9.5"
   resolved "https://registry.yarnpkg.com/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz#80224a6919272f405b87913ca13b92929bdf3c4d"
   integrity sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==
+
+"@xstate/react@^1.1.0":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.2.2.tgz#54d32034d40384782ee11145bbbb31b841a5a464"
+  integrity sha512-pXcUtts6EaEUmquzpMZ2yhAZZLAFYxKVaaHnQ8MPWpGuby0B5QMch17Ij59+LGQACQTSE0nDqXrvvBQId6m8qQ==
+  dependencies:
+    use-isomorphic-layout-effect "^1.0.0"
+    use-subscription "^1.3.0"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -14429,7 +14441,7 @@ prompts@^2.0.1, prompts@^2.3.2:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
-prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -14878,6 +14890,13 @@ react-transition-group@^2.2.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
+
+react-typist@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/react-typist/-/react-typist-2.0.5.tgz#9830395a73a03e6368e1392ecb98edaa3a648e44"
+  integrity sha512-iZCkeqeegO0TlkTMiH2JD1tvMtY9RrXkRylnAI6m8aCVAUUwNzoWTVF7CKLij6THeOMcUDCznLDDvNp55s+YZA==
+  dependencies:
+    prop-types "^15.5.10"
 
 react-universal-interface@^0.6.2:
   version "0.6.2"
@@ -18137,6 +18156,11 @@ use-dark-mode@^2.3.1:
     "@use-it/event-listener" "^0.1.2"
     use-persisted-state "^0.3.0"
 
+use-isomorphic-layout-effect@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz#7bb6589170cd2987a152042f9084f9effb75c225"
+  integrity sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==
+
 use-media@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/use-media/-/use-media-1.4.0.tgz#e777bf1f382a7aacabbd1f9ce3da2b62e58b2a98"
@@ -18153,6 +18177,13 @@ use-persisted-state@^0.3.0:
   integrity sha512-UlWEq0JYg7NbvcRBZ1g6Bwe4SEbYfr1wr/D5mrmfCzSxXSwsPRYygGLlsxHcW58Rf7gGwRPBT23sNVvyVn4WYg==
   dependencies:
     "@use-it/event-listener" "^0.1.2"
+
+use-subscription@^1.3.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.5.1.tgz#73501107f02fad84c6dd57965beb0b75c68c42d1"
+  integrity sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==
+  dependencies:
+    object-assign "^4.1.1"
 
 use@^3.1.0:
   version "3.1.1"
@@ -18997,6 +19028,11 @@ xstate@^4.14.0:
   version "4.15.1"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.15.1.tgz#0553453c1cd201fedaf35a3cc518fe56090dbc3a"
   integrity sha512-8dD/GnTwxUuDr/cY42vi+Enu4mpbuUXWISYJ0a9BC+cIFvqufJsepyDLS6lLsznfUP0GS5Yx9m3IQWFhAoGt/A==
+
+xstate@^4.15.1:
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.15.2.tgz#52213ecbca7b9458ff9162c977c4944ee16891c8"
+  integrity sha512-C+3jzJbhkp9ywGB+E2YMbS4mLyuxv366+KGi2RBX6y99xZFezbrGfaPQGRvFvn58OlLlCuSfCwn6bPcp78aMyw==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## Description
This PR bumps the theme from [`v1.17.1` to `v1.18.1`](https://github.com/newrelic/gatsby-theme-newrelic/compare/v1.17.1...v1.18.1).