### PR TITLE
Added Infrastructure Agent to the Agents list

### DIFF
--- a/src/nav/agents.yml
+++ b/src/nav/agents.yml
@@ -1,16 +1,16 @@
 title: Agents
 path: /docs/agents
 pages:
-  - title: Infrastructure Agent
+  - title: Infrastructure agent
     pages:
-      - title: Get Started with Infrastructure Monitoring
-        path: https://docs.newrelic.com/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring
-      - title: Install the Infrastructure Agent
-        path: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent
-      - title: Configure the Agent
-        path: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent
-      - title: Infrastructure Integrations
-        path: https://docs.newrelic.com/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations
+      - title: Get started with infrastructure monitoring
+        path: /docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring
+      - title: Install the infrastructure agent
+        path: /docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent
+      - title: Configure the agent
+        path: /docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent
+      - title: Infrastructure integrations
+        path: /docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations
   - title: Manage APM agents
     pages:
       - title: Agent data

--- a/src/nav/agents.yml
+++ b/src/nav/agents.yml
@@ -1,6 +1,16 @@
 title: Agents
 path: /docs/agents
 pages:
+  - title: Infrastructure Agent
+    pages:
+      - title: Get Started with Infrastructure Monitoring
+        path: https://docs.newrelic.com/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring
+      - title: Install the Infrastructure Agent
+        path: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent
+      - title: Configure the Agent
+        path: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent
+      - title: Infrastructure Integrations
+        path: https://docs.newrelic.com/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations
   - title: Manage APM agents
     pages:
       - title: Agent data


### PR DESCRIPTION
Our Infrastructure Agent was missing from the Agents list :( so I added it :)

### Tell us why

The Infrastructure Agent docs were missing from the Agents list

### Anything else you'd like to share?

N/A

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/) 
in your commit messages and pull request title.