### PR TITLE
Correct typo in fedramp-compliant-endpoints.mdx

### DIFF
--- a/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
+++ b/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
@@ -428,7 +428,7 @@ To ensure FedRAMP compliance, all traffic reporting to `insights-collector.newre
 
 ## Browser monitoring [#browser-endpoints]
 
-Oue browser monitoring agent transmits data to New Relic's [collectors](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/glossary#collector) by using the domain `gov-bam.nr-data.net` for both `beacon` and `error_beacon`.
+Our browser monitoring agent transmits data to New Relic's [collectors](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/glossary#collector) by using the domain `gov-bam.nr-data.net` for both `beacon` and `error_beacon`.
 
 Ensure the script element tag that contains configuration and timing data is updated to the following:
 


### PR DESCRIPTION
Correct a typo in the browser endpoint section.