### PR TITLE
Fix taxonomy redirects to existing index files

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -165,6 +165,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
           }
           frontmatter {
             subject
+            redirects
           }
         }
       }
@@ -211,13 +212,25 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       (node) => node.frontmatter.subject === fieldValue
     );
 
-    landingPage &&
+    if (landingPage) {
+      const { redirects } = landingPage.frontmatter;
       createRedirect({
         fromPath: path.join(landingPage.fields.slug, 'current'),
         toPath: nodes[0].fields.slug,
         isPermanent: false,
         redirectInBrowser: true,
       });
+      if (redirects) {
+        redirects.forEach((fromPath) => {
+          createRedirect({
+            fromPath,
+            toPath: landingPage.fields.slug,
+            isPermanent: false,
+            redirectInBrowser: true,
+          });
+        });
+      }
+    }
   });
 
   const translatedContentNodes = allI18nMdx.edges.map(({ node }) => node);

--- a/src/content/docs/agents/net-agent/net-agent-api/index.mdx
+++ b/src/content/docs/agents/net-agent/net-agent-api/index.mdx
@@ -1,6 +1,12 @@
 ---
 title: .NET agent API
 type: apiLandingPage
+redirects:
+  - /docs/dotnet/AgentApi
+  - /docs/dotnet/the-net-agent-api
+  - /docs/dotnet/net-agent-api
+  - /docs/agents/net-agent/net-agent-api/view-all-methods
+  - /docs/agents/net-agent/features/net-agent-api
 ---
 
 The .NET agent API allows you to extend the functionality of the .NET agent. To use the library, add a reference to `NewRelic.Api.Agent.dll` to your project. You can also view the package in the [NuGet Gallery](https://www.nuget.org/packages/NewRelic.Agent.Api/ 'Link opens in a new window.') . If you've disabled or uninstalled the agent, invoking these API calls has no effect.

--- a/src/content/docs/agents/php-agent/php-agent-api/index.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/index.mdx
@@ -1,6 +1,11 @@
 ---
 title: PHP agent API
 type: apiLandingPage
+redirects:
+  - '/docs/php/the-php-api'
+  - '/docs/php/php-agent-api'
+  - '/docs/agents/php-agent/php-agent-api/view-all-methods'
+  - '/docs/agents/php-agent/configuration/php-agent-api'
 ---
 
 The PHP agent API allows you to extend the functionality of the PHP agent. The agent API is included by default with your installation, so no additional configuration is required to use the agent.

--- a/src/content/docs/agents/python-agent/python-agent-api/index.mdx
+++ b/src/content/docs/agents/python-agent/python-agent-api/index.mdx
@@ -1,6 +1,9 @@
 ---
 title: Python agent API
 type: apiLandingPage
+redirects:
+  - /docs/agents/python-agent/python-agent-api/view-all-python-agent-api-calls
+  - /docs/adduserattribute-python-agent-api
 ---
 
 The Python agent API allows you to set up custom instrumentation and performance monitoring of your Python application. For an introduction to the API and tips for accomplishing specific tasks, see the [Python agent API overview](/docs/agents/python-agent/customization-extension/python-agent-api-overview).

--- a/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/index.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/index.mdx
@@ -1,4 +1,20 @@
 ---
 title: Browser agent and SPA API
 type: apiLandingPage
+redirects:
+  - /docs/browser/new-relic-browser/browser-agent-apis/browser-agent-api
+  - /docs/browser/new-relic-browser/browser-agent-apis/reporting-data-events-browser-agent-api
+  - /docs/browser/new-relic-browser/browser-agent-apis/new-relic-single-page-app-monitoring-api
+  - /docs/browser/new-relic-browser/browser-agent-apis/new-relic-spa-api
+  - /docs/browser/new-relic-browser/browser-agent-apis/javascript-api-deprecated
+  - /docs/features/manually-reporting-page-load-timing-data
+  - /docs/features/monitoring-flash-apps-with-rum
+  - /docs/new-relic-browser/manually-reporting-page-load-timing-data
+  - /docs/browser/new-relic-browser/browser-agent-apis/manually-reporting-page-load-timing-data
+  - /docs/browser/new-relic-browser/browser-agent-api
+  - /docs/browser/new-relic-browser/browser-agent-apis/report-data-events-browser-agent-api
+  - /docs/browser/single-page-app-monitoring/spa-api/spa-api
+  - /docs/browser/new-relic-browser/browser-agent-apis
+  - /docs/browser/new-relic-browser/browser-agent-spa-api/view-all-methods
+  - /docs/browser/new-relic-browser/browser-agent-spa-ap
 ---

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/index.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: Android SDK API
 type: apiLandingPage
+redirects:
+  - /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/view-all-methods
 ---
 
 New Relic Mobile for Android has an SDK API for customizing how New Relic monitors your app. Below are all the methods in this API. For an overview on how to use the API, see [the Android SDK API guide](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api).

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/index.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: iOS SDK API
 type: apiLandingPage
+redirects:
+  - /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/view-all-methods
 ---
 
 New Relic Mobile has an SDK API to customize how New Relic monitors your app. For example, use methods in the **NewRelic** object to [send custom attributes and events](/docs/insights/new-relic-insights/adding-querying-data/custom-attributes-events-new-relic-mobile) for your iOS app to New Relic Insights.

--- a/src/content/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: C SDK
+redirects:
+  - /docs/release-notes/agent-release-notes/c-release-notes
+  - /docs/agents/c-sdk/get-started/c-sdk-release-notes
 ---
-

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/index.mdx
@@ -1,4 +1,5 @@
 ---
 subject: Go agent
+redirects:
+  - /docs/agents/go-agent/get-started/go-agent-release-notes
 ---
-

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: Java agent
+redirects:
+  - /docs/releases/java
+  - /docs/agents/java-agent/getting-started/java-release-notes
 ---
-

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: .NET agent
+redirects:
+  - /docs/releases/dotnet
+  - /docs/agents/net-agent/getting-started/net-release-notes
 ---
-

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: Node.js agent
+redirects:
+  - /docs/releases/node
+  - /docs/agents/nodejs-agent/getting-started/nodejs-release-notes
 ---
-

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: PHP agent
+redirects:
+  - /docs/releases/php
+  - /docs/agents/php-agent/getting-started/php-agent-release-notes
 ---
-

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/index.mdx
@@ -1,4 +1,7 @@
 ---
 subject: Python agent
+redirects:
+  - /docs/releases/python
+  - /docs/agents/python-agent/getting-started/python-release-notes
+  - /docs/python/python-agent-release-notes
 ---
-

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: Ruby agent
+redirects:
+  - /docs/releases/ruby
+  - /docs/agents/ruby-agent/getting-started/ruby-release-notes
 ---
-

--- a/src/content/docs/release-notes/index.mdx
+++ b/src/content/docs/release-notes/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: Release notes
 type: landingPage
+redirects:
+  - /docs/releases
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc in commodo ante.

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/index.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/index.mdx
@@ -1,4 +1,5 @@
 ---
 subject: New Relic infrastructure agent
+redirects:
+  - /docs/infrastructure/new-relic-infrastructure/getting-started/infrastructure-agent-release-notes
 ---
-

--- a/src/content/docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: Insights for Android
+redirects:
+  - /docs/mobile-monitoring/new-relic-mobile-apps/insights-app/insights-android-release-notes
+  - /docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-android-release-notes
 ---
-

--- a/src/content/docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: Insights for iOS
+redirects:
+  - /docs/mobile-monitoring/new-relic-mobile-apps/insights-app/insights-ios-release-notes
+  - /docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-ios-release-notes
 ---
-

--- a/src/content/docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: Insights for tvOS
+redirects:
+  - /docs/mobile-monitoring/new-relic-mobile-apps/insights-app/insights-tvos-release-notes
+  - /docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-tvos-release-notes
 ---
-

--- a/src/content/docs/release-notes/mobile-release-notes/android-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/android-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: Android
+redirects:
+  - /docs/releases/android
+  - /docs/mobile-monitoring/new-relic-mobile-android/get-started/android-release-notes
 ---
-

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: iOS agent
+redirects:
+  - /docs/releases/ios
+  - /docs/mobile-monitoring/new-relic-mobile-ios/get-started/ios-release-notes
 ---
-

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/index.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: Browser agent
+redirects:
+  - /docs/release-notes/browser-agent-release-notes
+  - /docs/browser/new-relic-browser/getting-started/browser-agent-release-notes
 ---
-

--- a/src/content/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/index.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/index.mdx
@@ -1,4 +1,26 @@
 ---
 subject: Containerized private minion (CPM)
+redirects:
+  - /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/feed
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-151
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-152
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-153
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-160
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-161
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-163
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-164
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-165
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-166
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-167
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-168
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-169
+  - /docs/release-notes/synthetics-release-notes/vm-private-minions-release-notes-legacy/private-minion-170
+  - /docs/release-notes/synthetics-release-notes/vm-private-minions-release-notes-legacy/private-minion-171
+  - /docs/release-notes/synthetics-release-notes/private-minion-151
+  - /docs/release-notes/synthetics-release-notes/private-minion-300
+  - /docs/release-notes/private-minion
+  - /docs/release-notes/synthetics-release-notes/private-minion-153-0
+  - /docs/release-notes/synthetics-release-notes/vm-private-minions-release-notes-legacy/private-minion-213
+  - /docs/release-notes/synthetics-release-notes/vm-private-minions-release-notes-legacy
+  - /docs/synthetics/synthetic-monitoring/getting-started/containerized-private-minions-cpm-release-note
 ---
-

--- a/src/manual-edits/content/docs/agents/net-agent/net-agent-api/index.mdx
+++ b/src/manual-edits/content/docs/agents/net-agent/net-agent-api/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: .NET agent API
 type: apiLandingPage
+redirects:
+  - /docs/agents/net-agent/net-agent-api/view-all-methods
 ---
 
 The .NET agent API allows you to extend the functionality of the .NET agent. To use the library, add a reference to `NewRelic.Api.Agent.dll` to your project. You can also view the package in the [NuGet Gallery](https://www.nuget.org/packages/NewRelic.Agent.Api/ 'Link opens in a new window.') . If you've disabled or uninstalled the agent, invoking these API calls has no effect.

--- a/src/manual-edits/content/docs/agents/php-agent/php-agent-api/index.mdx
+++ b/src/manual-edits/content/docs/agents/php-agent/php-agent-api/index.mdx
@@ -1,6 +1,11 @@
 ---
 title: PHP agent API
 type: apiLandingPage
+redirects:
+  - '/docs/php/the-php-api'
+  - '/docs/php/php-agent-api'
+  - '/docs/agents/php-agent/php-agent-api/view-all-methods'
+  - '/docs/agents/php-agent/configuration/php-agent-api'
 ---
 
 The PHP agent API allows you to extend the functionality of the PHP agent. The agent API is included by default with your installation, so no additional configuration is required to use the agent.

--- a/src/manual-edits/content/docs/agents/python-agent/python-agent-api/index.mdx
+++ b/src/manual-edits/content/docs/agents/python-agent/python-agent-api/index.mdx
@@ -1,6 +1,9 @@
 ---
 title: Python agent API
 type: apiLandingPage
+redirects:
+  - /docs/agents/python-agent/python-agent-api/view-all-python-agent-api-calls
+  - /docs/adduserattribute-python-agent-api
 ---
 
 The Python agent API allows you to set up custom instrumentation and performance monitoring of your Python application. For an introduction to the API and tips for accomplishing specific tasks, see the [Python agent API overview](/docs/agents/python-agent/customization-extension/python-agent-api-overview).

--- a/src/manual-edits/content/docs/browser/new-relic-browser/browser-agent-spa-api/index.mdx
+++ b/src/manual-edits/content/docs/browser/new-relic-browser/browser-agent-spa-api/index.mdx
@@ -1,4 +1,20 @@
 ---
 title: Browser agent and SPA API
 type: apiLandingPage
+redirects:
+  - /docs/browser/new-relic-browser/browser-agent-apis/browser-agent-api
+  - /docs/browser/new-relic-browser/browser-agent-apis/reporting-data-events-browser-agent-api
+  - /docs/browser/new-relic-browser/browser-agent-apis/new-relic-single-page-app-monitoring-api
+  - /docs/browser/new-relic-browser/browser-agent-apis/new-relic-spa-api
+  - /docs/browser/new-relic-browser/browser-agent-apis/javascript-api-deprecated
+  - /docs/features/manually-reporting-page-load-timing-data
+  - /docs/features/monitoring-flash-apps-with-rum
+  - /docs/new-relic-browser/manually-reporting-page-load-timing-data
+  - /docs/browser/new-relic-browser/browser-agent-apis/manually-reporting-page-load-timing-data
+  - /docs/browser/new-relic-browser/browser-agent-api
+  - /docs/browser/new-relic-browser/browser-agent-apis/report-data-events-browser-agent-api
+  - /docs/browser/single-page-app-monitoring/spa-api/spa-api
+  - /docs/browser/new-relic-browser/browser-agent-apis
+  - /docs/browser/new-relic-browser/browser-agent-spa-api/view-all-methods
+  - /docs/browser/new-relic-browser/browser-agent-spa-ap
 ---

--- a/src/manual-edits/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/index.mdx
+++ b/src/manual-edits/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: Android SDK API
 type: apiLandingPage
+redirects:
+  - /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/view-all-methods
 ---
 
 New Relic Mobile for Android has an SDK API for customizing how New Relic monitors your app. Below are all the methods in this API. For an overview on how to use the API, see [the Android SDK API guide](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api).

--- a/src/manual-edits/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/index.mdx
+++ b/src/manual-edits/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: iOS SDK API
 type: apiLandingPage
+redirects:
+  - /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/view-all-methods
 ---
 
 New Relic Mobile has an SDK API to customize how New Relic monitors your app. For example, use methods in the **NewRelic** object to [send custom attributes and events](/docs/insights/new-relic-insights/adding-querying-data/custom-attributes-events-new-relic-mobile) for your iOS app to New Relic Insights.

--- a/src/manual-edits/content/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: C SDK
+redirects:
+  - /docs/release-notes/agent-release-notes/c-release-notes
+  - /docs/agents/c-sdk/get-started/c-sdk-release-notes
 ---
-

--- a/src/manual-edits/content/docs/release-notes/agent-release-notes/go-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/agent-release-notes/go-release-notes/index.mdx
@@ -1,4 +1,5 @@
 ---
 subject: Go agent
+redirects:
+  - /docs/agents/go-agent/get-started/go-agent-release-notes
 ---
-

--- a/src/manual-edits/content/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: Java agent
+redirects:
+  - /docs/releases/java
+  - /docs/agents/java-agent/getting-started/java-release-notes
 ---
-

--- a/src/manual-edits/content/docs/release-notes/agent-release-notes/net-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/agent-release-notes/net-release-notes/index.mdx
@@ -1,4 +1,5 @@
 ---
 subject: .NET agent
+redirects:
+  - /docs/releases/dotnet
 ---
-

--- a/src/manual-edits/content/docs/release-notes/agent-release-notes/nodejs-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/agent-release-notes/nodejs-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: Node.js agent
+redirects:
+  - /docs/releases/node
+  - /docs/agents/nodejs-agent/getting-started/nodejs-release-notes
 ---
-

--- a/src/manual-edits/content/docs/release-notes/agent-release-notes/php-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/agent-release-notes/php-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: PHP agent
+redirects:
+  - /docs/releases/php
+  - /docs/agents/php-agent/getting-started/php-agent-release-notes
 ---
-

--- a/src/manual-edits/content/docs/release-notes/agent-release-notes/python-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/agent-release-notes/python-release-notes/index.mdx
@@ -1,4 +1,7 @@
 ---
 subject: Python agent
+redirects:
+  - /docs/releases/python
+  - /docs/agents/python-agent/getting-started/python-release-notes
+  - /docs/python/python-agent-release-notes
 ---
-

--- a/src/manual-edits/content/docs/release-notes/agent-release-notes/ruby-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/agent-release-notes/ruby-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: Ruby agent
+redirects:
+  - /docs/releases/ruby
+  - /docs/agents/ruby-agent/getting-started/ruby-release-notes
 ---
-

--- a/src/manual-edits/content/docs/release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: Release notes
 type: landingPage
+redirects:
+  - /docs/releases
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc in commodo ante.

--- a/src/manual-edits/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/index.mdx
@@ -1,4 +1,5 @@
 ---
 subject: New Relic infrastructure agent
+redirects:
+  - /docs/infrastructure/new-relic-infrastructure/getting-started/infrastructure-agent-release-notes
 ---
-

--- a/src/manual-edits/content/docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/mobile-apps-release-notes/insights-android-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: Insights for Android
+redirects:
+  - /docs/mobile-monitoring/new-relic-mobile-apps/insights-app/insights-android-release-notes
+  - /docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-android-release-notes
 ---
-

--- a/src/manual-edits/content/docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/mobile-apps-release-notes/insights-ios-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: Insights for iOS
+redirects:
+  - /docs/mobile-monitoring/new-relic-mobile-apps/insights-app/insights-ios-release-notes
+  - /docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-ios-release-notes
 ---
-

--- a/src/manual-edits/content/docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/mobile-apps-release-notes/insights-tvos-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: Insights for tvOS
+redirects:
+  - /docs/mobile-monitoring/new-relic-mobile-apps/insights-app/insights-tvos-release-notes
+  - /docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-tvos-release-notes
 ---
-

--- a/src/manual-edits/content/docs/release-notes/mobile-release-notes/android-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/mobile-release-notes/android-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: Android
+redirects:
+  - /docs/releases/android
+  - /docs/mobile-monitoring/new-relic-mobile-android/get-started/android-release-notes
 ---
-

--- a/src/manual-edits/content/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: iOS agent
+redirects:
+  - /docs/releases/ios
+  - /docs/mobile-monitoring/new-relic-mobile-ios/get-started/ios-release-notes
 ---
-

--- a/src/manual-edits/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/index.mdx
@@ -1,4 +1,6 @@
 ---
 subject: Browser agent
+redirects:
+  - /docs/release-notes/browser-agent-release-notes
+  - /docs/browser/new-relic-browser/getting-started/browser-agent-release-notes
 ---
-

--- a/src/manual-edits/content/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/index.mdx
@@ -1,4 +1,26 @@
 ---
 subject: Containerized private minion (CPM)
+redirects:
+  - /docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/feed
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-151
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-152
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-153
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-160
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-161
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-163
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-164
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-165
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-166
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-167
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-168
+  - /docs/release-notes/synthetics-release-notes/private-minions-release-notes/private-minion-169
+  - /docs/release-notes/synthetics-release-notes/vm-private-minions-release-notes-legacy/private-minion-170
+  - /docs/release-notes/synthetics-release-notes/vm-private-minions-release-notes-legacy/private-minion-171
+  - /docs/release-notes/synthetics-release-notes/private-minion-151
+  - /docs/release-notes/synthetics-release-notes/private-minion-300
+  - /docs/release-notes/private-minion
+  - /docs/release-notes/synthetics-release-notes/private-minion-153-0
+  - /docs/release-notes/synthetics-release-notes/vm-private-minions-release-notes-legacy/private-minion-213
+  - /docs/release-notes/synthetics-release-notes/vm-private-minions-release-notes-legacy
+  - /docs/synthetics/synthetic-monitoring/getting-started/containerized-private-minions-cpm-release-note
 ---
-


### PR DESCRIPTION
## Description
Fixes taxonomy redirects to index pages in `docs/release-notes` and agent API index pages. Those index.mdx files are added via `manual-edits` folder. The `gatsby-plugin-auto-index-pages` plugin reads the `taxonomy-redirects.json` and if a directory is set to skip via config (release notes is because we handle those differently) OR if there's already an index.mdx for a given `url` it doesn't do its thing.

This adds the relevant redirects to agent release note index pages AND agent API index pages (view all methods links) to index.mdx frontmatter and updates `gatsby-node.js` to look for and create them for release notes.

## Related issues/PRs
- #851
- #758  