### PR TITLE
Add Google Search Console verification

### DIFF
--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { SEO } from '@newrelic/gatsby-theme-newrelic';
+
+const metadata = [{ name: 'google-site-verification', content: '' }];
+
+const DocsSiteSeo = ({ location }) => (
+  <SEO location={location}>
+    {metadata.map((data) => (
+      <meta key={data.name} {...data} />
+    ))}
+  </SEO>
+);
+
+DocsSiteSeo.propTypes = {
+  location: PropTypes.string.isRequired,
+  title: PropTypes.string,
+};
+
+export default DocsSiteSeo;

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -3,7 +3,12 @@ import PropTypes from 'prop-types';
 
 import { SEO } from '@newrelic/gatsby-theme-newrelic';
 
-const METADATA = [{ name: 'google-site-verification', content: '' }];
+const METADATA = [
+  {
+    name: 'google-site-verification',
+    content: 'eT8TSNhvMuDmAtqbtq5jygZKVkhDmz565fYQ3DVop4g',
+  },
+];
 
 const DocsSiteSeo = ({ location, title }) => (
   <SEO location={location} title={title}>

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 
 import { SEO } from '@newrelic/gatsby-theme-newrelic';
 
-const metadata = [{ name: 'google-site-verification', content: '' }];
+const METADATA = [{ name: 'google-site-verification', content: '' }];
 
 const DocsSiteSeo = ({ location }) => (
   <SEO location={location}>
-    {metadata.map((data) => (
+    {METADATA.map((data) => (
       <meta key={data.name} {...data} />
     ))}
   </SEO>

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -5,8 +5,8 @@ import { SEO } from '@newrelic/gatsby-theme-newrelic';
 
 const METADATA = [{ name: 'google-site-verification', content: '' }];
 
-const DocsSiteSeo = ({ location }) => (
-  <SEO location={location}>
+const DocsSiteSeo = ({ location, title }) => (
+  <SEO location={location} title={title}>
     {METADATA.map((data) => (
       <meta key={data.name} {...data} />
     ))}

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -47,9 +47,7 @@ const MainLayout = ({ data = {}, children, pageContext }) => {
 
   return (
     <>
-      <SEO location={location}>
-        <meta name="google-site-verification" content="foobar" />
-      </SEO>
+      <SEO location={location} />
       <GlobalHeader />
       {isSmallScreen && (
         <MobileHeader

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -5,12 +5,12 @@ import {
   Layout,
   Link,
   Logo,
-  SEO,
   useLayout,
 } from '@newrelic/gatsby-theme-newrelic';
 import { graphql } from 'gatsby';
 import { css } from '@emotion/core';
 import MobileHeader from '../components/MobileHeader';
+import SEO from '../components/SEO';
 import { useMedia } from 'react-use';
 import RootNavigation from '../components/RootNavigation';
 import SubNavigation from '../components/SubNavigation';
@@ -47,7 +47,9 @@ const MainLayout = ({ data = {}, children, pageContext }) => {
 
   return (
     <>
-      <SEO location={location} />
+      <SEO location={location}>
+        <meta name="google-site-verification" content="foobar" />
+      </SEO>
       <GlobalHeader />
       {isSmallScreen && (
         <MobileHeader

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -10,7 +10,6 @@ import {
   Link,
   Tag,
   TagList,
-  SEO,
   useQueryParams,
   Icon,
   useTranslation,
@@ -19,6 +18,7 @@ import {
 } from '@newrelic/gatsby-theme-newrelic';
 
 import DataDictionaryFilter from '../components/DataDictionaryFilter';
+import SEO from '../components/SEO';
 import PageTitle from '../components/PageTitle';
 
 import { useMedia } from 'react-use';

--- a/src/pages/whats-new.js
+++ b/src/pages/whats-new.js
@@ -3,13 +3,9 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import PageTitle from '../components/PageTitle';
 import { graphql } from 'gatsby';
-import {
-  Layout,
-  Link,
-  SEO,
-  useTranslation,
-} from '@newrelic/gatsby-theme-newrelic';
+import { Layout, Link, useTranslation } from '@newrelic/gatsby-theme-newrelic';
 import Timeline from '../components/Timeline';
+import SEO from '../components/SEO';
 
 const WhatsNew = ({ data, location }) => {
   const now = useMemo(() => new Date(), []);

--- a/src/templates/apiLandingPage.js
+++ b/src/templates/apiLandingPage.js
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
 import PageTitle from '../components/PageTitle';
-import { Layout, Link, SEO } from '@newrelic/gatsby-theme-newrelic';
+import { Layout, Link } from '@newrelic/gatsby-theme-newrelic';
 import MDXContainer from '../components/MDXContainer';
+import SEO from '../components/SEO';
 
 const ApiIndexPage = ({ data, location }) => {
   const {

--- a/src/templates/docPage.js
+++ b/src/templates/docPage.js
@@ -10,12 +10,12 @@ import {
   Layout,
   RelatedResources,
   SimpleFeedback,
-  SEO,
   TableOfContents,
   useTranslation,
 } from '@newrelic/gatsby-theme-newrelic';
 import DefaultRelatedContent from '../components/DefaultRelatedContent';
 import Watermark from '../components/Watermark';
+import SEO from '../components/SEO';
 import GithubSlugger from 'github-slugger';
 import { parseHeading } from '../../plugins/gatsby-remark-custom-heading-ids/utils/heading';
 

--- a/src/templates/indexPage.js
+++ b/src/templates/indexPage.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Layout, SEO } from '@newrelic/gatsby-theme-newrelic';
+import { Layout } from '@newrelic/gatsby-theme-newrelic';
 import { graphql } from 'gatsby';
 import PageTitle from '../components/PageTitle';
 import IndexContents from '../components/IndexContents';
 import TableOfContentsContainer from '../components/TableOfContentsContainer';
+import SEO from '../components/SEO';
 
 const IndexPage = ({ data, pageContext, location }) => {
   const { nav } = data;

--- a/src/templates/landingPage.js
+++ b/src/templates/landingPage.js
@@ -2,9 +2,10 @@ import React, { Children } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { graphql } from 'gatsby';
-import { Layout, SEO } from '@newrelic/gatsby-theme-newrelic';
+import { Layout } from '@newrelic/gatsby-theme-newrelic';
 import PageTitle from '../components/PageTitle';
 import MDXContainer from '../components/MDXContainer';
+import SEO from '../components/SEO';
 
 const isMdxType = (element, mdxType) => element.props?.mdxType === mdxType;
 

--- a/src/templates/releaseNote.js
+++ b/src/templates/releaseNote.js
@@ -2,10 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { graphql } from 'gatsby';
-import { Icon, Layout, Link, SEO } from '@newrelic/gatsby-theme-newrelic';
+import { Icon, Layout, Link } from '@newrelic/gatsby-theme-newrelic';
 import PageTitle from '../components/PageTitle';
 import MDXContainer from '../components/MDXContainer';
 import Watermark from '../components/Watermark';
+import SEO from '../components/SEO';
 
 const ReleaseNoteTemplate = ({ data, location }) => {
   const {

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -4,7 +4,8 @@ import { css } from '@emotion/core';
 import { graphql } from 'gatsby';
 import PageTitle from '../components/PageTitle';
 import Timeline from '../components/Timeline';
-import { Icon, Layout, Link, SEO } from '@newrelic/gatsby-theme-newrelic';
+import SEO from '../components/SEO';
+import { Icon, Layout, Link } from '@newrelic/gatsby-theme-newrelic';
 import filter from 'unist-util-filter';
 import toString from 'mdast-util-to-string';
 

--- a/src/templates/tableOfContents.js
+++ b/src/templates/tableOfContents.js
@@ -2,15 +2,10 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { graphql } from 'gatsby';
-import {
-  Icon,
-  Layout,
-  Link,
-  SEO,
-  useLocale,
-} from '@newrelic/gatsby-theme-newrelic';
+import { Icon, Layout, Link, useLocale } from '@newrelic/gatsby-theme-newrelic';
 import PageTitle from '../components/PageTitle';
 import IndexContents from '../components/IndexContents';
+import SEO from '../components/SEO';
 
 const TableOfContentsPage = ({ data, pageContext, location }) => {
   const { title } = pageContext;

--- a/src/templates/whatsNew.js
+++ b/src/templates/whatsNew.js
@@ -7,8 +7,8 @@ import {
   Layout,
   Link,
   MarkdownContainer,
-  SEO,
 } from '@newrelic/gatsby-theme-newrelic';
+import SEO from '../components/SEO';
 import PageTitle from '../components/PageTitle';
 
 const WhatsNewTemplate = ({ data, location }) => {


### PR DESCRIPTION
## Description
Creates a `SEO` component that extends the theme with docs-site-specific meta content (so that we don't need to constantly update a ton of files).

Also adds the site verification code for docs.newrelic.com.

## Related Issue(s)
* Closes #791
