### PR TITLE
Account for new release notes, optional version number

### DIFF
--- a/plugins/gatsby-source-nav/gatsby-node.js
+++ b/plugins/gatsby-source-nav/gatsby-node.js
@@ -193,7 +193,9 @@ const createReleaseNotesNav = async ({ createNodeId, nodeModel }) => {
 
   const formatReleaseNotePosts = (posts) =>
     posts.map((post) => ({
-      title: `${post.frontmatter.subject} v${post.frontmatter.version}`,
+      title: post.frontmatter.version
+        ? `${post.frontmatter.subject} v${post.frontmatter.version}`
+        : post.frontmatter.subject,
       url: post.fields.slug,
       pages: [],
     }));

--- a/src/content/docs/release-notes/diagnostics-release-notes/diagnostics-cli-release-notes/index.mdx
+++ b/src/content/docs/release-notes/diagnostics-release-notes/diagnostics-cli-release-notes/index.mdx
@@ -1,0 +1,6 @@
+---
+subject: Diagnostics CLI
+redirects:
+  - /docs/release-notes/platform-release-notes/diagnostics-release-notes
+  - /docs/using-new-relic/cross-product-functions/diagnostics-cli-nrdiag/diagnostics-release-notes
+---

--- a/src/content/docs/release-notes/index.mdx
+++ b/src/content/docs/release-notes/index.mdx
@@ -59,6 +59,11 @@ To take full advantage of New Relic's latest features, enhancements, and importa
     to="/docs/release-notes/agent-release-notes/java-release-notes"
   />
   <TechTile
+    name="New Relic diagnostics CLI"
+    icon="logo-newrelic"
+    to="/docs/release-notes/diagnostics-release-notes/diagnostics-cli-release-notes"
+  />
+  <TechTile
     name="New Relic infrastructure agent"
     icon="logo-newrelic"
     to="/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes"
@@ -67,6 +72,16 @@ To take full advantage of New Relic's latest features, enhancements, and importa
     name="New Relic infrastructure Windows agent"
     icon="logo-windows"
     to="/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes"
+  />
+  <TechTile
+    name="New Relic infrastructure cloud integrations"
+    icon="logo-newrelic"
+    to="/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes"
+  />
+  <TechTile
+    name="New Relic infrastructure kubernetes integrations"
+    icon="logo-kubernetes"
+    to="/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes"
   />
   <TechTile
     name="New Relic for Android"

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/index.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/index.mdx
@@ -1,0 +1,6 @@
+---
+subject: New Relic infrastructure cloud integration
+redirects:
+  - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes
+  - /docs/integrations/infrastructure-integrations/cloud-integrations/cloud-integrations-release-notes
+---

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/index.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/index.mdx
@@ -1,0 +1,6 @@
+---
+subject: Kubernetes integration
+redirects:
+  - /docs/release-notes/platform-release-notes/kubernetes-integration-release-notes
+  - /docs/integrations/kubernetes-integration/get-started/release-notes
+---

--- a/src/manual-edits/content/docs/release-notes/diagnostics-release-notes/diagnostics-cli-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/diagnostics-release-notes/diagnostics-cli-release-notes/index.mdx
@@ -1,0 +1,6 @@
+---
+subject: Diagnostics CLI
+redirects:
+  - /docs/release-notes/platform-release-notes/diagnostics-release-notes
+  - /docs/using-new-relic/cross-product-functions/diagnostics-cli-nrdiag/diagnostics-release-notes
+---

--- a/src/manual-edits/content/docs/release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/index.mdx
@@ -59,6 +59,11 @@ To take full advantage of New Relic's latest features, enhancements, and importa
     to="/docs/release-notes/agent-release-notes/java-release-notes"
   />
   <TechTile
+    name="New Relic diagnostics CLI"
+    icon="logo-newrelic"
+    to="/docs/release-notes/diagnostics-release-notes/diagnostics-cli-release-notes"
+  />
+  <TechTile
     name="New Relic infrastructure agent"
     icon="logo-newrelic"
     to="/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes"
@@ -67,6 +72,16 @@ To take full advantage of New Relic's latest features, enhancements, and importa
     name="New Relic infrastructure Windows agent"
     icon="logo-windows"
     to="/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes"
+  />
+  <TechTile
+    name="New Relic infrastructure cloud integrations"
+    icon="logo-newrelic"
+    to="/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes"
+  />
+  <TechTile
+    name="New Relic infrastructure kubernetes integrations"
+    icon="logo-kubernetes"
+    to="/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes"
   />
   <TechTile
     name="New Relic for Android"

--- a/src/manual-edits/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/index.mdx
@@ -1,0 +1,6 @@
+---
+subject: New Relic infrastructure cloud integration
+redirects:
+  - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes
+  - /docs/integrations/infrastructure-integrations/cloud-integrations/cloud-integrations-release-notes
+---

--- a/src/manual-edits/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/index.mdx
+++ b/src/manual-edits/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/index.mdx
@@ -1,0 +1,6 @@
+---
+subject: Kubernetes integration
+redirects:
+  - /docs/release-notes/platform-release-notes/kubernetes-integration-release-notes
+  - /docs/integrations/kubernetes-integration/get-started/release-notes
+---

--- a/src/templates/releaseNote.js
+++ b/src/templates/releaseNote.js
@@ -24,7 +24,7 @@ const ReleaseNoteTemplate = ({ data, location }) => {
     },
   } = data;
 
-  const title = `${subject} v${version}`;
+  const title = version ? `${subject} v${version}` : subject;
 
   return (
     <>


### PR DESCRIPTION
## Description

Sets up support for #892. Updates nav and `releaseNote.js` template so `version` isn't required for a release note (cloud integrations do not have a version number).

Adds dummy doc and original platform release note index link to redirects in the index.mdx files for each directory. Adds those index.mdx files on migration via `manual-edits`.

## Screenshot(s)

Example of a cloud integration release note will look like (the subject / name will actually be `New Relic infrastructure cloud integration`)

<img width="1148" alt="2021-02-24_14-55-16" src="https://user-images.githubusercontent.com/2952843/109081128-9c19e400-76b6-11eb-941e-021773643b27.png">
