### PR TITLE
chore: testing mark tags (Don't Merge)

### DIFF
--- a/src/content/docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications.mdx
+++ b/src/content/docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications.mdx
@@ -11,17 +11,17 @@ redirects:
 
 [New Relic for Java](/docs/agents/java-agent/getting-started/introduction-new-relic-java) (agent [version 3.37](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-3370) or higher) includes an API to instrument asynchronous activity. For [supported frameworks](/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent), the agent usually instruments async work automatically. However, the async API can still be useful to add detail. This document provides examples of using tokens and segments to instrument your app.
 
-* For more information about how New Relic instruments and displays async work in the APM UI, see [Monitoring considerations for asynchronous applications](/docs/agents/java-agent/instrumentation/asynchronous-applications-monitoring-considerations).
-* For details on the actual classes and methods, see the [Javadoc](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/NewRelic.html).
-* For general information on the Java agent API, see the [Java agent API guide](/docs/agents/java-agent/custom-instrumentation/java-agent-api-guide).
-* For troubleshooting common problems, see [Troubleshooting Java asynchronous applications](/docs/agents/java-agent/java-agent-api/troubleshooting-java-asynchronous-applications).
+- For more information about how New Relic instruments and displays async work in the APM UI, see [Monitoring considerations for asynchronous applications](/docs/agents/java-agent/instrumentation/asynchronous-applications-monitoring-considerations).
+- For details on the actual classes and methods, see the [Javadoc](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/NewRelic.html).
+- For general information on the Java agent API, see the [Java agent API guide](/docs/agents/java-agent/custom-instrumentation/java-agent-api-guide).
+- For troubleshooting common problems, see [Troubleshooting Java asynchronous applications](/docs/agents/java-agent/java-agent-api/troubleshooting-java-asynchronous-applications).
 
 ## Async tracking tools: Tokens and segments [#tokens_segments]
 
 The Java agent API provides two ways to trace asynchronous activity:
 
-* **[Tokens](#tokens)**: Tokens are passed between threads to link asynchronous units of work to a specific transaction. They do not perform any timing directly.
-* **[Segments](#segments)**: Segments are used to measure an arbitrary piece of asynchronous application code, not necessarily associated with a method or thread. Segments are typically used to track external calls that are completed by a callback mechanism.
+- **[Tokens](#tokens)**: Tokens are passed between threads to link asynchronous units of work to a specific transaction. They do not perform any timing directly.
+- **[Segments](#segments)**: Segments are used to measure an arbitrary piece of asynchronous application code, not necessarily associated with a method or thread. Segments are typically used to track external calls that are completed by a callback mechanism.
 
 ## Tokens: Connect async threads [#tokens]
 
@@ -56,9 +56,10 @@ To use tokens, you first need to create the token, then link another call to the
 
     The agent API calls in this sample are:
 
-    * `@Trace(dispatcher = true)`: Tells the agent to start a transaction. For more on this method, see the [Javadoc](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/Trace.html).
-    * `getToken()`: Creates the token which will link the work together. For more on this method, see the [Javadoc](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/Transaction.html#getToken()).
-    * `token.expire()`: Expires the token. This allows the transaction to end. For more on this method, see the [Javadoc](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/Token.html#expire()).
+    * <mark>@Trace(dispatcher = true)</mark>: Tells the agent to start a transaction. For more on this method, see the [Javadoc](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/Trace.html).
+    * <mark>getToken()</mark>: Creates the token which will link the work together. For more on this method, see the [Javadoc](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/Transaction.html#getToken()).
+    * <mark>token.expire()</mark>: Expires the token. This allows the transaction to end. For more on this method, see the [Javadoc](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/Token.html#expire()).
+
   </Collapser>
 
   <Collapser
@@ -81,6 +82,7 @@ To use tokens, you first need to create the token, then link another call to the
 
     * `@Trace(async = true)`: Starts a transaction. For more on this method, see the [Javadoc](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/Trace.html).
     * `token.link()`: Links the work being done in `requestItemAsync()` (which is executing on a different thread) to the requesting thread. For more on this method, see the [Javadoc](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/Token.html#link()).
+
   </Collapser>
 
   <Collapser
@@ -98,20 +100,27 @@ To use tokens, you first need to create the token, then link another call to the
 
     All asynchronous method calls linked with a token are indicated with an <Icon name="fe-search"/>
     **Async** icon in the **Drilldown** column. It's not necessary to link methods that are on the same thread, but doing so will have no negative effect. It's often the case that a single token can be shared, like in the `parallelStream()` example.
+
   </Collapser>
 </CollapserGroup>
 
 <Callout variant="tip">
-  By default, a transaction can create a maximum of 3000 tokens and each token has a default timeout of 180s. You can change the former limit with the `token_limit` config option and the latter with the [`token_timeout`](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#cfg-token_timeout) config option. Traces for transactions that exceed the `token_limit` will contain a `token_clamp` attribute. Increasing either config option may increase agent memory usage.
+  By default, a transaction can create a maximum of 3000 tokens and each token
+  has a default timeout of 180s. You can change the former limit with the
+  `token_limit` config option and the latter with the
+  [`token_timeout`](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#cfg-token_timeout)
+  config option. Traces for transactions that exceed the `token_limit` will
+  contain a `token_clamp` attribute. Increasing either config option may
+  increase agent memory usage.
 </Callout>
 
 ## Segments: Time arbitrary async activity [#segments]
 
 Segments are used to measure an arbitrary piece of asynchronous application code, not necessarily associated with a method or thread. This is most commonly used to time connections to external services. Use segments if you want to:
 
-* Time code that completes via a callback
-* Time an asynchronous call that spans many methods
-* Measure the time between when work is created and when it executed (for example, in a thread pool)
+- Time code that completes via a callback
+- Time an asynchronous call that spans many methods
+- Measure the time between when work is created and when it executed (for example, in a thread pool)
 
 <CollapserGroup>
   <Collapser
@@ -141,6 +150,7 @@ Segments are used to measure an arbitrary piece of asynchronous application code
     The agent API call in this sample is:
 
     * `@Trace(dispatcher = true)`: Starts a transaction. For more on this method, see the [Javadoc](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/Trace.html).
+
   </Collapser>
 
   <Collapser
@@ -174,6 +184,7 @@ Segments are used to measure an arbitrary piece of asynchronous application code
     * `startSegment(...)`: Begins the segment that will time the code. For more on this method, see the [Javadoc](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/Segment.html).
     * `reportAsExternal(DatastoreParameters())`: Associates the time with a datastore external call This will show up in APM with [datastore data](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues). For more information, see [reportAsExternal API](http://newrelic.github.io/java-agent-api/javadoc/index.html?com/newrelic/api/agent/TracedMethod.html).
     * `segment.end()`: Stops timing this segment. For more on this method, see the [Javadoc](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/Segment.html#end()).
+
   </Collapser>
 
   <Collapser
@@ -187,9 +198,15 @@ Segments are used to measure an arbitrary piece of asynchronous application code
     <figcaption>
       **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Transactions > Transaction trace > Trace details:** A single asynchronous segment is called out in the **Drilldown** column.
     </figcaption>
+
   </Collapser>
 </CollapserGroup>
 
 <Callout variant="tip">
-  By default, the agent can track a maximum of 1000 segments during a given transaction. You can change this limit with the [`segment_timeout`](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#cfg-segment_timeout) config option. Traces of transactions that exceed this limit will contain a `segment_clamp` attribute. Increasing this limit may increase agent memory usage.
+  By default, the agent can track a maximum of 1000 segments during a given
+  transaction. You can change this limit with the
+  [`segment_timeout`](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#cfg-segment_timeout)
+  config option. Traces of transactions that exceed this limit will contain a
+  `segment_clamp` attribute. Increasing this limit may increase agent memory
+  usage.
 </Callout>


### PR DESCRIPTION
This PR tests using `mark` tags in content sections outside of code blocks. It also has markdown linter corrections. 😉 