### PR TITLE
Remove all translation context when job is complete

### DIFF
--- a/scripts/actions/remove-completed-batch.js
+++ b/scripts/actions/remove-completed-batch.js
@@ -57,7 +57,7 @@ const removePageContext = async (fileUris) => {
     .filter(({ name }) => [...fileNames, ...fileUris].includes(name))
     .map(({ name, contextUid }) => ({
       fileUri: name,
-      contextUid: contextUid,
+      contextUid,
     }));
 
   const results = await Promise.all(

--- a/scripts/actions/remove-completed-batch.js
+++ b/scripts/actions/remove-completed-batch.js
@@ -51,12 +51,14 @@ const removePageContext = async (fileUris) => {
     accessToken,
   });
 
+  // Find the smartling context to be removed. This includes context manually
+  // uploaded (fileNames) as well as the "context" created by smartling (fileUris).
   const contextUids = items
-    .filter((item) => fileNames.includes(item.name))
-    .map((item) => {
+    .filter(({ name }) => fileNames.includes(name) || fileUris.includes(name))
+    .map(({ name, contextUid }) => {
       return {
-        fileUri: item.name,
-        contextUid: item.contextUid,
+        fileUri: name,
+        contextUid: contextUid,
       };
     });
 

--- a/scripts/actions/remove-completed-batch.js
+++ b/scripts/actions/remove-completed-batch.js
@@ -54,7 +54,7 @@ const removePageContext = async (fileUris) => {
   // Find the smartling context to be removed. This includes context manually
   // uploaded (fileNames) as well as the "context" created by smartling (fileUris).
   const contextUids = items
-    .filter(({ name }) => fileNames.includes(name) || fileUris.includes(name))
+    .filter(({ name }) => [...fileNames, ...fileUris].includes(name))
     .map(({ name, contextUid }) => ({
       fileUri: name,
       contextUid: contextUid,

--- a/scripts/actions/remove-completed-batch.js
+++ b/scripts/actions/remove-completed-batch.js
@@ -55,12 +55,10 @@ const removePageContext = async (fileUris) => {
   // uploaded (fileNames) as well as the "context" created by smartling (fileUris).
   const contextUids = items
     .filter(({ name }) => fileNames.includes(name) || fileUris.includes(name))
-    .map(({ name, contextUid }) => {
-      return {
-        fileUri: name,
-        contextUid: contextUid,
-      };
-    });
+    .map(({ name, contextUid }) => ({
+      fileUri: name,
+      contextUid: contextUid,
+    }));
 
   const results = await Promise.all(
     contextUids.map(async ({ contextUid, fileUri }) => {


### PR DESCRIPTION
## Description
When a translation job is complete, we remove the "context" files from our translation vendor's platform. However, when we upload files, the vendor will make a _second_ "context" from the uploaded file. This PR ensures that we're removing _all_ context associated with a particular page.

## Related Issue(s)
* Closes #796 