### PR TITLE
Enable incremental builds and fix gatsby cache for build

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,4 +1,7 @@
-version: 0.1
+version: 1
+env:
+  variables:
+    GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES: true
 frontend:
   phases:
     preBuild:
@@ -9,9 +12,9 @@ frontend:
       commands:
         - |
           if [ "${AWS_BRANCH}" = "main" ]; then
-            yarn run build:production;
+            yarn run build:production --log-pages;
           else
-            yarn run build:staging;
+            yarn run build:staging --log-pages;
           fi
   artifacts:
     baseDirectory: public
@@ -20,5 +23,5 @@ frontend:
   cache:
     paths:
       - node_modules/**/*
-      - gatsby/.cache/**/*
-      - gatsby/public/static/**/*
+      - .cache/**/*
+      - public/**/*


### PR DESCRIPTION
Closes #553

# Description

Enables Gatsby incremental builds on Amplify and fixes the Gatsby cache path
