### PR TITLE
Adding back the Windows installation instructions

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/snmp-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/snmp-monitoring-integration.mdx
@@ -69,6 +69,36 @@ To install the SNMP integration, follow the instructions for your environment:
     5. Edit the `snmp-metrics.yml` file as described in the [metric collection files](#metrics-collection).
     6. [Restart the infrastructure agent](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
   </Collapser>
+
+
+   <Collapser
+     id="windows-install"
+     title="Windows"
+   >
+     1. Download the `nri-snmp` .MSI installer image from:
+        [http://download.newrelic.com/infrastructure_agent/windows/integrations/nri-snmp/nri-snmp-amd64.msi](http://download.newrelic.com/infrastructure_agent/windows/integrations/nri-snmp/nri-snmp-amd64.msi)
+     2. To install from the Windows command prompt, run:
+
+        ```
+        msiexec.exe /qn /i <var>PATH\TO\</var>nri-snmp-amd64.msi
+        ```
+
+        or double-click the file in Explorer.
+     3. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration and metrics files by running:
+
+        ```
+        copy snmp-config.yml.sample snmp-config.yml
+        ```
+
+        ```
+        copy snmp-metrics.yml.sample snmp-metrics.yml
+        ```
+     4. Edit the `snmp-config.yml` file as described in the [configuration settings](#config).
+     5. Edit the `snmp-metrics.yml` file as described in the [metric collection files](#metrics-collection).
+     6. [Restart the infrastructure agent](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
+   </Collapser>
+
+
 </CollapserGroup>
 
 Additional notes:


### PR DESCRIPTION
We support Windows again.

Closes #1215 

### Tell us why

We released SNMP integration 1.3.0 which adds support for Windows (.msi package released).