### PR TITLE
Provides wrapper around buttons in mdx docs

### DIFF
--- a/src/components/MDXButton.js
+++ b/src/components/MDXButton.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import { Button } from '@newrelic/gatsby-theme-newrelic';
+
+const ALIGNMENTS = {
+  LEFT: 'left',
+  CENTER: 'center',
+  INLINE: 'inline',
+};
+
+const styles = {
+  alignment: {
+    [ALIGNMENTS.CENTER]: css`
+      justify-content: center;
+    `,
+    [ALIGNMENTS.LEFT]: css`
+      justify-content: flex-start;
+    `,
+  },
+};
+
+const MDXButton = ({ alignment = 'center', ...props }) => {
+  if (alignment === ALIGNMENTS.INLINE) {
+    return <Button {...props} />;
+  }
+
+  return (
+    <div
+      css={css`
+        display: flex;
+        &:not(:last-child) {
+          margin-bottom: 1rem;
+        }
+        ${styles.alignment[alignment]}
+      `}
+    >
+      <Button {...props} />
+    </div>
+  );
+};
+MDXButton.ALIGNMENT = ALIGNMENTS;
+
+MDXButton.propTypes = {
+  alignment: PropTypes.oneOf(Object.values(MDXButton.ALIGNMENT)),
+};
+
+export default MDXButton;

