### PR TITLE
Serialize code blocks without the embedded code

### DIFF
--- a/scripts/actions/__tests__/__snapshots__/serialize-mdx.test.js.snap
+++ b/scripts/actions/__tests__/__snapshots__/serialize-mdx.test.js.snap
@@ -66,30 +66,21 @@ exports[`kitchen sink 1`] = `
     </tr>
   </tbody>
 </table>
-<pre><code>@newrelic.agent.lambda_handler()
-def handler(event, context):
-    newrelic.agent.record_custom_event('CustomEvent', {'foo': 'bar'})
-</code></pre>
+<pre data-type=\\"component\\" data-component=\\"CodeBlock\\" data-props=\\"eyJsYW5nIjpudWxsLCJtZXRhIjpudWxsLCJ2YWx1ZSI6IkBuZXdyZWxpYy5hZ2VudC5sYW1iZGFfaGFuZGxlcigpXG5kZWYgaGFuZGxlcihldmVudCwgY29udGV4dCk6XG4gICAgbmV3cmVsaWMuYWdlbnQucmVjb3JkX2N1c3RvbV9ldmVudCgnQ3VzdG9tRXZlbnQnLCB7J2Zvbyc6ICdiYXInfSkiLCJwb3NpdGlvbiI6eyJzdGFydCI6eyJsaW5lIjo4NCwiY29sdW1uIjoxLCJvZmZzZXQiOjI5MTJ9LCJlbmQiOnsibGluZSI6ODgsImNvbHVtbiI6NCwib2Zmc2V0IjozMDUxfSwiaW5kZW50IjpbMSwxLDEsMV19fQ==\\"><code></code></pre>
 <div data-type=\\"component\\" data-component=\\"CollapserGroup\\">
   <div data-type=\\"prop\\" data-prop=\\"children\\">
     <div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJpZCIsInZhbHVlIjoiZXZlbnRzLWFwaS1rZXkifSx7InR5cGUiOiJtZHhBdHRyaWJ1dGUiLCJuYW1lIjoidGl0bGUiLCJ2YWx1ZSI6IldoYXQgYWNjb3VudCBjaGFuZ2VzIGhhdmUgYmVlbiBtYWRlIHVzaW5nIGFuIEFQSSBrZXk/In1d\\">
       <div data-type=\\"prop\\" data-prop=\\"title\\">What account changes have been made using an API key?</div>
       <div data-type=\\"prop\\" data-prop=\\"children\\">
         <p>To see detailed information about changes to the account that were made using an API key during a specific time frame, include <a href=\\"#actorType\\"><code>actorType = 'api_key'</code></a> in the query. For example:</p>
-        <pre><code>SELECT actionIdentifier, description, targetType, targetId, actorAPIKey, actorId, actorEmail
-FROM NrAuditEvent WHERE actorType = 'api_key' SINCE 1 week ago
-</code></pre>
+        <pre data-type=\\"component\\" data-component=\\"CodeBlock\\" data-props=\\"eyJsYW5nIjpudWxsLCJtZXRhIjpudWxsLCJ2YWx1ZSI6IlNFTEVDVCBhY3Rpb25JZGVudGlmaWVyLCBkZXNjcmlwdGlvbiwgdGFyZ2V0VHlwZSwgdGFyZ2V0SWQsIGFjdG9yQVBJS2V5LCBhY3RvcklkLCBhY3RvckVtYWlsXG5GUk9NIE5yQXVkaXRFdmVudCBXSEVSRSBhY3RvclR5cGUgPSAnYXBpX2tleScgU0lOQ0UgMSB3ZWVrIGFnbyIsInBvc2l0aW9uIjp7InN0YXJ0Ijp7ImxpbmUiOjk3LCJjb2x1bW4iOjEsIm9mZnNldCI6MzM3NH0sImVuZCI6eyJsaW5lIjoxMDEsImNvbHVtbiI6Mywib2Zmc2V0IjozNTU2fSwiaW5kZW50IjpbMSwxLDEsMV19fQ==\\"><code></code></pre>
       </div>
     </div>
     <div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJpZCIsInZhbHVlIjoic3ludGgtdXNlciJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiU3ludGhldGljczogV2hhdCBtb25pdG9ycyB3ZXJlIGNyZWF0ZWQgYnkgYSBzcGVjaWZpYyB1c2VyPyJ9XQ==\\">
       <div data-type=\\"prop\\" data-prop=\\"title\\">Synthetics: What monitors were created by a specific user?</div>
       <div data-type=\\"prop\\" data-prop=\\"children\\">
         <p>To query Synthetics monitor updates made by a specific user, include the <a href=\\"/attribute-dictionary/nrauditevent/actionidentifier\\"><code>actionIdentifier</code></a> and <a href=\\"/attribute-dictionary/nrauditevent/actoremail\\"><code>actorEmail</code></a> attribute in your query. For example:</p>
-        <pre><code>SELECT count(*) FROM NrAuditEvent
-WHERE actionIdentifier = 'synthetics_monitor.update_script'
-FACET actorEmail, actionIdentifier, description
-SINCE 1 week ago LIMIT 1000
-</code></pre>
+        <pre data-type=\\"component\\" data-component=\\"CodeBlock\\" data-props=\\"eyJsYW5nIjpudWxsLCJtZXRhIjpudWxsLCJ2YWx1ZSI6IlNFTEVDVCBjb3VudCgqKSBGUk9NIE5yQXVkaXRFdmVudFxuV0hFUkUgYWN0aW9uSWRlbnRpZmllciA9ICdzeW50aGV0aWNzX21vbml0b3IudXBkYXRlX3NjcmlwdCdcbkZBQ0VUIGFjdG9yRW1haWwsIGFjdGlvbklkZW50aWZpZXIsIGRlc2NyaXB0aW9uXG5TSU5DRSAxIHdlZWsgYWdvIExJTUlUIDEwMDAiLCJwb3NpdGlvbiI6eyJzdGFydCI6eyJsaW5lIjoxMDksImNvbHVtbiI6MSwib2Zmc2V0IjozOTM0fSwiZW5kIjp7ImxpbmUiOjExNSwiY29sdW1uIjozLCJvZmZzZXQiOjQxMzh9LCJpbmRlbnQiOlsxLDEsMSwxLDEsMV19fQ==\\"><code></code></pre>
       </div>
     </div>
   </div>

--- a/scripts/actions/__tests__/__snapshots__/serialize-mdx.test.js.snap
+++ b/scripts/actions/__tests__/__snapshots__/serialize-mdx.test.js.snap
@@ -66,21 +66,21 @@ exports[`kitchen sink 1`] = `
     </tr>
   </tbody>
 </table>
