### PR TITLE
generate-docs-json checks for node parent 

### DIFF
--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -28,6 +28,7 @@ module.exports = {
     const srcUrl = getSrcUrl(fileRelativePath, node.url);
 
     const isBlockImage =
+      node.parent &&
       isMdxElement('paragraph', node.parent) &&
       node.parent.children.length === 1;
 


### PR DESCRIPTION
## Summary 
the docs json was not building because of not checking the node.parent existance when checking for whether the element is a block element. This PR now checks for that, as well as errors when the generate-doc-json fails to build