### PR TITLE
Update rules-limits-alerts.mdx

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/rules-limits-glossary/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/rules-limits-glossary/rules-limits-alerts.mdx
@@ -136,7 +136,7 @@ The following rules apply both to the New Relic One user interface and to the RE
       </td>
 
       <td>
-        64 characters
+        128 characters
       </td>
     </tr>
 


### PR DESCRIPTION
Update condition name max length to 128 characters

# Description

The condition name character limit is supposed to be 128. This brings the documentation in line with the limit enforced by the UI and the backend API.