### PR TITLE
Nr1 help fixes - turn jsx titles to text and add two redirects

### DIFF
--- a/plugins/gatsby-plugin-generate-doc-json/gatsby-node.js
+++ b/plugins/gatsby-plugin-generate-doc-json/gatsby-node.js
@@ -74,6 +74,14 @@ exports.onPostBuild = async ({ graphql, store }) => {
 
     const filepath = path.join(program.directory, 'public', `${slug}.json`);
 
+    const imports = mdxAST.children.reduce((acc, node) => {
+      if (node.type === 'import') {
+        const importArray = node.value.split(' ');
+        acc[importArray[1]] = importArray[3].slice(1, -1);
+      }
+      return acc;
+    }, {});
+
     const transformedAST = htmlGenerator.runSync(mdxAST);
     const html = htmlGenerator.stringify(
       toHast(transformedAST, {
@@ -82,7 +90,7 @@ exports.onPostBuild = async ({ graphql, store }) => {
           mdxBlockElement: mdxElement,
           code: handlers.CodeBlock,
           image: (h, node) =>
-            handlers.image(h, node, imageHashMap, fileRelativePath),
+            handlers.image(h, node, imageHashMap, fileRelativePath, imports),
         },
       })
     );

--- a/plugins/gatsby-plugin-generate-doc-json/gatsby-node.js
+++ b/plugins/gatsby-plugin-generate-doc-json/gatsby-node.js
@@ -74,14 +74,6 @@ exports.onPostBuild = async ({ graphql, store }) => {
 
     const filepath = path.join(program.directory, 'public', `${slug}.json`);
 
-    const imports = mdxAST.children.reduce((acc, node) => {
-      if (node.type === 'import') {
-        const importArray = node.value.split(' ');
-        acc[importArray[1]] = importArray[3].slice(1, -1);
-      }
-      return acc;
-    }, {});
-
     const transformedAST = htmlGenerator.runSync(mdxAST);
     const html = htmlGenerator.stringify(
       toHast(transformedAST, {
@@ -90,7 +82,7 @@ exports.onPostBuild = async ({ graphql, store }) => {
           mdxBlockElement: mdxElement,
           code: handlers.CodeBlock,
           image: (h, node) =>
-            handlers.image(h, node, imageHashMap, fileRelativePath, imports),
+            handlers.image(h, node, imageHashMap, fileRelativePath),
         },
       })
     );

--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -4,9 +4,6 @@ const {
   findAttribute,
   isMdxElement,
 } = require('../../../codemods/utils/mdxast');
-const {
-  mdxValueExpression,
-} = require('../../../codemods/utils/mdxast-builder');
 const toString = require('mdast-util-to-string');
 const u = require('unist-builder');
 const { compileStyleObject } = require('../../../rehype-plugins/utils/styles');
@@ -35,10 +32,6 @@ const removeParagraphs = () => (tree) => {
   visit(tree, 'paragraph', (node, idx, parent) => {
     parent.children.splice(idx, 1, ...node.children);
   });
-};
-
-const getImportUrl = (node, importObject) => {
-  return importObject[node.url.value];
 };
 
 const attributeProcessor = unified()

--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -80,9 +80,6 @@ module.exports = {
       ]
     );
   },
