### PR TITLE
added page title and path

### DIFF
--- a/src/nav/attribute-dictionary.yml
+++ b/src/nav/attribute-dictionary.yml
@@ -1,5 +1,5 @@
 title: Attribute Dictionary
-path: /attribute-dictionary/
+path: /attribute-dictionary
 pages:
   - title: Events
-    path: /attribute-dictionary/
+    path: /attribute-dictionary

--- a/src/nav/attribute-dictionary.yml
+++ b/src/nav/attribute-dictionary.yml
@@ -1,2 +1,5 @@
 title: Attribute Dictionary
-path: /attribute-dictionary
+path: /attribute-dictionary/
+pages:
+  - title: Events
+    path: /attribute-dictionary/


### PR DESCRIPTION
this PR attempts to fix the issue with the `https://docs-preview.newrelic.com/attribute-dictionary`  not loading when a user clicks on Attributes Dictionary from the left nav by added a trailing slash.

Also the PR attempts to add a single navigation element for Events.

Both of these things aren't working at the moment.  