### PR TITLE
chore: update to stale bot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,8 +4,9 @@ daysUntilStale: 30
 daysUntilClose: 10
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - security 
+  - security
   - content
+  - roadmap
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
This PR updates stalebot to exclude the label roadmap from stalebot's relentless pursuit.