### PR TITLE
Ensure redirects are created for each locale

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -77,12 +77,6 @@ module.exports = {
                 '/docs/agents/ruby-agent/features/ruby-vm-measurements',
               ].includes(slug);
 
-              console.log({
-                slug,
-                fetch: result,
-                env: Boolean(process.env.BUILD_RELATED_CONTENT),
-              });
-
               return result;
             },
             getParams: ({ node }) => {


### PR DESCRIPTION
Closes #963

### Tell us why

Japanese redirects are currently not working, and result in a 404. This PR ensures that redirects are created for localized pages by using the redirects frontmatter in the English doc to create a redirect for its associated locale page.
