### PR TITLE
Add learn more and getting started links to whats new posts

### DIFF
--- a/src/templates/whatsNew.js
+++ b/src/templates/whatsNew.js
@@ -5,6 +5,7 @@ import { graphql } from 'gatsby';
 import {
   Icon,
   Layout,
+  Link,
   MarkdownContainer,
   SEO,
 } from '@newrelic/gatsby-theme-newrelic';
@@ -12,9 +13,18 @@ import PageTitle from '../components/PageTitle';
 
 const WhatsNewTemplate = ({ data, location }) => {
   const {
+    site: {
+      siteMetadata: { siteUrl },
+    },
     markdownRemark: {
       html,
-      frontmatter: { title, summary, releaseDate },
+      frontmatter: {
+        title,
+        summary,
+        releaseDate,
+        learnMoreLink,
+        getStartedLink,
+      },
     },
   } = data;
 
@@ -55,18 +65,58 @@ const WhatsNewTemplate = ({ data, location }) => {
           />
           {releaseDate}
         </div>
-        <p
+        <div
           css={css`
             color: var(--secondary-text-color);
             font-size: 1.125rem;
             line-height: 1.75;
             padding-bottom: 1rem;
             border-bottom: 1px solid var(--divider-color);
-            margin-bottom: 1rem;
+
+            && {
+              margin-bottom: 1rem;
+            }
           `}
         >
-          {summary}
-        </p>
+          <p>{summary}</p>
+          {(learnMoreLink || getStartedLink) && (
+            <ul
+              css={css`
+                display: flex;
+                list-style: none;
+                margin: 0;
+                padding: 0;
+                font-size: 0.875rem;
+                gap: 1rem;
+
+                > li {
+                  margin: 0;
+                }
+
+                @supports not (gap: 1rem) {
+                  > li:not(:last-child) {
+                    margin-right: 1rem;
+                  }
+                }
+              `}
+            >
+              {learnMoreLink && (
+                <li>
+                  <MetaLink to={learnMoreLink} siteUrl={siteUrl}>
+                    Learn more
+                  </MetaLink>
+                </li>
+              )}
+              {getStartedLink && (
+                <li>
+                  <MetaLink to={getStartedLink} siteUrl={siteUrl}>
+                    Get started
+                  </MetaLink>
+                </li>
+              )}
+            </ul>
+          )}
+        </div>
       </div>
       <Layout.Content
         css={css`
@@ -86,17 +136,54 @@ WhatsNewTemplate.propTypes = {
 
 export const pageQuery = graphql`
   query($slug: String!, $locale: String) {
+    site {
+      siteMetadata {
+        siteUrl
+      }
+    }
     markdownRemark(fields: { slug: { eq: $slug } }) {
       html
       frontmatter {
         title
         releaseDate(formatString: "MMMM D, YYYY")
         summary
+        learnMoreLink
+        getStartedLink
       }
     }
 
     ...MainLayout_query
   }
 `;
+
+const MetaLink = ({ children, to, siteUrl }) => {
+  const isExternalLink = to.startsWith('http') && !to.startsWith(siteUrl);
+
+  return (
+    <Link
+      to={to}
+      css={css`
+        display: flex;
+        align-items: center;
+      `}
+    >
+      {children}{' '}
+      {isExternalLink && (
+        <Icon
+          name="fe-external-link"
+          css={css`
+            margin-left: 0.5rem;
+          `}
+        />
+      )}
+    </Link>
+  );
+};
+
+MetaLink.propTypes = {
+  children: PropTypes.node.isRequired,
+  to: PropTypes.string.isRequired,
+  siteUrl: PropTypes.string.isRequired,
+};
 
 export default WhatsNewTemplate;


### PR DESCRIPTION
Closes #671

# Description

Adds the learn more and getting started links to the whats new posts.

## Screenshots

<img width="1017" alt="Screen Shot 2021-01-29 at 12 10 19 PM" src="https://user-images.githubusercontent.com/565661/106322648-feec9c80-622a-11eb-9fb6-b70335f9e67b.png">
