### PR TITLE
Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,26 @@
-## Description
+<!-- If this PR addresses an open issue, add that here. Remember to remove this comment when updating to ensure the changes are seen in the PR description.
+Closes #<Issue number>
+-->
 
-Add a short description about the purpose of this PR here.
+# Description
 
+<!-- Add a short description about the purpose of this PR here. -->
+
+<!--
 ## Reviewer Notes
 
-If there are links or steps needed to test this work, add them here.
+If there are links or steps needed to test this work, add them here. Remove this
+section if there are no additional reviewer notes.
+-->
 
-## Related Issue(s) / Ticket(s)
-
-If there are any related [GitHub Issues](https://github.com/newrelic/docs-website/issues) or JIRA tickets, add links to them here.
-* [issue]()
-
+<!--
 ## Screenshot(s)
 
-If relevant, add screenshots here.
+If relevant, add screenshots here. Remove this section if there are no
+screenshots to share.
+-->
 
+<!--
 ## Use Conventional Commits
 
 Please help the maintainers by leveraging the following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
@@ -22,9 +28,9 @@ standards in your pull request title and commit messages.
 
 ## Use `chore`
 
-* for minor changes / additions / corrections to content.
-* for minor changes / additions / corrections to images.
-* for minor non-functional changes / additions to github actions, github templates, package or config updates, etc
+- for minor changes / additions / corrections to content.
+- for minor changes / additions / corrections to images.
+- for minor non-functional changes / additions to github actions, github templates, package or config updates, etc
 
 ```bash
 git commit -m "chore: adjusting config and content"
@@ -32,7 +38,7 @@ git commit -m "chore: adjusting config and content"
 
 ## Use `fix`
 
-* for minor functional corrections to code.
+- for minor functional corrections to code.
 
 ```bash
 git commit -m "fix: typo and prop error in the code of conduct"
@@ -40,8 +46,9 @@ git commit -m "fix: typo and prop error in the code of conduct"
 
 ## Use `feat`
 
-* for major functional changes or additions to code.
+- for major functional changes or additions to code.
 
 ```bash
 git commit -m "feat(media): creating a video landing page"
 ```
+-->


### PR DESCRIPTION
# Description

The PRs are noisy if a contributor forgets or doesn't remove sections when updating the PR description. This PR uses comments to hide sections of the template that we don't care about in PR descriptions. 