### PR TITLE
Create redirects for more dummy docs to tax term / index paths

### DIFF
--- a/scripts/utils/migrate/taxonomy-redirects.js
+++ b/scripts/utils/migrate/taxonomy-redirects.js
@@ -41,7 +41,6 @@ const getNodePath = async (uri) => {
     const json = await res.json();
     return get(json, 'docs[0].doc.path');
   } catch (error) {
-    fs.writeFileSync('src/data/nodes.txt', url);
     return null;
   }
 };

--- a/scripts/utils/migrate/taxonomy-redirects.js
+++ b/scripts/utils/migrate/taxonomy-redirects.js
@@ -22,7 +22,6 @@ const getTaxonomyPath = async (uri) => {
   try {
     const res = await fetch(url, { headers });
     const json = await res.json();
-
     return get(json, 'terms[0].term.urlPath');
   } catch (error) {
     return null;
@@ -39,7 +38,9 @@ const getNodePath = async (uri) => {
   try {
     const res = await fetch(url, { headers });
     const json = await res.json();
-    return get(json, 'docs[0].doc.path');
+    const { docs } = json;
+
+    return docs.length ? get(json, 'docs[0].doc.path') : null;
   } catch (error) {
     return null;
   }
@@ -59,11 +60,11 @@ const fetchTaxonomyRedirects = async (redirects) => {
         .map(async (path) =>
           path.startsWith('/node') ? await getNodePath(path) : path
         )
-        .filter((path) => Boolean(path))
     );
+    const finalPaths = filteredPaths.filter((path) => Boolean(path));
 
-    return Boolean(url) && (await filteredPaths.length) > 0
-      ? { ...(await memo), [url]: await filteredPaths }
+    return Boolean(url) && finalPaths.length > 0
+      ? { ...(await memo), [url]: finalPaths }
       : await memo;
   }, {});
 };

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -10,7 +10,6 @@
       "/docs/servers/new-relic-servers-linux/maintenance/server-monitor-known-issues",
       "/docs/servers/new-relic-servers-linux/maintenance/servers-linux-known-issues",
       "/docs/servers/new-relic-servers-linux/troubleshooting/servers-linux-known-issues",
-      null,
       "/docs/infrastructure/new-relic-infrastructure/troubleshooting",
       "/docs/infrastructure/config-management-tools/troubleshooting",
       "/docs/servers/new-relic-servers-linux/troubleshooting/missing-processes-servers-linux",
@@ -36,8 +35,7 @@
     "url": "/docs/agents/php-agent/troubleshooting",
     "paths": [
       "/docs/php/php-agent-faq",
-      "/docs/agents/php-agent/getting-started/new-relic-php-faqs",
-      null
+      "/docs/agents/php-agent/getting-started/new-relic-php-faqs"
     ]
   },
   {

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -10,6 +10,7 @@
       "/docs/servers/new-relic-servers-linux/maintenance/server-monitor-known-issues",
       "/docs/servers/new-relic-servers-linux/maintenance/servers-linux-known-issues",
       "/docs/servers/new-relic-servers-linux/troubleshooting/servers-linux-known-issues",
+      null,
       "/docs/infrastructure/new-relic-infrastructure/troubleshooting",
       "/docs/infrastructure/config-management-tools/troubleshooting",
       "/docs/servers/new-relic-servers-linux/troubleshooting/missing-processes-servers-linux",
@@ -35,7 +36,8 @@
     "url": "/docs/agents/php-agent/troubleshooting",
     "paths": [
       "/docs/php/php-agent-faq",
-      "/docs/agents/php-agent/getting-started/new-relic-php-faqs"
+      "/docs/agents/php-agent/getting-started/new-relic-php-faqs",
+      null
     ]
   },
   {
@@ -43,6 +45,7 @@
     "paths": [
       "/docs/php/the-php-api",
       "/docs/php/php-agent-api",
+      "/docs/agents/php-agent/php-agent-api/view-all-methods",
       "/docs/agents/php-agent/configuration/php-agent-api"
     ]
   },
@@ -52,6 +55,7 @@
       "/docs/dotnet/AgentApi",
       "/docs/dotnet/the-net-agent-api",
       "/docs/dotnet/net-agent-api",
+      "/docs/agents/net-agent/net-agent-api/view-all-methods",
       "/docs/agents/net-agent/features/net-agent-api"
     ]
   },
