### PR TITLE
Switch query to prevent sharp warnings on build

### DIFF
--- a/plugins/gatsby-plugin-generate-doc-json/gatsby-node.js
+++ b/plugins/gatsby-plugin-generate-doc-json/gatsby-node.js
@@ -59,8 +59,8 @@ exports.onPostBuild = async ({ graphql, store }) => {
     const { allMdx, allImageSharp } = data;
 
     const imageHashMap = allImageSharp.nodes.reduce(
-      (memo, { fluid, parent }) => ({
-        ...memo,
+      (acc, { fluid, parent }) => ({
+        ...acc,
         [parent.relativePath]: fluid.src,
       }),
       {}


### PR DESCRIPTION
# Description

Currently PR builds emit a bunch of warnings related to querying `childImageSharp` on files that will return null. This PR attempts to silence those warnings by querying for image through allImageSharp.
