### PR TITLE
fix broken link for "Contributors guide"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We're here working every day to improve our docs and we'd love to hear from you.
 
 ## Get started
 
-On each page of our docs, you can [create an issue](https://github.com/newrelic/docs-website/issues/new/choose) or [edit a page](https://github.com/newrelic/docs-website/blob/develop/CONTRIBUTING.md).
+On each page of our docs, you can [create an issue](https://github.com/newrelic/docs-website/issues/new/choose) or [edit a page](CONTRIBUTING.md).
 
 ### Create an issue
 
@@ -32,7 +32,7 @@ Go here to [create an issue](https://github.com/newrelic/docs-website/issues/new
 
 If you'd like to get more directly involved, you can make some changes yourself. On any doc, click the **Edit this page** button to get started making a change.
 You can edit a doc directly on the GitHub site. You don't need to actively fork the site or build it locally to help out. This is the easiest way to contribute.
-If you'd like to go deeper, see our [Contributors guide](https://github.com/newrelic/docs-website/blob/readme-update/CONTRIBUTING.md) for information on how to fork our site, build it locally, and submit pull requests.
+If you'd like to go deeper, see our [Contributors guide](CONTRIBUTING.md) for information on how to fork our site, build it locally, and submit pull requests.
 
 Our [Style guide](https://github.com/newrelic/docs-website/blob/readme-update/STYLE_GUIDE.md) will give you some insight into how we think about writing and documentation, as well as our flavor of Markdown.
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! Your changes will help thousands of
New Relic users around the world. -->

<!-- Fill out this template to help us review your changes and route them to the
best team. See our [README.md](https://github.com/newrelic/docs-website/) for 
information on how to contribute. -->

The "Contributors guide" link in the README referred to `https://github.com/newrelic/docs-website/blob/readme-update/CONTRIBUTING.md`, which returns a 404.  This PR removes the reference to the (no longer extant?) `readme-update` branch.  It also uses one consist reference to CONTRIBUTING.md; there are currently (3) different references in the page.