### PR TITLE
Update Alerts and AI link to point to actual page instead of 404

### DIFF
--- a/scripts/utils/migrate/instruction-set.js
+++ b/scripts/utils/migrate/instruction-set.js
@@ -379,6 +379,7 @@ module.exports = [
     path: ['Alerts and Applied intelligence'],
     node: {
       icon: 'nr-ai',
+      path: '/docs/alerts-applied-intelligence',
     },
   },
   {
@@ -527,5 +528,18 @@ module.exports = [
       path:
         '/docs/release-notes/agent-release-notes/nodejs-release-notes/current',
     },
+  },
+  {
+    type: INSTRUCTIONS.RENAME,
+    path: [
+      'Alerts and Applied Intelligence',
+      'Alerts and Applied Intelligence',
+    ],
+    title: 'Overview',
+  },
+  {
+    type: INSTRUCTIONS.REORDER,
+    path: ['Alerts and Applied Intelligence', 'Overview'],
+    index: 0,
   },
 ];

--- a/src/nav/alerts-and-applied-intelligence.yml
+++ b/src/nav/alerts-and-applied-intelligence.yml
@@ -1,7 +1,9 @@
 title: Alerts and Applied Intelligence
-path: /docs/alerts-and-applied-intelligence
+path: /docs/alerts-applied-intelligence
 icon: nr-ai
 pages:
+  - title: Overview
+    path: /docs/alerts-applied-intelligence
   - title: New Relic Alerts
     pages:
       - title: Get started
@@ -144,5 +146,3 @@ pages:
             path: /docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/enhance-notifications-incident-workflows
           - title: Custom variables
             path: /docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/custom-variables-incident-workflows
-  - title: Alerts and Applied Intelligence
-    path: /docs/alerts-applied-intelligence


### PR DESCRIPTION
Closes #584

## Description

Updates the migration instruction set to point the alerts and AI page to a real page instead of a 404 page.