--- a/src/components/MDXButton.js
+++ b/src/components/MDXButton.js
@@ -27,12 +27,11 @@ const MDXButton = ({ alignment = 'center', ...props }) => {
 
   return (
     <div
+      className="MDXButton"
       css={css`
         display: flex;
-        &:not(:last-child) {
-          margin-bottom: 1rem;
-        }
         ${styles.alignment[alignment]}
+        margin-bottom: 2rem;
       `}
     >
       <Button {...props} />

--- a/src/components/MDXButtonGroup.js
+++ b/src/components/MDXButtonGroup.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+
+const ALIGNMENTS = {
+  CENTER: 'center',
+  LEFT: 'left',
+};
+const DIRECTIONS = {
+  ROW: 'row',
+  COLUMN: 'column',
+};
+
+const MDXButtonGroup = ({
+  children,
+  alignment = 'center',
+  direction = 'row',
+}) => {
+  return (
+    <div
+      css={css`
+        display: flex;
+        ${styles.alignment[alignment]}
+        ${styles.direction[direction]}
+        div {
+          display: block;
+        }
+      `}
+    >
+      {children}
+    </div>
+  );
+};
+
+const styles = {
+  alignment: {
+    [ALIGNMENTS.CENTER]: css`
+      justify-content: center;
+    `,
+    [ALIGNMENTS.LEFT]: css`
+      justify-content: flex-start;
+    `,
+  },
+  direction: {
+    [DIRECTIONS.ROW]: css`
+      flex-direction: row;
+      align-items: baseline;
+      div {
+        margin-left: 0.5rem;
+        margin-right: 0.5rem;
+      }
+    `,
+    [DIRECTIONS.COLUMN]: css`
+      flex-direction: column;
+      div {
+        &:not(:last-child) {
+          margin-bottom: 1rem;
+        }
+      }
+    `,
+  },
+};
+
+MDXButtonGroup.ALIGNMENT = ALIGNMENTS;
+MDXButtonGroup.DIRECTION = DIRECTIONS;
+
+MDXButtonGroup.propTypes = {
+  alignment: PropTypes.oneOf(Object.values(MDXButtonGroup.ALIGNMENT)),
+  direction: PropTypes.oneOf(Object.values(MDXButtonGroup.DIRECTION)),
+  children: PropTypes.node.isRequired,
+};
+
+export default MDXButtonGroup;

--- a/src/components/MDXContainer.js
+++ b/src/components/MDXContainer.js
@@ -5,12 +5,14 @@ import {
   MarkdownContainer,
   MDX,
   ExternalLink,
+  Link,
 } from '@newrelic/gatsby-theme-newrelic';
 import LandingPageHero from './LandingPageHero';
 import LandingPageTile from './LandingPageTile';
 import LandingPageTileGrid from './LandingPageTileGrid';
 import TechTile from './TechTile';
 import MDXTechTileGrid from './MDXTechTileGrid';
+import MDXButton from './MDXButton';
 
 const defaultComponents = {
   ExternalLink: (props) => (
@@ -22,6 +24,8 @@ const defaultComponents = {
   LandingPageTileGrid,
   TechTile,
   TechTileGrid: MDXTechTileGrid,
+  Button: MDXButton,
+  ButtonLink: (props) => <MDXButton as={Link} {...props} />,
 };
 
 const MDXContainer = ({ body, children, components }) => {

--- a/src/components/MDXContainer.js
+++ b/src/components/MDXContainer.js
@@ -13,6 +13,7 @@ import LandingPageTileGrid from './LandingPageTileGrid';
 import TechTile from './TechTile';
 import MDXTechTileGrid from './MDXTechTileGrid';
 import MDXButton from './MDXButton';
+import MDXButtonGroup from './MDXButtonGroup';
 
 const defaultComponents = {
   ExternalLink: (props) => (
@@ -26,6 +27,7 @@ const defaultComponents = {
   TechTileGrid: MDXTechTileGrid,
   Button: MDXButton,
   ButtonLink: (props) => <MDXButton as={Link} {...props} />,
+  ButtonGroup: MDXButtonGroup,
 };
 
 const MDXContainer = ({ body, children, components }) => {

--- a/src/content/docs/agents/c-sdk/get-started/introduction-c-sdk.mdx
+++ b/src/content/docs/agents/c-sdk/get-started/introduction-c-sdk.mdx
@@ -131,6 +131,7 @@ To use our C SDK agent:
 2. If you do not already have one, [sign up for a free New Relic account](https://newrelic.com/signup).
 3. Use our launcher, or follow the [installation and instrumentation procedures](/docs/install-c-sdk-compile-link-your-code) to install the agent. Within a few minutes, you will be able to view data from your application in your New Relic account's UI.
 
+<ButtonGroup>
 <ButtonLink
   role="button"
   to="/docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code"
@@ -146,6 +147,7 @@ To use our C SDK agent:
 >
   Add C data
 </ButtonLink>
+</ButtonGroup>
 
 ## Check the source code [#source-code]
 

--- a/src/content/docs/agents/go-agent/get-started/introduction-new-relic-go.mdx
+++ b/src/content/docs/agents/go-agent/get-started/introduction-new-relic-go.mdx
@@ -59,6 +59,7 @@ To use New Relic for Go:
 2. If you do not already have one, [sign up for a free New Relic account](https://newrelic.com/signup).
 3. To install the agent, use our launcher, or follow the New Relic Go agent's [installation and instrumentation procedures](/docs/agents/go-agent/get-started/get-new-relic-go). Wait a few minutes to view data from your Go app in your New Relic account's UI.
 
+<ButtonGroup>
 <ButtonLink
   role="button"
   to="/docs/agents/go-agent/installation/install-new-relic-go"
@@ -74,6 +75,7 @@ To use New Relic for Go:
 >
   Add Go data
 </ButtonLink>
+</ButtonGroup>
 
 We recommend [instrumenting your Go code](/docs/agents/go-agent/instrumentation) to get the maximum benefits from the New Relic Go agent. But we make it easy to get great data in couple of ways:
 

--- a/src/content/docs/agents/java-agent/getting-started/introduction-new-relic-java.mdx
+++ b/src/content/docs/agents/java-agent/getting-started/introduction-new-relic-java.mdx
@@ -27,6 +27,7 @@ To use the Java agent:
 2. [Sign up](/docs/accounts-partnerships/accounts/account-setup/creating-your-new-relic-account) for a New Relic account.
 3. Install the Java agent using our launcher, or by following the [standard installation procedures](/docs/agents/java-agent/installation/java-agent-manual-installation). Depending on your tools and frameworks, refer to [additional installation procedures](/docs/agents/java-agent/additional-installation) to install or configure the Java agent.
 
+<ButtonGroup>
 <ButtonLink
   role="button"
   to="/docs/agents/java-agent/installation/install-java-agent"
@@ -42,6 +43,7 @@ To use the Java agent:
 >
   Add Java data
 </ButtonLink>
+</ButtonGroup>
 
 To [view your app's performance in the New Relic UI](/docs/apm/applications-menu/monitoring/apm-overview-page), go to **[https://one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Summary**. The APM user interface includes a dedicated [**JVM metrics** page](/docs/agents/java-agent/features/jvm-metrics-page), [transaction](/docs/apm/transactions) and [error](/docs/apm/applications-menu/error-analytics/introduction-error-analytics) details, a [thread profiler tool](/docs/apm/applications-menu/events/thread-profiler-tool) to sample Java threads and report stack traces, and [more](/docs/apm/applications-menu).
 

--- a/src/content/docs/agents/python-agent/getting-started/introduction-new-relic-python.mdx
+++ b/src/content/docs/agents/python-agent/getting-started/introduction-new-relic-python.mdx
@@ -18,10 +18,7 @@ Our Python agent monitors your Python application to help you identify and solve
 Our Python works with a wide variety of [web frameworks and hosting mechanisms](/docs/agents/python-agent/getting-started/instrumented-python-packages), including Django, Gunicorn, WSGI, CherryPy, uWSGI, and more. You can also install the Python agent in a [Google App Engine flexible environment](/docs/agents/python-agent/hosting-services/install-new-relic-python-agent-gae-flexible-environment).
 
 <Callout variant="tip">
-  To use Python or any other agent, as well as the rest of our [observability
-  platform](https://one.newrelic.com), join the New Relic family! [Sign
-  up](https://newrelic.com/signup) to create your free account in only a few
-  seconds. Then ingest up to 100GB of data for free each month. Forever.
+  To use Python or any other agent, as well as the rest of our [observability platform](https://one.newrelic.com), join the New Relic family! [Sign up](https://newrelic.com/signup) to create your free account in only a few seconds. Then ingest up to 100GB of data for free each month. Forever.
 </Callout>
 
 ## Monitor app performance [#monitor-performance]
@@ -30,24 +27,24 @@ After you [install](#installation) the Python agent, it begins to collect data a
 
 **View the big picture of your app.**
 
-- Monitor your app's [Apdex (user satisfaction)](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction).
-- Get a high-level summary of your app with [Summary page](/docs/apm/applications-menu/monitoring/apm-overview-page).
-- Enable [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) to see activity across an architecture having many services.
-- Install [Infrastructure monitoring](/docs/infrastructure/new-relic-infrastructure/getting-started/introduction-new-relic-infrastructure) and view detailed server/host data for your app.
+* Monitor your app's [Apdex (user satisfaction)](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction).
+* Get a high-level summary of your app with [Summary page](/docs/apm/applications-menu/monitoring/apm-overview-page).
+* Enable [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) to see activity across an architecture having many services.
+* Install [Infrastructure monitoring](/docs/infrastructure/new-relic-infrastructure/getting-started/introduction-new-relic-infrastructure) and view detailed server/host data for your app.
 
 **Find errors and problems quickly.**
 
-- Track [key transactions](/docs/apm/transactions/key-transactions/key-transactions-tracking-important-transactions-or-events) specific to your business.
-- Create [custom dashboards](/docs/dashboards/new-relic-dashboards/custom-dashboards/custom-dashboards) for important metrics.
-- [Alert](/docs/alerts/alert-policies/understanding-alert-policies/alerting-new-relic) your team when an error or problem occurs before it affects your users.
-- View performance [after a deployment](/docs/apm/applications-menu/events/deployments-page).
+* Track [key transactions](/docs/apm/transactions/key-transactions/key-transactions-tracking-important-transactions-or-events) specific to your business.
+* Create [custom dashboards](/docs/dashboards/new-relic-dashboards/custom-dashboards/custom-dashboards) for important metrics.
+* [Alert](/docs/alerts/alert-policies/understanding-alert-policies/alerting-new-relic) your team when an error or problem occurs before it affects your users.
+* View performance [after a deployment](/docs/apm/applications-menu/events/deployments-page).
 
 **Drill down into performance details.**
 
-- Examine code-level [transaction traces](/docs/apm/transactions/transaction-traces/transaction-traces).
-- Examine [database query traces](/apm/transactions/transaction-traces/troubleshoot-sql-statements).
-- Examine [error traces](/docs/apm/applications-menu/events/view-apm-error-analytics).
-- Use [thread profiler sessions](/docs/apm/applications-menu/events/thread-profiler-tool) to see detailed stack traces of sampled threads
+* Examine code-level [transaction traces](/docs/apm/transactions/transaction-traces/transaction-traces).
+* Examine [database query traces](/apm/transactions/transaction-traces/troubleshoot-sql-statements).
+* Examine [error traces](/docs/apm/applications-menu/events/view-apm-error-analytics).
+* Use [thread profiler sessions](/docs/apm/applications-menu/events/thread-profiler-tool) to see detailed stack traces of sampled threads
 
 Other helpful tools include:
 
@@ -62,7 +59,6 @@ Other helpful tools include:
         **Description**
       </th>
     </tr>
-
   </thead>
 
   <tbody>
@@ -100,7 +96,6 @@ Other helpful tools include:
         * Create and share customizable, interactive [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards).
       </td>
     </tr>
-
   </tbody>
 </table>
 
@@ -115,8 +110,6 @@ For a quick and simple install process that will work for the majority of setups
 1. Download and install the Python package.
 2. Create config file.
 3. Integrate the Python agent with your application.
-
-<ButtonGroup>
 
 <ButtonLink
   role="button"
@@ -134,8 +127,6 @@ For a quick and simple install process that will work for the majority of setups
   Add Python data
 </ButtonLink>
 
-</ButtonGroup>
-
 ## Monitor non-web scripts, background tasks, and functions [#non-web]
 
 The Python agent also lets you monitor non-web scripts, worker processes, tasks, and functions. The installation process for these non-web transactions is similar to the one used for a web app, with one major difference: instead of going through the standard integration process described in the [install instructions](/docs/agents/python-agent/getting-started/python-agent-quick-start), you would manually "wrap" any function you want to monitor. For more information, see [Non-web tasks and processes](/docs/agents/python-agent/supported-features/python-background-tasks). For instructions on monitoring Celery tasks, see [Celery background tasks](/docs/agents/python-agent/back-end-services/python-agent-celery).
@@ -144,20 +135,20 @@ The Python agent also lets you monitor non-web scripts, worker processes, tasks,
 
 Once you get the agent up and running, some suggested next steps are:
 
-- Explore your data in and get comfortable with the user interface.
-- Read some documentation about Full-Stack Observability. For example, read about the capabilities of [Full-Stack observability](/docs/full-stack-observability/monitor-everything/get-started-new-relic-monitoring-tools/get-started-full-stack-observability) and the [APM page](/docs/apm).
-- [Change your application's name](/docs/agents/manage-apm-agents/app-naming/rename-your-application), or other [configuration options](/docs/agents/python-agent/installation-configuration/python-agent-configuration).
-- Learn about setting up [custom instrumentation](/docs/agents/python-agent/custom-instrumentation/python-custom-instrumentation) for application activity not monitored by default.
-- Consider these open source telemetry tools: [OpenCensus exporter](/docs/integrations/open-source-telemetry-integrations/open-source-telemetry-integration-list/new-relics-opencensus-integration) and [Python Telemetry SDK](/docs/data-ingest-apis/get-data-new-relic/new-relic-sdks/telemetry-sdks-send-custom-telemetry-data-new-relic).
+* Explore your data in and get comfortable with the user interface.
+* Read some documentation about Full-Stack Observability. For example, read about the capabilities of [Full-Stack observability](/docs/full-stack-observability/monitor-everything/get-started-new-relic-monitoring-tools/get-started-full-stack-observability) and the [APM page](/docs/apm).
+* [Change your application's name](/docs/agents/manage-apm-agents/app-naming/rename-your-application), or other [configuration options](/docs/agents/python-agent/installation-configuration/python-agent-configuration).
+* Learn about setting up [custom instrumentation](/docs/agents/python-agent/custom-instrumentation/python-custom-instrumentation) for application activity not monitored by default.
+* Consider these open source telemetry tools: [OpenCensus exporter](/docs/integrations/open-source-telemetry-integrations/open-source-telemetry-integration-list/new-relics-opencensus-integration) and [Python Telemetry SDK](/docs/data-ingest-apis/get-data-new-relic/new-relic-sdks/telemetry-sdks-send-custom-telemetry-data-new-relic).
 
 ## Troubleshooting
 
 After you complete the install process, your data should appear in the [APM UI](/docs/apm/applications-menu/monitoring/apm-overview-page) within five minutes. If it does not, use these troubleshooting resources:
 
-- If no data appears, follow these [troubleshooting steps](/docs/agents/python-agent/troubleshooting/no-data-appears-python).
-- If you experience issues when installing or running the Python agent on a new host, [test that the package is installed correctly](/docs/agents/python-agent/installation-configuration/testing-python-agent) and that it can contact New Relic's data collector service.
-- For other problems, see the [full list of troubleshooting documentation](/docs/agents/python-agent/troubleshooting/).
+* If no data appears, follow these [troubleshooting steps](/docs/agents/python-agent/troubleshooting/no-data-appears-python).
+* If you experience issues when installing or running the Python agent on a new host, [test that the package is installed correctly](/docs/agents/python-agent/installation-configuration/testing-python-agent) and that it can contact New Relic's data collector service.
+* For other problems, see the [full list of troubleshooting documentation](/docs/agents/python-agent/troubleshooting/).
 
 ## Check the source code [#source-code]
 
-The Python agent is open source software. That means you can [browse its source code](https://github.com/newrelic/newrelic-python-agent 'Link opens in a new window.') and send improvements, or create your own fork and build it. For more information, see the [README](https://github.com/newrelic/newrelic-python-agent/blob/main/README.rst 'Link opens in a new window.').
+The Python agent is open source software. That means you can [browse its source code](https://github.com/newrelic/newrelic-python-agent "Link opens in a new window.") and send improvements, or create your own fork and build it. For more information, see the [README](https://github.com/newrelic/newrelic-python-agent/blob/main/README.rst "Link opens in a new window.").

--- a/src/content/docs/agents/python-agent/getting-started/introduction-new-relic-python.mdx
+++ b/src/content/docs/agents/python-agent/getting-started/introduction-new-relic-python.mdx
@@ -18,7 +18,10 @@ Our Python agent monitors your Python application to help you identify and solve
 Our Python works with a wide variety of [web frameworks and hosting mechanisms](/docs/agents/python-agent/getting-started/instrumented-python-packages), including Django, Gunicorn, WSGI, CherryPy, uWSGI, and more. You can also install the Python agent in a [Google App Engine flexible environment](/docs/agents/python-agent/hosting-services/install-new-relic-python-agent-gae-flexible-environment).
 
 <Callout variant="tip">
-  To use Python or any other agent, as well as the rest of our [observability platform](https://one.newrelic.com), join the New Relic family! [Sign up](https://newrelic.com/signup) to create your free account in only a few seconds. Then ingest up to 100GB of data for free each month. Forever.
+  To use Python or any other agent, as well as the rest of our [observability
+  platform](https://one.newrelic.com), join the New Relic family! [Sign
+  up](https://newrelic.com/signup) to create your free account in only a few
+  seconds. Then ingest up to 100GB of data for free each month. Forever.
 </Callout>
 
 ## Monitor app performance [#monitor-performance]
@@ -27,24 +30,24 @@ After you [install](#installation) the Python agent, it begins to collect data a
 
 **View the big picture of your app.**
 
-* Monitor your app's [Apdex (user satisfaction)](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction).
-* Get a high-level summary of your app with [Summary page](/docs/apm/applications-menu/monitoring/apm-overview-page).
-* Enable [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) to see activity across an architecture having many services.
-* Install [Infrastructure monitoring](/docs/infrastructure/new-relic-infrastructure/getting-started/introduction-new-relic-infrastructure) and view detailed server/host data for your app.
+- Monitor your app's [Apdex (user satisfaction)](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction).
+- Get a high-level summary of your app with [Summary page](/docs/apm/applications-menu/monitoring/apm-overview-page).
+- Enable [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) to see activity across an architecture having many services.
+- Install [Infrastructure monitoring](/docs/infrastructure/new-relic-infrastructure/getting-started/introduction-new-relic-infrastructure) and view detailed server/host data for your app.
 
 **Find errors and problems quickly.**
 
-* Track [key transactions](/docs/apm/transactions/key-transactions/key-transactions-tracking-important-transactions-or-events) specific to your business.
-* Create [custom dashboards](/docs/dashboards/new-relic-dashboards/custom-dashboards/custom-dashboards) for important metrics.
-* [Alert](/docs/alerts/alert-policies/understanding-alert-policies/alerting-new-relic) your team when an error or problem occurs before it affects your users.
-* View performance [after a deployment](/docs/apm/applications-menu/events/deployments-page).
+- Track [key transactions](/docs/apm/transactions/key-transactions/key-transactions-tracking-important-transactions-or-events) specific to your business.
+- Create [custom dashboards](/docs/dashboards/new-relic-dashboards/custom-dashboards/custom-dashboards) for important metrics.
+- [Alert](/docs/alerts/alert-policies/understanding-alert-policies/alerting-new-relic) your team when an error or problem occurs before it affects your users.
+- View performance [after a deployment](/docs/apm/applications-menu/events/deployments-page).
 
 **Drill down into performance details.**
 
-* Examine code-level [transaction traces](/docs/apm/transactions/transaction-traces/transaction-traces).
-* Examine [database query traces](/apm/transactions/transaction-traces/troubleshoot-sql-statements).
-* Examine [error traces](/docs/apm/applications-menu/events/view-apm-error-analytics).
-* Use [thread profiler sessions](/docs/apm/applications-menu/events/thread-profiler-tool) to see detailed stack traces of sampled threads
+- Examine code-level [transaction traces](/docs/apm/transactions/transaction-traces/transaction-traces).
+- Examine [database query traces](/apm/transactions/transaction-traces/troubleshoot-sql-statements).
+- Examine [error traces](/docs/apm/applications-menu/events/view-apm-error-analytics).
+- Use [thread profiler sessions](/docs/apm/applications-menu/events/thread-profiler-tool) to see detailed stack traces of sampled threads
 
 Other helpful tools include:
 
@@ -59,6 +62,7 @@ Other helpful tools include:
         **Description**
       </th>
     </tr>
+
   </thead>
 
   <tbody>
@@ -96,6 +100,7 @@ Other helpful tools include:
         * Create and share customizable, interactive [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards).
       </td>
     </tr>
+
   </tbody>
 </table>
 
@@ -110,6 +115,8 @@ For a quick and simple install process that will work for the majority of setups
 1. Download and install the Python package.
 2. Create config file.
 3. Integrate the Python agent with your application.
+
+<ButtonGroup>
 
 <ButtonLink
   role="button"
@@ -127,6 +134,8 @@ For a quick and simple install process that will work for the majority of setups
   Add Python data
 </ButtonLink>
 
+</ButtonGroup>
+
 ## Monitor non-web scripts, background tasks, and functions [#non-web]
 
 The Python agent also lets you monitor non-web scripts, worker processes, tasks, and functions. The installation process for these non-web transactions is similar to the one used for a web app, with one major difference: instead of going through the standard integration process described in the [install instructions](/docs/agents/python-agent/getting-started/python-agent-quick-start), you would manually "wrap" any function you want to monitor. For more information, see [Non-web tasks and processes](/docs/agents/python-agent/supported-features/python-background-tasks). For instructions on monitoring Celery tasks, see [Celery background tasks](/docs/agents/python-agent/back-end-services/python-agent-celery).
@@ -135,20 +144,20 @@ The Python agent also lets you monitor non-web scripts, worker processes, tasks,
 
 Once you get the agent up and running, some suggested next steps are:
 
-* Explore your data in and get comfortable with the user interface.
-* Read some documentation about Full-Stack Observability. For example, read about the capabilities of [Full-Stack observability](/docs/full-stack-observability/monitor-everything/get-started-new-relic-monitoring-tools/get-started-full-stack-observability) and the [APM page](/docs/apm).
-* [Change your application's name](/docs/agents/manage-apm-agents/app-naming/rename-your-application), or other [configuration options](/docs/agents/python-agent/installation-configuration/python-agent-configuration).
-* Learn about setting up [custom instrumentation](/docs/agents/python-agent/custom-instrumentation/python-custom-instrumentation) for application activity not monitored by default.
-* Consider these open source telemetry tools: [OpenCensus exporter](/docs/integrations/open-source-telemetry-integrations/open-source-telemetry-integration-list/new-relics-opencensus-integration) and [Python Telemetry SDK](/docs/data-ingest-apis/get-data-new-relic/new-relic-sdks/telemetry-sdks-send-custom-telemetry-data-new-relic).
+- Explore your data in and get comfortable with the user interface.
+- Read some documentation about Full-Stack Observability. For example, read about the capabilities of [Full-Stack observability](/docs/full-stack-observability/monitor-everything/get-started-new-relic-monitoring-tools/get-started-full-stack-observability) and the [APM page](/docs/apm).
+- [Change your application's name](/docs/agents/manage-apm-agents/app-naming/rename-your-application), or other [configuration options](/docs/agents/python-agent/installation-configuration/python-agent-configuration).
+- Learn about setting up [custom instrumentation](/docs/agents/python-agent/custom-instrumentation/python-custom-instrumentation) for application activity not monitored by default.
+- Consider these open source telemetry tools: [OpenCensus exporter](/docs/integrations/open-source-telemetry-integrations/open-source-telemetry-integration-list/new-relics-opencensus-integration) and [Python Telemetry SDK](/docs/data-ingest-apis/get-data-new-relic/new-relic-sdks/telemetry-sdks-send-custom-telemetry-data-new-relic).
 
 ## Troubleshooting
 
 After you complete the install process, your data should appear in the [APM UI](/docs/apm/applications-menu/monitoring/apm-overview-page) within five minutes. If it does not, use these troubleshooting resources:
 
-* If no data appears, follow these [troubleshooting steps](/docs/agents/python-agent/troubleshooting/no-data-appears-python).
-* If you experience issues when installing or running the Python agent on a new host, [test that the package is installed correctly](/docs/agents/python-agent/installation-configuration/testing-python-agent) and that it can contact New Relic's data collector service.
-* For other problems, see the [full list of troubleshooting documentation](/docs/agents/python-agent/troubleshooting/).
+- If no data appears, follow these [troubleshooting steps](/docs/agents/python-agent/troubleshooting/no-data-appears-python).
+- If you experience issues when installing or running the Python agent on a new host, [test that the package is installed correctly](/docs/agents/python-agent/installation-configuration/testing-python-agent) and that it can contact New Relic's data collector service.
+- For other problems, see the [full list of troubleshooting documentation](/docs/agents/python-agent/troubleshooting/).
 
 ## Check the source code [#source-code]
 
-The Python agent is open source software. That means you can [browse its source code](https://github.com/newrelic/newrelic-python-agent "Link opens in a new window.") and send improvements, or create your own fork and build it. For more information, see the [README](https://github.com/newrelic/newrelic-python-agent/blob/main/README.rst "Link opens in a new window.").
+The Python agent is open source software. That means you can [browse its source code](https://github.com/newrelic/newrelic-python-agent 'Link opens in a new window.') and send improvements, or create your own fork and build it. For more information, see the [README](https://github.com/newrelic/newrelic-python-agent/blob/main/README.rst 'Link opens in a new window.').

--- a/src/content/docs/agents/python-agent/getting-started/introduction-new-relic-python.mdx
+++ b/src/content/docs/agents/python-agent/getting-started/introduction-new-relic-python.mdx
@@ -111,6 +111,7 @@ For a quick and simple install process that will work for the majority of setups
 2. Create config file.
 3. Integrate the Python agent with your application.
 
+<ButtonGroup>
 <ButtonLink
   role="button"
   to="/docs/agents/python-agent/getting-started/python-agent-quick-start"
@@ -126,6 +127,7 @@ For a quick and simple install process that will work for the majority of setups
 >
   Add Python data
 </ButtonLink>
+</ButtonGroup>
 
 ## Monitor non-web scripts, background tasks, and functions [#non-web]
 

--- a/src/content/docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby.mdx
+++ b/src/content/docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby.mdx
@@ -62,6 +62,7 @@ Use the Ruby agent to organize, query, and visualize your data to answer key que
 
 After creating a [New Relic account](/docs/subscriptions/creating-your-new-relic-account), use our launcher or see the installation instructions.
 
+<ButtonGroup>
 <ButtonLink
   role="button"
   to="/docs/agents/ruby-agent/installation/install-new-relic-ruby-agent"
@@ -85,6 +86,7 @@ After creating a [New Relic account](/docs/subscriptions/creating-your-new-relic
 >
   Add Ruby data
 </ButtonLink>
+<ButtonGroup>
 
 ## Extend agent instrumentation [#extend]
 

--- a/src/content/docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby.mdx
+++ b/src/content/docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby.mdx
@@ -86,7 +86,7 @@ After creating a [New Relic account](/docs/subscriptions/creating-your-new-relic
 >
   Add Ruby data
 </ButtonLink>
-<ButtonGroup>
+</ButtonGroup>
 
 ## Extend agent instrumentation [#extend]
 

--- a/src/content/docs/integrations/kubernetes-integration/get-started/introduction-kubernetes-integration.mdx
+++ b/src/content/docs/integrations/kubernetes-integration/get-started/introduction-kubernetes-integration.mdx
@@ -36,6 +36,7 @@ Here's what the automated installer does:
 3. Asks for the installation method: manifest file or Helm.
 4. Generates either the manifest or Helm chart.
 
+<ButtonGroup>
 <ButtonLink
   role="button"
   to="/docs/integrations/kubernetes-integration/installation/kubernetes-integration-install-configure"
@@ -52,6 +53,7 @@ Here's what the automated installer does:
 >
   Start the installer
 </ButtonLink>
+</ButtonGroup>
 
 <Callout variant="tip">
   If your New Relic account [is in the EU region](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers), access the automated installer from [one.eu.newrelic.com](http://one.eu.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJrOHMtY2x1c3Rlci1leHBsb3Jlci1uZXJkbGV0Lms4cy1zZXR1cCJ9).

--- a/src/content/docs/integrations/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic.mdx
+++ b/src/content/docs/integrations/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic.mdx
@@ -132,6 +132,7 @@ With the Prometheus remote write integration, you can:
 4. Check for your data.
 5. Query and explore!
 
+<ButtonGroup>
 <ButtonLink
   role="button"
   to="/docs/integrations/prometheus-integrations/install-configure/set-your-prometheus-remote-write-integration"
@@ -147,6 +148,7 @@ With the Prometheus remote write integration, you can:
 >
   Add Prometheus data
 </ButtonLink>
+</ButtonGroup>
 
 ### Remote write compatibility and requirements [#remote-write-compatibility]
 


### PR DESCRIPTION
## Summary 
We want to make all buttons center on the docs site! If there's more than one button, we will want to have them both centered in a row. This PR creates two components: `MDXButton` which is a wrapper around the `Button` component and `MDXButtonGroup` which creates a `ButtonGroup` component to be used to wrap two buttons. This PR also changes all the buttons to match this pattern! The details of this was specified by austin in [this slack thread](https://newrelic.slack.com/archives/C017ZNASGUX/p1614889222478200) to handle these two cases. 

## Buttons
### Before
<img width="796" alt="Screen Shot 2021-03-04 at 9 33 57 PM" src="https://user-images.githubusercontent.com/38332422/110058978-5ce03880-7d31-11eb-8860-cab6456b44a3.png">

### After
<img width="791" alt="Screen Shot 2021-03-04 at 9 33 42 PM" src="https://user-images.githubusercontent.com/38332422/110058983-5fdb2900-7d31-11eb-891e-1b0683a0e52c.png">


## Two buttons 
### Before 
<img width="792" alt="Screen Shot 2021-03-04 at 9 30 55 PM" src="https://user-images.githubusercontent.com/38332422/110059018-69649100-7d31-11eb-8f25-1ccc0bf61fe3.png">

### After (requiring a `ButtonGroup` to be wrapped around the two)
<img width="763" alt="Screen Shot 2021-03-04 at 9 35 43 PM" src="https://user-images.githubusercontent.com/38332422/110059125-a0d33d80-7d31-11eb-83f0-a49e2a5dbe98.png">


