### PR TITLE
Fix cloud integrations release notes

### DIFF
--- a/plugins/gatsby-source-nav/gatsby-node.js
+++ b/plugins/gatsby-source-nav/gatsby-node.js
@@ -192,13 +192,17 @@ const createReleaseNotesNav = async ({ createNodeId, nodeModel }) => {
     .sort();
 
   const formatReleaseNotePosts = (posts) =>
-    posts.map((post) => ({
-      title: post.frontmatter.version
+    posts.map((post) => {
+      const derivedTitle = post.frontmatter.version
         ? `${post.frontmatter.subject} v${post.frontmatter.version}`
-        : post.frontmatter.subject,
-      url: post.fields.slug,
-      pages: [],
-    }));
+        : post.frontmatter.subject;
+
+      return {
+        title: post.frontmatter.title ? post.frontmatter.title : derivedTitle,
+        url: post.fields.slug,
+        pages: [],
+      };
+    });
 
   const filterBySubject = (subject, posts) =>
     posts.filter((post) => post.frontmatter.subject === subject);

--- a/src/content/docs/agents/python-agent/web-frameworks-servers/python-agent-starlette-web-framework.mdx
+++ b/src/content/docs/agents/python-agent/web-frameworks-servers/python-agent-starlette-web-framework.mdx
@@ -3,7 +3,7 @@ title: Python agent and Starlette web framework
 tags:
   - Agents
   - Python agent
-  - Async instrumentation
+  - Web frameworks and servers
 metaDescription: How to use New Relic's Python agent with apps that use the Starlette.io web framework.
 ---
 
@@ -26,4 +26,3 @@ You can use the [Python agent API](/docs/agents/python-agent/python-agent-api) t
 ## Event loop diagnostic support [#event-loops]
 
 Our Python agent supports `asyncio` event loop diagnostics. For more information, see [Python event loop diagnostics](/docs/agents/python-agent/supported-features/python-event-loop-diagnostics).
-cs).

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/1-new-integrations-available-aws-new-statistics.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/1-new-integrations-available-aws-new-statistics.mdx
@@ -1,5 +1,6 @@
 ---
-subject: ''
+title: 1 new integrations available for AWS and new statistics
+subject: Cloud integrations
 releaseDate: '2020-08-20'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/1-new-integrations-available-aws-new-statistics

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/5-new-integrations-available-azure-aws.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/5-new-integrations-available-azure-aws.mdx
@@ -1,5 +1,6 @@
 ---
-subject: ''
+title: 5 new integrations available for Azure and AWS
+subject: Cloud integrations
 releaseDate: '2020-08-13'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/5-new-integrations-available-azure-aws

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/9-new-integrations-available-aws-govcloud.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/9-new-integrations-available-aws-govcloud.mdx
@@ -1,5 +1,6 @@
 ---
-subject: ''
+title: 9 new integrations available in AWS GovCloud
+subject: Cloud integrations
 releaseDate: '2020-07-24'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/integrations-9-new-integrations-available-aws-govcloud

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/9-new-integrations-v10-available-azure-aws.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/9-new-integrations-v10-available-azure-aws.mdx
@@ -1,5 +1,6 @@
 ---
-subject: ''
+title: 9 new integrations (v1.0) available for Azure and AWS
+subject: Cloud integrations
 releaseDate: '2020-11-20'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/3-new-integrations-available-azure-aws
@@ -9,7 +10,7 @@ redirects:
 ### New
 
 * The following integrations are now stable (v1.0):
-  * &lt;!--&#x7B;C}%3C!%2D%2Dtd%20%7Bborder%3A%201px%20solid%20%23ccc%3B%7Dbr%20%7Bmso-data-placement%3Asame-cell%3B%7D%2D%2D%3E--> [AWS Kinesis Data Analytics](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/amazon-kinesis-data-analytics-monitoring-integration)
+  * [AWS Kinesis Data Analytics](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/amazon-kinesis-data-analytics-monitoring-integration)
   * [AWS Elemental MediaCovert](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-elemental-mediaconvert-monitoring-integration)
   * [AWS FSx](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-fsx-monitoring-integration)
   * [AWS Elemental MediaPackage VOD](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-elemental-mediapackage-vod-monitoring-integration)

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/account-status-dashboard.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/account-status-dashboard.mdx
@@ -1,5 +1,6 @@
 ---
