### PR TITLE
Update sign up tile style

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -103,6 +103,7 @@ const HomePage = ({ data }) => {
               to="https://newrelic.com/signup"
               title={t('home.welcome.t1.title')}
               description={t('home.welcome.t1.description')}
+              variant="cta"
             />
             <WelcomeTile
               to="https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJ0dWNzb24ucGxnLWluc3RydW1lbnQtZXZlcnl0aGluZyJ9"
@@ -319,7 +320,7 @@ const pulse = keyframes`
 }
 `;
 
-const WelcomeTile = ({ description, title, to }) => (
+const WelcomeTile = ({ description, title, to, variant = 'normal' }) => (
   <SurfaceLink
     base={Surface.BASE.PRIMARY}
     to={to}
@@ -329,6 +330,7 @@ const WelcomeTile = ({ description, title, to }) => (
       color: currentColor;
       position: relative;
       min-height: 200px;
+      border-color: var(--tile-border-color, var(--border-color));
 
       @media screen and (max-width: 1050px) {
         min-height: 175px;
@@ -350,10 +352,6 @@ const WelcomeTile = ({ description, title, to }) => (
         }
       }
 
-      .light-mode & {
-        border: 1px solid var(--border-color);
-      }
-
       &::before {
         content: counter(welcome-tile);
         counter-increment: welcome-tile;
@@ -367,8 +365,9 @@ const WelcomeTile = ({ description, title, to }) => (
         border-radius: 50%;
         height: 2rem;
         width: 2rem;
-        border: 1px solid var(--color-teal-500);
-        background: var(--primary-background-color);
+        color: var(--number-color, currentColor);
+        border: 1px solid var(--number-border-color);
+        background: var(--number-background-color);
         z-index: 1;
       }
 
@@ -381,13 +380,10 @@ const WelcomeTile = ({ description, title, to }) => (
         border-radius: 50%;
         height: 2.75rem;
         width: 2.75rem;
-        border: 1px solid var(--color-dark-100);
+        border: 1px solid
+          var(--outer-ring-border-color, var(--tile-border-color));
         background: var(--primary-background-color);
         transition: border-color 0.15s ease-out;
-
-        .light-mode & {
-          border: 1px solid ${rgba('#008c99', 0.3)};
-        }
       }
 
       &:hover {
@@ -397,6 +393,8 @@ const WelcomeTile = ({ description, title, to }) => (
           animation: ${pulse} 1.5s infinite;
         }
       }
+
+      ${welcomeTileStyles[variant]};
     `}
   >
     <h3>{title}</h3>
@@ -408,6 +406,34 @@ WelcomeTile.propTypes = {
   description: PropTypes.node,
   title: PropTypes.string,
   to: PropTypes.string,
+  variant: PropTypes.oneOf(['normal', 'cta']),
+};
+
+const welcomeTileStyles = {
+  normal: css`
+    --number-background-color: var(--primary-background-color);
+    --number-border-color: var(--color-teal-500);
+    --outer-ring-border-color: var(--border-color);
+  `,
+  cta: css`
+    --tile-border-color: var(--color-teal-400);
+    --number-background-color: var(--color-teal-400);
+    --number-color: white;
+    --outer-ring-border-color: var(--border-color);
+
+    &:hover {
+      border-color: var(--color-teal-300);
+
+      .dark-mode & {
+        border-color: var(--color-teal-500);
+      }
+    }
+
+    .dark-mode & {
+      --tile-border-color: var(--color-teal-600);
+      --number-background-color: var(--color-teal-600);
+    }
+  `,
 };
 
 const DocTileGrid = ({ children }) => {


### PR DESCRIPTION
Closes #846

# Description

Updates the sign up tile style on the home page to make it pop a bit more.

## Screenshots

<img width="1648" alt="Screen Shot 2021-02-16 at 12 15 08 PM" src="https://user-images.githubusercontent.com/565661/108116588-a7cf3000-7050-11eb-93fb-75df09440af6.png">
<img width="1623" alt="Screen Shot 2021-02-16 at 12 15 14 PM" src="https://user-images.githubusercontent.com/565661/108116595-aa318a00-7050-11eb-8683-8d500229d7cc.png">

