### PR TITLE
chore: added gitub action for issue routing

### DIFF
--- a/.github/workflows/issue-pr-triage.yml
+++ b/.github/workflows/issue-pr-triage.yml
@@ -1,0 +1,34 @@
+name: Auto-triage to project boards
+
+on:
+  issues:
+    types: [opened, labeled]
+  pull_request:
+    types: [opened, labeled]
+
+jobs:
+  content_project:
+    runs-on: ubuntu-latest
+    name: Triage to Content Project
+    steps:
+    - name: Triages NEW issues and NEW pull requests to the Content Project
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      if: |
+        contains(github.event.issue.labels.*.name, 'content') ||
+        contains(github.event.pull_request.labels.*.name, 'content')
+      with:
+        project: 'https://github.com/newrelic/docs-website/projects/3'
+        column_name: 'Needs Triage'
+
+  localization_project:
+    runs-on: ubuntu-latest
+    name: Triages to Localization Project
+    steps:
+    - name: Triages NEW issues and NEW pull requests to the Localization Project
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      if: |
+        contains(github.event.issue.labels.*.name, 'localization') ||
+        contains(github.event.pull_request.labels.*.name, 'localization')
+      with:
+        project: 'https://github.com/orgs/newrelic/projects/47/'
+        column_name: 'Needs Triage'


### PR DESCRIPTION
This PR is to add a github action to route issues and prs with labels of `content` or `localization` to the correct boards. 

I tested using [act](https://github.com/nektos/act) and when running 

act  issues and act pull_request  the action ran ok, but threw this error, which I thought was related to the fact no label was passed in my test, if there are better ways to test this just let me know.

[Auto-triage to project boards/Triage to Content Project      ]   ❌  Error in if: expression - Triages NEW issues and NEW pull requests to the Content Project
Error: TypeError: Cannot access member 'labels' of undefined