### PR TITLE
Taxonomy Redirects

### DIFF
--- a/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
+++ b/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
@@ -3,10 +3,11 @@ const fromList = require('./utils/unist-fs-util-from-list');
 const visit = require('unist-util-visit');
 const generateHTML = require('./utils/generate-html');
 const { sentenceCase } = require('./utils/string');
+const taxonomyRedirects = require('../../src/data/taxonomy-redirects.json');
 
 exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
   const { skippedDirectories } = pluginOptions;
-  const { createPage } = actions;
+  const { createPage, createRedirect } = actions;
 
   const { data, errors } = await graphql(`
     query MyQuery {
@@ -129,6 +130,20 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
         fileRelativePath: null,
       },
     });
+
+    console.log(`Setup taxonomy redirects for ${slug}`);
+    Object.entries(taxonomyRedirects)
+      .filter(([to]) => to === slug)
+      .map(([_to, from]) => from)
+      .forEach((from) => {
+        console.log(`Redirect from ${from}`);
+        createRedirect({
+          fromPath: from,
+          toPath: slug,
+          isPermanent: true,
+          redirectInBrowser: true,
+        });
+      });
 
     locales.forEach(({ localizedPath }) => {
       const localizedSlug = path.join(`/${localizedPath}`, slug);

--- a/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
+++ b/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
@@ -134,10 +134,10 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
     const redirectsFrom = taxonomyRedirects.find(({ url }) => url === slug);
 
     if (redirectsFrom) {
-      console.log(`Setup taxonomy redirects for ${slug}`);
+      reporter.verbose(`Setup taxonomy redirects for ${slug}`);
 
       redirectsFrom.paths.forEach((from) => {
-        console.log(`\tRedirect from ${from}`);
+        reporter.verbose(`\tRedirect from ${from}`);
         createRedirect({
           fromPath: from,
           toPath: slug,

--- a/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
+++ b/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
@@ -131,12 +131,13 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
       },
     });
 
-    console.log(`Setup taxonomy redirects for ${slug}`);
-    Object.entries(taxonomyRedirects)
-      .filter(([to]) => to === slug)
-      .map(([_to, from]) => from)
-      .forEach((from) => {
-        console.log(`Redirect from ${from}`);
+    const redirectsFrom = taxonomyRedirects.find(({ url }) => url === slug);
+
+    if (redirectsFrom) {
+      console.log(`Setup taxonomy redirects for ${slug}`);
+
+      redirectsFrom.paths.forEach((from) => {
+        console.log(`\tRedirect from ${from}`);
         createRedirect({
           fromPath: from,
           toPath: slug,
@@ -144,6 +145,7 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
           redirectInBrowser: true,
         });
       });
+    }
 
     locales.forEach(({ localizedPath }) => {
       const localizedSlug = path.join(`/${localizedPath}`, slug);

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -236,7 +236,7 @@ const run = async () => {
     );
 
     logger.info('Writing taxonomy redirects');
-    writeTaxonomyRedirects(redirects);
+    await writeTaxonomyRedirects(redirects);
 
     logger.info('Saving changes to files');
     createDirectories(allDocsFiles);

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -32,6 +32,7 @@ const { fetchAllRedirects } = require('./utils/migrate/fetch-redirects');
 const fetchJpDocs = require('./utils/migrate/fetch-jp-docs');
 const createNavJpStructure = require('./utils/migrate/create-nav-jp-structure');
 const writeExternalRedirects = require('./utils/migrate/external-redirects');
+const writeTaxonomyRedirects = require('./utils/migrate/taxonomy-redirects');
 const { appendDummyRedirects } = require('./utils/migrate/redirects');
 
 const all = (list, fn) => Promise.all(list.map(fn));
@@ -96,7 +97,6 @@ const run = async () => {
     );
 
     logger.info('Fetching redirects');
-
     const redirects = await fetchAllRedirects();
 
     logger.info('Migrating docs');
@@ -234,6 +234,9 @@ const run = async () => {
           .map((file) => file.data.doc)
       )
     );
+
+    logger.info('Writing taxonomy redirects');
+    writeTaxonomyRedirects(redirects);
 
     logger.info('Saving changes to files');
     createDirectories(allDocsFiles);

--- a/scripts/utils/migrate/taxonomy-redirects.js
+++ b/scripts/utils/migrate/taxonomy-redirects.js
@@ -7,8 +7,8 @@ const DATA_FILE = 'src/data/taxonomy-redirects.json';
 /*
 TODO
   - [x] Get information about each taxonomy term (filepath)
-  - [ ] Store the index page path (not the taxonomy id) in the JSON
-  - [ ] Figure out how to add redirects at build time
+  - [x] Store the index page path (not the taxonomy id) in the JSON
+  - [x] Figure out how to add redirects at build time
 */
 
 /**

--- a/scripts/utils/migrate/taxonomy-redirects.js
+++ b/scripts/utils/migrate/taxonomy-redirects.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+
+const DATA_FILE = 'src/data/taxonomy-redirects.json';
+
+/*
+query for the taxonomy information (new resource in dupal)
+drupal = taxonomy
+  nested
+  SHOULD map to the file system (IA updates might mess with this)
+  Nah, IA should only impact nav
+gatsby = file system
+we will need to add the redirects at build time
+  this is when we create these index pages
+  we will need to know the redirects and the information about each term
+    URL / path
+    what will redirect to it
+we will need to save the information to the file system and check it in
+  this is not the most ergonomic setup for content creators
+  side-effect of making the index pages dynamic
+"/accounts/accounts/account-maintance": [
+    'from-page-1',
+    'from-page-2
+ ]
+ */
+
+module.exports = (redirects) => {
+  const taxonomyRedirects = Object.entries(redirects)
+    .filter(([url]) => url.startsWith('/taxonomy'))
+    .map(([url, paths]) => ({ url, paths }));
+
+  fs.writeFileSync(
+    DATA_FILE,
+    JSON.stringify(taxonomyRedirects, null, 2),
+    'utf-8'
+  );
+};

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -1,0 +1,3746 @@
+[
+  {
+    "url": "/taxonomy/term/6951",
+    "paths": [
+      "/docs/windows-server-monitoring/wsm-kb-100",
+      "/docs/windows-server-monitoring/windows-server-monitor-known-issues",
+      "/docs/windows-server-monitoring/wsm-kb-101",
+      "/docs/windows-server-monitoring/wsm-kb-102",
+      "/docs/server/server-monitor-known-issues",
+      "/docs/servers/new-relic-servers-linux/maintenance/server-monitor-known-issues",
+      "/docs/servers/new-relic-servers-linux/maintenance/servers-linux-known-issues",
+      "/docs/servers/new-relic-servers-linux/troubleshooting/servers-linux-known-issues",
+      "/node/6896",
+      "/docs/infrastructure/new-relic-infrastructure/troubleshooting",
+      "/docs/infrastructure/config-management-tools/troubleshooting",
+      "/docs/servers/new-relic-servers-linux/troubleshooting/missing-processes-servers-linux",
+      "/docs/servers/new-relic-servers-linux/troubleshooting/memory-cpu-or-version-settings-do-not-update-servers-linux",
+      "/docs/servers/new-relic-servers-linux/troubleshooting/incorrect-memory-usage-metrics-individual-processes-servers-linux",
+      "/docs/servers/new-relic-servers-linux/troubleshooting/cpu-version-settings-do-not-update-servers-linux",
+      "/docs/servers/new-relic-servers-linux/troubleshooting/missing-file-system-statistics-servers-linux",
+      "/docs/servers/new-relic-servers-linux/troubleshooting/missing-processes-new-relic-servers-linux",
+      "/docs/servers/new-relic-servers-windows/troubleshooting/environment-data-not-updating-servers-windows",
+      "/docs/servers/new-relic-servers-windows/troubleshooting/file-system-statistics-unavailable",
+      "/docs/servers/new-relic-servers-windows/troubleshooting/increase-cpu-utilization",
+      "/docs/servers/new-relic-servers-windows/troubleshooting/missing-process-performance-counters",
+      "/docs/servers/new-relic-servers-windows/troubleshooting/service-fails-run",
+      "/docs/servers/new-relic-servers-windows/troubleshooting/servers-windows-service-unexpectedly-ends-once-each-day",
+      "/docs/servers/new-relic-servers-linux/troubleshooting",
+      "/docs/servers/new-relic-servers-windows/troubleshooting",
+      "/docs/infrastructure/troubleshooting-0",
+      "/docs/infrastructure/troubleshooting",
+      "/docs/infrastructure/infrastructure-troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2176",
+    "paths": [
+      "/docs/rubicon/known-limitations",
+      "/docs/insights/known-limitations",
+      "/docs/insights/new-relic-insights/troubleshooting/known-limitations",
+      "/taxonomy/term/2181",
+      "/docs/insights/new-relic-insights"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2406",
+    "paths": [
+      "/docs/php/php-agent-faq",
+      "/docs/agents/php-agent/getting-started/new-relic-php-faqs",
+      "/node/1546"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6906",
+    "paths": [
+      "/docs/server/new-relic-for-server-monitoring",
+      "/docs/server",
+      "/docs/meatballs-table-contents",
+      "/docs/infrastructure-table-contents",
+      "/docs/infrastrcuture",
+      "/docs/servers/new-relic-servers/getting-started/new-relic-servers-new-relic-infrastructure",
+      "/docs/servers/new-relic-servers-linux/getting-started/new-relic-servers-linux",
+      "/docs/servers",
+      "/docs/servers/new-relic-servers",
+      "/docs/integrations/intro-integrations/get-started/infrastructure-monitoring",
+      "/docs/full-stack-observability/monitor-everything/observability-solutions/infrastructure-monitoring"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7111",
+    "paths": [
+      "/docs/php/the-php-api",
+      "/docs/php/php-agent-api",
+      "/node/12311",
+      "/docs/agents/php-agent/configuration/php-agent-api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7076",
+    "paths": [
+      "/docs/dotnet/AgentApi",
+      "/docs/dotnet/the-net-agent-api",
+      "/docs/dotnet/net-agent-api",
+      "/node/11661",
+      "/docs/agents/net-agent/features/net-agent-api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2451",
+    "paths": [
+      "/docs/python/python-web-frameworks",
+      "/docs/agents/python-agent/web-frameworks/python-web-frameworks"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2446",
+    "paths": [
+      "/docs/python/python-hosting-services",
+      "/docs/agents/python-agent/hosting-mechanisms/python-hosting-services",
+      "/docs/agents/python-agent/hosting-services/python-hosting-services"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2441",
+    "paths": [
+      "/docs/python/python-hosting-mechanisms",
+      "/docs/agents/python-agent/hosting-mechanisms/python-hosting-mechanisms",
+      "/docs/agents/python-agent/hosting-mechanisms",
+      "/docs/agents/python-agent/web-frameworksservers",
+      "/taxonomy/term/2451"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2456",
+    "paths": [
+      "/docs/python/python-backend-services",
+      "/docs/agents/python-agent/backend-services/python-backend-services",
+      "/docs/agents/python-agent/backend-services",
+      "/docs/agents/python-agent/backend-services/python-back-end-services",
+      "/docs/agents/python-agent/back-end-services/python-back-end-services"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8051",
+    "paths": [
+      "/docs/partnerships/engine-yard-using-new-relic",
+      "/docs/partnerships/engine-yard-users",
+      "/docs/partnerships/engine-yard-troubleshooting",
+      "/docs/accounts-partnerships/partnerships/engine-yard-and-new-relic/engine-yard-installing-new-relic",
+      "/docs/accounts-partnerships/partnerships/engine-yard-and-new-relic/engine-yard-using-new-relic",
+      "/docs/accounts-partnerships/partnerships/engine-yard-and-new-relic/engine-yard-troubleshooting-new",
+      "/docs/accounts-partnerships/partnerships/engine-yard-and-new-relic",
+      "/docs/accounts-partnerships/partnerships/engine-yard-new-relic",
+      "/docs/accounts-partnerships/partnerships/engine-yard-new-relic/engine-yard-installing-new-relic",
+      "/docs/accounts-partnerships/partnerships/engine-yard-new-relic/engine-yard-troubleshooting-new-relic",
+      "/docs/accounts-partnerships/partnerships/engine-yard-new-relic/engine-yard-using-new-relic",
+      "/docs/new-relic-partnerships/partnerships/engine-yard-new-relic/engine-yard-using-new-relic",
+      "/docs/accounts-partnerships/accounts/install-new-relic/partner-based-installation/engine-yard-install-new-relic",
+      "/docs/accounts-partnerships/install-new-relic/partner-based-installation",
+      "/docs/accounts-partnerships/install-new-relic/partner-based-installation/engine-yard-install-new-relic",
+      "/docs/accounts/install-new-relic/partner-based-installation/engine-yard-install-new-relic"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2906",
+    "paths": [
+      "/docs/platform/plugins-new-relic"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2911",
+    "paths": [
+      "/docs/platform/plugins-new-relic/getting-started",
+      "/docs/plugins/plugins-new-relic/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2916",
+    "paths": [
+      "/docs/platform/plugins-new-relic/installing-plugins",
+      "/docs/plugins/plugins-new-relic/installing-plugins"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2921",
+    "paths": [
+      "/docs/platform/plugins-new-relic/using-plugins"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2926",
+    "paths": [
+      "/docs/platform/plugins-new-relic/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2931",
+    "paths": [
+      "/docs/platform/developing-plugins",
+      "/docs/plugin-dev"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2951",
+    "paths": [
+      "/docs/platform/developing-plugins/writing-code"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2941",
+    "paths": [
+      "/docs/platform/developing-plugins/structuring-your-plugin"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2946",
+    "paths": [
+      "/docs/platform/developing-plugins/sharing-your-plugin"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2961",
+    "paths": [
+      "/docs/platform/developing-plugins/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3221",
+    "paths": [
+      "/docs/platform/plugin-developer-resources",
+      "/docs/plugin-developer-resources"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2936",
+    "paths": [
+      "/docs/platform/plugin-developer-resources/planning-your-plugin"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2956",
+    "paths": [
+      "/docs/platform/plugin-developer-resources/developer-reference"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3226",
+    "paths": [
+      "/docs/platform/plugin-developer-resources/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2136",
+    "paths": [
+      "/docs/partnerships",
+      "/docs/accounts-partnerships/partnerships"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3126",
+    "paths": [
+      "/docs/releases/java",
+      "/node/5336"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3131",
+    "paths": [
+      "/docs/releases/dotnet",
+      "/node/5341"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3136",
+    "paths": [
+      "/docs/releases/node",
+      "/node/5346"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3141",
+    "paths": [
+      "/docs/releases/php",
+      "/node/5351"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3146",
+    "paths": [
+      "/docs/releases/python",
+      "/node/5356",
+      "/docs/python/python-agent-release-notes"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3151",
+    "paths": [
+      "/docs/releases/ruby",
+      "/node/5361"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3156",
+    "paths": [
+      "/docs/releases/android",
+      "/node/5366"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3161",
+    "paths": [
+      "/docs/releases/ios",
+      "/node/5371"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3166",
+    "paths": [
+      "/docs/releases/titanium"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2111",
+    "paths": [
+      "/docs/subscriptions",
+      "/docs/accounts-partnerships/accounts",
+      "/docs/accounts/accounts/account-maintenance/update-your-new-relic-account",
+      "/docs/accounts/accounts"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2231",
+    "paths": [
+      "/docs/new-relic-browser",
+      "/docs/browser/new-relic-browser"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2261",
+    "paths": [
+      "/docs/java"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2306",
+    "paths": [
+      "/docs/dotnet"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2346",
+    "paths": [
+      "/docs/nodejs"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2376",
+    "paths": [
+      "/docs/php"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2416",
+    "paths": [
+      "/docs/python",
+      "/docs/python/python-web-applications"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2466",
+    "paths": [
+      "/docs/ruby",
+      "/docs/agents/ruby-agent/faqs/middleware-changes-390"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2531",
+    "paths": [
+      "/docs/site"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6401",
+    "paths": [
+      "/docs/features",
+      "/docs/apm/other-features",
+      "/docs/data-analysis/user-interface-functions"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2621",
+    "paths": [
+      "/docs/applications-menu",
+      "/docs/applications-dashboards",
+      "/docs/apm/applications-menu"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6101",
+    "paths": [
+      "/docs/transactions-menu",
+      "/docs/traces",
+      "/docs/apm/transactions-menu",
+      "/docs/apm/selected-transactions",
+      "/docs/apm/traces",
+      "/docs/apm/transactions/x-ray-sessions"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2691",
+    "paths": [
+      "/docs/dashboards-menu",
+      "/docs/apm/dashboards-menu"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2711",
+    "paths": [
+      "/docs/reports"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2741",
+    "paths": [
+      "/docs/alert-policies"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2826",
+    "paths": [
+      "/docs/mobile-monitoring-installation"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2851",
+    "paths": [
+      "/docs/mobile-monitoring-ui"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2871",
+    "paths": [
+      "/docs/mobile-sdk-api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3336",
+    "paths": [
+      "/docs/insights-ios-app",
+      "/docs/mobile-apps/insights-ios-app"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2806",
+    "paths": [
+      "/docs/new-relic-android-app"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3311",
+    "paths": [
+      "/docs/new-relic-ios-app"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2101",
+    "paths": [
+      "/docs/releases"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3066",
+    "paths": [
+      "/docs/nronly"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2316",
+    "paths": [
+      "/docs/agents/net-agent/installation-and-configuration",
+      "/docs/agents/net-agent/installation-configuration"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2426",
+    "paths": [
+      "/docs/agents/python-agent/installation-and-configuration",
+      "/docs/agents/python-agent/installation-configuration"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2436",
+    "paths": [
+      "/docs/agents/python-agent/customization-and-extension",
+      "/docs/agents/python-agent/customization-extension",
+      "/docs/agents/python-agent/api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3381",
+    "paths": [
+      "/docs/apm/apis/api-v2-examples"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2096",
+    "paths": [
+      "/docs/news"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2166",
+    "paths": [
+      "/docs/accounts-partnerships/partnerships/heroku-and-new-relic",
+      "/docs/accounts-partnerships/partnerships/heroku-new-relic"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2186",
+    "paths": [
+      "/docs/insights/new-relic-insights/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2196",
+    "paths": [
+      "/docs/insights/new-relic-insights/managing-dashboards-and-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2211",
+    "paths": [
+      "/docs/insights/new-relic-insights/adding-and-querying-data",
+      "/docs/insights/new-relic-insights/adding-querying-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5871",
+    "paths": [
+      "/docs/new-relic-synthetics/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5876",
+    "paths": [
+      "/docs/new-relic-synthetics/using-monitors"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5881",
+    "paths": [
+      "/docs/new-relic-synthetics/scripting-monitors"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5886",
+    "paths": [
+      "/docs/new-relic-synthetics/dashboards"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5891",
+    "paths": [
+      "/docs/new-relic-synthetics/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5896",
+    "paths": [
+      "/docs/new-relic-synthetics/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5866",
+    "paths": [
+      "/docs/new-relic-synthetics",
+      "/docs/full-stack-observability/monitor-everything/observability-solutions/synthetic-monitoring"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5901",
+    "paths": [
+      "/docs/new-relic-synthetics/new-relic-synthetics",
+      "/docs/synthetics/new-relic-synthetics"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5911",
+    "paths": [
+      "/docs/new-relic-synthetics/new-relic-synthetics/getting-started",
+      "/docs/synthetics/new-relic-synthetics/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5916",
+    "paths": [
+      "/docs/new-relic-synthetics/new-relic-synthetics/using-monitors",
+      "/docs/synthetics/new-relic-synthetics/using-monitors"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5921",
+    "paths": [
+      "/docs/new-relic-synthetics/new-relic-synthetics/scripting-monitors",
+      "/docs/synthetics/new-relic-synthetics/scripting-monitors"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5926",
+    "paths": [
+      "/docs/new-relic-synthetics/new-relic-synthetics/dashboards",
+      "/docs/synthetics/new-relic-synthetics/dashboards",
+      "/docs/synthetics/new-relic-synthetics/pages"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5931",
+    "paths": [
+      "/docs/new-relic-synthetics/new-relic-synthetics/troubleshooting",
+      "/docs/synthetics/new-relic-synthetics/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5936",
+    "paths": [
+      "/docs/new-relic-synthetics/new-relic-synthetics/miscellaneous",
+      "/docs/synthetics/new-relic-synthetics/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5971",
+    "paths": [
+      "/docs/alerts/alert-policies-v2",
+      "/docs/alerts/alert-policies-v3",
+      "/docs/alerts/new-relic-alerting",
+      "/docs/alerts/new-relic-alerts-beta"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5996",
+    "paths": [
+      "/docs/new-relic-only/drupal-configuration/drupal-methods-insights"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5976",
+    "paths": [
+      "/docs/alerts/alert-policies-v3/getting-started",
+      "/docs/alerts/new-relic-alerting/getting-started",
+      "/docs/alerts/new-relic-alerts-beta/getting-started",
+      "/docs/alerts/new-relic-alerts/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5981",
+    "paths": [
+      "/docs/alerts/alert-policies-v3/configuring-alert-policies",
+      "/docs/alerts/new-relic-alerting/configuring-alert-policies",
+      "/docs/alerts/new-relic-alerts-beta/configuring-alert-policies",
+      "/docs/alerts/new-relic-alerts/configuring-alert-policies"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5986",
+    "paths": [
+      "/docs/alerts/alert-policies-v3/managing-notification-channels",
+      "/docs/alerts/new-relic-alerting/managing-notification-channels",
+      "/docs/alerts/new-relic-alerts-beta/managing-notification-channels",
+      "/docs/alerts/new-relic-alerts/managing-notification-channels",
+      "/docs/alerts/new-relic-alerts/notifications"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5991",
+    "paths": [
+      "/docs/alerts/alert-policies-v3/reviewing-alert-incidents",
+      "/docs/alerts/new-relic-alerting/reviewing-alert-incidents",
+      "/docs/alerts/new-relic-alerts-beta/reviewing-alert-incidents",
+      "/docs/seymour/new-relic-seymour",
+      "/docs/seymour/new-relic-seymour/getting-started",
+      "/docs/radar/new-relic-radar",
+      "/docs/radar/new-relic-radar/getting-started",
+      "/taxonomy/term/7531",
+      "/taxonomy/term/7526",
+      "/docs/radar",
+      "/docs/using-new-relic/new-relic-radar/getting-started",
+      "/docs/using-new-relic/new-relic-radar",
+      "/docs/alerts/new-relic-alerts/reviewing-alert-incidents"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2651",
+    "paths": [
+      "/docs/apm/transactions-menu/key-transactions",
+      "/docs/apm/selected-transactions/key-transactions"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2681",
+    "paths": [
+      "/docs/apm/transactions-menu/x-ray-sessions",
+      "/docs/apm/transactions/transaction-traces",
+      "/docs/apm/traces/transaction-traces",
+      "/docs/apm/selected-transactions/x-ray-sessions",
+      "/taxonomy/term/2656"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2661",
+    "paths": [
+      "/docs/apm/transactions-menu/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6071",
+    "paths": [
+      "/docs/browser/new-relic-browser/torubleshooting",
+      "/docs/browser/new-relic-browser/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6086",
+    "paths": [
+      "/docs/insights/new-relic-insights/data-apps-0"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7276",
+    "paths": [
+      "/docs/browser/new-relic-browser/browser-agent-apis/browser-agent-api",
+      "/docs/browser/new-relic-browser/browser-agent-apis/reporting-data-events-browser-agent-api",
+      "/docs/browser/new-relic-browser/browser-agent-apis/new-relic-single-page-app-monitoring-api",
+      "/docs/browser/new-relic-browser/browser-agent-apis/new-relic-spa-api",
+      "/docs/browser/new-relic-browser/browser-agent-apis/javascript-api-deprecated",
+      "/docs/features/manually-reporting-page-load-timing-data",
+      "/docs/features/monitoring-flash-apps-with-rum",
+      "/docs/new-relic-browser/manually-reporting-page-load-timing-data",
+      "/docs/browser/new-relic-browser/browser-agent-apis/manually-reporting-page-load-timing-data",
+      "/docs/browser/new-relic-browser/browser-agent-api",
+      "/docs/browser/new-relic-browser/browser-agent-apis/report-data-events-browser-agent-api",
+      "/node/9886",
+      "/docs/browser/single-page-app-monitoring/spa-api/spa-api",
+      "/taxonomy/term/3366",
+      "/docs/browser/new-relic-browser/browser-agent-apis",
+      "/docs/browser/new-relic-browser/browser-agent-spa-api/view-all-methods",
+      "/docs/browser/new-relic-browser/browser-agent-spa-api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6281",
+    "paths": [
+      "/docs/apis/rest-api-v1",
+      "/docs/apm/apis/new-relic-rest-api-v1"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6231",
+    "paths": [
+      "/docs/apm/apis/server-examples-v2"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6246",
+    "paths": [
+      "/docs/apm/apis/plugin-examples-v2"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6271",
+    "paths": [
+      "/apm/apis"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6216",
+    "paths": [
+      "/docs/apm/apis/api-explorer-v2"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6221",
+    "paths": [
+      "/docs/apm/apis/application-examples-v2"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6226",
+    "paths": [
+      "/docs/apm/apis/browser-examples-v2"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6236",
+    "paths": [
+      "/docs/apm/apis/alert-examples-v2",
+      "/docs/apis/rest-api-v2/alert-examples-v2"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6241",
+    "paths": [
+      "/docs/apm/apis/labels-examples-v2"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6181",
+    "paths": [
+      "/docs/accounts-partnerships/partner-integration-guide/account-maintenance",
+      "/docs/accounts-partnerships/partner-integration-guide/partner-account-maintenance"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2356",
+    "paths": [
+      "/docs/agents/nodejs-agent/installation-and-configuration"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2476",
+    "paths": [
+      "/docs/agents/ruby-agent/installation-and-configuration",
+      "/docs/agents/ruby-agent/installation-configuration"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9821",
+    "paths": [
+      "/docs/servers/new-relic-servers-windows/installation-and-configuration",
+      "/docs/infrastructure/install-configure-infrastructure/windows-installation",
+      "/docs/install-configure-infrastructure/windows-installation",
+      "/docs/infrastructure/install-configure-manage-infrastructure/windows-installation",
+      "/docs/infrastructure/install-configure-manage-infrastructure-agent/windows-installation"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2696",
+    "paths": [
+      "/docs/apm/dashboards-menu/custom-dashboards",
+      "/docs/dashboards/custom-dashboards"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2701",
+    "paths": [
+      "/docs/apm/dashboards-menu/legacy-custom-dashboards",
+      "/docs/dashboards/legacy-custom-dashboards"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2706",
+    "paths": [
+      "/docs/apm/dashboards-menu/miscellaneous",
+      "/docs/dashboards/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5766",
+    "paths": [
+      "/docs/accounts-partnerships/education/finding-help",
+      "/docs/accounts-partnerships/education/getting-started-new-relic",
+      "/docs/accounts/education/getting-started-new-relic"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2856",
+    "paths": [
+      "/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-dashboards"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3391",
+    "paths": [
+      "/docs/mobile-monitoring/mobile-monitoring-ui/network-dashboards"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2861",
+    "paths": [
+      "/docs/mobile-monitoring/mobile-monitoring-ui/usage-dashboards"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6946",
+    "paths": [
+      "/docs/servers/servers-dashboards",
+      "/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages",
+      "/docs/infrastructure/config-management-tools/infrastructure-ui-pages",
+      "/docs/servers/servers-dashboards/servers-ui",
+      "/docs/servers/servers-pages",
+      "/docs/servers/servers-pages/servers-ui",
+      "/docs/infrastructure/new-relic-infrastructure/infra-ui-pages",
+      "/docs/infrastructure/infrastructure-ui-pages/infra-ui-pages",
+      "/docs/infrastructure/infrastructure-ui-pages/infrastructure-ui",
+      "/docs/infrastructure/infrastructure-ui-pages/hosts-page"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6576",
+    "paths": [
+      "/docs/agents/manage-apm-agents/application-naming"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6541",
+    "paths": [
+      "/docs/apm/new-relic-apm/installation-and-configuration"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6581",
+    "paths": [
+      "/docs/agents/manage-apm-agents/metrics",
+      "/docs/agents/manage-apm-agents/agent-metrics"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6481",
+    "paths": [
+      "/node/9416"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5451",
+    "paths": [
+      "/docs/agents/nodejs-agent/getting-started/known-nodejs-limitations",
+      "/docs/nodejs/known-nodejs-limitations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2331",
+    "paths": [
+      "/docs/agents/net-agent/installation-configuration/known-issues-net"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6441",
+    "paths": [
+      "/docs/accounts-partnerships/accounts/account-usage",
+      "/docs/accounts-partnerships/accounts/account-billing-usage"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6136",
+    "paths": [
+      "/docs/licenses/new-relic-products/new-relic-alerts",
+      "/docs/licenses/new-relic-products/new-relic-alerts-licenses"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6711",
+    "paths": [
+      "/docs/mobile-monitoring/new-relic-mobile-android/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6691",
+    "paths": [
+      "/docs/mobile-monitoring/new-relic-mobile-ios/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6671",
+    "paths": [
+      "/docs/mobile-monitoring/new-relic-mobile/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6631",
+    "paths": [
+      "/docs/mobile-monitoring/mobile-monitoring-installation/legacy",
+      "/docs/legacy"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2866",
+    "paths": [
+      "/docs/mobile-monitoring/mobile-monitoring-uii/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2321",
+    "paths": [
+      "/docs/agents/net-agent/azure-installation/azure-virtual-machines"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6771",
+    "paths": [
+      "/docs/browser/spa"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6801",
+    "paths": [
+      "/docs/browser/single-page-app-monitoring/browser-ui"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6816",
+    "paths": [
+      "/docs/agents/go-agent",
+      "/docs/go-agent"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6821",
+    "paths": [
+      "/docs/agents/go-agent/get-started",
+      "/docs/go-agent/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6841",
+    "paths": [
+      "/docs/installation-configuration",
+      "/docs/agents/go-agent/installation-configuration"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6856",
+    "paths": [
+      "/docs/release-notes/browser-agent-release-notes"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6861",
+    "paths": [
+      "/node/10486"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6846",
+    "paths": [
+      "/docs/agents/go-agent/get-started/go-agent-release-notes"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6971",
+    "paths": [
+      "/docs/infrastructure-pro-table-contents",
+      "/docs/infrastructure-integrations-table-contents",
+      "/docs/infrastructure/infrastructure-integrations",
+      "/docs/infrastructure/integrations/integrations/amazonaws-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6901",
+    "paths": [
+      "/docs/alerts/new-relic-alerts/getting-started/new-relic-alerts-release-notes"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2146",
+    "paths": [
+      "/docs/accounts-partnerships/partnerships/partner-integration-guide",
+      "/docs/accounts-partnerships/partnerships/former-partner-integration-guide"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2671",
+    "paths": [
+      "/docs/apm/traces/browser-traces"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2676",
+    "paths": [
+      "/docs/apm/traces/cross-application-traces"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9786",
+    "paths": [
+      "/docs/infrastructure-installation",
+      "/docs/infrastructure/new-relic-infrastructure/installation",
+      "/docs/infrastructure/install-configure",
+      "/docs/infrastructure/install-configure-infrastructure/installation",
+      "/docs/infrastructure/install-configure-infrastructure",
+      "/docs/install-configure-infrastructure",
+      "/docs/full-stack-observability/instrument-everything/instrument-applications-infrastructure/infrastructure-agent",
+      "/docs/infrastructure/install-configure-manage-infrastructure",
+      "/docs/infrastructure/install-configure-manage-infrastructure-agent"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6941",
+    "paths": [
+      "/docs/infrastructure/new-relic-infrastructure/scope-filter",
+      "/docs/infrastructure/new-relic-infrastructure/filter-group",
+      "/docs/infrastructure/config-management-tools/filter-group"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6961",
+    "paths": [
+      "/docs/infrastructure/new-relic-infrastructure/miscellaneous",
+      "/docs/infrastructure/new-relic-infrastructure/config-management-tools",
+      "/docs/infrastructure/install-configure-infrastructure/config-management-tools",
+      "/docs/install-configure-infrastructure/config-management-tools",
+      "/docs/infrastructure/install-configure-manage-infrastructure/config-management-tools",
+      "/docs/infrastructure/install-configure-manage-infrastructure-agent/config-management-tools"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6911",
+    "paths": [
+      "/docs/infrastructure/new-relic-infrastructure",
+      "/docs/infrastructure/config-management-tools"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6916",
+    "paths": [
+      "/docs/infrastructure/new-relic-infrastructure/getting-started",
+      "/docs/infrastructure/config-management-tools/getting-started",
+      "/docs/infrastructure/new-relic-infrastructure/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6926",
+    "paths": [
+      "/docs/infrastructure/new-relic-infrastructure/configuration",
+      "/docs/infrastructure/config-management-tools/configuration",
+      "/docs/infrastructure/install-configure-infrastructure/configuration",
+      "/docs/install-configure-infrastructure/configuration",
+      "/docs/infrastructure/install-configure-manage-infrastructure/configuration",
+      "/docs/infrastructure/install-configure-manage-infrastructure-agent/configuration"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6936",
+    "paths": [
+      "/docs/infrastructure/new-relic-infrastructure/data-instrumentation",
+      "/docs/infrastructure/config-management-tools/data-instrumentation"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6931",
+    "paths": [
+      "/docs/infrastructure/new-relic-infrastructure/share-charts",
+      "/docs/infrastructure/config-management-tools/share-charts"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6921",
+    "paths": [
+      "/docs/infrastructure/config-management-tools/installation",
+      "/docs/servers/new-relic-servers-linux/installation-configuration",
+      "/docs/infrastructure/install-configure-infrastructure/linux-installation",
+      "/docs/install-configure-infrastructure/linux-installation",
+      "/docs/infrastructure/install-configure-manage-infrastructure/linux-installation",
+      "/docs/infrastructure/install-configure-manage-infrastructure-agent/linux-installation"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6956",
+    "paths": [
+      "/docs/infrastructure/config-management-tools/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6096",
+    "paths": [
+      "/docs/alerts/new-relic-alerts-beta/reviewing-events"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6991",
+    "paths": [
+      "/docs/dashboards",
+      "/docs/dashboards/new-relic-dashboards"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6996",
+    "paths": [
+      "/docs/dashboards/new-relic-dashboards/custom-dashboards"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7001",
+    "paths": [
+      "/docs/dashboards/new-relic-dashboards/legacy-custom-dashboards"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7006",
+    "paths": [
+      "/docs/dashboards/new-relic-dashboards/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7021",
+    "paths": [
+      "/docs/alerts/new-relic-alerts/rest-api-alerts",
+      "/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7026",
+    "paths": [
+      "/docs/alerts/alert-policies/rest-api-alert-policies"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2736",
+    "paths": [
+      "/docs/alerts/alert-policies",
+      "/docs/alerts/new-relic-alerts/getting-started/transition-legacy-alerting-new-relic-alerts",
+      "/docs/alerts/new-relic-alerts-beta/getting-started/converting-new-relic-alerts-v2-v3",
+      "/docs/alerts/new-relic-alerts-beta/getting-started/convert-new-relic-alerts-v2-v3",
+      "/docs/alerts/new-relic-alerts-beta/getting-started/convert-legacy-alerting-new-relic-alerts",
+      "/docs/alerts/new-relic-alerts/getting-started/access-new-relic-alerts-legacy-alerting",
+      "/docs/alerts/new-relic-alerts-beta/getting-started/known-alerting-limitations-v3",
+      "/docs/alerts/new-relic-alerts-beta/getting-started/known-limitations-new-relic-alerts",
+      "/docs/alerts/new-relic-alerts/getting-started/known-limitations-new-relic-alerts",
+      "/docs/alerts/new-relic-alerts/getting-started/access-alerting-systems-new-relic",
+      "/docs/alerts/new-relic-alerts-0",
+      "/docs/alerts"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7036",
+    "paths": [
+      "/node/11376"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2486",
+    "paths": [
+      "/docs/agents/ruby-agent/frameworks"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7121",
+    "paths": [
+      "/docs/agents/go-agent/other"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7196",
+    "paths": [
+      "/docs/agents/java-agent/features-ui"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7211",
+    "paths": [
+      "/docs/insights/nrql-new-relic-query-language/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7231",
+    "paths": [
+      "/docs/insights/explore-data/data-explorer",
+      "/docs/insights/explore-data/data-explorer-ui"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7216",
+    "paths": [
+      "/docs/insights/nrql-new-relic-query-language/nrql-resources"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7246",
+    "paths": [
+      "/docs/insights/explore-data/attributes",
+      "/docs/insights/explore-data/default-attributes",
+      "/docs/insights/explore-add-data/default-attributes",
+      "/docs/insights/insights-data-sources/default-attributes",
+      "/docs/insights/insights-data-sources/default-events-attributes",
+      "/docs/insights/insights-data-sources/default-events-attributes-landing-page-1",
+      "/docs/insights/explore-data/attributes/insights-attributes-data-new-relic-products",
+      "/docs/insights/insights-data-sources/default-data",
+      "/docs/insights/event-data-sources/default-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7261",
+    "paths": [
+      "/docs/insights/export-insights-data/insights-rest-api",
+      "/docs/insights/export-insights-data/export-api",
+      "/docs/insights/insights-api/export-api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7166",
+    "paths": [
+      "/docs/insights/using-insights-ui"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7171",
+    "paths": [
+      "/docs/insights/using-insights-ui/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7176",
+    "paths": [
+      "/docs/insights/using-insights-ui/basic-ui-tasks"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7181",
+    "paths": [
+      "/docs/insights/using-insights-ui/advanced-ui-tasks"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7266",
+    "paths": [
+      "/docs/insights/using-insights-ui/filter-segment"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7271",
+    "paths": [
+      "/docs/insights/using-insights-ui/time-settings"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7226",
+    "paths": [
+      "/docs/insights/explore-data",
+      "/docs/insights/explore-add-data",
+      "/taxonomy/term/7251",
+      "/docs/insights/new-relic-insights/custom-events",
+      "/docs/insights/basic-attributes",
+      "/docs/insights/insights-data-sources"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7241",
+    "paths": [
+      "/docs/insights/explore-data/custom-events",
+      "/docs/insights/explore-add-data/custom-events",
+      "/docs/insights/insights-data-sources/custom-events",
+      "/docs/insights/new-relic-insights/decorating-events/insights-attributes",
+      "/docs/insights/insights-data-sources/custom-data",
+      "/docs/insights/event-data-sources/custom-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7251",
+    "paths": [
+      "/docs/insights/explore-data/custom-attributes",
+      "/docs/insights/explore-add-data/custom-attributes"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6966",
+    "paths": [
+      "/docs/licenses/new-relic-products/new-relic-infrastructure-licenses",
+      "/docs/licenses/new-relic-products/new-relic-infrastructure"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7316",
+    "paths": [
+      "/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/view-all-methods"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7151",
+    "paths": [
+      "/docs/mobile-monitoring/new-relic-mobile-cordova-phonegap"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6661",
+    "paths": [
+      "/docs/mobile-monitoring/new-relic-mobile-apps/insights-app/insights-tvos-release-notes",
+      "/docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-tvos-release-notes"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6636",
+    "paths": [
+      "/docs/mobile-monitoring/new-relic-mobile-apps/insights-app/insights-android-release-notes",
+      "/docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-android-release-notes"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6316",
+    "paths": [
+      "/docs/mobile-monitoring/new-relic-mobile-apps/insights-app/insights-ios-release-notes",
+      "/docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-ios-release-notes"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2526",
+    "paths": [
+      "/docs/reports/publicizing-your-rankings",
+      "/docs/full-stack-observability/monitor-everything/observability-solutions/application-monitoring-apm"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2326",
+    "paths": [
+      "/docs/agents/net-agent/features"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5096",
+    "paths": [
+      "/docs/servers/servers-dashboards/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6976",
+    "paths": [
+      "/docs/infrastructure/infrastructure-integrations/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6981",
+    "paths": [
+      "/docs/infrastructure/infrastructure-integrations/amazon-integrations",
+      "/node/13796",
+      "/docs/infrastructure/new-relic-infrastructure/integrations/aws-integrations",
+      "/docs/infrastructure/amazon-integrations/amazon-integrations",
+      "/docs/infrastructure/amazon-integrations/aws-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7356",
+    "paths": [
+      "/docs/infrastructure/infrastructure-integrations/custom-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6986",
+    "paths": [
+      "/docs/infrastructure/infrastructure-integrations/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7436",
+    "paths": [
+      "/docs/infrastructure/integrations-sdk/integration-building-tools",
+      "/docs/infrastructure/integrations-sdk/tools-resources"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7431",
+    "paths": [
+      "/docs/infrastructure/integrations-sdk/filedata-specifications"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7486",
+    "paths": [
+      "/docs/data-apps"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7471",
+    "paths": [
+      "/docs/explore-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7476",
+    "paths": [
+      "/docs/export-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7466",
+    "paths": [
+      "/docs/manage-account-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7481",
+    "paths": [
+      "/docs/manage-dashboards"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7206",
+    "paths": [
+      "/docs/insights/export-insights-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5836",
+    "paths": [
+      "/docs/browser/new-relic-browser/installation-configuration",
+      "/docs/browser/new-relic-browser/installation"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6121",
+    "paths": [
+      "/docs/licenses/license-information/new-relic-insights-licenses",
+      "/docs/licenses/new-relic-products/new-relic-insights"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6111",
+    "paths": [
+      "/docs/licenses/license-information/new-relic-browser-licenses",
+      "/docs/licenses/new-relic-products/new-relic-browser"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6126",
+    "paths": [
+      "/docs/licenses/license-information/new-relic-plugins-licenses",
+      "/docs/licenses/new-relic-products/new-relic-plugins"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3051",
+    "paths": [
+      "/docs/licenses/license-information/new-relic-server-licenses"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6116",
+    "paths": [
+      "/docs/licenses/license-information/new-relic-synthetics-licenses",
+      "/docs/licenses/new-relic-products/new-relic-synthetics"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3261",
+    "paths": [
+      "/docs/new-relic-only/drupal-configuration/users-and-roles"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3256",
+    "paths": [
+      "/docs/new-relic-only/drupal-configuration/taxonomy"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7451",
+    "paths": [
+      "/docs/infrastructure/integrations/get-started",
+      "/docs/infrastructure/integrations/getting-started",
+      "/docs/infrastructure/integrations-getting-started/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7426",
+    "paths": [
+      "/docs/infrastructure/integrations-sdk/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2801",
+    "paths": [
+      "/docs/mobile",
+      "/docs/integrations/intro-integrations/get-started/mobile-monitoring",
+      "/docs/full-stack-observability/monitor-everything/observability-solutions/mobile-monitoring"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7536",
+    "paths": [
+      "/node/13901",
+      "/docs/adduserattribute-python-agent-api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7541",
+    "paths": [
+      "/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/view-all-methods"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7281",
+    "paths": [
+      "/docs/agents/java-agent/java-agent-api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5541",
+    "paths": [
+      "/docs/agents/net-agent/instrumentation",
+      "/docs/agents/net-agent/additional-installation",
+      "/docs/agents/net-agent/install-guides"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7676",
+    "paths": [
+      "/docs/infrastructure/azure-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7681",
+    "paths": [
+      "/docs/infrastructure/azure-integrations/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7696",
+    "paths": [
+      "/node/14171",
+      "/docs/infrastructure/new-relic-infrastructure/integrations/azure-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7446",
+    "paths": [
+      "/docs/infrastructure/integrations",
+      "/docs/infrastructure/integrations-getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7456",
+    "paths": [
+      "/docs/infrastructure/integrations/integrations",
+      "/docs/infrastructure/integrations-getting-started/integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7461",
+    "paths": [
+      "/docs/infrastructure/integrations/use-integration-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7716",
+    "paths": [
+      "/docs/infrastructure/integrations-getting-started/integrations/host-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7721",
+    "paths": [
+      "/docs/infrastructure/host-integrations/find-use-data",
+      "/docs/infrastructure/host-integrations/use-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7726",
+    "paths": [
+      "/docs/infrastructure/amazon-integrations/find-use-data",
+      "/docs/infrastructure/amazon-integrations/use-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7731",
+    "paths": [
+      "/docs/infrastructure/microsoft-azure-integrations/find-use-data",
+      "/docs/infrastructure/microsoft-azure-integrations/use-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7326",
+    "paths": [
+      "/docs/insights/nrql-new-relic-query-language/troubleshooting",
+      "/docs/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6686",
+    "paths": [
+      "/docs/mobile-monitoring/new-relic-mobile-ios/install-configure"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6871",
+    "paths": [
+      "/docs/new-relic-only/basic-style-guide/basic-style-guide"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7836",
+    "paths": [
+      "/docs/integrations/getting-started",
+      "/docs/integrations/new-relic-integrations",
+      "/docs/kubernetes-integration/new-relic-integrations",
+      "/docs/infrastructure-integrations/new-relic-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7861",
+    "paths": [
+      "/docs/integrations/getting-started/getting-started",
+      "/docs/integrations/new-relic-integrations/getting-started",
+      "/docs/kubernetes-integration/new-relic-integrations/getting-started",
+      "/docs/integrations/new-relic-integrations/get-started",
+      "/docs/infrastructure-integrations/new-relic-integrations/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2141",
+    "paths": [
+      "/docs/accounts-partnerships/partnerships/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2156",
+    "paths": [
+      "/docs/accounts-partnerships/partnerships/partner-based-installation",
+      "/docs/new-relic-partnerships/partnerships/partner-based-installation",
+      "/docs/accounts-partnerships/partner-based-installation",
+      "/docs/accounts-partnerships/accounts/install-new-relic/partner-based-installation",
+      "/docs/accounts/accounts-partnerships/install-new-relic/partner-based-installation"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7611",
+    "paths": [
+      "/docs/accounts-partnerships/partnerships/google-cloud-platform-gcp"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2151",
+    "paths": [
+      "/docs/accounts-partnerships/partnerships/partner-api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2171",
+    "paths": [
+      "/docs/accounts-partnerships/partnerships/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6171",
+    "paths": [
+      "/docs/accounts-partnerships/partner-integration-guide"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6176",
+    "paths": [
+      "/docs/accounts-partnerships/partner-integration-guide/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6191",
+    "paths": [
+      "/docs/accounts-partnerships/partner-integration-guide/partner-apis"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6196",
+    "paths": [
+      "/docs/accounts-partnerships/partner-integration-guide/new-relic-products-features"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6201",
+    "paths": [
+      "/docs/accounts-partnerships/partner-integration-guide/appendix"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6291",
+    "paths": [
+      "/docs/accounts-partnerships/partner-integration-guide/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5771",
+    "paths": [
+      "/docs/accounts-partnerships/education/new-relic-university",
+      "/docs/accounts-partnerships/accounts/install-new-relic/new-relic-university",
+      "/docs/accounts/accounts-partnerships/install-new-relic/new-relic-university"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7956",
+    "paths": [
+      "/docs/accounts-partnerships/getting-started-new-relic",
+      "/docs/accounts-partnerships/getting-started",
+      "/docs/accounts-partnerships/welcome-new-relic/getting-started",
+      "/docs/using-new-relic/welcome-new-relic/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3421",
+    "paths": [
+      "/docs/accounts-partnerships/accounts/security",
+      "/docs/accounts-partnerships/welcome-new-relic/security",
+      "/docs/accounts-partnerships/new-relic-security/security",
+      "/docs/using-new-relic/new-relic-security/security",
+      "/docs/using-new-relic/new-relic-security/data-privacy",
+      "/docs/security/new-relic-security/data-privacy",
+      "/docs/security/data-privacy"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7061",
+    "paths": [
+      "/docs/accounts-partnerships/accounts/security-bulletins",
+      "/docs/accounts-partnerships/welcome-new-relic/security-bulletins",
+      "/docs/accounts-partnerships/new-relic-security/security-bulletins",
+      "/docs/using-new-relic/new-relic-security/security-bulletins",
+      "/docs/security/new-relic-security/security-bulletins",
+      "/docs/security/security-bulletins"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6021",
+    "paths": [
+      "/docs/new-relic-only/advanced-style-guide"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6031",
+    "paths": [
+      "/docs/new-relic-only/advanced-style-guide/writing-guidelines",
+      "/docs/new-relic-only/tech-writer-style-guide/writing-guidelines"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6036",
+    "paths": [
+      "/docs/new-relic-only/advanced-style-guide/processes-procedures"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6041",
+    "paths": [
+      "/docs/new-relic-only/advanced-style-guide/design-specifications"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6046",
+    "paths": [
+      "/docs/new-relic-only/advanced-style-guide/article-templates"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6051",
+    "paths": [
+      "/docs/new-relic-only/advanced-style-guide/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7921",
+    "paths": [
+      "/taxonomy/term/6981",
+      "/docs/infrastructure/amazon-integrations/aws-integrations-list",
+      "/docs/integrations/amazon-integrations/aws-integrations-list",
+      "/docs/kubernetes-integration/amazon-integrations/aws-integrations-list",
+      "/docs/integrations/new-relic-integrations/cloud-integrations/aws-integrations",
+      "/docs/infrastructure-integrations/amazon-integrations/aws-integrations-list"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7846",
+    "paths": [
+      "/taxonomy/term/6971",
+      "/docs/infrastructure/amazon-integrations",
+      "/docs/integrations/amazon-integrations",
+      "/docs/kubernetes-integration/amazon-integrations",
+      "/docs/infrastructure-integrations/amazon-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7906",
+    "paths": [
+      "/taxonomy/term/6986",
+      "/docs/integrations/amazon-integrations/troubleshooting",
+      "/docs/kubernetes-integration/amazon-integrations/troubleshooting",
+      "/docs/infrastructure-integrations/amazon-integrations/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7871",
+    "paths": [
+      "/taxonomy/term/6976",
+      "/docs/integrations/amazon-integrations/getting-started",
+      "/docs/integrations/amazon-integrations/get-started",
+      "/docs/kubernetes-integration/amazon-integrations/get-started",
+      "/docs/infrastructure-integrations/amazon-integrations/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7926",
+    "paths": [
+      "/taxonomy/term/7696",
+      "/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list",
+      "/docs/integrations/microsoft-azure-integrations/azure-integrations-list",
+      "/docs/kubernetes-integration/microsoft-azure-integrations/azure-integrations-list",
+      "/docs/integrations/new-relic-integrations/cloud-integrations/azure-integrations",
+      "/docs/infrastructure-integrations/microsoft-azure-integrations/azure-integrations-list"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7851",
+    "paths": [
+      "/taxonomy/term/7676",
+      "/docs/integrations/microsoft-azure-integrations",
+      "/docs/kubernetes-integration/microsoft-azure-integrations",
+      "/docs/infrastructure-integrations/microsoft-azure-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7886",
+    "paths": [
+      "/taxonomy/term/7716",
+      "/docs/infrastructure/host-integrations/host-integrations-list",
+      "/docs/infrastructure/integrations/types-integrations/open-source-host-integration",
+      "/docs/infrastructure/new-relic-infrastructure/integrations/open-source-host-integrations",
+      "/docs/integrations/host-integrations/host-integrations-list",
+      "/docs/kubernetes-integration/host-integrations/host-integrations-list",
+      "/docs/kubernetes-integration/host-integrations/open-source-host-integrations-list",
+      "/docs/integrations/host-integrations/community-host-integrations-list",
+      "/taxonomy/term/8461",
+      "/docs/integrations/new-relic-integrations/host-integrations/host-integrations-list",
+      "/docs/infrastructure-integrations/host-integrations/host-integrations-list"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7831",
+    "paths": [
+      "/taxonomy/term/7446",
+      "/node/12911",
+      "/docs/integrations",
+      "/docs/kubernetes-integration",
+      "/docs/infrastructure-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7856",
+    "paths": [
+      "/docs/infrastructure/integrations-sdk",
+      "/docs/kubernetes-integration/integrations-sdk",
+      "/docs/infrastructure-integrations/integrations-sdk"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7976",
+    "paths": [
+      "/docs/apis/getting-started",
+      "/docs/apis/intro-apis"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7961",
+    "paths": [
+      "/docs/accounts-partnerships/welcome-new-relic"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6596",
+    "paths": [
+      "/docs/data-analysis/user-interface-functions/view-your-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6606",
+    "paths": [
+      "/docs/data-analysis/user-interface-functions/organize-your-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6601",
+    "paths": [
+      "/docs/data-analysis/user-interface-functions/share-your-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6881",
+    "paths": [
+      "/docs/data-analysis/user-interface-functions/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6411",
+    "paths": [
+      "/docs/data-analysis/metrics",
+      "/docs/using-new-relic/metrics"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6611",
+    "paths": [
+      "/docs/data-analysis/metrics/analyze-your-metrics",
+      "/docs/using-new-relic/metrics/analyze-your-metrics",
+      "/docs/using-new-relic/data/analyze-your-metrics",
+      "/docs/using-new-relic/data/data-types"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7406",
+    "paths": [
+      "/docs/data-analysis/health-map",
+      "/docs/using-new-relic/health-map"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7411",
+    "paths": [
+      "/docs/data-analysis/health-map/get-started",
+      "/docs/using-new-relic/health-map/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6766",
+    "paths": [
+      "/docs/data-analysis/service-maps/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6761",
+    "paths": [
+      "/docs/data-analysis/service-maps/service-maps"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7951",
+    "paths": [
+      "/docs/accounts-partnerships/accounts/install-new-relic",
+      "/docs/accounts/accounts-partnerships/install-new-relic"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7971",
+    "paths": [
+      "/docs/accounts-partnerships/new-relic-security",
+      "/docs/using-new-relic/new-relic-security",
+      "/docs/security/new-relic-security"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2116",
+    "paths": [
+      "/docs/accounts-partnerships/accounts/account-setup",
+      "/docs/accounts/accounts-partnerships/install-new-relic/account-setup"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2106",
+    "paths": [
+      "/docs/accounts-partnerships"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8046",
+    "paths": [
+      "/docs/accounts-partnerships/install-new-relic"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8056",
+    "paths": [
+      "/docs/accounts-partnerships/install-new-relic/account-setup"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8066",
+    "paths": [
+      "/docs/accounts-partnerships/install-new-relic/install-agent"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7991",
+    "paths": [
+      "/docs/accounts-partnerships/accounts/roles-permissions",
+      "/docs/accounts/accounts/roles-permissions"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2121",
+    "paths": [
+      "/docs/accounts-partnerships/accounts/account-maintenance",
+      "/docs/accounts/accounts/account-maintenance",
+      "/docs/accounts/accounts-billing/account-maintenance"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8061",
+    "paths": [
+      "/docs/accounts-partnerships/accounts/subscription-pricing",
+      "/docs/accounts/accounts/subscription-pricing",
+      "/docs/accounts/accounts-billing/subscription-pricing",
+      "/docs/accounts/accounts-billing/new-relic-one-pricing-users"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7996",
+    "paths": [
+      "/docs/accounts-partnerships/accounts/billing"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2126",
+    "paths": [
+      "/docs/accounts-partnerships/accounts/saml-single-sign",
+      "/docs/accounts/accounts/saml-single-sign"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2131",
+    "paths": [
+      "/docs/accounts-partnerships/accounts/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8001",
+    "paths": [
+      "/docs/accounts-partnerships/new-relic-account-usage",
+      "/docs/accounts-partnerships/new-relic-account-usage/legacy-account-usage",
+      "/docs/accounts/new-relic-account-usage/legacy-account-usage",
+      "/docs/accounts/new-relic-account-usage/deprecated-usage-apis"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8006",
+    "paths": [
+      "/docs/accounts-partnerships/new-relic-account-usage/getting-started-usage"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8011",
+    "paths": [
+      "/docs/accounts-partnerships/new-relic-account-usage/apm-usage",
+      "/docs/accounts/new-relic-account-usage/apm-usage"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8016",
+    "paths": [
+      "/docs/accounts-partnerships/new-relic-account-usage/browser-usage"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8021",
+    "paths": [
+      "/docs/accounts-partnerships/new-relic-account-usage/infrastructure-usage"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8026",
+    "paths": [
+      "/docs/accounts-partnerships/new-relic-account-usage/insights-usage"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8031",
+    "paths": [
+      "/docs/accounts-partnerships/new-relic-account-usage/mobile-usage"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8036",
+    "paths": [
+      "/docs/accounts-partnerships/new-relic-account-usage/synthetics-usage"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5761",
+    "paths": [
+      "/docs/accounts-partnerships/education"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7841",
+    "paths": [
+      "/docs/integrations/host-integrations/host-integrations-list/config",
+      "/docs/integrations/host-integrations",
+      "/docs/kubernetes-integration/host-integrations",
+      "/docs/infrastructure-integrations/host-integrations",
+      "/docs/full-stack-observability/instrument-everything/instrument-core-services-applications/core-services-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6676",
+    "paths": [
+      "/docs/ios"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8076",
+    "paths": [
+      "/taxonomy/term/6996",
+      "/docs/data-analysis/legacy-custom-dashboards/custom-dashboards-v2",
+      "/docs/data-analysis/legacy-custom-dashboards/custom-dashboards-v1",
+      "/docs/data-analysis/legacy-custom-dashboards/custom-views",
+      "/docs/data-analysis/legacy-custom-dashboards"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5861",
+    "paths": [
+      "/taxonomy/term/2246",
+      "/docs/browser/new-relic-browser/page-load-timing",
+      "/docs/browser/new-relic-browser/page-load-timing-resources"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7586",
+    "paths": [
+      "/docs/mobile-monitoring/new-relic-mobile-apps"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8151?field_products_tid%255B%255D=8106",
+    "paths": [
+      "/docs/integrations/new-relic-integrations/getting-started/integrations-release-notes"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8151?field_products_tid%255B%255D=8081",
+    "paths": [
+      "/taxonomy/term/6896",
+      "/taxonomy/term/6901",
+      "/docs/release-notes/alerts-release-notes/new-relic-alerts-release-notes/20161115-support-mobile-crash-analysis",
+      "/docs/release-notes/alerts-release-notes/new-relic-alerts-release-notes/20161007-more-pagination-search-permalinks",
+      "/docs/release-notes/alerts-release-notes/new-relic-alerts-release-notes/20161026-api-performance-improvements-pagination-policies"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8211",
+    "paths": [
+      "/https:/docs.newrelidocs/infrastructure/integrations/google-cloud-platform-integrations",
+      "/docs/infrastructure/integrations/types-integrations/google-cloud-integrations",
+      "/docs/infrastructure/new-relic-infrastructure/integrations/gcp-integrations",
+      "/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list",
+      "/docs/kubernetes-integration/google-cloud-platform-integrations/gcp-integrations-list",
+      "/docs/infrastructure-integrations/google-cloud-platform-integrations/gcp-integrations-list"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8201",
+    "paths": [
+      "/docs/google-cloud-platform-integrations",
+      "/docs/integrations/google-cloud-platform-integrations",
+      "/docs/kubernetes-integration/google-cloud-platform-integrations",
+      "/docs/integrations/new-relic-integrations/cloud-integrations/google-cloud-platform-integrations",
+      "/docs/infrastructure-integrations/google-cloud-platform-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8156/feed",
+    "paths": [
+      "/docs/release-notes/alerts-release-notes/new-relic-alerts-release-notes/feed"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8221",
+    "paths": [
+      "/docs/using-new-relic/welcome-new-relic/measure-your-devops-success"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8236",
+    "paths": [
+      "/event-types/transaction",
+      "/attribute-dictionary?events_tids%5B%5D=8236",
+      "/attribute-dictionary/event/Transaction"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8297",
+    "paths": [
+      "/attribute-dictionary/event-data-sources/new-relic-browser-agent"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2341",
+    "paths": [
+      "/docs/agents/net-agent/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8246",
+    "paths": [
+      "/units-measure/megabytes-mb"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6641",
+    "paths": [
+      "/docs/agents/net-agent/azure-installation/azure-troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8721",
+    "paths": [
+      "/docs/infrastructure/new-relic-infrastructure/agent-performance",
+      "/docs/infrastructure/new-relic-infrastructure/infrastructure-agent-performance"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8317",
+    "paths": [
+      "/attribute-dictionary/events/spa-ajaxrequest"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8312",
+    "paths": [
+      "/attribute-dictionary/events/spa-browserinteraction"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8322",
+    "paths": [
+      "/attribute-dictionary/events/spa-browsertiming"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8241",
+    "paths": [
+      "/event-types/transactionerror"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8441",
+    "paths": [
+      "/attribute-dictionary/units-measure/bytes"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8716",
+    "paths": [
+      "/attribute-dictionary/units-measure/microseconds"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8256",
+    "paths": [
+      "/attribute-dictionary/units-measure/milliseconds"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8251",
+    "paths": [
+      "/attribute-dictionary/units-measure/seconds"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7866",
+    "paths": [
+      "/docs/integrations/host-integrations/getting-started",
+      "/docs/kubernetes-integration/host-integrations/getting-started",
+      "/docs/integrations/host-integrations/get-started",
+      "/docs/infrastructure-integrations/host-integrations/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8461",
+    "paths": [
+      "/docs/integrations/host-integrations/open-source-host-integrations-list"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7891",
+    "paths": [
+      "/docs/integrations/host-integrations/installation",
+      "/docs/kubernetes-integration/host-integrations/installation",
+      "/docs/infrastructure-integrations/host-integrations/installation"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7896",
+    "paths": [
+      "/docs/integrations/host-integrations/understand-use-data",
+      "/docs/kubernetes-integration/host-integrations/understand-use-data",
+      "/docs/infrastructure-integrations/host-integrations/understand-use-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7901",
+    "paths": [
+      "/docs/integrations/host-integrations/troubleshooting",
+      "/docs/kubernetes-integration/host-integrations/troubleshooting",
+      "/docs/infrastructure-integrations/host-integrations/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8206",
+    "paths": [
+      "/docs/integrations/google-cloud-platform-integrations/getting-started",
+      "/docs/kubernetes-integration/google-cloud-platform-integrations/getting-started",
+      "/docs/integrations/google-cloud-platform-integrations/get-started",
+      "/docs/infrastructure-integrations/google-cloud-platform-integrations/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8216",
+    "paths": [
+      "/docs/integrations/google-cloud-platform-integrations/troubleshooting",
+      "/docs/kubernetes-integration/google-cloud-platform-integrations/troubleshooting",
+      "/docs/infrastructure-integrations/google-cloud-platform-integrations/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7876",
+    "paths": [
+      "/docs/integrations/microsoft-azure-integrations/getting-started",
+      "/docs/kubernetes-integration/microsoft-azure-integrations/getting-started",
+      "/docs/integrations/microsoft-azure-integrations/get-started",
+      "/docs/infrastructure-integrations/microsoft-azure-integrations/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8496",
+    "paths": [
+      "/docs/integrations/microsoft-azure-integrations/troubleshooting",
+      "/docs/kubernetes-integration/microsoft-azure-integrations/troubleshooting",
+      "/docs/infrastructure-integrations/microsoft-azure-integrations/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10451",
+    "paths": [
+      "/docs/integrations/integrations-sdk",
+      "/docs/full-stack-observability/instrument-everything/develop-your-own-integrations/new-relic-integrations-sdk"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7881",
+    "paths": [
+      "/docs/integrations/integrations-sdk/getting-started",
+      "/docs/kubernetes-integration/integrations-sdk/getting-started",
+      "/docs/integrations/integrations-sdk/get-started",
+      "/docs/infrastructure-integrations/integrations-sdk/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8501",
+    "paths": [
+      "/docs/integrations/integrations-sdk/build-tools",
+      "/docs/kubernetes-integration/integrations-sdk/build-tools",
+      "/docs/infrastructure-integrations/integrations-sdk/build-tools"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7931",
+    "paths": [
+      "/docs/integrations/integrations-sdk/file-specifications",
+      "/docs/kubernetes-integration/integrations-sdk/file-specifications",
+      "/docs/infrastructure-integrations/integrations-sdk/file-specifications"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7916",
+    "paths": [
+      "/docs/integrations/integrations-sdk/troubleshooting",
+      "/docs/kubernetes-integration/integrations-sdk/troubleshooting",
+      "/docs/infrastructure-integrations/integrations-sdk/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8876",
+    "paths": [
+      "/docs/integrations/kubernetes-integration/metadata-injection",
+      "/docs/integrations/kubernetes-integration/link-your-applications",
+      "/docs/integrations/kubernetes-integration/link-apps-services",
+      "/docs/infrastructure-integrations/kubernetes-integration/link-apps-services"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8901",
+    "paths": [
+      "/attribute-dictionary/event-data-sources/aws-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8726",
+    "paths": [
+      "/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/feed",
+      "/docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-151",
+      "/docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-152",
+      "/docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-153",
+      "/docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-160",
+      "/docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-161",
+      "/docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-163",
+      "/docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-164",
+      "/docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-165",
+      "/docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-166",
+      "/docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-167",
+      "/docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-168",
+      "/docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-169",
+      "/docs/release-notes/synthetics-release-notes/vm-private-minions-release-notes-legacy/private-minion-170",
+      "/docs/release-notes/synthetics-release-notes/vm-private-minions-release-notes-legacy/private-minion-171",
+      "/docs/release-notes/synthetics-release-notes/private-minion-151",
+      "/docs/release-notes/synthetics-release-notes/private-minion-300",
+      "/docs/release-notes/private-minion",
+      "/docs/release-notes/synthetics-release-notes/private-minion-153-0",
+      "/docs/release-notes/synthetics-release-notes/vm-private-minions-release-notes-legacy/private-minion-213",
+      "/docs/release-notes/synthetics-release-notes/vm-private-minions-release-notes-legacy",
+      "/docs/synthetics/synthetic-monitoring/getting-started/containerized-private-minions-cpm-release-notes"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9311",
+    "paths": [
+      "/docs/alerts/new-relic-alerts/glossary-limits"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9536",
+    "paths": [
+      "/docs/c-agent-table-contents"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9531",
+    "paths": [
+      "/docs/apis/insights-apis/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7981",
+    "paths": [
+      "/docs/apis/getting-started/intro-apis",
+      "/docs/full-stack-observability/instrument-everything/develop-your-own-integrations/new-relic-apis"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8431",
+    "paths": [
+      "/docs/apis/graphql-api/getting-started",
+      "/docs/apis/graphql-api/get-started",
+      "/docs/apis/nerdgraph-graphiql/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7201",
+    "paths": [
+      "/docs/apis/rest-api-v2/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2886",
+    "paths": [
+      "/docs/mobile-monitoring/new-relic-mobile/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8831",
+    "paths": [
+      "/docs/integrations/kubernetes-integration/getting-started",
+      "/docs/integrations/kubernetes-integration/get-started",
+      "/docs/infrastructure-integrations/kubernetes-integration/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6376",
+    "paths": [
+      "/docs/apis/rest-api-v2/account-examples-v2"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9506",
+    "paths": [
+      "/docs/release-notes/agent-release-notes/c-release-notes",
+      "/docs/agents/c-sdk/get-started/c-sdk-release-notes"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9681",
+    "paths": [
+      "/docs/understand-dependencies/understand-system-dependencies",
+      "/docs/understand-dependencies/upstream-downstream-relationships"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9686",
+    "paths": [
+      "/docs/understand-dependencies/understand-system-dependencies/service-maps",
+      "/docs/understand-dependencies/upstream-downstream-relationships/service-maps"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9691",
+    "paths": [
+      "/docs/understand-dependencies/understand-system-dependencies/relationship-api",
+      "/docs/understand-dependencies/upstream-downstream-relationships/relationship-api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10551",
+    "paths": [
+      "/docs/dashboards/get-started",
+      "/docs/dashboards/new-relic-one-dashboards/get-started",
+      "/docs/dashboards/explore-dashboards-index",
+      "/docs/dashboards/manage-your-dashboard",
+      "/docs/dashboards/new-relic-one-dashboards/key-visual-elements",
+      "/docs/dashboards/new-relic-one-dashboards",
+      "/docs/dashboards/new-relic-one-dashboards/explore-dashboards-index",
+      "/docs/dashboards/new-relic-one-dashboards/key-visual-tools",
+      "/docs/dashboards/new-relic-one-dashboards/manage-your-dashboard",
+      "/docs/query-your-data/new-relic-one-dashboards",
+      "/docs/query-your-data/new-relic-one-dashboards/get-started",
+      "/docs/query-your-data/new-relic-one-dashboards/explore-dashboards-index",
+      "/docs/query-your-data/new-relic-one-dashboards/manage-your-dashboard",
+      "/docs/query-your-data/new-relic-one-dashboards/key-visual-tools",
+      "/docs/query-your-data/explore-query-data/data-explorer/dashboards",
+      "/docs/explore-query-data/data-explorer/dashboards",
+      "/docs/query-your-data/new-relic-one-dashboards/global-performance-dataset"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9661",
+    "paths": [
+      "/docs/get-started",
+      "/docs/new-relic-one-dashboards/get-started",
+      "/docs/explore-query-data/new-relic-one-dashboards/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9666",
+    "paths": [
+      "/docs/explore-dashboards-index",
+      "/docs/new-relic-one-dashboards/explore-dashboards-index",
+      "/docs/explore-query-data/new-relic-one-dashboards/explore-dashboards-index"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9671",
+    "paths": [
+      "/docs/manage-your-dashboard",
+      "/docs/new-relic-one-dashboards/manage-your-dashboard",
+      "/docs/explore-query-data/new-relic-one-dashboards/manage-your-dashboard"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9731",
+    "paths": [
+      "/docs/chart-builder/use-chart-builder/choose-data-chart"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9736",
+    "paths": [
+      "/docs/chart-builder/use-chart-builder/new-relic-query-language"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7186",
+    "paths": [
+      "/docs/chart-builder/use-chart-builder/nrql/nrql-new-relic-query-language"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9566",
+    "paths": [
+      "/attribute-dictionary/events/syntheticprivatelocationstatus"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9801",
+    "paths": [
+      "/docs/infrastructure/ui-pages",
+      "/docs/infrastructure/infrastructure-ui-pages"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7336",
+    "paths": [
+      "/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9811",
+    "paths": [
+      "/docs/infrastructure/troubleshooting/infra-troubleshooting",
+      "/docs/infrastructure/infrastructure-troubleshooting/infra-troubleshooting",
+      "/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9826",
+    "paths": [
+      "/docs/infrastructure/install-configure-infrastructure/elastic-beanstalk-installation",
+      "/docs/install-configure-infrastructure/elastic-beanstalk-installation",
+      "/docs/infrastructure/install-configure-manage-infrastructure/elastic-beanstalk-installation"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9831",
+    "paths": [
+      "/docs/infrastructure/install-configure-infrastructure/docker-installation",
+      "/docs/install-configure-infrastructure/docker-installation",
+      "/docs/infrastructure/install-configure-manage-infrastructure/docker-installation"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9836",
+    "paths": [
+      "/docs/infrastructure/install-configure-infrastructure/update-or-uninstall",
+      "/docs/install-configure-infrastructure/update-or-uninstall",
+      "/docs/infrastructure/install-configure-manage-infrastructure/update-or-uninstall",
+      "/docs/infrastructure/install-configure-manage-infrastructure-agent/update-or-uninstall"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9841",
+    "paths": [
+      "/docs/manage-your-agent",
+      "/docs/install-configure-infrastructure/manage-your-agent",
+      "/docs/infrastructure/install-configure-infrastructure/manage-your-agent",
+      "/docs/infrastructure/install-configure-manage-infrastructure/manage-your-agent",
+      "/docs/infrastructure/install-configure-manage-infrastructure-agent/manage-your-agent"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9851",
+    "paths": [
+      "/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infra-logs",
+      "/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6131",
+    "paths": [
+      "/docs/licenses/new-relic-products"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6146",
+    "paths": [
+      "/docs/licenses/new-relic-products/new-relic-mobile"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6141",
+    "paths": [
+      "/docs/licenses/new-relic-products/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3416",
+    "paths": [
+      "/docs/licenses/license-information/mobile-app-licenses"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3046",
+    "paths": [
+      "/docs/licenses/license-information/agent-licenses",
+      "/docs/licenses/license-information/new-relic-apm-licenses",
+      "/docs/licenses/product-or-service-licenses/new-relic-apm-licenses",
+      "/taxonomy/term/3181"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/3056",
+    "paths": [
+      "/docs/licenses/license-information/other-licenses"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9886",
+    "paths": [
+      "/docs/query-data/nrql-new-relic-query-language/getting-strated",
+      "/taxonomy/term/7216",
+      "/docs/query-data/nrql-new-relic-query-language/getting-started",
+      "/docs/query-data/nrql-new-relic-query-language/get-started",
+      "/docs/query-your-data/nrql-new-relic-query-language/get-started",
+      "/docs/explore-query-data/nrql-new-relic-query-language/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9861",
+    "paths": [
+      "/docs/licenses/license-information/generally-applicable-licenses"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9856",
+    "paths": [
+      "/taxonomy/term/9571"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9891",
+    "paths": [
+      "/taxonomy/term/7286",
+      "/docs/query-data/nrql-new-relic-query-language/nrql-query-examples",
+      "/docs/query-data/nrql-new-relic-query-language/nrql-query-tutorials",
+      "/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials",
+      "/docs/explore-query-data/nrql-new-relic-query-language/nrql-query-tutorials"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9871",
+    "paths": [
+      "/taxonomy/term/7186",
+      "/docs/query-data/nrql-new-relic-query-language",
+      "/docs/query-your-data/nrql-new-relic-query-language",
+      "/docs/explore-query-data/nrql-new-relic-query-language"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10026",
+    "paths": [
+      "/docs/new-relic-logs"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8426",
+    "paths": [
+      "/docs/apis/graphql-api",
+      "/docs/apis/nerdgraph-graphiql"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8436",
+    "paths": [
+      "/docs/apis/graphql-api/tutorials",
+      "/docs/apis/nerdgraph-graphiql/tutorials",
+      "/docs/apis/nerdgraph/tutorials"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10016",
+    "paths": [
+      "/docs/logs/new-relic-logs/logs-api",
+      "/docs/logs/new-relic-logs/log-api",
+      "/docs/logs/log-monitoring/log-api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9701",
+    "paths": [
+      "/docs/apm/distributed-tracing",
+      "/docs/full-stack-observability/monitor-everything/observability-solutions/distributed-tracing"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9976",
+    "paths": [
+      "/docs/integrations/prometheus-integrations/prometheus-docker",
+      "/docs/integrations/prometheus-integrations/get-started",
+      "/docs/infrastructure-integrations/prometheus-integrations/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10051",
+    "paths": [
+      "/docs/kubernetes-events",
+      "/docs/integrations/kubernetes-integration/kubernetes-events",
+      "/docs/infrastructure-integrations/kubernetes-integration/kubernetes-events"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10081",
+    "paths": [
+      "/docs/integrations/prometheus-integrations/configure-0",
+      "/docs/integrations/prometheus-integrations/configure",
+      "/docs/integrations/prometheus-integrations/install-configure",
+      "/docs/infrastructure-integrations/prometheus-integrations/install-configure"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7156",
+    "paths": [
+      "/docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7161",
+    "paths": [
+      "/docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/install-configure"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10111",
+    "paths": [
+      "/docs/security/compliance",
+      "/docs/security/new-relic-security/compliance"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10236",
+    "paths": [
+      "/docs/mobile-extensible-agent-toc",
+      "/docs/mobile-react-native-agent-toc"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10171",
+    "paths": [
+      "/docs/logs/enable-logs/configure-logs-context-apis",
+      "/docs/logs/enable-logs/configure-logs-context-agent-apis",
+      "/docs/logs/enable-logs/configure-logs-context-ruby-0",
+      "/docs/logs/enable-logs/logs-context-ruby",
+      "/docs/logs/enable-new-relic-logs/logs-context-ruby",
+      "/docs/logs/enable-log-monitoring-new-relic/logs-context-ruby"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10136",
+    "paths": [
+      "/docs/logs/enable-logs/configure-logs-context-go",
+      "/docs/logs/enable-logs/logs-context-go",
+      "/docs/logs/enable-new-relic-logs/logs-context-go",
+      "/docs/logs/enable-log-monitoring-new-relic/logs-context-go"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10141",
+    "paths": [
+      "/docs/logs/enable-logs/configure-logs-context-java",
+      "/docs/logs/enable-logs/logs-context-java",
+      "/docs/logs/enable-new-relic-logs/logs-context-java",
+      "/docs/logs/enable-log-monitoring-new-relic/logs-context-java"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10146",
+    "paths": [
+      "/docs/logs/enable-logs/configure-logs-context-net",
+      "/docs/logs/enable-logs/logs-context-net",
+      "/docs/logs/enable-new-relic-logs/logs-context-net",
+      "/docs/logs/enable-log-monitoring-new-relic/logs-context-net"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10151",
+    "paths": [
+      "/docs/logs/enable-logs/configure-logs-context-node",
+      "/docs/logs/enable-logs/logs-context-node",
+      "/docs/logs/enable-logs/logs-context-nodejs",
+      "/docs/logs/enable-new-relic-logs/logs-context-nodejs",
+      "/docs/logs/enable-log-monitoring-new-relic/logs-context-nodejs"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10156",
+    "paths": [
+      "/docs/logs/enable-logs/configure-logs-context-php",
+      "/docs/logs/enable-logs/logs-context-php",
+      "/docs/logs/enable-new-relic-logs/logs-context-php",
+      "/docs/logs/enable-log-monitoring-new-relic/logs-context-php"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10161",
+    "paths": [
+      "/docs/logs/enable-logs/configure-logs-context-python",
+      "/docs/logs/enable-logs/logs-context-python",
+      "/docs/logs/enable-new-relic-logs/logs-context-python",
+      "/docs/logs/enable-log-monitoring-new-relic/logs-context-python"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10166",
+    "paths": [
+      "/docs/logs/enable-logs/configure-logs-context-ruby",
+      "/docs/logs/enable-logs/logs-context-apm-agent-apis",
+      "/docs/logs/enable-logs/logs-context-agent-apis",
+      "/docs/logs/enable-new-relic-logs/logs-context-agent-apis",
+      "/docs/logs/enable-log-monitoring-new-relic/logs-context-agent-apis"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10176",
+    "paths": [
+      "/docs/logs/enable-logs/configure-logs-context-apm",
+      "/docs/logs/enable-logs/configure-logs-context-apm-agents",
+      "/docs/logs/enable-logs/configure-logs-context",
+      "/docs/logs/enable-new-relic-logs/configure-logs-context",
+      "/docs/logs/enable-new-relic-logs/2-configure-logs-context",
+      "/docs/logs/enable-log-monitoring-new-relic/2-configure-logs-context",
+      "/docs/logs/enable-log-monitoring-new-relic/configure-logs-context"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10121",
+    "paths": [
+      "/docs/logs/enable-logs",
+      "/docs/logs/enable-new-relic-logs",
+      "/docs/logs/enable-log-monitoring-new-relic"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10126",
+    "paths": [
+      "/docs/logs/enable-logs/new-relic-logs",
+      "/docs/logs/enable-new-relic-logs/new-relic-logs",
+      "/docs/logs/enable-log-monitoring-new-relic/new-relic-logs"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10131",
+    "paths": [
+      "/docs/logs/enable-logs/enable-logs",
+      "/docs/logs/enable-new-relic-logs/enable-logs",
+      "/docs/logs/enable-new-relic-logs/1-enable-logs",
+      "/docs/logs/enable-log-monitoring-new-relic/1-enable-logs",
+      "/docs/logs/enable-log-monitoring-new-relic/enable-log-monitoring-new-relic"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6211",
+    "paths": [
+      "/docs/apis/rest-api-v2/requirements"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10246",
+    "paths": [
+      "/docs/install-configure"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10211",
+    "paths": [
+      "/docs/integrations/vmware-tanzu-integration"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10281",
+    "paths": [
+      "/docs/vmware-esxi-integration"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10276",
+    "paths": [
+      "/docs/vmware-tanzu-integration"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10286",
+    "paths": [
+      "/docs/covid-19"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8181",
+    "paths": [
+      "/docs/integrations/kubernetes-integration/get-started/release-notes",
+      "/docs/release-notes/platform-release-notes/host-integrations-release-notes"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2626",
+    "paths": [
+      "/docs/apm/applications-menu/monitoring"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6876",
+    "paths": [
+      "/docs/apm/applications-menu/error-analytics"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6166",
+    "paths": [
+      "/docs/apm/applications-menu/service-maps"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2631",
+    "paths": [
+      "/docs/apm/applications-menu/features"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2636",
+    "paths": [
+      "/docs/apm/applications-menu/events"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2641",
+    "paths": [
+      "/docs/apm/applications-menu/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10306",
+    "paths": [
+      "/docs/integrations/aws-elastic-container-service-integration",
+      "/docs/integrations/elastic-container-service-integration",
+      "/docs/infrastructure-integrations/elastic-container-service-integration",
+      "/docs/full-stack-observability/instrument-everything/instrument-core-services-applications/amazon-ecs-integration"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8886",
+    "paths": [
+      "/docs/integrations/new-relic-integrations/cloud-integrations",
+      "/docs/infrastructure-integrations/new-relic-integrations/cloud-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10191",
+    "paths": [
+      "/docs/integrations/new-relic-integrations/host-integrations",
+      "/docs/infrastructure-integrations/new-relic-integrations/host-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8821",
+    "paths": [
+      "/docs/integrations/kubernetes-integration",
+      "/docs/infrastructure-integrations/kubernetes-integration",
+      "/docs/full-stack-observability/monitor-everything/observability-solutions/kubernetes-monitoring",
+      "/docs/full-stack-observability/instrument-everything/instrument-core-services-applications/kubernetes-integration"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8826",
+    "paths": [
+      "/docs/integrations/kubernetes-integration/installation",
+      "/docs/infrastructure-integrations/kubernetes-integration/installation"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8836",
+    "paths": [
+      "/docs/integrations/kubernetes-integration/understand-use-data",
+      "/docs/infrastructure-integrations/kubernetes-integration/understand-use-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8841",
+    "paths": [
+      "/docs/integrations/kubernetes-integration/cluster-explorer",
+      "/docs/infrastructure-integrations/kubernetes-integration/cluster-explorer"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10186",
+    "paths": [
+      "/docs/integrations/kubernetes-integration/logs",
+      "/docs/infrastructure-integrations/kubernetes-integration/logs"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/8846",
+    "paths": [
+      "/docs/integrations/kubernetes-integration/troubleshooting",
+      "/docs/infrastructure-integrations/kubernetes-integration/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10311",
+    "paths": [
+      "/docs/integrations/elastic-container-service-integration/get-started",
+      "/docs/infrastructure-integrations/elastic-container-service-integration/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10316",
+    "paths": [
+      "/docs/integrations/elastic-container-service-integration/installation",
+      "/docs/infrastructure-integrations/elastic-container-service-integration/installation"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10321",
+    "paths": [
+      "/docs/integrations/elastic-container-service-integration/understand-use-data",
+      "/docs/infrastructure-integrations/elastic-container-service-integration/understand-use-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10326",
+    "paths": [
+      "/docs/integrations/elastic-container-service-integration/troubleshooting",
+      "/docs/infrastructure-integrations/elastic-container-service-integration/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9966",
+    "paths": [
+      "/docs/integrations/prometheus-integrations",
+      "/docs/infrastructure-integrations/prometheus-integrations",
+      "/docs/integrations/open-source-telemetry-integrations/open-source-telemetry-integration-list/prometheus-integration"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10076",
+    "paths": [
+      "/docs/integrations/prometheus-integrations/view-query-data",
+      "/docs/infrastructure-integrations/prometheus-integrations/view-query-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10086",
+    "paths": [
+      "/docs/integrations/prometheus-integrations/troubleshooting",
+      "/docs/infrastructure-integrations/prometheus-integrations/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10231",
+    "paths": [
+      "/docs/using-new-relic/data/customize-data/manage-your-data",
+      "/docs/accounts/accounts/data-management"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10416",
+    "paths": [
+      "/docs/integrations/exporters",
+      "/docs/full-stack-observability/instrument-everything/instrument-core-services-applications/open-source-telemetry-integrations",
+      "/docs/full-stack-observability/instrument-everything/instrument-core-services-applications/prometheus-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10421",
+    "paths": [
+      "/docs/integrations/exporters/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10426",
+    "paths": [
+      "/docs/integrations/exporters/exporter-list",
+      "/docs/integrations/open-source-telemetry-integrations/exporter-list"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9866",
+    "paths": [
+      "/docs/query-data",
+      "/docs/query-your-data",
+      "/docs/explore-query-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9896",
+    "paths": [
+      "/docs/query-data/nrql-new-relic-query-language/query-tools",
+      "/docs/query-your-data/nrql-new-relic-query-language/query-tools",
+      "/docs/explore-query-data/nrql-new-relic-query-language/query-tools"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9711",
+    "paths": [
+      "/docs/new-relic-one-dashboards",
+      "/docs/explore-query-data/new-relic-one-dashboards"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9716",
+    "paths": [
+      "/docs/new-relic-one-dashboards/key-visual-tools",
+      "/docs/explore-query-data/new-relic-one-dashboards/key-visual-tools"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9721",
+    "paths": [
+      "/docs/chart-builder/use-chart-builder",
+      "/docs/query-your-data/use-chart-builder",
+      "/docs/query-your-data/chart-builder",
+      "/docs/explore-query-data/chart-builder"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9726",
+    "paths": [
+      "/docs/chart-builder/use-chart-builder/get-started",
+      "/docs/query-your-data/use-chart-builder/get-started",
+      "/docs/query-your-data/chart-builder/get-started",
+      "/docs/explore-query-data/chart-builder/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9751",
+    "paths": [
+      "/docs/chart-builder/use-chart-builder/choose-data",
+      "/docs/query-your-data/use-chart-builder/choose-data",
+      "/docs/query-your-data/chart-builder/choose-data",
+      "/docs/explore-query-data/chart-builder/choose-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9756",
+    "paths": [
+      "/docs/chart-builder/use-chart-builder/nrql",
+      "/docs/query-your-data/use-chart-builder/nrql",
+      "/docs/query-your-data/chart-builder/nrql",
+      "/docs/explore-query-data/chart-builder/nrql"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9741",
+    "paths": [
+      "/docs/chart-builder/use-chart-builder/use-charts",
+      "/docs/query-your-data/use-chart-builder/use-charts",
+      "/docs/query-your-data/chart-builder/use-charts",
+      "/docs/explore-query-data/chart-builder/use-charts"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10486",
+    "paths": [
+      "/docs/query-your-data/explore-query-data/nrql",
+      "/docs/query-your-data/explore-query-data/new-relic-query-language",
+      "/docs/query-your-data/explore-query-data/nqrl",
+      "/docs/explore-query-data/new-relic-query-language"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10491",
+    "paths": [
+      "/docs/original-new-relic-accounts"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10496",
+    "paths": [
+      "/docs/original-new-relic-accounts/original-account-management"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10501",
+    "paths": [
+      "/docs/original-new-relic-accounts/original-account-management/product-pricing-plan"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10506",
+    "paths": [
+      "/docs/original-new-relic-accounts/original-account-management/usage"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10511",
+    "paths": [
+      "/docs/original-new-relic-accounts/original-account-management/users"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10526",
+    "paths": [
+      "/docs/workloads/workloads"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2226",
+    "paths": [
+      "/docs/integrations/intro-integrations/get-started/browser-monitoring",
+      "/docs/full-stack-observability/monitor-everything/observability-solutions/browser-monitoring"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10471",
+    "paths": [
+      "/docs/query-your-data/explore-query-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10476",
+    "paths": [
+      "/docs/query-your-data/explore-query-data/chart-builder"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10516",
+    "paths": [
+      "/docs/query-your-data/explore-query-data/data-explorer",
+      "/docs/explore-query-data/data-explorer"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10481",
+    "paths": [
+      "/docs/query-your-data/explore-query-data/use-charts",
+      "/docs/explore-query-data/use-charts"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10401",
+    "paths": [
+      "/docs/accounts/accounts/account-setup"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10396",
+    "paths": [
+      "/docs/accounts/accounts/product-usage"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10411",
+    "paths": [
+      "/docs/accounts/accounts/account-structure"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10336",
+    "paths": [
+      "/docs/accounts/accounts/automated-user-management"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10406",
+    "paths": [
+      "/docs/accounts/accounts/partner-installation"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9926",
+    "paths": [
+      "/docs/data-ingest-apis"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9931",
+    "paths": [
+      "/docs/data-ingest-apis/get-data-new-relic",
+      "/docs/telemetry-data-platform/get-data-new-relic",
+      "/docs/telemetry-data-platform/get-started",
+      "/docs/telemetry-data-platform/data-ingest-query"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9936",
+    "paths": [
+      "/docs/data-ingest-apis/get-data-new-relic/getting-started",
+      "/docs/telemetry-data-platform/get-data-new-relic/getting-started",
+      "/docs/telemetry-data-platform/get-data-new-relic/capabilities",
+      "/docs/telemetry-data-platform/get-started/capabilities",
+      "/docs/telemetry-data-platform/data-ingest-query/capabilities",
+      "/docs/telemetry-data-platform/data-ingest-query/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9941",
+    "paths": [
+      "/docs/data-ingest-apis/get-data-new-relic/new-relic-sdks",
+      "/docs/telemetry-data-platform/get-data-new-relic/new-relic-sdks",
+      "/docs/telemetry-data-platform/get-started/new-relic-sdks"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9946",
+    "paths": [
+      "/docs/data-ingest-apis/get-data-new-relic/metric-api",
+      "/docs/telemetry-data-platform/get-data-new-relic/metric-api",
+      "/docs/telemetry-data-platform/get-started/metric-api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9961",
+    "paths": [
+      "/docs/data-ingest-apis/get-data-new-relic/event-api",
+      "/docs/telemetry-data-platform/get-data-new-relic/event-api",
+      "/docs/telemetry-data-platform/get-started/event-api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9956",
+    "paths": [
+      "/docs/data-ingest-apis/get-data-new-relic/log-api",
+      "/docs/telemetry-data-platform/get-data-new-relic/log-api",
+      "/docs/telemetry-data-platform/get-started/log-api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9951",
+    "paths": [
+      "/docs/data-ingest-apis/get-data-new-relic/trace-api",
+      "/docs/telemetry-data-platform/get-data-new-relic/trace-api",
+      "/docs/telemetry-data-platform/get-started/trace-api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7016",
+    "paths": [
+      "/docs/alerts/rest-api-alerts"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10606",
+    "paths": [
+      "/docs/alerts/alerts-nerdgraph",
+      "/docs/alerts-applied-intelligence/alerts-nerdgraph"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10226",
+    "paths": [
+      "/docs/alerts/alerts-nerdgraph/nerdgraph-examples",
+      "/docs/alerts-applied-intelligence/alerts-nerdgraph/nerdgraph-examples"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10646",
+    "paths": [
+      "/docs/alerts/proactive-detection",
+      "/docs/alerts-applied-intelligence/proactive-detection"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10651",
+    "paths": [
+      "/docs/alerts/incident-intelligence",
+      "/docs/alerts-applied-intelligence/incident-intelligence"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10656",
+    "paths": [
+      "/docs/alerts/incident-workflows",
+      "/docs/alerts-applied-intelligence/incident-workflows"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10666",
+    "paths": [
+      "/docs/licenses/license-information/usage-plan-description",
+      "/docs/licenses/license-information/usage-plan-descriptions"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10756",
+    "paths": [
+      "/docs/observability-solutions",
+      "/docs/full-stack-observability/monitor-everything/observability-solutions"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9611",
+    "paths": [
+      "/docs/full-stack-observability/monitor-everything/observability-solutions/serverless-monitoring"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9986",
+    "paths": [
+      "/docs/full-stack-observability/monitor-everything/observability-solutions/logs-context"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10711",
+    "paths": [
+      "/docs/full-stack-observability/monitor-everything/get-started-new-relic-monitoring-tools",
+      "/docs/full-stack-observability/monitor-everything/get-started-new-relic-observability"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10706",
+    "paths": [
+      "/docs/full-stack-observability/monitor-everything"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2256",
+    "paths": [
+      "/docs/full-stack-observability/instrument-everything/instrument-applications-infrastructure/language-agents-apm"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10696",
+    "paths": [
+      "/docs/full-stack-observability/instrument-everything/instrument-core-services"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10691",
+    "paths": [
+      "/docs/full-stack-observability/instrument-everything/instrument-applications-infrastructure"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10576",
+    "paths": [
+      "/docs/full-stack-observability/instrument-everything/instrument-core-services-applications/grafana-integrations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10641",
+    "paths": [
+      "/docs/telemetry-data-platform/get-data-new-relic/manage-data",
+      "/taxonomy/term/10231",
+      "/docs/telemetry-data-platform/get-started/manage-data",
+      "/docs/telemetry-data-platform/data-ingest-query/manage-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10771",
+    "paths": [
+      "/docs/accounts/original-accounts-billing/product-based-data-retention"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10636",
+    "paths": [
+      "/docs/accounts/original-accounts-billing/users-roles"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10626",
+    "paths": [
+      "/docs/accounts/original-accounts-billing/usage"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10621",
+    "paths": [
+      "/docs/accounts/original-accounts-billing/product-based-pricing"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7661",
+    "paths": [
+      "/docs/infrastructure/new-relic-infrastructure/guides"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9816",
+    "paths": [
+      "/docs/infrastructure/new-relic-infrastructure/infrastructure-security"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9991",
+    "paths": [
+      "/docs/logs/new-relic-logs",
+      "/docs/logs/log-monitoring"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/9996",
+    "paths": [
+      "/docs/logs/new-relic-logs/get-started",
+      "/docs/logs/log-monitoring/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10001",
+    "paths": [
+      "/docs/logs/new-relic-logs/enable-logs",
+      "/docs/logs/log-monitoring/enable-logs"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10011",
+    "paths": [
+      "/docs/logs/new-relic-logs/ui-data",
+      "/docs/logs/log-monitoring/ui-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10021",
+    "paths": [
+      "/docs/logs/new-relic-logs/troubleshooting",
+      "/docs/logs/log-monitoring/troubleshooting"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10796",
+    "paths": [
+      "/docs/infrastructure/install-configure-manage-infrastructure-agent/get-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7697",
+    "paths": [
+      "/docs/synthetics/new-relic-synthetics/guides"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6491",
+    "paths": [
+      "/docs/synthetics/new-relic-synthetics/administration"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6156",
+    "paths": [
+      "/docs/synthetics/new-relic-synthetics/private-locations"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/6656",
+    "paths": [
+      "/docs/synthetics/new-relic-synthetics/synthetics-api"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10806",
+    "paths": [
+      "/docs/telemetry-data-platform/data-ingest-query/apis",
+      "/docs/telemetry-data-platform/data-ingest-query/ingest-apis"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10801",
+    "paths": [
+      "/docs/telemetry-data-platform/data-ingest-query/understand-data"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2236",
+    "paths": [
+      "/docs/browser/new-relic-browser/getting-started"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7656",
+    "paths": [
+      "/docs/browser/new-relic-browser/guides"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/7546",
+    "paths": [
+      "/docs/browser/new-relic-browser/configuration"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5841",
+    "paths": [
+      "/docs/browser/new-relic-browser/browser-pro-features"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5851",
+    "paths": [
+      "/docs/browser/new-relic-browser/additional-standard-features"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/5856",
+    "paths": [
+      "/docs/browser/new-relic-browser/performance-quality"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2251",
+    "paths": [
+      "/docs/browser/new-relic-browser/miscellaneous"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10221",
+    "paths": [
+      "/alerts/new-relic-alerts/alerts-nerdgraph"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10851",
+    "paths": [
+      "/docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10861",
+    "paths": [
+      "/docs/security/new-relic-security/information-security"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/10866",
+    "paths": [
+      "/docs/enable-lambda-monitoring"
+    ]
+  },
+  {
+    "url": "/taxonomy/term/2361",
+    "paths": [
+      "/docs/agents/nodejs-agent/supported-features"
+    ]
+  }
+]

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -10,7 +10,6 @@
       "/docs/servers/new-relic-servers-linux/maintenance/server-monitor-known-issues",
       "/docs/servers/new-relic-servers-linux/maintenance/servers-linux-known-issues",
       "/docs/servers/new-relic-servers-linux/troubleshooting/servers-linux-known-issues",
-      "/node/6896",
       "/docs/infrastructure/new-relic-infrastructure/troubleshooting",
       "/docs/infrastructure/config-management-tools/troubleshooting",
       "/docs/servers/new-relic-servers-linux/troubleshooting/missing-processes-servers-linux",
@@ -38,7 +37,6 @@
       "/docs/rubicon/known-limitations",
       "/docs/insights/known-limitations",
       "/docs/insights/new-relic-insights/troubleshooting/known-limitations",
-      "/taxonomy/term/2181",
       "/docs/insights/new-relic-insights"
     ]
   },
@@ -46,8 +44,7 @@
     "url": "/docs/agents/php-agent/troubleshooting",
     "paths": [
       "/docs/php/php-agent-faq",
-      "/docs/agents/php-agent/getting-started/new-relic-php-faqs",
-      "/node/1546"
+      "/docs/agents/php-agent/getting-started/new-relic-php-faqs"
     ]
   },
   {
@@ -71,7 +68,6 @@
     "paths": [
       "/docs/php/the-php-api",
       "/docs/php/php-agent-api",
-      "/node/12311",
       "/docs/agents/php-agent/configuration/php-agent-api"
     ]
   },
@@ -81,7 +77,6 @@
       "/docs/dotnet/AgentApi",
       "/docs/dotnet/the-net-agent-api",
       "/docs/dotnet/net-agent-api",
-      "/node/11661",
       "/docs/agents/net-agent/features/net-agent-api"
     ]
   },
@@ -107,7 +102,7 @@
       "/docs/agents/python-agent/hosting-mechanisms/python-hosting-mechanisms",
       "/docs/agents/python-agent/hosting-mechanisms",
       "/docs/agents/python-agent/web-frameworksservers",
-      "/taxonomy/term/2451"
+      "/docs/agents/python-agent/web-frameworks"
     ]
   },
   {
@@ -118,27 +113,6 @@
       "/docs/agents/python-agent/backend-services",
       "/docs/agents/python-agent/backend-services/python-back-end-services",
       "/docs/agents/python-agent/back-end-services/python-back-end-services"
-    ]
-  },
-  {
-    "url": "8051",
-    "paths": [
-      "/docs/partnerships/engine-yard-using-new-relic",
-      "/docs/partnerships/engine-yard-users",
-      "/docs/partnerships/engine-yard-troubleshooting",
-      "/docs/accounts-partnerships/partnerships/engine-yard-and-new-relic/engine-yard-installing-new-relic",
-      "/docs/accounts-partnerships/partnerships/engine-yard-and-new-relic/engine-yard-using-new-relic",
-      "/docs/accounts-partnerships/partnerships/engine-yard-and-new-relic/engine-yard-troubleshooting-new",
-      "/docs/accounts-partnerships/partnerships/engine-yard-and-new-relic",
-      "/docs/accounts-partnerships/partnerships/engine-yard-new-relic",
-      "/docs/accounts-partnerships/partnerships/engine-yard-new-relic/engine-yard-installing-new-relic",
-      "/docs/accounts-partnerships/partnerships/engine-yard-new-relic/engine-yard-troubleshooting-new-relic",
-      "/docs/accounts-partnerships/partnerships/engine-yard-new-relic/engine-yard-using-new-relic",
-      "/docs/new-relic-partnerships/partnerships/engine-yard-new-relic/engine-yard-using-new-relic",
-      "/docs/accounts-partnerships/accounts/install-new-relic/partner-based-installation/engine-yard-install-new-relic",
-      "/docs/accounts-partnerships/install-new-relic/partner-based-installation",
-      "/docs/accounts-partnerships/install-new-relic/partner-based-installation/engine-yard-install-new-relic",
-      "/docs/accounts/install-new-relic/partner-based-installation/engine-yard-install-new-relic"
     ]
   },
   {
@@ -162,49 +136,6 @@
     ]
   },
   {
-    "url": "2921",
-    "paths": [
-      "/docs/platform/plugins-new-relic/using-plugins"
-    ]
-  },
-  {
-    "url": "2926",
-    "paths": [
-      "/docs/platform/plugins-new-relic/miscellaneous"
-    ]
-  },
-  {
-    "url": "2931",
-    "paths": [
-      "/docs/platform/developing-plugins",
-      "/docs/plugin-dev"
-    ]
-  },
-  {
-    "url": "2951",
-    "paths": [
-      "/docs/platform/developing-plugins/writing-code"
-    ]
-  },
-  {
-    "url": "2941",
-    "paths": [
-      "/docs/platform/developing-plugins/structuring-your-plugin"
-    ]
-  },
-  {
-    "url": "2946",
-    "paths": [
-      "/docs/platform/developing-plugins/sharing-your-plugin"
-    ]
-  },
-  {
-    "url": "2961",
-    "paths": [
-      "/docs/platform/developing-plugins/miscellaneous"
-    ]
-  },
-  {
     "url": "/docs/plugins/plugin-developer-resources",
     "paths": [
       "/docs/platform/plugin-developer-resources",
@@ -212,21 +143,9 @@
     ]
   },
   {
-    "url": "2936",
-    "paths": [
-      "/docs/platform/plugin-developer-resources/planning-your-plugin"
-    ]
-  },
-  {
     "url": "/docs/plugins/plugin-developer-resources/developer-reference",
     "paths": [
       "/docs/platform/plugin-developer-resources/developer-reference"
-    ]
-  },
-  {
-    "url": "3226",
-    "paths": [
-      "/docs/platform/plugin-developer-resources/miscellaneous"
     ]
   },
   {
@@ -239,64 +158,50 @@
   {
     "url": "/docs/release-notes/agent-release-notes/java-release-notes",
     "paths": [
-      "/docs/releases/java",
-      "/node/5336"
+      "/docs/releases/java"
     ]
   },
   {
     "url": "/docs/release-notes/agent-release-notes/net-release-notes",
     "paths": [
-      "/docs/releases/dotnet",
-      "/node/5341"
+      "/docs/releases/dotnet"
     ]
   },
   {
     "url": "/docs/release-notes/agent-release-notes/nodejs-release-notes",
     "paths": [
-      "/docs/releases/node",
-      "/node/5346"
+      "/docs/releases/node"
     ]
   },
   {
     "url": "/docs/release-notes/agent-release-notes/php-release-notes",
     "paths": [
-      "/docs/releases/php",
-      "/node/5351"
+      "/docs/releases/php"
     ]
   },
   {
     "url": "/docs/release-notes/agent-release-notes/python-release-notes",
     "paths": [
       "/docs/releases/python",
-      "/node/5356",
       "/docs/python/python-agent-release-notes"
     ]
   },
   {
     "url": "/docs/release-notes/agent-release-notes/ruby-release-notes",
     "paths": [
-      "/docs/releases/ruby",
-      "/node/5361"
+      "/docs/releases/ruby"
     ]
   },
   {
     "url": "/docs/release-notes/mobile-release-notes/android-release-notes",
     "paths": [
-      "/docs/releases/android",
-      "/node/5366"
+      "/docs/releases/android"
     ]
   },
   {
     "url": "/docs/release-notes/mobile-release-notes/ios-release-notes",
     "paths": [
-      "/docs/releases/ios",
-      "/node/5371"
-    ]
-  },
-  {
-    "url": "3166",
-    "paths": [
-      "/docs/releases/titanium"
+      "/docs/releases/ios"
     ]
   },
   {
@@ -360,14 +265,6 @@
     ]
   },
   {
-    "url": "6401",
-    "paths": [
-      "/docs/features",
-      "/docs/apm/other-features",
-      "/docs/data-analysis/user-interface-functions"
-    ]
-  },
-  {
     "url": "/docs/apm/apm-ui-pages",
     "paths": [
       "/docs/applications-menu",
@@ -387,28 +284,9 @@
     ]
   },
   {
-    "url": "2691",
-    "paths": [
-      "/docs/dashboards-menu",
-      "/docs/apm/dashboards-menu"
-    ]
-  },
-  {
     "url": "/docs/apm/reports",
     "paths": [
       "/docs/reports"
-    ]
-  },
-  {
-    "url": "2741",
-    "paths": [
-      "/docs/alert-policies"
-    ]
-  },
-  {
-    "url": "2826",
-    "paths": [
-      "/docs/mobile-monitoring-installation"
     ]
   },
   {
@@ -418,40 +296,9 @@
     ]
   },
   {
-    "url": "2871",
-    "paths": [
-      "/docs/mobile-sdk-api"
-    ]
-  },
-  {
-    "url": "3336",
-    "paths": [
-      "/docs/insights-ios-app",
-      "/docs/mobile-apps/insights-ios-app"
-    ]
-  },
-  {
-    "url": "2806",
-    "paths": [
-      "/docs/new-relic-android-app"
-    ]
-  },
-  {
-    "url": "3311",
-    "paths": [
-      "/docs/new-relic-ios-app"
-    ]
-  },
-  {
     "url": "/docs/release-notes",
     "paths": [
       "/docs/releases"
-    ]
-  },
-  {
-    "url": "3066",
-    "paths": [
-      "/docs/nronly"
     ]
   },
   {
@@ -474,80 +321,6 @@
       "/docs/agents/python-agent/customization-and-extension",
       "/docs/agents/python-agent/customization-extension",
       "/docs/agents/python-agent/api"
-    ]
-  },
-  {
-    "url": "3381",
-    "paths": [
-      "/docs/apm/apis/api-v2-examples"
-    ]
-  },
-  {
-    "url": "2096",
-    "paths": [
-      "/docs/news"
-    ]
-  },
-  {
-    "url": "2166",
-    "paths": [
-      "/docs/accounts-partnerships/partnerships/heroku-and-new-relic",
-      "/docs/accounts-partnerships/partnerships/heroku-new-relic"
-    ]
-  },
-  {
-    "url": "2186",
-    "paths": [
-      "/docs/insights/new-relic-insights/getting-started"
-    ]
-  },
-  {
-    "url": "2196",
-    "paths": [
-      "/docs/insights/new-relic-insights/managing-dashboards-and-data"
-    ]
-  },
-  {
-    "url": "2211",
-    "paths": [
-      "/docs/insights/new-relic-insights/adding-and-querying-data",
-      "/docs/insights/new-relic-insights/adding-querying-data"
-    ]
-  },
-  {
-    "url": "5871",
-    "paths": [
-      "/docs/new-relic-synthetics/getting-started"
-    ]
-  },
-  {
-    "url": "5876",
-    "paths": [
-      "/docs/new-relic-synthetics/using-monitors"
-    ]
-  },
-  {
-    "url": "5881",
-    "paths": [
-      "/docs/new-relic-synthetics/scripting-monitors"
-    ]
-  },
-  {
-    "url": "5886",
-    "paths": [
-      "/docs/new-relic-synthetics/dashboards"
-    ]
-  },
-  {
-    "url": "5891",
-    "paths": [
-      "/docs/new-relic-synthetics/troubleshooting"
-    ]
-  },
-  {
-    "url": "5896",
-    "paths": [
-      "/docs/new-relic-synthetics/miscellaneous"
     ]
   },
   {
@@ -660,8 +433,6 @@
       "/docs/seymour/new-relic-seymour/getting-started",
       "/docs/radar/new-relic-radar",
       "/docs/radar/new-relic-radar/getting-started",
-      "/taxonomy/term/7531",
-      "/taxonomy/term/7526",
       "/docs/radar",
       "/docs/using-new-relic/new-relic-radar/getting-started",
       "/docs/using-new-relic/new-relic-radar",
@@ -681,14 +452,7 @@
       "/docs/apm/transactions-menu/x-ray-sessions",
       "/docs/apm/transactions/transaction-traces",
       "/docs/apm/traces/transaction-traces",
-      "/docs/apm/selected-transactions/x-ray-sessions",
-      "/taxonomy/term/2656"
-    ]
-  },
-  {
-    "url": "2661",
-    "paths": [
-      "/docs/apm/transactions-menu/miscellaneous"
+      "/docs/apm/selected-transactions/x-ray-sessions"
     ]
   },
   {
@@ -696,12 +460,6 @@
     "paths": [
       "/docs/browser/new-relic-browser/torubleshooting",
       "/docs/browser/new-relic-browser/troubleshooting"
-    ]
-  },
-  {
-    "url": "6086",
-    "paths": [
-      "/docs/insights/new-relic-insights/data-apps-0"
     ]
   },
   {
@@ -718,9 +476,7 @@
       "/docs/browser/new-relic-browser/browser-agent-apis/manually-reporting-page-load-timing-data",
       "/docs/browser/new-relic-browser/browser-agent-api",
       "/docs/browser/new-relic-browser/browser-agent-apis/report-data-events-browser-agent-api",
-      "/node/9886",
       "/docs/browser/single-page-app-monitoring/spa-api/spa-api",
-      "/taxonomy/term/3366",
       "/docs/browser/new-relic-browser/browser-agent-apis",
       "/docs/browser/new-relic-browser/browser-agent-spa-api/view-all-methods",
       "/docs/browser/new-relic-browser/browser-agent-spa-api"
@@ -813,35 +569,6 @@
     ]
   },
   {
-    "url": "2696",
-    "paths": [
-      "/docs/apm/dashboards-menu/custom-dashboards",
-      "/docs/dashboards/custom-dashboards"
-    ]
-  },
-  {
-    "url": "2701",
-    "paths": [
-      "/docs/apm/dashboards-menu/legacy-custom-dashboards",
-      "/docs/dashboards/legacy-custom-dashboards"
-    ]
-  },
-  {
-    "url": "2706",
-    "paths": [
-      "/docs/apm/dashboards-menu/miscellaneous",
-      "/docs/dashboards/miscellaneous"
-    ]
-  },
-  {
-    "url": "5766",
-    "paths": [
-      "/docs/accounts-partnerships/education/finding-help",
-      "/docs/accounts-partnerships/education/getting-started-new-relic",
-      "/docs/accounts/education/getting-started-new-relic"
-    ]
-  },
-  {
     "url": "/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages",
     "paths": [
       "/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-dashboards"
@@ -895,9 +622,7 @@
   },
   {
     "url": "/docs/apis/synthetics-rest-api",
-    "paths": [
-      "/node/9416"
-    ]
+    "paths": []
   },
   {
     "url": "/docs/agents/nodejs-agent/troubleshooting",
@@ -910,13 +635,6 @@
     "url": "/docs/agents/net-agent/troubleshooting",
     "paths": [
       "/docs/agents/net-agent/installation-configuration/known-issues-net"
-    ]
-  },
-  {
-    "url": "6441",
-    "paths": [
-      "/docs/accounts-partnerships/accounts/account-usage",
-      "/docs/accounts-partnerships/accounts/account-billing-usage"
     ]
   },
   {
@@ -964,12 +682,6 @@
     ]
   },
   {
-    "url": "6771",
-    "paths": [
-      "/docs/browser/spa"
-    ]
-  },
-  {
     "url": "/docs/browser/single-page-app-monitoring/use-spa-data",
     "paths": [
       "/docs/browser/single-page-app-monitoring/browser-ui"
@@ -1004,36 +716,12 @@
   },
   {
     "url": "/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes",
-    "paths": [
-      "/node/10486"
-    ]
+    "paths": []
   },
   {
     "url": "/docs/release-notes/agent-release-notes/go-release-notes",
     "paths": [
       "/docs/agents/go-agent/get-started/go-agent-release-notes"
-    ]
-  },
-  {
-    "url": "6971",
-    "paths": [
-      "/docs/infrastructure-pro-table-contents",
-      "/docs/infrastructure-integrations-table-contents",
-      "/docs/infrastructure/infrastructure-integrations",
-      "/docs/infrastructure/integrations/integrations/amazonaws-integrations"
-    ]
-  },
-  {
-    "url": "6901",
-    "paths": [
-      "/docs/alerts/new-relic-alerts/getting-started/new-relic-alerts-release-notes"
-    ]
-  },
-  {
-    "url": "2146",
-    "paths": [
-      "/docs/accounts-partnerships/partnerships/partner-integration-guide",
-      "/docs/accounts-partnerships/partnerships/former-partner-integration-guide"
     ]
   },
   {
@@ -1133,53 +821,10 @@
     ]
   },
   {
-    "url": "6956",
-    "paths": [
-      "/docs/infrastructure/config-management-tools/miscellaneous"
-    ]
-  },
-  {
-    "url": "6096",
-    "paths": [
-      "/docs/alerts/new-relic-alerts-beta/reviewing-events"
-    ]
-  },
-  {
-    "url": "6991",
-    "paths": [
-      "/docs/dashboards",
-      "/docs/dashboards/new-relic-dashboards"
-    ]
-  },
-  {
-    "url": "6996",
-    "paths": [
-      "/docs/dashboards/new-relic-dashboards/custom-dashboards"
-    ]
-  },
-  {
-    "url": "7001",
-    "paths": [
-      "/docs/dashboards/new-relic-dashboards/legacy-custom-dashboards"
-    ]
-  },
-  {
-    "url": "7006",
-    "paths": [
-      "/docs/dashboards/new-relic-dashboards/miscellaneous"
-    ]
-  },
-  {
     "url": "/docs/alerts-applied-intelligence/rest-api-alerts/new-relic-alerts-rest-api",
     "paths": [
       "/docs/alerts/new-relic-alerts/rest-api-alerts",
       "/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api"
-    ]
-  },
-  {
-    "url": "7026",
-    "paths": [
-      "/docs/alerts/alert-policies/rest-api-alert-policies"
     ]
   },
   {
@@ -1201,9 +846,7 @@
   },
   {
     "url": "/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes",
-    "paths": [
-      "/node/11376"
-    ]
+    "paths": []
   },
   {
     "url": "/docs/agents/ruby-agent/instrumented-gems",
@@ -1221,25 +864,6 @@
     "url": "/docs/agents/java-agent/features",
     "paths": [
       "/docs/agents/java-agent/features-ui"
-    ]
-  },
-  {
-    "url": "7211",
-    "paths": [
-      "/docs/insights/nrql-new-relic-query-language/getting-started"
-    ]
-  },
-  {
-    "url": "7231",
-    "paths": [
-      "/docs/insights/explore-data/data-explorer",
-      "/docs/insights/explore-data/data-explorer-ui"
-    ]
-  },
-  {
-    "url": "7216",
-    "paths": [
-      "/docs/insights/nrql-new-relic-query-language/nrql-resources"
     ]
   },
   {
@@ -1277,24 +901,6 @@
     ]
   },
   {
-    "url": "7176",
-    "paths": [
-      "/docs/insights/using-insights-ui/basic-ui-tasks"
-    ]
-  },
-  {
-    "url": "7181",
-    "paths": [
-      "/docs/insights/using-insights-ui/advanced-ui-tasks"
-    ]
-  },
-  {
-    "url": "7266",
-    "paths": [
-      "/docs/insights/using-insights-ui/filter-segment"
-    ]
-  },
-  {
     "url": "/docs/insights/use-insights-ui/time-settings",
     "paths": [
       "/docs/insights/using-insights-ui/time-settings"
@@ -1305,7 +911,6 @@
     "paths": [
       "/docs/insights/explore-data",
       "/docs/insights/explore-add-data",
-      "/taxonomy/term/7251",
       "/docs/insights/new-relic-insights/custom-events",
       "/docs/insights/basic-attributes",
       "/docs/insights/insights-data-sources"
@@ -1320,13 +925,6 @@
       "/docs/insights/new-relic-insights/decorating-events/insights-attributes",
       "/docs/insights/insights-data-sources/custom-data",
       "/docs/insights/event-data-sources/custom-data"
-    ]
-  },
-  {
-    "url": "7251",
-    "paths": [
-      "/docs/insights/explore-data/custom-attributes",
-      "/docs/insights/explore-add-data/custom-attributes"
     ]
   },
   {
@@ -1374,65 +972,6 @@
     "paths": [
       "/docs/reports/publicizing-your-rankings",
       "/docs/full-stack-observability/monitor-everything/observability-solutions/application-monitoring-apm"
-    ]
-  },
-  {
-    "url": "2326",
-    "paths": [
-      "/docs/agents/net-agent/features"
-    ]
-  },
-  {
-    "url": "5096",
-    "paths": [
-      "/docs/servers/servers-dashboards/miscellaneous"
-    ]
-  },
-  {
-    "url": "6976",
-    "paths": [
-      "/docs/infrastructure/infrastructure-integrations/getting-started"
-    ]
-  },
-  {
-    "url": "6981",
-    "paths": [
-      "/docs/infrastructure/infrastructure-integrations/amazon-integrations",
-      "/node/13796",
-      "/docs/infrastructure/new-relic-infrastructure/integrations/aws-integrations",
-      "/docs/infrastructure/amazon-integrations/amazon-integrations",
-      "/docs/infrastructure/amazon-integrations/aws-integrations"
-    ]
-  },
-  {
-    "url": "7356",
-    "paths": [
-      "/docs/infrastructure/infrastructure-integrations/custom-integrations"
-    ]
-  },
-  {
-    "url": "6986",
-    "paths": [
-      "/docs/infrastructure/infrastructure-integrations/troubleshooting"
-    ]
-  },
-  {
-    "url": "7436",
-    "paths": [
-      "/docs/infrastructure/integrations-sdk/integration-building-tools",
-      "/docs/infrastructure/integrations-sdk/tools-resources"
-    ]
-  },
-  {
-    "url": "7431",
-    "paths": [
-      "/docs/infrastructure/integrations-sdk/filedata-specifications"
-    ]
-  },
-  {
-    "url": "7486",
-    "paths": [
-      "/docs/data-apps"
     ]
   },
   {
@@ -1494,42 +1033,10 @@
     ]
   },
   {
-    "url": "3051",
-    "paths": [
-      "/docs/licenses/license-information/new-relic-server-licenses"
-    ]
-  },
-  {
     "url": "/docs/licenses/product-or-service-licenses/new-relic-synthetics",
     "paths": [
       "/docs/licenses/license-information/new-relic-synthetics-licenses",
       "/docs/licenses/new-relic-products/new-relic-synthetics"
-    ]
-  },
-  {
-    "url": "3261",
-    "paths": [
-      "/docs/new-relic-only/drupal-configuration/users-and-roles"
-    ]
-  },
-  {
-    "url": "3256",
-    "paths": [
-      "/docs/new-relic-only/drupal-configuration/taxonomy"
-    ]
-  },
-  {
-    "url": "7451",
-    "paths": [
-      "/docs/infrastructure/integrations/get-started",
-      "/docs/infrastructure/integrations/getting-started",
-      "/docs/infrastructure/integrations-getting-started/getting-started"
-    ]
-  },
-  {
-    "url": "7426",
-    "paths": [
-      "/docs/infrastructure/integrations-sdk/get-started"
     ]
   },
   {
@@ -1543,7 +1050,6 @@
   {
     "url": "/docs/agents/python-agent/python-agent-api",
     "paths": [
-      "/node/13901",
       "/docs/adduserattribute-python-agent-api"
     ]
   },
@@ -1560,33 +1066,6 @@
     ]
   },
   {
-    "url": "5541",
-    "paths": [
-      "/docs/agents/net-agent/instrumentation",
-      "/docs/agents/net-agent/additional-installation",
-      "/docs/agents/net-agent/install-guides"
-    ]
-  },
-  {
-    "url": "7676",
-    "paths": [
-      "/docs/infrastructure/azure-integrations"
-    ]
-  },
-  {
-    "url": "7681",
-    "paths": [
-      "/docs/infrastructure/azure-integrations/getting-started"
-    ]
-  },
-  {
-    "url": "7696",
-    "paths": [
-      "/node/14171",
-      "/docs/infrastructure/new-relic-infrastructure/integrations/azure-integrations"
-    ]
-  },
-  {
     "url": "/docs/infrastructure/integrations",
     "paths": [
       "/docs/infrastructure/integrations",
@@ -1598,39 +1077,6 @@
     "paths": [
       "/docs/infrastructure/integrations/integrations",
       "/docs/infrastructure/integrations-getting-started/integrations"
-    ]
-  },
-  {
-    "url": "7461",
-    "paths": [
-      "/docs/infrastructure/integrations/use-integration-data"
-    ]
-  },
-  {
-    "url": "7716",
-    "paths": [
-      "/docs/infrastructure/integrations-getting-started/integrations/host-integrations"
-    ]
-  },
-  {
-    "url": "7721",
-    "paths": [
-      "/docs/infrastructure/host-integrations/find-use-data",
-      "/docs/infrastructure/host-integrations/use-data"
-    ]
-  },
-  {
-    "url": "7726",
-    "paths": [
-      "/docs/infrastructure/amazon-integrations/find-use-data",
-      "/docs/infrastructure/amazon-integrations/use-data"
-    ]
-  },
-  {
-    "url": "7731",
-    "paths": [
-      "/docs/infrastructure/microsoft-azure-integrations/find-use-data",
-      "/docs/infrastructure/microsoft-azure-integrations/use-data"
     ]
   },
   {
@@ -1678,31 +1124,9 @@
     ]
   },
   {
-    "url": "2156",
-    "paths": [
-      "/docs/accounts-partnerships/partnerships/partner-based-installation",
-      "/docs/new-relic-partnerships/partnerships/partner-based-installation",
-      "/docs/accounts-partnerships/partner-based-installation",
-      "/docs/accounts-partnerships/accounts/install-new-relic/partner-based-installation",
-      "/docs/accounts/accounts-partnerships/install-new-relic/partner-based-installation"
-    ]
-  },
-  {
-    "url": "7611",
-    "paths": [
-      "/docs/accounts-partnerships/partnerships/google-cloud-platform-gcp"
-    ]
-  },
-  {
     "url": "/docs/new-relic-partnerships/partnerships/partner-api",
     "paths": [
       "/docs/accounts-partnerships/partnerships/partner-api"
-    ]
-  },
-  {
-    "url": "2171",
-    "paths": [
-      "/docs/accounts-partnerships/partnerships/miscellaneous"
     ]
   },
   {
@@ -1733,12 +1157,6 @@
     "url": "/docs/new-relic-partnerships/partner-integration-guide/appendix",
     "paths": [
       "/docs/accounts-partnerships/partner-integration-guide/appendix"
-    ]
-  },
-  {
-    "url": "6291",
-    "paths": [
-      "/docs/accounts-partnerships/partner-integration-guide/miscellaneous"
     ]
   },
   {
@@ -1821,7 +1239,6 @@
   {
     "url": "/docs/integrations/amazon-integrations/aws-integrations-list",
     "paths": [
-      "/taxonomy/term/6981",
       "/docs/infrastructure/amazon-integrations/aws-integrations-list",
       "/docs/integrations/amazon-integrations/aws-integrations-list",
       "/docs/kubernetes-integration/amazon-integrations/aws-integrations-list",
@@ -1832,7 +1249,6 @@
   {
     "url": "/docs/integrations/amazon-integrations",
     "paths": [
-      "/taxonomy/term/6971",
       "/docs/infrastructure/amazon-integrations",
       "/docs/integrations/amazon-integrations",
       "/docs/kubernetes-integration/amazon-integrations",
@@ -1842,7 +1258,6 @@
   {
     "url": "/docs/integrations/amazon-integrations/troubleshooting",
     "paths": [
-      "/taxonomy/term/6986",
       "/docs/integrations/amazon-integrations/troubleshooting",
       "/docs/kubernetes-integration/amazon-integrations/troubleshooting",
       "/docs/infrastructure-integrations/amazon-integrations/troubleshooting"
@@ -1851,7 +1266,6 @@
   {
     "url": "/docs/integrations/amazon-integrations/get-started",
     "paths": [
-      "/taxonomy/term/6976",
       "/docs/integrations/amazon-integrations/getting-started",
       "/docs/integrations/amazon-integrations/get-started",
       "/docs/kubernetes-integration/amazon-integrations/get-started",
@@ -1861,7 +1275,6 @@
   {
     "url": "/docs/integrations/microsoft-azure-integrations/azure-integrations-list",
     "paths": [
-      "/taxonomy/term/7696",
       "/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list",
       "/docs/integrations/microsoft-azure-integrations/azure-integrations-list",
       "/docs/kubernetes-integration/microsoft-azure-integrations/azure-integrations-list",
@@ -1872,7 +1285,6 @@
   {
     "url": "/docs/integrations/microsoft-azure-integrations",
     "paths": [
-      "/taxonomy/term/7676",
       "/docs/integrations/microsoft-azure-integrations",
       "/docs/kubernetes-integration/microsoft-azure-integrations",
       "/docs/infrastructure-integrations/microsoft-azure-integrations"
@@ -1881,7 +1293,6 @@
   {
     "url": "/docs/integrations/host-integrations/host-integrations-list",
     "paths": [
-      "/taxonomy/term/7716",
       "/docs/infrastructure/host-integrations/host-integrations-list",
       "/docs/infrastructure/integrations/types-integrations/open-source-host-integration",
       "/docs/infrastructure/new-relic-infrastructure/integrations/open-source-host-integrations",
@@ -1889,7 +1300,6 @@
       "/docs/kubernetes-integration/host-integrations/host-integrations-list",
       "/docs/kubernetes-integration/host-integrations/open-source-host-integrations-list",
       "/docs/integrations/host-integrations/community-host-integrations-list",
-      "/taxonomy/term/8461",
       "/docs/integrations/new-relic-integrations/host-integrations/host-integrations-list",
       "/docs/infrastructure-integrations/host-integrations/host-integrations-list"
     ]
@@ -1897,19 +1307,10 @@
   {
     "url": "/docs/integrations",
     "paths": [
-      "/taxonomy/term/7446",
-      "/node/12911",
+      "/docs/infrastructure/integrations",
       "/docs/integrations",
       "/docs/kubernetes-integration",
       "/docs/infrastructure-integrations"
-    ]
-  },
-  {
-    "url": "7856",
-    "paths": [
-      "/docs/infrastructure/integrations-sdk",
-      "/docs/kubernetes-integration/integrations-sdk",
-      "/docs/infrastructure-integrations/integrations-sdk"
     ]
   },
   {
@@ -1926,79 +1327,6 @@
     ]
   },
   {
-    "url": "6596",
-    "paths": [
-      "/docs/data-analysis/user-interface-functions/view-your-data"
-    ]
-  },
-  {
-    "url": "6606",
-    "paths": [
-      "/docs/data-analysis/user-interface-functions/organize-your-data"
-    ]
-  },
-  {
-    "url": "6601",
-    "paths": [
-      "/docs/data-analysis/user-interface-functions/share-your-data"
-    ]
-  },
-  {
-    "url": "6881",
-    "paths": [
-      "/docs/data-analysis/user-interface-functions/troubleshooting"
-    ]
-  },
-  {
-    "url": "6411",
-    "paths": [
-      "/docs/data-analysis/metrics",
-      "/docs/using-new-relic/metrics"
-    ]
-  },
-  {
-    "url": "6611",
-    "paths": [
-      "/docs/data-analysis/metrics/analyze-your-metrics",
-      "/docs/using-new-relic/metrics/analyze-your-metrics",
-      "/docs/using-new-relic/data/analyze-your-metrics",
-      "/docs/using-new-relic/data/data-types"
-    ]
-  },
-  {
-    "url": "7406",
-    "paths": [
-      "/docs/data-analysis/health-map",
-      "/docs/using-new-relic/health-map"
-    ]
-  },
-  {
-    "url": "7411",
-    "paths": [
-      "/docs/data-analysis/health-map/get-started",
-      "/docs/using-new-relic/health-map/get-started"
-    ]
-  },
-  {
-    "url": "6766",
-    "paths": [
-      "/docs/data-analysis/service-maps/get-started"
-    ]
-  },
-  {
-    "url": "6761",
-    "paths": [
-      "/docs/data-analysis/service-maps/service-maps"
-    ]
-  },
-  {
-    "url": "7951",
-    "paths": [
-      "/docs/accounts-partnerships/accounts/install-new-relic",
-      "/docs/accounts/accounts-partnerships/install-new-relic"
-    ]
-  },
-  {
     "url": "/docs/security/security-privacy",
     "paths": [
       "/docs/accounts-partnerships/new-relic-security",
@@ -2007,41 +1335,9 @@
     ]
   },
   {
-    "url": "2116",
-    "paths": [
-      "/docs/accounts-partnerships/accounts/account-setup",
-      "/docs/accounts/accounts-partnerships/install-new-relic/account-setup"
-    ]
-  },
-  {
     "url": "/docs/accounts",
     "paths": [
       "/docs/accounts-partnerships"
-    ]
-  },
-  {
-    "url": "8046",
-    "paths": [
-      "/docs/accounts-partnerships/install-new-relic"
-    ]
-  },
-  {
-    "url": "8056",
-    "paths": [
-      "/docs/accounts-partnerships/install-new-relic/account-setup"
-    ]
-  },
-  {
-    "url": "8066",
-    "paths": [
-      "/docs/accounts-partnerships/install-new-relic/install-agent"
-    ]
-  },
-  {
-    "url": "7991",
-    "paths": [
-      "/docs/accounts-partnerships/accounts/roles-permissions",
-      "/docs/accounts/accounts/roles-permissions"
     ]
   },
   {
@@ -2059,83 +1355,6 @@
       "/docs/accounts/accounts/subscription-pricing",
       "/docs/accounts/accounts-billing/subscription-pricing",
       "/docs/accounts/accounts-billing/new-relic-one-pricing-users"
-    ]
-  },
-  {
-    "url": "7996",
-    "paths": [
-      "/docs/accounts-partnerships/accounts/billing"
-    ]
-  },
-  {
-    "url": "2126",
-    "paths": [
-      "/docs/accounts-partnerships/accounts/saml-single-sign",
-      "/docs/accounts/accounts/saml-single-sign"
-    ]
-  },
-  {
-    "url": "2131",
-    "paths": [
-      "/docs/accounts-partnerships/accounts/miscellaneous"
-    ]
-  },
-  {
-    "url": "8001",
-    "paths": [
-      "/docs/accounts-partnerships/new-relic-account-usage",
-      "/docs/accounts-partnerships/new-relic-account-usage/legacy-account-usage",
-      "/docs/accounts/new-relic-account-usage/legacy-account-usage",
-      "/docs/accounts/new-relic-account-usage/deprecated-usage-apis"
-    ]
-  },
-  {
-    "url": "8006",
-    "paths": [
-      "/docs/accounts-partnerships/new-relic-account-usage/getting-started-usage"
-    ]
-  },
-  {
-    "url": "8011",
-    "paths": [
-      "/docs/accounts-partnerships/new-relic-account-usage/apm-usage",
-      "/docs/accounts/new-relic-account-usage/apm-usage"
-    ]
-  },
-  {
-    "url": "8016",
-    "paths": [
-      "/docs/accounts-partnerships/new-relic-account-usage/browser-usage"
-    ]
-  },
-  {
-    "url": "8021",
-    "paths": [
-      "/docs/accounts-partnerships/new-relic-account-usage/infrastructure-usage"
-    ]
-  },
-  {
-    "url": "8026",
-    "paths": [
-      "/docs/accounts-partnerships/new-relic-account-usage/insights-usage"
-    ]
-  },
-  {
-    "url": "8031",
-    "paths": [
-      "/docs/accounts-partnerships/new-relic-account-usage/mobile-usage"
-    ]
-  },
-  {
-    "url": "8036",
-    "paths": [
-      "/docs/accounts-partnerships/new-relic-account-usage/synthetics-usage"
-    ]
-  },
-  {
-    "url": "5761",
-    "paths": [
-      "/docs/accounts-partnerships/education"
     ]
   },
   {
@@ -2157,7 +1376,6 @@
   {
     "url": "/docs/plugins/plugins-new-relic/custom-dashboards-custom-views",
     "paths": [
-      "/taxonomy/term/6996",
       "/docs/data-analysis/legacy-custom-dashboards/custom-dashboards-v2",
       "/docs/data-analysis/legacy-custom-dashboards/custom-dashboards-v1",
       "/docs/data-analysis/legacy-custom-dashboards/custom-views",
@@ -2167,7 +1385,6 @@
   {
     "url": "/docs/browser/browser-monitoring/page-load-timing-resources",
     "paths": [
-      "/taxonomy/term/2246",
       "/docs/browser/new-relic-browser/page-load-timing",
       "/docs/browser/new-relic-browser/page-load-timing-resources"
     ]
@@ -2187,8 +1404,6 @@
   {
     "url": "/docs/release-notes/platform-release-notes",
     "paths": [
-      "/taxonomy/term/6896",
-      "/taxonomy/term/6901",
       "/docs/release-notes/alerts-release-notes/new-relic-alerts-release-notes/20161115-support-mobile-crash-analysis",
       "/docs/release-notes/alerts-release-notes/new-relic-alerts-release-notes/20161007-more-pagination-search-permalinks",
       "/docs/release-notes/alerts-release-notes/new-relic-alerts-release-notes/20161026-api-performance-improvements-pagination-policies"
@@ -2216,41 +1431,9 @@
     ]
   },
   {
-    "url": "feed",
-    "paths": [
-      "/docs/release-notes/alerts-release-notes/new-relic-alerts-release-notes/feed"
-    ]
-  },
-  {
-    "url": "8221",
-    "paths": [
-      "/docs/using-new-relic/welcome-new-relic/measure-your-devops-success"
-    ]
-  },
-  {
-    "url": "8236",
-    "paths": [
-      "/event-types/transaction",
-      "/attribute-dictionary?events_tids%5B%5D=8236",
-      "/attribute-dictionary/event/Transaction"
-    ]
-  },
-  {
-    "url": "8297",
-    "paths": [
-      "/attribute-dictionary/event-data-sources/new-relic-browser-agent"
-    ]
-  },
-  {
     "url": "/docs/agents/net-agent/other-features",
     "paths": [
       "/docs/agents/net-agent/miscellaneous"
-    ]
-  },
-  {
-    "url": "8246",
-    "paths": [
-      "/units-measure/megabytes-mb"
     ]
   },
   {
@@ -2267,66 +1450,12 @@
     ]
   },
   {
-    "url": "8317",
-    "paths": [
-      "/attribute-dictionary/events/spa-ajaxrequest"
-    ]
-  },
-  {
-    "url": "8312",
-    "paths": [
-      "/attribute-dictionary/events/spa-browserinteraction"
-    ]
-  },
-  {
-    "url": "8322",
-    "paths": [
-      "/attribute-dictionary/events/spa-browsertiming"
-    ]
-  },
-  {
-    "url": "8241",
-    "paths": [
-      "/event-types/transactionerror"
-    ]
-  },
-  {
-    "url": "8441",
-    "paths": [
-      "/attribute-dictionary/units-measure/bytes"
-    ]
-  },
-  {
-    "url": "8716",
-    "paths": [
-      "/attribute-dictionary/units-measure/microseconds"
-    ]
-  },
-  {
-    "url": "8256",
-    "paths": [
-      "/attribute-dictionary/units-measure/milliseconds"
-    ]
-  },
-  {
-    "url": "8251",
-    "paths": [
-      "/attribute-dictionary/units-measure/seconds"
-    ]
-  },
-  {
     "url": "/docs/integrations/host-integrations/get-started",
     "paths": [
       "/docs/integrations/host-integrations/getting-started",
       "/docs/kubernetes-integration/host-integrations/getting-started",
       "/docs/integrations/host-integrations/get-started",
       "/docs/infrastructure-integrations/host-integrations/get-started"
-    ]
-  },
-  {
-    "url": "8461",
-    "paths": [
-      "/docs/integrations/host-integrations/open-source-host-integrations-list"
     ]
   },
   {
@@ -2395,51 +1524,12 @@
     ]
   },
   {
-    "url": "7881",
-    "paths": [
-      "/docs/integrations/integrations-sdk/getting-started",
-      "/docs/kubernetes-integration/integrations-sdk/getting-started",
-      "/docs/integrations/integrations-sdk/get-started",
-      "/docs/infrastructure-integrations/integrations-sdk/get-started"
-    ]
-  },
-  {
-    "url": "8501",
-    "paths": [
-      "/docs/integrations/integrations-sdk/build-tools",
-      "/docs/kubernetes-integration/integrations-sdk/build-tools",
-      "/docs/infrastructure-integrations/integrations-sdk/build-tools"
-    ]
-  },
-  {
-    "url": "7931",
-    "paths": [
-      "/docs/integrations/integrations-sdk/file-specifications",
-      "/docs/kubernetes-integration/integrations-sdk/file-specifications",
-      "/docs/infrastructure-integrations/integrations-sdk/file-specifications"
-    ]
-  },
-  {
-    "url": "7916",
-    "paths": [
-      "/docs/integrations/integrations-sdk/troubleshooting",
-      "/docs/kubernetes-integration/integrations-sdk/troubleshooting",
-      "/docs/infrastructure-integrations/integrations-sdk/troubleshooting"
-    ]
-  },
-  {
     "url": "/docs/integrations/kubernetes-integration/link-apps-services",
     "paths": [
       "/docs/integrations/kubernetes-integration/metadata-injection",
       "/docs/integrations/kubernetes-integration/link-your-applications",
       "/docs/integrations/kubernetes-integration/link-apps-services",
       "/docs/infrastructure-integrations/kubernetes-integration/link-apps-services"
-    ]
-  },
-  {
-    "url": "8901",
-    "paths": [
-      "/attribute-dictionary/event-data-sources/aws-integrations"
     ]
   },
   {
@@ -2579,54 +1669,6 @@
     ]
   },
   {
-    "url": "9661",
-    "paths": [
-      "/docs/get-started",
-      "/docs/new-relic-one-dashboards/get-started",
-      "/docs/explore-query-data/new-relic-one-dashboards/get-started"
-    ]
-  },
-  {
-    "url": "9666",
-    "paths": [
-      "/docs/explore-dashboards-index",
-      "/docs/new-relic-one-dashboards/explore-dashboards-index",
-      "/docs/explore-query-data/new-relic-one-dashboards/explore-dashboards-index"
-    ]
-  },
-  {
-    "url": "9671",
-    "paths": [
-      "/docs/manage-your-dashboard",
-      "/docs/new-relic-one-dashboards/manage-your-dashboard",
-      "/docs/explore-query-data/new-relic-one-dashboards/manage-your-dashboard"
-    ]
-  },
-  {
-    "url": "9731",
-    "paths": [
-      "/docs/chart-builder/use-chart-builder/choose-data-chart"
-    ]
-  },
-  {
-    "url": "9736",
-    "paths": [
-      "/docs/chart-builder/use-chart-builder/new-relic-query-language"
-    ]
-  },
-  {
-    "url": "7186",
-    "paths": [
-      "/docs/chart-builder/use-chart-builder/nrql/nrql-new-relic-query-language"
-    ]
-  },
-  {
-    "url": "9566",
-    "paths": [
-      "/attribute-dictionary/events/syntheticprivatelocationstatus"
-    ]
-  },
-  {
     "url": "/docs/infrastructure/infrastructure-monitoring-ui",
     "paths": [
       "/docs/infrastructure/ui-pages",
@@ -2645,22 +1687,6 @@
       "/docs/infrastructure/troubleshooting/infra-troubleshooting",
       "/docs/infrastructure/infrastructure-troubleshooting/infra-troubleshooting",
       "/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure"
-    ]
-  },
-  {
-    "url": "9826",
-    "paths": [
-      "/docs/infrastructure/install-configure-infrastructure/elastic-beanstalk-installation",
-      "/docs/install-configure-infrastructure/elastic-beanstalk-installation",
-      "/docs/infrastructure/install-configure-manage-infrastructure/elastic-beanstalk-installation"
-    ]
-  },
-  {
-    "url": "9831",
-    "paths": [
-      "/docs/infrastructure/install-configure-infrastructure/docker-installation",
-      "/docs/install-configure-infrastructure/docker-installation",
-      "/docs/infrastructure/install-configure-manage-infrastructure/docker-installation"
     ]
   },
   {
@@ -2718,8 +1744,7 @@
     "paths": [
       "/docs/licenses/license-information/agent-licenses",
       "/docs/licenses/license-information/new-relic-apm-licenses",
-      "/docs/licenses/product-or-service-licenses/new-relic-apm-licenses",
-      "/taxonomy/term/3181"
+      "/docs/licenses/product-or-service-licenses/new-relic-apm-licenses"
     ]
   },
   {
@@ -2732,7 +1757,6 @@
     "url": "/docs/query-your-data/nrql-new-relic-query-language/get-started",
     "paths": [
       "/docs/query-data/nrql-new-relic-query-language/getting-strated",
-      "/taxonomy/term/7216",
       "/docs/query-data/nrql-new-relic-query-language/getting-started",
       "/docs/query-data/nrql-new-relic-query-language/get-started",
       "/docs/query-your-data/nrql-new-relic-query-language/get-started",
@@ -2747,14 +1771,11 @@
   },
   {
     "url": "/docs/licenses/license-information/general-usage-licenses",
-    "paths": [
-      "/taxonomy/term/9571"
-    ]
+    "paths": []
   },
   {
     "url": "/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials",
     "paths": [
-      "/taxonomy/term/7286",
       "/docs/query-data/nrql-new-relic-query-language/nrql-query-examples",
       "/docs/query-data/nrql-new-relic-query-language/nrql-query-tutorials",
       "/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials",
@@ -2764,7 +1785,6 @@
   {
     "url": "/docs/query-your-data/nrql-new-relic-query-language",
     "paths": [
-      "/taxonomy/term/7186",
       "/docs/query-data/nrql-new-relic-query-language",
       "/docs/query-your-data/nrql-new-relic-query-language",
       "/docs/explore-query-data/nrql-new-relic-query-language"
@@ -2984,30 +2004,6 @@
     ]
   },
   {
-    "url": "10211",
-    "paths": [
-      "/docs/integrations/vmware-tanzu-integration"
-    ]
-  },
-  {
-    "url": "10281",
-    "paths": [
-      "/docs/vmware-esxi-integration"
-    ]
-  },
-  {
-    "url": "10276",
-    "paths": [
-      "/docs/vmware-tanzu-integration"
-    ]
-  },
-  {
-    "url": "10286",
-    "paths": [
-      "/docs/covid-19"
-    ]
-  },
-  {
     "url": "/docs/release-notes/platform-release-notes/kubernetes-integration-release-notes",
     "paths": [
       "/docs/integrations/kubernetes-integration/get-started/release-notes",
@@ -3042,12 +2038,6 @@
     "url": "/docs/apm/apm-ui-pages/events",
     "paths": [
       "/docs/apm/applications-menu/events"
-    ]
-  },
-  {
-    "url": "2641",
-    "paths": [
-      "/docs/apm/applications-menu/miscellaneous"
     ]
   },
   {
@@ -3094,13 +2084,6 @@
     "paths": [
       "/docs/integrations/kubernetes-integration/understand-use-data",
       "/docs/infrastructure-integrations/kubernetes-integration/understand-use-data"
-    ]
-  },
-  {
-    "url": "8841",
-    "paths": [
-      "/docs/integrations/kubernetes-integration/cluster-explorer",
-      "/docs/infrastructure-integrations/kubernetes-integration/cluster-explorer"
     ]
   },
   {
@@ -3168,13 +2151,6 @@
     ]
   },
   {
-    "url": "10231",
-    "paths": [
-      "/docs/using-new-relic/data/customize-data/manage-your-data",
-      "/docs/accounts/accounts/data-management"
-    ]
-  },
-  {
     "url": "/docs/integrations/open-source-telemetry-integrations",
     "paths": [
       "/docs/integrations/exporters",
@@ -3212,107 +2188,12 @@
     ]
   },
   {
-    "url": "9711",
-    "paths": [
-      "/docs/new-relic-one-dashboards",
-      "/docs/explore-query-data/new-relic-one-dashboards"
-    ]
-  },
-  {
-    "url": "9716",
-    "paths": [
-      "/docs/new-relic-one-dashboards/key-visual-tools",
-      "/docs/explore-query-data/new-relic-one-dashboards/key-visual-tools"
-    ]
-  },
-  {
-    "url": "9721",
-    "paths": [
-      "/docs/chart-builder/use-chart-builder",
-      "/docs/query-your-data/use-chart-builder",
-      "/docs/query-your-data/chart-builder",
-      "/docs/explore-query-data/chart-builder"
-    ]
-  },
-  {
-    "url": "9726",
-    "paths": [
-      "/docs/chart-builder/use-chart-builder/get-started",
-      "/docs/query-your-data/use-chart-builder/get-started",
-      "/docs/query-your-data/chart-builder/get-started",
-      "/docs/explore-query-data/chart-builder/get-started"
-    ]
-  },
-  {
-    "url": "9751",
-    "paths": [
-      "/docs/chart-builder/use-chart-builder/choose-data",
-      "/docs/query-your-data/use-chart-builder/choose-data",
-      "/docs/query-your-data/chart-builder/choose-data",
-      "/docs/explore-query-data/chart-builder/choose-data"
-    ]
-  },
-  {
-    "url": "9756",
-    "paths": [
-      "/docs/chart-builder/use-chart-builder/nrql",
-      "/docs/query-your-data/use-chart-builder/nrql",
-      "/docs/query-your-data/chart-builder/nrql",
-      "/docs/explore-query-data/chart-builder/nrql"
-    ]
-  },
-  {
-    "url": "9741",
-    "paths": [
-      "/docs/chart-builder/use-chart-builder/use-charts",
-      "/docs/query-your-data/use-chart-builder/use-charts",
-      "/docs/query-your-data/chart-builder/use-charts",
-      "/docs/explore-query-data/chart-builder/use-charts"
-    ]
-  },
-  {
     "url": "/docs/query-your-data/explore-query-data/new-relic-query-language",
     "paths": [
       "/docs/query-your-data/explore-query-data/nrql",
       "/docs/query-your-data/explore-query-data/new-relic-query-language",
       "/docs/query-your-data/explore-query-data/nqrl",
       "/docs/explore-query-data/new-relic-query-language"
-    ]
-  },
-  {
-    "url": "10491",
-    "paths": [
-      "/docs/original-new-relic-accounts"
-    ]
-  },
-  {
-    "url": "10496",
-    "paths": [
-      "/docs/original-new-relic-accounts/original-account-management"
-    ]
-  },
-  {
-    "url": "10501",
-    "paths": [
-      "/docs/original-new-relic-accounts/original-account-management/product-pricing-plan"
-    ]
-  },
-  {
-    "url": "10506",
-    "paths": [
-      "/docs/original-new-relic-accounts/original-account-management/usage"
-    ]
-  },
-  {
-    "url": "10511",
-    "paths": [
-      "/docs/original-new-relic-accounts/original-account-management/users"
-    ]
-  },
-  {
-    "url": "10526",
-    "paths": [
-      "/docs/workloads/workloads"
     ]
   },
   {
@@ -3355,18 +2236,6 @@
     ]
   },
   {
-    "url": "10396",
-    "paths": [
-      "/docs/accounts/accounts/product-usage"
-    ]
-  },
-  {
-    "url": "10411",
-    "paths": [
-      "/docs/accounts/accounts/account-structure"
-    ]
-  },
-  {
     "url": "/docs/accounts/accounts-billing/automated-user-management",
     "paths": [
       "/docs/accounts/accounts/automated-user-management"
@@ -3405,46 +2274,6 @@
     ]
   },
   {
-    "url": "9941",
-    "paths": [
-      "/docs/data-ingest-apis/get-data-new-relic/new-relic-sdks",
-      "/docs/telemetry-data-platform/get-data-new-relic/new-relic-sdks",
-      "/docs/telemetry-data-platform/get-started/new-relic-sdks"
-    ]
-  },
-  {
-    "url": "9946",
-    "paths": [
-      "/docs/data-ingest-apis/get-data-new-relic/metric-api",
-      "/docs/telemetry-data-platform/get-data-new-relic/metric-api",
-      "/docs/telemetry-data-platform/get-started/metric-api"
-    ]
-  },
-  {
-    "url": "9961",
-    "paths": [
-      "/docs/data-ingest-apis/get-data-new-relic/event-api",
-      "/docs/telemetry-data-platform/get-data-new-relic/event-api",
-      "/docs/telemetry-data-platform/get-started/event-api"
-    ]
-  },
-  {
-    "url": "9956",
-    "paths": [
-      "/docs/data-ingest-apis/get-data-new-relic/log-api",
-      "/docs/telemetry-data-platform/get-data-new-relic/log-api",
-      "/docs/telemetry-data-platform/get-started/log-api"
-    ]
-  },
-  {
-    "url": "9951",
-    "paths": [
-      "/docs/data-ingest-apis/get-data-new-relic/trace-api",
-      "/docs/telemetry-data-platform/get-data-new-relic/trace-api",
-      "/docs/telemetry-data-platform/get-started/trace-api"
-    ]
-  },
-  {
     "url": "/docs/alerts-applied-intelligence/rest-api-alerts",
     "paths": [
       "/docs/alerts/rest-api-alerts"
@@ -3455,13 +2284,6 @@
     "paths": [
       "/docs/alerts/alerts-nerdgraph",
       "/docs/alerts-applied-intelligence/alerts-nerdgraph"
-    ]
-  },
-  {
-    "url": "10226",
-    "paths": [
-      "/docs/alerts/alerts-nerdgraph/nerdgraph-examples",
-      "/docs/alerts-applied-intelligence/alerts-nerdgraph/nerdgraph-examples"
     ]
   },
   {
@@ -3552,7 +2374,6 @@
     "url": "/docs/telemetry-data-platform/ingest-manage-data/manage-data",
     "paths": [
       "/docs/telemetry-data-platform/get-data-new-relic/manage-data",
-      "/taxonomy/term/10231",
       "/docs/telemetry-data-platform/get-started/manage-data",
       "/docs/telemetry-data-platform/data-ingest-query/manage-data"
     ]
@@ -3711,12 +2532,6 @@
     "url": "/docs/browser/browser-monitoring/miscellaneous",
     "paths": [
       "/docs/browser/new-relic-browser/miscellaneous"
-    ]
-  },
-  {
-    "url": "10221",
-    "paths": [
-      "/alerts/new-relic-alerts/alerts-nerdgraph"
     ]
   },
   {

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "/taxonomy/term/6951",
+    "url": "/docs/infrastructure/infrastructure-monitoring-troubleshooting",
     "paths": [
       "/docs/windows-server-monitoring/wsm-kb-100",
       "/docs/windows-server-monitoring/windows-server-monitor-known-issues",
@@ -33,7 +33,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/2176",
+    "url": "/docs/insights",
     "paths": [
       "/docs/rubicon/known-limitations",
       "/docs/insights/known-limitations",
@@ -43,7 +43,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/2406",
+    "url": "/docs/agents/php-agent/troubleshooting",
     "paths": [
       "/docs/php/php-agent-faq",
       "/docs/agents/php-agent/getting-started/new-relic-php-faqs",
@@ -51,7 +51,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/6906",
+    "url": "/docs/infrastructure",
     "paths": [
       "/docs/server/new-relic-for-server-monitoring",
       "/docs/server",
@@ -67,7 +67,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7111",
+    "url": "/docs/agents/php-agent/php-agent-api",
     "paths": [
       "/docs/php/the-php-api",
       "/docs/php/php-agent-api",
@@ -76,7 +76,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7076",
+    "url": "/docs/agents/net-agent/net-agent-api",
     "paths": [
       "/docs/dotnet/AgentApi",
       "/docs/dotnet/the-net-agent-api",
@@ -86,14 +86,14 @@
     ]
   },
   {
-    "url": "/taxonomy/term/2451",
+    "url": "/docs/agents/python-agent/web-frameworks",
     "paths": [
       "/docs/python/python-web-frameworks",
       "/docs/agents/python-agent/web-frameworks/python-web-frameworks"
     ]
   },
   {
-    "url": "/taxonomy/term/2446",
+    "url": "/docs/agents/python-agent/hosting-services",
     "paths": [
       "/docs/python/python-hosting-services",
       "/docs/agents/python-agent/hosting-mechanisms/python-hosting-services",
@@ -101,7 +101,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/2441",
+    "url": "/docs/agents/python-agent/web-frameworks-servers",
     "paths": [
       "/docs/python/python-hosting-mechanisms",
       "/docs/agents/python-agent/hosting-mechanisms/python-hosting-mechanisms",
@@ -111,7 +111,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/2456",
+    "url": "/docs/agents/python-agent/back-end-services",
     "paths": [
       "/docs/python/python-backend-services",
       "/docs/agents/python-agent/backend-services/python-backend-services",
@@ -121,7 +121,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/8051",
+    "url": "8051",
     "paths": [
       "/docs/partnerships/engine-yard-using-new-relic",
       "/docs/partnerships/engine-yard-users",
@@ -142,130 +142,130 @@
     ]
   },
   {
-    "url": "/taxonomy/term/2906",
+    "url": "/docs/plugins/plugins-new-relic",
     "paths": [
       "/docs/platform/plugins-new-relic"
     ]
   },
   {
-    "url": "/taxonomy/term/2911",
+    "url": "/docs/plugins/plugins-new-relic/get-started",
     "paths": [
       "/docs/platform/plugins-new-relic/getting-started",
       "/docs/plugins/plugins-new-relic/getting-started"
     ]
   },
   {
-    "url": "/taxonomy/term/2916",
+    "url": "/docs/plugins/plugins-new-relic/install-plugins",
     "paths": [
       "/docs/platform/plugins-new-relic/installing-plugins",
       "/docs/plugins/plugins-new-relic/installing-plugins"
     ]
   },
   {
-    "url": "/taxonomy/term/2921",
+    "url": "2921",
     "paths": [
       "/docs/platform/plugins-new-relic/using-plugins"
     ]
   },
   {
-    "url": "/taxonomy/term/2926",
+    "url": "2926",
     "paths": [
       "/docs/platform/plugins-new-relic/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/2931",
+    "url": "2931",
     "paths": [
       "/docs/platform/developing-plugins",
       "/docs/plugin-dev"
     ]
   },
   {
-    "url": "/taxonomy/term/2951",
+    "url": "2951",
     "paths": [
       "/docs/platform/developing-plugins/writing-code"
     ]
   },
   {
-    "url": "/taxonomy/term/2941",
+    "url": "2941",
     "paths": [
       "/docs/platform/developing-plugins/structuring-your-plugin"
     ]
   },
   {
-    "url": "/taxonomy/term/2946",
+    "url": "2946",
     "paths": [
       "/docs/platform/developing-plugins/sharing-your-plugin"
     ]
   },
   {
-    "url": "/taxonomy/term/2961",
+    "url": "2961",
     "paths": [
       "/docs/platform/developing-plugins/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/3221",
+    "url": "/docs/plugins/plugin-developer-resources",
     "paths": [
       "/docs/platform/plugin-developer-resources",
       "/docs/plugin-developer-resources"
     ]
   },
   {
-    "url": "/taxonomy/term/2936",
+    "url": "2936",
     "paths": [
       "/docs/platform/plugin-developer-resources/planning-your-plugin"
     ]
   },
   {
-    "url": "/taxonomy/term/2956",
+    "url": "/docs/plugins/plugin-developer-resources/developer-reference",
     "paths": [
       "/docs/platform/plugin-developer-resources/developer-reference"
     ]
   },
   {
-    "url": "/taxonomy/term/3226",
+    "url": "3226",
     "paths": [
       "/docs/platform/plugin-developer-resources/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/2136",
+    "url": "/docs/new-relic-partnerships/partnerships",
     "paths": [
       "/docs/partnerships",
       "/docs/accounts-partnerships/partnerships"
     ]
   },
   {
-    "url": "/taxonomy/term/3126",
+    "url": "/docs/release-notes/agent-release-notes/java-release-notes",
     "paths": [
       "/docs/releases/java",
       "/node/5336"
     ]
   },
   {
-    "url": "/taxonomy/term/3131",
+    "url": "/docs/release-notes/agent-release-notes/net-release-notes",
     "paths": [
       "/docs/releases/dotnet",
       "/node/5341"
     ]
   },
   {
-    "url": "/taxonomy/term/3136",
+    "url": "/docs/release-notes/agent-release-notes/nodejs-release-notes",
     "paths": [
       "/docs/releases/node",
       "/node/5346"
     ]
   },
   {
-    "url": "/taxonomy/term/3141",
+    "url": "/docs/release-notes/agent-release-notes/php-release-notes",
     "paths": [
       "/docs/releases/php",
       "/node/5351"
     ]
   },
   {
-    "url": "/taxonomy/term/3146",
+    "url": "/docs/release-notes/agent-release-notes/python-release-notes",
     "paths": [
       "/docs/releases/python",
       "/node/5356",
@@ -273,34 +273,34 @@
     ]
   },
   {
-    "url": "/taxonomy/term/3151",
+    "url": "/docs/release-notes/agent-release-notes/ruby-release-notes",
     "paths": [
       "/docs/releases/ruby",
       "/node/5361"
     ]
   },
   {
-    "url": "/taxonomy/term/3156",
+    "url": "/docs/release-notes/mobile-release-notes/android-release-notes",
     "paths": [
       "/docs/releases/android",
       "/node/5366"
     ]
   },
   {
-    "url": "/taxonomy/term/3161",
+    "url": "/docs/release-notes/mobile-release-notes/ios-release-notes",
     "paths": [
       "/docs/releases/ios",
       "/node/5371"
     ]
   },
   {
-    "url": "/taxonomy/term/3166",
+    "url": "3166",
     "paths": [
       "/docs/releases/titanium"
     ]
   },
   {
-    "url": "/taxonomy/term/2111",
+    "url": "/docs/accounts/accounts-billing",
     "paths": [
       "/docs/subscriptions",
       "/docs/accounts-partnerships/accounts",
@@ -309,58 +309,58 @@
     ]
   },
   {
-    "url": "/taxonomy/term/2231",
+    "url": "/docs/browser/browser-monitoring",
     "paths": [
       "/docs/new-relic-browser",
       "/docs/browser/new-relic-browser"
     ]
   },
   {
-    "url": "/taxonomy/term/2261",
+    "url": "/docs/agents/java-agent",
     "paths": [
       "/docs/java"
     ]
   },
   {
-    "url": "/taxonomy/term/2306",
+    "url": "/docs/agents/net-agent",
     "paths": [
       "/docs/dotnet"
     ]
   },
   {
-    "url": "/taxonomy/term/2346",
+    "url": "/docs/agents/nodejs-agent",
     "paths": [
       "/docs/nodejs"
     ]
   },
   {
-    "url": "/taxonomy/term/2376",
+    "url": "/docs/agents/php-agent",
     "paths": [
       "/docs/php"
     ]
   },
   {
-    "url": "/taxonomy/term/2416",
+    "url": "/docs/agents/python-agent",
     "paths": [
       "/docs/python",
       "/docs/python/python-web-applications"
     ]
   },
   {
-    "url": "/taxonomy/term/2466",
+    "url": "/docs/agents/ruby-agent",
     "paths": [
       "/docs/ruby",
       "/docs/agents/ruby-agent/faqs/middleware-changes-390"
     ]
   },
   {
-    "url": "/taxonomy/term/2531",
+    "url": "/docs/apm/new-relic-apm",
     "paths": [
       "/docs/site"
     ]
   },
   {
-    "url": "/taxonomy/term/6401",
+    "url": "6401",
     "paths": [
       "/docs/features",
       "/docs/apm/other-features",
@@ -368,7 +368,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/2621",
+    "url": "/docs/apm/apm-ui-pages",
     "paths": [
       "/docs/applications-menu",
       "/docs/applications-dashboards",
@@ -376,7 +376,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/6101",
+    "url": "/docs/apm/transactions",
     "paths": [
       "/docs/transactions-menu",
       "/docs/traces",
@@ -387,89 +387,89 @@
     ]
   },
   {
-    "url": "/taxonomy/term/2691",
+    "url": "2691",
     "paths": [
       "/docs/dashboards-menu",
       "/docs/apm/dashboards-menu"
     ]
   },
   {
-    "url": "/taxonomy/term/2711",
+    "url": "/docs/apm/reports",
     "paths": [
       "/docs/reports"
     ]
   },
   {
-    "url": "/taxonomy/term/2741",
+    "url": "2741",
     "paths": [
       "/docs/alert-policies"
     ]
   },
   {
-    "url": "/taxonomy/term/2826",
+    "url": "2826",
     "paths": [
       "/docs/mobile-monitoring-installation"
     ]
   },
   {
-    "url": "/taxonomy/term/2851",
+    "url": "/docs/mobile-monitoring/mobile-monitoring-ui",
     "paths": [
       "/docs/mobile-monitoring-ui"
     ]
   },
   {
-    "url": "/taxonomy/term/2871",
+    "url": "2871",
     "paths": [
       "/docs/mobile-sdk-api"
     ]
   },
   {
-    "url": "/taxonomy/term/3336",
+    "url": "3336",
     "paths": [
       "/docs/insights-ios-app",
       "/docs/mobile-apps/insights-ios-app"
     ]
   },
   {
-    "url": "/taxonomy/term/2806",
+    "url": "2806",
     "paths": [
       "/docs/new-relic-android-app"
     ]
   },
   {
-    "url": "/taxonomy/term/3311",
+    "url": "3311",
     "paths": [
       "/docs/new-relic-ios-app"
     ]
   },
   {
-    "url": "/taxonomy/term/2101",
+    "url": "/docs/release-notes",
     "paths": [
       "/docs/releases"
     ]
   },
   {
-    "url": "/taxonomy/term/3066",
+    "url": "3066",
     "paths": [
       "/docs/nronly"
     ]
   },
   {
-    "url": "/taxonomy/term/2316",
+    "url": "/docs/agents/net-agent/installation",
     "paths": [
       "/docs/agents/net-agent/installation-and-configuration",
       "/docs/agents/net-agent/installation-configuration"
     ]
   },
   {
-    "url": "/taxonomy/term/2426",
+    "url": "/docs/agents/python-agent/installation",
     "paths": [
       "/docs/agents/python-agent/installation-and-configuration",
       "/docs/agents/python-agent/installation-configuration"
     ]
   },
   {
-    "url": "/taxonomy/term/2436",
+    "url": "/docs/agents/python-agent/api-guides",
     "paths": [
       "/docs/agents/python-agent/customization-and-extension",
       "/docs/agents/python-agent/customization-extension",
@@ -477,116 +477,116 @@
     ]
   },
   {
-    "url": "/taxonomy/term/3381",
+    "url": "3381",
     "paths": [
       "/docs/apm/apis/api-v2-examples"
     ]
   },
   {
-    "url": "/taxonomy/term/2096",
+    "url": "2096",
     "paths": [
       "/docs/news"
     ]
   },
   {
-    "url": "/taxonomy/term/2166",
+    "url": "2166",
     "paths": [
       "/docs/accounts-partnerships/partnerships/heroku-and-new-relic",
       "/docs/accounts-partnerships/partnerships/heroku-new-relic"
     ]
   },
   {
-    "url": "/taxonomy/term/2186",
+    "url": "2186",
     "paths": [
       "/docs/insights/new-relic-insights/getting-started"
     ]
   },
   {
-    "url": "/taxonomy/term/2196",
+    "url": "2196",
     "paths": [
       "/docs/insights/new-relic-insights/managing-dashboards-and-data"
     ]
   },
   {
-    "url": "/taxonomy/term/2211",
+    "url": "2211",
     "paths": [
       "/docs/insights/new-relic-insights/adding-and-querying-data",
       "/docs/insights/new-relic-insights/adding-querying-data"
     ]
   },
   {
-    "url": "/taxonomy/term/5871",
+    "url": "5871",
     "paths": [
       "/docs/new-relic-synthetics/getting-started"
     ]
   },
   {
-    "url": "/taxonomy/term/5876",
+    "url": "5876",
     "paths": [
       "/docs/new-relic-synthetics/using-monitors"
     ]
   },
   {
-    "url": "/taxonomy/term/5881",
+    "url": "5881",
     "paths": [
       "/docs/new-relic-synthetics/scripting-monitors"
     ]
   },
   {
-    "url": "/taxonomy/term/5886",
+    "url": "5886",
     "paths": [
       "/docs/new-relic-synthetics/dashboards"
     ]
   },
   {
-    "url": "/taxonomy/term/5891",
+    "url": "5891",
     "paths": [
       "/docs/new-relic-synthetics/troubleshooting"
     ]
   },
   {
-    "url": "/taxonomy/term/5896",
+    "url": "5896",
     "paths": [
       "/docs/new-relic-synthetics/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/5866",
+    "url": "/docs/synthetics",
     "paths": [
       "/docs/new-relic-synthetics",
       "/docs/full-stack-observability/monitor-everything/observability-solutions/synthetic-monitoring"
     ]
   },
   {
-    "url": "/taxonomy/term/5901",
+    "url": "/docs/synthetics/synthetic-monitoring",
     "paths": [
       "/docs/new-relic-synthetics/new-relic-synthetics",
       "/docs/synthetics/new-relic-synthetics"
     ]
   },
   {
-    "url": "/taxonomy/term/5911",
+    "url": "/docs/synthetics/synthetic-monitoring/getting-started",
     "paths": [
       "/docs/new-relic-synthetics/new-relic-synthetics/getting-started",
       "/docs/synthetics/new-relic-synthetics/getting-started"
     ]
   },
   {
-    "url": "/taxonomy/term/5916",
+    "url": "/docs/synthetics/synthetic-monitoring/using-monitors",
     "paths": [
       "/docs/new-relic-synthetics/new-relic-synthetics/using-monitors",
       "/docs/synthetics/new-relic-synthetics/using-monitors"
     ]
   },
   {
-    "url": "/taxonomy/term/5921",
+    "url": "/docs/synthetics/synthetic-monitoring/scripting-monitors",
     "paths": [
       "/docs/new-relic-synthetics/new-relic-synthetics/scripting-monitors",
       "/docs/synthetics/new-relic-synthetics/scripting-monitors"
     ]
   },
   {
-    "url": "/taxonomy/term/5926",
+    "url": "/docs/synthetics/synthetic-monitoring/pages",
     "paths": [
       "/docs/new-relic-synthetics/new-relic-synthetics/dashboards",
       "/docs/synthetics/new-relic-synthetics/dashboards",
@@ -594,21 +594,21 @@
     ]
   },
   {
-    "url": "/taxonomy/term/5931",
+    "url": "/docs/synthetics/synthetic-monitoring/troubleshooting",
     "paths": [
       "/docs/new-relic-synthetics/new-relic-synthetics/troubleshooting",
       "/docs/synthetics/new-relic-synthetics/troubleshooting"
     ]
   },
   {
-    "url": "/taxonomy/term/5936",
+    "url": "/docs/synthetics/synthetic-monitoring/miscellaneous",
     "paths": [
       "/docs/new-relic-synthetics/new-relic-synthetics/miscellaneous",
       "/docs/synthetics/new-relic-synthetics/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/5971",
+    "url": "/docs/alerts/new-relic-alerts",
     "paths": [
       "/docs/alerts/alert-policies-v2",
       "/docs/alerts/alert-policies-v3",
@@ -617,13 +617,13 @@
     ]
   },
   {
-    "url": "/taxonomy/term/5996",
+    "url": "/docs/new-relic-only/drupal-configuration/drupal-methods",
     "paths": [
       "/docs/new-relic-only/drupal-configuration/drupal-methods-insights"
     ]
   },
   {
-    "url": "/taxonomy/term/5976",
+    "url": "/docs/alerts/new-relic-alerts/get-started",
     "paths": [
       "/docs/alerts/alert-policies-v3/getting-started",
       "/docs/alerts/new-relic-alerting/getting-started",
@@ -632,7 +632,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/5981",
+    "url": "/docs/alerts/new-relic-alerts/alert-policies",
     "paths": [
       "/docs/alerts/alert-policies-v3/configuring-alert-policies",
       "/docs/alerts/new-relic-alerting/configuring-alert-policies",
@@ -641,7 +641,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/5986",
+    "url": "/docs/alerts/new-relic-alerts/alert-notifications",
     "paths": [
       "/docs/alerts/alert-policies-v3/managing-notification-channels",
       "/docs/alerts/new-relic-alerting/managing-notification-channels",
@@ -651,7 +651,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/5991",
+    "url": "/docs/alerts/new-relic-alerts/alert-incidents",
     "paths": [
       "/docs/alerts/alert-policies-v3/reviewing-alert-incidents",
       "/docs/alerts/new-relic-alerting/reviewing-alert-incidents",
@@ -669,14 +669,14 @@
     ]
   },
   {
-    "url": "/taxonomy/term/2651",
+    "url": "/docs/apm/transactions/key-transactions",
     "paths": [
       "/docs/apm/transactions-menu/key-transactions",
       "/docs/apm/selected-transactions/key-transactions"
     ]
   },
   {
-    "url": "/taxonomy/term/2681",
+    "url": "/docs/apm/transactions/transaction-traces",
     "paths": [
       "/docs/apm/transactions-menu/x-ray-sessions",
       "/docs/apm/transactions/transaction-traces",
@@ -686,26 +686,26 @@
     ]
   },
   {
-    "url": "/taxonomy/term/2661",
+    "url": "2661",
     "paths": [
       "/docs/apm/transactions-menu/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/6071",
+    "url": "/docs/browser/browser-monitoring/troubleshooting",
     "paths": [
       "/docs/browser/new-relic-browser/torubleshooting",
       "/docs/browser/new-relic-browser/troubleshooting"
     ]
   },
   {
-    "url": "/taxonomy/term/6086",
+    "url": "6086",
     "paths": [
       "/docs/insights/new-relic-insights/data-apps-0"
     ]
   },
   {
-    "url": "/taxonomy/term/7276",
+    "url": "/docs/browser/browser-monitoring/browser-agent-spa-api",
     "paths": [
       "/docs/browser/new-relic-browser/browser-agent-apis/browser-agent-api",
       "/docs/browser/new-relic-browser/browser-agent-apis/reporting-data-events-browser-agent-api",
@@ -727,83 +727,83 @@
     ]
   },
   {
-    "url": "/taxonomy/term/6281",
+    "url": "/docs/apis/rest-api-v1-deprecated",
     "paths": [
       "/docs/apis/rest-api-v1",
       "/docs/apm/apis/new-relic-rest-api-v1"
     ]
   },
   {
-    "url": "/taxonomy/term/6231",
+    "url": "/docs/apis/rest-api-v2/server-examples-v2",
     "paths": [
       "/docs/apm/apis/server-examples-v2"
     ]
   },
   {
-    "url": "/taxonomy/term/6246",
+    "url": "/docs/apis/rest-api-v2/plugin-examples-v2",
     "paths": [
       "/docs/apm/apis/plugin-examples-v2"
     ]
   },
   {
-    "url": "/taxonomy/term/6271",
+    "url": "/docs/apis/rest-api-v2",
     "paths": [
       "/apm/apis"
     ]
   },
   {
-    "url": "/taxonomy/term/6216",
+    "url": "/docs/apis/rest-api-v2/api-explorer-v2",
     "paths": [
       "/docs/apm/apis/api-explorer-v2"
     ]
   },
   {
-    "url": "/taxonomy/term/6221",
+    "url": "/docs/apis/rest-api-v2/application-examples-v2",
     "paths": [
       "/docs/apm/apis/application-examples-v2"
     ]
   },
   {
-    "url": "/taxonomy/term/6226",
+    "url": "/docs/apis/rest-api-v2/browser-examples-v2",
     "paths": [
       "/docs/apm/apis/browser-examples-v2"
     ]
   },
   {
-    "url": "/taxonomy/term/6236",
+    "url": "/docs/apis/rest-api-v2/alerts-examples-v2",
     "paths": [
       "/docs/apm/apis/alert-examples-v2",
       "/docs/apis/rest-api-v2/alert-examples-v2"
     ]
   },
   {
-    "url": "/taxonomy/term/6241",
+    "url": "/docs/apis/rest-api-v2/labels-examples-v2",
     "paths": [
       "/docs/apm/apis/labels-examples-v2"
     ]
   },
   {
-    "url": "/taxonomy/term/6181",
+    "url": "/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance",
     "paths": [
       "/docs/accounts-partnerships/partner-integration-guide/account-maintenance",
       "/docs/accounts-partnerships/partner-integration-guide/partner-account-maintenance"
     ]
   },
   {
-    "url": "/taxonomy/term/2356",
+    "url": "/docs/agents/nodejs-agent/installation-configuration",
     "paths": [
       "/docs/agents/nodejs-agent/installation-and-configuration"
     ]
   },
   {
-    "url": "/taxonomy/term/2476",
+    "url": "/docs/agents/ruby-agent/installation",
     "paths": [
       "/docs/agents/ruby-agent/installation-and-configuration",
       "/docs/agents/ruby-agent/installation-configuration"
     ]
   },
   {
-    "url": "/taxonomy/term/9821",
+    "url": "/docs/infrastructure/install-infrastructure-agent/windows-installation",
     "paths": [
       "/docs/servers/new-relic-servers-windows/installation-and-configuration",
       "/docs/infrastructure/install-configure-infrastructure/windows-installation",
@@ -813,28 +813,28 @@
     ]
   },
   {
-    "url": "/taxonomy/term/2696",
+    "url": "2696",
     "paths": [
       "/docs/apm/dashboards-menu/custom-dashboards",
       "/docs/dashboards/custom-dashboards"
     ]
   },
   {
-    "url": "/taxonomy/term/2701",
+    "url": "2701",
     "paths": [
       "/docs/apm/dashboards-menu/legacy-custom-dashboards",
       "/docs/dashboards/legacy-custom-dashboards"
     ]
   },
   {
-    "url": "/taxonomy/term/2706",
+    "url": "2706",
     "paths": [
       "/docs/apm/dashboards-menu/miscellaneous",
       "/docs/dashboards/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/5766",
+    "url": "5766",
     "paths": [
       "/docs/accounts-partnerships/education/finding-help",
       "/docs/accounts-partnerships/education/getting-started-new-relic",
@@ -842,25 +842,25 @@
     ]
   },
   {
-    "url": "/taxonomy/term/2856",
+    "url": "/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages",
     "paths": [
       "/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-dashboards"
     ]
   },
   {
-    "url": "/taxonomy/term/3391",
+    "url": "/docs/mobile-monitoring/mobile-monitoring-ui/network-pages",
     "paths": [
       "/docs/mobile-monitoring/mobile-monitoring-ui/network-dashboards"
     ]
   },
   {
-    "url": "/taxonomy/term/2861",
+    "url": "/docs/mobile-monitoring/mobile-monitoring-ui/usage-pages",
     "paths": [
       "/docs/mobile-monitoring/mobile-monitoring-ui/usage-dashboards"
     ]
   },
   {
-    "url": "/taxonomy/term/6946",
+    "url": "/docs/infrastructure/infrastructure-monitoring-ui/infrastructure-ui",
     "paths": [
       "/docs/servers/servers-dashboards",
       "/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages",
@@ -875,147 +875,147 @@
     ]
   },
   {
-    "url": "/taxonomy/term/6576",
+    "url": "/docs/agents/manage-apm-agents/app-naming",
     "paths": [
       "/docs/agents/manage-apm-agents/application-naming"
     ]
   },
   {
-    "url": "/taxonomy/term/6541",
+    "url": "/docs/agents/manage-apm-agents",
     "paths": [
       "/docs/apm/new-relic-apm/installation-and-configuration"
     ]
   },
   {
-    "url": "/taxonomy/term/6581",
+    "url": "/docs/agents/manage-apm-agents/agent-data",
     "paths": [
       "/docs/agents/manage-apm-agents/metrics",
       "/docs/agents/manage-apm-agents/agent-metrics"
     ]
   },
   {
-    "url": "/taxonomy/term/6481",
+    "url": "/docs/apis/synthetics-rest-api",
     "paths": [
       "/node/9416"
     ]
   },
   {
-    "url": "/taxonomy/term/5451",
+    "url": "/docs/agents/nodejs-agent/troubleshooting",
     "paths": [
       "/docs/agents/nodejs-agent/getting-started/known-nodejs-limitations",
       "/docs/nodejs/known-nodejs-limitations"
     ]
   },
   {
-    "url": "/taxonomy/term/2331",
+    "url": "/docs/agents/net-agent/troubleshooting",
     "paths": [
       "/docs/agents/net-agent/installation-configuration/known-issues-net"
     ]
   },
   {
-    "url": "/taxonomy/term/6441",
+    "url": "6441",
     "paths": [
       "/docs/accounts-partnerships/accounts/account-usage",
       "/docs/accounts-partnerships/accounts/account-billing-usage"
     ]
   },
   {
-    "url": "/taxonomy/term/6136",
+    "url": "/docs/licenses/product-or-service-licenses/new-relic-alerts",
     "paths": [
       "/docs/licenses/new-relic-products/new-relic-alerts",
       "/docs/licenses/new-relic-products/new-relic-alerts-licenses"
     ]
   },
   {
-    "url": "/taxonomy/term/6711",
+    "url": "/docs/mobile-monitoring/new-relic-mobile-android/troubleshoot",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile-android/troubleshooting"
     ]
   },
   {
-    "url": "/taxonomy/term/6691",
+    "url": "/docs/mobile-monitoring/new-relic-mobile-ios/troubleshoot",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile-ios/troubleshooting"
     ]
   },
   {
-    "url": "/taxonomy/term/6671",
+    "url": "/docs/mobile-monitoring/new-relic-mobile/troubleshoot",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile/troubleshooting"
     ]
   },
   {
-    "url": "/taxonomy/term/6631",
+    "url": "/docs/mobile-monitoring/new-relic-mobile-android/legacy",
     "paths": [
       "/docs/mobile-monitoring/mobile-monitoring-installation/legacy",
       "/docs/legacy"
     ]
   },
   {
-    "url": "/taxonomy/term/2866",
+    "url": "/docs/mobile-monitoring/mobile-monitoring-ui/miscellaneous",
     "paths": [
       "/docs/mobile-monitoring/mobile-monitoring-uii/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/2321",
+    "url": "/docs/agents/net-agent/azure-installation",
     "paths": [
       "/docs/agents/net-agent/azure-installation/azure-virtual-machines"
     ]
   },
   {
-    "url": "/taxonomy/term/6771",
+    "url": "6771",
     "paths": [
       "/docs/browser/spa"
     ]
   },
   {
-    "url": "/taxonomy/term/6801",
+    "url": "/docs/browser/single-page-app-monitoring/use-spa-data",
     "paths": [
       "/docs/browser/single-page-app-monitoring/browser-ui"
     ]
   },
   {
-    "url": "/taxonomy/term/6816",
+    "url": "/docs/agents/go-agent",
     "paths": [
       "/docs/agents/go-agent",
       "/docs/go-agent"
     ]
   },
   {
-    "url": "/taxonomy/term/6821",
+    "url": "/docs/agents/go-agent/get-started",
     "paths": [
       "/docs/agents/go-agent/get-started",
       "/docs/go-agent/get-started"
     ]
   },
   {
-    "url": "/taxonomy/term/6841",
+    "url": "/docs/agents/go-agent/instrumentation",
     "paths": [
       "/docs/installation-configuration",
       "/docs/agents/go-agent/installation-configuration"
     ]
   },
   {
-    "url": "/taxonomy/term/6856",
+    "url": "/docs/release-notes/new-relic-browser-release-notes",
     "paths": [
       "/docs/release-notes/browser-agent-release-notes"
     ]
   },
   {
-    "url": "/taxonomy/term/6861",
+    "url": "/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes",
     "paths": [
       "/node/10486"
     ]
   },
   {
-    "url": "/taxonomy/term/6846",
+    "url": "/docs/release-notes/agent-release-notes/go-release-notes",
     "paths": [
       "/docs/agents/go-agent/get-started/go-agent-release-notes"
     ]
   },
   {
-    "url": "/taxonomy/term/6971",
+    "url": "6971",
     "paths": [
       "/docs/infrastructure-pro-table-contents",
       "/docs/infrastructure-integrations-table-contents",
@@ -1024,32 +1024,32 @@
     ]
   },
   {
-    "url": "/taxonomy/term/6901",
+    "url": "6901",
     "paths": [
       "/docs/alerts/new-relic-alerts/getting-started/new-relic-alerts-release-notes"
     ]
   },
   {
-    "url": "/taxonomy/term/2146",
+    "url": "2146",
     "paths": [
       "/docs/accounts-partnerships/partnerships/partner-integration-guide",
       "/docs/accounts-partnerships/partnerships/former-partner-integration-guide"
     ]
   },
   {
-    "url": "/taxonomy/term/2671",
+    "url": "/docs/apm/transactions/browser-traces",
     "paths": [
       "/docs/apm/traces/browser-traces"
     ]
   },
   {
-    "url": "/taxonomy/term/2676",
+    "url": "/docs/apm/transactions/cross-application-traces",
     "paths": [
       "/docs/apm/traces/cross-application-traces"
     ]
   },
   {
-    "url": "/taxonomy/term/9786",
+    "url": "/docs/infrastructure/install-infrastructure-agent",
     "paths": [
       "/docs/infrastructure-installation",
       "/docs/infrastructure/new-relic-infrastructure/installation",
@@ -1063,7 +1063,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/6941",
+    "url": "/docs/infrastructure/manage-your-data/filter-group",
     "paths": [
       "/docs/infrastructure/new-relic-infrastructure/scope-filter",
       "/docs/infrastructure/new-relic-infrastructure/filter-group",
@@ -1071,7 +1071,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/6961",
+    "url": "/docs/infrastructure/install-infrastructure-agent/config-management-tools",
     "paths": [
       "/docs/infrastructure/new-relic-infrastructure/miscellaneous",
       "/docs/infrastructure/new-relic-infrastructure/config-management-tools",
@@ -1082,14 +1082,14 @@
     ]
   },
   {
-    "url": "/taxonomy/term/6911",
+    "url": "/docs/infrastructure/infrastructure-monitoring",
     "paths": [
       "/docs/infrastructure/new-relic-infrastructure",
       "/docs/infrastructure/config-management-tools"
     ]
   },
   {
-    "url": "/taxonomy/term/6916",
+    "url": "/docs/infrastructure/infrastructure-monitoring/get-started",
     "paths": [
       "/docs/infrastructure/new-relic-infrastructure/getting-started",
       "/docs/infrastructure/config-management-tools/getting-started",
@@ -1097,7 +1097,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/6926",
+    "url": "/docs/infrastructure/install-infrastructure-agent/configuration",
     "paths": [
       "/docs/infrastructure/new-relic-infrastructure/configuration",
       "/docs/infrastructure/config-management-tools/configuration",
@@ -1108,21 +1108,21 @@
     ]
   },
   {
-    "url": "/taxonomy/term/6936",
+    "url": "/docs/infrastructure/manage-your-data/data-instrumentation",
     "paths": [
       "/docs/infrastructure/new-relic-infrastructure/data-instrumentation",
       "/docs/infrastructure/config-management-tools/data-instrumentation"
     ]
   },
   {
-    "url": "/taxonomy/term/6931",
+    "url": "/docs/infrastructure/manage-your-data/share-charts",
     "paths": [
       "/docs/infrastructure/new-relic-infrastructure/share-charts",
       "/docs/infrastructure/config-management-tools/share-charts"
     ]
   },
   {
-    "url": "/taxonomy/term/6921",
+    "url": "/docs/infrastructure/install-infrastructure-agent/linux-installation",
     "paths": [
       "/docs/infrastructure/config-management-tools/installation",
       "/docs/servers/new-relic-servers-linux/installation-configuration",
@@ -1133,57 +1133,57 @@
     ]
   },
   {
-    "url": "/taxonomy/term/6956",
+    "url": "6956",
     "paths": [
       "/docs/infrastructure/config-management-tools/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/6096",
+    "url": "6096",
     "paths": [
       "/docs/alerts/new-relic-alerts-beta/reviewing-events"
     ]
   },
   {
-    "url": "/taxonomy/term/6991",
+    "url": "6991",
     "paths": [
       "/docs/dashboards",
       "/docs/dashboards/new-relic-dashboards"
     ]
   },
   {
-    "url": "/taxonomy/term/6996",
+    "url": "6996",
     "paths": [
       "/docs/dashboards/new-relic-dashboards/custom-dashboards"
     ]
   },
   {
-    "url": "/taxonomy/term/7001",
+    "url": "7001",
     "paths": [
       "/docs/dashboards/new-relic-dashboards/legacy-custom-dashboards"
     ]
   },
   {
-    "url": "/taxonomy/term/7006",
+    "url": "7006",
     "paths": [
       "/docs/dashboards/new-relic-dashboards/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/7021",
+    "url": "/docs/alerts-applied-intelligence/rest-api-alerts/new-relic-alerts-rest-api",
     "paths": [
       "/docs/alerts/new-relic-alerts/rest-api-alerts",
       "/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api"
     ]
   },
   {
-    "url": "/taxonomy/term/7026",
+    "url": "7026",
     "paths": [
       "/docs/alerts/alert-policies/rest-api-alert-policies"
     ]
   },
   {
-    "url": "/taxonomy/term/2736",
+    "url": "/docs/alerts-applied-intelligence",
     "paths": [
       "/docs/alerts/alert-policies",
       "/docs/alerts/new-relic-alerts/getting-started/transition-legacy-alerting-new-relic-alerts",
@@ -1200,50 +1200,50 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7036",
+    "url": "/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes",
     "paths": [
       "/node/11376"
     ]
   },
   {
-    "url": "/taxonomy/term/2486",
+    "url": "/docs/agents/ruby-agent/instrumented-gems",
     "paths": [
       "/docs/agents/ruby-agent/frameworks"
     ]
   },
   {
-    "url": "/taxonomy/term/7121",
+    "url": "/docs/agents/go-agent/features",
     "paths": [
       "/docs/agents/go-agent/other"
     ]
   },
   {
-    "url": "/taxonomy/term/7196",
+    "url": "/docs/agents/java-agent/features",
     "paths": [
       "/docs/agents/java-agent/features-ui"
     ]
   },
   {
-    "url": "/taxonomy/term/7211",
+    "url": "7211",
     "paths": [
       "/docs/insights/nrql-new-relic-query-language/getting-started"
     ]
   },
   {
-    "url": "/taxonomy/term/7231",
+    "url": "7231",
     "paths": [
       "/docs/insights/explore-data/data-explorer",
       "/docs/insights/explore-data/data-explorer-ui"
     ]
   },
   {
-    "url": "/taxonomy/term/7216",
+    "url": "7216",
     "paths": [
       "/docs/insights/nrql-new-relic-query-language/nrql-resources"
     ]
   },
   {
-    "url": "/taxonomy/term/7246",
+    "url": "/docs/insights/event-data-sources/default-events",
     "paths": [
       "/docs/insights/explore-data/attributes",
       "/docs/insights/explore-data/default-attributes",
@@ -1257,7 +1257,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7261",
+    "url": "/docs/insights/insights-api/get-data",
     "paths": [
       "/docs/insights/export-insights-data/insights-rest-api",
       "/docs/insights/export-insights-data/export-api",
@@ -1265,43 +1265,43 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7166",
+    "url": "/docs/insights/use-insights-ui",
     "paths": [
       "/docs/insights/using-insights-ui"
     ]
   },
   {
-    "url": "/taxonomy/term/7171",
+    "url": "/docs/insights/use-insights-ui/getting-started",
     "paths": [
       "/docs/insights/using-insights-ui/getting-started"
     ]
   },
   {
-    "url": "/taxonomy/term/7176",
+    "url": "7176",
     "paths": [
       "/docs/insights/using-insights-ui/basic-ui-tasks"
     ]
   },
   {
-    "url": "/taxonomy/term/7181",
+    "url": "7181",
     "paths": [
       "/docs/insights/using-insights-ui/advanced-ui-tasks"
     ]
   },
   {
-    "url": "/taxonomy/term/7266",
+    "url": "7266",
     "paths": [
       "/docs/insights/using-insights-ui/filter-segment"
     ]
   },
   {
-    "url": "/taxonomy/term/7271",
+    "url": "/docs/insights/use-insights-ui/time-settings",
     "paths": [
       "/docs/insights/using-insights-ui/time-settings"
     ]
   },
   {
-    "url": "/taxonomy/term/7226",
+    "url": "/docs/insights/event-data-sources",
     "paths": [
       "/docs/insights/explore-data",
       "/docs/insights/explore-add-data",
@@ -1312,7 +1312,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7241",
+    "url": "/docs/insights/event-data-sources/custom-events",
     "paths": [
       "/docs/insights/explore-data/custom-events",
       "/docs/insights/explore-add-data/custom-events",
@@ -1323,79 +1323,79 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7251",
+    "url": "7251",
     "paths": [
       "/docs/insights/explore-data/custom-attributes",
       "/docs/insights/explore-add-data/custom-attributes"
     ]
   },
   {
-    "url": "/taxonomy/term/6966",
+    "url": "/docs/licenses/product-or-service-licenses/new-relic-infrastructure",
     "paths": [
       "/docs/licenses/new-relic-products/new-relic-infrastructure-licenses",
       "/docs/licenses/new-relic-products/new-relic-infrastructure"
     ]
   },
   {
-    "url": "/taxonomy/term/7316",
+    "url": "/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/view-all-methods"
     ]
   },
   {
-    "url": "/taxonomy/term/7151",
+    "url": "/docs/mobile-monitoring/new-relic-mobile-cordova",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile-cordova-phonegap"
     ]
   },
   {
-    "url": "/taxonomy/term/6661",
+    "url": "/docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile-apps/insights-app/insights-tvos-release-notes",
       "/docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-tvos-release-notes"
     ]
   },
   {
-    "url": "/taxonomy/term/6636",
+    "url": "/docs/release-notes/mobile-apps-release-notes/insights-android-release-notes",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile-apps/insights-app/insights-android-release-notes",
       "/docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-android-release-notes"
     ]
   },
   {
-    "url": "/taxonomy/term/6316",
+    "url": "/docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile-apps/insights-app/insights-ios-release-notes",
       "/docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-ios-release-notes"
     ]
   },
   {
-    "url": "/taxonomy/term/2526",
+    "url": "/docs/apm",
     "paths": [
       "/docs/reports/publicizing-your-rankings",
       "/docs/full-stack-observability/monitor-everything/observability-solutions/application-monitoring-apm"
     ]
   },
   {
-    "url": "/taxonomy/term/2326",
+    "url": "2326",
     "paths": [
       "/docs/agents/net-agent/features"
     ]
   },
   {
-    "url": "/taxonomy/term/5096",
+    "url": "5096",
     "paths": [
       "/docs/servers/servers-dashboards/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/6976",
+    "url": "6976",
     "paths": [
       "/docs/infrastructure/infrastructure-integrations/getting-started"
     ]
   },
   {
-    "url": "/taxonomy/term/6981",
+    "url": "6981",
     "paths": [
       "/docs/infrastructure/infrastructure-integrations/amazon-integrations",
       "/node/13796",
@@ -1405,121 +1405,121 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7356",
+    "url": "7356",
     "paths": [
       "/docs/infrastructure/infrastructure-integrations/custom-integrations"
     ]
   },
   {
-    "url": "/taxonomy/term/6986",
+    "url": "6986",
     "paths": [
       "/docs/infrastructure/infrastructure-integrations/troubleshooting"
     ]
   },
   {
-    "url": "/taxonomy/term/7436",
+    "url": "7436",
     "paths": [
       "/docs/infrastructure/integrations-sdk/integration-building-tools",
       "/docs/infrastructure/integrations-sdk/tools-resources"
     ]
   },
   {
-    "url": "/taxonomy/term/7431",
+    "url": "7431",
     "paths": [
       "/docs/infrastructure/integrations-sdk/filedata-specifications"
     ]
   },
   {
-    "url": "/taxonomy/term/7486",
+    "url": "7486",
     "paths": [
       "/docs/data-apps"
     ]
   },
   {
-    "url": "/taxonomy/term/7471",
+    "url": "/docs/insights/use-insights-ui/explore-data",
     "paths": [
       "/docs/explore-data"
     ]
   },
   {
-    "url": "/taxonomy/term/7476",
+    "url": "/docs/insights/use-insights-ui/export-data",
     "paths": [
       "/docs/export-data"
     ]
   },
   {
-    "url": "/taxonomy/term/7466",
+    "url": "/docs/insights/use-insights-ui/manage-account-data",
     "paths": [
       "/docs/manage-account-data"
     ]
   },
   {
-    "url": "/taxonomy/term/7481",
+    "url": "/docs/insights/use-insights-ui/manage-dashboards",
     "paths": [
       "/docs/manage-dashboards"
     ]
   },
   {
-    "url": "/taxonomy/term/7206",
+    "url": "/docs/insights/insights-api",
     "paths": [
       "/docs/insights/export-insights-data"
     ]
   },
   {
-    "url": "/taxonomy/term/5836",
+    "url": "/docs/browser/browser-monitoring/installation",
     "paths": [
       "/docs/browser/new-relic-browser/installation-configuration",
       "/docs/browser/new-relic-browser/installation"
     ]
   },
   {
-    "url": "/taxonomy/term/6121",
+    "url": "/docs/licenses/product-or-service-licenses/new-relic-insights",
     "paths": [
       "/docs/licenses/license-information/new-relic-insights-licenses",
       "/docs/licenses/new-relic-products/new-relic-insights"
     ]
   },
   {
-    "url": "/taxonomy/term/6111",
+    "url": "/docs/licenses/product-or-service-licenses/new-relic-browser",
     "paths": [
       "/docs/licenses/license-information/new-relic-browser-licenses",
       "/docs/licenses/new-relic-products/new-relic-browser"
     ]
   },
   {
-    "url": "/taxonomy/term/6126",
+    "url": "/docs/licenses/product-or-service-licenses/new-relic-plugins",
     "paths": [
       "/docs/licenses/license-information/new-relic-plugins-licenses",
       "/docs/licenses/new-relic-products/new-relic-plugins"
     ]
   },
   {
-    "url": "/taxonomy/term/3051",
+    "url": "3051",
     "paths": [
       "/docs/licenses/license-information/new-relic-server-licenses"
     ]
   },
   {
-    "url": "/taxonomy/term/6116",
+    "url": "/docs/licenses/product-or-service-licenses/new-relic-synthetics",
     "paths": [
       "/docs/licenses/license-information/new-relic-synthetics-licenses",
       "/docs/licenses/new-relic-products/new-relic-synthetics"
     ]
   },
   {
-    "url": "/taxonomy/term/3261",
+    "url": "3261",
     "paths": [
       "/docs/new-relic-only/drupal-configuration/users-and-roles"
     ]
   },
   {
-    "url": "/taxonomy/term/3256",
+    "url": "3256",
     "paths": [
       "/docs/new-relic-only/drupal-configuration/taxonomy"
     ]
   },
   {
-    "url": "/taxonomy/term/7451",
+    "url": "7451",
     "paths": [
       "/docs/infrastructure/integrations/get-started",
       "/docs/infrastructure/integrations/getting-started",
@@ -1527,13 +1527,13 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7426",
+    "url": "7426",
     "paths": [
       "/docs/infrastructure/integrations-sdk/get-started"
     ]
   },
   {
-    "url": "/taxonomy/term/2801",
+    "url": "/docs/mobile-monitoring",
     "paths": [
       "/docs/mobile",
       "/docs/integrations/intro-integrations/get-started/mobile-monitoring",
@@ -1541,26 +1541,26 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7536",
+    "url": "/docs/agents/python-agent/python-agent-api",
     "paths": [
       "/node/13901",
       "/docs/adduserattribute-python-agent-api"
     ]
   },
   {
-    "url": "/taxonomy/term/7541",
+    "url": "/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/view-all-methods"
     ]
   },
   {
-    "url": "/taxonomy/term/7281",
+    "url": "/docs/agents/java-agent/api-guides",
     "paths": [
       "/docs/agents/java-agent/java-agent-api"
     ]
   },
   {
-    "url": "/taxonomy/term/5541",
+    "url": "5541",
     "paths": [
       "/docs/agents/net-agent/instrumentation",
       "/docs/agents/net-agent/additional-installation",
@@ -1568,92 +1568,92 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7676",
+    "url": "7676",
     "paths": [
       "/docs/infrastructure/azure-integrations"
     ]
   },
   {
-    "url": "/taxonomy/term/7681",
+    "url": "7681",
     "paths": [
       "/docs/infrastructure/azure-integrations/getting-started"
     ]
   },
   {
-    "url": "/taxonomy/term/7696",
+    "url": "7696",
     "paths": [
       "/node/14171",
       "/docs/infrastructure/new-relic-infrastructure/integrations/azure-integrations"
     ]
   },
   {
-    "url": "/taxonomy/term/7446",
+    "url": "/docs/infrastructure/integrations",
     "paths": [
       "/docs/infrastructure/integrations",
       "/docs/infrastructure/integrations-getting-started"
     ]
   },
   {
-    "url": "/taxonomy/term/7456",
+    "url": "/docs/infrastructure/integrations/types-integrations",
     "paths": [
       "/docs/infrastructure/integrations/integrations",
       "/docs/infrastructure/integrations-getting-started/integrations"
     ]
   },
   {
-    "url": "/taxonomy/term/7461",
+    "url": "7461",
     "paths": [
       "/docs/infrastructure/integrations/use-integration-data"
     ]
   },
   {
-    "url": "/taxonomy/term/7716",
+    "url": "7716",
     "paths": [
       "/docs/infrastructure/integrations-getting-started/integrations/host-integrations"
     ]
   },
   {
-    "url": "/taxonomy/term/7721",
+    "url": "7721",
     "paths": [
       "/docs/infrastructure/host-integrations/find-use-data",
       "/docs/infrastructure/host-integrations/use-data"
     ]
   },
   {
-    "url": "/taxonomy/term/7726",
+    "url": "7726",
     "paths": [
       "/docs/infrastructure/amazon-integrations/find-use-data",
       "/docs/infrastructure/amazon-integrations/use-data"
     ]
   },
   {
-    "url": "/taxonomy/term/7731",
+    "url": "7731",
     "paths": [
       "/docs/infrastructure/microsoft-azure-integrations/find-use-data",
       "/docs/infrastructure/microsoft-azure-integrations/use-data"
     ]
   },
   {
-    "url": "/taxonomy/term/7326",
+    "url": "/docs/insights/use-insights-ui/troubleshooting",
     "paths": [
       "/docs/insights/nrql-new-relic-query-language/troubleshooting",
       "/docs/troubleshooting"
     ]
   },
   {
-    "url": "/taxonomy/term/6686",
+    "url": "/docs/mobile-monitoring/new-relic-mobile-ios/configuration",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile-ios/install-configure"
     ]
   },
   {
-    "url": "/taxonomy/term/6871",
+    "url": "/docs/new-relic-only/basic-style-guide/writing-guidelines",
     "paths": [
       "/docs/new-relic-only/basic-style-guide/basic-style-guide"
     ]
   },
   {
-    "url": "/taxonomy/term/7836",
+    "url": "/docs/integrations/infrastructure-integrations",
     "paths": [
       "/docs/integrations/getting-started",
       "/docs/integrations/new-relic-integrations",
@@ -1662,7 +1662,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7861",
+    "url": "/docs/integrations/infrastructure-integrations/get-started",
     "paths": [
       "/docs/integrations/getting-started/getting-started",
       "/docs/integrations/new-relic-integrations/getting-started",
@@ -1672,13 +1672,13 @@
     ]
   },
   {
-    "url": "/taxonomy/term/2141",
+    "url": "/docs/new-relic-partnerships/partnerships/getting-started",
     "paths": [
       "/docs/accounts-partnerships/partnerships/getting-started"
     ]
   },
   {
-    "url": "/taxonomy/term/2156",
+    "url": "2156",
     "paths": [
       "/docs/accounts-partnerships/partnerships/partner-based-installation",
       "/docs/new-relic-partnerships/partnerships/partner-based-installation",
@@ -1688,61 +1688,61 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7611",
+    "url": "7611",
     "paths": [
       "/docs/accounts-partnerships/partnerships/google-cloud-platform-gcp"
     ]
   },
   {
-    "url": "/taxonomy/term/2151",
+    "url": "/docs/new-relic-partnerships/partnerships/partner-api",
     "paths": [
       "/docs/accounts-partnerships/partnerships/partner-api"
     ]
   },
   {
-    "url": "/taxonomy/term/2171",
+    "url": "2171",
     "paths": [
       "/docs/accounts-partnerships/partnerships/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/6171",
+    "url": "/docs/new-relic-partnerships/partner-integration-guide",
     "paths": [
       "/docs/accounts-partnerships/partner-integration-guide"
     ]
   },
   {
-    "url": "/taxonomy/term/6176",
+    "url": "/docs/new-relic-partnerships/partner-integration-guide/getting-started",
     "paths": [
       "/docs/accounts-partnerships/partner-integration-guide/getting-started"
     ]
   },
   {
-    "url": "/taxonomy/term/6191",
+    "url": "/docs/new-relic-partnerships/partner-integration-guide/partner-apis",
     "paths": [
       "/docs/accounts-partnerships/partner-integration-guide/partner-apis"
     ]
   },
   {
-    "url": "/taxonomy/term/6196",
+    "url": "/docs/new-relic-partnerships/partner-integration-guide/new-relic-products-features",
     "paths": [
       "/docs/accounts-partnerships/partner-integration-guide/new-relic-products-features"
     ]
   },
   {
-    "url": "/taxonomy/term/6201",
+    "url": "/docs/new-relic-partnerships/partner-integration-guide/appendix",
     "paths": [
       "/docs/accounts-partnerships/partner-integration-guide/appendix"
     ]
   },
   {
-    "url": "/taxonomy/term/6291",
+    "url": "6291",
     "paths": [
       "/docs/accounts-partnerships/partner-integration-guide/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/5771",
+    "url": "/docs/using-new-relic/welcome-new-relic/new-relic-university",
     "paths": [
       "/docs/accounts-partnerships/education/new-relic-university",
       "/docs/accounts-partnerships/accounts/install-new-relic/new-relic-university",
@@ -1750,7 +1750,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7956",
+    "url": "/docs/using-new-relic/welcome-new-relic/get-started",
     "paths": [
       "/docs/accounts-partnerships/getting-started-new-relic",
       "/docs/accounts-partnerships/getting-started",
@@ -1759,7 +1759,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/3421",
+    "url": "/docs/security/security-privacy/data-privacy",
     "paths": [
       "/docs/accounts-partnerships/accounts/security",
       "/docs/accounts-partnerships/welcome-new-relic/security",
@@ -1771,7 +1771,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7061",
+    "url": "/docs/security/security-privacy/security-bulletins",
     "paths": [
       "/docs/accounts-partnerships/accounts/security-bulletins",
       "/docs/accounts-partnerships/welcome-new-relic/security-bulletins",
@@ -1782,44 +1782,44 @@
     ]
   },
   {
-    "url": "/taxonomy/term/6021",
+    "url": "/docs/new-relic-only/tech-writer-style-guide",
     "paths": [
       "/docs/new-relic-only/advanced-style-guide"
     ]
   },
   {
-    "url": "/taxonomy/term/6031",
+    "url": "/docs/new-relic-only/tech-writer-style-guide/api-writing-guidelines",
     "paths": [
       "/docs/new-relic-only/advanced-style-guide/writing-guidelines",
       "/docs/new-relic-only/tech-writer-style-guide/writing-guidelines"
     ]
   },
   {
-    "url": "/taxonomy/term/6036",
+    "url": "/docs/new-relic-only/tech-writer-style-guide/processes-procedures",
     "paths": [
       "/docs/new-relic-only/advanced-style-guide/processes-procedures"
     ]
   },
   {
-    "url": "/taxonomy/term/6041",
+    "url": "/docs/new-relic-only/tech-writer-style-guide/design-specifications",
     "paths": [
       "/docs/new-relic-only/advanced-style-guide/design-specifications"
     ]
   },
   {
-    "url": "/taxonomy/term/6046",
+    "url": "/docs/new-relic-only/tech-writer-style-guide/article-templates",
     "paths": [
       "/docs/new-relic-only/advanced-style-guide/article-templates"
     ]
   },
   {
-    "url": "/taxonomy/term/6051",
+    "url": "/docs/new-relic-only/tech-writer-style-guide/miscellaneous",
     "paths": [
       "/docs/new-relic-only/advanced-style-guide/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/7921",
+    "url": "/docs/integrations/amazon-integrations/aws-integrations-list",
     "paths": [
       "/taxonomy/term/6981",
       "/docs/infrastructure/amazon-integrations/aws-integrations-list",
@@ -1830,7 +1830,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7846",
+    "url": "/docs/integrations/amazon-integrations",
     "paths": [
       "/taxonomy/term/6971",
       "/docs/infrastructure/amazon-integrations",
@@ -1840,7 +1840,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7906",
+    "url": "/docs/integrations/amazon-integrations/troubleshooting",
     "paths": [
       "/taxonomy/term/6986",
       "/docs/integrations/amazon-integrations/troubleshooting",
@@ -1849,7 +1849,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7871",
+    "url": "/docs/integrations/amazon-integrations/get-started",
     "paths": [
       "/taxonomy/term/6976",
       "/docs/integrations/amazon-integrations/getting-started",
@@ -1859,7 +1859,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7926",
+    "url": "/docs/integrations/microsoft-azure-integrations/azure-integrations-list",
     "paths": [
       "/taxonomy/term/7696",
       "/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list",
@@ -1870,7 +1870,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7851",
+    "url": "/docs/integrations/microsoft-azure-integrations",
     "paths": [
       "/taxonomy/term/7676",
       "/docs/integrations/microsoft-azure-integrations",
@@ -1879,7 +1879,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7886",
+    "url": "/docs/integrations/host-integrations/host-integrations-list",
     "paths": [
       "/taxonomy/term/7716",
       "/docs/infrastructure/host-integrations/host-integrations-list",
@@ -1895,7 +1895,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7831",
+    "url": "/docs/integrations",
     "paths": [
       "/taxonomy/term/7446",
       "/node/12911",
@@ -1905,7 +1905,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7856",
+    "url": "7856",
     "paths": [
       "/docs/infrastructure/integrations-sdk",
       "/docs/kubernetes-integration/integrations-sdk",
@@ -1913,51 +1913,51 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7976",
+    "url": "/docs/apis/get-started",
     "paths": [
       "/docs/apis/getting-started",
       "/docs/apis/intro-apis"
     ]
   },
   {
-    "url": "/taxonomy/term/7961",
+    "url": "/docs/using-new-relic/welcome-new-relic",
     "paths": [
       "/docs/accounts-partnerships/welcome-new-relic"
     ]
   },
   {
-    "url": "/taxonomy/term/6596",
+    "url": "6596",
     "paths": [
       "/docs/data-analysis/user-interface-functions/view-your-data"
     ]
   },
   {
-    "url": "/taxonomy/term/6606",
+    "url": "6606",
     "paths": [
       "/docs/data-analysis/user-interface-functions/organize-your-data"
     ]
   },
   {
-    "url": "/taxonomy/term/6601",
+    "url": "6601",
     "paths": [
       "/docs/data-analysis/user-interface-functions/share-your-data"
     ]
   },
   {
-    "url": "/taxonomy/term/6881",
+    "url": "6881",
     "paths": [
       "/docs/data-analysis/user-interface-functions/troubleshooting"
     ]
   },
   {
-    "url": "/taxonomy/term/6411",
+    "url": "6411",
     "paths": [
       "/docs/data-analysis/metrics",
       "/docs/using-new-relic/metrics"
     ]
   },
   {
-    "url": "/taxonomy/term/6611",
+    "url": "6611",
     "paths": [
       "/docs/data-analysis/metrics/analyze-your-metrics",
       "/docs/using-new-relic/metrics/analyze-your-metrics",
@@ -1966,40 +1966,40 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7406",
+    "url": "7406",
     "paths": [
       "/docs/data-analysis/health-map",
       "/docs/using-new-relic/health-map"
     ]
   },
   {
-    "url": "/taxonomy/term/7411",
+    "url": "7411",
     "paths": [
       "/docs/data-analysis/health-map/get-started",
       "/docs/using-new-relic/health-map/get-started"
     ]
   },
   {
-    "url": "/taxonomy/term/6766",
+    "url": "6766",
     "paths": [
       "/docs/data-analysis/service-maps/get-started"
     ]
   },
   {
-    "url": "/taxonomy/term/6761",
+    "url": "6761",
     "paths": [
       "/docs/data-analysis/service-maps/service-maps"
     ]
   },
   {
-    "url": "/taxonomy/term/7951",
+    "url": "7951",
     "paths": [
       "/docs/accounts-partnerships/accounts/install-new-relic",
       "/docs/accounts/accounts-partnerships/install-new-relic"
     ]
   },
   {
-    "url": "/taxonomy/term/7971",
+    "url": "/docs/security/security-privacy",
     "paths": [
       "/docs/accounts-partnerships/new-relic-security",
       "/docs/using-new-relic/new-relic-security",
@@ -2007,45 +2007,45 @@
     ]
   },
   {
-    "url": "/taxonomy/term/2116",
+    "url": "2116",
     "paths": [
       "/docs/accounts-partnerships/accounts/account-setup",
       "/docs/accounts/accounts-partnerships/install-new-relic/account-setup"
     ]
   },
   {
-    "url": "/taxonomy/term/2106",
+    "url": "/docs/accounts",
     "paths": [
       "/docs/accounts-partnerships"
     ]
   },
   {
-    "url": "/taxonomy/term/8046",
+    "url": "8046",
     "paths": [
       "/docs/accounts-partnerships/install-new-relic"
     ]
   },
   {
-    "url": "/taxonomy/term/8056",
+    "url": "8056",
     "paths": [
       "/docs/accounts-partnerships/install-new-relic/account-setup"
     ]
   },
   {
-    "url": "/taxonomy/term/8066",
+    "url": "8066",
     "paths": [
       "/docs/accounts-partnerships/install-new-relic/install-agent"
     ]
   },
   {
-    "url": "/taxonomy/term/7991",
+    "url": "7991",
     "paths": [
       "/docs/accounts-partnerships/accounts/roles-permissions",
       "/docs/accounts/accounts/roles-permissions"
     ]
   },
   {
-    "url": "/taxonomy/term/2121",
+    "url": "/docs/accounts/accounts-billing/general-account-settings",
     "paths": [
       "/docs/accounts-partnerships/accounts/account-maintenance",
       "/docs/accounts/accounts/account-maintenance",
@@ -2053,7 +2053,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/8061",
+    "url": "/docs/accounts/accounts-billing/new-relic-one-pricing-billing",
     "paths": [
       "/docs/accounts-partnerships/accounts/subscription-pricing",
       "/docs/accounts/accounts/subscription-pricing",
@@ -2062,26 +2062,26 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7996",
+    "url": "7996",
     "paths": [
       "/docs/accounts-partnerships/accounts/billing"
     ]
   },
   {
-    "url": "/taxonomy/term/2126",
+    "url": "2126",
     "paths": [
       "/docs/accounts-partnerships/accounts/saml-single-sign",
       "/docs/accounts/accounts/saml-single-sign"
     ]
   },
   {
-    "url": "/taxonomy/term/2131",
+    "url": "2131",
     "paths": [
       "/docs/accounts-partnerships/accounts/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/8001",
+    "url": "8001",
     "paths": [
       "/docs/accounts-partnerships/new-relic-account-usage",
       "/docs/accounts-partnerships/new-relic-account-usage/legacy-account-usage",
@@ -2090,56 +2090,56 @@
     ]
   },
   {
-    "url": "/taxonomy/term/8006",
+    "url": "8006",
     "paths": [
       "/docs/accounts-partnerships/new-relic-account-usage/getting-started-usage"
     ]
   },
   {
-    "url": "/taxonomy/term/8011",
+    "url": "8011",
     "paths": [
       "/docs/accounts-partnerships/new-relic-account-usage/apm-usage",
       "/docs/accounts/new-relic-account-usage/apm-usage"
     ]
   },
   {
-    "url": "/taxonomy/term/8016",
+    "url": "8016",
     "paths": [
       "/docs/accounts-partnerships/new-relic-account-usage/browser-usage"
     ]
   },
   {
-    "url": "/taxonomy/term/8021",
+    "url": "8021",
     "paths": [
       "/docs/accounts-partnerships/new-relic-account-usage/infrastructure-usage"
     ]
   },
   {
-    "url": "/taxonomy/term/8026",
+    "url": "8026",
     "paths": [
       "/docs/accounts-partnerships/new-relic-account-usage/insights-usage"
     ]
   },
   {
-    "url": "/taxonomy/term/8031",
+    "url": "8031",
     "paths": [
       "/docs/accounts-partnerships/new-relic-account-usage/mobile-usage"
     ]
   },
   {
-    "url": "/taxonomy/term/8036",
+    "url": "8036",
     "paths": [
       "/docs/accounts-partnerships/new-relic-account-usage/synthetics-usage"
     ]
   },
   {
-    "url": "/taxonomy/term/5761",
+    "url": "5761",
     "paths": [
       "/docs/accounts-partnerships/education"
     ]
   },
   {
-    "url": "/taxonomy/term/7841",
+    "url": "/docs/integrations/host-integrations",
     "paths": [
       "/docs/integrations/host-integrations/host-integrations-list/config",
       "/docs/integrations/host-integrations",
@@ -2149,13 +2149,13 @@
     ]
   },
   {
-    "url": "/taxonomy/term/6676",
+    "url": "/docs/mobile-monitoring/new-relic-mobile-ios",
     "paths": [
       "/docs/ios"
     ]
   },
   {
-    "url": "/taxonomy/term/8076",
+    "url": "/docs/plugins/plugins-new-relic/custom-dashboards-custom-views",
     "paths": [
       "/taxonomy/term/6996",
       "/docs/data-analysis/legacy-custom-dashboards/custom-dashboards-v2",
@@ -2165,7 +2165,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/5861",
+    "url": "/docs/browser/browser-monitoring/page-load-timing-resources",
     "paths": [
       "/taxonomy/term/2246",
       "/docs/browser/new-relic-browser/page-load-timing",
@@ -2173,19 +2173,19 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7586",
+    "url": "/docs/mobile-apps/new-relic-mobile-apps",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile-apps"
     ]
   },
   {
-    "url": "/taxonomy/term/8151?field_products_tid%255B%255D=8106",
+    "url": "/docs/release-notes/platform-release-notes",
     "paths": [
       "/docs/integrations/new-relic-integrations/getting-started/integrations-release-notes"
     ]
   },
   {
-    "url": "/taxonomy/term/8151?field_products_tid%255B%255D=8081",
+    "url": "/docs/release-notes/platform-release-notes",
     "paths": [
       "/taxonomy/term/6896",
       "/taxonomy/term/6901",
@@ -2195,7 +2195,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/8211",
+    "url": "/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list",
     "paths": [
       "/https:/docs.newrelidocs/infrastructure/integrations/google-cloud-platform-integrations",
       "/docs/infrastructure/integrations/types-integrations/google-cloud-integrations",
@@ -2206,7 +2206,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/8201",
+    "url": "/docs/integrations/google-cloud-platform-integrations",
     "paths": [
       "/docs/google-cloud-platform-integrations",
       "/docs/integrations/google-cloud-platform-integrations",
@@ -2216,19 +2216,19 @@
     ]
   },
   {
-    "url": "/taxonomy/term/8156/feed",
+    "url": "feed",
     "paths": [
       "/docs/release-notes/alerts-release-notes/new-relic-alerts-release-notes/feed"
     ]
   },
   {
-    "url": "/taxonomy/term/8221",
+    "url": "8221",
     "paths": [
       "/docs/using-new-relic/welcome-new-relic/measure-your-devops-success"
     ]
   },
   {
-    "url": "/taxonomy/term/8236",
+    "url": "8236",
     "paths": [
       "/event-types/transaction",
       "/attribute-dictionary?events_tids%5B%5D=8236",
@@ -2236,86 +2236,86 @@
     ]
   },
   {
-    "url": "/taxonomy/term/8297",
+    "url": "8297",
     "paths": [
       "/attribute-dictionary/event-data-sources/new-relic-browser-agent"
     ]
   },
   {
-    "url": "/taxonomy/term/2341",
+    "url": "/docs/agents/net-agent/other-features",
     "paths": [
       "/docs/agents/net-agent/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/8246",
+    "url": "8246",
     "paths": [
       "/units-measure/megabytes-mb"
     ]
   },
   {
-    "url": "/taxonomy/term/6641",
+    "url": "/docs/agents/net-agent/azure-troubleshooting",
     "paths": [
       "/docs/agents/net-agent/azure-installation/azure-troubleshooting"
     ]
   },
   {
-    "url": "/taxonomy/term/8721",
+    "url": "/docs/infrastructure/infrastructure-monitoring/infrastructure-agent-performance",
     "paths": [
       "/docs/infrastructure/new-relic-infrastructure/agent-performance",
       "/docs/infrastructure/new-relic-infrastructure/infrastructure-agent-performance"
     ]
   },
   {
-    "url": "/taxonomy/term/8317",
+    "url": "8317",
     "paths": [
       "/attribute-dictionary/events/spa-ajaxrequest"
     ]
   },
   {
-    "url": "/taxonomy/term/8312",
+    "url": "8312",
     "paths": [
       "/attribute-dictionary/events/spa-browserinteraction"
     ]
   },
   {
-    "url": "/taxonomy/term/8322",
+    "url": "8322",
     "paths": [
       "/attribute-dictionary/events/spa-browsertiming"
     ]
   },
   {
-    "url": "/taxonomy/term/8241",
+    "url": "8241",
     "paths": [
       "/event-types/transactionerror"
     ]
   },
   {
-    "url": "/taxonomy/term/8441",
+    "url": "8441",
     "paths": [
       "/attribute-dictionary/units-measure/bytes"
     ]
   },
   {
-    "url": "/taxonomy/term/8716",
+    "url": "8716",
     "paths": [
       "/attribute-dictionary/units-measure/microseconds"
     ]
   },
   {
-    "url": "/taxonomy/term/8256",
+    "url": "8256",
     "paths": [
       "/attribute-dictionary/units-measure/milliseconds"
     ]
   },
   {
-    "url": "/taxonomy/term/8251",
+    "url": "8251",
     "paths": [
       "/attribute-dictionary/units-measure/seconds"
     ]
   },
   {
-    "url": "/taxonomy/term/7866",
+    "url": "/docs/integrations/host-integrations/get-started",
     "paths": [
       "/docs/integrations/host-integrations/getting-started",
       "/docs/kubernetes-integration/host-integrations/getting-started",
@@ -2324,13 +2324,13 @@
     ]
   },
   {
-    "url": "/taxonomy/term/8461",
+    "url": "8461",
     "paths": [
       "/docs/integrations/host-integrations/open-source-host-integrations-list"
     ]
   },
   {
-    "url": "/taxonomy/term/7891",
+    "url": "/docs/integrations/host-integrations/installation",
     "paths": [
       "/docs/integrations/host-integrations/installation",
       "/docs/kubernetes-integration/host-integrations/installation",
@@ -2338,7 +2338,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7896",
+    "url": "/docs/integrations/host-integrations/understand-use-data",
     "paths": [
       "/docs/integrations/host-integrations/understand-use-data",
       "/docs/kubernetes-integration/host-integrations/understand-use-data",
@@ -2346,7 +2346,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7901",
+    "url": "/docs/integrations/host-integrations/troubleshooting",
     "paths": [
       "/docs/integrations/host-integrations/troubleshooting",
       "/docs/kubernetes-integration/host-integrations/troubleshooting",
@@ -2354,7 +2354,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/8206",
+    "url": "/docs/integrations/google-cloud-platform-integrations/get-started",
     "paths": [
       "/docs/integrations/google-cloud-platform-integrations/getting-started",
       "/docs/kubernetes-integration/google-cloud-platform-integrations/getting-started",
@@ -2363,7 +2363,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/8216",
+    "url": "/docs/integrations/google-cloud-platform-integrations/troubleshooting",
     "paths": [
       "/docs/integrations/google-cloud-platform-integrations/troubleshooting",
       "/docs/kubernetes-integration/google-cloud-platform-integrations/troubleshooting",
@@ -2371,7 +2371,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7876",
+    "url": "/docs/integrations/microsoft-azure-integrations/get-started",
     "paths": [
       "/docs/integrations/microsoft-azure-integrations/getting-started",
       "/docs/kubernetes-integration/microsoft-azure-integrations/getting-started",
@@ -2380,7 +2380,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/8496",
+    "url": "/docs/integrations/microsoft-azure-integrations/troubleshooting",
     "paths": [
       "/docs/integrations/microsoft-azure-integrations/troubleshooting",
       "/docs/kubernetes-integration/microsoft-azure-integrations/troubleshooting",
@@ -2388,14 +2388,14 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10451",
+    "url": "/docs/create-integrations/infrastructure-integrations-sdk",
     "paths": [
       "/docs/integrations/integrations-sdk",
       "/docs/full-stack-observability/instrument-everything/develop-your-own-integrations/new-relic-integrations-sdk"
     ]
   },
   {
-    "url": "/taxonomy/term/7881",
+    "url": "7881",
     "paths": [
       "/docs/integrations/integrations-sdk/getting-started",
       "/docs/kubernetes-integration/integrations-sdk/getting-started",
@@ -2404,7 +2404,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/8501",
+    "url": "8501",
     "paths": [
       "/docs/integrations/integrations-sdk/build-tools",
       "/docs/kubernetes-integration/integrations-sdk/build-tools",
@@ -2412,7 +2412,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7931",
+    "url": "7931",
     "paths": [
       "/docs/integrations/integrations-sdk/file-specifications",
       "/docs/kubernetes-integration/integrations-sdk/file-specifications",
@@ -2420,7 +2420,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7916",
+    "url": "7916",
     "paths": [
       "/docs/integrations/integrations-sdk/troubleshooting",
       "/docs/kubernetes-integration/integrations-sdk/troubleshooting",
@@ -2428,7 +2428,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/8876",
+    "url": "/docs/integrations/kubernetes-integration/link-apps-services",
     "paths": [
       "/docs/integrations/kubernetes-integration/metadata-injection",
       "/docs/integrations/kubernetes-integration/link-your-applications",
@@ -2437,13 +2437,13 @@
     ]
   },
   {
-    "url": "/taxonomy/term/8901",
+    "url": "8901",
     "paths": [
       "/attribute-dictionary/event-data-sources/aws-integrations"
     ]
   },
   {
-    "url": "/taxonomy/term/8726",
+    "url": "/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes",
     "paths": [
       "/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/feed",
       "/docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-151",
@@ -2470,32 +2470,32 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9311",
+    "url": "/docs/alerts/new-relic-alerts/rules-limits-glossary",
     "paths": [
       "/docs/alerts/new-relic-alerts/glossary-limits"
     ]
   },
   {
-    "url": "/taxonomy/term/9536",
+    "url": "/docs/agents/c-sdk",
     "paths": [
       "/docs/c-agent-table-contents"
     ]
   },
   {
-    "url": "/taxonomy/term/9531",
+    "url": "/docs/apis/insights-apis/get-started",
     "paths": [
       "/docs/apis/insights-apis/getting-started"
     ]
   },
   {
-    "url": "/taxonomy/term/7981",
+    "url": "/docs/apis/get-started/intro-apis",
     "paths": [
       "/docs/apis/getting-started/intro-apis",
       "/docs/full-stack-observability/instrument-everything/develop-your-own-integrations/new-relic-apis"
     ]
   },
   {
-    "url": "/taxonomy/term/8431",
+    "url": "/docs/apis/nerdgraph/get-started",
     "paths": [
       "/docs/apis/graphql-api/getting-started",
       "/docs/apis/graphql-api/get-started",
@@ -2503,19 +2503,19 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7201",
+    "url": "/docs/apis/rest-api-v2/get-started",
     "paths": [
       "/docs/apis/rest-api-v2/getting-started"
     ]
   },
   {
-    "url": "/taxonomy/term/2886",
+    "url": "/docs/mobile-monitoring/new-relic-mobile/get-started",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile/getting-started"
     ]
   },
   {
-    "url": "/taxonomy/term/8831",
+    "url": "/docs/integrations/kubernetes-integration/get-started",
     "paths": [
       "/docs/integrations/kubernetes-integration/getting-started",
       "/docs/integrations/kubernetes-integration/get-started",
@@ -2523,41 +2523,41 @@
     ]
   },
   {
-    "url": "/taxonomy/term/6376",
+    "url": "/docs/apis/rest-api-v2/account-admin-usage-v2",
     "paths": [
       "/docs/apis/rest-api-v2/account-examples-v2"
     ]
   },
   {
-    "url": "/taxonomy/term/9506",
+    "url": "/docs/release-notes/agent-release-notes/c-sdk-release-notes",
     "paths": [
       "/docs/release-notes/agent-release-notes/c-release-notes",
       "/docs/agents/c-sdk/get-started/c-sdk-release-notes"
     ]
   },
   {
-    "url": "/taxonomy/term/9681",
+    "url": "/docs/understand-dependencies/understand-system-dependencies",
     "paths": [
       "/docs/understand-dependencies/understand-system-dependencies",
       "/docs/understand-dependencies/upstream-downstream-relationships"
     ]
   },
   {
-    "url": "/taxonomy/term/9686",
+    "url": "/docs/understand-dependencies/understand-system-dependencies/service-maps",
     "paths": [
       "/docs/understand-dependencies/understand-system-dependencies/service-maps",
       "/docs/understand-dependencies/upstream-downstream-relationships/service-maps"
     ]
   },
   {
-    "url": "/taxonomy/term/9691",
+    "url": "/docs/understand-dependencies/understand-system-dependencies/relationship-api",
     "paths": [
       "/docs/understand-dependencies/understand-system-dependencies/relationship-api",
       "/docs/understand-dependencies/upstream-downstream-relationships/relationship-api"
     ]
   },
   {
-    "url": "/taxonomy/term/10551",
+    "url": "/docs/query-your-data/explore-query-data/dashboards",
     "paths": [
       "/docs/dashboards/get-started",
       "/docs/dashboards/new-relic-one-dashboards/get-started",
@@ -2579,7 +2579,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9661",
+    "url": "9661",
     "paths": [
       "/docs/get-started",
       "/docs/new-relic-one-dashboards/get-started",
@@ -2587,7 +2587,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9666",
+    "url": "9666",
     "paths": [
       "/docs/explore-dashboards-index",
       "/docs/new-relic-one-dashboards/explore-dashboards-index",
@@ -2595,7 +2595,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9671",
+    "url": "9671",
     "paths": [
       "/docs/manage-your-dashboard",
       "/docs/new-relic-one-dashboards/manage-your-dashboard",
@@ -2603,44 +2603,44 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9731",
+    "url": "9731",
     "paths": [
       "/docs/chart-builder/use-chart-builder/choose-data-chart"
     ]
   },
   {
-    "url": "/taxonomy/term/9736",
+    "url": "9736",
     "paths": [
       "/docs/chart-builder/use-chart-builder/new-relic-query-language"
     ]
   },
   {
-    "url": "/taxonomy/term/7186",
+    "url": "7186",
     "paths": [
       "/docs/chart-builder/use-chart-builder/nrql/nrql-new-relic-query-language"
     ]
   },
   {
-    "url": "/taxonomy/term/9566",
+    "url": "9566",
     "paths": [
       "/attribute-dictionary/events/syntheticprivatelocationstatus"
     ]
   },
   {
-    "url": "/taxonomy/term/9801",
+    "url": "/docs/infrastructure/infrastructure-monitoring-ui",
     "paths": [
       "/docs/infrastructure/ui-pages",
       "/docs/infrastructure/infrastructure-ui-pages"
     ]
   },
   {
-    "url": "/taxonomy/term/7336",
+    "url": "/docs/infrastructure/infrastructure-alerts/infrastructure-alert-conditions",
     "paths": [
       "/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions"
     ]
   },
   {
-    "url": "/taxonomy/term/9811",
+    "url": "/docs/infrastructure/infrastructure-monitoring-troubleshooting/troubleshoot-infrastructure",
     "paths": [
       "/docs/infrastructure/troubleshooting/infra-troubleshooting",
       "/docs/infrastructure/infrastructure-troubleshooting/infra-troubleshooting",
@@ -2648,7 +2648,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9826",
+    "url": "9826",
     "paths": [
       "/docs/infrastructure/install-configure-infrastructure/elastic-beanstalk-installation",
       "/docs/install-configure-infrastructure/elastic-beanstalk-installation",
@@ -2656,7 +2656,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9831",
+    "url": "9831",
     "paths": [
       "/docs/infrastructure/install-configure-infrastructure/docker-installation",
       "/docs/install-configure-infrastructure/docker-installation",
@@ -2664,7 +2664,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9836",
+    "url": "/docs/infrastructure/install-infrastructure-agent/update-or-uninstall",
     "paths": [
       "/docs/infrastructure/install-configure-infrastructure/update-or-uninstall",
       "/docs/install-configure-infrastructure/update-or-uninstall",
@@ -2673,7 +2673,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9841",
+    "url": "/docs/infrastructure/install-infrastructure-agent/manage-your-agent",
     "paths": [
       "/docs/manage-your-agent",
       "/docs/install-configure-infrastructure/manage-your-agent",
@@ -2683,38 +2683,38 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9851",
+    "url": "/docs/infrastructure/infrastructure-monitoring-troubleshooting/troubleshoot-logs",
     "paths": [
       "/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infra-logs",
       "/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs"
     ]
   },
   {
-    "url": "/taxonomy/term/6131",
+    "url": "/docs/licenses/product-or-service-licenses",
     "paths": [
       "/docs/licenses/new-relic-products"
     ]
   },
   {
-    "url": "/taxonomy/term/6146",
+    "url": "/docs/licenses/product-or-service-licenses/new-relic-mobile",
     "paths": [
       "/docs/licenses/new-relic-products/new-relic-mobile"
     ]
   },
   {
-    "url": "/taxonomy/term/6141",
+    "url": "/docs/licenses/product-or-service-licenses/miscellaneous",
     "paths": [
       "/docs/licenses/new-relic-products/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/3416",
+    "url": "/docs/licenses/product-or-service-licenses/mobile-app-licenses",
     "paths": [
       "/docs/licenses/license-information/mobile-app-licenses"
     ]
   },
   {
-    "url": "/taxonomy/term/3046",
+    "url": "/docs/licenses/product-or-service-licenses/new-relic-apm",
     "paths": [
       "/docs/licenses/license-information/agent-licenses",
       "/docs/licenses/license-information/new-relic-apm-licenses",
@@ -2723,13 +2723,13 @@
     ]
   },
   {
-    "url": "/taxonomy/term/3056",
+    "url": "/docs/licenses/license-information/distributed-licenses",
     "paths": [
       "/docs/licenses/license-information/other-licenses"
     ]
   },
   {
-    "url": "/taxonomy/term/9886",
+    "url": "/docs/query-your-data/nrql-new-relic-query-language/get-started",
     "paths": [
       "/docs/query-data/nrql-new-relic-query-language/getting-strated",
       "/taxonomy/term/7216",
@@ -2740,19 +2740,19 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9861",
+    "url": "/docs/licenses/license-information/special-services-licenses",
     "paths": [
       "/docs/licenses/license-information/generally-applicable-licenses"
     ]
   },
   {
-    "url": "/taxonomy/term/9856",
+    "url": "/docs/licenses/license-information/general-usage-licenses",
     "paths": [
       "/taxonomy/term/9571"
     ]
   },
   {
-    "url": "/taxonomy/term/9891",
+    "url": "/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials",
     "paths": [
       "/taxonomy/term/7286",
       "/docs/query-data/nrql-new-relic-query-language/nrql-query-examples",
@@ -2762,7 +2762,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9871",
+    "url": "/docs/query-your-data/nrql-new-relic-query-language",
     "paths": [
       "/taxonomy/term/7186",
       "/docs/query-data/nrql-new-relic-query-language",
@@ -2771,20 +2771,20 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10026",
+    "url": "/docs/licenses/product-or-service-licenses/new-relic-logs",
     "paths": [
       "/docs/new-relic-logs"
     ]
   },
   {
-    "url": "/taxonomy/term/8426",
+    "url": "/docs/apis/nerdgraph",
     "paths": [
       "/docs/apis/graphql-api",
       "/docs/apis/nerdgraph-graphiql"
     ]
   },
   {
-    "url": "/taxonomy/term/8436",
+    "url": "/docs/apis/nerdgraph/examples",
     "paths": [
       "/docs/apis/graphql-api/tutorials",
       "/docs/apis/nerdgraph-graphiql/tutorials",
@@ -2792,7 +2792,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10016",
+    "url": "/docs/logs/log-management/log-api",
     "paths": [
       "/docs/logs/new-relic-logs/logs-api",
       "/docs/logs/new-relic-logs/log-api",
@@ -2800,14 +2800,14 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9701",
+    "url": "/docs/understand-dependencies/distributed-tracing",
     "paths": [
       "/docs/apm/distributed-tracing",
       "/docs/full-stack-observability/monitor-everything/observability-solutions/distributed-tracing"
     ]
   },
   {
-    "url": "/taxonomy/term/9976",
+    "url": "/docs/integrations/prometheus-integrations/get-started",
     "paths": [
       "/docs/integrations/prometheus-integrations/prometheus-docker",
       "/docs/integrations/prometheus-integrations/get-started",
@@ -2815,7 +2815,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10051",
+    "url": "/docs/integrations/kubernetes-integration/kubernetes-events",
     "paths": [
       "/docs/kubernetes-events",
       "/docs/integrations/kubernetes-integration/kubernetes-events",
@@ -2823,7 +2823,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10081",
+    "url": "/docs/integrations/prometheus-integrations/install-configure-remote-write",
     "paths": [
       "/docs/integrations/prometheus-integrations/configure-0",
       "/docs/integrations/prometheus-integrations/configure",
@@ -2832,33 +2832,33 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7156",
+    "url": "/docs/mobile-monitoring/new-relic-mobile-cordova/get-started",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/get-started"
     ]
   },
   {
-    "url": "/taxonomy/term/7161",
+    "url": "/docs/mobile-monitoring/new-relic-mobile-cordova/install-configure",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/install-configure"
     ]
   },
   {
-    "url": "/taxonomy/term/10111",
+    "url": "/docs/security/security-privacy/compliance",
     "paths": [
       "/docs/security/compliance",
       "/docs/security/new-relic-security/compliance"
     ]
   },
   {
-    "url": "/taxonomy/term/10236",
+    "url": "/docs/mobile-monitoring/new-relic-mobile-react-native",
     "paths": [
       "/docs/mobile-extensible-agent-toc",
       "/docs/mobile-react-native-agent-toc"
     ]
   },
   {
-    "url": "/taxonomy/term/10171",
+    "url": "/docs/logs/enable-log-management-new-relic/logs-context-ruby",
     "paths": [
       "/docs/logs/enable-logs/configure-logs-context-apis",
       "/docs/logs/enable-logs/configure-logs-context-agent-apis",
@@ -2869,7 +2869,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10136",
+    "url": "/docs/logs/enable-log-management-new-relic/logs-context-go",
     "paths": [
       "/docs/logs/enable-logs/configure-logs-context-go",
       "/docs/logs/enable-logs/logs-context-go",
@@ -2878,7 +2878,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10141",
+    "url": "/docs/logs/enable-log-management-new-relic/logs-context-java",
     "paths": [
       "/docs/logs/enable-logs/configure-logs-context-java",
       "/docs/logs/enable-logs/logs-context-java",
@@ -2887,7 +2887,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10146",
+    "url": "/docs/logs/enable-log-management-new-relic/logs-context-net",
     "paths": [
       "/docs/logs/enable-logs/configure-logs-context-net",
       "/docs/logs/enable-logs/logs-context-net",
@@ -2896,7 +2896,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10151",
+    "url": "/docs/logs/enable-log-management-new-relic/logs-context-nodejs",
     "paths": [
       "/docs/logs/enable-logs/configure-logs-context-node",
       "/docs/logs/enable-logs/logs-context-node",
@@ -2906,7 +2906,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10156",
+    "url": "/docs/logs/enable-log-management-new-relic/logs-context-php",
     "paths": [
       "/docs/logs/enable-logs/configure-logs-context-php",
       "/docs/logs/enable-logs/logs-context-php",
@@ -2915,7 +2915,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10161",
+    "url": "/docs/logs/enable-log-management-new-relic/logs-context-python",
     "paths": [
       "/docs/logs/enable-logs/configure-logs-context-python",
       "/docs/logs/enable-logs/logs-context-python",
@@ -2924,7 +2924,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10166",
+    "url": "/docs/logs/enable-log-management-new-relic/logs-context-agent-apis",
     "paths": [
       "/docs/logs/enable-logs/configure-logs-context-ruby",
       "/docs/logs/enable-logs/logs-context-apm-agent-apis",
@@ -2934,7 +2934,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10176",
+    "url": "/docs/logs/enable-log-management-new-relic/configure-logs-context",
     "paths": [
       "/docs/logs/enable-logs/configure-logs-context-apm",
       "/docs/logs/enable-logs/configure-logs-context-apm-agents",
@@ -2946,7 +2946,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10121",
+    "url": "/docs/logs/enable-log-management-new-relic",
     "paths": [
       "/docs/logs/enable-logs",
       "/docs/logs/enable-new-relic-logs",
@@ -2954,7 +2954,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10126",
+    "url": "/docs/logs/enable-log-management-new-relic/new-relic-logs",
     "paths": [
       "/docs/logs/enable-logs/new-relic-logs",
       "/docs/logs/enable-new-relic-logs/new-relic-logs",
@@ -2962,7 +2962,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10131",
+    "url": "/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic",
     "paths": [
       "/docs/logs/enable-logs/enable-logs",
       "/docs/logs/enable-new-relic-logs/enable-logs",
@@ -2972,86 +2972,86 @@
     ]
   },
   {
-    "url": "/taxonomy/term/6211",
+    "url": "/docs/apis/rest-api-v2/basic-functions",
     "paths": [
       "/docs/apis/rest-api-v2/requirements"
     ]
   },
   {
-    "url": "/taxonomy/term/10246",
+    "url": "/docs/mobile-monitoring/new-relic-mobile-react-native/install-configure",
     "paths": [
       "/docs/install-configure"
     ]
   },
   {
-    "url": "/taxonomy/term/10211",
+    "url": "10211",
     "paths": [
       "/docs/integrations/vmware-tanzu-integration"
     ]
   },
   {
-    "url": "/taxonomy/term/10281",
+    "url": "10281",
     "paths": [
       "/docs/vmware-esxi-integration"
     ]
   },
   {
-    "url": "/taxonomy/term/10276",
+    "url": "10276",
     "paths": [
       "/docs/vmware-tanzu-integration"
     ]
   },
   {
-    "url": "/taxonomy/term/10286",
+    "url": "10286",
     "paths": [
       "/docs/covid-19"
     ]
   },
   {
-    "url": "/taxonomy/term/8181",
+    "url": "/docs/release-notes/platform-release-notes/kubernetes-integration-release-notes",
     "paths": [
       "/docs/integrations/kubernetes-integration/get-started/release-notes",
       "/docs/release-notes/platform-release-notes/host-integrations-release-notes"
     ]
   },
   {
-    "url": "/taxonomy/term/2626",
+    "url": "/docs/apm/apm-ui-pages/monitoring",
     "paths": [
       "/docs/apm/applications-menu/monitoring"
     ]
   },
   {
-    "url": "/taxonomy/term/6876",
+    "url": "/docs/apm/apm-ui-pages/error-analytics",
     "paths": [
       "/docs/apm/applications-menu/error-analytics"
     ]
   },
   {
-    "url": "/taxonomy/term/6166",
+    "url": "/docs/apm/apm-ui-pages/service-maps",
     "paths": [
       "/docs/apm/applications-menu/service-maps"
     ]
   },
   {
-    "url": "/taxonomy/term/2631",
+    "url": "/docs/apm/apm-ui-pages/features",
     "paths": [
       "/docs/apm/applications-menu/features"
     ]
   },
   {
-    "url": "/taxonomy/term/2636",
+    "url": "/docs/apm/apm-ui-pages/events",
     "paths": [
       "/docs/apm/applications-menu/events"
     ]
   },
   {
-    "url": "/taxonomy/term/2641",
+    "url": "2641",
     "paths": [
       "/docs/apm/applications-menu/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/10306",
+    "url": "/docs/integrations/elastic-container-service-integration",
     "paths": [
       "/docs/integrations/aws-elastic-container-service-integration",
       "/docs/integrations/elastic-container-service-integration",
@@ -3060,21 +3060,21 @@
     ]
   },
   {
-    "url": "/taxonomy/term/8886",
+    "url": "/docs/integrations/infrastructure-integrations/cloud-integrations",
     "paths": [
       "/docs/integrations/new-relic-integrations/cloud-integrations",
       "/docs/infrastructure-integrations/new-relic-integrations/cloud-integrations"
     ]
   },
   {
-    "url": "/taxonomy/term/10191",
+    "url": "/docs/integrations/infrastructure-integrations/host-integrations",
     "paths": [
       "/docs/integrations/new-relic-integrations/host-integrations",
       "/docs/infrastructure-integrations/new-relic-integrations/host-integrations"
     ]
   },
   {
-    "url": "/taxonomy/term/8821",
+    "url": "/docs/integrations/kubernetes-integration",
     "paths": [
       "/docs/integrations/kubernetes-integration",
       "/docs/infrastructure-integrations/kubernetes-integration",
@@ -3083,70 +3083,70 @@
     ]
   },
   {
-    "url": "/taxonomy/term/8826",
+    "url": "/docs/integrations/kubernetes-integration/installation",
     "paths": [
       "/docs/integrations/kubernetes-integration/installation",
       "/docs/infrastructure-integrations/kubernetes-integration/installation"
     ]
   },
   {
-    "url": "/taxonomy/term/8836",
+    "url": "/docs/integrations/kubernetes-integration/understand-use-data",
     "paths": [
       "/docs/integrations/kubernetes-integration/understand-use-data",
       "/docs/infrastructure-integrations/kubernetes-integration/understand-use-data"
     ]
   },
   {
-    "url": "/taxonomy/term/8841",
+    "url": "8841",
     "paths": [
       "/docs/integrations/kubernetes-integration/cluster-explorer",
       "/docs/infrastructure-integrations/kubernetes-integration/cluster-explorer"
     ]
   },
   {
-    "url": "/taxonomy/term/10186",
+    "url": "/docs/integrations/kubernetes-integration/kubernetes-plugin-logs",
     "paths": [
       "/docs/integrations/kubernetes-integration/logs",
       "/docs/infrastructure-integrations/kubernetes-integration/logs"
     ]
   },
   {
-    "url": "/taxonomy/term/8846",
+    "url": "/docs/integrations/kubernetes-integration/troubleshooting",
     "paths": [
       "/docs/integrations/kubernetes-integration/troubleshooting",
       "/docs/infrastructure-integrations/kubernetes-integration/troubleshooting"
     ]
   },
   {
-    "url": "/taxonomy/term/10311",
+    "url": "/docs/integrations/elastic-container-service-integration/get-started",
     "paths": [
       "/docs/integrations/elastic-container-service-integration/get-started",
       "/docs/infrastructure-integrations/elastic-container-service-integration/get-started"
     ]
   },
   {
-    "url": "/taxonomy/term/10316",
+    "url": "/docs/integrations/elastic-container-service-integration/installation",
     "paths": [
       "/docs/integrations/elastic-container-service-integration/installation",
       "/docs/infrastructure-integrations/elastic-container-service-integration/installation"
     ]
   },
   {
-    "url": "/taxonomy/term/10321",
+    "url": "/docs/integrations/elastic-container-service-integration/understand-use-data",
     "paths": [
       "/docs/integrations/elastic-container-service-integration/understand-use-data",
       "/docs/infrastructure-integrations/elastic-container-service-integration/understand-use-data"
     ]
   },
   {
-    "url": "/taxonomy/term/10326",
+    "url": "/docs/integrations/elastic-container-service-integration/troubleshooting",
     "paths": [
       "/docs/integrations/elastic-container-service-integration/troubleshooting",
       "/docs/infrastructure-integrations/elastic-container-service-integration/troubleshooting"
     ]
   },
   {
-    "url": "/taxonomy/term/9966",
+    "url": "/docs/integrations/prometheus-integrations",
     "paths": [
       "/docs/integrations/prometheus-integrations",
       "/docs/infrastructure-integrations/prometheus-integrations",
@@ -3154,28 +3154,28 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10076",
+    "url": "/docs/integrations/prometheus-integrations/view-query-data",
     "paths": [
       "/docs/integrations/prometheus-integrations/view-query-data",
       "/docs/infrastructure-integrations/prometheus-integrations/view-query-data"
     ]
   },
   {
-    "url": "/taxonomy/term/10086",
+    "url": "/docs/integrations/prometheus-integrations/troubleshooting",
     "paths": [
       "/docs/integrations/prometheus-integrations/troubleshooting",
       "/docs/infrastructure-integrations/prometheus-integrations/troubleshooting"
     ]
   },
   {
-    "url": "/taxonomy/term/10231",
+    "url": "10231",
     "paths": [
       "/docs/using-new-relic/data/customize-data/manage-your-data",
       "/docs/accounts/accounts/data-management"
     ]
   },
   {
-    "url": "/taxonomy/term/10416",
+    "url": "/docs/integrations/open-source-telemetry-integrations",
     "paths": [
       "/docs/integrations/exporters",
       "/docs/full-stack-observability/instrument-everything/instrument-core-services-applications/open-source-telemetry-integrations",
@@ -3183,20 +3183,20 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10421",
+    "url": "/docs/integrations/open-source-telemetry-integrations/get-started",
     "paths": [
       "/docs/integrations/exporters/get-started"
     ]
   },
   {
-    "url": "/taxonomy/term/10426",
+    "url": "/docs/integrations/open-source-telemetry-integrations/open-source-telemetry-integration-list",
     "paths": [
       "/docs/integrations/exporters/exporter-list",
       "/docs/integrations/open-source-telemetry-integrations/exporter-list"
     ]
   },
   {
-    "url": "/taxonomy/term/9866",
+    "url": "/docs/query-your-data",
     "paths": [
       "/docs/query-data",
       "/docs/query-your-data",
@@ -3204,7 +3204,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9896",
+    "url": "/docs/query-your-data/nrql-new-relic-query-language/query-tools",
     "paths": [
       "/docs/query-data/nrql-new-relic-query-language/query-tools",
       "/docs/query-your-data/nrql-new-relic-query-language/query-tools",
@@ -3212,21 +3212,21 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9711",
+    "url": "9711",
     "paths": [
       "/docs/new-relic-one-dashboards",
       "/docs/explore-query-data/new-relic-one-dashboards"
     ]
   },
   {
-    "url": "/taxonomy/term/9716",
+    "url": "9716",
     "paths": [
       "/docs/new-relic-one-dashboards/key-visual-tools",
       "/docs/explore-query-data/new-relic-one-dashboards/key-visual-tools"
     ]
   },
   {
-    "url": "/taxonomy/term/9721",
+    "url": "9721",
     "paths": [
       "/docs/chart-builder/use-chart-builder",
       "/docs/query-your-data/use-chart-builder",
@@ -3235,7 +3235,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9726",
+    "url": "9726",
     "paths": [
       "/docs/chart-builder/use-chart-builder/get-started",
       "/docs/query-your-data/use-chart-builder/get-started",
@@ -3244,7 +3244,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9751",
+    "url": "9751",
     "paths": [
       "/docs/chart-builder/use-chart-builder/choose-data",
       "/docs/query-your-data/use-chart-builder/choose-data",
@@ -3253,7 +3253,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9756",
+    "url": "9756",
     "paths": [
       "/docs/chart-builder/use-chart-builder/nrql",
       "/docs/query-your-data/use-chart-builder/nrql",
@@ -3262,7 +3262,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9741",
+    "url": "9741",
     "paths": [
       "/docs/chart-builder/use-chart-builder/use-charts",
       "/docs/query-your-data/use-chart-builder/use-charts",
@@ -3271,7 +3271,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10486",
+    "url": "/docs/query-your-data/explore-query-data/new-relic-query-language",
     "paths": [
       "/docs/query-your-data/explore-query-data/nrql",
       "/docs/query-your-data/explore-query-data/new-relic-query-language",
@@ -3280,112 +3280,112 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10491",
+    "url": "10491",
     "paths": [
       "/docs/original-new-relic-accounts"
     ]
   },
   {
-    "url": "/taxonomy/term/10496",
+    "url": "10496",
     "paths": [
       "/docs/original-new-relic-accounts/original-account-management"
     ]
   },
   {
-    "url": "/taxonomy/term/10501",
+    "url": "10501",
     "paths": [
       "/docs/original-new-relic-accounts/original-account-management/product-pricing-plan"
     ]
   },
   {
-    "url": "/taxonomy/term/10506",
+    "url": "10506",
     "paths": [
       "/docs/original-new-relic-accounts/original-account-management/usage"
     ]
   },
   {
-    "url": "/taxonomy/term/10511",
+    "url": "10511",
     "paths": [
       "/docs/original-new-relic-accounts/original-account-management/users"
     ]
   },
   {
-    "url": "/taxonomy/term/10526",
+    "url": "10526",
     "paths": [
       "/docs/workloads/workloads"
     ]
   },
   {
-    "url": "/taxonomy/term/2226",
+    "url": "/docs/browser",
     "paths": [
       "/docs/integrations/intro-integrations/get-started/browser-monitoring",
       "/docs/full-stack-observability/monitor-everything/observability-solutions/browser-monitoring"
     ]
   },
   {
-    "url": "/taxonomy/term/10471",
+    "url": "/docs/query-your-data/explore-query-data",
     "paths": [
       "/docs/query-your-data/explore-query-data"
     ]
   },
   {
-    "url": "/taxonomy/term/10476",
+    "url": "/docs/query-your-data/explore-query-data/query-builder",
     "paths": [
       "/docs/query-your-data/explore-query-data/chart-builder"
     ]
   },
   {
-    "url": "/taxonomy/term/10516",
+    "url": "/docs/query-your-data/explore-query-data/explore-data",
     "paths": [
       "/docs/query-your-data/explore-query-data/data-explorer",
       "/docs/explore-query-data/data-explorer"
     ]
   },
   {
-    "url": "/taxonomy/term/10481",
+    "url": "/docs/query-your-data/explore-query-data/use-charts",
     "paths": [
       "/docs/query-your-data/explore-query-data/use-charts",
       "/docs/explore-query-data/use-charts"
     ]
   },
   {
-    "url": "/taxonomy/term/10401",
+    "url": "/docs/accounts/accounts-billing/account-setup",
     "paths": [
       "/docs/accounts/accounts/account-setup"
     ]
   },
   {
-    "url": "/taxonomy/term/10396",
+    "url": "10396",
     "paths": [
       "/docs/accounts/accounts/product-usage"
     ]
   },
   {
-    "url": "/taxonomy/term/10411",
+    "url": "10411",
     "paths": [
       "/docs/accounts/accounts/account-structure"
     ]
   },
   {
-    "url": "/taxonomy/term/10336",
+    "url": "/docs/accounts/accounts-billing/automated-user-management",
     "paths": [
       "/docs/accounts/accounts/automated-user-management"
     ]
   },
   {
-    "url": "/taxonomy/term/10406",
+    "url": "/docs/accounts/accounts-billing/partner-installation",
     "paths": [
       "/docs/accounts/accounts/partner-installation"
     ]
   },
   {
-    "url": "/taxonomy/term/9926",
+    "url": "/docs/telemetry-data-platform",
     "paths": [
       "/docs/data-ingest-apis"
     ]
   },
   {
-    "url": "/taxonomy/term/9931",
+    "url": "/docs/telemetry-data-platform/ingest-manage-data",
     "paths": [
       "/docs/data-ingest-apis/get-data-new-relic",
       "/docs/telemetry-data-platform/get-data-new-relic",
@@ -3394,7 +3394,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9936",
+    "url": "/docs/telemetry-data-platform/ingest-manage-data/get-started",
     "paths": [
       "/docs/data-ingest-apis/get-data-new-relic/getting-started",
       "/docs/telemetry-data-platform/get-data-new-relic/getting-started",
@@ -3405,7 +3405,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9941",
+    "url": "9941",
     "paths": [
       "/docs/data-ingest-apis/get-data-new-relic/new-relic-sdks",
       "/docs/telemetry-data-platform/get-data-new-relic/new-relic-sdks",
@@ -3413,7 +3413,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9946",
+    "url": "9946",
     "paths": [
       "/docs/data-ingest-apis/get-data-new-relic/metric-api",
       "/docs/telemetry-data-platform/get-data-new-relic/metric-api",
@@ -3421,7 +3421,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9961",
+    "url": "9961",
     "paths": [
       "/docs/data-ingest-apis/get-data-new-relic/event-api",
       "/docs/telemetry-data-platform/get-data-new-relic/event-api",
@@ -3429,7 +3429,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9956",
+    "url": "9956",
     "paths": [
       "/docs/data-ingest-apis/get-data-new-relic/log-api",
       "/docs/telemetry-data-platform/get-data-new-relic/log-api",
@@ -3437,7 +3437,7 @@
     ]
   },
   {
-    "url": "/taxonomy/term/9951",
+    "url": "9951",
     "paths": [
       "/docs/data-ingest-apis/get-data-new-relic/trace-api",
       "/docs/telemetry-data-platform/get-data-new-relic/trace-api",
@@ -3445,111 +3445,111 @@
     ]
   },
   {
-    "url": "/taxonomy/term/7016",
+    "url": "/docs/alerts-applied-intelligence/rest-api-alerts",
     "paths": [
       "/docs/alerts/rest-api-alerts"
     ]
   },
   {
-    "url": "/taxonomy/term/10606",
+    "url": "/docs/alerts/new-relic-alerts/alerts-nerdgraph",
     "paths": [
       "/docs/alerts/alerts-nerdgraph",
       "/docs/alerts-applied-intelligence/alerts-nerdgraph"
     ]
   },
   {
-    "url": "/taxonomy/term/10226",
+    "url": "10226",
     "paths": [
       "/docs/alerts/alerts-nerdgraph/nerdgraph-examples",
       "/docs/alerts-applied-intelligence/alerts-nerdgraph/nerdgraph-examples"
     ]
   },
   {
-    "url": "/taxonomy/term/10646",
+    "url": "/docs/alerts-applied-intelligence/applied-intelligence/proactive-detection",
     "paths": [
       "/docs/alerts/proactive-detection",
       "/docs/alerts-applied-intelligence/proactive-detection"
     ]
   },
   {
-    "url": "/taxonomy/term/10651",
+    "url": "/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence",
     "paths": [
       "/docs/alerts/incident-intelligence",
       "/docs/alerts-applied-intelligence/incident-intelligence"
     ]
   },
   {
-    "url": "/taxonomy/term/10656",
+    "url": "/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows",
     "paths": [
       "/docs/alerts/incident-workflows",
       "/docs/alerts-applied-intelligence/incident-workflows"
     ]
   },
   {
-    "url": "/taxonomy/term/10666",
+    "url": "/docs/licenses/license-information/usage-plans",
     "paths": [
       "/docs/licenses/license-information/usage-plan-description",
       "/docs/licenses/license-information/usage-plan-descriptions"
     ]
   },
   {
-    "url": "/taxonomy/term/10756",
+    "url": "/docs/full-stack-observability/observe-everything/observability-solutions",
     "paths": [
       "/docs/observability-solutions",
       "/docs/full-stack-observability/monitor-everything/observability-solutions"
     ]
   },
   {
-    "url": "/taxonomy/term/9611",
+    "url": "/docs/serverless-function-monitoring",
     "paths": [
       "/docs/full-stack-observability/monitor-everything/observability-solutions/serverless-monitoring"
     ]
   },
   {
-    "url": "/taxonomy/term/9986",
+    "url": "/docs/logs",
     "paths": [
       "/docs/full-stack-observability/monitor-everything/observability-solutions/logs-context"
     ]
   },
   {
-    "url": "/taxonomy/term/10711",
+    "url": "/docs/full-stack-observability/observe-everything/get-started-new-relic-observability",
     "paths": [
       "/docs/full-stack-observability/monitor-everything/get-started-new-relic-monitoring-tools",
       "/docs/full-stack-observability/monitor-everything/get-started-new-relic-observability"
     ]
   },
   {
-    "url": "/taxonomy/term/10706",
+    "url": "/docs/full-stack-observability/observe-everything",
     "paths": [
       "/docs/full-stack-observability/monitor-everything"
     ]
   },
   {
-    "url": "/taxonomy/term/2256",
+    "url": "/docs/agents",
     "paths": [
       "/docs/full-stack-observability/instrument-everything/instrument-applications-infrastructure/language-agents-apm"
     ]
   },
   {
-    "url": "/taxonomy/term/10696",
+    "url": "/docs/full-stack-observability/instrument-everything/instrument-core-services-applications",
     "paths": [
       "/docs/full-stack-observability/instrument-everything/instrument-core-services"
     ]
   },
   {
-    "url": "/taxonomy/term/10691",
+    "url": "/docs/full-stack-observability/instrument-everything/instrument-your-code-infrastructure",
     "paths": [
       "/docs/full-stack-observability/instrument-everything/instrument-applications-infrastructure"
     ]
   },
   {
-    "url": "/taxonomy/term/10576",
+    "url": "/docs/integrations/grafana-integrations",
     "paths": [
       "/docs/full-stack-observability/instrument-everything/instrument-core-services-applications/grafana-integrations"
     ]
   },
   {
-    "url": "/taxonomy/term/10641",
+    "url": "/docs/telemetry-data-platform/ingest-manage-data/manage-data",
     "paths": [
       "/docs/telemetry-data-platform/get-data-new-relic/manage-data",
       "/taxonomy/term/10231",
@@ -3558,187 +3558,187 @@
     ]
   },
   {
-    "url": "/taxonomy/term/10771",
+    "url": "/docs/accounts/original-accounts-billing/original-data-retention",
     "paths": [
       "/docs/accounts/original-accounts-billing/product-based-data-retention"
     ]
   },
   {
-    "url": "/taxonomy/term/10636",
+    "url": "/docs/accounts/original-accounts-billing/original-users-roles",
     "paths": [
       "/docs/accounts/original-accounts-billing/users-roles"
     ]
   },
   {
-    "url": "/taxonomy/term/10626",
+    "url": "/docs/accounts/original-accounts-billing/original-pricing-plan-usage",
     "paths": [
       "/docs/accounts/original-accounts-billing/usage"
     ]
   },
   {
-    "url": "/taxonomy/term/10621",
+    "url": "/docs/accounts/original-accounts-billing/original-product-based-pricing",
     "paths": [
       "/docs/accounts/original-accounts-billing/product-based-pricing"
     ]
   },
   {
-    "url": "/taxonomy/term/7661",
+    "url": "/docs/infrastructure/infrastructure-monitoring/guides",
     "paths": [
       "/docs/infrastructure/new-relic-infrastructure/guides"
     ]
   },
   {
-    "url": "/taxonomy/term/9816",
+    "url": "/docs/infrastructure/infrastructure-monitoring/infrastructure-security",
     "paths": [
       "/docs/infrastructure/new-relic-infrastructure/infrastructure-security"
     ]
   },
   {
-    "url": "/taxonomy/term/9991",
+    "url": "/docs/logs/log-management-0",
     "paths": [
       "/docs/logs/new-relic-logs",
       "/docs/logs/log-monitoring"
     ]
   },
   {
-    "url": "/taxonomy/term/9996",
+    "url": "/docs/logs/log-management/get-started",
     "paths": [
       "/docs/logs/new-relic-logs/get-started",
       "/docs/logs/log-monitoring/get-started"
     ]
   },
   {
-    "url": "/taxonomy/term/10001",
+    "url": "/docs/logs/log-management/enable-logs",
     "paths": [
       "/docs/logs/new-relic-logs/enable-logs",
       "/docs/logs/log-monitoring/enable-logs"
     ]
   },
   {
-    "url": "/taxonomy/term/10011",
+    "url": "/docs/logs/log-management/ui-data",
     "paths": [
       "/docs/logs/new-relic-logs/ui-data",
       "/docs/logs/log-monitoring/ui-data"
     ]
   },
   {
-    "url": "/taxonomy/term/10021",
+    "url": "/docs/logs/log-management/troubleshooting",
     "paths": [
       "/docs/logs/new-relic-logs/troubleshooting",
       "/docs/logs/log-monitoring/troubleshooting"
     ]
   },
   {
-    "url": "/taxonomy/term/10796",
+    "url": "/docs/infrastructure/install-infrastructure-agent/get-started",
     "paths": [
       "/docs/infrastructure/install-configure-manage-infrastructure-agent/get-started"
     ]
   },
   {
-    "url": "/taxonomy/term/7697",
+    "url": "/docs/synthetics/synthetic-monitoring/guides",
     "paths": [
       "/docs/synthetics/new-relic-synthetics/guides"
     ]
   },
   {
-    "url": "/taxonomy/term/6491",
+    "url": "/docs/synthetics/synthetic-monitoring/administration",
     "paths": [
       "/docs/synthetics/new-relic-synthetics/administration"
     ]
   },
   {
-    "url": "/taxonomy/term/6156",
+    "url": "/docs/synthetics/synthetic-monitoring/private-locations",
     "paths": [
       "/docs/synthetics/new-relic-synthetics/private-locations"
     ]
   },
   {
-    "url": "/taxonomy/term/6656",
+    "url": "/docs/synthetics/synthetic-monitoring/synthetics-api",
     "paths": [
       "/docs/synthetics/new-relic-synthetics/synthetics-api"
     ]
   },
   {
-    "url": "/taxonomy/term/10806",
+    "url": "/docs/telemetry-data-platform/ingest-manage-data/ingest-apis",
     "paths": [
       "/docs/telemetry-data-platform/data-ingest-query/apis",
       "/docs/telemetry-data-platform/data-ingest-query/ingest-apis"
     ]
   },
   {
-    "url": "/taxonomy/term/10801",
+    "url": "/docs/telemetry-data-platform/ingest-manage-data/understand-data",
     "paths": [
       "/docs/telemetry-data-platform/data-ingest-query/understand-data"
     ]
   },
   {
-    "url": "/taxonomy/term/2236",
+    "url": "/docs/browser/browser-monitoring/getting-started",
     "paths": [
       "/docs/browser/new-relic-browser/getting-started"
     ]
   },
   {
-    "url": "/taxonomy/term/7656",
+    "url": "/docs/browser/browser-monitoring/guides",
     "paths": [
       "/docs/browser/new-relic-browser/guides"
     ]
   },
   {
-    "url": "/taxonomy/term/7546",
+    "url": "/docs/browser/browser-monitoring/configuration",
     "paths": [
       "/docs/browser/new-relic-browser/configuration"
     ]
   },
   {
-    "url": "/taxonomy/term/5841",
+    "url": "/docs/browser/browser-monitoring/browser-pro-features",
     "paths": [
       "/docs/browser/new-relic-browser/browser-pro-features"
     ]
   },
   {
-    "url": "/taxonomy/term/5851",
+    "url": "/docs/browser/browser-monitoring/additional-standard-features",
     "paths": [
       "/docs/browser/new-relic-browser/additional-standard-features"
     ]
   },
   {
-    "url": "/taxonomy/term/5856",
+    "url": "/docs/browser/browser-monitoring/performance-quality",
     "paths": [
       "/docs/browser/new-relic-browser/performance-quality"
     ]
   },
   {
-    "url": "/taxonomy/term/2251",
+    "url": "/docs/browser/browser-monitoring/miscellaneous",
     "paths": [
       "/docs/browser/new-relic-browser/miscellaneous"
     ]
   },
   {
-    "url": "/taxonomy/term/10221",
+    "url": "10221",
     "paths": [
       "/alerts/new-relic-alerts/alerts-nerdgraph"
     ]
   },
   {
-    "url": "/taxonomy/term/10851",
+    "url": "/docs/new-relic-solutions/new-relic-solutions/cloud-adoption",
     "paths": [
       "/docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption"
     ]
   },
   {
-    "url": "/taxonomy/term/10861",
+    "url": "/docs/security/security-privacy/information-security",
     "paths": [
       "/docs/security/new-relic-security/information-security"
     ]
   },
   {
-    "url": "/taxonomy/term/10866",
+    "url": "/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring",
     "paths": [
       "/docs/enable-lambda-monitoring"
     ]
   },
   {
-    "url": "/taxonomy/term/2361",
+    "url": "/docs/agents/nodejs-agent/extend-your-instrumentation",
     "paths": [
       "/docs/agents/nodejs-agent/supported-features"
     ]


### PR DESCRIPTION
## Description
Sets up redirects for _Taxonomy_ (index pages in Gatsby).

## To Do
* [x] Filter out taxonomy IDs that no longer exist in Drupal (because it doesn't prune this stuff)
* [x] Ensure that the redirects are being created at build time

## Related Issue(s)
* Closes #364 