-subject: Account status dashboard
+title: Account status dashboard
+subject: Cloud integrations
 releaseDate: '2019-03-13'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2019-03-13-integrations-account-status-dashboard

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/additional-aws-lambda-regions.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/additional-aws-lambda-regions.mdx
@@ -1,5 +1,6 @@
 ---
-subject: Additional AWS Lambda regions
+title: Additional AWS Lambda regions
+subject: Cloud integrations
 releaseDate: '2018-03-31'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/new-regions-aws-lambda

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/aws-trusted-advisor-azure-cost-management-integrations.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/aws-trusted-advisor-azure-cost-management-integrations.mdx
@@ -1,5 +1,6 @@
 ---
-subject: 'AWS Trusted Advisor, Azure Cost Management integrations'
+title: 'AWS Trusted Advisor, Azure Cost Management integrations'
+subject: Cloud integrations
 releaseDate: '2019-10-02'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2019-10-2-integrations-aws-trusted-advisor-azure-cost-management-integrations

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/azure-app-service-renamed-metrics.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/azure-app-service-renamed-metrics.mdx
@@ -1,5 +1,6 @@
 ---
-subject: Azure App Service renamed metrics
+title: Azure App Service renamed metrics
+subject: Cloud integrations
 releaseDate: '2020-04-21'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2020-04-21-integrations-azure-app-service-renamed-metrics

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/azure-cost-management-integration-new-aws-rds-metrics.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/azure-cost-management-integration-new-aws-rds-metrics.mdx
@@ -1,5 +1,6 @@
 ---
-subject: 'Azure Cost Management integration, new AWS RDS metrics'
+title: 'Azure Cost Management integration, new AWS RDS metrics'
+subject: Cloud integrations
 releaseDate: '2019-09-13'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2019-09-13-integrations-azure-cost-management-integration-new-aws-rds-metrics

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/azure-databases-postgresql-mysql-mariadb-monitoring-integration.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/azure-databases-postgresql-mysql-mariadb-monitoring-integration.mdx
@@ -1,5 +1,6 @@
 ---
-subject: 'Azure Databases for PostgreSQL, MySQL, and MariaDB monitoring integration'
+title: 'Azure Databases for PostgreSQL, MySQL, and MariaDB monitoring integration'
+subject: Cloud integrations
 releaseDate: '2019-08-08'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/azure-databases-postgresql-mysql-mariadb-monitoring-integration

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/bug-fix-aws-auto-scaling.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/bug-fix-aws-auto-scaling.mdx
@@ -1,5 +1,6 @@
 ---
-subject: Bug fix for AWS Auto Scaling
+title: Bug fix for AWS Auto Scaling
+subject: Cloud integrations
 releaseDate: '2019-04-10'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2019-04-10-integrations-bug-fix-aws-auto-scaling

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/bug-fixes-google-cloud-integrations.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/bug-fixes-google-cloud-integrations.mdx
@@ -1,5 +1,6 @@
 ---
-subject: Bug fixes for Google Cloud integrations
+title: Bug fixes for Google Cloud integrations
+subject: Cloud integrations
 releaseDate: '2019-03-28'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2019-02-28-integrations-bug-fixes-google-cloud-integrations

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/changes-attribute-names.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/changes-attribute-names.mdx
@@ -1,5 +1,6 @@
 ---
-subject: Changes to attribute names
+title: Changes to attribute names
+subject: Cloud integrations
 releaseDate: '2018-05-30'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/integrations-changes-attribute-names

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/changes-curated-dashboards.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/changes-curated-dashboards.mdx
@@ -1,5 +1,6 @@
 ---
-subject: Changes in curated dashboards
+title: Changes in curated dashboards
+subject: Cloud integrations
 releaseDate: '2018-11-30'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2018-11-30-integrations-changes-curated-dashboards

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/enabled-aws-ses-new-supported-regions.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/enabled-aws-ses-new-supported-regions.mdx
@@ -1,5 +1,6 @@
 ---
