### PR TITLE
Add actual logic for fetching related content

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -70,14 +70,32 @@ module.exports = {
             resultsPath: `${__dirname}/src/data/swiftype-resources.json`,
             engineKey: 'Ad9HfGjDw4GRkcmJjUut',
             refetch: Boolean(process.env.BUILD_RELATED_CONTENT),
-            filter: ({ slug }) => {
-              const result = [
-                '/docs/apm/new-relic-apm/apdex/change-your-apdex-settings',
-                '/docs/integrations/kubernetes-integration/understand-use-data/kubernetes-cluster-explorer',
-                '/docs/agents/ruby-agent/features/ruby-vm-measurements',
-              ].includes(slug);
+            filter: (node) => {
+              const includedTypes = ['apiDoc', 'troubleshooting'];
+              const excludedFolders = [
+                'src/content/docs/release-notes',
+                'src/content/whats-new',
+              ];
 
-              return result;
+              const {
+                frontmatter,
+                fields: { fileRelativePath },
+              } = node;
+
+              if (node.internal.type !== 'Mdx') {
+                return false;
+              }
+
+              if (
+                excludedFolders.some((path) => fileRelativePath.includes(path))
+              ) {
+                return false;
+              }
+
+              return (
+                frontmatter.type == null ||
+                includedTypes.includes(frontmatter.type)
+              );
             },
             getParams: ({ node }) => {
               const { tags, title } = node.frontmatter;

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -70,7 +70,7 @@ module.exports = {
             resultsPath: `${__dirname}/src/data/swiftype-resources.json`,
             engineKey: 'Ad9HfGjDw4GRkcmJjUut',
             refetch: Boolean(process.env.BUILD_RELATED_CONTENT),
-            filter: (node) => {
+            filter: ({ node }) => {
               if (node.internal.type !== 'Mdx') {
                 return false;
               }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -71,6 +71,10 @@ module.exports = {
             engineKey: 'Ad9HfGjDw4GRkcmJjUut',
             refetch: Boolean(process.env.BUILD_RELATED_CONTENT),
             filter: (node) => {
+              if (node.internal.type !== 'Mdx') {
+                return false;
+              }
+
               const includedTypes = ['apiDoc', 'troubleshooting'];
               const excludedFolders = [
                 'src/content/docs/release-notes',
@@ -81,10 +85,6 @@ module.exports = {
                 frontmatter,
                 fields: { fileRelativePath },
               } = node;
-
-              if (node.internal.type !== 'Mdx') {
-                return false;
-              }
 
               if (
                 excludedFolders.some((path) => fileRelativePath.includes(path))

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "^2.0.0-next.8",
     "@mdx-js/react": "^2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "^1.32.2",
+    "@newrelic/gatsby-theme-newrelic": "^1.32.3",
     "@splitsoftware/splitio-react": "^1.2.0",
     "babel-jest": "^26.3.0",
     "date-fns": "^2.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2222,10 +2222,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^1.32.2":
-  version "1.32.2"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.32.2.tgz#0fd5002412f91e7abec8245433c4d094bafb644e"
-  integrity sha512-GoDmOJAGDSDlGG5O5XV0teGvNRcmtpBY9rTtsvCpp+Nyt9d8ILv60c3NpBXndS2Hvkxusm+nxdLOoRc36DoaXw==
+"@newrelic/gatsby-theme-newrelic@^1.32.3":
+  version "1.32.3"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.32.3.tgz#d3dccc74170ec7af65389cf77ae5c829f920899e"
+  integrity sha512-E5pGeOZ4LhHUcsc43ssND5raLkGwfQUKuR0hgzzTyg4CEQcaLus9yilARGTlVvxKufeBHempYiID6Jmbvbtbsw==
   dependencies:
     "@elastic/react-search-ui" "^1.4.1"
     "@elastic/react-search-ui-views" "^1.4.1"


### PR DESCRIPTION
### Tell us why

Updates the logic that determines which docs to fetch related resources for to include all basic doc pages, troubleshooting, and api doc pages.
