### PR TITLE
Add meta tag to disable swiftype robots on auto-generated localized pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -271,6 +271,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       createPageFromNode(i18nNode || node, {
         prefix: i18nNode ? '' : locale,
         createPage,
+        disableSEO: !i18nNode,
       });
     });
   });
@@ -329,7 +330,7 @@ exports.createResolvers = ({ createResolvers }) => {
 
 exports.onCreatePage = ({ page, actions }) => {
   const { createPage, deletePage } = actions;
-  const oldPage = Object.assign({}, page);
+  const oldPage = { ...page };
 
   if (page.path.match(/404/)) {
     page.context.layout = 'basic';
@@ -372,7 +373,10 @@ const createLocalizedRedirect = ({
   });
 };
 
-const createPageFromNode = (node, { createPage, prefix = '' }) => {
+const createPageFromNode = (
+  node,
+  { createPage, prefix = '', disableSEO = false }
+) => {
   const {
     fields: { fileRelativePath, slug },
   } = node;
@@ -398,6 +402,7 @@ const createPageFromNode = (node, { createPage, prefix = '' }) => {
         fileRelativePath,
         slug,
         slugRegex: `${slug}/.+/`,
+        disableSEO,
       },
     });
   }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -330,7 +330,7 @@ exports.createResolvers = ({ createResolvers }) => {
 
 exports.onCreatePage = ({ page, actions }) => {
   const { createPage, deletePage } = actions;
-  const oldPage = { ...page };
+  const oldPage = Object.assign({}, page);
 
   if (page.path.match(/404/)) {
     page.context.layout = 'basic';

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -271,7 +271,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       createPageFromNode(i18nNode || node, {
         prefix: i18nNode ? '' : locale,
         createPage,
-        disableSEO: !i18nNode,
+        disableSwiftype: !i18nNode,
       });
     });
   });
