### PR TITLE
Remove migration CLI progress bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "add": "^2.0.6",
     "aws-sdk": "^2.827.0",
     "chalk": "^4.1.0",
-    "cli-progress": "^3.8.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.7.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4941,14 +4941,6 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
-cli-progress@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.8.2.tgz#abaf1fc6d6401351f16f068117a410554a0eb8c7"
-  integrity sha512-qRwBxLldMSfxB+YGFgNRaj5vyyHe1yMpVeDL79c+7puGujdKJHQHydgqXDcrkvQgJ5U/d3lpf6vffSoVVUftVQ==
-  dependencies:
-    colors "^1.1.2"
-    string-width "^4.2.0"
-
 cli-table3@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.5.1.tgz#0252372d94dfc40dbd8df06005f48f31f656f202"


### PR DESCRIPTION
## Description

Removes `cli-progress` module from migration. Seemed to be hanging my migration script so it wouldn't complete. Added basic logger messages in its stead.