### PR TITLE
Explicilty set page title for swiftype

### DIFF
--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { SEO } from '@newrelic/gatsby-theme-newrelic';
-import PageTitle from './PageTitle';
 
 const METADATA = [
   {

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { SEO } from '@newrelic/gatsby-theme-newrelic';
+import PageTitle from './PageTitle';
 
 const METADATA = [
   {
@@ -46,6 +47,15 @@ const DocsSiteSeo = ({
         name="document_type"
         data-type="enum"
         content={type}
+      />
+    )}
+
+    {title && (
+      <meta
+        className="swiftype"
+        name="title"
+        data-type="text"
+        content={title}
       />
     )}
 


### PR DESCRIPTION
## Description
The template used to generate the title of a page (that swiftype then indexes and NR1 Help XP then uses as its title when rendering content) is: `Title of page | New Relic Documentation`. This may make for weird matching when querying against the `title` field or displaying those titles in NR1 Help XP. In other contexts, we may want to keep the site name at the end (ex, a Slack link preview).

This updates the `<SEO>` component to explicitly set the swiftype `title` field.

## Screenshots

<img width="1535" alt="Screen Shot 2021-03-08 at 10 24 40" src="https://user-images.githubusercontent.com/2952843/110352561-ebcbaa00-7fea-11eb-961c-82ac635d5c5e.png">
<img width="1291" alt="Screen Shot 2021-03-08 at 10 24 04" src="https://user-images.githubusercontent.com/2952843/110352598-f7b76c00-7fea-11eb-8b48-2da278c5de03.png">