@@ -330,7 +330,7 @@ exports.createResolvers = ({ createResolvers }) => {
 
 exports.onCreatePage = ({ page, actions }) => {
   const { createPage, deletePage } = actions;
-  const oldPage = Object.assign({}, page);
+  const oldPage = { ...page };
 
   if (page.path.match(/404/)) {
     page.context.layout = 'basic';
@@ -375,7 +375,7 @@ const createLocalizedRedirect = ({
 
 const createPageFromNode = (
   node,
-  { createPage, prefix = '', disableSEO = false }
+  { createPage, prefix = '', disableSwiftype = false }
 ) => {
   const {
     fields: { fileRelativePath, slug },
@@ -402,7 +402,7 @@ const createPageFromNode = (
         fileRelativePath,
         slug,
         slugRegex: `${slug}/.+/`,
-        disableSEO,
+        disableSwiftype,
       },
     });
   }

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -66,7 +66,7 @@ DocsSiteSeo.propTypes = {
   description: PropTypes.string,
   type: PropTypes.string,
   tags: PropTypes.array,
-  disable: PropTypes.bool,
+  disableSwiftype: PropTypes.bool,
 };
 
 export default DocsSiteSeo;

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -16,9 +16,16 @@ const METADATA = [
   },
 ];
 
-const DocsSiteSeo = ({ location, title, description, type, tags, disable }) => (
+const DocsSiteSeo = ({
+  location,
+  title,
+  description,
+  type,
+  tags,
+  disableSwiftype,
+}) => (
   <SEO location={location} title={title}>
-    {disable ? (
+    {disableSwiftype ? (
       <>
         {METADATA.map((data) => (
           <meta key={data.name} {...data} />

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { SEO } from '@newrelic/gatsby-theme-newrelic';
-import { Helmet } from 'react-helmet';
 
 const METADATA = [
   {
@@ -17,41 +16,42 @@ const METADATA = [
   },
 ];
 
-const DocsSiteSeo = ({ location, title, description, type, tags, disable }) =>
-  disable ? (
-    <Helmet>
-      <meta name="robots" content="nofollow, noindex" />
-    </Helmet>
-  ) : (
-    <SEO location={location} title={title}>
-      {METADATA.map((data) => (
-        <meta key={data.name} {...data} />
-      ))}
+const DocsSiteSeo = ({ location, title, description, type, tags, disable }) => (
+  <SEO location={location} title={title}>
+    {disable ? (
+      <>
+        {METADATA.map((data) => (
+          <meta key={data.name} {...data} />
+        ))}
 
-      {(tags || []).map((tag) => (
-        <meta
-          key={tag}
-          name="tags"
-          className="swiftype"
-          data-type="string"
-          content={tag}
-        />
-      ))}
+        {(tags || []).map((tag) => (
+          <meta
+            key={tag}
+            name="tags"
+            className="swiftype"
+            data-type="string"
+            content={tag}
+          />
+        ))}
 
-      {type && (
-        <meta
-          className="swiftype"
-          name="document_type"
-          data-type="enum"
-          content={type}
-        />
-      )}
+        {type && (
+          <meta
+            className="swiftype"
+            name="document_type"
+            data-type="enum"
+            content={type}
+          />
+        )}
 
-      {(description || title) && (
-        <meta name="description" content={description || title} />
-      )}
-    </SEO>
-  );
+        {(description || title) && (
+          <meta name="description" content={description || title} />
+        )}
+      </>
+    ) : (
+      <meta name="st:robots" content="nofollow, noindex" />
+    )}
+  </SEO>
+);
 
 DocsSiteSeo.propTypes = {
   location: PropTypes.string.isRequired,

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { SEO } from '@newrelic/gatsby-theme-newrelic';
+import { Helmet } from 'react-helmet';
 
 const METADATA = [
   {
@@ -16,36 +17,41 @@ const METADATA = [
   },
 ];
 
-const DocsSiteSeo = ({ location, title, description, type, tags }) => (
-  <SEO location={location} title={title}>
-    {METADATA.map((data) => (
-      <meta key={data.name} {...data} />
-    ))}
+const DocsSiteSeo = ({ location, title, description, type, tags, disable }) =>
+  disable ? (
+    <Helmet>
+      <meta name="robots" content="nofollow, noindex" />
+    </Helmet>
+  ) : (
+    <SEO location={location} title={title}>
+      {METADATA.map((data) => (
+        <meta key={data.name} {...data} />
+      ))}
 
-    {(tags || []).map((tag) => (
-      <meta
-        key={tag}
-        name="tags"
-        className="swiftype"
-        data-type="string"
-        content={tag}
-      />
-    ))}
+      {(tags || []).map((tag) => (
+        <meta
+          key={tag}
+          name="tags"
+          className="swiftype"
+          data-type="string"
+          content={tag}
+        />
+      ))}
 
-    {type && (
-      <meta
-        className="swiftype"
-        name="document_type"
-        data-type="enum"
-        content={type}
-      />
-    )}
+      {type && (
+        <meta
+          className="swiftype"
+          name="document_type"
+          data-type="enum"
+          content={type}
+        />
+      )}
 
-    {(description || title) && (
-      <meta name="description" content={description || title} />
-    )}
-  </SEO>
-);
+      {(description || title) && (
+        <meta name="description" content={description || title} />
+      )}
+    </SEO>
+  );
 
 DocsSiteSeo.propTypes = {
   location: PropTypes.string.isRequired,
@@ -53,6 +59,7 @@ DocsSiteSeo.propTypes = {
   description: PropTypes.string,
   type: PropTypes.string,
   tags: PropTypes.array,
+  disable: PropTypes.bool,
 };
 
 export default DocsSiteSeo;

--- a/src/templates/apiLandingPage.js
+++ b/src/templates/apiLandingPage.js
@@ -7,7 +7,7 @@ import MDXContainer from '../components/MDXContainer';
 import SEO from '../components/SEO';
 import { TYPES } from '../utils/constants';
 
-const ApiIndexPage = ({ data, location }) => {
+const ApiIndexPage = ({ data, location, pageContext }) => {
   const {
     mdx: {
       body,
@@ -15,9 +15,15 @@ const ApiIndexPage = ({ data, location }) => {
     },
     allMdx: { nodes: apiDocPages },
   } = data;
+  const { disableSEO } = pageContext;
   return (
     <>
-      <SEO location={location} title={title} type={TYPES.API_LANDING_PAGE} />
+      <SEO
+        location={location}
+        title={title}
+        type={TYPES.API_LANDING_PAGE}
+        disable={disableSEO}
+      />
       <PageTitle>{title}</PageTitle>
       <Layout.Content>
         <MDXContainer body={body}>

--- a/src/templates/apiLandingPage.js
+++ b/src/templates/apiLandingPage.js
@@ -15,14 +15,14 @@ const ApiIndexPage = ({ data, location, pageContext }) => {
     },
     allMdx: { nodes: apiDocPages },
   } = data;
-  const { disableSEO } = pageContext;
+  const { disableSwiftype } = pageContext;
   return (
     <>
       <SEO
         location={location}
         title={title}
         type={TYPES.API_LANDING_PAGE}
-        disable={disableSEO}
+        disableSwiftype={disableSwiftype}
       />
       <PageTitle>{title}</PageTitle>
       <Layout.Content>

--- a/src/templates/apiLandingPage.js
+++ b/src/templates/apiLandingPage.js
@@ -68,6 +68,7 @@ export const pageQuery = graphql`
 ApiIndexPage.propTypes = {
   data: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
+  pageContext: PropTypes.object.isRequired,
 };
 
 export default ApiIndexPage;

--- a/src/templates/docPage.js
+++ b/src/templates/docPage.js
@@ -131,6 +131,7 @@ const BasicDoc = ({ data, location, pageContext }) => {
 BasicDoc.propTypes = {
   data: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
+  pageContext: PropTypes.object.isRequired,
 };
 
 export const pageQuery = graphql`

--- a/src/templates/docPage.js
+++ b/src/templates/docPage.js
@@ -30,7 +30,7 @@ const BasicDoc = ({ data, location, pageContext }) => {
     fields: { fileRelativePath },
     relatedResources,
   } = mdx;
-  const { disableSEO } = pageContext;
+  const { disableSwiftype } = pageContext;
 
   const moreHelpHeading = mdxAST.children
     .filter((node) => node.type === 'heading')
@@ -73,7 +73,7 @@ const BasicDoc = ({ data, location, pageContext }) => {
         description={metaDescription}
         type={type ? TYPES.BASIC_PAGE[type] : TYPES.BASIC_PAGE.default}
         tags={tags}
-        disable={disableSEO}
+        disableSwiftype={disableSwiftype}
       />
       <div
         css={css`

--- a/src/templates/docPage.js
+++ b/src/templates/docPage.js
@@ -20,7 +20,7 @@ import GithubSlugger from 'github-slugger';
 import { parseHeading } from '../../plugins/gatsby-remark-custom-heading-ids/utils/heading';
 import { TYPES } from '../utils/constants';
 
-const BasicDoc = ({ data, location }) => {
+const BasicDoc = ({ data, location, pageContext }) => {
   const { t } = useTranslation();
   const { mdx } = data;
   const {
@@ -30,6 +30,7 @@ const BasicDoc = ({ data, location }) => {
     fields: { fileRelativePath },
     relatedResources,
   } = mdx;
+  const { disableSEO } = pageContext;
 
   const moreHelpHeading = mdxAST.children
     .filter((node) => node.type === 'heading')
@@ -72,6 +73,7 @@ const BasicDoc = ({ data, location }) => {
         description={metaDescription}
         type={type ? TYPES.BASIC_PAGE[type] : TYPES.BASIC_PAGE.default}
         tags={tags}
+        disable={disableSEO}
       />
       <div
         css={css`

--- a/src/templates/indexPage.js
+++ b/src/templates/indexPage.js
@@ -10,7 +10,7 @@ import { TYPES } from '../utils/constants';
 
 const IndexPage = ({ data, pageContext, location }) => {
   const { nav } = data;
-  const { html, disableSEO } = pageContext;
+  const { html, disableSwiftype } = pageContext;
   const title = nav ? nav.title : pageContext.title;
 
   return (
@@ -19,7 +19,7 @@ const IndexPage = ({ data, pageContext, location }) => {
         location={location}
         title={title}
         type={TYPES.AUTO_INDEX_PAGE}
-        disable={disableSEO}
+        disableSwiftype={disableSwiftype}
       />
       <PageTitle>{title}</PageTitle>
       <Layout.Content>

--- a/src/templates/indexPage.js
+++ b/src/templates/indexPage.js
@@ -10,12 +10,17 @@ import { TYPES } from '../utils/constants';
 
 const IndexPage = ({ data, pageContext, location }) => {
   const { nav } = data;
-  const { html } = pageContext;
+  const { html, disableSEO } = pageContext;
   const title = nav ? nav.title : pageContext.title;
 
   return (
     <>
-      <SEO location={location} title={title} type={TYPES.AUTO_INDEX_PAGE} />
+      <SEO
+        location={location}
+        title={title}
+        type={TYPES.AUTO_INDEX_PAGE}
+        disable={disableSEO}
+      />
       <PageTitle>{title}</PageTitle>
       <Layout.Content>
         {nav ? (

--- a/src/templates/landingPage.js
+++ b/src/templates/landingPage.js
@@ -46,7 +46,7 @@ const components = {
 const LandingPage = ({ data, location, pageContext }) => {
   const { mdx } = data;
   const { frontmatter, body } = mdx;
-  const { disableSEO } = pageContext;
+  const { disableSwiftype } = pageContext;
 
   return (
     <>
@@ -55,7 +55,7 @@ const LandingPage = ({ data, location, pageContext }) => {
         title={frontmatter.title}
         description={frontmatter.metaDescription}
         type={TYPES.LANDING_PAGE}
-        disable={disableSEO}
+        disableSwiftype={disableSwiftype}
       />
       <PageTitle>{frontmatter.title}</PageTitle>
       <Layout.Content>

--- a/src/templates/landingPage.js
+++ b/src/templates/landingPage.js
@@ -43,9 +43,10 @@ const components = {
   wrapper: Wrapper,
 };
 
-const LandingPage = ({ data, location }) => {
+const LandingPage = ({ data, location, pageContext }) => {
   const { mdx } = data;
   const { frontmatter, body } = mdx;
+  const { disableSEO } = pageContext;
 
   return (
     <>
@@ -54,6 +55,7 @@ const LandingPage = ({ data, location }) => {
         title={frontmatter.title}
         description={frontmatter.metaDescription}
         type={TYPES.LANDING_PAGE}
+        disable={disableSEO}
       />
       <PageTitle>{frontmatter.title}</PageTitle>
       <Layout.Content>

--- a/src/templates/landingPage.js
+++ b/src/templates/landingPage.js
@@ -68,6 +68,7 @@ const LandingPage = ({ data, location, pageContext }) => {
 LandingPage.propTypes = {
   data: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
+  pageContext: PropTypes.object.isRequired,
 };
 
 export const pageQuery = graphql`

--- a/src/templates/releaseNote.js
+++ b/src/templates/releaseNote.js
@@ -111,6 +111,7 @@ const ReleaseNoteTemplate = ({ data, location, pageContext }) => {
 ReleaseNoteTemplate.propTypes = {
   data: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
+  pageContext: PropTypes.object.isRequired,
 };
 
 export const pageQuery = graphql`

--- a/src/templates/releaseNote.js
+++ b/src/templates/releaseNote.js
@@ -17,7 +17,7 @@ const getTitle = ({ title, version, subject }) => {
   return version ? `${subject} v${version}` : subject;
 };
 
-const ReleaseNoteTemplate = ({ data, location }) => {
+const ReleaseNoteTemplate = ({ data, location, pageContext }) => {
   const {
     mdx: {
       body,
@@ -25,6 +25,8 @@ const ReleaseNoteTemplate = ({ data, location }) => {
       frontmatter: { downloadLink, releaseDate, watermark, metaDescription },
     },
   } = data;
+
+  const { disableSEO } = pageContext;
 
   const title = getTitle(frontmatter);
 
@@ -35,6 +37,7 @@ const ReleaseNoteTemplate = ({ data, location }) => {
         title={title}
         description={metaDescription}
         type={TYPES.RELEASE_NOTE}
+        disable={disableSEO}
       />
       <PageTitle
         css={css`

--- a/src/templates/releaseNote.js
+++ b/src/templates/releaseNote.js
@@ -26,7 +26,7 @@ const ReleaseNoteTemplate = ({ data, location, pageContext }) => {
     },
   } = data;
 
-  const { disableSEO } = pageContext;
+  const { disableSwiftype } = pageContext;
 
   const title = getTitle(frontmatter);
 
@@ -37,7 +37,7 @@ const ReleaseNoteTemplate = ({ data, location, pageContext }) => {
         title={title}
         description={metaDescription}
         type={TYPES.RELEASE_NOTE}
-        disable={disableSEO}
+        disableSwiftype={disableSwiftype}
       />
       <PageTitle
         css={css`

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -13,7 +13,7 @@ import { TYPES } from '../utils/constants';
 const EXCERPT_LENGTH = 200;
 
 const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
-  const { slug } = pageContext;
+  const { slug, disableSEO } = pageContext;
   const {
     allMdx: { nodes: posts },
     mdx: {
@@ -39,7 +39,12 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
 
   return (
     <>
-      <SEO location={location} title={title} type={TYPES.LANDING_PAGE} />
+      <SEO
+        location={location}
+        title={title}
+        type={TYPES.LANDING_PAGE}
+        disable={disableSEO}
+      />
       <PageTitle
         css={css`
           display: flex;

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -13,7 +13,7 @@ import { TYPES } from '../utils/constants';
 const EXCERPT_LENGTH = 200;
 
 const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
-  const { slug, disableSEO } = pageContext;
+  const { slug, disableSwiftype } = pageContext;
   const {
     allMdx: { nodes: posts },
     mdx: {
@@ -43,7 +43,7 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
         location={location}
         title={title}
         type={TYPES.LANDING_PAGE}
-        disable={disableSEO}
+        disableSwiftype={disableSwiftype}
       />
       <PageTitle
         css={css`

--- a/src/templates/tableOfContents.js
+++ b/src/templates/tableOfContents.js
@@ -11,7 +11,7 @@ import { TYPES } from '../utils/constants';
 const TableOfContentsPage = ({ data, pageContext, location }) => {
   const { localizedPath } = useLocale();
   const { nav } = data;
-  const { slug, disableSEO, title } = pageContext;
+  const { slug, disableSwiftype, title } = pageContext;
   const landingPageSlug = slug.replace('/table-of-contents', '');
   const subnav = useMemo(
     () =>
@@ -33,7 +33,7 @@ const TableOfContentsPage = ({ data, pageContext, location }) => {
         location={location}
         title={title}
         type={TYPES.TABLE_OF_CONTENTS}
-        disable={disableSEO}
+        disableSwiftype={disableSwiftype}
       />
       <PageTitle>{title}</PageTitle>
       <Link

--- a/src/templates/tableOfContents.js
+++ b/src/templates/tableOfContents.js
@@ -9,10 +9,9 @@ import SEO from '../components/SEO';
 import { TYPES } from '../utils/constants';
 
 const TableOfContentsPage = ({ data, pageContext, location }) => {
-  const { title } = pageContext;
   const { localizedPath } = useLocale();
   const { nav } = data;
-  const { slug } = pageContext;
+  const { slug, disableSEO, title } = pageContext;
   const landingPageSlug = slug.replace('/table-of-contents', '');
   const subnav = useMemo(
     () =>
@@ -30,7 +29,12 @@ const TableOfContentsPage = ({ data, pageContext, location }) => {
 
   return (
     <>
-      <SEO location={location} title={title} type={TYPES.TABLE_OF_CONTENTS} />
+      <SEO
+        location={location}
+        title={title}
+        type={TYPES.TABLE_OF_CONTENTS}
+        disable={disableSEO}
+      />
       <PageTitle>{title}</PageTitle>
       <Link
         to={landingPageSlug}

--- a/src/templates/whatsNew.js
+++ b/src/templates/whatsNew.js
@@ -12,7 +12,7 @@ import SEO from '../components/SEO';
 import PageTitle from '../components/PageTitle';
 import { TYPES } from '../utils/constants';
 
-const WhatsNewTemplate = ({ data, location }) => {
+const WhatsNewTemplate = ({ data, location, pageContext }) => {
   const {
     site: {
       siteMetadata: { siteUrl },
@@ -29,9 +29,16 @@ const WhatsNewTemplate = ({ data, location }) => {
     },
   } = data;
 
+  const { disableSEO } = pageContext;
+
   return (
     <>
-      <SEO location={location} title={title} type={TYPES.WHATS_NEW} />
+      <SEO
+        location={location}
+        title={title}
+        type={TYPES.WHATS_NEW}
+        disable={disableSEO}
+      />
       <PageTitle
         css={css`
           max-width: 850px;

--- a/src/templates/whatsNew.js
+++ b/src/templates/whatsNew.js
@@ -140,6 +140,7 @@ const WhatsNewTemplate = ({ data, location, pageContext }) => {
 WhatsNewTemplate.propTypes = {
   data: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
+  pageContext: PropTypes.object.isRequired,
 };
 
 export const pageQuery = graphql`

--- a/src/templates/whatsNew.js
+++ b/src/templates/whatsNew.js
@@ -29,7 +29,7 @@ const WhatsNewTemplate = ({ data, location, pageContext }) => {
     },
   } = data;
 
-  const { disableSEO } = pageContext;
+  const { disableSwiftype } = pageContext;
 
   return (
     <>
@@ -37,7 +37,7 @@ const WhatsNewTemplate = ({ data, location, pageContext }) => {
         location={location}
         title={title}
         type={TYPES.WHATS_NEW}
-        disable={disableSEO}
+        disableSwiftype={disableSwiftype}
       />
       <PageTitle
         css={css`


### PR DESCRIPTION
closes #1191  after it is deployed and we trigger a recrawl. 

### Summary 
Disables swiftype robots by a meta-tag when the page generated automatically rather than from a localized mdx page. According to the [documentation](https://swiftype.com/documentation/site-search/crawler-configuration/meta-tags#swiftbot) when added to the page this will override all other swiftype meta tags on the page (which is what we want, so it doesn't really matter that if in the SEO component there's any ones being added or elsewhere). This will make sure that when a user is searching in Japanese they will get a page that has actual japanese content on it. 