-subject: Enabled AWS SES for new supported regions
+title: Enabled AWS SES for new supported regions
+subject: Cloud integrations
 releaseDate: '2020-04-30'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2020-04-31-integrations-enabled-aws-ses-new-supported-regions

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/extended-inventory.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/extended-inventory.mdx
@@ -1,5 +1,6 @@
 ---
-subject: Extended inventory
+title: Extended inventory
+subject: Cloud integrations
 releaseDate: '2019-01-10'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2019-01-10-integrations-extended-inventory

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/externalid-required-aws-role-integrations-reaching-10.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/externalid-required-aws-role-integrations-reaching-10.mdx
@@ -1,5 +1,6 @@
 ---
-subject: externalID required in AWS Role / Integrations reaching
+title: externalID required in AWS Role / Integrations reaching
+subject: Cloud integrations
 releaseDate: '2020-07-10'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2020-07-10-integrations-security-patch-aws-integrations-reaching-10

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/fixes-optimizations.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/fixes-optimizations.mdx
@@ -1,5 +1,6 @@
 ---
-subject: Fixes and optimizations
+title: Fixes and optimizations
+subject: Cloud integrations
 releaseDate: '2019-02-20'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2019-02-20-integrations-fixes-optimizations

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/important-enhancements-gcp-aws-monitoring.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/important-enhancements-gcp-aws-monitoring.mdx
@@ -1,5 +1,6 @@
 ---
-subject: Important enhancements to GCP and AWS monitoring
+title: Important enhancements to GCP and AWS monitoring
+subject: Cloud integrations
 releaseDate: '2018-07-20'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2018-07-20-integrations-important-enhancements-gcp-aws-monitoring

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/improved-infrastructure-cloud-alerting-performance-reliability.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/improved-infrastructure-cloud-alerting-performance-reliability.mdx
@@ -1,5 +1,6 @@
 ---
-subject: Improved Infrastructure cloud alerting performance and reliability
+title: Improved Infrastructure cloud alerting performance and reliability
+subject: Cloud integrations
 releaseDate: '2020-11-12'
 redirects:
   - /docs/release-notes/platform-release-notes/alerts-release-notes/11-12-2020-improved-infrastructure-cloud-alerting-performance-reliability

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/index.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/index.mdx
@@ -1,5 +1,6 @@
 ---
-subject: New Relic infrastructure cloud integration
+title: New Relic infrastructure cloud integration
+subject: Cloud integrations
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes
   - /docs/integrations/infrastructure-integrations/cloud-integrations/cloud-integrations-release-notes

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/label-collection-google-cloud-integrations.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/label-collection-google-cloud-integrations.mdx
@@ -1,5 +1,6 @@
 ---
-subject: Label collection for Google Cloud integrations
+title: Label collection for Google Cloud integrations
+subject: Cloud integrations
 releaseDate: '2019-03-29'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2019-03-28-integrations-label-collection-google-cloud-integrations

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/more-accessible-menus-ec2-ip-filter.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/more-accessible-menus-ec2-ip-filter.mdx
@@ -1,5 +1,6 @@
 ---
-subject: More accessible menus and EC
+title: More accessible menus and EC
+subject: Cloud integrations
 releaseDate: '2019-07-01'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2019-07-01-integrations-more-accessible-menus-ec2-ip-filter

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-attributes-aws-services.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-attributes-aws-services.mdx
@@ -1,5 +1,6 @@
 ---
-subject: New attributes for AWS services
+title: New attributes for AWS services
+subject: Cloud integrations
 releaseDate: '2018-07-06'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2018-07-06-new-attributes-aws-services

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-aws-azure-integrations.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-aws-azure-integrations.mdx
@@ -1,5 +1,6 @@
 ---
-subject: New AWS and Azure integrations
+title: New AWS and Azure integrations
+subject: Cloud integrations
 releaseDate: '2018-04-09'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2018-04-09-integrations-new-aws-azure-integrations

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-aws-beta-integrations.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-aws-beta-integrations.mdx
@@ -1,5 +1,6 @@
 ---