-<pre data-type=\\"component\\" data-component=\\"CodeBlock\\" data-props=\\"eyJsYW5nIjpudWxsLCJtZXRhIjpudWxsLCJ2YWx1ZSI6IkBuZXdyZWxpYy5hZ2VudC5sYW1iZGFfaGFuZGxlcigpXG5kZWYgaGFuZGxlcihldmVudCwgY29udGV4dCk6XG4gICAgbmV3cmVsaWMuYWdlbnQucmVjb3JkX2N1c3RvbV9ldmVudCgnQ3VzdG9tRXZlbnQnLCB7J2Zvbyc6ICdiYXInfSkiLCJwb3NpdGlvbiI6eyJzdGFydCI6eyJsaW5lIjo4NCwiY29sdW1uIjoxLCJvZmZzZXQiOjI5MTJ9LCJlbmQiOnsibGluZSI6ODgsImNvbHVtbiI6NCwib2Zmc2V0IjozMDUxfSwiaW5kZW50IjpbMSwxLDEsMV19fQ==\\"><code></code></pre>
+<pre data-type=\\"component\\" data-component=\\"CodeBlock\\" data-props=\\"eyJsYW5nIjoicHl0aG9uIiwibWV0YSI6ImNvcHlhYmxlPWZhbHNlIiwidmFsdWUiOiJAbmV3cmVsaWMuYWdlbnQubGFtYmRhX2hhbmRsZXIoKVxuZGVmIGhhbmRsZXIoZXZlbnQsIGNvbnRleHQpOlxuICAgIG5ld3JlbGljLmFnZW50LnJlY29yZF9jdXN0b21fZXZlbnQoJ0N1c3RvbUV2ZW50Jywgeydmb28nOiAnYmFyJ30pIiwicG9zaXRpb24iOnsic3RhcnQiOnsibGluZSI6ODQsImNvbHVtbiI6MSwib2Zmc2V0IjoyOTEyfSwiZW5kIjp7ImxpbmUiOjg4LCJjb2x1bW4iOjQsIm9mZnNldCI6MzA3Mn0sImluZGVudCI6WzEsMSwxLDFdfX0=\\"><code></code></pre>
 <div data-type=\\"component\\" data-component=\\"CollapserGroup\\">
   <div data-type=\\"prop\\" data-prop=\\"children\\">
     <div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJpZCIsInZhbHVlIjoiZXZlbnRzLWFwaS1rZXkifSx7InR5cGUiOiJtZHhBdHRyaWJ1dGUiLCJuYW1lIjoidGl0bGUiLCJ2YWx1ZSI6IldoYXQgYWNjb3VudCBjaGFuZ2VzIGhhdmUgYmVlbiBtYWRlIHVzaW5nIGFuIEFQSSBrZXk/In1d\\">
       <div data-type=\\"prop\\" data-prop=\\"title\\">What account changes have been made using an API key?</div>
       <div data-type=\\"prop\\" data-prop=\\"children\\">
         <p>To see detailed information about changes to the account that were made using an API key during a specific time frame, include <a href=\\"#actorType\\"><code>actorType = 'api_key'</code></a> in the query. For example:</p>
