### PR TITLE
Add translations for 404, whats-new, attribute-dictionary

### DIFF
--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -1,12 +1,12 @@
 {
   "404": {
-    "h1": "404",
-    "text": "The URL you entered may be broken, or the page has been removed.<2>Go back to the home page</2>"
+    "statusCode": "404",
+    "errorMessage": "The URL you entered may be broken, or the page has been removed.<1> </1><2>Go back to the home page</2>"
   },
   "dataDictionary": {
     "title": "New Relic data dictionary",
-    "intro": "<0>This data dictionary lists and defines the <2>attributes</2> attached to New Relic events and other data objects (like Metric and Span data).</0>",
-    "callout": "<0>This dictionary does not contain data reported by Infrastructure integrations. To learn about that data, see the <2>integration documentation</2>.</0>"
+    "intro": "This data dictionary lists and defines the <2>attributes</2> attached to New Relic events and other data objects (like Metric and Span data).",
+    "callout": "This dictionary does not contain data reported by Infrastructure integrations. To learn about that data, see the <2>integration documentation</2>."
   },
   "whatsNew": {
     "title": "What's new in New Relic"

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -1,7 +1,7 @@
 {
   "404": {
     "statusCode": "404",
-    "errorMessage": "The URL you entered may be broken, or the page has been removed.<1> </1><2>Go back to the home page</2>"
+    "errorMessage": "The URL you entered may be broken, or the page has been removed. <2>Go back to the home page</2>"
   },
   "dataDictionary": {
     "title": "New Relic data dictionary",

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -1,1 +1,14 @@
-{}
+{
+  "404": {
+    "h1": "404",
+    "text": "<0>The URL you entered may be broken, or the page has been removed.</0><1> </1><2>Go back to the home page</2>"
+  },
+  "dataDictionary": {
+    "title": "New Relic data dictionary",
+    "intro": "<0>This data dictionary lists and defines the <2>attributes</2> attached to New Relic events and other data objects (like Metric and Span data).</0>",
+    "callout": "<0>This dictionary does not contain data reported by Infrastructure integrations. To learn about that data, see the <2>integration documentation</2>.</0>"
+  },
+  "whatsNew": {
+    "title": "What's new in New Relic"
+  }
+}

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -1,7 +1,7 @@
 {
   "404": {
     "h1": "404",
-    "text": "<0>The URL you entered may be broken, or the page has been removed.</0><1> </1><2>Go back to the home page</2>"
+    "text": "The URL you entered may be broken, or the page has been removed.<2>Go back to the home page</2>"
   },
   "dataDictionary": {
     "title": "New Relic data dictionary",

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -3,9 +3,15 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { Link } from 'gatsby';
 import SkewedContainer from '../components/SkewedContainer';
-import { GlobalHeader, GlobalFooter } from '@newrelic/gatsby-theme-newrelic';
+import {
+  GlobalHeader,
+  GlobalFooter,
+  Trans,
+  useTranslation,
+} from '@newrelic/gatsby-theme-newrelic';
 
 const NotFoundPage = ({ pageContext }) => {
+  const { t } = useTranslation();
   return (
     <>
       <GlobalHeader />
@@ -42,12 +48,12 @@ const NotFoundPage = ({ pageContext }) => {
                 line-height: 1;
               `}
             >
-              404
+              {t('404.h1')}
             </h1>
-            <p>
+            <Trans i18nKey="404.content" parent="p">
               The URL you entered may be broken, or the page has been removed.{' '}
               <Link to="/">Go back to the home page</Link>.
-            </p>
+            </Trans>
           </SkewedContainer>
         </div>
         <GlobalFooter fileRelativePath={pageContext.fileRelativePath} />

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -48,9 +48,9 @@ const NotFoundPage = ({ pageContext }) => {
                 line-height: 1;
               `}
             >
-              {t('404.h1')}
+              {t('404.statusCode')}
             </h1>
-            <Trans i18nKey="404.content" parent="p">
+            <Trans i18nKey="404.errorMessage" parent="p">
               The URL you entered may be broken, or the page has been removed.{' '}
               <Link to="/">Go back to the home page</Link>.
             </Trans>

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -11,6 +11,8 @@ import {
   TagList,
   useQueryParams,
   Icon,
+  useTranslation,
+  Trans,
 } from '@newrelic/gatsby-theme-newrelic';
 
 import SEO from '../components/seo';
@@ -54,6 +56,8 @@ const AttributeDictionary = ({ data, pageContext }) => {
     filterEvents();
   }, [queryParams, events]);
 
+  const { t } = useTranslation();
+
   return (
     <>
       <SEO title="New Relic data dictionary" />
@@ -76,31 +80,34 @@ const AttributeDictionary = ({ data, pageContext }) => {
           }
         `}
       >
-        <PageTitle>New Relic data dictionary</PageTitle>
+        <PageTitle>{t('dataDictionary.title')}</PageTitle>
         <div
           css={css`
             grid-area: 'page-description';
           `}
         >
-          <p
-            css={css`
-              color: var(--secondary-text-color);
-              font-size: 1.125rem;
-            `}
-          >
-            This data dictionary lists and defines the{' '}
-            <Link to="/docs/using-new-relic/welcome-new-relic/getting-started/glossary#attribute">
-              attributes
-            </Link>{' '}
-            attached to New Relic events and other data objects (like Metric and
-            Span data).
-          </p>
-          <Callout variant={Callout.VARIANT.TIP}>
-            This dictionary does not contain data reported by Infrastructure
-            integrations. To learn about that data, see the{' '}
-            <Link to="/docs/integrations">integration documentation</Link>.
-          </Callout>
-
+          <Trans i18nKey="dataDictionary.intro" parent="div">
+            <p
+              css={css`
+                color: var(--secondary-text-color);
+                font-size: 1.125rem;
+              `}
+            >
+              This data dictionary lists and defines the{' '}
+              <Link to="/docs/using-new-relic/welcome-new-relic/getting-started/glossary#attribute">
+                attributes
+              </Link>{' '}
+              attached to New Relic events and other data objects (like Metric
+              and Span data).
+            </p>
+          </Trans>
+          <Trans i18nKey="dataDictionary.callout">
+            <Callout variant={Callout.VARIANT.TIP}>
+              This dictionary does not contain data reported by Infrastructure
+              integrations. To learn about that data, see the{' '}
+              <Link to="/docs/integrations">integration documentation</Link>.
+            </Callout>
+          </Trans>
           <hr />
         </div>
         <Layout.Content>

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -86,28 +86,30 @@ const AttributeDictionary = ({ data, pageContext }) => {
             grid-area: 'page-description';
           `}
         >
-          <Trans i18nKey="dataDictionary.intro" parent="div">
-            <p
-              css={css`
-                color: var(--secondary-text-color);
-                font-size: 1.125rem;
-              `}
-            >
-              This data dictionary lists and defines the{' '}
-              <Link to="/docs/using-new-relic/welcome-new-relic/getting-started/glossary#attribute">
-                attributes
-              </Link>{' '}
-              attached to New Relic events and other data objects (like Metric
-              and Span data).
-            </p>
+          <Trans
+            i18nKey="dataDictionary.intro"
+            parent="p"
+            css={css`
+              color: var(--secondary-text-color);
+              font-size: 1.125rem;
+            `}
+          >
+            This data dictionary lists and defines the{' '}
+            <Link to="/docs/using-new-relic/welcome-new-relic/getting-started/glossary#attribute">
+              attributes
+            </Link>{' '}
+            attached to New Relic events and other data objects (like Metric and
+            Span data).
           </Trans>
-          <Trans i18nKey="dataDictionary.callout">
-            <Callout variant={Callout.VARIANT.TIP}>
+
+          <Callout variant={Callout.VARIANT.TIP}>
+            <Trans i18nKey="dataDictionary.callout">
               This dictionary does not contain data reported by Infrastructure
               integrations. To learn about that data, see the{' '}
               <Link to="/docs/integrations">integration documentation</Link>.
-            </Callout>
-          </Trans>
+            </Trans>
+          </Callout>
+
           <hr />
         </div>
         <Layout.Content>

--- a/src/pages/whats-new.js
+++ b/src/pages/whats-new.js
@@ -4,7 +4,7 @@ import { css } from '@emotion/core';
 import SEO from '../components/seo';
 import PageTitle from '../components/PageTitle';
 import { graphql } from 'gatsby';
-import { Layout, Link } from '@newrelic/gatsby-theme-newrelic';
+import { Layout, Link, useTranslation } from '@newrelic/gatsby-theme-newrelic';
 import Timeline from '../components/Timeline';
 
 const WhatsNew = ({ data }) => {
@@ -24,6 +24,8 @@ const WhatsNew = ({ data }) => {
       .entries()
   );
 
+  const { t } = useTranslation();
+
   return (
     <>
       <SEO title="What's new in New Relic" />
@@ -33,7 +35,7 @@ const WhatsNew = ({ data }) => {
             margin-bottom: 2rem;
           `}
         >
-          What's new in New Relic
+          {t('whatsNew.title')}
         </PageTitle>
         <Layout.Content>
           <Timeline>


### PR DESCRIPTION
Closes #527 

## Description

Implements `i18next` via the theme for 404, whats-new, and attribute-dictionary pages.

No Japanese translations currently exist for that content, so just English was added.