-subject: New AWS beta integrations
+title: New AWS beta integrations
+subject: Cloud integrations
 releaseDate: '2019-12-31'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2019-12-31-integrations-new-azure-beta-integrations

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-azure-beta-integrations-new-data-account-status-dashboard.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-azure-beta-integrations-new-data-account-status-dashboard.mdx
@@ -1,5 +1,6 @@
 ---
-subject: New Azure beta integrations / New data in Account status dashboard
+title: New Azure beta integrations / New data in Account status dashboard
+subject: Cloud integrations
 releaseDate: '2020-02-29'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2020-02-29-integrations-new-azure-beta-integrations-new-data-account-status-dashboard

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-azure-beta-integrations.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-azure-beta-integrations.mdx
@@ -1,5 +1,6 @@
 ---
-subject: New Azure beta integrations
+title: New Azure beta integrations
+subject: Cloud integrations
 releaseDate: '2019-11-30'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2019-11-30-integrations-new-azure-beta-integrations

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-beta-azure-integrations.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-beta-azure-integrations.mdx
@@ -1,5 +1,6 @@
 ---
-subject: New beta Azure integrations
+title: New beta Azure integrations
+subject: Cloud integrations
 releaseDate: '2020-06-30'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2020-6-30-new-beta-azure-integrations

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-beta-integrations-fixes.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-beta-integrations-fixes.mdx
@@ -1,5 +1,6 @@
 ---
-subject: New beta integrations and fixes
+title: New beta integrations and fixes
+subject: Cloud integrations
 releaseDate: '2020-03-31'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2020-03-31-integrations-new-beta-integrations-fixes

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-beta-integrations-integrations-reaching-10.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-beta-integrations-integrations-reaching-10.mdx
@@ -1,5 +1,6 @@
 ---
-subject: New beta integrations / Integrations reaching
+title: New beta integrations / Integrations reaching
+subject: Cloud integrations
 releaseDate: '2020-05-13'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2020-05-31-integrations-new-beta-integrations-integrations-reaching-10

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-beta-integrations.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-beta-integrations.mdx
@@ -1,5 +1,6 @@
 ---
-subject: New beta integrations
+title: New beta integrations
+subject: Cloud integrations
 releaseDate: '2020-06-19'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2020-6-19-new-beta-integrations

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-data-aws-integrations.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-data-aws-integrations.mdx
@@ -1,5 +1,6 @@
 ---
-subject: New data for AWS integrations
+title: New data for AWS integrations
+subject: Cloud integrations
 releaseDate: '2018-09-05'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2018-09-05-integrations-new-data-aws-integrations

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-data-cloud-integrations.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-data-cloud-integrations.mdx
@@ -1,5 +1,6 @@
 ---
-subject: New data in Cloud Integrations
+title: New data in Cloud Integrations
+subject: Cloud integrations
 releaseDate: '2018-10-19'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2018-10-19-integrations-new-data-cloud-integrations

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-google-cloud-platform-integrations-0.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-google-cloud-platform-integrations-0.mdx
@@ -1,5 +1,6 @@
 ---
-subject: New Google Cloud Platform integrations
+title: New Google Cloud Platform integrations
+subject: Cloud integrations
 releaseDate: '2018-04-12'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2018-04-12-integrations-new-google-cloud-platform-integrations

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-google-cloud-platform-integrations.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-google-cloud-platform-integrations.mdx
@@ -1,5 +1,6 @@
 ---
-subject: New Google Cloud Platform integrations
+title: New Google Cloud Platform integrations
+subject: Cloud integrations
 releaseDate: '2019-02-28'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2019-02-28-integrations-new-google-cloud-platform-integrations

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-metrics-amazon-elasticache.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-metrics-amazon-elasticache.mdx
@@ -1,5 +1,6 @@
 ---
-subject: New metrics for Amazon ElastiCache
+title: New metrics for Amazon ElastiCache
+subject: Cloud integrations
 releaseDate: '2020-07-30'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2020-07-30-new-metrics-amazon-elasticache

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-metrics-aws-elasticsearch.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-metrics-aws-elasticsearch.mdx
@@ -1,5 +1,6 @@
 ---
