### PR TITLE
Fix empty root table of contents pages

### DIFF
--- a/plugins/gatsby-source-nav/gatsby-node.js
+++ b/plugins/gatsby-source-nav/gatsby-node.js
@@ -11,6 +11,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       id: ID!
       title(locale: String = "en"): String
       filterable: Boolean!
+      url: String
       pages: [NavItem!]!
     }
 
@@ -68,6 +69,9 @@ exports.createResolvers = ({ createResolvers, createNodeId }) => {
       filterable: {
         resolve: (source) =>
           hasOwnProperty(source, 'filterable') ? source.filterable : true,
+      },
+      url: {
+        resolve: (source) => source.url || source.path,
       },
       title: {
         resolve: findTranslatedTitle,

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -114,6 +114,7 @@ export const query = graphql`
     nav(slug: $slug) {
       id
       title(locale: $locale)
+      url
       filterable
       pages {
         ...MainLayout_navPages


### PR DESCRIPTION
Closes #877

### Tell us why

Ensures table of contents pages created from root nav links generate the content for the page. Currently these are blank for TDP, AI, and FSO table of contents pages.

### Screenshots

<img width="1684" alt="Screen Shot 2021-02-26 at 12 49 59 AM" src="https://user-images.githubusercontent.com/565661/109277777-9adadb00-77cc-11eb-910e-0cedf9d55d48.png">



