### PR TITLE
Instrument hash requests

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,1 +1,2 @@
+export { default as onRouteUpdate } from './gatsby/on-route-update';
 export { default as wrapPageElement } from './gatsby/wrap-page-element';

--- a/gatsby/on-route-update.js
+++ b/gatsby/on-route-update.js
@@ -1,0 +1,11 @@
+const onRouteUpdate = ({ location, prevLocation }) => {
+  if (
+    window.newrelic &&
+    location.hash &&
+    location.pathname !== prevLocation?.pathname
+  ) {
+    window.newrelic.addPageAction('hash_request', { hash: location.hash });
+  }
+};
+
+export default onRouteUpdate;


### PR DESCRIPTION
Closes #788

## Description

Instrument requests that contain a hash in the URL. Will only instrument hash
requests when the page first loads, or navigating to a different page with a
hash.
