### PR TITLE
Removed redirect pointing to same doc

### DIFF
--- a/src/content/docs/accounts/original-accounts-billing/product-pricing/product-based-pricing.mdx
+++ b/src/content/docs/accounts/original-accounts-billing/product-pricing/product-based-pricing.mdx
@@ -36,7 +36,6 @@ redirects:
   - /docs/accounts/accounts/billing/invoices-receipts
   - /docs/accounts-partnerships/accounts/account-billing-usage/invoices-receipts
   - /docs/accounts-partnerships/accounts/billing/invoices-receipts
-  - /docs/accounts/original-accounts-billing/product-pricing/product-based-pricing
   - /docs/accounts/original-accounts-billing/product-based-pricing/original-product-based-pricing
   - >-
     /docs/accounts-partnerships/accounts/account-billing-usage/change-credit-card-or-payment-method


### PR DESCRIPTION
The [original product based pricing doc](https://docs.newrelic.com/docs/accounts/original-accounts-billing/product-pricing/product-based-pricing/) was redirecting to itself. This PR removes that redirect.

Closes #1227. 