-        <pre data-type=\\"component\\" data-component=\\"CodeBlock\\" data-props=\\"eyJsYW5nIjpudWxsLCJtZXRhIjpudWxsLCJ2YWx1ZSI6IlNFTEVDVCBhY3Rpb25JZGVudGlmaWVyLCBkZXNjcmlwdGlvbiwgdGFyZ2V0VHlwZSwgdGFyZ2V0SWQsIGFjdG9yQVBJS2V5LCBhY3RvcklkLCBhY3RvckVtYWlsXG5GUk9NIE5yQXVkaXRFdmVudCBXSEVSRSBhY3RvclR5cGUgPSAnYXBpX2tleScgU0lOQ0UgMSB3ZWVrIGFnbyIsInBvc2l0aW9uIjp7InN0YXJ0Ijp7ImxpbmUiOjk3LCJjb2x1bW4iOjEsIm9mZnNldCI6MzM3NH0sImVuZCI6eyJsaW5lIjoxMDEsImNvbHVtbiI6Mywib2Zmc2V0IjozNTU2fSwiaW5kZW50IjpbMSwxLDEsMV19fQ==\\"><code></code></pre>
+        <pre data-type=\\"component\\" data-component=\\"CodeBlock\\" data-props=\\"eyJsYW5nIjpudWxsLCJtZXRhIjpudWxsLCJ2YWx1ZSI6IlNFTEVDVCBhY3Rpb25JZGVudGlmaWVyLCBkZXNjcmlwdGlvbiwgdGFyZ2V0VHlwZSwgdGFyZ2V0SWQsIGFjdG9yQVBJS2V5LCBhY3RvcklkLCBhY3RvckVtYWlsXG5GUk9NIE5yQXVkaXRFdmVudCBXSEVSRSBhY3RvclR5cGUgPSAnYXBpX2tleScgU0lOQ0UgMSB3ZWVrIGFnbyIsInBvc2l0aW9uIjp7InN0YXJ0Ijp7ImxpbmUiOjk3LCJjb2x1bW4iOjEsIm9mZnNldCI6MzM5NX0sImVuZCI6eyJsaW5lIjoxMDEsImNvbHVtbiI6Mywib2Zmc2V0IjozNTc3fSwiaW5kZW50IjpbMSwxLDEsMV19fQ==\\"><code></code></pre>
       </div>
     </div>
     <div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJpZCIsInZhbHVlIjoic3ludGgtdXNlciJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiU3ludGhldGljczogV2hhdCBtb25pdG9ycyB3ZXJlIGNyZWF0ZWQgYnkgYSBzcGVjaWZpYyB1c2VyPyJ9XQ==\\">
       <div data-type=\\"prop\\" data-prop=\\"title\\">Synthetics: What monitors were created by a specific user?</div>
       <div data-type=\\"prop\\" data-prop=\\"children\\">
         <p>To query Synthetics monitor updates made by a specific user, include the <a href=\\"/attribute-dictionary/nrauditevent/actionidentifier\\"><code>actionIdentifier</code></a> and <a href=\\"/attribute-dictionary/nrauditevent/actoremail\\"><code>actorEmail</code></a> attribute in your query. For example:</p>
