### PR TITLE
Renders inline jsx as children of component for collapsers and tech tiles

### DIFF
--- a/codemods/utils/mdxast.js
+++ b/codemods/utils/mdxast.js
@@ -125,6 +125,7 @@ const containsImport = (tree, node) => {
 module.exports = {
   addAttribute,
   containsImport,
+  parseImport,
   flatten,
   isMdxBlockElement,
   isMdxElement,

--- a/plugins/gatsby-plugin-generate-doc-json/gatsby-node.js
+++ b/plugins/gatsby-plugin-generate-doc-json/gatsby-node.js
@@ -22,9 +22,9 @@ const mdxElement = (h, node) => {
 
 const htmlGenerator = unified()
   .use(jsxImagesToChildren)
+  .use(fencedCodeBlock)
   .use(removeImports)
   .use(removeExports)
-  .use(fencedCodeBlock)
   .use(customHeadingIds)
   .use(html);
 

--- a/plugins/gatsby-plugin-generate-doc-json/gatsby-node.js
+++ b/plugins/gatsby-plugin-generate-doc-json/gatsby-node.js
@@ -8,6 +8,7 @@ const removeExports = require('remark-mdx-remove-exports');
 const fencedCodeBlock = require('../../codemods/fencedCodeBlock');
 const customHeadingIds = require('../gatsby-remark-custom-heading-ids/utils/visitor');
 const handlers = require('./utils/handlers');
+const jsxImagesToChildren = require('./utils/jsxImagesToChildren');
 const all = require('mdast-util-to-hast/lib/all');
 
 const mdxElement = (h, node) => {
@@ -20,6 +21,7 @@ const mdxElement = (h, node) => {
 };
 
 const htmlGenerator = unified()
+  .use(jsxImagesToChildren)
   .use(removeImports)
   .use(removeExports)
   .use(fencedCodeBlock)

--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -133,37 +133,23 @@ module.exports = {
     );
   },
   Collapser: (h, node) => {
-    const title = findAttribute('title', node);
-
-    if (title.type === 'mdxValueExpression') {
-      const root = attributeProcessor.parse(title.value);
-      const { children } = attributeProcessor.runSync(root);
-
-      const parsedChildren =
-        children[0].name !== null ? children[0] : children[0].children;
-
-      const titleNode =
-        Array.isArray(parsedChildren) &&
-        parsedChildren.find((child) => child.type === 'text');
-
-      return h(
-        node,
-        'div',
-        {
-          className: 'collapser',
-          title: titleNode && titleNode.value ? titleNode.value.trim() : '',
-        },
-        all(h, node)
-      );
-    }
-
     return h(
       node,
       'div',
-      {
+      stripNulls({
         className: 'collapser',
         title: findAttribute('title', node),
-      },
+      }),
+      all(h, node)
+    );
+  },
+  CollapserTitle: (h, node) => {
+    return h(
+      node,
+      'div',
+      stripNulls({
+        className: 'collapser-title',
+      }),
       all(h, node)
     );
   },
@@ -211,6 +197,22 @@ module.exports = {
 
     return one(h, image, node.parent);
   },
+  TechTile: (h, node) => {
+    const attributes = JSON.stringify(getAllAttributes(node));
+    return h(
+      node,
+      'div',
+      {
+        className: 'tech-tile',
+        'data-props': attributes,
+      },
+      all(h, node)
+    );
+  },
+  TechTileGrid: (h, node) =>
+    h(node, 'div', { className: 'tech-tile-grid' }, all(h, node)),
+  TechTileIcon: (h, node) =>
+    h(node, 'div', { className: 'tech-tile-icon' }, all(h, node)),
   InlineCode: (h, node) => h(node, 'code', {}, [u('text', toString(node))]),
   table: (h, node) => h(node, 'table', {}, all(h, node)),
   thead: (h, node) => h(node, 'thead', {}, all(h, node)),

--- a/plugins/gatsby-plugin-generate-doc-json/utils/jsxImagesToChildren.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/jsxImagesToChildren.js
@@ -18,11 +18,11 @@ const removeParagraphs = () => (tree) => {
   });
 };
 
-const findAttributeNode = (attributeName, node) => {
+const findAttributeNode = (attrName, node) => {
   if (!node.attributes) {
     return null;
   }
-  const attribute = node.attributes.find((attr) => attr.name === attributeName);
+  const attribute = node.attributes.find((attr) => attr.name === attrName);
   return attribute;
 };
 
@@ -37,9 +37,11 @@ const capitalize = (s) => {
 };
 
 const jsxPropToElement = (attrName, node) => {
-  const name = findAttributeNode(attrName, node);
+  const {
+    value: { value: jsx },
+  } = findAttributeNode(attrName, node);
 
-  const root = attributeProcessor.parse(name.value.value);
+  const root = attributeProcessor.parse(jsx);
   const { children } = attributeProcessor.runSync(root);
   const element = mdxBlockElement(
     `${node.name}${capitalize(attrName)}`,

--- a/plugins/gatsby-plugin-generate-doc-json/utils/jsxImagesToChildren.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/jsxImagesToChildren.js
@@ -122,4 +122,4 @@ const jsxImagesToChildren = () => (tree) => {
   );
 };
 
-module.exports = jsxPropsToChildren;
+module.exports = jsxImagesToChildren;

--- a/plugins/gatsby-plugin-generate-doc-json/utils/jsxImagesToChildren.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/jsxImagesToChildren.js
@@ -1,0 +1,125 @@
+const visit = require('unist-util-visit');
+const {
+  isMdxElement,
+  parseImport,
+  findAttribute,
+  removeAttribute,
+} = require('../../../codemods/utils/mdxast');
+const { mdxBlockElement } = require('../../../codemods/utils/mdxast-builder');
+const toMDAST = require('remark-parse');
+const remarkMdx = require('remark-mdx');
+const remarkMdxjs = require('remark-mdxjs');
+const unified = require('unified');
+const { set } = require('lodash');
+
+const removeParagraphs = () => (tree) => {
+  visit(tree, 'paragraph', (node, idx, parent) => {
+    parent.children.splice(idx, 1, ...node.children);
+  });
+};
+
+const findAttributeNode = (attributeName, node) => {
+  if (!node.attributes) {
+    return null;
+  }
+  const attribute = node.attributes.find((attr) => attr.name === attributeName);
+  return attribute;
+};
+
+const isAttributeMdxValueExpression = (attrName, node) => {
+  const name = findAttributeNode(attrName, node);
+  return name && name.value.type === 'mdxValueExpression';
+};
+
+const capitalize = (s) => {
+  if (typeof s !== 'string') return '';
+  return s.charAt(0).toUpperCase() + s.slice(1);
+};
+
+const jsxPropToElement = (attrName, node) => {
+  const name = findAttributeNode(attrName, node);
+
+  const root = attributeProcessor.parse(name.value.value);
+  const { children } = attributeProcessor.runSync(root);
+  const element = mdxBlockElement(
+    `${node.name}${capitalize(attrName)}`,
+    [],
+    children
+  );
+  return element;
+};
+
+const attributeProcessor = unified()
+  .use(toMDAST)
+  .use(remarkMdx)
+  .use(remarkMdxjs)
+  .use(removeParagraphs);
+
+const jsxImagesToChildren = () => (tree) => {
+  const imageImports = {};
+
+  visit(
+    tree,
+    (node) => node.type === 'import',
+    (node) => {
+      const { expression, path } = parseImport(node);
+      imageImports[expression] = path;
+    }
+  );
+
+  visit(
+    tree,
+    (node) => {
+      if (isMdxElement('Collapser', node)) {
+        return isAttributeMdxValueExpression('title', node);
+      }
+    },
+    (node) => {
+      const collapserTitle = jsxPropToElement('title', node);
+      node.children.unshift(collapserTitle);
+      removeAttribute('title', node);
+    }
+  );
+
+  visit(
+    tree,
+    (node) => {
+      if (isMdxElement('TechTile', node)) {
+        return isAttributeMdxValueExpression('icon', node);
+      }
+    },
+    (node) => {
+      const techTileIcon = jsxPropToElement('icon', node);
+      node.children.unshift(techTileIcon);
+      removeAttribute('icon', node);
+    }
+  );
+
+  visit(
+    tree,
+    (node) => isMdxElement('img', node) && findAttribute('src', node),
+    (node) => {
+      const src = findAttribute('src', node);
+      node.type = 'image';
+      node.url =
+        src.type === 'mdxValueExpression' ? imageImports[src.value] : src;
+
+      set(node, 'title', findAttribute('title', node));
+      set(node, 'alt', findAttribute('alt', node));
+      const style = findAttribute('style', node);
+
+      style &&
+        set(
+          node,
+          'data.style',
+          style.value.replace(/[{}]/g, '').split(',').join('').trim('')
+        );
+
+      delete node.name;
+      delete node.attributes;
+      delete node.children;
+    }
+  );
+};
+
+module.exports = jsxPropsToChildren;


### PR DESCRIPTION
## Summary 
This allows for titles for Collapsers and icons Tech Tiles to be rendered in the in-product help xp. Before this gets merged in, there will need to be some work on the side of the in-help-xp to handle the collapser titles as children and support for tech tiles in general. 

In the future (when react 17 is up and running in the product) we should move away from this and try to serve the mdx and use mdx in the product to render the components! but that's a thing for the future :) 