### PR TITLE
release notes: add missing release notes for k8s

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-0-0.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-0-0.mdx
@@ -1,0 +1,10 @@
+---
+subject: Kubernetes integration
+releaseDate: '2020-12-02'
+version: 2.0.0
+---
+
+## Changelog
+
+- Improve e2e testing and move it to Github Actions
+- Release docker images and artifacts using Github Actions

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-0-0.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-0-0.mdx
@@ -6,5 +6,5 @@ version: 2.0.0
 
 ## Changelog
 
-- Improve e2e testing and move it to Github Actions
-- Release docker images and artifacts using Github Actions
+- Improve end-to-end testing and move it to GitHub Actions.
+- Release Docker images and artifacts using GitHub Actions.

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-0-1.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-0-1.mdx
@@ -1,0 +1,9 @@
+---
+subject: Kubernetes integration
+releaseDate: '2020-12-23'
+version: 2.0.1
+---
+
+## Changelog
+
+- The base image of newrelic/infrastructure-k8s has been updated to 2.0.1.

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-1-0.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-1-0.mdx
@@ -6,4 +6,4 @@ version: 2.1.0
 
 ## Changelog
 
-- Add aggregate cpu and memory request metrics for nodes
+- Added aggregate CPU and memory request metrics for nodes.

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-1-0.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-1-0.mdx
@@ -1,0 +1,9 @@
+---
+subject: Kubernetes integration
+releaseDate: '2021-01-04'
+version: 2.1.0
+---
+
+## Changelog
+
+- Add aggregate cpu and memory request metrics for nodes

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-2-0.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-2-0.mdx
@@ -1,0 +1,10 @@
+---
+subject: Kubernetes integration
+releaseDate: '2021-01-27'
+version: 2.2.0
+---
+
+## Changelog
+
+- The base image of newrelic/infrastructure-k8s has been updated to 2.2.1. This base image has fixed an issue where nrjmx was not properly running due to the bundled java version.
+- More info regarding all the integration upgraded can be found in the [release notes of the base image (https://github.com/newrelic/infrastructure-bundle/releases/tag/2.2.1)

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-2-0.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-2-0.mdx
@@ -7,4 +7,4 @@ version: 2.2.0
 ## Changelog
 
 - The base image of newrelic/infrastructure-k8s has been updated to 2.2.1. This base image has fixed an issue where nrjmx was not properly running due to the bundled java version.
-- More info regarding all the integration upgraded can be found in the [release notes of the base image (https://github.com/newrelic/infrastructure-bundle/releases/tag/2.2.1)
+- More info regarding all the upgraded integrations can be found in the [release notes of the base image](https://github.com/newrelic/infrastructure-bundle/releases/tag/2.2.1).

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-3-0.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-3-0.mdx
@@ -9,12 +9,12 @@ version: 2.3.0
 ### Changed
 
 - The base image of `newrelic/infrastructure-k8s` has been updated to `2.2.3`.
-More info regarding all the integrations upgraded can be found in the [release notes of the base image](https://github.com/newrelic/infrastructure-bundle/releases/tag/2.2.3).
+More info regarding all the upgraded integrations can be found in the [release notes of the base image](https://github.com/newrelic/infrastructure-bundle/releases/tag/2.2.3).
 
 ### Added
 
-- Added metrics pertaining to Horizontal Pod Autoscaler. More information about the collected metrics can be found in the [official documentation](https://docs.newrelic.com/docs/integrations/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data)
+- Added metrics belonging to Horizontal Pod Autoscaler. More information about the collected metrics can be found in the [official documentation](https://docs.newrelic.com/docs/integrations/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data).
 
 ### Fixed
 
-- LoadBalancerIP was not being collected properly. It is now fetched from KSM metric `kube_service_status_load_balancer_ingress`
+- LoadBalancerIP was not being collected properly. It's now fetched from KSM metric `kube_service_status_load_balancer_ingress`.

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-3-0.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-3-0.mdx
@@ -1,0 +1,20 @@
+---
+subject: Kubernetes integration
+releaseDate: '2021-02-24'
+version: 1.26.8
+---
+
+## Changelog
+
+### Changed
+
+- The base image of `newrelic/infrastructure-k8s` has been updated to `2.2.3`.
+More info regarding all the integrations upgraded can be found in the [release notes of the base image](https://github.com/newrelic/infrastructure-bundle/releases/tag/2.2.3).
+
+### Added
+
+- Added metrics pertaining to Horizontal Pod Autoscaler. More information about the collected metrics can be found in the [official documentation](https://docs.newrelic.com/docs/integrations/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data)
+
+### Fixed
+
+- LoadBalancerIP was not being collected properly. It is now fetched from KSM metric `kube_service_status_load_balancer_ingress`

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-3-0.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-2-3-0.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Kubernetes integration
 releaseDate: '2021-02-24'
-version: 1.26.8
+version: 2.3.0
 ---
 
 ## Changelog


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! Your changes will help thousands of New 
Relic users around the world. -->

<!-- Fill out this template to help us review your changes and route them to the
best team. See our [README.md](https://github.com/newrelic/docs-website/) for 
information on how to contribute. -->

### Tell us why

This PR ports release notes for nri-kubernetes from the [release notes page](https://github.com/newrelic/nri-kubernetes/releases).

### Anything else you'd like to share?

Some other release notes pages had a `redirects` attribute in the front matter, but I do not know what this is used for. Please tell me if you want me to add this back.
