### PR TITLE
Update Data Dictionary dropdown color in Firefox

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -74,6 +74,10 @@ const Select = ({ disabled, ...props }) => (
 
         .dark-mode & {
           color: var(--color-dark-900);
+
+          option {
+            color: var(--color-dark-050);
+          }
         }
       `}
       {...props}


### PR DESCRIPTION
## Description
Fixes the text color for the `<option>` elements on the data dictionary (when in dark mode). See screenshots.

## Related Issue(s)
* Closes #907

## Screenshot(s)
**Before**
![Screen Shot 2021-02-25 at 11 09 32 AM](https://user-images.githubusercontent.com/1946433/109204554-59114c80-775a-11eb-964f-4aec104817ed.png)

**After**
![Screen Shot 2021-02-25 at 11 09 53 AM](https://user-images.githubusercontent.com/1946433/109204579-60d0f100-775a-11eb-82f8-048f83f724ef.png)
