### PR TITLE
Update NR in Practice nav path

### DIFF
--- a/scripts/utils/migrate/instruction-set.js
+++ b/scripts/utils/migrate/instruction-set.js
@@ -431,6 +431,13 @@ module.exports = [
     to: ['New Relic in practice'],
   },
   {
+    type: INSTRUCTIONS.UPDATE,
+    path: ['New Relic in practice'],
+    node: {
+      path: '/docs/using-new-relic',
+    },
+  },
+  {
     type: INSTRUCTIONS.REMOVE,
     path: ['Plugins'],
   },

--- a/src/manual-edits/content/docs/agents/net-agent/net-agent-api/index.mdx
+++ b/src/manual-edits/content/docs/agents/net-agent/net-agent-api/index.mdx
@@ -2,7 +2,11 @@
 title: .NET agent API
 type: apiLandingPage
 redirects:
+  - /docs/dotnet/AgentApi
+  - /docs/dotnet/the-net-agent-api
+  - /docs/dotnet/net-agent-api
   - /docs/agents/net-agent/net-agent-api/view-all-methods
+  - /docs/agents/net-agent/features/net-agent-api
 ---
 
 The .NET agent API allows you to extend the functionality of the .NET agent. To use the library, add a reference to `NewRelic.Api.Agent.dll` to your project. You can also view the package in the [NuGet Gallery](https://www.nuget.org/packages/NewRelic.Agent.Api/ 'Link opens in a new window.') . If you've disabled or uninstalled the agent, invoking these API calls has no effect.

--- a/src/manual-edits/content/docs/release-notes/agent-release-notes/net-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/agent-release-notes/net-release-notes/index.mdx
@@ -2,4 +2,5 @@
 subject: .NET agent
 redirects:
   - /docs/releases/dotnet
+  - /docs/agents/net-agent/getting-started/net-release-notes
 ---

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -1202,7 +1202,7 @@ pages:
             path: /docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-04x-or-lower
           - title: Import Node.js modules
             path: /docs/synthetics/synthetic-monitoring/scripting-monitors/import-nodejs-modules
-          - title: Add attributes to synthetic&#039;s data
+          - title: Add attributes to synthetic's data
             path: /docs/synthetics/synthetic-monitoring/scripting-monitors/add-custom-attributes-synthetic-monitoring-data
           - title: Set proxy settings and properties
             path: /docs/synthetics/synthetic-monitoring/scripting-monitors/set-proxy-settings-properties-scripted-monitors

--- a/src/nav/new-relic-in-practice.yml
+++ b/src/nav/new-relic-in-practice.yml
@@ -1,5 +1,5 @@
 title: New Relic in practice
-path: /docs/new-relic-in-practice
+path: /docs/using-new-relic
 pages:
   - title: Using New Relic
     path: /docs/using-new-relic


### PR DESCRIPTION
Closes #940

## Description

Update nav migration instructions to set NR in Practice to link to https://docs-preview.newrelic.com/docs/using-new-relic . The previous path led to a 404 page. 

Also included are redirects to existing index pages in `manual-edits` that I must've missed. And on migration a single quote came through un-encoded which looked legit to me so committed it.

## Screenshot(s)

<img width="1231" alt="2021-02-24_14-16-21" src="https://user-images.githubusercontent.com/2952843/109073201-ec8b4480-76aa-11eb-8b97-5728ca80306c.png">