@@ -132,50 +136,58 @@
   {
     "url": "/docs/release-notes/agent-release-notes/java-release-notes",
     "paths": [
-      "/docs/releases/java"
+      "/docs/releases/java",
+      "/docs/agents/java-agent/getting-started/java-release-notes"
     ]
   },
   {
     "url": "/docs/release-notes/agent-release-notes/net-release-notes",
     "paths": [
-      "/docs/releases/dotnet"
+      "/docs/releases/dotnet",
+      "/docs/agents/net-agent/getting-started/net-release-notes"
     ]
   },
   {
     "url": "/docs/release-notes/agent-release-notes/nodejs-release-notes",
     "paths": [
-      "/docs/releases/node"
+      "/docs/releases/node",
+      "/docs/agents/nodejs-agent/getting-started/nodejs-release-notes"
     ]
   },
   {
     "url": "/docs/release-notes/agent-release-notes/php-release-notes",
     "paths": [
-      "/docs/releases/php"
+      "/docs/releases/php",
+      "/docs/agents/php-agent/getting-started/php-agent-release-notes"
     ]
   },
   {
     "url": "/docs/release-notes/agent-release-notes/python-release-notes",
     "paths": [
       "/docs/releases/python",
+      "/docs/agents/python-agent/getting-started/python-release-notes",
       "/docs/python/python-agent-release-notes"
     ]
   },
   {
     "url": "/docs/release-notes/agent-release-notes/ruby-release-notes",
     "paths": [
-      "/docs/releases/ruby"
+      "/docs/releases/ruby",
+      "/docs/agents/ruby-agent/getting-started/ruby-release-notes"
     ]
   },
   {
     "url": "/docs/release-notes/mobile-release-notes/android-release-notes",
     "paths": [
-      "/docs/releases/android"
+      "/docs/releases/android",
+      "/docs/mobile-monitoring/new-relic-mobile-android/get-started/android-release-notes"
     ]
   },
   {
     "url": "/docs/release-notes/mobile-release-notes/ios-release-notes",
     "paths": [
-      "/docs/releases/ios"
+      "/docs/releases/ios",
+      "/docs/mobile-monitoring/new-relic-mobile-ios/get-started/ios-release-notes"
     ]
   },
   {
@@ -549,6 +561,12 @@
     ]
   },
   {
+    "url": "/docs/apis/synthetics-rest-api",
+    "paths": [
+      "/docs/synthetics/new-relic-synthetics/synthetics-api/synthetics-rest-api"
+    ]
+  },
+  {
     "url": "/docs/agents/nodejs-agent/troubleshooting",
     "paths": [
       "/docs/agents/nodejs-agent/getting-started/known-nodejs-limitations",
@@ -628,6 +646,12 @@
     "url": "/docs/release-notes/new-relic-browser-release-notes",
     "paths": [
       "/docs/release-notes/browser-agent-release-notes"
+    ]
+  },
+  {
+    "url": "/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes",
+    "paths": [
+      "/docs/browser/new-relic-browser/getting-started/browser-agent-release-notes"
     ]
   },
   {
@@ -737,6 +761,12 @@
     "paths": [
       "/docs/alerts/new-relic-alerts/rest-api-alerts",
       "/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api"
+    ]
+  },
+  {
+    "url": "/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes",
+    "paths": [
+      "/docs/infrastructure/new-relic-infrastructure/getting-started/infrastructure-agent-release-notes"
     ]
   },
   {
@@ -926,6 +956,7 @@
   {
     "url": "/docs/agents/python-agent/python-agent-api",
     "paths": [
+      "/docs/agents/python-agent/python-agent-api/view-all-python-agent-api-calls",
       "/docs/adduserattribute-python-agent-api"
     ]
   },
@@ -1175,6 +1206,7 @@
   {
     "url": "/docs/integrations",
     "paths": [
+      "/docs/infrastructure/new-relic-infrastructure/getting-started/infrastructure-integrations",
       "/docs/kubernetes-integration",
       "/docs/infrastructure-integrations"
     ]


### PR DESCRIPTION
Closes #758, closes #804

## Description
This supports redirecting dummy docs (like those in agent docs that link to that agent's release note index page AND view all agent API methods links) that link to an index page.

Uses a new migration API resource to get a Drupal node's URL alias given the node URI in the redirect data.