### PR TITLE
Add New Relic deployment marker action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   pull_request:
     types:
-      - main
+      - closed
     branches:
       - main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  release:
+    types:
+      - created
+  pull_request:
+    types:
+      - main
+    branches:
+      - main
+
+jobs:
+  newrelic:
+    name: New Relic deployment marker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set release version from tag
+        run: echo "RELEASE_VERSION=${{ GITHUB_REF:10 }}" >> $GITHUB_ENV
+
+      - name: Create New Relic deployment marker
+        uses: newrelic/deployment-marker-action@v1
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+          applicationId: ${{ secrets.NEW_RELIC_APPLICATION_ID }}
+          revision: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  release:
-    types:
-      - created
   pull_request:
     types:
       - main


### PR DESCRIPTION
## Description
Adds [`newrelic/deployment-marker-action@v1`](https://github.com/newrelic/deployment-marker-action) to a new workflow that is triggered whenever a PR into main is merged (or a release is published). This relies on credentials which are already added to the repository secrets.

The `applicationId` is for our [browser application](https://staging.one.nr/0LkjnevlRo1).

We may want to consider adding a slack message that gets triggered on release as well, but it's outside the scope of this PR.

## Related Issue(s)
* Closes #644