### PR TITLE
Add missing ruby release notes redirect 

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/index.mdx
@@ -3,4 +3,5 @@ subject: Ruby agent
 redirects:
   - /docs/releases/ruby
   - /docs/agents/ruby-agent/getting-started/ruby-release-notes
+  - /docs/release-notes/apm-agent-release-notes/ruby-release-notes
 ---


### PR DESCRIPTION
### Tell us why

The ruby release notes page was missing a redirect. This issue was posted in the #documentation channel