### PR TITLE
Ensure srcset property uses absolute image path

### DIFF
--- a/rehype-plugins/utils/addAbsoluteImagePath.js
+++ b/rehype-plugins/utils/addAbsoluteImagePath.js
@@ -1,13 +1,19 @@
 const visit = require('unist-util-visit');
 const is = require('hast-util-is-element');
-const DOCS_SITE_URL = 'https://docs.newrelic.com';
+
+const prependSiteUrl = (src) => `https://docs.newrelic.com${src}`;
 
 const addAbsoluteImagePath = () => (tree) => {
   visit(
     tree,
     (node) => is(node, 'img'),
     (img) => {
-      img.properties.src = `${DOCS_SITE_URL}${img.properties.src}`;
+      img.properties.src = prependSiteUrl(img.properties.src);
+      img.properties.srcSet = (img.properties.srcSet || []).map((entry) => {
+        const [src, size] = entry.split(' ');
+
+        return [prependSiteUrl(src), size].join(' ');
+      });
     }
   );
 };


### PR DESCRIPTION
Closes #1125 

### Tell us why

The `src` attribute on images has been fixed on What's new posts, but the `srcset` property is still using relative paths. Browsers that support this property are still showing a broken images. This PR ensures the `srcset` is updated to use the absolute images URLs.
