### PR TITLE
Use htmlAST instead of html in whats-new json

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -341,7 +341,7 @@ module.exports = {
               fields {
                 slug
               }
-              htmlAST
+              htmlAst
             }
           }
         }
@@ -360,7 +360,7 @@ module.exports = {
           return {
             announcements: data.allMarkdownRemark.nodes.map(
               ({ frontmatter, htmlAST, fields }) => {
-                const parsedHtml = htmlParser.runSync(htmlAST);
+                const parsedHtml = htmlParser.runSync(htmlAst);
                 return {
                   docsID: ids[fields.slug],
                   title: frontmatter.title,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,7 +3,7 @@ const path = require('path');
 const parse = require('rehype-parse');
 const unified = require('unified');
 const addAbsoluteImagePath = require('./rehype-plugins/utils/addAbsoluteImagePath');
-const html = require('rehype-stringify');
+const rehypeStringify = require('rehype-stringify');
 
 const siteUrl = 'https://docs.newrelic.com';
 const dataDictionaryPath = `${__dirname}/src/data-dictionary`;
@@ -341,7 +341,7 @@ module.exports = {
               fields {
                 slug
               }
-              html
+              htmlAST
             }
           }
         }
@@ -355,12 +355,12 @@ module.exports = {
           const htmlParser = unified()
             .use(parse)
             .use(addAbsoluteImagePath)
-            .use(html);
+            .use(rehypeStringify);
 
           return {
             announcements: data.allMarkdownRemark.nodes.map(
-              ({ frontmatter, html, fields }) => {
-                const parsedHtml = htmlParser.runSync(html);
+              ({ frontmatter, htmlAST, fields }) => {
+                const parsedHtml = htmlParser.runSync(htmlAST);
                 return {
                   docsID: ids[fields.slug],
                   title: frontmatter.title,

--- a/plugins/gatsby-plugin-generate-json/gatsby-node.js
+++ b/plugins/gatsby-plugin-generate-json/gatsby-node.js
@@ -5,7 +5,7 @@ exports.onPostBuild = async ({ graphql, store }, pluginOptions) => {
   const { program } = store.getState();
   const { query, serialize } = pluginOptions;
 
-  console.log(`Creating JSON for ${path}`);
+  console.log(`Creating JSON for ${filepath}`);
   const data = query
     ? serialize(await graphql(query))
     : serialize({ data: null });

--- a/plugins/gatsby-plugin-generate-json/gatsby-node.js
+++ b/plugins/gatsby-plugin-generate-json/gatsby-node.js
@@ -5,7 +5,7 @@ exports.onPostBuild = async ({ graphql, store }, pluginOptions) => {
   const { program } = store.getState();
   const { query, serialize } = pluginOptions;
 
-  console.log(`Creating JSON for ${filepath}`);
+  console.log(`Creating JSON for ${pluginOptions.path}`);
   const data = query
     ? serialize(await graphql(query))
     : serialize({ data: null });

--- a/plugins/gatsby-plugin-generate-json/gatsby-node.js
+++ b/plugins/gatsby-plugin-generate-json/gatsby-node.js
@@ -5,20 +5,17 @@ exports.onPostBuild = async ({ graphql, store }, pluginOptions) => {
   const { program } = store.getState();
   const { query, serialize } = pluginOptions;
 
-  try {
-    const data = query
-      ? serialize(await graphql(query))
-      : serialize({ data: null });
+  console.log(`Creating JSON for ${path}`);
+  const data = query
+    ? serialize(await graphql(query))
+    : serialize({ data: null });
 
-    const filepath = path.join(program.directory, 'public', pluginOptions.path);
-    const dir = path.dirname(filepath);
+  const filepath = path.join(program.directory, 'public', pluginOptions.path);
+  const dir = path.dirname(filepath);
 
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
-    }
-
-    fs.writeFileSync(filepath, JSON.stringify(data));
-  } catch (error) {
-    console.error(`Unable to fetch data for JSON: ${error}`);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
   }
+
+  fs.writeFileSync(filepath, JSON.stringify(data));
 };


### PR DESCRIPTION
## Summary 
Wasn't building because html was being used instead of htmlAST. This also now causes the build to fail if the json isn't generated, which is important because we would like to know when our json isn't being served (as some services rely on it).