### PR TITLE
Adding missing agent RN redirects

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
@@ -3,4 +3,5 @@ subject: C SDK
 redirects:
   - /docs/release-notes/agent-release-notes/c-release-notes
   - /docs/agents/c-sdk/get-started/c-sdk-release-notes
+  - /docs/release-notes/apm-agent-release-notes/c-sdk-release-notes
 ---

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/index.mdx
@@ -2,4 +2,6 @@
 subject: Go agent
 redirects:
   - /docs/agents/go-agent/get-started/go-agent-release-notes
+  - /docs/release-notes/apm-agent-release-notes/go-agent-release-notes
+  - /docs/release-notes/apm-agent-release-notes/go-release-notes
 ---

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/index.mdx
@@ -3,4 +3,5 @@ subject: Java agent
 redirects:
   - /docs/releases/java
   - /docs/agents/java-agent/getting-started/java-release-notes
+  - /docs/release-notes/apm-agent-release-notes/java-release-notes
 ---

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/index.mdx
@@ -3,4 +3,5 @@ subject: .NET agent
 redirects:
   - /docs/releases/dotnet
   - /docs/agents/net-agent/getting-started/net-release-notes
+  - /docs/release-notes/apm-agent-release-notes/net-release-notes
 ---

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/index.mdx
@@ -3,4 +3,5 @@ subject: Node.js agent
 redirects:
   - /docs/releases/node
   - /docs/agents/nodejs-agent/getting-started/nodejs-release-notes
+  - /docs/release-notes/apm-agent-release-notes/nodejs-release-notes
 ---

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/index.mdx
@@ -3,4 +3,5 @@ subject: PHP agent
 redirects:
   - /docs/releases/php
   - /docs/agents/php-agent/getting-started/php-agent-release-notes
+  - /docs/release-notes/apm-agent-release-notes/php-release-notes
 ---

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/index.mdx
@@ -4,4 +4,5 @@ redirects:
   - /docs/releases/python
   - /docs/agents/python-agent/getting-started/python-release-notes
   - /docs/python/python-agent-release-notes
+  - /docs/release-notes/apm-agent-release-notes/python-release-notes
 ---

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/index.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/index.mdx
@@ -3,4 +3,5 @@ subject: Browser agent
 redirects:
   - /docs/release-notes/browser-agent-release-notes
   - /docs/browser/new-relic-browser/getting-started/browser-agent-release-notes
+  - /docs/release-notes/browser-release-notes/browser-agent-release-notes
 ---


### PR DESCRIPTION
### Tell us why

Someone reported in #documentation that the old root/index pages for agent release notes are missing redirects. 

I found the new URLs by playing around in the old Drupal-based docs-dev site.

Opening as draft because I still need to test the redirects locally.