### PR TITLE
PR validation workflow (gatsby build)

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -11,10 +11,50 @@ jobs:
     name: Gatsby Build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 12
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: /usr/local/share/.cache/yarn/v4
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Gatsby build
+        run: yarn build:production
+
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: /usr/local/share/.cache/yarn/v4
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Jest test
+        run: yarn test --passWithNoTests

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,20 @@
+name: Validate Pull Request
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+
+jobs:
+  build:
+    name: Gatsby Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12


### PR DESCRIPTION
## Description
Creates a simple workflow that runs `yarn build:production` and `yarn test --passWithNoTests` whenever a PR is created into the `develop` or `main` branches. This can be used as a way to validate whether a PR is good to be merged in and will be our "source of truth" check (rather than relying on Amplify).

## Reviewer Notes
I'm not sure if this will get kicked off when I create this PR, but you can run this locally with the help of [act](https://github.com/nektos/act).

## Related Issue(s)
* Closes #518
