### PR TITLE
Use default robots config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -119,13 +119,6 @@ module.exports = {
             },
           },
         },
-        // This option is set to disallow to prevent crawling of the site during preview
-        // mode
-        robots: {
-          host: 'https://docs.newrelic.com',
-          sitemap: 'https://docs.newrelic.com/sitemap.xml',
-          policy: [{ userAgent: '*', disallow: '/' }],
-        },
         newrelic: {
           configs: {
             development: {


### PR DESCRIPTION
Closes #962

### Tell us why

Now that we are going live, we need to make sure the site is crawlable. Use the default options from the theme.
