### PR TITLE
Checks for empty file queue

### DIFF
--- a/scripts/actions/add-files-to-translation-queue.js
+++ b/scripts/actions/add-files-to-translation-queue.js
@@ -18,15 +18,19 @@ const getUpdatedQueue = async (url, queue) => {
   const files = await resp.json();
 
   const mdxFiles = files
-    .filter((file) => path.extname(file.filename) === '.mdx')
-    .reduce((files, file) => {
-      const contents = fs.readFileSync(path.join(process.cwd(), file.filename));
-      const { data } = frontmatter(contents);
+    ? files
+        .filter((file) => path.extname(file.filename) === '.mdx')
+        .reduce((files, file) => {
+          const contents = fs.readFileSync(
+            path.join(process.cwd(), file.filename)
+          );
+          const { data } = frontmatter(contents);
 
-      return data.translate && data.translate.length
-        ? [...files, { ...file, locales: data.translate }]
-        : files;
-    }, []);
+          return data.translate && data.translate.length
+            ? [...files, { ...file, locales: data.translate }]
+            : files;
+        }, [])
+    : [];
 
   const addedMdxFiles = mdxFiles
     .filter((f) => f.status !== 'removed')
@@ -44,10 +48,13 @@ const getUpdatedQueue = async (url, queue) => {
     .filter((f) => f.status === 'removed')
     .map(prop('filename'));
 
-  return Object.entries(queue)
+  const queueFiles =
+    Object.entries(queue).length === 0 ? Object.entries(queue) : [];
+
+  return queueFiles
     .map(([locale, files]) => [
       locale,
-      files.filter((f) => !removedMdxFileNames.includes(f)),
+      files ? files.filter((f) => !removedMdxFileNames.includes(f)) : [],
     ])
     .reduce(
       (acc, [locale, filenames]) => ({

--- a/scripts/actions/add-files-to-translation-queue.js
+++ b/scripts/actions/add-files-to-translation-queue.js
@@ -14,55 +14,61 @@ const { prop } = require('../utils/functional');
  * @returns {Promise<Object<string, string[]>>} An updated queue.
  */
 const getUpdatedQueue = async (url, queue) => {
-  const resp = await fetch(url);
-  const files = await resp.json();
+  try {
+    const resp = await fetch(url);
+    const files = await resp.json();
 
-  const mdxFiles = files
-    ? files
-        .filter((file) => path.extname(file.filename) === '.mdx')
-        .reduce((files, file) => {
-          const contents = fs.readFileSync(
-            path.join(process.cwd(), file.filename)
-          );
-          const { data } = frontmatter(contents);
+    const mdxFiles = files
+      ? files
+          .filter((file) => path.extname(file.filename) === '.mdx')
+          .reduce((files, file) => {
+            const contents = fs.readFileSync(
+              path.join(process.cwd(), file.filename)
+            );
+            const { data } = frontmatter(contents);
 
-          return data.translate && data.translate.length
-            ? [...files, { ...file, locales: data.translate }]
-            : files;
-        }, [])
-    : [];
+            return data.translate && data.translate.length
+              ? [...files, { ...file, locales: data.translate }]
+              : files;
+          }, [])
+      : [];
 
-  const addedMdxFiles = mdxFiles
-    .filter((f) => f.status !== 'removed')
-    .reduce((files, file) => {
-      return file.locales.reduce(
-        (acc, locale) => ({
+    const addedMdxFiles = mdxFiles
+      .filter((f) => f.status !== 'removed')
+      .reduce((files, file) => {
+        return file.locales.reduce(
+          (acc, locale) => ({
+            ...acc,
+            [locale]: [...(acc[locale] || []), file.filename],
+          }),
+          files
+        );
+      }, {});
+
+    const removedMdxFileNames = mdxFiles
+      .filter((f) => f.status === 'removed')
+      .map(prop('filename'));
+
+    const queueFiles =
+      Object.entries(queue).length === 0 ? Object.entries(queue) : [];
+
+    return queueFiles
+      .map(([locale, files]) => [
+        locale,
+        files ? files.filter((f) => !removedMdxFileNames.includes(f)) : [],
+      ])
+      .reduce(
+        (acc, [locale, filenames]) => ({
           ...acc,
-          [locale]: [...(acc[locale] || []), file.filename],
+          [locale]: filenames.concat(acc[locale] || []),
         }),
-        files
+        addedMdxFiles
       );
-    }, {});
-
-  const removedMdxFileNames = mdxFiles
-    .filter((f) => f.status === 'removed')
-    .map(prop('filename'));
-
-  const queueFiles =
-    Object.entries(queue).length === 0 ? Object.entries(queue) : [];
-
-  return queueFiles
-    .map(([locale, files]) => [
-      locale,
-      files ? files.filter((f) => !removedMdxFileNames.includes(f)) : [],
-    ])
-    .reduce(
-      (acc, [locale, filenames]) => ({
-        ...acc,
-        [locale]: filenames.concat(acc[locale] || []),
-      }),
-      addedMdxFiles
-    );
+  } catch (error) {
+    console.log(`[!] Unable to get updated queue`);
+    console.log(error);
+    process.exit(1);
+  }
 };
 
 /** Entrypoint. */


### PR DESCRIPTION
## Summary 
If there is an empty file queue, the slugs would not get updated and the job would not fail. This makes sure that the job fails and it also be able to get the updated queue when there's no files in the current queue. 