### PR TITLE
Terraform configuration for alerts and synthetics

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -30,11 +30,24 @@ data "newrelic_entity" "browser" {
   }
 }
 
+resource "newrelic_synthetics_monitor" "docs_site_monitor" {
+  name      = "docs.newrelic.com"
+  type      = "SIMPLE"
+  frequency = 5
+  status    = "ENABLED"
+
+  # Portland, London, Hong Kong
+  locations = ["AWS_US_WEST_2", "AWS_EU_WEST_2", "AWS_AP_EAST_1"]
+
+  uri        = "https://docs.newrelic.com"
+  verify_ssl = true
+}
+
 module "docs_site_alerts" {
   source = "./modules/alerts"
 
   application_id = newrelic_entity.browser.application_id
-  synthetics_id  = 0 # TODO
+  synthetics_id  = newrelic_synthetics_monitor.docs_site_monitor.id
 
   # Alert configuration (within the last 5 minutes)
   page_load_warning  = 3 # seconds

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     newrelic = {
       source  = "newrelic/newrelic"
-      version = "~> 2.12"
+      version = "~> 2.21"
     }
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,7 +15,7 @@ locals {
 
 provider "newrelic" {
   account_id = local.account_id
-  api_key    = var.api_key # TODO
+  api_key    = var.api_key
   region     = "US"
 }
 
@@ -57,5 +57,5 @@ module "docs_site_alerts" {
   js_errors_warning   = 10 # unique sessions
   js_errors_critical  = 20 # unique sessions
   synthetics_warning  = 1 # failure
-  synthetics_critical = 2 #failures
+  synthetics_critical = 2 # failures
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = "~> 0.13.0"
+
+  required_providers {
+    newrelic = {
+      source  = "newrelic/newrelic"
+      version = "~> 2.12"
+    }
+  }
+}
+
+provider "newrelic" {
+  account_id = 10956800
+  api_key    = var.api_key # TODO
+  region     = "US"
+}
+
+module "docs_site_alerts" {
+  source = "./modules/alerts" # TODO
+}
+
+module "docs_site_synthetics" {
+  source = "./modules/synthetics" # TODO
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,16 +9,38 @@ terraform {
   }
 }
 
-provider "newrelic" {
+locals {
   account_id = 10956800
+}
+
+provider "newrelic" {
+  account_id = local.account_id
   api_key    = var.api_key # TODO
   region     = "US"
 }
 
-module "docs_site_alerts" {
-  source = "./modules/alerts" # TODO
+data "newrelic_entity" "browser" {
+  name   = "docs.newrelic.com"
+  domain = "BROWSER"
+  type   = "APPLICATION"
+
+  tag {
+    key   = "accountID"
+    value = local.account_id
+  }
 }
 
-module "docs_site_synthetics" {
-  source = "./modules/synthetics" # TODO
+module "docs_site_alerts" {
+  source = "./modules/alerts"
+
+  application_id = newrelic_entity.browser.application_id
+  synthetics_id  = 0 # TODO
+
+  # Alert configuration (within the last 5 minutes)
+  page_load_warning  = 3 # seconds
+  page_load_critical = 5 # seconds
+  apdex_warning      = 0.7
+  apdex_critical     = 0.5
+  js_errors_warning  = 10 # unique sessions
+  js_errors_critical = 20 # unique sessions
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -50,10 +50,12 @@ module "docs_site_alerts" {
   synthetics_id  = newrelic_synthetics_monitor.docs_site_monitor.id
 
   # Alert configuration (within the last 5 minutes)
-  page_load_warning  = 3 # seconds
-  page_load_critical = 5 # seconds
-  apdex_warning      = 0.7
-  apdex_critical     = 0.5
-  js_errors_warning  = 10 # unique sessions
-  js_errors_critical = 20 # unique sessions
+  page_load_warning   = 3 # seconds
+  page_load_critical  = 5 # seconds
+  apdex_warning       = 0.7
+  apdex_critical      = 0.5
+  js_errors_warning   = 10 # unique sessions
+  js_errors_critical  = 20 # unique sessions
+  synthetics_warning  = 1 # failure
+  synthetics_critical = 2 #failures
 }

--- a/terraform/modules/alerts/main.tf
+++ b/terraform/modules/alerts/main.tf
@@ -1,0 +1,24 @@
+data "newrelic_entity" "browser" {
+  name   = "docs.newrelic.com"
+  domain = "BROWSER"
+  type   = "APPLICATION"
+
+  tag {
+    key   = "accountID"
+    value = 10956800
+  }
+}
+
+data "newrelic_alert_channel" {
+  name = "Developer Enablement"
+  type = "pagerduty"
+}
+
+data "newrelic_alert_channel" {
+  name = "#dev-enablement-bots"
+  type = "slack"
+}
+
+# TODO: policy
+# TODO: policy_channels
+# TODO: conditions

--- a/terraform/modules/alerts/main.tf
+++ b/terraform/modules/alerts/main.tf
@@ -78,6 +78,22 @@ resource "newrelic_alert_condition" "apdex_low" {
   }
 }
 
+resource "newrelic_synthetics_multilocation_alert_condition" "synthetics_failures" {
+  policy_id = newrelic_alert_policy.id
+
+  name        = "Synthetics Failures"
+  entities    = [var.synthetics_id]
+  runbook_url = local.runbook_url
+
+  warning {
+    threshold = synthetics_warning
+  }
+
+  critical {
+    threshold = synthetics_critical
+  }
+}
+
 resource "newrelic_nrql_alert_condition" "js_errors" {
   policy_id = newrelic_alert_policy.id
 

--- a/terraform/modules/alerts/main.tf
+++ b/terraform/modules/alerts/main.tf
@@ -1,24 +1,79 @@
-data "newrelic_entity" "browser" {
-  name   = "docs.newrelic.com"
-  domain = "BROWSER"
-  type   = "APPLICATION"
-
-  tag {
-    key   = "accountID"
-    value = 10956800
-  }
+locals {
+  runbook_url = "https://github.com/newrelic/docs-website/wiki/Emergency-Runbook"
 }
 
-data "newrelic_alert_channel" {
+data "newrelic_alert_channel" "pagerduty" {
   name = "Developer Enablement"
   type = "pagerduty"
 }
 
-data "newrelic_alert_channel" {
+data "newrelic_alert_channel" "slack" {
   name = "#dev-enablement-bots"
   type = "slack"
 }
 
-# TODO: policy
-# TODO: policy_channels
-# TODO: conditions
+resource "newrelic_alert_policy" "docs_site_policy" {
+  name = "docs.newrelic.com"
+}
+
+# Connect the alert channels to the policy
+resource "newrelic_alert_policy_channel" "docs_site_policy_channels" {
+  policy_id = newrelic_alert_policy.docs_site_policy.id
+
+  channel_ids = [
+    newrelic_alert_channel.pagerduty.id,
+    newrelic_alert_channel.slack.id,
+  ]
+}
+
+resource "newrelic_alert_condition" "page_load_high" {
+  policy_id = newrelic_alert_policy.id
+
+  name        = "Total page load (High)"
+  type        = "apm_app_metric"
+  entities    = [var.application_id]
+  metric      = "total_page_load"
+  runbook_url = local.runbook_url
+
+  term {
+    duration      = 5
+    operator      = "above"
+    priority      = "warning"
+    threshold     = 3 # seconds
+    time_function = "all"
+  }
+
+  term {
+    duration      = 5
+    operator      = "above"
+    priority      = "critical"
+    threshold     = 5 # seconds
+    time_function = "all"
+  }
+}
+
+resource "newrelic_alert_condition" "apdex_low" {
+  policy_id = newrelic_alert_policy.id
+
+  name        = "End User Apdex (Low)"
+  type        = "apm_app_metric"
+  entities    = [var.application_id]
+  metric      = "end_user_apdex"
+  runbook_url = local.runbook_url
+
+  term {
+    duration      = 5
+    operator      = "below"
+    priority      = "warning"
+    threshold     = 0.7
+    time_function = "all"
+  }
+
+  term {
+    duration      = 5
+    operator      = "below"
+    priority      = "critical"
+    threshold     = 0.5
+    time_function = "all"
+  }
+}

--- a/terraform/modules/alerts/main.tf
+++ b/terraform/modules/alerts/main.tf
@@ -86,11 +86,11 @@ resource "newrelic_synthetics_multilocation_alert_condition" "synthetics_failure
   runbook_url = local.runbook_url
 
   warning {
-    threshold = synthetics_warning
+    threshold = var.synthetics_warning
   }
 
   critical {
-    threshold = synthetics_critical
+    threshold = var.synthetics_critical
   }
 }
 

--- a/terraform/modules/alerts/main.tf
+++ b/terraform/modules/alerts/main.tf
@@ -39,7 +39,7 @@ resource "newrelic_alert_condition" "page_load_high" {
     duration      = 5
     operator      = "above"
     priority      = "warning"
-    threshold     = 3 # seconds
+    threshold     = var.page_load_warning
     time_function = "all"
   }
 
@@ -47,7 +47,7 @@ resource "newrelic_alert_condition" "page_load_high" {
     duration      = 5
     operator      = "above"
     priority      = "critical"
-    threshold     = 5 # seconds
+    threshold     = var.page_load_critical
     time_function = "all"
   }
 }
@@ -65,7 +65,7 @@ resource "newrelic_alert_condition" "apdex_low" {
     duration      = 5
     operator      = "below"
     priority      = "warning"
-    threshold     = 0.7
+    threshold     = var.apdex_warning
     time_function = "all"
   }
 
@@ -73,7 +73,35 @@ resource "newrelic_alert_condition" "apdex_low" {
     duration      = 5
     operator      = "below"
     priority      = "critical"
-    threshold     = 0.5
+    threshold     = var.apdex_critical
     time_function = "all"
+  }
+}
+
+resource "newrelic_nrql_alert_condition" "js_errors" {
+  policy_id = newrelic_alert_policy.id
+
+  name           = "JS Errors (High)"
+  type           = "static"
+  value_function = "single_value"
+  runbook_url    = local.runbook_url
+
+  nrql {
+    query             = "SELECT (uniqueCount(JavaScriptError.session) / uniqueCount(PageView.session)) * 100 AS '% Errors' FROM JavaScriptError, PageView WHERE appName = 'docs.newrelic.com' AND errorMessage != 'Unexpected token _ in JSON at position 0'"
+    evaluation_offset = 3
+  }
+
+  warning {
+    operator              = "above"
+    threshold             = var.js_errors_warning
+    threshold_duration    = 300 # 5 minutes
+    threshold_occurrances = "all"
+  }
+
+  critical {
+    operator              = "above"
+    threshold             = var.js_errors_critical
+    threshold_duration    = 300 # 5 minutes
+    threshold_occurrances = "all"
   }
 }

--- a/terraform/modules/alerts/variables.tf
+++ b/terraform/modules/alerts/variables.tf
@@ -1,0 +1,39 @@
+variable "application_id" {
+  type        = number
+  description = "The Browser appliation ID (under the DevEn account)"
+}
+
+variable "synthetics_id" {
+  type        = number
+  description = "Sythentics monitor for docs.newrelic.com"
+}
+
+variable "page_load_warning" {
+  type        = number
+  description = "Warning when page load gets above x sec"
+}
+
+variable "page_load_critical" {
+  type        = number
+  description = "Alert when page load gets above x sec"
+}
+
+variable "apdex_warning" {
+  type        = number
+  description = "Warning when apdex gets below x"
+}
+
+variable "apdex_critical" {
+  type        = number
+  description = "Alert when apdex gets below x"
+}
+
+variable "js_errors_warning" {
+  type        = number
+  description = "Warning when x unique sessions gets above x"
+}
+
+variable "js_errors_critical" {
+  type        = number
+  description = "Alert when x unique sessions gets above x"
+}


### PR DESCRIPTION
## Description
We need to adjust which account owns the browser agent, sytnethetics monitor, and related alert conditions. Unfortunately, entities and policies can not be moved between accounts - they need to be recreated. I'd like to take another shot at configuring this stuff with _Terraform_ and automating the application of it using [atlantis](https://www.runatlantis.io/).

## Reviewer Notes
This is not a high-priority item, but it would be nice to get it set up sometime in the next two weeks.