### PR TITLE
Added schema definition for `grid_column_count`

### DIFF
--- a/src/content/docs/insights/event-data-sources/insights-api/insights-dashboard-api.mdx
+++ b/src/content/docs/insights/event-data-sources/insights-api/insights-dashboard-api.mdx
@@ -234,6 +234,7 @@ JSON is the only supported format. When using API functions, be sure to add `.js
         "<a href="#metadata">metadata</a>": { "version": 1 },
         "<a href="#title">title</a>": "API Widget Sample",
         "<a href="#icon">icon</a>":"none|archive|bar-chart|line-chart|bullseye|user|usd|money|thumbs-up|thumbs-down|cloud|bell|bullhorn|comments-o|envelope|globe|shopping-cart|sitemap|clock-o|crosshairs|rocket|users|mobile|tablet|adjust|dashboard|flag|flask|road|bolt|cog|leaf|magic|puzzle-piece|bug|fire|legal|trophy|pie-chart|sliders|paper-plane|life-ring|heart",
+        "<a href="#grid_column_count">grid_column_count</a>": 3|12,
         "<a href="#visibility">visibility</a>": "owner|all",
         "<a href="#editable">editable</a>": "read_only|editable_by_owner|editable_by_all",
         "<a href="#filter">filter</a>": {
@@ -407,6 +408,18 @@ For examples of these data elements being used in a JSON call, see the [Dashboar
 
       <td>
         Name of an icon from the Insights icon library.
+      </td>
+    </tr>
+
+    <tr id="grid_column_count">
+      <td>
+        `grid_column_count`
+
+        _Integer_
+      </td>
+
+      <td>
+        Specifies the number of columns in the grid layout.
       </td>
     </tr>
 


### PR DESCRIPTION
### Summary

Per [this thread](https://discuss.newrelic.com/t/100354) on the Explorers Hub community forum, a new field—`grid_column_count`—was added to the dashboard's data definition schema. For ease of consistent reference, this implementation should be reflected in the official documentation as well.

### Changes

In the following places:

* In the "Example dashboard schema" code snippet, added `"grid_column_count": 3|12`.
* In the "Dashboard data definitions" table, added data element entry for `grid_column_count`.

### To-do

Follow-up checks for the reviewer:

* Confirm whether type is actually `Integer` or some other numeric type like `Long`.
* Confirm whether values other than 3 and 12 are supported in any capacity.
* Amend the "Important" and "Caution" call-outs regarding dashboard's widget size limits and column configuration, in accordance with `grid_column_count`.


</br>
Thank you.