### PR TITLE
Fix table of contents link text/href on content pages

### DIFF
--- a/plugins/gatsby-remark-custom-heading-ids/index.js
+++ b/plugins/gatsby-remark-custom-heading-ids/index.js
@@ -1,23 +1,11 @@
 const visit = require('unist-util-visit');
 const remove = require('unist-util-remove');
-const { last, get, set } = require('lodash');
-
-const CUSTOM_ID = /^#[\w-]+$/;
-
-const isHeadingWithCustomId = (node) => {
-  const lastChild = last(node.children);
-
-  return (
-    node.type === 'heading' &&
-    lastChild.type === 'linkReference' &&
-    CUSTOM_ID.test(lastChild.label)
-  );
-};
+const { get, set } = require('lodash');
+const { isHeadingWithCustomId, getId } = require('./utils/heading');
 
 module.exports = ({ markdownAST }) => {
   visit(markdownAST, isHeadingWithCustomId, (heading) => {
-    const { label } = last(heading.children);
-    const id = label.replace(/^#/, '');
+    const id = getId(heading);
 
     set(heading, 'data.id', id);
     set(heading, 'data.htmlAttributes.id', id);

--- a/plugins/gatsby-remark-custom-heading-ids/utils/heading.js
+++ b/plugins/gatsby-remark-custom-heading-ids/utils/heading.js
@@ -1,6 +1,6 @@
 const remove = require('unist-util-remove');
 const toString = require('mdast-util-to-string');
-const { last } = require('lodash');
+const { cloneDeep, last } = require('lodash');
 
 const CUSTOM_ID = /^#[\w-]+$/;
 
@@ -20,8 +20,6 @@ const isHeadingWithCustomId = (node) => {
   );
 };
 
-const copy = (node) => ({ ...node });
-
 const parseHeading = (node) => {
   if (node.type !== 'heading') {
     throw new Error('Node must be a heading');
@@ -30,7 +28,7 @@ const parseHeading = (node) => {
   if (isHeadingWithCustomId(node)) {
     // make a copy of the node so that removing the linkReference does not
     // mutate the original node object
-    const nodeCopy = copy(node);
+    const nodeCopy = cloneDeep(node);
     const id = getId(nodeCopy);
 
     remove(nodeCopy, 'linkReference');

--- a/plugins/gatsby-remark-custom-heading-ids/utils/heading.js
+++ b/plugins/gatsby-remark-custom-heading-ids/utils/heading.js
@@ -1,4 +1,5 @@
 const remove = require('unist-util-remove');
+const toString = require('mdast-util-to-string');
 const { last } = require('lodash');
 
 const CUSTOM_ID = /^#[\w-]+$/;
@@ -30,9 +31,11 @@ const parseHeading = (node) => {
     // make a copy of the node so that removing the linkReference does not
     // mutate the original node object
     const nodeCopy = copy(node);
+    const id = getId(nodeCopy);
+
     remove(nodeCopy, 'linkReference');
 
-    return { id: getId(node), text: toString(nodeCopy) };
+    return { id, text: toString(nodeCopy).trim() };
   }
 
   return { id: null, text: toString(node) };

--- a/plugins/gatsby-remark-custom-heading-ids/utils/heading.js
+++ b/plugins/gatsby-remark-custom-heading-ids/utils/heading.js
@@ -1,0 +1,41 @@
+const remove = require('unist-util-remove');
+const { last } = require('lodash');
+
+const CUSTOM_ID = /^#[\w-]+$/;
+
+const getId = (node) => {
+  const { label } = last(node.children);
+
+  return label.replace(/^#/, '');
+};
+
+const isHeadingWithCustomId = (node) => {
+  const lastChild = last(node.children);
+
+  return (
+    node.type === 'heading' &&
+    lastChild.type === 'linkReference' &&
+    CUSTOM_ID.test(lastChild.label)
+  );
+};
+
+const copy = (node) => ({ ...node });
+
+const parseHeading = (node) => {
+  if (node.type !== 'heading') {
+    throw new Error('Node must be a heading');
+  }
+
+  if (isHeadingWithCustomId(node)) {
+    // make a copy of the node so that removing the linkReference does not
+    // mutate the original node object
+    const nodeCopy = copy(node);
+    remove(nodeCopy, 'linkReference');
+
+    return { id: getId(node), text: toString(nodeCopy) };
+  }
+
+  return { id: null, text: toString(node) };
+};
+
+module.exports = { getId, parseHeading, isHeadingWithCustomId };

--- a/src/components/TableOfContents.js
+++ b/src/components/TableOfContents.js
@@ -2,12 +2,11 @@ import React, { useEffect, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { graphql } from 'gatsby';
-import { useMedia } from 'react-use';
+import { useMedia, usePrevious } from 'react-use';
 import { Icon, PageTools } from '@newrelic/gatsby-theme-newrelic';
 import useActiveHash from '../hooks/useActiveHash';
-import { usePrevious } from 'react-use';
 import GithubSlugger from 'github-slugger';
-import toString from 'mdast-util-to-string';
+import { parseHeading } from '../../plugins/gatsby-remark-custom-heading-ids/utils/heading';
 
 const prop = (name) => (obj) => obj[name];
 
@@ -20,9 +19,9 @@ const TableOfContents = ({ page }) => {
     return mdxAST.children
       .filter((node) => node.type === 'heading' && node.depth === 2)
       .map((heading) => {
-        const text = toString(heading);
+        const { id, text } = parseHeading(heading);
 
-        return { id: slugs.slug(text), text };
+        return { id: id || slugs.slug(text), text };
       });
   }, [mdxAST]);
 


### PR DESCRIPTION
Closes #493 

## Description

Fixes the table of contents links on pages that render a table of contents to strip the custom ID from the text and use the custom ID for linking.

## Screenshots

**Before**
<img width="345" alt="Screen Shot 2021-01-04 at 12 44 14 PM" src="https://user-images.githubusercontent.com/565661/103577981-a247cd00-4e8a-11eb-8b58-084b609c8734.png">

**After**
<img width="355" alt="Screen Shot 2021-01-04 at 12 44 08 PM" src="https://user-images.githubusercontent.com/565661/103577993-a83dae00-4e8a-11eb-8696-e6043debb5cb.png">
