### PR TITLE
Sort release notes nav as case insensitive

### DIFF
--- a/plugins/gatsby-source-nav/gatsby-node.js
+++ b/plugins/gatsby-source-nav/gatsby-node.js
@@ -189,7 +189,12 @@ const createReleaseNotesNav = async ({ createNodeId, nodeModel }) => {
   const subjects = posts
     .reduce((acc, curr) => [...new Set([...acc, curr.frontmatter.subject])], [])
     .filter(Boolean)
-    .sort();
+    .sort((a, b) =>
+      a
+        .toLowerCase()
+        .replace(/\W/, '')
+        .localeCompare(b.toLowerCase().replace(/\W/, ''))
+    );
 
   const formatReleaseNotePosts = (posts) =>
     posts.map((post) => {


### PR DESCRIPTION
Closes #974

### Tell us why

This PR updates the sorting of the release notes nav by case insensitive alpha. Also compares against word-only characters to ensure release notes such as `.NET` show up with the `n`s.

## Screenshots

<img width="317" alt="Screen Shot 2021-02-26 at 12 14 21 AM" src="https://user-images.githubusercontent.com/565661/109274039-db842580-77c7-11eb-9d24-22beaeaead02.png">

