### PR TITLE
Add redirect to browser API page

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action.mdx
@@ -11,7 +11,6 @@ redirects:
   - /docs/browser/new-relic-browser/browser-agent-apis/browser-api-newrelicaddpageaction
   - /docs/browser/new-relic-browser/browser-agent-api/browser-api-newrelicaddpageaction
   - /docs/browser/new-relic-browser/browser-agent-spa-api/newrelicaddpageaction-browser-agent-api
-  - /docs/browser/browser-monitoring/browser-agent-spa-api
 ---
 
 ## Syntax

--- a/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action.mdx
@@ -11,6 +11,7 @@ redirects:
   - /docs/browser/new-relic-browser/browser-agent-apis/browser-api-newrelicaddpageaction
   - /docs/browser/new-relic-browser/browser-agent-api/browser-api-newrelicaddpageaction
   - /docs/browser/new-relic-browser/browser-agent-spa-api/newrelicaddpageaction-browser-agent-api
+  - /docs/browser/browser-monitoring/browser-agent-spa-api
 ---
 
 ## Syntax

--- a/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/index.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/index.mdx
@@ -17,4 +17,5 @@ redirects:
   - /docs/browser/new-relic-browser/browser-agent-apis
   - /docs/browser/new-relic-browser/browser-agent-spa-api/view-all-methods
   - /docs/browser/new-relic-browser/browser-agent-spa-ap
+  - /docs/browser/browser-monitoring/browser-agent-spa-api
 ---


### PR DESCRIPTION
### Tell us why

When Googling "New Relic Browser API" and clicking on the first result, I'm taken to a page at https://docs.newrelic.com/docs/browser/browser-monitoring/browser-agent-spa-api, which results in a 404. This page lives at https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api. This PR adds the necessary redirect to ensure the page does not 404.
