### PR TITLE
Try moving incremental build variable inline with build command

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,7 +1,4 @@
 version: 1
-env:
-  variables:
-    GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES: true
 frontend:
   phases:
     preBuild:
@@ -12,9 +9,9 @@ frontend:
       commands:
         - |
           if [ "${AWS_BRANCH}" = "main" ]; then
-            yarn run build:production --log-pages;
+            GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true yarn run build:production --log-pages;
           else
-            yarn run build:staging --log-pages;
+            GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true yarn run build:staging --log-pages;
           fi
   artifacts:
     baseDirectory: public


### PR DESCRIPTION
### Tell us why

Builds in Amplify are still taking a while, even for small edits. This tries another attempt at moving the env variable inline with the build command.
