### PR TITLE
Hero edit: Corrected two links in "Manage synthetic monitors via REST API"

### DIFF
--- a/src/content/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api.mdx
+++ b/src/content/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api.mdx
@@ -148,7 +148,7 @@ These are the [monitor types](/docs/synthetics/new-relic-synthetics/using-monito
 
 To use the [Synthetics REST API](/docs/apis/synthetics-rest-api), you must have the ability to manage synthetics monitors and use a [user key](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key) (the REST API key won't work).
 
-This API can be used for all Synthetics monitors. (Additional API methods for [scripted browser and API test monitors](/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-via-rest-api#scripted-api-monitors-api) are also available to update the script associated with those monitors.) All Synthetics data is available via the API. API examples show cURL commands.
+This API can be used for all Synthetics monitors. (Additional API methods for [scripted browser and API test monitors](#scripted-api-monitors-api) are also available to update the script associated with those monitors.) All Synthetics data is available via the API. API examples show cURL commands.
 
 For US-based accounts, use the following endpoint:
 
@@ -285,7 +285,7 @@ https://synthetics.eu.newrelic.com/synthetics/api
     }
     ```
 
-    In addition, to **add the script for a scripted monitor** via the REST API, call an [additional API endpoint](/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitor-scripts-rest-api) to send the script for the monitor just created. If you are using private locations with [verified script execution](/docs/synthetics/new-relic-synthetics/private-locations/verified-script-execution-private-locations) enabled, see [script locations with verified script execution](#scriptlocations).
+    In addition, to **add the script for a scripted monitor** via the REST API, call an [additional API endpoint](#scripted-api-monitors-api) to send the script for the monitor just created. If you are using private locations with [verified script execution](/docs/synthetics/new-relic-synthetics/private-locations/verified-script-execution-private-locations) enabled, see [script locations with verified script execution](#scriptlocations).
 
     Replace the [Synthetics REST API attributes](/docs/apis/synthetics-rest-api/monitor-examples/payload-attributes-synthetics-rest-api) in the following example with your specific values:
 

--- a/src/data/whats-new-ids.json
+++ b/src/data/whats-new-ids.json
@@ -45,5 +45,6 @@
   "/whats-new/2021/02/data-dropping-update-now-drop-entire-dimensional-metrics": "42366",
   "/whats-new/2021/01/new-python-agent-features": "42376",
   "/whats-new/2021/02/nerdlog-featured-weekly-releases": "42671",
-  "/whats-new/2021/02/new-relic-explorer-say-goodbye-blindspots": "42681"
+  "/whats-new/2021/02/new-relic-explorer-say-goodbye-blindspots": "42681",
+  "/whats-new/2021/02/nerdlog-weekly-roundup": "42682"
 }


### PR DESCRIPTION
Two links in this doc had problems: they were pointing to the same doc. I confirmed with Brian Peck that these two links should point to a lower section in the same doc called “Script API for scripted browser and API test monitors.”

Also, this commit included a bonus change that I didn't create for `src > data > whats-new-ids.json`.   @jerelmiller said I should commit this. 