### PR TITLE
PR for any tech writers: Updated TOC in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,6 @@
   - [Reusable components](#reusable-components)
   - [Editing existing pages](#editing-existing-pages)
   - [Creating new pages](#creating-new-pages)
-    - [Adding a what's new post](#adding-a-whats-new-post)
-    - [What's new post frontmatter example](#whats-new-post-frontmatter-example)
   - [Deleting pages](#deleting-pages)
   - [Updating the navigation](#updating-the-navigation)
   - [Adding a new page](#adding-a-new-page)


### PR DESCRIPTION
Previously, I had removed the "What's new?" section out of Contributing.md and into the style guide. Alas, I forgot to remove the manual table of contents entries. So, I just removed the following TOC entries:

    - [Adding a what's new post](#adding-a-whats-new-post)
    - [What's new post frontmatter example](#whats-new-post-frontmatter-example)

