### PR TITLE
chore: updated component guide

### DIFF
--- a/COMPONENT_GUIDE.md
+++ b/COMPONENT_GUIDE.md
@@ -1,4 +1,10 @@
 # Component Documentation
 
+## Global Components
+
 Refer to the [New Relic Gatsby Theme](https://github.com/newrelic/gatsby-theme-newrelic/blob/develop/packages/gatsby-theme-newrelic/README.md)
 component documentation for details on all the components used on this site.
+
+## Docs Site Components
+
+Currently the Docs Site only uses global components for all patterns.


### PR DESCRIPTION
This PR clarifies that the docs site only use global components. 