### PR TITLE
Restore style guide docs in taxonomy

### DIFF
--- a/src/nav/style-guide.yml
+++ b/src/nav/style-guide.yml
@@ -58,6 +58,8 @@ pages:
         path: /docs/style-guide/writing-guidelines/formatting-terminal-commands
   - title: Processes and procedures
     pages:
+      - title: Tech Writer workflow
+        path: /docs/style-guide/processes-procedures/tech-writer-workflow
       - title: Use content types and text formats
         path: /docs/style-guide/processes-procedures/use-content-types-text-formats
       - title: Edit checklist
@@ -74,6 +76,10 @@ pages:
         path: /docs/style-guide/processes-procedures/publication-checklist
       - title: Embed videos
         path: /docs/style-guide/processes-procedures/embed-videos
+      - title: Update left navigation pane
+        path: /docs/style-guide/processes-procedures/update-left-navigation-pane
+      - title: Dummy docs
+        path: /docs/style-guide/processes-procedures/dummy-docs  
   - title: Article templates
     pages:
       - title: GraphQL API tutorial template
@@ -82,3 +88,7 @@ pages:
         path: /docs/style-guide/article-templates/basic-doc-template
       - title: Agent release notes template
         path: /docs/style-guide/article-templates/agent-release-notes-template-123
+      - title: HTML template
+        path: /docs/style-guide/article-templates/html-template
+      - title: Landing page template
+        path: /docs/style-guide/article-templates/landing-page-template

--- a/src/nav/style-guide.yml
+++ b/src/nav/style-guide.yml
@@ -58,7 +58,7 @@ pages:
         path: /docs/style-guide/writing-guidelines/formatting-terminal-commands
   - title: Processes and procedures
     pages:
-      - title: Tech Writer workflow
+      - title: Tech writer workflow
         path: /docs/style-guide/processes-procedures/tech-writer-workflow
       - title: Use content types and text formats
         path: /docs/style-guide/processes-procedures/use-content-types-text-formats


### PR DESCRIPTION
### Tell us why
There were some missing docs in the style guide taxonomy. This PR restores them.