-        <pre data-type=\\"component\\" data-component=\\"CodeBlock\\" data-props=\\"eyJsYW5nIjpudWxsLCJtZXRhIjpudWxsLCJ2YWx1ZSI6IlNFTEVDVCBjb3VudCgqKSBGUk9NIE5yQXVkaXRFdmVudFxuV0hFUkUgYWN0aW9uSWRlbnRpZmllciA9ICdzeW50aGV0aWNzX21vbml0b3IudXBkYXRlX3NjcmlwdCdcbkZBQ0VUIGFjdG9yRW1haWwsIGFjdGlvbklkZW50aWZpZXIsIGRlc2NyaXB0aW9uXG5TSU5DRSAxIHdlZWsgYWdvIExJTUlUIDEwMDAiLCJwb3NpdGlvbiI6eyJzdGFydCI6eyJsaW5lIjoxMDksImNvbHVtbiI6MSwib2Zmc2V0IjozOTM0fSwiZW5kIjp7ImxpbmUiOjExNSwiY29sdW1uIjozLCJvZmZzZXQiOjQxMzh9LCJpbmRlbnQiOlsxLDEsMSwxLDEsMV19fQ==\\"><code></code></pre>
+        <pre data-type=\\"component\\" data-component=\\"CodeBlock\\" data-props=\\"eyJsYW5nIjpudWxsLCJtZXRhIjpudWxsLCJ2YWx1ZSI6IlNFTEVDVCBjb3VudCgqKSBGUk9NIE5yQXVkaXRFdmVudFxuV0hFUkUgYWN0aW9uSWRlbnRpZmllciA9ICdzeW50aGV0aWNzX21vbml0b3IudXBkYXRlX3NjcmlwdCdcbkZBQ0VUIGFjdG9yRW1haWwsIGFjdGlvbklkZW50aWZpZXIsIGRlc2NyaXB0aW9uXG5TSU5DRSAxIHdlZWsgYWdvIExJTUlUIDEwMDAiLCJwb3NpdGlvbiI6eyJzdGFydCI6eyJsaW5lIjoxMDksImNvbHVtbiI6MSwib2Zmc2V0IjozOTU1fSwiZW5kIjp7ImxpbmUiOjExNSwiY29sdW1uIjozLCJvZmZzZXQiOjQxNTl9LCJpbmRlbnQiOlsxLDEsMSwxLDEsMV19fQ==\\"><code></code></pre>
       </div>
     </div>
   </div>

--- a/scripts/actions/__tests__/kitchen-sink.mdx
+++ b/scripts/actions/__tests__/kitchen-sink.mdx
@@ -81,7 +81,7 @@ To instrument errors in transactions:
   </tbody>
 </Table>
 
-```
+```python copyable=false
 @newrelic.agent.lambda_handler()
 def handler(event, context):
     newrelic.agent.record_custom_event('CustomEvent', {'foo': 'bar'})

--- a/scripts/actions/deserialize-html.js
+++ b/scripts/actions/deserialize-html.js
@@ -76,6 +76,7 @@ const processor = unified()
       th: component,
       span: component,
       div: component,
+      pre: component,
       h1: headingWithCustomId,
       h2: headingWithCustomId,
       h3: headingWithCustomId,

--- a/scripts/actions/serialize-mdx.js
+++ b/scripts/actions/serialize-mdx.js
@@ -10,7 +10,7 @@ const html = require('rehype-stringify');
 const format = require('rehype-format');
 const customHeadingIds = require('../../plugins/gatsby-remark-custom-heading-ids/utils/visitor');
 
-const mdxToHTML = (h, node) => {
+const mdxElement = (h, node) => {
   const handler = handlers[node.name];
 
   if (!handler || !handler.serialize) {
@@ -33,8 +33,9 @@ const processor = unified()
     handlers: {
       import: handlers.import.serialize,
       yaml: handlers.frontmatter.serialize,
-      mdxSpanElement: mdxToHTML,
-      mdxBlockElement: mdxToHTML,
+      mdxSpanElement: mdxElement,
+      mdxBlockElement: mdxElement,
+      code: handlers.CodeBlock.serialize,
     },
   })
   .use(format)

--- a/scripts/actions/utils/handlers.js
+++ b/scripts/actions/utils/handlers.js
@@ -9,8 +9,22 @@ const {
 const yaml = require('js-yaml');
 const u = require('unist-builder');
 const toString = require('mdast-util-to-string');
+const { omit } = require('lodash');
 
 module.exports = {
+  CodeBlock: {
+    serialize: (h, node) =>
+      h(
+        node,
+        'pre',
+        {
+          'data-type': 'component',
+          'data-component': 'CodeBlock',
+          'data-props': serializeJSValue(omit(node, ['type'])),
+        },
+        [h(node, 'code')]
+      ),
+  },
   import: {
     deserialize: (h, node) => {
       const value = Buffer.from(node.properties.dataValue, 'base64').toString();

--- a/scripts/actions/utils/handlers.js
+++ b/scripts/actions/utils/handlers.js
@@ -24,6 +24,8 @@ module.exports = {
         },
         [h(node, 'code')]
       ),
+    deserialize: (h, node) =>
+      h(node, 'code', deserializeJSValue(node.properties.dataProps)),
   },
   import: {
     deserialize: (h, node) => {


### PR DESCRIPTION
## Description

Serializes code block content into an HTML attribute rather than leaving the text. This ensures that translators ignore the code in a code block as we do not want this translated.
