### PR TITLE
Serializes fenced codeblocks correctly

### DIFF
--- a/codemods/fencedCodeBlock.js
+++ b/codemods/fencedCodeBlock.js
@@ -1,0 +1,25 @@
+const { createCompiler } = require('@mdx-js/mdx');
+const visit = require('unist-util-visit');
+
+const INVALID_CODE_BLOCK = /`{3,}\n/;
+
+const compiler = createCompiler();
+
+const fencedCodeBlock = () => (tree) => {
+  visit(
+    tree,
+    (node) => node.type === 'code' && INVALID_CODE_BLOCK.test(node.value),
+    (node, idx, parent) => {
+      const idxOfCode = node.value.indexOf('```');
+      const text = node.value.slice(0, idxOfCode);
+      const parsed = compiler.parse(
+        node.value.slice(idxOfCode).replace(/^`+/, '')
+      );
+
+      node.value = text.trim();
+      parent.children.splice(idx + 1, 0, ...parsed.children);
+    }
+  );
+};
+
+module.exports = fencedCodeBlock;

--- a/scripts/actions/serialize-mdx.js
+++ b/scripts/actions/serialize-mdx.js
@@ -1,5 +1,5 @@
 const handlers = require('./utils/handlers');
-const indentedCodeBlock = require('../../codemods/indentedCodeBlock');
+const fencedCodeBlock = require('../../codemods/fencedCodeBlock');
 const unified = require('unified');
 const toMDAST = require('remark-parse');
 const frontmatter = require('remark-frontmatter');
@@ -27,7 +27,7 @@ const processor = unified()
   .use(remarkMdx)
   .use(remarkMdxjs)
   .use(frontmatter, ['yaml'])
-  .use(indentedCodeBlock)
+  .use(fencedCodeBlock)
   .use(customHeadingIds)
   .use(remark2rehype, {
     handlers: {


### PR DESCRIPTION
Pulls in the logic from the gatsby-plugin jerel created in this PR: https://github.com/newrelic/docs-website/pull/686/files to correctly parse fenced code blocks