### PR TITLE
Removed the docs@newrelic.com email address

### DIFF
--- a/src/content/docs/new-relic-only/drupal-configuration/page-components/manage-content-footers.mdx
+++ b/src/content/docs/new-relic-only/drupal-configuration/page-components/manage-content-footers.mdx
@@ -9,7 +9,7 @@ redirects:
 ---
 
 <Callout variant="important">
-  Only the Docs team can edit and create new footer blocks. If you'd like to request additions, changes, or deletions to footer content, contact `@hero` in the [#documentation](https://newrelic.slack.com/messages/documentation) Slack channel or send an email to [docs@newrelic.com](mailto:docs@newrelic.com).
+  Only the Docs team can edit and create new footer blocks. If you'd like to request additions, changes, or deletions to footer content, contact `@hero` in the [#documentation](https://newrelic.slack.com/messages/documentation) Slack channel (internal New Relic) or [create a GitHub issue](https://github.com/newrelic/docs-website/issues/new?assignees=&labels=enhancement%2C+content&template=content-enhancement.md&title=Request+some+docs+improvements%21).
 </Callout>
 
 Content footer blocks are standardized and customizable text that Drupal automatically places at the bottom of each document on the New Relic Docs site. This is the content under the **For more help** section header. Footer block content varies by document category, but often begins with:

--- a/src/content/docs/new-relic-only/drupal-configuration/page-components/manage-content-footers.mdx
+++ b/src/content/docs/new-relic-only/drupal-configuration/page-components/manage-content-footers.mdx
@@ -9,7 +9,7 @@ redirects:
 ---
 
 <Callout variant="important">
-  Only the Docs team can edit and create new footer blocks. If you'd like to request additions, changes, or deletions to footer content, contact `@hero` in the [#documentation](https://newrelic.slack.com/messages/documentation) Slack channel (internal New Relic) or [create a GitHub issue](https://github.com/newrelic/docs-website/issues/new?assignees=&labels=enhancement%2C+content&template=content-enhancement.md&title=Request+some+docs+improvements%21).
+  Only the Docs team can edit and create new footer blocks. If you'd like to request additions, changes, or deletions to footer content, contact `@hero` in the [#documentation](https://newrelic.slack.com/messages/documentation) Slack channel (internal New Relic) or [create a GitHub issue](https://github.com/newrelic/docs-website/issues/new/choose).
 </Callout>
 
 Content footer blocks are standardized and customizable text that Drupal automatically places at the bottom of each document on the New Relic Docs site. This is the content under the **For more help** section header. Footer block content varies by document category, but often begins with:

--- a/src/content/docs/new-relic-only/tech-writer-style-guide/processes-procedures/edit-images.mdx
+++ b/src/content/docs/new-relic-only/tech-writer-style-guide/processes-procedures/edit-images.mdx
@@ -17,7 +17,7 @@ A well-chosen screenshot or image can greatly improve the readability and clarit
 Read on for more information about our best practices when creating images.
 
 <Callout variant="important">
-  If you're not part of the Docs team and you want to add an image to the docs site, create a [GitHub issue](https://github.com/newrelic/docs-website/issues/new/choose) or send an email to [docs@newrelic.com](mailto:docs@newrelic.com). 
+  If you're not part of the Docs team and you want to add an image to the docs site, create a [GitHub issue](https://github.com/newrelic/docs-website/issues/new/choose). 
   
   If you're a New Relic employee, contact `@hero` in the [#documentation](https://newrelic.slack.com/messages/documentation) Slack channel.
 </Callout>

--- a/src/content/docs/new-relic-only/tech-writer-style-guide/processes-procedures/embed-images.mdx
+++ b/src/content/docs/new-relic-only/tech-writer-style-guide/processes-procedures/embed-images.mdx
@@ -18,7 +18,7 @@ A well-chosen screenshot or image can greatly improve the readability and clarit
 Read on for more information about how to get an image added to one of our docs.
 
 <Callout variant="important">
-  If you're not part of the Docs team and you want to add an image to the docs site, create a [GitHub issue](https://github.com/newrelic/docs-website/issues/new/choose) or send an email to [docs@newrelic.com](mailto:docs@newrelic.com). 
+  If you're not part of the Docs team and you want to add an image to the docs site, create a [GitHub issue](https://github.com/newrelic/docs-website/issues/new/choose). 
   
   If you're a New Relic employee, contact `@hero` in the [#documentation](https://newrelic.slack.com/messages/documentation) Slack channel.
 </Callout>

--- a/src/manual-edits/content/docs/new-relic-only/tech-writer-style-guide/processes-procedures/edit-images.mdx
+++ b/src/manual-edits/content/docs/new-relic-only/tech-writer-style-guide/processes-procedures/edit-images.mdx
@@ -17,7 +17,7 @@ A well-chosen screenshot or image can greatly improve the readability and clarit
 Read on for more information about our best practices when creating images.
 
 <Callout variant="important">
-  If you're not part of the Docs team and you want to add an image to the docs site, create a [GitHub issue](https://github.com/newrelic/docs-website/issues/new/choose) or send an email to [docs@newrelic.com](mailto:docs@newrelic.com). 
+  If you're not part of the Docs team and you want to add an image to the docs site, create a [GitHub issue](https://github.com/newrelic/docs-website/issues/new/choose). 
   
   If you're a New Relic employee, contact `@hero` in the [#documentation](https://newrelic.slack.com/messages/documentation) Slack channel.
 </Callout>

--- a/src/manual-edits/content/docs/new-relic-only/tech-writer-style-guide/processes-procedures/embed-images.mdx
+++ b/src/manual-edits/content/docs/new-relic-only/tech-writer-style-guide/processes-procedures/embed-images.mdx
@@ -18,7 +18,7 @@ A well-chosen screenshot or image can greatly improve the readability and clarit
 Read on for more information about how to get an image added to one of our docs.
 
 <Callout variant="important">
-  If you're not part of the Docs team and you want to add an image to the docs site, create a [GitHub issue](https://github.com/newrelic/docs-website/issues/new/choose) or send an email to [docs@newrelic.com](mailto:docs@newrelic.com). 
+  If you're not part of the Docs team and you want to add an image to the docs site, create a [GitHub issue](https://github.com/newrelic/docs-website/issues/new/choose). 
   
   If you're a New Relic employee, contact `@hero` in the [#documentation](https://newrelic.slack.com/messages/documentation) Slack channel.
 </Callout>


### PR DESCRIPTION
We don't want to get a ton of emails from people. We prefer people create GitHub issues.

# Description

Because the style guide docs will be public, we don't want people emailing our Docs email address. This is a minor update.