-subject: New metrics for AWS Elasticsearch
+title: New metrics for AWS Elasticsearch
+subject: Cloud integrations
 releaseDate: '2019-06-18'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2019-06-18-integrations-new-metrics-aws-elasticsearch

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/single-polling-interval.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/single-polling-interval.mdx
@@ -1,5 +1,6 @@
 ---
-subject: Single polling interval
+title: Single polling interval
+subject: Cloud integrations
 releaseDate: '2019-03-12'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2019-03-08-integrations-single-polling-interval

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/updated-aws-elb-integrations-alb-nlb-elb-classic.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/updated-aws-elb-integrations-alb-nlb-elb-classic.mdx
@@ -1,5 +1,6 @@
 ---
-subject: 'Updated AWS ELB integrations (ALB, NLB, ELB Classic)'
+title: 'Updated AWS ELB integrations (ALB, NLB, ELB Classic)'
+subject: Cloud integrations
 releaseDate: '2019-08-13'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2019-08-12-integrations-updated-aws-elb-integrations-alb-nlb-elb-classic

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/usage-aws-resource-tagging-api-rta.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/usage-aws-resource-tagging-api-rta.mdx
@@ -1,5 +1,6 @@
 ---
-subject: Usage of AWS Resource Tagging API (RTA)
+title: Usage of AWS Resource Tagging API (RTA)
+subject: Cloud integrations
 releaseDate: '2020-06-04'
 redirects:
   - /docs/release-notes/platform-release-notes/cloud-integrations-release-notes/2020-6-4-usage-aws-resource-tagging-api-rta

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/deprecation-notice-kubernetes-v17-or-lower.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/deprecation-notice-kubernetes-v17-or-lower.mdx
@@ -1,5 +1,6 @@
 ---
-subject: 'Deprecation notice: Kubernetes'
+title: 'Deprecation notice: Kubernetes'
+subject: Kubernetes events integration
 releaseDate: '2020-05-15'
 redirects:
   - /docs/release-notes/platform-release-notes/kubernetes-integration-release-notes/deprecation-notice-kubernetes-v17-or-lower

--- a/src/templates/releaseNote.js
+++ b/src/templates/releaseNote.js
@@ -9,22 +9,24 @@ import Watermark from '../components/Watermark';
 import SEO from '../components/SEO';
 import { TYPES } from '../utils/constants';
 
+const getTitle = ({ title, version, subject }) => {
+  if (title) {
+    return title;
+  }
+
+  return version ? `${subject} v${version}` : subject;
+};
+
 const ReleaseNoteTemplate = ({ data, location }) => {
   const {
     mdx: {
       body,
-      frontmatter: {
-        downloadLink,
-        subject,
-        version,
-        releaseDate,
-        watermark,
-        metaDescription,
-      },
+      frontmatter,
+      frontmatter: { downloadLink, releaseDate, watermark, metaDescription },
     },
   } = data;
 
-  const title = version ? `${subject} v${version}` : subject;
+  const title = getTitle(frontmatter);
 
   return (
     <>
@@ -115,6 +117,7 @@ export const pageQuery = graphql`
       frontmatter {
         subject
         version
+        title
         releaseDate(formatString: "MMMM D, YYYY")
         downloadLink
         watermark

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -103,7 +103,9 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
                           margin-bottom: 0.5rem;
                         `}
                       >
-                        {subject} v{post.frontmatter.version}
+                        {post.frontmatter.title
+                          ? post.frontmatter.title
+                          : `${subject} v${post.frontmatter.version}`}
                       </Link>
                       <p
                         css={css`
@@ -145,6 +147,7 @@ export const pageQuery = graphql`
           slug
         }
         frontmatter {
+          title
           version
           releaseDate(formatString: "MMMM D, YYYY")
         }


### PR DESCRIPTION
Closes #892

### Tell us why

This fixes the cloud integrations release notes by updating all the release note
docs to use a "Cloud integrations" `subject`. This PR also adds the ability to
override the generated title by defining a `title` property on the release note.
