### PR TITLE
Cache Gatsby folders for GitHub actions

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -6,6 +6,9 @@ on:
       - develop
       - main
 
+env:
+  NODE_OPTIONS: '--max-old-space-size=4096'
+
 jobs:
   build:
     name: Gatsby Build
@@ -19,13 +22,33 @@ jobs:
         with:
           node-version: 12
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          path: /usr/local/share/.cache/yarn/v4
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
+      - name: Cache Gatsby cache folder
+        uses: actions/cache@v2
+        with:
+          path: .cache
+          key: ${{ runner.os }}-cache-gatsby-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-cache-gatsby-
+
+      - name: Gatsby public folder
+        uses: actions/cache@v2
+        with:
+          path: public
+          key: ${{ runner.os }}-cache-public-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-cache-public-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -45,10 +68,14 @@ jobs:
         with:
           node-version: 12
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          path: /usr/local/share/.cache/yarn/v4
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-


### PR DESCRIPTION
## Description

This is a followup to #554. Unfortunately #554 was failing Amplify builds for [some weird reason](https://github.com/newrelic/docs-website/pull/554#issuecomment-759757675). This PR adds back just the GitHub workflow caching to speed up the PR build check.
