### PR TITLE
Reduces the space between timeline events

### DIFF
--- a/src/pages/whats-new.js
+++ b/src/pages/whats-new.js
@@ -51,7 +51,7 @@ const WhatsNew = ({ data, location }) => {
                         margin-bottom: 2rem;
 
                         &:last-child {
-                          margin-bottom: ${isLast ? 0 : '4rem'};
+                          margin-bottom: ${isLast ? 0 : '3rem'};
                         }
                       `}
                     >

--- a/src/pages/whats-new.js
+++ b/src/pages/whats-new.js
@@ -51,7 +51,7 @@ const WhatsNew = ({ data, location }) => {
                         margin-bottom: 2rem;
 
                         &:last-child {
-                          margin-bottom: ${isLast ? 0 : '3rem'};
+                          margin-bottom: ${isLast ? 0 : '2rem'};
                         }
                       `}
                     >

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -91,7 +91,7 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
                         margin-bottom: 2rem;
 
                         &:last-child {
-                          margin-bottom: ${isLast ? 0 : '3rem'};
+                          margin-bottom: ${isLast ? 0 : '2rem'};
                         }
                       `}
                     >

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -91,7 +91,7 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
                         margin-bottom: 2rem;
 
                         &:last-child {
-                          margin-bottom: ${isLast ? 0 : '4rem'};
+                          margin-bottom: ${isLast ? 0 : '3rem'};
                         }
                       `}
                     >


### PR DESCRIPTION
Reduces the space between timeline events for whatsnew and releasenotes 

closes #911 

## Before 
<img width="1119" alt="Screen Shot 2021-03-04 at 2 41 56 PM" src="https://user-images.githubusercontent.com/38332422/110020640-d2c7ae00-7cf7-11eb-98db-73aeba75b462.png">


## After
<img width="1143" alt="Screen Shot 2021-03-04 at 2 49 24 PM" src="https://user-images.githubusercontent.com/38332422/110021507-d3147900-7cf8-11eb-962f-31f72314159a.png">
