### PR TITLE
Fix erroneous redirect on .NET install doc

### DIFF
--- a/src/content/docs/agents/net-agent/installation/introduction-net-agent-install.mdx
+++ b/src/content/docs/agents/net-agent/installation/introduction-net-agent-install.mdx
@@ -18,7 +18,6 @@ redirects:
   - /docs/agents/net-agent/installation/install-new-relic-net-agent
   - /node/19576
   - /docs/agents/net-agent/installation/install-enable-new-relic-net-agent
-  - /docs/agents/net-agent/installation/install-net-agent-windows
   - /docs/agents/net-agent/installation/new-relic-net-agent-install-introduction
   - /docs/agents/net-agent/installation/install-net-agent-using-scriptable-installer
   - /docs/agents/net-agent/installation/net-agent-install-introduction


### PR DESCRIPTION
Closes #803 

## Description
This removes the redirect in the frontmatter for the .NET intro install doc that prevented accessing the page for the .NET install for Windows  link. The redirect was disabled in Drupal, but our migration doesn't check for that (super rare for redirects to be disabled). 

## Screenshot
<img width="1577" alt="Screen Shot 2021-02-10 at 15 02 53" src="https://user-images.githubusercontent.com/2952843/107584403-3d7e4180-6bb1-11eb-93ee-ae73a4fbeb50.png">
This was removed from prod/dev Drupal and migration was re-run to ensure it was removed.