-  CollapserTitle: (h, node) => {
-    return h(node, 'div', { className: 'collapser-title' }, all(h, node));
-  },
   CodeBlock: (h, node) => {
     const props =
       node.meta &&
@@ -157,37 +154,16 @@ module.exports = {
       const parsedChildren =
         children[0].name !== null ? children[0] : children[0].children;
 
-      if (Array.isArray(parsedChildren)) {
-        parsedChildren.forEach((child) => {
-          if (child.name === 'img') {
-            child.name = 'image';
-            const url = findAttribute('src', child);
-            child.url = typeof url === 'string' ? url : mdxValueExpression(url);
-          }
-        });
-      } else {
-        if (parsedChildren.name === 'img') {
-          parsedChildren.name = 'image';
-          const url = findAttribute('src', parsedChildren);
-          parsedChildren.url =
-            typeof url === 'string' ? url : mdxValueExpression(url);
-        }
-      }
+      const titleNode =
+        Array.isArray(parsedChildren) &&
+        parsedChildren.find((child) => child.type === 'text');
 
-      const newMdxElement = {
-        type: 'mdxBlockElement',
-        attributes: [],
-        name: 'CollapserTitle',
-        children:
-          children[0].name !== null ? children[0] : children[0].children,
-      };
-
-      node.children.unshift(newMdxElement);
       return h(
         node,
         'div',
         {
           className: 'collapser',
+          title: titleNode.value.trim() || '',
         },
         all(h, node)
       );

--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -157,13 +157,22 @@ module.exports = {
       const parsedChildren =
         children[0].name !== null ? children[0] : children[0].children;
 
-      parsedChildren.forEach((child) => {
-        if (child.name === 'img') {
-          child.name = 'image';
-          const url = findAttribute('src', child);
-          child.url = typeof url === 'string' ? url : mdxValueExpression(url);
+      if (Array.isArray(parsedChildren)) {
+        parsedChildren.forEach((child) => {
+          if (child.name === 'img') {
+            child.name = 'image';
+            const url = findAttribute('src', child);
+            child.url = typeof url === 'string' ? url : mdxValueExpression(url);
+          }
+        });
+      } else {
+        if (parsedChildren.name === 'img') {
+          parsedChildren.name = 'image';
+          const url = findAttribute('src', parsedChildren);
+          parsedChildren.url =
+            typeof url === 'string' ? url : mdxValueExpression(url);
         }
-      });
+      }
 
       const newMdxElement = {
         type: 'mdxBlockElement',

--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -151,7 +151,7 @@ module.exports = {
         'div',
         {
           className: 'collapser',
-          title: titleNode.value ? titleNode.value.trim() : '',
+          title: titleNode && titleNode.value ? titleNode.value.trim() : '',
         },
         all(h, node)
       );

--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -48,13 +48,8 @@ const attributeProcessor = unified()
   .use(removeParagraphs);
 
 module.exports = {
-  image: (h, node, imageHashMap, fileRelativePath, importObject) => {
-    const relPath =
-      node.url.type === 'mdxValueExpression'
-        ? getImportUrl(node, importObject)
-        : '';
-
-    const srcUrl = getSrcUrl(fileRelativePath, relPath);
+  image: (h, node, imageHashMap, fileRelativePath) => {
+    const srcUrl = getSrcUrl(fileRelativePath, node.url);
 
     const isBlockImage =
       node.parent &&
@@ -73,7 +68,7 @@ module.exports = {
           node,
           'img',
           stripNulls({
-            src: imageHashMap[srcUrl.substr(1)] || srcUrl.substr(1),
+            src: imageHashMap[srcUrl.substr(1)] || node.url,
             alt: node.alt,
           })
         ),

--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -151,7 +151,7 @@ module.exports = {
         'div',
         {
           className: 'collapser',
-          title: titleNode.value?.trim() || '',
+          title: titleNode.value ? titleNode.value.trim() : '',
         },
         all(h, node)
       );

--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -151,7 +151,7 @@ module.exports = {
         'div',
         {
           className: 'collapser',
-          title: titleNode.value.trim() || '',
+          title: titleNode.value?.trim() || '',
         },
         all(h, node)
       );

--- a/src/content/docs/release-notes/mobile-release-notes/android-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/android-release-notes/index.mdx
@@ -3,4 +3,5 @@ subject: Android agent
 redirects:
   - /docs/releases/android
   - /docs/mobile-monitoring/new-relic-mobile-android/get-started/android-release-notes
+  - /docs/release-notes/mobile-apps-release-notes/android-app-release-notes
 ---

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
@@ -3,4 +3,5 @@ subject: iOS agent
 redirects:
   - /docs/releases/ios
   - /docs/mobile-monitoring/new-relic-mobile-ios/get-started/ios-release-notes
+  - /docs/release-notes/mobile-apps-release-notes/ios-app-release-notes
 ---


### PR DESCRIPTION
This is just a temporary fix to avoid `Object` being rendered as the title :) 
We also will need to eventually handle TechTiles. I will add this all in an issue to follow up. 
<img width="689" alt="Screen Shot 2021-03-01 at 11 32 07 AM" src="https://user-images.githubusercontent.com/38332422/109527533-c508f300-7a81-11eb-972b-0bd1fe460423.png">

Avoids this problem ^^ 
