### PR TITLE
Fix intro paragraph

### DIFF
--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -14,9 +14,9 @@
   "home": {
     "title": "Welcome to New Relic",
     "intro": {
-      "p1": "If you're new, follow these three steps to create an account and get going (it's free!).",
-      "p2": "If you're catching up on the changes in New Relic One, start with <2>this transition guide</2> or check out <5>what's new</5>.",
-      "p3": "Scroll on for more about our Telemetry Data Platform, Full-Stack Observability, and Applied Intelligence. Or get a wider view of the platform with our<2>Intro to New Relic</2>."
+      "p1": "If you're new, follow these three steps to create an account and get going. (It's free!)",
+      "p2": "If you're catching up on the changes in New Relic One, start with this <2>transition guide</2>, or check out <4>what's new</4>.",
+      "p3": "Scroll on for more about our Telemetry Data Platform, Full-Stack Observability, and Applied Intelligence. Or, to get a wider view of our platform's capabilities, read the <2>Intro to New Relic</2>, and use our <5>solutions and best practices guides</5>."
     },
     "welcome": {
       "t1": {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -119,7 +119,6 @@ const HomePage = ({ data }) => {
       <Section alternate layout={layout}>
         <SectionTitle title={t('home.tdp.title')} icon="nr-tdp" />
         <SectionDescription>{t('home.tdp.description')}</SectionDescription>
-        <p>{t('home.tdp.t1.title')}</p>
         <DocTileGrid>
           {tdp.tiles.map((link, idx) => (
             <DocTile

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -50,19 +50,24 @@ const HomePage = ({ data }) => {
             <p>{t('home.intro.p1')}</p>
 
             <Trans i18nKey="home.intro.p2" parent="p">
-              If you're catching up on the changes in New Relic One, start with{' '}
+              If you're catching up on the changes in New Relic One, start with
+              this{' '}
               <Link to="/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-one-transition-guide-july-2020">
-                this transition guide
-              </Link>{' '}
-              or check out <Link to="/whats-new">what's new</Link>.
+                transition guide
+              </Link>
+              , or check out <Link to="/whats-new">what's new</Link>.
             </Trans>
 
             <Trans i18nKey="home.intro.p3" parent="p">
               Scroll on for more about our Telemetry Data Platform, Full-Stack
-              Observability, and Applied Intelligence. Or get a wider view of
-              the platform with our{' '}
+              Observability, and Applied Intelligence. Or, to get a wider view
+              of our platform's capabilities, read the{' '}
               <Link to="/docs/using-new-relic/welcome-new-relic/get-started/introduction-new-relic">
                 Intro to New Relic
+              </Link>
+              , and use our{' '}
+              <Link to="/docs/new-relic-solutions">
+                solutions and best practices guides
               </Link>
               .
             </Trans>


### PR DESCRIPTION
## Description

The intro paragraph on the homepage didn't include a space before the "Intro to New Relic" link. This PR updates the intro paragraphs to match the latest on the current docs site.
