### PR TITLE
Updated the Learn about AI tile to point to a better place

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/index.mdx
+++ b/src/content/docs/alerts-applied-intelligence/index.mdx
@@ -70,7 +70,7 @@ redirects:
 
   <LandingPageTile
     title="Learn about AI."
-    href="/docs/alerts/new-relic-alerts/reviewing-alert-incidents"
+    href="/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence"
     icon="fe-alert-triangle"
   >
 


### PR DESCRIPTION
We found this incorrect link during the Docs team test.

