### PR TITLE
Add cookie consent dialog to new docs site

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -48,6 +48,7 @@ module.exports = {
           maxWidth: '1600px',
           component: require.resolve('./src/layouts'),
         },
+        gaTrackingId: 'UA-3047412-33',
         i18n: {
           translationsPath: `${__dirname}/src/i18n/translations`,
           additionalLocales: [{ name: '日本語', locale: 'jp' }],

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
+  CookieConsentDialog,
   GlobalHeader,
   Layout,
   Link,
@@ -105,6 +106,7 @@ const MainLayout = ({ data = {}, children, pageContext }) => {
         </Layout.Main>
         <Layout.Footer fileRelativePath={pageContext.fileRelativePath} />
       </Layout>
+      <CookieConsentDialog />
     </>
   );
 };


### PR DESCRIPTION
closes #870 

The cookie consent dialog is now on the docs site! Uses the GA tracking code we decided on. Also adds GA to our site by gatsby-theme-newrelic.