### PR TITLE
chore: added Gh token to action

### DIFF
--- a/.github/workflows/issue-pr-triage.yml
+++ b/.github/workflows/issue-pr-triage.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, labeled]
 
+env:
+  GITHUB_TOKEN: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
+
 jobs:
   content_project:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds the github opensource_bot_token to the github action in order for the action to work correctly.