### PR TITLE
Remove leading slash

### DIFF
--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -44,7 +44,7 @@ module.exports = {
           node,
           'img',
           stripNulls({
-            src: imageHashMap[srcUrl] || node.url,
+            src: imageHashMap[srcUrl.substr(1)] || node.url,
             alt: node.alt,
           })
         ),


### PR DESCRIPTION
removes leading slash from `srcUrl` so that the hashmap works :) 