### PR TITLE
Fix nav migration

### DIFF
--- a/scripts/utils/migrate/instruction-set.js
+++ b/scripts/utils/migrate/instruction-set.js
@@ -454,6 +454,7 @@ module.exports = [
   {
     type: INSTRUCTIONS.ADD,
     path: ['Agents', '.NET agent'],
+    index: -2,
     node: {
       title: 'Latest release',
       path: '/docs/release-notes/agent-release-notes/net-release-notes/current',
@@ -462,6 +463,7 @@ module.exports = [
   {
     type: INSTRUCTIONS.ADD,
     path: ['Agents', 'Java agent'],
+    index: -2,
     node: {
       title: 'Latest release',
       path:
@@ -471,6 +473,7 @@ module.exports = [
   {
     type: INSTRUCTIONS.ADD,
     path: ['Agents', 'Go agent'],
+    index: -2,
     node: {
       title: 'Latest release',
       path: '/docs/release-notes/agent-release-notes/go-release-notes/current',
@@ -479,6 +482,7 @@ module.exports = [
   {
     type: INSTRUCTIONS.ADD,
     path: ['Agents', 'C SDK'],
+    index: -2,
     node: {
       title: 'Latest release',
       path:
@@ -488,6 +492,7 @@ module.exports = [
   {
     type: INSTRUCTIONS.ADD,
     path: ['Agents', 'Ruby agent'],
+    index: -2,
     node: {
       title: 'Latest release',
       path:
@@ -497,6 +502,7 @@ module.exports = [
   {
     type: INSTRUCTIONS.ADD,
     path: ['Agents', 'Python agent'],
+    index: -2,
     node: {
       title: 'Latest release',
       path:
@@ -506,6 +512,7 @@ module.exports = [
   {
     type: INSTRUCTIONS.ADD,
     path: ['Agents', 'PHP agent'],
+    index: -2,
     node: {
       title: 'Latest release',
       path: '/docs/release-notes/agent-release-notes/php-release-notes/current',
@@ -514,6 +521,7 @@ module.exports = [
   {
     type: INSTRUCTIONS.ADD,
     path: ['Agents', 'Node.js agent'],
+    index: -2,
     node: {
       title: 'Latest release',
       path:

--- a/scripts/utils/migrate/instruction-set.js
+++ b/scripts/utils/migrate/instruction-set.js
@@ -453,7 +453,7 @@ module.exports = [
   },
   {
     type: INSTRUCTIONS.ADD,
-    path: ['Agents, .NET agent'],
+    path: ['Agents', '.NET agent'],
     node: {
       title: 'Latest release',
       path: '/docs/release-notes/agent-release-notes/net-release-notes/current',
@@ -461,7 +461,7 @@ module.exports = [
   },
   {
     type: INSTRUCTIONS.ADD,
-    path: ['Agents, Java agent'],
+    path: ['Agents', 'Java agent'],
     node: {
       title: 'Latest release',
       path:
@@ -470,7 +470,7 @@ module.exports = [
   },
   {
     type: INSTRUCTIONS.ADD,
-    path: ['Agents, Go agent'],
+    path: ['Agents', 'Go agent'],
     node: {
       title: 'Latest release',
       path: '/docs/release-notes/agent-release-notes/go-release-notes/current',
@@ -478,7 +478,7 @@ module.exports = [
   },
   {
     type: INSTRUCTIONS.ADD,
-    path: ['Agents, C SDK'],
+    path: ['Agents', 'C SDK'],
     node: {
       title: 'Latest release',
       path:
@@ -487,7 +487,7 @@ module.exports = [
   },
   {
     type: INSTRUCTIONS.ADD,
-    path: ['Agents, Ruby agent'],
+    path: ['Agents', 'Ruby agent'],
     node: {
       title: 'Latest release',
       path:
@@ -496,7 +496,7 @@ module.exports = [
   },
   {
     type: INSTRUCTIONS.ADD,
-    path: ['Agents, Python agent'],
+    path: ['Agents', 'Python agent'],
     node: {
       title: 'Latest release',
       path:
@@ -505,7 +505,7 @@ module.exports = [
   },
   {
     type: INSTRUCTIONS.ADD,
-    path: ['Agents, PHP agent'],
+    path: ['Agents', 'PHP agent'],
     node: {
       title: 'Latest release',
       path: '/docs/release-notes/agent-release-notes/php-release-notes/current',
@@ -513,7 +513,7 @@ module.exports = [
   },
   {
     type: INSTRUCTIONS.ADD,
-    path: ['Agents, Node.js agent'],
+    path: ['Agents', 'Node.js agent'],
     node: {
       title: 'Latest release',
       path:

--- a/scripts/utils/migrate/migrate-nav-structure.js
+++ b/scripts/utils/migrate/migrate-nav-structure.js
@@ -211,7 +211,7 @@ const duplicate = (files, { from, to }) => {
   return child ? add(files, { node: child, path: to }) : files;
 };
 
-const add = (files, { node, path: pathSegments }) => {
+const add = (files, { node, path: pathSegments, index }) => {
   let destinationFile = findFile(
     files,
     isRoot(pathSegments) ? [node.title] : pathSegments
@@ -236,7 +236,8 @@ const add = (files, { node, path: pathSegments }) => {
   const updatedNav = addChild(
     node,
     load(destinationFile),
-    pathSegments.slice(1)
+    pathSegments.slice(1),
+    index
   );
 
   write(destinationFile, updatedNav);
@@ -318,7 +319,7 @@ const updateNodeAtPath = (
   );
 };
 
-const addChild = (node, parent, pathSegments) => {
+const addChild = (node, parent, pathSegments, index) => {
   const [title, ...remainingSegments] = pathSegments;
   const { pages = [] } = parent;
   const idx = pages.findIndex((node) => node.title === title);
@@ -326,7 +327,10 @@ const addChild = (node, parent, pathSegments) => {
   if (pathSegments.length === 0) {
     return {
       ...parent,
-      pages: [...pages, node],
+      pages:
+        index == null
+          ? [...pages, node]
+          : [...pages.slice(0, idx), node, ...pages.slice(idx)],
     };
   }
 
@@ -335,13 +339,13 @@ const addChild = (node, parent, pathSegments) => {
       ...parent,
       pages: [
         ...pages,
-        addChild(node, { title, pages: [] }, remainingSegments),
+        addChild(node, { title, pages: [] }, remainingSegments, index),
       ],
     };
   }
 
   return updateChild(parent, idx, (child) =>
-    addChild(node, child, remainingSegments)
+    addChild(node, child, remainingSegments, index)
   );
 };
 

--- a/src/nav/agents.yml
+++ b/src/nav/agents.yml
@@ -159,6 +159,8 @@ pages:
         pages:
           - title: API guide
             path: /docs/agents/php-agent/api-guides/guide-using-php-agent-api
+      - title: Latest release
+        path: /docs/release-notes/agent-release-notes/php-release-notes/current
       - title: Troubleshooting
         pages:
           - title: No data appears
@@ -203,8 +205,6 @@ pages:
             path: /docs/agents/php-agent/troubleshooting/data-stops-reporting
           - title: First transaction not reported
             path: /docs/agents/php-agent/troubleshooting/first-php-transaction-not-reported
-      - title: Latest release
-        path: /docs/release-notes/agent-release-notes/php-release-notes/current
   - title: Node.js agent
     path: /docs/agents/nodejs-agent
     pages:
@@ -264,6 +264,8 @@ pages:
         pages:
           - title: Node.js agent attributes
             path: /docs/agents/nodejs-agent/attributes/nodejs-agent-attributes
+      - title: Latest release
+        path: /docs/release-notes/agent-release-notes/nodejs-release-notes/current
       - title: Troubleshooting
         pages:
           - title: Troubleshoot your installation
@@ -276,8 +278,6 @@ pages:
             path: /docs/agents/nodejs-agent/troubleshooting/troubleshooting-large-memory-usage-nodejs
           - title: Troubleshoot Browser
             path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-browser-instrumentation-nodejs
-      - title: Latest release
-        path: /docs/release-notes/agent-release-notes/nodejs-release-notes/current
   - title: .NET agent
     path: /docs/agents/net-agent
     pages:
@@ -416,6 +416,8 @@ pages:
             path: /docs/agents/net-agent/other-features/async-support-net
           - title: Add Browser monitoring
             path: /docs/agents/net-agent/other-features/browser-monitoring-net-agent
+      - title: Latest release
+        path: /docs/release-notes/agent-release-notes/net-release-notes/current
       - title: Troubleshooting
         pages:
           - title: Agent changes Content-Type header for WCF apps (.NET)
@@ -456,8 +458,6 @@ pages:
             path: /docs/agents/net-agent/troubleshooting/no-data-appears-after-disabling-tls-10
           - title: Monitor short-lived processes
             path: /docs/agents/net-agent/troubleshooting/monitor-short-lived-net-processes
-      - title: Latest release
-        path: /docs/release-notes/agent-release-notes/net-release-notes/current
   - title: Python agent
     path: /docs/agents/python-agent
     pages:
@@ -652,6 +652,8 @@ pages:
             path: /docs/agents/python-agent/custom-instrumentation/python-custom-instrumentation
           - title: Instrumentation via config file
             path: /docs/agents/python-agent/custom-instrumentation/python-custom-instrumentation-config-file
+      - title: Latest release
+        path: /docs/release-notes/agent-release-notes/python-release-notes/current
       - title: Troubleshooting
         pages:
           - title: No data appears
@@ -668,8 +670,6 @@ pages:
             path: /docs/agents/python-agent/troubleshooting/missing-information-when-using-ensurefuture-python
           - title: Activate application warning
             path: /docs/agents/python-agent/troubleshooting/activate-application-warning-python
-      - title: Latest release
-        path: /docs/release-notes/agent-release-notes/python-release-notes/current
   - title: Java agent
     path: /docs/agents/java-agent
     pages:
@@ -797,6 +797,8 @@ pages:
             path: /docs/agents/java-agent/api-guides/java-agent-api-custom-instrumentation-annotation-example-app
           - title: 'API example: Datastore and CAT'
             path: /docs/agents/java-agent/api-guides/java-agent-api-instrumenting-example-app-external-datastore-calls-cat
+      - title: Latest release
+        path: /docs/release-notes/agent-release-notes/java-release-notes/current
       - title: Troubleshooting
         pages:
           - title: No data appears
@@ -837,8 +839,6 @@ pages:
             path: /docs/agents/java-agent/troubleshooting/application-server-jmx-setup
           - title: Large number of false positive security vulnerabilities
             path: /docs/agents/java-agent/troubleshooting/large-number-false-positive-security-vulnerabilities
-      - title: Latest release
-        path: /docs/release-notes/agent-release-notes/java-release-notes/current
   - title: Ruby agent
     path: /docs/agents/ruby-agent
     pages:
@@ -944,6 +944,8 @@ pages:
             path: /docs/agents/ruby-agent/frameworks/sequel-instrumentation
           - title: Sinatra instrumentation
             path: /docs/agents/ruby-agent/instrumented-gems/sinatra-instrumentation
+      - title: Latest release
+        path: /docs/release-notes/agent-release-notes/ruby-release-notes/current
       - title: Troubleshooting
         pages:
           - title: No data appears
@@ -970,8 +972,6 @@ pages:
             path: /docs/agents/ruby-agent/troubleshooting/update-private-api-calls-public-tracer-api
           - title: Not installing Grape
             path: /docs/agents/ruby-agent/troubleshooting/not-installing-new-relic-supported-grape
-      - title: Latest release
-        path: /docs/release-notes/agent-release-notes/ruby-release-notes/current
   - title: C SDK
     path: /docs/agents/c-sdk
     pages:
@@ -997,14 +997,14 @@ pages:
         pages:
           - title: Use default or custom attributes
             path: /docs/agents/c-sdk/instrumentation/use-default-or-custom-attributes-c-sdk
+      - title: Latest release
+        path: /docs/release-notes/agent-release-notes/c-sdk-release-notes/current
       - title: Troubleshooting
         pages:
           - title: No data appears (C SDK)
             path: /docs/agents/c-sdk/troubleshooting/no-data-appears-c-sdk
           - title: Troubleshooting logs (C SDK)
             path: /docs/agents/c-sdk/troubleshooting/generate-logs-troubleshooting-c-sdk
-      - title: Latest release
-        path: /docs/release-notes/agent-release-notes/c-sdk-release-notes/current
   - title: Go agent
     path: /docs/agents/go-agent
     pages:
@@ -1060,12 +1060,12 @@ pages:
         pages:
           - title: Go agent API guide
             path: /docs/agents/go-agent/api-guides/guide-using-go-agent-api
+      - title: Latest release
+        path: /docs/release-notes/agent-release-notes/go-release-notes/current
       - title: Troubleshooting
         pages:
           - title: No data appears
             path: /docs/agents/go-agent/troubleshooting/no-data-appears-go
-      - title: Latest release
-        path: /docs/release-notes/agent-release-notes/go-release-notes/current
   - title: Open-source licensed agents
     pages:
       - title: Open-source licensed agents

--- a/src/nav/agents.yml
+++ b/src/nav/agents.yml
@@ -1,409 +1,478 @@
 title: Agents
 path: /docs/agents
 pages:
-  - title: Java agent
-    path: /docs/agents/java-agent
+  - title: PHP agent
+    path: /docs/agents/php-agent
     pages:
       - title: Getting started
         pages:
-          - title: Java release notes
-            path: /docs/agents/java-agent/getting-started/java-release-notes
-          - title: Java agent security
-            path: /docs/agents/java-agent/getting-started/apm-agent-security-java
-          - title: New Relic for Java
-            path: /docs/agents/java-agent/getting-started/introduction-new-relic-java
+          - title: New Relic for PHP
+            path: /docs/agents/php-agent/getting-started/introduction-new-relic-php
+          - title: New Relic daemon processes
+            path: /docs/agents/php-agent/getting-started/new-relic-daemon-processes
+          - title: PHP agent security
+            path: /docs/agents/php-agent/getting-started/apm-agent-security-php
+          - title: PHP agent release notes
+            path: /docs/agents/php-agent/getting-started/php-agent-release-notes
           - title: Compatibility and requirements
-            path: /docs/agents/java-agent/getting-started/compatibility-requirements-java-agent
-      - title: Instrumentation
+            path: /docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
+      - title: Advanced installation
         pages:
-          - title: Transaction naming protocol
-            path: /docs/agents/java-agent/instrumentation/transaction-naming-protocol
-          - title: Monitor deployments
-            path: /docs/agents/java-agent/instrumentation/monitor-deployments-java-agent
-          - title: Instrument webpages via API
-            path: /docs/agents/java-agent/instrumentation/instrument-browser-monitoring-java-agent-api
-          - title: Use RabbitMQ or JMS for message queues
-            path: /docs/agents/java-agent/instrumentation/use-rabbitmq-or-jms-message-queues
-          - title: Instrumentation modules
-            path: /docs/agents/java-agent/instrumentation/extension-additional-instrumentation-modules
-          - title: Ignore transactions
-            path: /docs/agents/java-agent/instrumentation/ignore-transactions-using-api
+          - title: The newrelic-install script
+            path: /docs/agents/php-agent/advanced-installation/using-newrelic-install-script
+          - title: Docker and other containers
+            path: /docs/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent
+          - title: Starting the PHP daemon
+            path: /docs/agents/php-agent/advanced-installation/starting-php-daemon-advanced
+          - title: Silent mode newrelic-install script
+            path: /docs/agents/php-agent/advanced-installation/silent-mode-install-script-advanced
+          - title: Non-standard PHP
+            path: /docs/agents/php-agent/advanced-installation/php-agent-installation-non-standard-php-advanced
+          - title: PHP agent and Heroku
+            path: /docs/agents/php-agent/advanced-installation/php-agent-heroku
+          - title: Uninstall the agent
+            path: /docs/agents/php-agent/advanced-installation/uninstalling-php-agent
+      - title: Configuration
+        pages:
+          - title: PHP agent configuration
+            path: /docs/agents/php-agent/configuration/php-agent-configuration
+          - title: Per-Directory INI settings
+            path: /docs/agents/php-agent/configuration/php-directory-ini-settings
+          - title: Name your PHP app
+            path: /docs/agents/php-agent/configuration/name-your-php-application
+          - title: Proxy daemon settings
+            path: /docs/agents/php-agent/configuration/proxy-daemon-newreliccfg-settings
+      - title: Attributes
+        pages:
+          - title: PHP agent attributes
+            path: /docs/agents/php-agent/attributes/php-agent-attributes
+          - title: Enable or disable attributes
+            path: /docs/agents/php-agent/attributes/enable-or-disable-attributes
+          - title: Attribute examples
+            path: /docs/agents/php-agent/attributes/attribute-examples
+      - title: Features
+        pages:
+          - title: Multiple accounts
+            path: /docs/agents/php-agent/features/multiple-accounts
+          - title: Distributed tracing
+            path: /docs/agents/php-agent/features/distributed-tracing-php-agent
+          - title: Browser monitoring
+            path: /docs/agents/php-agent/features/browser-monitoring-php-agent
+          - title: PHP custom instrumentation
+            path: /docs/agents/php-agent/features/php-custom-instrumentation
+          - title: Recording deployments
+            path: /docs/agents/php-agent/features/recording-deployments-using-php-script
+      - title: Frameworks and libraries
+        pages:
+          - title: Integrate support for New Relic
+            path: /docs/agents/php-agent/frameworks-libraries/php-frameworks-integrate-support-new-relic
+          - title: Analyze PHPUnit test data in New Relic
+            path: /docs/agents/php-agent/frameworks-libraries/analyze-phpunit-test-data-new-relic
+          - title: AWS Elastic Beanstalk installation
+            path: /docs/agents/php-agent/frameworks-libraries/aws-elastic-beanstalk-installation-php
+          - title: Drupal-specific functionality
+            path: /docs/agents/php-agent/frameworks-libraries/drupal-specific-functionality
+          - title: Guzzle
+            path: /docs/agents/php-agent/frameworks-libraries/guzzle
+          - title: Magento-specific functionality
+            path: /docs/agents/php-agent/frameworks-libraries/magento-specific-functionality
+          - title: Predis library
+            path: /docs/agents/php-agent/frameworks-libraries/predis-library-php
+          - title: WordPress specific functionality
+            path: /docs/agents/php-agent/frameworks-libraries/wordpress-specific-functionality
+      - title: Installation
+        pages:
+          - title: Installation overview
+            path: /docs/agents/php-agent/installation/php-agent-installation-overview
+          - title: 'AWS Linux, RedHat and CentOS'
+            path: /docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos
+          - title: Ubuntu and Debian
+            path: /docs/agents/php-agent/installation/php-agent-installation-ubuntu-debian
+          - title: Tar archive
+            path: /docs/agents/php-agent/installation/php-agent-installation-tar-file
+          - title: Install agent on shared hosting service
+            path: /docs/agents/php-agent/installation/install-php-agent-shared-hosting-service
+          - title: Update the PHP agent
+            path: /docs/agents/php-agent/installation/update-php-agent
+      - title: PHP agent API
+        path: /docs/agents/php-agent/php-agent-api
+        pages:
+          - title: View all methods
+            path: /docs/agents/php-agent/php-agent-api/view-all-methods
+          - title: newrelic_accept_distributed_trace_headers
+            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtraceheaders
+          - title: newrelic_accept_distributed_trace_payload
+            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtracepayload-php-agent-api
+          - title: newrelic_accept_distributed_trace_payload_httpsafe
+            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtracepayloadhttpsafe-php-agent-api
+          - title: newrelic_add_custom_parameter
+            path: /docs/agents/php-agent/php-agent-api/newrelic_add_custom_parameter
+          - title: newrelic_add_custom_span_parameter
+            path: /docs/agents/php-agent/php-agent-api/newrelicaddcustomspanparameter-php-agent-api
+          - title: newrelic_add_custom_tracer
+            path: /docs/agents/php-agent/php-agent-api/newrelic_add_custom_tracer
+          - title: newrelic_background_job
+            path: /docs/agents/php-agent/php-agent-api/newrelic_background_job
+          - title: newrelic_capture_params
+            path: /docs/agents/php-agent/php-agent-api/newrelic_capture_params
+          - title: newrelic_create_distributed_trace_payload
+            path: /docs/agents/php-agent/php-agent-api/newreliccreatedistributedtracepayload-php-agent-api
+          - title: newrelic_custom_metric
+            path: /docs/agents/php-agent/php-agent-api/newreliccustommetric-php-agent-api
+          - title: newrelic_disable_autorum
+            path: /docs/agents/php-agent/php-agent-api/newrelic_disable_autorum
+          - title: newrelic_end_of_transaction
+            path: /docs/agents/php-agent/php-agent-api/newrelic_end_of_transaction
+          - title: newrelic_end_transaction
+            path: /docs/agents/php-agent/php-agent-api/newrelic_end_transaction
+          - title: newrelic_get_browser_timing_footer
+            path: /docs/agents/php-agent/php-agent-api/newrelic_get_browser_timing_footer
+          - title: newrelic_get_browser_timing_header
+            path: /docs/agents/php-agent/php-agent-api/newrelic_get_browser_timing_header
+          - title: newrelic_get_linking_metadata
+            path: /docs/agents/php-agent/php-agent-api/newrelicgetlinkingmetadata
+          - title: newrelic_get_trace_metadata
+            path: /docs/agents/php-agent/php-agent-api/newrelicgettracemetadata
+          - title: newrelic_ignore_apdex
+            path: /docs/agents/php-agent/php-agent-api/newrelic_ignore_apdex
+          - title: newrelic_ignore_transaction
+            path: /docs/agents/php-agent/php-agent-api/newrelic_ignore_transaction
+          - title: newrelic_insert_distributed_trace_headers
+            path: /docs/agents/php-agent/php-agent-api/newrelicinsertdistributedtraceheaders
+          - title: newrelic_is_sampled
+            path: /docs/agents/php-agent/php-agent-api/newrelicissampled
+          - title: newrelic_name_transaction
+            path: /docs/agents/php-agent/php-agent-api/newrelic_name_transaction
+          - title: newrelic_notice_error
+            path: /docs/agents/php-agent/php-agent-api/newrelic_notice_error
+          - title: newrelic_record_custom_event
+            path: /docs/agents/php-agent/php-agent-api/newrelic_record_custom_event
+          - title: newrelic_record_datastore_segment
+            path: /docs/agents/php-agent/php-agent-api/newrelic_record_datastore_segment
+          - title: newrelic_set_appname
+            path: /docs/agents/php-agent/php-agent-api/newrelic_set_appname
+          - title: newrelic_set_user_attributes
+            path: /docs/agents/php-agent/php-agent-api/newrelic_set_user_attributes
+          - title: newrelic_start_transaction
+            path: /docs/agents/php-agent/php-agent-api/newrelic_start_transaction
+      - title: API guides
+        pages:
+          - title: API guide
+            path: /docs/agents/php-agent/api-guides/guide-using-php-agent-api
+      - title: Troubleshooting
+        pages:
+          - title: No data appears
+            path: /docs/agents/php-agent/troubleshooting/no-data-appears-php
+          - title: Agent not reporting errors
+            path: /docs/agents/php-agent/troubleshooting/php-agent-not-reporting-errors
+          - title: Determine permissions requirements
+            path: /docs/agents/php-agent/troubleshooting/determine-permissions-requirements-php
+          - title: Generating logs for troubleshooting
+            path: /docs/agents/php-agent/troubleshooting/generating-logs-troubleshooting-php
+          - title: Data stops reporting while using SELinux
+            path: /docs/agents/php-agent/troubleshooting/data-stops-reporting-while-using-selinux
+          - title: Protocol mismatch error
+            path: /docs/agents/php-agent/troubleshooting/protocol-mismatch-error
+          - title: INI settings not taking effect immediately
+            path: /docs/agents/php-agent/troubleshooting/ini-settings-not-taking-effect-immediately
+          - title: Submitting troubleshooting results
+            path: /docs/agents/php-agent/troubleshooting/submitting-troubleshooting-results-php
+          - title: Threaded Apache worker MPMs
+            path: /docs/agents/php-agent/troubleshooting/threaded-apache-worker-mpms
+          - title: Transactions /index.php or /unknown
+            path: /docs/agents/php-agent/troubleshooting/transactions-named-indexphp-or-unknown
+          - title: What the PHP instance count means
+            path: /docs/agents/php-agent/troubleshooting/troubleshoot-php-agent-instance-count
+          - title: Uninstrumented time in traces
+            path: /docs/agents/php-agent/troubleshooting/uninstrumented-time-traces
+          - title: Using phpinfo to verify PHP
+            path: /docs/agents/php-agent/troubleshooting/using-phpinfo-verify-php
+          - title: Agents stops after updating PHP
+            path: /docs/agents/php-agent/troubleshooting/agent-stops-working-after-updating-php
+          - title: Checking loaded configuration files directory
+            path: /docs/agents/php-agent/troubleshooting/checking-loaded-configuration-files-directory
+          - title: Missing PHP module
+            path: /docs/agents/php-agent/troubleshooting/missing-php-module
+          - title: Verifying the PHP daemon
+            path: /docs/agents/php-agent/troubleshooting/verifying-php-daemon
+          - title: When to restart your web server
+            path: /docs/agents/php-agent/troubleshooting/why-when-restart-your-web-server-php
+          - title: PHP installation fails on El Capitan
+            path: /docs/agents/php-agent/troubleshooting/php-installation-fails-os-x-1011-el-capitan
+          - title: Data stops reporting
+            path: /docs/agents/php-agent/troubleshooting/data-stops-reporting
+          - title: First transaction not reported
+            path: /docs/agents/php-agent/troubleshooting/first-php-transaction-not-reported
+      - title: Latest release
+        path: /docs/release-notes/agent-release-notes/php-release-notes/current
+  - title: Node.js agent
+    path: /docs/agents/nodejs-agent
+    pages:
+      - title: Getting started
+        pages:
+          - title: New Relic for Node.js
+            path: /docs/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs
+          - title: Node.js agent security
+            path: /docs/agents/nodejs-agent/getting-started/apm-agent-security-nodejs
+          - title: Node.js release notes
+            path: /docs/agents/nodejs-agent/getting-started/nodejs-release-notes
+          - title: Compatibility and requirements
+            path: /docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent
+      - title: Installation and configuration
+        pages:
+          - title: Install the Node.js agent
+            path: /docs/agents/nodejs-agent/installation-configuration/install-nodejs-agent
+          - title: Node.js agent configuration
+            path: /docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration
+          - title: Update the Node.js agent
+            path: /docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent
+          - title: Uninstall the agent
+            path: /docs/agents/nodejs-agent/installation-configuration/uninstall-nodejs-agent
+      - title: Extend your instrumentation
+        pages:
+          - title: Node.js custom instrumentation
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation
+          - title: Node.js custom metrics
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-metrics
+          - title: Node.js VMs statistics page
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-vms-statistics-page
+          - title: Distributed tracing
+            path: /docs/agents/nodejs-agent/supported-features/enable-distributed-tracing-nodejs-agent
+          - title: Message queues
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/message-queues
+          - title: Browser monitoring
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/browser-monitoring-nodejs-agent
+          - title: Node.js VM measurements
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-vm-measurements
+          - title: Node.js v1 custom instrumentation
+            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-v1-custom-instrumentation-legacy
+      - title: Hosting services
+        pages:
+          - title: GAE flex
+            path: /docs/agents/nodejs-agent/hosting-services/install-new-relic-nodejs-agent-gae-flexible-environment
+          - title: Install on Azure Web Apps
+            path: /docs/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure
+          - title: Node.js agent and Heroku
+            path: /docs/agents/nodejs-agent/hosting-services/nodejs-agent-heroku
+      - title: API guides
+        pages:
+          - title: Guide to Node.js agent API
+            path: /docs/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api
+          - title: Node.js agent API
+            path: /docs/agents/nodejs-agent/api-guides/nodejs-agent-api
+      - title: Attributes
+        pages:
+          - title: Node.js agent attributes
+            path: /docs/agents/nodejs-agent/attributes/nodejs-agent-attributes
+      - title: Troubleshooting
+        pages:
+          - title: Troubleshoot your installation
+            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-your-nodejs-installation
+          - title: Logs for troubleshooting
+            path: /docs/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs
+          - title: Troubleshoot message consumers
+            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-message-consumers
+          - title: Large memory usage
+            path: /docs/agents/nodejs-agent/troubleshooting/troubleshooting-large-memory-usage-nodejs
+          - title: Troubleshoot Browser
+            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-browser-instrumentation-nodejs
+      - title: Latest release
+        path: /docs/release-notes/agent-release-notes/nodejs-release-notes/current
+  - title: .NET agent
+    path: /docs/agents/net-agent
+    pages:
+      - title: Getting started
+        pages:
+          - title: New Relic for .NET
+            path: /docs/agents/net-agent/getting-started/introduction-new-relic-net
+          - title: Compatibility and requirements (Framework)
+            path: /docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework
+          - title: Compatibility and requirements (Core)
+            path: /docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core
+          - title: 'APM agent security: .NET'
+            path: /docs/agents/net-agent/getting-started/apm-agent-security-net
+          - title: .NET release notes
+            path: /docs/agents/net-agent/getting-started/net-release-notes
       - title: Custom instrumentation
         pages:
-          - title: Java custom instrumentation
-            path: /docs/agents/java-agent/custom-instrumentation/java-custom-instrumentation
-          - title: Custom instrumentation editor
-            path: /docs/agents/java-agent/custom-instrumentation/custom-instrumentation-editor-instrument-ui
-          - title: Scala instrumentation
-            path: /docs/agents/java-agent/frameworks/scala-installation-java
-          - title: Java instrumentation by XML
-            path: /docs/agents/java-agent/custom-instrumentation/java-instrumentation-xml
-          - title: XML instrumentation example
-            path: /docs/agents/java-agent/custom-instrumentation/java-xml-instrumentation-examples
-          - title: Custom JMX instrumentation
-            path: /docs/agents/java-agent/custom-instrumentation/java-agent-custom-jmx-instrumentation-yaml
-          - title: Custom JMX YAML examples
-            path: /docs/agents/java-agent/custom-instrumentation/custom-jmx-yaml-examples
-          - title: Troubleshooting Java custom instrumentation
-            path: /docs/agents/java-agent/custom-instrumentation/troubleshooting-java-custom-instrumentation
-          - title: Circuit breaker
-            path: /docs/agents/java-agent/custom-instrumentation/circuit-breaker-java-custom-instrumentation
-      - title: Installation
-        pages:
-          - title: Install the Java agent
-            path: /docs/agents/java-agent/installation/install-java-agent
-          - title: Include agent with JVM
-            path: /docs/agents/java-agent/installation/include-java-agent-jvm-argument
-          - title: Update the Java agent
-            path: /docs/agents/java-agent/installation/update-java-agent
-          - title: Uninstall the Java agent
-            path: /docs/agents/java-agent/installation/uninstall-java-agent
-      - title: Configuration
-        pages:
-          - title: Java agent configuration
-            path: /docs/agents/java-agent/configuration/java-agent-configuration-config-file
-          - title: Java agent config file template
-            path: /docs/agents/java-agent/configuration/java-agent-config-file-template
-          - title: Hostname logic
-            path: /docs/agents/java-agent/configuration/hostname-logic-java
-          - title: Distributed tracing
-            path: /docs/agents/java-agent/configuration/enable-distributed-tracing-java-agent
-          - title: Automatic application naming
-            path: /docs/agents/java-agent/configuration/automatic-application-naming
-          - title: Error configuration
-            path: /docs/agents/java-agent/configuration/java-agent-error-configuration
-          - title: Configuring your SSL certificates
-            path: /docs/agents/java-agent/configuration/configuring-your-ssl-certificates
-      - title: Features
-        pages:
-          - title: JVM metrics page (Java)
-            path: /docs/agents/java-agent/features/jvms-page-java-view-app-server-metrics-jmx
-      - title: Heroku
-        pages:
-          - title: Java agent and Heroku
-            path: /docs/agents/java-agent/heroku/java-agent-heroku
-          - title: Scala and Heroku
-            path: /docs/agents/java-agent/heroku/java-agent-scala-heroku
-          - title: No data appears (Heroku)
-            path: /docs/agents/java-agent/heroku/no-data-appears-heroku-java
-      - title: Async instrumentation
-        pages:
-          - title: Async instrumentation
-            path: /docs/agents/java-agent/async-instrumentation/introduction-java-async-instrumentation
-          - title: Java async API
-            path: /docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications
-          - title: Troubleshoot async
-            path: /docs/agents/java-agent/async-instrumentation/troubleshoot-java-asynchronous-instrumentation
-          - title: Disable async frameworks
-            path: /docs/agents/java-agent/async-instrumentation/disable-scala-netty-akka-play-2-instrumentation
-      - title: Additional installation
-        pages:
-          - title: Docker
-            path: /docs/agents/java-agent/additional-installation/install-new-relic-java-agent-docker
-          - title: AWS Elastic Beanstalk
-            path: /docs/agents/java-agent/additional-installation/aws-elastic-beanstalk-installation-java
-          - title: WildFly installation
-            path: /docs/agents/java-agent/additional-installation/wildfly-installation-java
-          - title: GAE flex
-            path: /docs/agents/java-agent/additional-installation/install-new-relic-java-agent-gae-flexible-environment
-          - title: WebSphere App Server
-            path: /docs/agents/java-agent/additional-installation/ibm-websphere-application-server
-          - title: Java 2 security installation
-            path: /docs/agents/java-agent/installation/install-java-agent-java-2-security
-          - title: Maven install
-            path: /docs/agents/java-agent/additional-installation/install-java-agent-using-maven
+          - title: Introduction to .NET custom instrumentation
+            path: /docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation
+          - title: Attribute custom instrumentation
+            path: /docs/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net
+          - title: XML to create transactions
+            path: /docs/agents/net-agent/custom-instrumentation/create-transactions-xml-net
+          - title: XML to add detail
+            path: /docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net
       - title: Attributes
         pages:
-          - title: Java agent attributes
-            path: /docs/agents/java-agent/attributes/java-agent-attributes
-      - title: API guides
-        pages:
-          - title: Java agent API guide
-            path: /docs/agents/java-agent/api-guides/guide-using-java-agent-api
-          - title: Java agent API annotation
-            path: /docs/agents/java-agent/api-guides/java-agent-api-instrument-using-annotation
-          - title: 'API: Externals, messaging, frameworks'
-            path: /docs/agents/java-agent/api-guides/java-agent-api-instrument-external-calls-messaging-datastore-web-frameworks
-          - title: 'API: Annotating example app'
-            path: /docs/agents/java-agent/api-guides/java-agent-api-custom-instrumentation-annotation-example-app
-          - title: 'API example: Datastore and CAT'
-            path: /docs/agents/java-agent/api-guides/java-agent-api-instrumenting-example-app-external-datastore-calls-cat
-      - title: Troubleshooting
-        pages:
-          - title: No data appears
-            path: /docs/agents/java-agent/troubleshooting/no-data-appears-java
-          - title: Determine permissions requirements
-            path: /docs/agents/java-agent/troubleshooting/determine-permissions-requirements-java
-          - title: Gather troubleshooting information
-            path: /docs/agents/java-agent/troubleshooting/gather-troubleshooting-information-java
-          - title: All hosts appear as localhost
-            path: /docs/agents/java-agent/troubleshooting/all-hosts-appear-localhost
-          - title: Error bootstrapping Java agent
-            path: /docs/agents/java-agent/troubleshooting/error-bootstrapping-new-relic-java-agent
-          - title: Errors starting Java app server
-            path: /docs/agents/java-agent/troubleshooting/errors-starting-java-app-server
-          - title: Firewall or traffic connectivity failures
-            path: /docs/agents/java-agent/troubleshooting/firewall-or-traffic-connectivity-failures
-          - title: Generate logs for troubleshooting
-            path: /docs/agents/java-agent/troubleshooting/generate-debug-logs-troubleshooting-java
-          - title: Host links missing
-            path: /docs/agents/java-agent/troubleshooting/host-links-missing-java-apps-apm-summary
-          - title: Solr data does not appear
-            path: /docs/agents/java-agent/troubleshooting/java-solr-data-does-not-appear
-          - title: No Browser data appears
-            path: /docs/agents/java-agent/troubleshooting/no-browser-data-appears-java
-          - title: No log file
-            path: /docs/agents/java-agent/troubleshooting/no-log-file-java
-          - title: No stack traces
-            path: /docs/agents/java-agent/troubleshooting/no-stack-traces-java
-          - title: NullPointerException issues
-            path: /docs/agents/java-agent/troubleshooting/nullpointerexception-issues-java
-          - title: Resolve metric grouping issues
-            path: /docs/agents/java-agent/troubleshooting/resolve-metric-grouping-issues-java-apps
-          - title: SSL or connection errors
-            path: /docs/agents/java-agent/troubleshooting/ssl-or-connection-errors-java
-          - title: Update legacy Java config
-            path: /docs/agents/java-agent/troubleshooting/update-java-config-legacy-agent-versions
-          - title: Application server JMX setup
-            path: /docs/agents/java-agent/troubleshooting/application-server-jmx-setup
-          - title: Large number of false positive security vulnerabilities
-            path: /docs/agents/java-agent/troubleshooting/large-number-false-positive-security-vulnerabilities
-  - title: Go agent
-    path: /docs/agents/go-agent
-    pages:
-      - title: Get started
-        pages:
-          - title: Go agent release notes
-            path: /docs/agents/go-agent/get-started/go-agent-release-notes
-          - title: Compatibility and requirements
-            path: /docs/agents/go-agent/get-started/go-agent-compatibility-requirements
-          - title: Go agent security
-            path: /docs/agents/go-agent/get-started/apm-agent-security-go
-          - title: New Relic for Go
-            path: /docs/agents/go-agent/get-started/introduction-new-relic-go
-      - title: Instrumentation
-        pages:
-          - title: Instrument Go transactions
-            path: /docs/agents/go-agent/instrumentation/instrument-go-transactions
-          - title: Instrument Go segments
-            path: /docs/agents/go-agent/instrumentation/instrument-go-segments
-          - title: Custom events
-            path: /docs/agents/go-agent/features/create-custom-events-go
-          - title: Go agent attributes
-            path: /docs/agents/go-agent/instrumentation/go-agent-attributes
-          - title: Create custom metrics in Go
-            path: /docs/agents/go-agent/instrumentation/create-custom-metrics-go
-      - title: Installation
-        pages:
-          - title: Install New Relic for Go
-            path: /docs/agents/go-agent/installation/install-new-relic-go
-          - title: Install in GAE flex
-            path: /docs/agents/go-agent/installation/install-go-agent-gae-flexible-environment
-          - title: Uninstall the Go agent
-            path: /docs/agents/go-agent/installation/uninstall-go-agent
-      - title: Configuration
-        pages:
-          - title: Go configuration
-            path: /docs/agents/go-agent/configuration/go-agent-configuration
-          - title: Go agent logging
-            path: /docs/agents/go-agent/configuration/go-agent-logging
-      - title: Features
-        pages:
-          - title: Go runtime UI page
-            path: /docs/agents/go-agent/features/go-runtime-page-troubleshoot-performance-problems
-          - title: Custom events
-            path: /docs/agents/go-agent/features/create-custom-events-go
-          - title: Add browser monitoring
-            path: /docs/agents/go-agent/features/add-browser-monitoring-your-go-apps
-          - title: Distributed tracing
-            path: /docs/agents/go-agent/features/enable-distributed-tracing-your-go-applications
-          - title: Cross application tracing
-            path: /docs/agents/go-agent/features/cross-application-tracing-go
-      - title: API guides
-        pages:
-          - title: Go agent API guide
-            path: /docs/agents/go-agent/api-guides/guide-using-go-agent-api
-      - title: Troubleshooting
-        pages:
-          - title: No data appears
-            path: /docs/agents/go-agent/troubleshooting/no-data-appears-go
-  - title: C SDK
-    path: /docs/agents/c-sdk
-    pages:
-      - title: Get started
-        pages:
-          - title: C SDK security
-            path: /docs/agents/c-sdk/get-started/apm-security-c-sdk
-          - title: Compatibility and requirements
-            path: /docs/agents/c-sdk/get-started/c-sdk-compatibility-requirements
-          - title: Introduction to the C SDK
-            path: /docs/agents/c-sdk/get-started/introduction-c-sdk
-      - title: Install and configure
-        pages:
-          - title: Install (compile) the C SDK
-            path: /docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code
-          - title: C SDK configuration
-            path: /docs/agents/c-sdk/install-configure/c-sdk-configuration
-          - title: Update your C SDK library
-            path: /docs/agents/c-sdk/install-configure/update-your-c-sdk-library
-          - title: Uninstall (remove) the C SDK
-            path: /docs/agents/c-sdk/install-configure/uninstall-remove-c-sdk
-      - title: Instrumentation
-        pages:
-          - title: Use default or custom attributes
-            path: /docs/agents/c-sdk/instrumentation/use-default-or-custom-attributes-c-sdk
-      - title: Troubleshooting
-        pages:
-          - title: No data appears (C SDK)
-            path: /docs/agents/c-sdk/troubleshooting/no-data-appears-c-sdk
-          - title: Troubleshooting logs (C SDK)
-            path: /docs/agents/c-sdk/troubleshooting/generate-logs-troubleshooting-c-sdk
-  - title: Ruby agent
-    path: /docs/agents/ruby-agent
-    pages:
-      - title: Getting started
-        pages:
-          - title: New Relic's GitHub repository
-            path: /docs/agents/ruby-agent/getting-started/new-relics-github-repository
-          - title: Ruby release notes
-            path: /docs/agents/ruby-agent/getting-started/ruby-release-notes
-          - title: New Relic for Ruby
-            path: /docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby
-          - title: Requirements and supported frameworks
-            path: /docs/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks
-          - title: Ruby agent security
-            path: /docs/agents/ruby-agent/getting-started/apm-agent-security-ruby
-      - title: Installation
-        pages:
-          - title: Ruby agent installation
-            path: /docs/agents/ruby-agent/installation/install-new-relic-ruby-agent
-          - title: Rails plugin installation
-            path: /docs/agents/ruby-agent/installation/ruby-agent-installation-rails-plugin
-          - title: GAE flex
-            path: /docs/agents/ruby-agent/installation/install-new-relic-ruby-agent-gae-flexible-environment
-          - title: Ruby agent and Heroku
-            path: /docs/agents/ruby-agent/installation/ruby-agent-heroku
-          - title: Update Ruby agent
-            path: /docs/agents/ruby-agent/installation/update-ruby-agent
-          - title: Uninstall Ruby agent
-            path: /docs/agents/ruby-agent/installation/uninstall-ruby-agent
-      - title: Configuration
-        pages:
-          - title: Ruby configuration
-            path: /docs/agents/ruby-agent/configuration/ruby-agent-configuration
-          - title: Custom SSL certificates
-            path: /docs/agents/ruby-agent/configuration/custom-ssl-certificates-ruby
-          - title: Connect hosts to account
-            path: /docs/agents/ruby-agent/configuration/connect-hosts-your-account
-      - title: API guides
-        pages:
-          - title: Ruby custom instrumentation
-            path: /docs/agents/ruby-agent/api-guides/ruby-custom-instrumentation
-          - title: API guide
-            path: /docs/agents/ruby-agent/api-guides/guide-using-ruby-agent-api
-          - title: Ruby custom metrics
-            path: /docs/agents/ruby-agent/api-guides/ruby-custom-metrics
-          - title: Ignoring specific transactions
-            path: /docs/agents/ruby-agent/api-guides/ignoring-specific-transactions
-          - title: Reporting handled errors
-            path: /docs/agents/ruby-agent/api-guides/sending-handled-errors-new-relic
-          - title: Third party instrumentation
-            path: /docs/agents/ruby-agent/api-guides/third-party-instrumentation
-      - title: Features
-        pages:
-          - title: Record deployments
-            path: /docs/agents/ruby-agent/features/record-deployments-ruby-agent
-          - title: Message queues
-            path: /docs/agents/ruby-agent/features/message-queues
-          - title: Ruby HTTP client tracing
-            path: /docs/agents/ruby-agent/features/http-client-tracing-ruby
-          - title: Ruby cross application tracing
-            path: /docs/agents/ruby-agent/features/cross-application-tracing-ruby
-          - title: Ruby VM measurements
-            path: /docs/agents/ruby-agent/features/ruby-vm-measurements
-          - title: Garbage collection
-            path: /docs/agents/ruby-agent/features/garbage-collection
-          - title: Browser monitoring
-            path: /docs/agents/ruby-agent/features/new-relic-browser-ruby-agent
-          - title: Developer mode
-            path: /docs/agents/ruby-agent/features/developer-mode
-      - title: Background jobs
-        pages:
-          - title: Resque instrumentation
-            path: /docs/agents/ruby-agent/background-jobs/resque-instrumentation
-          - title: Sidekiq instrumentation
-            path: /docs/agents/ruby-agent/background-jobs/sidekiq-instrumentation
-          - title: Rake instrumentation
-            path: /docs/agents/ruby-agent/background-jobs/rake-instrumentation
-          - title: Monitor background processes
-            path: /docs/agents/ruby-agent/background-jobs/monitor-ruby-background-processes
-          - title: 'Delayed::Job instrumentation'
-            path: /docs/agents/ruby-agent/background-jobs/delayedjob-instrumentation
-      - title: Attributes
-        pages:
+          - title: .NET agent attributes
+            path: /docs/agents/net-agent/attributes/net-agent-attributes
+          - title: .NET attribute examples
+            path: /docs/agents/net-agent/attributes/net-attribute-examples
           - title: Enable and disable attributes
-            path: /docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby
-          - title: Ruby agent attributes
-            path: /docs/agents/ruby-agent/attributes/ruby-agent-attributes
-          - title: Attribute examples
-            path: /docs/agents/ruby-agent/attributes/ruby-attribute-examples
-      - title: Instrumented gems
+            path: /docs/agents/net-agent/attributes/enable-disable-attributes-net
+      - title: Azure troubleshooting
         pages:
-          - title: Redis instrumentation
-            path: /docs/agents/ruby-agent/instrumented-gems/redis-instrumentation
-          - title: Mongo instrumentation
-            path: /docs/agents/ruby-agent/frameworks/mongo-instrumentation
-          - title: Rack and Metal support
-            path: /docs/agents/ruby-agent/frameworks/rack-metal-support
-          - title: Rack middlewares
-            path: /docs/agents/ruby-agent/instrumented-gems/rack-middlewares
-          - title: Metal controller instrumentation
-            path: /docs/agents/ruby-agent/frameworks/metal-controller-instrumentation
-          - title: Sequel instrumentation
-            path: /docs/agents/ruby-agent/frameworks/sequel-instrumentation
-          - title: Sinatra instrumentation
-            path: /docs/agents/ruby-agent/instrumented-gems/sinatra-instrumentation
+          - title: 'Azure Cloud Services: No data appears'
+            path: /docs/agents/net-agent/azure-troubleshooting/azure-cloud-services-no-data-appears
+          - title: 'Azure Web Apps: No data appears'
+            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-using-always-no-data-appears
+          - title: 'Azure Web Apps: Unable to open log file'
+            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-unable-open-log-file
+          - title: Profiler .dll locks during deployment
+            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-profiler-dll-locks-during-deployment
+          - title: No data with Microsoft App Insights
+            path: /docs/agents/net-agent/azure-troubleshooting/no-data-reporting-microsoft-application-insights
+      - title: NET agent API
+        path: /docs/agents/net-agent/net-agent-api
+        pages:
+          - title: View all methods
+            path: /docs/agents/net-agent/net-agent-api/view-all-methods
+          - title: AddCustomParameter
+            path: /docs/agents/net-agent/net-agent-api/addcustomparameter-net-agent-api
+          - title: DisableBrowserMonitoring
+            path: /docs/agents/net-agent/net-agent-api/disablebrowsermonitoring-net-agent-api
+          - title: GetAgent
+            path: /docs/agents/net-agent/net-agent-api/getagent
+          - title: GetBrowserTimingHeader
+            path: /docs/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent-api
+          - title: GetLinkingMetadata
+            path: /docs/agents/net-agent/net-agent-api/getlinkingmetadata-net-agent-api
+          - title: IAgent
+            path: /docs/agents/net-agent/net-agent-api/iagent
+          - title: IDistributedTracePayload
+            path: /docs/agents/net-agent/net-agent-api/idistributedtracepayload-net-agent-api
+          - title: ITransaction
+            path: /docs/agents/net-agent/net-agent-api/itransaction
+          - title: ISpan
+            path: /docs/agents/net-agent/net-agent-api/ispan
+          - title: IgnoreApdex
+            path: /docs/agents/net-agent/net-agent-api/ignore-apdex
+          - title: IgnoreTransaction
+            path: /docs/agents/net-agent/net-agent-api/ignore-transaction
+          - title: NoticeError
+            path: /docs/agents/net-agent/net-agent-api/noticeerror-net-agent-api
+          - title: IncrementCounter
+            path: /docs/agents/net-agent/net-agent-api/incrementcounter-net-agent-api
+          - title: RecordCustomEvent
+            path: /docs/agents/net-agent/net-agent-api/recordcustomevent-net-agent-api
+          - title: RecordMetric
+            path: /docs/agents/net-agent/net-agent-api/recordmetric-net-agent-api
+          - title: RecordResponseTimeMetric
+            path: /docs/agents/net-agent/net-agent-api/recordresponsetimemetric-net-agent-api
+          - title: SetApplicationName
+            path: /docs/agents/net-agent/net-agent-api/set-application-name
+          - title: SetTransactionName
+            path: /docs/agents/net-agent/net-agent-api/settransactionname-net-agent-api
+          - title: SetTransactionUri
+            path: /docs/agents/net-agent/net-agent-api/set-transaction-uri
+          - title: SetUserParameters
+            path: /docs/agents/net-agent/net-agent-api/set-user-parameters
+          - title: StartAgent
+            path: /docs/agents/net-agent/net-agent-api/start-agent
+          - title: TraceMetadata
+            path: /docs/agents/net-agent/net-agent-api/tracemetadata-net-agent-api-0
+      - title: API guides
+        pages:
+          - title: .NET agent API guide
+            path: /docs/agents/net-agent/api-guides/guide-using-net-agent-api
+      - title: Installation
+        pages:
+          - title: Install introduction
+            path: /docs/agents/net-agent/installation/introduction-net-agent-install
+          - title: Update the agent
+            path: /docs/agents/net-agent/installation/update-net-agent
+          - title: Uninstall the agent
+            path: /docs/agents/net-agent/installation/uninstall-net-agent
+      - title: Other installation
+        pages:
+          - title: Install with NuGet
+            path: /docs/agents/net-agent/install-guides/install-net-agent-using-nuget
+          - title: Install for Docker
+            path: /docs/agents/net-agent/installation/install-docker-container
+          - title: Install resources (advanced)
+            path: /docs/net-agent-install-resources
+      - title: Configuration
+        pages:
+          - title: .NET agent configuration
+            path: /docs/agents/net-agent/configuration/net-agent-configuration
+          - title: Name your .NET application
+            path: /docs/agents/net-agent/configuration/name-your-net-application
+      - title: Azure installation
+        pages:
+          - title: Azure Cloud Services
+            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-cloud-services
+          - title: Azure Service Fabric
+            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-service-fabric
+          - title: Azure Web Apps
+            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-web-apps
+          - title: Azure Marketplace app
+            path: /docs/agents/net-agent/azure-installation/install-azure-marketplace-app-new-relic
+          - title: Azure troubleshooting
+            path: /docs/agents/net-agent/azure-installation/azure-troubleshooting
+      - title: Other features
+        pages:
+          - title: Async support in .NET
+            path: /docs/agents/net-agent/other-features/async-support-net
+          - title: Add Browser monitoring
+            path: /docs/agents/net-agent/other-features/browser-monitoring-net-agent
       - title: Troubleshooting
         pages:
-          - title: Passenger troubleshooting
-            path: /docs/agents/ruby-agent/troubleshooting/passenger-troubleshooting
-          - title: Generating logs
-            path: /docs/agents/ruby-agent/troubleshooting/generating-logs-troubleshooting-ruby
+          - title: Agent changes Content-Type header for WCF apps (.NET)
+            path: /docs/agents/net-agent/troubleshooting/agent-changes-content-type-header-wcf-apps-net
+          - title: Azure Pipelines wipes out NewRelic.Azure.WebSites.Extension directories
+            path: /docs/agents/net-agent/troubleshooting/azure-pipelines-wipes-out-newrelicazurewebsitesextension-directories
           - title: No data appears
-            path: /docs/agents/ruby-agent/troubleshooting/no-data-appears-ruby
-          - title: Incompatible gems
-            path: /docs/agents/ruby-agent/troubleshooting/incompatible-gems
-          - title: No log file
-            path: /docs/agents/ruby-agent/troubleshooting/no-log-file-ruby
-          - title: Control when the agent starts
-            path: /docs/agents/ruby-agent/troubleshooting/control-when-ruby-agent-starts
-          - title: 'SystemStackError: stack level too deep'
-            path: /docs/agents/ruby-agent/troubleshooting/systemstackerror-stack-level-too-deep
-          - title: Ruby agent audit log
-            path: /docs/agents/ruby-agent/troubleshooting/ruby-agent-audit-log
-          - title: No data with Unicorn
-            path: /docs/agents/ruby-agent/troubleshooting/no-data-unicorn
-          - title: Update deprecated API calls
-            path: /docs/agents/ruby-agent/troubleshooting/update-deprecated-api-calls
-          - title: Update private API calls to public Tracer API
-            path: /docs/agents/ruby-agent/troubleshooting/update-private-api-calls-public-tracer-api
-          - title: Not installing Grape
-            path: /docs/agents/ruby-agent/troubleshooting/not-installing-new-relic-supported-grape
+            path: /docs/agents/net-agent/troubleshooting/no-data-appears-net
+          - title: Support for Framework 4.0 or lower
+            path: /docs/agents/net-agent/troubleshooting/technical-support-net-framework-40-or-lower
+          - title: Generate logs for troubleshooting
+            path: /docs/agents/net-agent/troubleshooting/generate-logs-troubleshooting-net
+          - title: No Browser data appears
+            path: /docs/agents/net-agent/troubleshooting/no-browser-data-appears-net
+          - title: Handled errors reported
+            path: /docs/agents/net-agent/troubleshooting/net-agent-reports-handled-errors
+          - title: No data and registry key permission issues
+            path: /docs/agents/net-agent/troubleshooting/no-data-registry-key-permission-issues
+          - title: High memory usage
+            path: /docs/agents/net-agent/troubleshooting/high-memory-usage-net
+          - title: Profiler conflicts
+            path: /docs/agents/net-agent/troubleshooting/profiler-conflicts
+          - title: 'CoCreate errors: No event log'
+            path: /docs/agents/net-agent/troubleshooting/cocreate-errors-no-event-log
+          - title: 'Browser injection: Health check conflict'
+            path: /docs/agents/net-agent/troubleshooting/browser-injection-health-check-conflict
+          - title: 'CoCreateInstance errors: No profiler log'
+            path: /docs/agents/net-agent/troubleshooting/cocreateinstance-errors-no-profiler-log
+          - title: Missing async metrics
+            path: /docs/agents/net-agent/troubleshooting/missing-net-async-metrics
+          - title: Missing Couchbase metrics
+            path: /docs/agents/net-agent/troubleshooting/missing-couchbase-metrics-net
+          - title: Status monitor
+            path: /docs/agents/net-agent/troubleshooting/new-relic-net-status-monitor
+          - title: Resolve .NET and SCOM conflicts
+            path: /docs/agents/net-agent/troubleshooting/resolve-net-scom-conflicts
+          - title: No data after disabling TLS 1.0
+            path: /docs/agents/net-agent/troubleshooting/no-data-appears-after-disabling-tls-10
+          - title: Monitor short-lived processes
+            path: /docs/agents/net-agent/troubleshooting/monitor-short-lived-net-processes
+      - title: Latest release
+        path: /docs/release-notes/agent-release-notes/net-release-notes/current
   - title: Python agent
     path: /docs/agents/python-agent
     pages:
       - title: Getting started
         pages:
+          - title: New Relic for Python
+            path: /docs/agents/python-agent/getting-started/introduction-new-relic-python
+          - title: Instrumented Python packages
+            path: /docs/agents/python-agent/getting-started/instrumented-python-packages
           - title: Python agent security
             path: /docs/agents/python-agent/getting-started/apm-agent-security-python
           - title: Python release notes
             path: /docs/agents/python-agent/getting-started/python-release-notes
-          - title: New Relic for Python
-            path: /docs/agents/python-agent/getting-started/introduction-new-relic-python
           - title: Compatibility and requirements
             path: /docs/agents/python-agent/getting-started/compatibility-requirements-python-agent
-          - title: Instrumented Python packages
-            path: /docs/agents/python-agent/getting-started/instrumented-python-packages
       - title: Supported features
         pages:
           - title: Custom metrics
@@ -585,10 +654,10 @@ pages:
             path: /docs/agents/python-agent/custom-instrumentation/python-custom-instrumentation-config-file
       - title: Troubleshooting
         pages:
-          - title: Troubleshooting Browser
-            path: /docs/agents/python-agent/troubleshooting/troubleshooting-browser-instrumentation-python
           - title: No data appears
             path: /docs/agents/python-agent/troubleshooting/no-data-appears-python
+          - title: Troubleshooting Browser
+            path: /docs/agents/python-agent/troubleshooting/troubleshooting-browser-instrumentation-python
           - title: Emulating legacy parameters
             path: /docs/agents/python-agent/troubleshooting/emulating-legacy-server-side-parameter-configuration-python
           - title: Testing the Python agent
@@ -599,457 +668,404 @@ pages:
             path: /docs/agents/python-agent/troubleshooting/missing-information-when-using-ensurefuture-python
           - title: Activate application warning
             path: /docs/agents/python-agent/troubleshooting/activate-application-warning-python
-  - title: PHP agent
-    path: /docs/agents/php-agent
+      - title: Latest release
+        path: /docs/release-notes/agent-release-notes/python-release-notes/current
+  - title: Java agent
+    path: /docs/agents/java-agent
     pages:
       - title: Getting started
         pages:
-          - title: PHP agent security
-            path: /docs/agents/php-agent/getting-started/apm-agent-security-php
-          - title: PHP agent release notes
-            path: /docs/agents/php-agent/getting-started/php-agent-release-notes
-          - title: New Relic for PHP
-            path: /docs/agents/php-agent/getting-started/introduction-new-relic-php
+          - title: New Relic for Java
+            path: /docs/agents/java-agent/getting-started/introduction-new-relic-java
+          - title: Java agent security
+            path: /docs/agents/java-agent/getting-started/apm-agent-security-java
+          - title: Java release notes
+            path: /docs/agents/java-agent/getting-started/java-release-notes
           - title: Compatibility and requirements
-            path: /docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-          - title: New Relic daemon processes
-            path: /docs/agents/php-agent/getting-started/new-relic-daemon-processes
-      - title: Advanced installation
+            path: /docs/agents/java-agent/getting-started/compatibility-requirements-java-agent
+      - title: Instrumentation
         pages:
-          - title: The newrelic-install script
-            path: /docs/agents/php-agent/advanced-installation/using-newrelic-install-script
-          - title: Docker and other containers
-            path: /docs/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent
-          - title: Starting the PHP daemon
-            path: /docs/agents/php-agent/advanced-installation/starting-php-daemon-advanced
-          - title: Silent mode newrelic-install script
-            path: /docs/agents/php-agent/advanced-installation/silent-mode-install-script-advanced
-          - title: Non-standard PHP
-            path: /docs/agents/php-agent/advanced-installation/php-agent-installation-non-standard-php-advanced
-          - title: PHP agent and Heroku
-            path: /docs/agents/php-agent/advanced-installation/php-agent-heroku
-          - title: Uninstall the agent
-            path: /docs/agents/php-agent/advanced-installation/uninstalling-php-agent
-      - title: Configuration
-        pages:
-          - title: PHP agent configuration
-            path: /docs/agents/php-agent/configuration/php-agent-configuration
-          - title: Per-Directory INI settings
-            path: /docs/agents/php-agent/configuration/php-directory-ini-settings
-          - title: Name your PHP app
-            path: /docs/agents/php-agent/configuration/name-your-php-application
-          - title: Proxy daemon settings
-            path: /docs/agents/php-agent/configuration/proxy-daemon-newreliccfg-settings
-      - title: Attributes
-        pages:
-          - title: PHP agent attributes
-            path: /docs/agents/php-agent/attributes/php-agent-attributes
-          - title: Enable or disable attributes
-            path: /docs/agents/php-agent/attributes/enable-or-disable-attributes
-          - title: Attribute examples
-            path: /docs/agents/php-agent/attributes/attribute-examples
-      - title: Features
-        pages:
-          - title: Multiple accounts
-            path: /docs/agents/php-agent/features/multiple-accounts
-          - title: Distributed tracing
-            path: /docs/agents/php-agent/features/distributed-tracing-php-agent
-          - title: Browser monitoring
-            path: /docs/agents/php-agent/features/browser-monitoring-php-agent
-          - title: PHP custom instrumentation
-            path: /docs/agents/php-agent/features/php-custom-instrumentation
-          - title: Recording deployments
-            path: /docs/agents/php-agent/features/recording-deployments-using-php-script
-      - title: Frameworks and libraries
-        pages:
-          - title: Integrate support for New Relic
-            path: /docs/agents/php-agent/frameworks-libraries/php-frameworks-integrate-support-new-relic
-          - title: Analyze PHPUnit test data in New Relic
-            path: /docs/agents/php-agent/frameworks-libraries/analyze-phpunit-test-data-new-relic
-          - title: AWS Elastic Beanstalk installation
-            path: /docs/agents/php-agent/frameworks-libraries/aws-elastic-beanstalk-installation-php
-          - title: Drupal-specific functionality
-            path: /docs/agents/php-agent/frameworks-libraries/drupal-specific-functionality
-          - title: Guzzle
-            path: /docs/agents/php-agent/frameworks-libraries/guzzle
-          - title: Magento-specific functionality
-            path: /docs/agents/php-agent/frameworks-libraries/magento-specific-functionality
-          - title: Predis library
-            path: /docs/agents/php-agent/frameworks-libraries/predis-library-php
-          - title: WordPress specific functionality
-            path: /docs/agents/php-agent/frameworks-libraries/wordpress-specific-functionality
-      - title: Installation
-        pages:
-          - title: Installation overview
-            path: /docs/agents/php-agent/installation/php-agent-installation-overview
-          - title: 'AWS Linux, RedHat and CentOS'
-            path: /docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos
-          - title: Ubuntu and Debian
-            path: /docs/agents/php-agent/installation/php-agent-installation-ubuntu-debian
-          - title: Tar archive
-            path: /docs/agents/php-agent/installation/php-agent-installation-tar-file
-          - title: Install agent on shared hosting service
-            path: /docs/agents/php-agent/installation/install-php-agent-shared-hosting-service
-          - title: Update the PHP agent
-            path: /docs/agents/php-agent/installation/update-php-agent
-      - title: PHP agent API
-        path: /docs/agents/php-agent/php-agent-api
-        pages:
-          - title: View all methods
-            path: /docs/agents/php-agent/php-agent-api/view-all-methods
-          - title: newrelic_accept_distributed_trace_headers
-            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtraceheaders
-          - title: newrelic_accept_distributed_trace_payload
-            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtracepayload-php-agent-api
-          - title: newrelic_accept_distributed_trace_payload_httpsafe
-            path: /docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtracepayloadhttpsafe-php-agent-api
-          - title: newrelic_add_custom_parameter
-            path: /docs/agents/php-agent/php-agent-api/newrelic_add_custom_parameter
-          - title: newrelic_add_custom_span_parameter
-            path: /docs/agents/php-agent/php-agent-api/newrelicaddcustomspanparameter-php-agent-api
-          - title: newrelic_add_custom_tracer
-            path: /docs/agents/php-agent/php-agent-api/newrelic_add_custom_tracer
-          - title: newrelic_background_job
-            path: /docs/agents/php-agent/php-agent-api/newrelic_background_job
-          - title: newrelic_capture_params
-            path: /docs/agents/php-agent/php-agent-api/newrelic_capture_params
-          - title: newrelic_create_distributed_trace_payload
-            path: /docs/agents/php-agent/php-agent-api/newreliccreatedistributedtracepayload-php-agent-api
-          - title: newrelic_custom_metric
-            path: /docs/agents/php-agent/php-agent-api/newreliccustommetric-php-agent-api
-          - title: newrelic_disable_autorum
-            path: /docs/agents/php-agent/php-agent-api/newrelic_disable_autorum
-          - title: newrelic_end_of_transaction
-            path: /docs/agents/php-agent/php-agent-api/newrelic_end_of_transaction
-          - title: newrelic_end_transaction
-            path: /docs/agents/php-agent/php-agent-api/newrelic_end_transaction
-          - title: newrelic_get_browser_timing_footer
-            path: /docs/agents/php-agent/php-agent-api/newrelic_get_browser_timing_footer
-          - title: newrelic_get_browser_timing_header
-            path: /docs/agents/php-agent/php-agent-api/newrelic_get_browser_timing_header
-          - title: newrelic_get_linking_metadata
-            path: /docs/agents/php-agent/php-agent-api/newrelicgetlinkingmetadata
-          - title: newrelic_get_trace_metadata
-            path: /docs/agents/php-agent/php-agent-api/newrelicgettracemetadata
-          - title: newrelic_ignore_apdex
-            path: /docs/agents/php-agent/php-agent-api/newrelic_ignore_apdex
-          - title: newrelic_ignore_transaction
-            path: /docs/agents/php-agent/php-agent-api/newrelic_ignore_transaction
-          - title: newrelic_insert_distributed_trace_headers
-            path: /docs/agents/php-agent/php-agent-api/newrelicinsertdistributedtraceheaders
-          - title: newrelic_is_sampled
-            path: /docs/agents/php-agent/php-agent-api/newrelicissampled
-          - title: newrelic_name_transaction
-            path: /docs/agents/php-agent/php-agent-api/newrelic_name_transaction
-          - title: newrelic_notice_error
-            path: /docs/agents/php-agent/php-agent-api/newrelic_notice_error
-          - title: newrelic_record_custom_event
-            path: /docs/agents/php-agent/php-agent-api/newrelic_record_custom_event
-          - title: newrelic_record_datastore_segment
-            path: /docs/agents/php-agent/php-agent-api/newrelic_record_datastore_segment
-          - title: newrelic_set_appname
-            path: /docs/agents/php-agent/php-agent-api/newrelic_set_appname
-          - title: newrelic_set_user_attributes
-            path: /docs/agents/php-agent/php-agent-api/newrelic_set_user_attributes
-          - title: newrelic_start_transaction
-            path: /docs/agents/php-agent/php-agent-api/newrelic_start_transaction
-      - title: API guides
-        pages:
-          - title: API guide
-            path: /docs/agents/php-agent/api-guides/guide-using-php-agent-api
-      - title: Troubleshooting
-        pages:
-          - title: Agent not reporting errors
-            path: /docs/agents/php-agent/troubleshooting/php-agent-not-reporting-errors
-          - title: No data appears
-            path: /docs/agents/php-agent/troubleshooting/no-data-appears-php
-          - title: Determine permissions requirements
-            path: /docs/agents/php-agent/troubleshooting/determine-permissions-requirements-php
-          - title: Generating logs for troubleshooting
-            path: /docs/agents/php-agent/troubleshooting/generating-logs-troubleshooting-php
-          - title: Data stops reporting while using SELinux
-            path: /docs/agents/php-agent/troubleshooting/data-stops-reporting-while-using-selinux
-          - title: Agents stops after updating PHP
-            path: /docs/agents/php-agent/troubleshooting/agent-stops-working-after-updating-php
-          - title: Checking loaded configuration files directory
-            path: /docs/agents/php-agent/troubleshooting/checking-loaded-configuration-files-directory
-          - title: Missing PHP module
-            path: /docs/agents/php-agent/troubleshooting/missing-php-module
-          - title: Protocol mismatch error
-            path: /docs/agents/php-agent/troubleshooting/protocol-mismatch-error
-          - title: INI settings not taking effect immediately
-            path: /docs/agents/php-agent/troubleshooting/ini-settings-not-taking-effect-immediately
-          - title: Submitting troubleshooting results
-            path: /docs/agents/php-agent/troubleshooting/submitting-troubleshooting-results-php
-          - title: Threaded Apache worker MPMs
-            path: /docs/agents/php-agent/troubleshooting/threaded-apache-worker-mpms
-          - title: Transactions /index.php or /unknown
-            path: /docs/agents/php-agent/troubleshooting/transactions-named-indexphp-or-unknown
-          - title: What the PHP instance count means
-            path: /docs/agents/php-agent/troubleshooting/troubleshoot-php-agent-instance-count
-          - title: Uninstrumented time in traces
-            path: /docs/agents/php-agent/troubleshooting/uninstrumented-time-traces
-          - title: Using phpinfo to verify PHP
-            path: /docs/agents/php-agent/troubleshooting/using-phpinfo-verify-php
-          - title: Verifying the PHP daemon
-            path: /docs/agents/php-agent/troubleshooting/verifying-php-daemon
-          - title: When to restart your web server
-            path: /docs/agents/php-agent/troubleshooting/why-when-restart-your-web-server-php
-          - title: PHP installation fails on El Capitan
-            path: /docs/agents/php-agent/troubleshooting/php-installation-fails-os-x-1011-el-capitan
-          - title: Data stops reporting
-            path: /docs/agents/php-agent/troubleshooting/data-stops-reporting
-          - title: First transaction not reported
-            path: /docs/agents/php-agent/troubleshooting/first-php-transaction-not-reported
-  - title: .NET agent
-    path: /docs/agents/net-agent
-    pages:
-      - title: Getting started
-        pages:
-          - title: 'APM agent security: .NET'
-            path: /docs/agents/net-agent/getting-started/apm-agent-security-net
-          - title: .NET release notes
-            path: /docs/agents/net-agent/getting-started/net-release-notes
-          - title: New Relic for .NET
-            path: /docs/agents/net-agent/getting-started/introduction-new-relic-net
-          - title: Compatibility and requirements (Framework)
-            path: /docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework
-          - title: Compatibility and requirements (Core)
-            path: /docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core
+          - title: Transaction naming protocol
+            path: /docs/agents/java-agent/instrumentation/transaction-naming-protocol
+          - title: Monitor deployments
+            path: /docs/agents/java-agent/instrumentation/monitor-deployments-java-agent
+          - title: Instrument webpages via API
+            path: /docs/agents/java-agent/instrumentation/instrument-browser-monitoring-java-agent-api
+          - title: Use RabbitMQ or JMS for message queues
+            path: /docs/agents/java-agent/instrumentation/use-rabbitmq-or-jms-message-queues
+          - title: Instrumentation modules
+            path: /docs/agents/java-agent/instrumentation/extension-additional-instrumentation-modules
+          - title: Ignore transactions
+            path: /docs/agents/java-agent/instrumentation/ignore-transactions-using-api
       - title: Custom instrumentation
         pages:
-          - title: Introduction to .NET custom instrumentation
-            path: /docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation
-          - title: Attribute custom instrumentation
-            path: /docs/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net
-          - title: XML to create transactions
-            path: /docs/agents/net-agent/custom-instrumentation/create-transactions-xml-net
-          - title: XML to add detail
-            path: /docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net
-      - title: Attributes
-        pages:
-          - title: .NET agent attributes
-            path: /docs/agents/net-agent/attributes/net-agent-attributes
-          - title: .NET attribute examples
-            path: /docs/agents/net-agent/attributes/net-attribute-examples
-          - title: Enable and disable attributes
-            path: /docs/agents/net-agent/attributes/enable-disable-attributes-net
-      - title: Azure troubleshooting
-        pages:
-          - title: 'Azure Cloud Services: No data appears'
-            path: /docs/agents/net-agent/azure-troubleshooting/azure-cloud-services-no-data-appears
-          - title: 'Azure Web Apps: No data appears'
-            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-using-always-no-data-appears
-          - title: 'Azure Web Apps: Unable to open log file'
-            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-unable-open-log-file
-          - title: Profiler .dll locks during deployment
-            path: /docs/agents/net-agent/azure-troubleshooting/azure-web-apps-profiler-dll-locks-during-deployment
-          - title: No data with Microsoft App Insights
-            path: /docs/agents/net-agent/azure-troubleshooting/no-data-reporting-microsoft-application-insights
-      - title: NET agent API
-        path: /docs/agents/net-agent/net-agent-api
-        pages:
-          - title: View all methods
-            path: /docs/agents/net-agent/net-agent-api/view-all-methods
-          - title: AddCustomParameter
-            path: /docs/agents/net-agent/net-agent-api/addcustomparameter-net-agent-api
-          - title: DisableBrowserMonitoring
-            path: /docs/agents/net-agent/net-agent-api/disablebrowsermonitoring-net-agent-api
-          - title: GetAgent
-            path: /docs/agents/net-agent/net-agent-api/getagent
-          - title: GetBrowserTimingHeader
-            path: /docs/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent-api
-          - title: GetLinkingMetadata
-            path: /docs/agents/net-agent/net-agent-api/getlinkingmetadata-net-agent-api
-          - title: IAgent
-            path: /docs/agents/net-agent/net-agent-api/iagent
-          - title: IDistributedTracePayload
-            path: /docs/agents/net-agent/net-agent-api/idistributedtracepayload-net-agent-api
-          - title: ITransaction
-            path: /docs/agents/net-agent/net-agent-api/itransaction
-          - title: ISpan
-            path: /docs/agents/net-agent/net-agent-api/ispan
-          - title: IgnoreApdex
-            path: /docs/agents/net-agent/net-agent-api/ignore-apdex
-          - title: IgnoreTransaction
-            path: /docs/agents/net-agent/net-agent-api/ignore-transaction
-          - title: NoticeError
-            path: /docs/agents/net-agent/net-agent-api/noticeerror-net-agent-api
-          - title: IncrementCounter
-            path: /docs/agents/net-agent/net-agent-api/incrementcounter-net-agent-api
-          - title: RecordCustomEvent
-            path: /docs/agents/net-agent/net-agent-api/recordcustomevent-net-agent-api
-          - title: RecordMetric
-            path: /docs/agents/net-agent/net-agent-api/recordmetric-net-agent-api
-          - title: RecordResponseTimeMetric
-            path: /docs/agents/net-agent/net-agent-api/recordresponsetimemetric-net-agent-api
-          - title: SetApplicationName
-            path: /docs/agents/net-agent/net-agent-api/set-application-name
-          - title: SetTransactionName
-            path: /docs/agents/net-agent/net-agent-api/settransactionname-net-agent-api
-          - title: SetTransactionUri
-            path: /docs/agents/net-agent/net-agent-api/set-transaction-uri
-          - title: SetUserParameters
-            path: /docs/agents/net-agent/net-agent-api/set-user-parameters
-          - title: StartAgent
-            path: /docs/agents/net-agent/net-agent-api/start-agent
-          - title: TraceMetadata
-            path: /docs/agents/net-agent/net-agent-api/tracemetadata-net-agent-api-0
-      - title: API guides
-        pages:
-          - title: .NET agent API guide
-            path: /docs/agents/net-agent/api-guides/guide-using-net-agent-api
+          - title: Java custom instrumentation
+            path: /docs/agents/java-agent/custom-instrumentation/java-custom-instrumentation
+          - title: Custom instrumentation editor
+            path: /docs/agents/java-agent/custom-instrumentation/custom-instrumentation-editor-instrument-ui
+          - title: Scala instrumentation
+            path: /docs/agents/java-agent/frameworks/scala-installation-java
+          - title: Java instrumentation by XML
+            path: /docs/agents/java-agent/custom-instrumentation/java-instrumentation-xml
+          - title: XML instrumentation example
+            path: /docs/agents/java-agent/custom-instrumentation/java-xml-instrumentation-examples
+          - title: Custom JMX instrumentation
+            path: /docs/agents/java-agent/custom-instrumentation/java-agent-custom-jmx-instrumentation-yaml
+          - title: Custom JMX YAML examples
+            path: /docs/agents/java-agent/custom-instrumentation/custom-jmx-yaml-examples
+          - title: Troubleshooting Java custom instrumentation
+            path: /docs/agents/java-agent/custom-instrumentation/troubleshooting-java-custom-instrumentation
+          - title: Circuit breaker
+            path: /docs/agents/java-agent/custom-instrumentation/circuit-breaker-java-custom-instrumentation
       - title: Installation
         pages:
-          - title: Install introduction
-            path: /docs/agents/net-agent/installation/introduction-net-agent-install
-          - title: Update the agent
-            path: /docs/agents/net-agent/installation/update-net-agent
-          - title: Uninstall the agent
-            path: /docs/agents/net-agent/installation/uninstall-net-agent
-      - title: Other installation
-        pages:
-          - title: Install with NuGet
-            path: /docs/agents/net-agent/install-guides/install-net-agent-using-nuget
-          - title: Install for Docker
-            path: /docs/agents/net-agent/installation/install-docker-container
-          - title: Install resources (advanced)
-            path: /docs/net-agent-install-resources
+          - title: Install the Java agent
+            path: /docs/agents/java-agent/installation/install-java-agent
+          - title: Include agent with JVM
+            path: /docs/agents/java-agent/installation/include-java-agent-jvm-argument
+          - title: Update the Java agent
+            path: /docs/agents/java-agent/installation/update-java-agent
+          - title: Uninstall the Java agent
+            path: /docs/agents/java-agent/installation/uninstall-java-agent
       - title: Configuration
         pages:
-          - title: .NET agent configuration
-            path: /docs/agents/net-agent/configuration/net-agent-configuration
-          - title: Name your .NET application
-            path: /docs/agents/net-agent/configuration/name-your-net-application
-      - title: Azure installation
+          - title: Java agent configuration
+            path: /docs/agents/java-agent/configuration/java-agent-configuration-config-file
+          - title: Java agent config file template
+            path: /docs/agents/java-agent/configuration/java-agent-config-file-template
+          - title: Hostname logic
+            path: /docs/agents/java-agent/configuration/hostname-logic-java
+          - title: Distributed tracing
+            path: /docs/agents/java-agent/configuration/enable-distributed-tracing-java-agent
+          - title: Automatic application naming
+            path: /docs/agents/java-agent/configuration/automatic-application-naming
+          - title: Error configuration
+            path: /docs/agents/java-agent/configuration/java-agent-error-configuration
+          - title: Configuring your SSL certificates
+            path: /docs/agents/java-agent/configuration/configuring-your-ssl-certificates
+      - title: Features
         pages:
-          - title: Azure Cloud Services
-            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-cloud-services
-          - title: Azure Service Fabric
-            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-service-fabric
-          - title: Azure Web Apps
-            path: /docs/agents/net-agent/azure-installation/install-net-agent-azure-web-apps
-          - title: Azure Marketplace app
-            path: /docs/agents/net-agent/azure-installation/install-azure-marketplace-app-new-relic
-          - title: Azure troubleshooting
-            path: /docs/agents/net-agent/azure-installation/azure-troubleshooting
-      - title: Other features
+          - title: JVM metrics page (Java)
+            path: /docs/agents/java-agent/features/jvms-page-java-view-app-server-metrics-jmx
+      - title: Heroku
         pages:
-          - title: Async support in .NET
-            path: /docs/agents/net-agent/other-features/async-support-net
-          - title: Add Browser monitoring
-            path: /docs/agents/net-agent/other-features/browser-monitoring-net-agent
+          - title: Java agent and Heroku
+            path: /docs/agents/java-agent/heroku/java-agent-heroku
+          - title: Scala and Heroku
+            path: /docs/agents/java-agent/heroku/java-agent-scala-heroku
+          - title: No data appears (Heroku)
+            path: /docs/agents/java-agent/heroku/no-data-appears-heroku-java
+      - title: Async instrumentation
+        pages:
+          - title: Async instrumentation
+            path: /docs/agents/java-agent/async-instrumentation/introduction-java-async-instrumentation
+          - title: Java async API
+            path: /docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications
+          - title: Troubleshoot async
+            path: /docs/agents/java-agent/async-instrumentation/troubleshoot-java-asynchronous-instrumentation
+          - title: Disable async frameworks
+            path: /docs/agents/java-agent/async-instrumentation/disable-scala-netty-akka-play-2-instrumentation
+      - title: Additional installation
+        pages:
+          - title: Docker
+            path: /docs/agents/java-agent/additional-installation/install-new-relic-java-agent-docker
+          - title: AWS Elastic Beanstalk
+            path: /docs/agents/java-agent/additional-installation/aws-elastic-beanstalk-installation-java
+          - title: WildFly installation
+            path: /docs/agents/java-agent/additional-installation/wildfly-installation-java
+          - title: GAE flex
+            path: /docs/agents/java-agent/additional-installation/install-new-relic-java-agent-gae-flexible-environment
+          - title: WebSphere App Server
+            path: /docs/agents/java-agent/additional-installation/ibm-websphere-application-server
+          - title: Java 2 security installation
+            path: /docs/agents/java-agent/installation/install-java-agent-java-2-security
+          - title: Maven install
+            path: /docs/agents/java-agent/additional-installation/install-java-agent-using-maven
+      - title: Attributes
+        pages:
+          - title: Java agent attributes
+            path: /docs/agents/java-agent/attributes/java-agent-attributes
+      - title: API guides
+        pages:
+          - title: Java agent API guide
+            path: /docs/agents/java-agent/api-guides/guide-using-java-agent-api
+          - title: Java agent API annotation
+            path: /docs/agents/java-agent/api-guides/java-agent-api-instrument-using-annotation
+          - title: 'API: Externals, messaging, frameworks'
+            path: /docs/agents/java-agent/api-guides/java-agent-api-instrument-external-calls-messaging-datastore-web-frameworks
+          - title: 'API: Annotating example app'
+            path: /docs/agents/java-agent/api-guides/java-agent-api-custom-instrumentation-annotation-example-app
+          - title: 'API example: Datastore and CAT'
+            path: /docs/agents/java-agent/api-guides/java-agent-api-instrumenting-example-app-external-datastore-calls-cat
       - title: Troubleshooting
         pages:
-          - title: Agent changes Content-Type header for WCF apps (.NET)
-            path: /docs/agents/net-agent/troubleshooting/agent-changes-content-type-header-wcf-apps-net
-          - title: Azure Pipelines wipes out NewRelic.Azure.WebSites.Extension directories
-            path: /docs/agents/net-agent/troubleshooting/azure-pipelines-wipes-out-newrelicazurewebsitesextension-directories
           - title: No data appears
-            path: /docs/agents/net-agent/troubleshooting/no-data-appears-net
-          - title: Support for Framework 4.0 or lower
-            path: /docs/agents/net-agent/troubleshooting/technical-support-net-framework-40-or-lower
+            path: /docs/agents/java-agent/troubleshooting/no-data-appears-java
+          - title: Determine permissions requirements
+            path: /docs/agents/java-agent/troubleshooting/determine-permissions-requirements-java
+          - title: Gather troubleshooting information
+            path: /docs/agents/java-agent/troubleshooting/gather-troubleshooting-information-java
+          - title: Error bootstrapping Java agent
+            path: /docs/agents/java-agent/troubleshooting/error-bootstrapping-new-relic-java-agent
+          - title: Errors starting Java app server
+            path: /docs/agents/java-agent/troubleshooting/errors-starting-java-app-server
+          - title: Firewall or traffic connectivity failures
+            path: /docs/agents/java-agent/troubleshooting/firewall-or-traffic-connectivity-failures
+          - title: All hosts appear as localhost
+            path: /docs/agents/java-agent/troubleshooting/all-hosts-appear-localhost
           - title: Generate logs for troubleshooting
-            path: /docs/agents/net-agent/troubleshooting/generate-logs-troubleshooting-net
+            path: /docs/agents/java-agent/troubleshooting/generate-debug-logs-troubleshooting-java
+          - title: Host links missing
+            path: /docs/agents/java-agent/troubleshooting/host-links-missing-java-apps-apm-summary
+          - title: Solr data does not appear
+            path: /docs/agents/java-agent/troubleshooting/java-solr-data-does-not-appear
           - title: No Browser data appears
-            path: /docs/agents/net-agent/troubleshooting/no-browser-data-appears-net
-          - title: Profiler conflicts
-            path: /docs/agents/net-agent/troubleshooting/profiler-conflicts
-          - title: Handled errors reported
-            path: /docs/agents/net-agent/troubleshooting/net-agent-reports-handled-errors
-          - title: No data and registry key permission issues
-            path: /docs/agents/net-agent/troubleshooting/no-data-registry-key-permission-issues
-          - title: High memory usage
-            path: /docs/agents/net-agent/troubleshooting/high-memory-usage-net
-          - title: 'CoCreate errors: No event log'
-            path: /docs/agents/net-agent/troubleshooting/cocreate-errors-no-event-log
-          - title: 'Browser injection: Health check conflict'
-            path: /docs/agents/net-agent/troubleshooting/browser-injection-health-check-conflict
-          - title: 'CoCreateInstance errors: No profiler log'
-            path: /docs/agents/net-agent/troubleshooting/cocreateinstance-errors-no-profiler-log
-          - title: Missing async metrics
-            path: /docs/agents/net-agent/troubleshooting/missing-net-async-metrics
-          - title: Missing Couchbase metrics
-            path: /docs/agents/net-agent/troubleshooting/missing-couchbase-metrics-net
-          - title: Status monitor
-            path: /docs/agents/net-agent/troubleshooting/new-relic-net-status-monitor
-          - title: Resolve .NET and SCOM conflicts
-            path: /docs/agents/net-agent/troubleshooting/resolve-net-scom-conflicts
-          - title: No data after disabling TLS 1.0
-            path: /docs/agents/net-agent/troubleshooting/no-data-appears-after-disabling-tls-10
-          - title: Monitor short-lived processes
-            path: /docs/agents/net-agent/troubleshooting/monitor-short-lived-net-processes
-  - title: Node.js agent
-    path: /docs/agents/nodejs-agent
+            path: /docs/agents/java-agent/troubleshooting/no-browser-data-appears-java
+          - title: No log file
+            path: /docs/agents/java-agent/troubleshooting/no-log-file-java
+          - title: No stack traces
+            path: /docs/agents/java-agent/troubleshooting/no-stack-traces-java
+          - title: NullPointerException issues
+            path: /docs/agents/java-agent/troubleshooting/nullpointerexception-issues-java
+          - title: Resolve metric grouping issues
+            path: /docs/agents/java-agent/troubleshooting/resolve-metric-grouping-issues-java-apps
+          - title: SSL or connection errors
+            path: /docs/agents/java-agent/troubleshooting/ssl-or-connection-errors-java
+          - title: Update legacy Java config
+            path: /docs/agents/java-agent/troubleshooting/update-java-config-legacy-agent-versions
+          - title: Application server JMX setup
+            path: /docs/agents/java-agent/troubleshooting/application-server-jmx-setup
+          - title: Large number of false positive security vulnerabilities
+            path: /docs/agents/java-agent/troubleshooting/large-number-false-positive-security-vulnerabilities
+      - title: Latest release
+        path: /docs/release-notes/agent-release-notes/java-release-notes/current
+  - title: Ruby agent
+    path: /docs/agents/ruby-agent
     pages:
       - title: Getting started
         pages:
-          - title: Node.js release notes
-            path: /docs/agents/nodejs-agent/getting-started/nodejs-release-notes
-          - title: New Relic for Node.js
-            path: /docs/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs
-          - title: Compatibility and requirements
-            path: /docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent
-          - title: Node.js agent security
-            path: /docs/agents/nodejs-agent/getting-started/apm-agent-security-nodejs
-      - title: Installation and configuration
+          - title: New Relic for Ruby
+            path: /docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby
+          - title: Requirements and supported frameworks
+            path: /docs/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks
+          - title: Ruby agent security
+            path: /docs/agents/ruby-agent/getting-started/apm-agent-security-ruby
+          - title: New Relic's GitHub repository
+            path: /docs/agents/ruby-agent/getting-started/new-relics-github-repository
+          - title: Ruby release notes
+            path: /docs/agents/ruby-agent/getting-started/ruby-release-notes
+      - title: Installation
         pages:
-          - title: Install the Node.js agent
-            path: /docs/agents/nodejs-agent/installation-configuration/install-nodejs-agent
-          - title: Node.js agent configuration
-            path: /docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration
-          - title: Update the Node.js agent
-            path: /docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent
-          - title: Uninstall the agent
-            path: /docs/agents/nodejs-agent/installation-configuration/uninstall-nodejs-agent
-      - title: Extend your instrumentation
-        pages:
-          - title: Node.js custom instrumentation
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation
-          - title: Node.js custom metrics
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-metrics
-          - title: Node.js VMs statistics page
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-vms-statistics-page
-          - title: Distributed tracing
-            path: /docs/agents/nodejs-agent/supported-features/enable-distributed-tracing-nodejs-agent
-          - title: Message queues
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/message-queues
-          - title: Browser monitoring
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/browser-monitoring-nodejs-agent
-          - title: Node.js VM measurements
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-vm-measurements
-          - title: Node.js v1 custom instrumentation
-            path: /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-v1-custom-instrumentation-legacy
-      - title: Hosting services
-        pages:
+          - title: Ruby agent installation
+            path: /docs/agents/ruby-agent/installation/install-new-relic-ruby-agent
+          - title: Rails plugin installation
+            path: /docs/agents/ruby-agent/installation/ruby-agent-installation-rails-plugin
           - title: GAE flex
-            path: /docs/agents/nodejs-agent/hosting-services/install-new-relic-nodejs-agent-gae-flexible-environment
-          - title: Install on Azure Web Apps
-            path: /docs/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure
-          - title: Node.js agent and Heroku
-            path: /docs/agents/nodejs-agent/hosting-services/nodejs-agent-heroku
+            path: /docs/agents/ruby-agent/installation/install-new-relic-ruby-agent-gae-flexible-environment
+          - title: Ruby agent and Heroku
+            path: /docs/agents/ruby-agent/installation/ruby-agent-heroku
+          - title: Update Ruby agent
+            path: /docs/agents/ruby-agent/installation/update-ruby-agent
+          - title: Uninstall Ruby agent
+            path: /docs/agents/ruby-agent/installation/uninstall-ruby-agent
+      - title: Configuration
+        pages:
+          - title: Ruby configuration
+            path: /docs/agents/ruby-agent/configuration/ruby-agent-configuration
+          - title: Custom SSL certificates
+            path: /docs/agents/ruby-agent/configuration/custom-ssl-certificates-ruby
+          - title: Connect hosts to account
+            path: /docs/agents/ruby-agent/configuration/connect-hosts-your-account
       - title: API guides
         pages:
-          - title: Guide to Node.js agent API
-            path: /docs/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api
-          - title: Node.js agent API
-            path: /docs/agents/nodejs-agent/api-guides/nodejs-agent-api
+          - title: Ruby custom instrumentation
+            path: /docs/agents/ruby-agent/api-guides/ruby-custom-instrumentation
+          - title: API guide
+            path: /docs/agents/ruby-agent/api-guides/guide-using-ruby-agent-api
+          - title: Ruby custom metrics
+            path: /docs/agents/ruby-agent/api-guides/ruby-custom-metrics
+          - title: Ignoring specific transactions
+            path: /docs/agents/ruby-agent/api-guides/ignoring-specific-transactions
+          - title: Reporting handled errors
+            path: /docs/agents/ruby-agent/api-guides/sending-handled-errors-new-relic
+          - title: Third party instrumentation
+            path: /docs/agents/ruby-agent/api-guides/third-party-instrumentation
+      - title: Features
+        pages:
+          - title: Record deployments
+            path: /docs/agents/ruby-agent/features/record-deployments-ruby-agent
+          - title: Message queues
+            path: /docs/agents/ruby-agent/features/message-queues
+          - title: Ruby HTTP client tracing
+            path: /docs/agents/ruby-agent/features/http-client-tracing-ruby
+          - title: Ruby cross application tracing
+            path: /docs/agents/ruby-agent/features/cross-application-tracing-ruby
+          - title: Ruby VM measurements
+            path: /docs/agents/ruby-agent/features/ruby-vm-measurements
+          - title: Garbage collection
+            path: /docs/agents/ruby-agent/features/garbage-collection
+          - title: Browser monitoring
+            path: /docs/agents/ruby-agent/features/new-relic-browser-ruby-agent
+          - title: Developer mode
+            path: /docs/agents/ruby-agent/features/developer-mode
+      - title: Background jobs
+        pages:
+          - title: Resque instrumentation
+            path: /docs/agents/ruby-agent/background-jobs/resque-instrumentation
+          - title: Sidekiq instrumentation
+            path: /docs/agents/ruby-agent/background-jobs/sidekiq-instrumentation
+          - title: Rake instrumentation
+            path: /docs/agents/ruby-agent/background-jobs/rake-instrumentation
+          - title: Monitor background processes
+            path: /docs/agents/ruby-agent/background-jobs/monitor-ruby-background-processes
+          - title: 'Delayed::Job instrumentation'
+            path: /docs/agents/ruby-agent/background-jobs/delayedjob-instrumentation
       - title: Attributes
         pages:
-          - title: Node.js agent attributes
-            path: /docs/agents/nodejs-agent/attributes/nodejs-agent-attributes
+          - title: Enable and disable attributes
+            path: /docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby
+          - title: Ruby agent attributes
+            path: /docs/agents/ruby-agent/attributes/ruby-agent-attributes
+          - title: Attribute examples
+            path: /docs/agents/ruby-agent/attributes/ruby-attribute-examples
+      - title: Instrumented gems
+        pages:
+          - title: Redis instrumentation
+            path: /docs/agents/ruby-agent/instrumented-gems/redis-instrumentation
+          - title: Mongo instrumentation
+            path: /docs/agents/ruby-agent/frameworks/mongo-instrumentation
+          - title: Rack and Metal support
+            path: /docs/agents/ruby-agent/frameworks/rack-metal-support
+          - title: Rack middlewares
+            path: /docs/agents/ruby-agent/instrumented-gems/rack-middlewares
+          - title: Metal controller instrumentation
+            path: /docs/agents/ruby-agent/frameworks/metal-controller-instrumentation
+          - title: Sequel instrumentation
+            path: /docs/agents/ruby-agent/frameworks/sequel-instrumentation
+          - title: Sinatra instrumentation
+            path: /docs/agents/ruby-agent/instrumented-gems/sinatra-instrumentation
       - title: Troubleshooting
         pages:
-          - title: Logs for troubleshooting
-            path: /docs/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs
-          - title: Troubleshoot your installation
-            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-your-nodejs-installation
-          - title: Troubleshoot message consumers
-            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-message-consumers
-          - title: Large memory usage
-            path: /docs/agents/nodejs-agent/troubleshooting/troubleshooting-large-memory-usage-nodejs
-          - title: Troubleshoot Browser
-            path: /docs/agents/nodejs-agent/troubleshooting/troubleshoot-browser-instrumentation-nodejs
+          - title: No data appears
+            path: /docs/agents/ruby-agent/troubleshooting/no-data-appears-ruby
+          - title: Generating logs
+            path: /docs/agents/ruby-agent/troubleshooting/generating-logs-troubleshooting-ruby
+          - title: Incompatible gems
+            path: /docs/agents/ruby-agent/troubleshooting/incompatible-gems
+          - title: No log file
+            path: /docs/agents/ruby-agent/troubleshooting/no-log-file-ruby
+          - title: Control when the agent starts
+            path: /docs/agents/ruby-agent/troubleshooting/control-when-ruby-agent-starts
+          - title: No data with Unicorn
+            path: /docs/agents/ruby-agent/troubleshooting/no-data-unicorn
+          - title: 'SystemStackError: stack level too deep'
+            path: /docs/agents/ruby-agent/troubleshooting/systemstackerror-stack-level-too-deep
+          - title: Ruby agent audit log
+            path: /docs/agents/ruby-agent/troubleshooting/ruby-agent-audit-log
+          - title: Passenger troubleshooting
+            path: /docs/agents/ruby-agent/troubleshooting/passenger-troubleshooting
+          - title: Update deprecated API calls
+            path: /docs/agents/ruby-agent/troubleshooting/update-deprecated-api-calls
+          - title: Update private API calls to public Tracer API
+            path: /docs/agents/ruby-agent/troubleshooting/update-private-api-calls-public-tracer-api
+          - title: Not installing Grape
+            path: /docs/agents/ruby-agent/troubleshooting/not-installing-new-relic-supported-grape
+      - title: Latest release
+        path: /docs/release-notes/agent-release-notes/ruby-release-notes/current
+  - title: C SDK
+    path: /docs/agents/c-sdk
+    pages:
+      - title: Get started
+        pages:
+          - title: Compatibility and requirements
+            path: /docs/agents/c-sdk/get-started/c-sdk-compatibility-requirements
+          - title: C SDK security
+            path: /docs/agents/c-sdk/get-started/apm-security-c-sdk
+          - title: Introduction to the C SDK
+            path: /docs/agents/c-sdk/get-started/introduction-c-sdk
+      - title: Install and configure
+        pages:
+          - title: Install (compile) the C SDK
+            path: /docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code
+          - title: C SDK configuration
+            path: /docs/agents/c-sdk/install-configure/c-sdk-configuration
+          - title: Update your C SDK library
+            path: /docs/agents/c-sdk/install-configure/update-your-c-sdk-library
+          - title: Uninstall (remove) the C SDK
+            path: /docs/agents/c-sdk/install-configure/uninstall-remove-c-sdk
+      - title: Instrumentation
+        pages:
+          - title: Use default or custom attributes
+            path: /docs/agents/c-sdk/instrumentation/use-default-or-custom-attributes-c-sdk
+      - title: Troubleshooting
+        pages:
+          - title: No data appears (C SDK)
+            path: /docs/agents/c-sdk/troubleshooting/no-data-appears-c-sdk
+          - title: Troubleshooting logs (C SDK)
+            path: /docs/agents/c-sdk/troubleshooting/generate-logs-troubleshooting-c-sdk
+      - title: Latest release
+        path: /docs/release-notes/agent-release-notes/c-sdk-release-notes/current
+  - title: Go agent
+    path: /docs/agents/go-agent
+    pages:
+      - title: Get started
+        pages:
+          - title: Go agent release notes
+            path: /docs/agents/go-agent/get-started/go-agent-release-notes
+          - title: Go agent security
+            path: /docs/agents/go-agent/get-started/apm-agent-security-go
+          - title: New Relic for Go
+            path: /docs/agents/go-agent/get-started/introduction-new-relic-go
+          - title: Compatibility and requirements
+            path: /docs/agents/go-agent/get-started/go-agent-compatibility-requirements
+      - title: Instrumentation
+        pages:
+          - title: Instrument Go transactions
+            path: /docs/agents/go-agent/instrumentation/instrument-go-transactions
+          - title: Instrument Go segments
+            path: /docs/agents/go-agent/instrumentation/instrument-go-segments
+          - title: Custom events
+            path: /docs/agents/go-agent/features/create-custom-events-go
+          - title: Go agent attributes
+            path: /docs/agents/go-agent/instrumentation/go-agent-attributes
+          - title: Create custom metrics in Go
+            path: /docs/agents/go-agent/instrumentation/create-custom-metrics-go
+      - title: Installation
+        pages:
+          - title: Install New Relic for Go
+            path: /docs/agents/go-agent/installation/install-new-relic-go
+          - title: Install in GAE flex
+            path: /docs/agents/go-agent/installation/install-go-agent-gae-flexible-environment
+          - title: Uninstall the Go agent
+            path: /docs/agents/go-agent/installation/uninstall-go-agent
+      - title: Configuration
+        pages:
+          - title: Go configuration
+            path: /docs/agents/go-agent/configuration/go-agent-configuration
+          - title: Go agent logging
+            path: /docs/agents/go-agent/configuration/go-agent-logging
+      - title: Features
+        pages:
+          - title: Go runtime UI page
+            path: /docs/agents/go-agent/features/go-runtime-page-troubleshoot-performance-problems
+          - title: Custom events
+            path: /docs/agents/go-agent/features/create-custom-events-go
+          - title: Add browser monitoring
+            path: /docs/agents/go-agent/features/add-browser-monitoring-your-go-apps
+          - title: Distributed tracing
+            path: /docs/agents/go-agent/features/enable-distributed-tracing-your-go-applications
+          - title: Cross application tracing
+            path: /docs/agents/go-agent/features/cross-application-tracing-go
+      - title: API guides
+        pages:
+          - title: Go agent API guide
+            path: /docs/agents/go-agent/api-guides/guide-using-go-agent-api
+      - title: Troubleshooting
+        pages:
+          - title: No data appears
+            path: /docs/agents/go-agent/troubleshooting/no-data-appears-go
+      - title: Latest release
+        path: /docs/release-notes/agent-release-notes/go-release-notes/current
   - title: Open-source licensed agents
     pages:
       - title: Open-source licensed agents

--- a/src/nav/alerts-and-applied-intelligence.yml
+++ b/src/nav/alerts-and-applied-intelligence.yml
@@ -6,10 +6,10 @@ pages:
     pages:
       - title: Get started
         pages:
-          - title: Introduction to Alerts
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-alerts
           - title: Basic concepts and workflow
             path: /docs/alerts-applied-intelligence/new-relic-alerts/get-started/alerts-concepts-workflow
+          - title: Introduction to Alerts
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-alerts
       - title: REST API alerts
         pages:
           - title: REST API for alerts

--- a/src/nav/create-integrations.yml
+++ b/src/nav/create-integrations.yml
@@ -5,14 +5,14 @@ pages:
     pages:
       - title: Get started
         pages:
-          - title: Compatibility and requirements
-            path: /docs/create-integrations/infrastructure-integrations-sdk/get-started/compatibility-requirements-infrastructure-integrations-sdk
           - title: Understand and use data
             path: /docs/infrastructure/integrations-sdk/understand-use-data/understand-use-integration-data
           - title: Go integration tutorial and tools
             path: /docs/create-integrations/infrastructure-integrations-sdk/get-started/go-language-integration-tutorial-build-tools
           - title: Introduction to Integrations SDK
             path: /docs/create-integrations/infrastructure-integrations-sdk/get-started/introduction-infrastructure-integrations-sdk
+          - title: Compatibility and requirements
+            path: /docs/create-integrations/infrastructure-integrations-sdk/get-started/compatibility-requirements-infrastructure-integrations-sdk
       - title: Specifications
         pages:
           - title: Required files

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -10,10 +10,10 @@ pages:
         pages:
           - title: Troubleshooting
             pages:
-              - title: Log message is truncated
-                path: /docs/logs/log-management/troubleshooting/log-message-truncated
               - title: No data appears
                 path: /docs/logs/log-management/troubleshooting/no-log-data-appears-ui
+              - title: Log message is truncated
+                path: /docs/logs/log-management/troubleshooting/log-message-truncated
               - title: JSON message not parsed
                 path: /docs/logs/new-relic-logs/troubleshooting/json-message-not-parsed
   - title: APM
@@ -137,12 +137,12 @@ pages:
                 path: /docs/apm/reports/other-performance-analysis/weekly-performance-report
       - title: Getting started
         pages:
-          - title: APM data security
-            path: /docs/apm/new-relic-apm/getting-started/apm-agent-data-security
           - title: Introduction to APM
             path: /docs/apm/new-relic-apm/getting-started/introduction-apm
           - title: Alert information in APM
             path: /docs/apm/new-relic-apm/getting-started/view-app-alert-information-apm
+          - title: APM data security
+            path: /docs/apm/new-relic-apm/getting-started/apm-agent-data-security
       - title: Apdex
         pages:
           - title: 'Apdex: Measure user satisfaction'
@@ -176,12 +176,12 @@ pages:
             path: /docs/browser/new-relic-browser/getting-started/introduction-browser-monitoring
           - title: Compatibility and requirements
             path: /docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring
+          - title: Browser Summary page
+            path: /docs/browser/browser-monitoring/getting-started/browser-summary-page
           - title: Browser agent release notes
             path: /docs/browser/new-relic-browser/getting-started/browser-agent-release-notes
           - title: Browser apps index
             path: /docs/browser/new-relic-browser/getting-started/browser-apps-index
-          - title: Browser Summary page
-            path: /docs/browser/browser-monitoring/getting-started/browser-summary-page
       - title: Performance quality
         pages:
           - title: Security for Browser
@@ -313,12 +313,6 @@ pages:
             path: /docs/browser/new-relic-browser/troubleshooting/troubleshoot-ajax-data-collection
           - title: Session trace collection
             path: /docs/browser/new-relic-browser/troubleshooting/troubleshooting-session-trace-collection
-          - title: AngularJS errors do not appear
-            path: /docs/browser/new-relic-browser/troubleshooting/angularjs-errors-do-not-appear
-          - title: Accelerated mobile pages (AMP)
-            path: /docs/browser/new-relic-browser/troubleshooting/google-amp-validator-fails-due-3rd-party-script
-          - title: HAR data collection
-            path: /docs/browser/new-relic-browser/troubleshooting/get-browser-side-troubleshooting-details-har-file
           - title: Not seeing specific page names
             path: /docs/browser/new-relic-browser/troubleshooting/not-seeing-specific-page-or-endpoint-names-browser-data
           - title: JavaScript injection causes problems
@@ -327,6 +321,12 @@ pages:
             path: /docs/browser/new-relic-browser/troubleshooting/third-party-js-errors-missing-stack-traces
           - title: RPM higher than PPM
             path: /docs/browser/new-relic-browser/troubleshooting/app-server-requests-greatly-outnumber-browser-pageview-transactions
+          - title: AngularJS errors do not appear
+            path: /docs/browser/new-relic-browser/troubleshooting/angularjs-errors-do-not-appear
+          - title: Accelerated mobile pages (AMP)
+            path: /docs/browser/new-relic-browser/troubleshooting/google-amp-validator-fails-due-3rd-party-script
+          - title: HAR data collection
+            path: /docs/browser/new-relic-browser/troubleshooting/get-browser-side-troubleshooting-details-har-file
           - title: AJAX call fails with a CORS redirect error message
             path: /docs/browser/new-relic-browser/troubleshooting/ajax-call-fails-cors-redirect-error-message
   - title: Understand dependencies
@@ -336,12 +336,12 @@ pages:
         pages:
           - title: Get started
             pages:
-              - title: Planning guide
-                path: /docs/understand-dependencies/distributed-tracing/get-started/distributed-tracing-planning-guide
               - title: How distributed tracing works
                 path: /docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works
               - title: Intro to distributed tracing
                 path: /docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing
+              - title: Planning guide
+                path: /docs/understand-dependencies/distributed-tracing/get-started/distributed-tracing-planning-guide
           - title: UI and data
             pages:
               - title: Understand and use the UI
@@ -455,26 +455,26 @@ pages:
                 path: /docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/events-heatmap-examine-patterns-time-range
       - title: Infrastructure monitoring troubleshooting
         pages:
-          - title: Troubleshoot logs
-            pages:
-              - title: Generate troubleshooting logs
-                path: /docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs/generate-logs-troubleshooting-infrastructure
-              - title: 'Agent doesn&#039;t start, no logs'
-                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/agent-not-starting-there-are-no-logs
           - title: Troubleshoot infrastructure
             pages:
-              - title: Incorrect host name reported
-                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/incorrect-host-name-reported
-              - title: HTTPS proxy configuration not working
-                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/https-proxy-configuration-missing
-              - title: Time gaps with missing data
-                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/time-gaps-missing-data
               - title: No data appears
                 path: /docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/no-data-appears-infrastructure
               - title: APM data missing
                 path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/apm-data-missing-infrastructure
               - title: Reduce CPU footprint
                 path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/reduce-infrastructure-agents-cpu-footprint
+              - title: Incorrect host name reported
+                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/incorrect-host-name-reported
+              - title: HTTPS proxy configuration not working
+                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/https-proxy-configuration-missing
+              - title: Time gaps with missing data
+                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/time-gaps-missing-data
+          - title: Troubleshoot logs
+            pages:
+              - title: 'Agent doesn&#039;t start, no logs'
+                path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/agent-not-starting-there-are-no-logs
+              - title: Generate troubleshooting logs
+                path: /docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs/generate-logs-troubleshooting-infrastructure
       - title: Types of integrations
         pages:
           - title: Amazon/AWS integrations
@@ -488,6 +488,93 @@ pages:
   - title: Mobile monitoring
     path: /docs/mobile-monitoring
     pages:
+      - title: New Relic Mobile Android
+        pages:
+          - title: Get started
+            pages:
+              - title: Android release notes
+                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/android-release-notes
+              - title: Compatibility and requirements
+                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements
+              - title: New Relic Mobile for Android
+                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/introduction-new-relic-mobile-android
+          - title: Install configure
+            pages:
+              - title: Gradle and Android Studio installation
+                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-apps-gradle-android-studio
+              - title: Configure ProGuard and DexGuard
+                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps
+              - title: Android crash reporting
+                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/android-agent-crash-reporting
+              - title: Installation for Instant Apps
+                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-new-relic-plugin-android-instant-apps
+              - title: Update the Android SDK
+                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/upgrade-new-relic-mobiles-android-sdk
+          - title: Android SDK API
+            path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api
+            pages:
+              - title: View all methods
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/view-all-methods
+              - title: crashNow
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/crashnow-android-sdk-api
+              - title: currentSessionId
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/currentsessionid-android-sdk-api
+              - title: endInteraction
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/end-interaction
+              - title: incrementAttribute
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/increment-attribute
+              - title: noticeHttpTransaction
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/notice-http-transaction
+              - title: noticeNetworkFailure
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/notice-network-failure
+              - title: recordBreadcrumb
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordbreadcrumb
+              - title: recordCustomEvent
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordcustomevent-android-sdk-api
+              - title: recordHandledException
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordhandledexception-android-sdk-api
+              - title: recordMetric
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordmetric-android-sdk-api
+              - title: removeAllAttributes
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/remove-all-attributes
+              - title: removeAttribute
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/remove-attribute
+              - title: setAttribute
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-attribute
+              - title: setInteractionName
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-interaction-name
+              - title: setMaxEventBufferTime
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-max-event-buffer-time
+              - title: setMaxEventPoolSize
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-max-event-pool-size
+              - title: setUserId
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-user-id
+              - title: startInteraction
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/start-interaction
+              - title: withApplicationBuild
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/with-application-build
+              - title: withApplicationVersion
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/with-application-version
+              - title: withInteractionTracing
+                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/with-interaction-tracing
+          - title: API guides
+            pages:
+              - title: Android config and feature flags
+                path: /docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-agent-configuration-feature-flags
+              - title: Add custom data
+                path: /docs/mobile-monitoring/new-relic-mobile-android/api-guides/add-custom-data
+              - title: Android SDK API guide
+                path: /docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-sdk-api-guide
+          - title: Legacy
+            pages:
+              - title: Legacy Android 2.2 support
+                path: /docs/mobile-monitoring/new-relic-mobile-android/legacy/install-android-apps-android-22-support
+          - title: Troubleshoot
+            pages:
+              - title: No data appears
+                path: /docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/no-data-appears-android
+              - title: 64k multidex limit
+                path: /docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/android-app-exceeds-64k-multidex-limit
       - title: New Relic Mobile iOS
         pages:
           - title: Get started
@@ -581,12 +668,12 @@ pages:
         pages:
           - title: Get started
             pages:
+              - title: Mobile app alerts
+                path: /docs/mobile-monitoring/new-relic-mobile/get-started/mobile-monitoring-alert-information
               - title: Data privacy and security
                 path: /docs/mobile-monitoring/new-relic-mobile/get-started/security-mobile-apps
               - title: Mobile monitoring
                 path: /docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring
-              - title: Mobile app alerts
-                path: /docs/mobile-monitoring/new-relic-mobile/get-started/mobile-monitoring-alert-information
           - title: Maintenance
             pages:
               - title: Customize mobile app settings
@@ -597,93 +684,6 @@ pages:
                 path: /docs/mobile-monitoring/new-relic-mobile/maintenance/viewing-your-application-token
               - title: Deleting a mobile app
                 path: /docs/mobile-monitoring/new-relic-mobile/maintenance/deleting-mobile-app
-      - title: New Relic Mobile Android
-        pages:
-          - title: Get started
-            pages:
-              - title: Android release notes
-                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/android-release-notes
-              - title: Compatibility and requirements
-                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements
-              - title: New Relic Mobile for Android
-                path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/introduction-new-relic-mobile-android
-          - title: Install configure
-            pages:
-              - title: Gradle and Android Studio installation
-                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-apps-gradle-android-studio
-              - title: Configure ProGuard and DexGuard
-                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps
-              - title: Android crash reporting
-                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/android-agent-crash-reporting
-              - title: Installation for Instant Apps
-                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-new-relic-plugin-android-instant-apps
-              - title: Update the Android SDK
-                path: /docs/mobile-monitoring/new-relic-mobile-android/install-configure/upgrade-new-relic-mobiles-android-sdk
-          - title: Android SDK API
-            path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api
-            pages:
-              - title: View all methods
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/view-all-methods
-              - title: crashNow
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/crashnow-android-sdk-api
-              - title: currentSessionId
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/currentsessionid-android-sdk-api
-              - title: endInteraction
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/end-interaction
-              - title: incrementAttribute
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/increment-attribute
-              - title: noticeHttpTransaction
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/notice-http-transaction
-              - title: noticeNetworkFailure
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/notice-network-failure
-              - title: recordBreadcrumb
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordbreadcrumb
-              - title: recordCustomEvent
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordcustomevent-android-sdk-api
-              - title: recordHandledException
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordhandledexception-android-sdk-api
-              - title: recordMetric
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordmetric-android-sdk-api
-              - title: removeAllAttributes
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/remove-all-attributes
-              - title: removeAttribute
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/remove-attribute
-              - title: setAttribute
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-attribute
-              - title: setInteractionName
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-interaction-name
-              - title: setMaxEventBufferTime
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-max-event-buffer-time
-              - title: setMaxEventPoolSize
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-max-event-pool-size
-              - title: setUserId
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-user-id
-              - title: startInteraction
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/start-interaction
-              - title: withApplicationBuild
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/with-application-build
-              - title: withApplicationVersion
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/with-application-version
-              - title: withInteractionTracing
-                path: /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/with-interaction-tracing
-          - title: API guides
-            pages:
-              - title: Android config and feature flags
-                path: /docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-agent-configuration-feature-flags
-              - title: Add custom data
-                path: /docs/mobile-monitoring/new-relic-mobile-android/api-guides/add-custom-data
-              - title: Android SDK API guide
-                path: /docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-sdk-api-guide
-          - title: Legacy
-            pages:
-              - title: Legacy Android 2.2 support
-                path: /docs/mobile-monitoring/new-relic-mobile-android/legacy/install-android-apps-android-22-support
-          - title: Troubleshoot
-            pages:
-              - title: 64k multidex limit
-                path: /docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/android-app-exceeds-64k-multidex-limit
-              - title: No data appears
-                path: /docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/no-data-appears-android
       - title: New Relic Mobile Cordova
         pages:
           - title: Get started

--- a/src/nav/integrations.yml
+++ b/src/nav/integrations.yml
@@ -21,10 +21,10 @@ pages:
             path: /docs/integrations/kubernetes-integration/installation/kubernetes-integration-install-configure
       - title: Troubleshooting
         pages:
-          - title: Not seeing data
-            path: /docs/integrations/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-not-seeing-data
           - title: Error message
             path: /docs/integrations/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-error-messages
+          - title: Not seeing data
+            path: /docs/integrations/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-not-seeing-data
           - title: Logs and version
             path: /docs/integrations/kubernetes-integration/troubleshooting/get-logs-version
           - title: Unidentified certificate
@@ -39,14 +39,14 @@ pages:
         pages:
           - title: Integrations release notes
             path: /docs/integrations/new-relic-integrations/getting-started/integrations-release-notes
-          - title: Understand and use data
-            path: /docs/integrations/infrastructure-integrations/get-started/understand-use-data-infrastructure-integrations
           - title: Integration dashboards
             path: /docs/integrations/infrastructure-integrations/get-started/infrastructure-integration-dashboards-charts
           - title: Integration data in dashboards
             path: /docs/integrations/infrastructure-integrations/get-started/use-integration-data-new-relic-dashboards
           - title: Introduction to integrations
             path: /docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations
+          - title: Understand and use data
+            path: /docs/integrations/infrastructure-integrations/get-started/understand-use-data-infrastructure-integrations
       - title: Cloud integrations
         pages:
           - title: Configuration for cloud integrations
@@ -57,16 +57,16 @@ pages:
     pages:
       - title: Get started
         pages:
-          - title: Connect AWS integrations
-            path: /docs/integrations/amazon-integrations/get-started/connect-aws-infrastructure
-          - title: Understand and use data
-            path: /docs/infrastructure/amazon-integrations/find-use-data/understand-use-integration-data
           - title: Polling intervals for AWS integrations
             path: /docs/integrations/amazon-integrations/get-started/polling-intervals-aws-integrations
-          - title: Introduction to AWS integrations
-            path: /docs/integrations/amazon-integrations/get-started/introduction-aws-integrations
           - title: Managed policies
             path: /docs/integrations/amazon-integrations/get-started/integrations-managed-policies
+          - title: Understand and use data
+            path: /docs/infrastructure/amazon-integrations/find-use-data/understand-use-integration-data
+          - title: Introduction to AWS integrations
+            path: /docs/integrations/amazon-integrations/get-started/introduction-aws-integrations
+          - title: Connect AWS integrations
+            path: /docs/integrations/amazon-integrations/get-started/connect-aws-infrastructure
       - title: AWS integrations list
         pages:
           - title: ALB/NLB integration
@@ -159,14 +159,14 @@ pages:
     pages:
       - title: Get started
         pages:
-          - title: Activate Azure integrations
-            path: /docs/integrations/microsoft-azure-integrations/getting-started/activate-azure-integrations
           - title: Understand and use data
             path: /docs/infrastructure/microsoft-azure-integrations/find-use-data/understand-use-integration-data
           - title: Azure polling intervals
             path: /docs/integrations/microsoft-azure-integrations/getting-started/polling-intervals-azure-integrations
           - title: Intro to Azure integrations
             path: /docs/integrations/microsoft-azure-integrations/getting-started/introduction-azure-monitoring-integrations
+          - title: Activate Azure integrations
+            path: /docs/integrations/microsoft-azure-integrations/getting-started/activate-azure-integrations
       - title: Azure integrations list
         pages:
           - title: Azure App Service integration
@@ -197,12 +197,12 @@ pages:
     pages:
       - title: Get started
         pages:
-          - title: Connect GCP integrations
-            path: /docs/integrations/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic
           - title: Polling intervals for GCP integrations
             path: /docs/integrations/google-cloud-platform-integrations/getting-started/polling-intervals-gcp-integrations
           - title: Introduction to GCP integrations
             path: /docs/integrations/google-cloud-platform-integrations/getting-started/introduction-google-cloud-platform-integrations
+          - title: Connect GCP integrations
+            path: /docs/integrations/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic
       - title: GCP integrations list
         pages:
           - title: App Engine integration
@@ -331,14 +331,14 @@ pages:
             path: /docs/integrations/prometheus-integrations/troubleshooting/no-data-appears-prometheus-integration
           - title: See exact metrics
             path: /docs/integrations/prometheus-integrations/troubleshooting/debug-issues-data-sent-metric-api-prometheus-integration
-          - title: Get logs (Prometheus integration)
-            path: /docs/integrations/prometheus-integrations/troubleshooting/get-logs-prometheus-integration
           - title: Get scraper metrics
             path: /docs/integrations/prometheus-integrations/troubleshooting/get-scraper-metrics-prometheus-integration
           - title: Rate limit errors (NrIntegrationError)
             path: /docs/integrations/prometheus-integrations/troubleshooting/rate-limit-errors-prometheus-integration
           - title: Restarts and gaps in data (Kubernetes)
             path: /docs/integrations/prometheus-integrations/troubleshooting/restarts-gaps-data-kubernetes
+          - title: Get logs (Prometheus integration)
+            path: /docs/integrations/prometheus-integrations/troubleshooting/get-logs-prometheus-integration
   - title: Grafana integrations
     pages:
       - title: Set up and configure

--- a/src/nav/new-relic-in-practice.yml
+++ b/src/nav/new-relic-in-practice.yml
@@ -8,14 +8,14 @@ pages:
         pages:
           - title: Get started
             pages:
+              - title: Glossary
+                path: /docs/using-new-relic/welcome-new-relic/get-started/glossary
               - title: EU and US data centers
                 path: /docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers
               - title: Introduction to New Relic
                 path: /docs/using-new-relic/welcome-new-relic/get-started/introduction-new-relic
               - title: Help and support portal
                 path: /docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal
-              - title: Glossary
-                path: /docs/using-new-relic/welcome-new-relic/get-started/glossary
           - title: New Relic University
             pages:
               - title: New Relic University
@@ -48,14 +48,14 @@ pages:
                 path: /docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics
               - title: Not seeing data
                 path: /docs/using-new-relic/cross-product-functions/troubleshooting/not-seeing-data
-              - title: Find agent&#039;s root directory
-                path: /docs/using-new-relic/cross-product-functions/troubleshooting/find-agent-root-directory
               - title: Generate logs
                 path: /docs/using-new-relic/cross-product-functions/troubleshooting/generate-new-relic-agent-logs-troubleshooting
               - title: 'Metric grouping issues (APM, browser, mobile)'
                 path: /docs/using-new-relic/cross-product-functions/troubleshooting/metric-grouping-issues
               - title: Audit all data transmitted
                 path: /docs/using-new-relic/cross-product-functions/troubleshooting/log-audit-all-data-your-new-relic-agent-transmits
+              - title: Find agent&#039;s root directory
+                path: /docs/using-new-relic/cross-product-functions/troubleshooting/find-agent-root-directory
   - title: New Relic One
     path: /docs/new-relic-one
     pages:
@@ -74,12 +74,12 @@ pages:
             pages:
               - title: NRQL rate limits
                 path: /docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries
+              - title: NRQL math
+                path: /docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-math-using-select
               - title: Intro to NRQL
                 path: /docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language
               - title: NRQL clauses and functions
                 path: /docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions
-              - title: NRQL math
-                path: /docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-math-using-select
           - title: NRQL query tutorials
             pages:
               - title: How funnels work

--- a/src/nav/new-relic-only.yml
+++ b/src/nav/new-relic-only.yml
@@ -62,6 +62,18 @@ pages:
             path: /docs/new-relic-only/tech-writer-style-guide/article-templates/troubleshooting-docs-guide
           - title: Agent release notes template 1.2.3
             path: /docs/new-relic-only/tech-writer-style-guide/article-templates/agent-release-notes-template-123
+  - title: Drupal configuration
+    pages:
+      - title: Page components
+        pages:
+          - title: Add or edit content at top of release notes page
+            path: /docs/new-relic-only/drupal-configuration/page-components/add-or-edit-content-top-release-notes-page
+          - title: Edit RSS links on release notes pages
+            path: /docs/new-relic-only/drupal-configuration/page-components/edit-rss-links-release-notes-pages
+          - title: Manage content footers
+            path: /docs/new-relic-only/drupal-configuration/page-components/manage-content-footers
+          - title: Embed Insights data in a page
+            path: /docs/new-relic-only/drupal-configuration/page-components/embed-insights-data-page
   - title: Basic style guide
     pages:
       - title: Writing guidelines

--- a/src/nav/new-relic-partnerships.yml
+++ b/src/nav/new-relic-partnerships.yml
@@ -5,18 +5,18 @@ pages:
     pages:
       - title: Getting started
         pages:
-          - title: Walkthrough and signoff
-            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/walkthrough-signoff
           - title: Partner integration requirements
             path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/partner-integration-requirements
           - title: 'Partners: Contact New Relic'
             path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/partners-contact-new-relic
+          - title: Partner resources
+            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/support-resources-new-relic-partners
+          - title: Walkthrough and signoff
+            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/walkthrough-signoff
           - title: Co-branding
             path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/co-branding-new-relic-partners
           - title: Partnership admin console
             path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/partnership-admin-console
-          - title: Partner resources
-            path: /docs/new-relic-partnerships/partner-integration-guide/getting-started/support-resources-new-relic-partners
       - title: Partner account maintenance
         pages:
           - title: Partnership accounts


### PR DESCRIPTION
## Description

The agent release link was populating in the wrong place during the migration. This PR fixes this issue and ensures the links populate in the proper nav yaml file.
