### PR TITLE
Create serverless landing page

### DIFF
--- a/src/content/docs/agents/net-agent/index.mdx
+++ b/src/content/docs/agents/net-agent/index.mdx
@@ -54,7 +54,7 @@ redirects:
     href="/docs/agents/net-agent/net-agent-api"
     icon="fe-tool"
   >
-     and **[custom instrumentation](/docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation)**. Control the agent or extend your instrumentation.
+    **[API](/docs/agents/net-agent/net-agent-api)** and **[custom instrumentation](/docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation)**. Control the agent or extend your instrumentation.
   </LandingPageTile>
 
   <LandingPageTile

--- a/src/content/docs/serverless-function-monitoring/index.mdx
+++ b/src/content/docs/serverless-function-monitoring/index.mdx
@@ -1,0 +1,30 @@
+---
+title: Serverless monitoring
+type: landingPage
+---
+
+<LandingPageHero>
+  <HeroContent>
+    Monitor your serverless functions from AWS, Azure, or Google Cloud. Monitor, visualize, troubleshoot, and alert on all your functions in a single place.
+  </HeroContent>
+</LandingPageHero>
+
+<LandingPageTileGrid>
+  <LandingPageTile
+    title="AWS Lambda"
+    href="/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/monitoring-aws-lambda-serverless-monitoring"
+    icon="logo-aws"
+  ></LandingPageTile>
+
+  <LandingPageTile
+    title="Azure Functions"
+    href="/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-functions-monitoring-integration"
+    icon="logo-azure"
+  ></LandingPageTile>
+
+  <LandingPageTile
+    title="Google Cloud Functions"
+    href="/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-functions-monitoring-integration"
+    icon="logo-gcloud"
+  ></LandingPageTile>
+</LandingPageTileGrid>


### PR DESCRIPTION
### Tell us why

Currently the homepage tile for serverless goes to a giant index page. This PR creates a micro-landing-page for serverless.

### Anything else you'd like to share?

@rhetoric101 rocks. Thanks for helping me crank this thing out!

### Screenshot

![image](https://user-images.githubusercontent.com/55203603/109371389-8a247680-7859-11eb-83dc-8679c53d511d.png)
