### PR TITLE
chore: removed docs migration count

### DIFF
--- a/src/announcements/beta-banner.mdx
+++ b/src/announcements/beta-banner.mdx
@@ -1,14 +1,10 @@
 ---
 startDate: 2020-09-24
-endDate: 2021-12-31
+endDate: 2021-03-03
 ---
-
-import data from '../data/count.json';
 
 # See the future of docs.newrelic.com!
 
 You're on the experimental version of our new docs site. We're moving the docs to the same open-source architecture as [developer.newrelic.com](https://developer.newrelic.com) and [opensource.newrelic.com](https://opensource.newrelic.com)—it'll be faster, more flexible, and open for your contributions. If you have feedback, [file an issue](https://github.com/newrelic/docs-website/issues) in our repo.
 
 This experimental version doesn't contain all our content, and not everything is stable. If you're looking to read our docs, go to [docs.newrelic.com](https://docs.newrelic.com).
-
-So far, we have migrated **{data.migratedCount}** out of **{data.totalCount}** content pages!


### PR DESCRIPTION
this PR removed the migration count from the announcement banner and also changed the end date until 3/3/21