### PR TITLE
Create redirects for data dictionary event pages

### DIFF
--- a/plugins/gatsby-source-data-dictionary/gatsby-node.js
+++ b/plugins/gatsby-source-data-dictionary/gatsby-node.js
@@ -118,6 +118,14 @@ exports.sourceNodes = (
         return id;
       });
 
+    createRedirect({
+      fromPath: `/attribute-dictionary/${event.name.toLowerCase()}`,
+      toPath: `/attribute-dictionary/?event=${event.name}`,
+      isPermanent: true,
+      redirectInBrowser: true,
+      trailingSlash: false,
+    });
+
     createNode({
       ...event,
       id: createNodeId(`DataDictionaryEvent-${event.name}`),


### PR DESCRIPTION
Closes #1087

### Tell us why

Search results still yield links to individual data dictionary event pages. This PR adds redirects for `/attribute-dictionary/<event-name>` URLs to the new attribute dictionary page. We currently have them in place for attributes but forgot to add them for events themselves.
