### PR TITLE
Sentence case attribute dictionary

### DIFF
--- a/src/nav/attribute-dictionary.yml
+++ b/src/nav/attribute-dictionary.yml
@@ -1,4 +1,4 @@
-title: Attribute Dictionary
+title: Attribute dictionary
 path: /attribute-dictionary
 filterable: false
 pages:


### PR DESCRIPTION
Please test this locally! I tested locally but it's a big enough change I think a second set of eyes would be goodl.

### Tell us why

Taxonomy names should be lower case.