### PR TITLE
Remove nav filter from attribute dictionary page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -294,6 +294,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     title: String!
     path: String
     icon: String
+    filterable: Boolean!
     pages: [NavYaml!]!
     rootNav: Boolean!
   }
@@ -309,6 +310,10 @@ exports.createResolvers = ({ createResolvers }) => {
         resolve: (source) => {
           return source.pages || [];
         },
+      },
+      filterable: {
+        resolve: (source) =>
+          hasOwnProperty(source, 'filterable') ? source.filterable : true,
       },
       rootNav: {
         resolve: (source) =>

--- a/plugins/gatsby-source-nav/gatsby-node.js
+++ b/plugins/gatsby-source-nav/gatsby-node.js
@@ -1,5 +1,8 @@
 const parseISO = require('date-fns/parseISO');
 
+const hasOwnProperty = (obj, key) =>
+  Object.prototype.hasOwnProperty.call(obj, key);
+
 exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions;
 
@@ -7,6 +10,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     type Nav {
       id: ID!
       title(locale: String = "en"): String
+      filterable: Boolean!
       pages: [NavItem!]!
     }
 
@@ -61,6 +65,10 @@ exports.createResolvers = ({ createResolvers, createNodeId }) => {
       },
     },
     Nav: {
+      filterable: {
+        resolve: (source) =>
+          hasOwnProperty(source, 'filterable') ? source.filterable : true,
+      },
       title: {
         resolve: findTranslatedTitle,
       },

--- a/plugins/gatsby-source-nav/gatsby-node.js
+++ b/plugins/gatsby-source-nav/gatsby-node.js
@@ -7,7 +7,7 @@ exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions;
 
   createTypes(`
-    type Nav {
+    type Nav @dontInfer {
       id: ID!
       title(locale: String = "en"): String
       filterable: Boolean!
@@ -254,9 +254,8 @@ const createNav = async ({ args, createNodeId, nodeModel, locales }) => {
   }
 
   return {
+    ...nav,
     id: createNodeId(nav.title),
-    title: nav.title,
-    pages: nav.pages,
   };
 };
 

--- a/src/components/SubNavigation.js
+++ b/src/components/SubNavigation.js
@@ -44,15 +44,17 @@ const SubNavigation = ({ nav }) => {
       {nav && (
         <>
           <h2>{nav.title}</h2>
-          <SearchInput
-            placeholder="Filter navigation"
-            onClear={() => setSearchTerm('')}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            value={searchTerm}
-            css={css`
-              margin-bottom: 0.5rem;
-            `}
-          />
+          {nav.filterable && (
+            <SearchInput
+              placeholder="Filter navigation"
+              onClear={() => setSearchTerm('')}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              value={searchTerm}
+              css={css`
+                margin-bottom: 0.5rem;
+              `}
+            />
+          )}
           <Navigation searchTerm={searchTerm}>
             {nav.pages.map((page) => (
               <NavItem key={page.title} page={page} />

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -114,6 +114,7 @@ export const query = graphql`
     nav(slug: $slug) {
       id
       title(locale: $locale)
+      filterable
       pages {
         ...MainLayout_navPages
         pages {

--- a/src/manual-edits/nav/attribute-dictionary.yml
+++ b/src/manual-edits/nav/attribute-dictionary.yml
@@ -1,5 +1,6 @@
 title: Attribute Dictionary
 path: /attribute-dictionary
+filterable: false
 pages:
   - title: Events
     path: /attribute-dictionary

--- a/src/nav/attribute-dictionary.yml
+++ b/src/nav/attribute-dictionary.yml
@@ -1,5 +1,6 @@
 title: Attribute Dictionary
 path: /attribute-dictionary
+filterable: false
 pages:
   - title: Events
     path: /attribute-dictionary


### PR DESCRIPTION
Closes #908

### Tell us why

The attribute dictionary page only has a single link and does not need the filter input. This PR adds the ability to disable the filter input for a nav by adding a `filterable: false` property to the nav
