### PR TITLE
Use translated titles on locale auto index pages

### DIFF
--- a/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
+++ b/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
@@ -182,31 +182,35 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
     locales.forEach(({ localizedPath }) => {
       const localizedSlug = path.join(`/${localizedPath}`, slug);
 
-      const localeDir = dir;
-
-      localeDir.children.forEach((child) => {
-        if (child.type === 'file') {
+      dir.children
+        .filter((child) => child.type === 'file')
+        .forEach((child) => {
+          const localizedFileSlug = path.join(
+            '/',
+            localizedPath,
+            child.data.fields.slug
+          );
           const matchedNode = translatedFileNodes.find(
             ({
               childMdx: {
                 fields: { slug },
               },
-            }) => slug === path.join('/', localizedPath, child.data.fields.slug)
+            }) => slug === localizedFileSlug
           );
           if (matchedNode) {
             child.data.frontmatter.title =
               matchedNode.childMdx.frontmatter.title;
           }
-        }
-      });
+          child.data.fields.slug = localizedFileSlug;
+        });
 
       createPage({
         path: localizedSlug,
         component: path.resolve('src/templates/indexPage.js'),
         context: {
           slug: localizedSlug,
-          html: generateHTML(localeDir),
-          title: sentenceCase(localeDir.basename),
+          html: generateHTML(dir),
+          title: sentenceCase(dir.basename),
           fileRelativePath: null,
         },
       });


### PR DESCRIPTION
Closes #565

## Description
Adds necessary graphql query and swaps out a title of a page if a translated version exists for each locale when creating auto index pages via `gatsby-plugin-auto-index-pages`. It also adds the locale slug for each link.

## Screenshot(s)

<img width="1164" alt="2021-02-22_10-01-31" src="https://user-images.githubusercontent.com/2952843/108750623-19e2c180-74f6-11eb-99fa-5299de8f31e4.png">

<img width="1015" alt="2021-02-22_16-11-13" src="https://user-images.githubusercontent.com/2952843/108786516-a0b09200-7528-11eb-9a68-c5316fe3d83f.png">
