### PR TITLE
chore: changes triage logic

### DIFF
--- a/.github/workflows/issue-pr-triage.yml
+++ b/.github/workflows/issue-pr-triage.yml
@@ -16,9 +16,7 @@ jobs:
     steps:
     - name: Triages NEW issues and NEW pull requests to the Content Project
       uses: srggrs/assign-one-project-github-action@1.2.0
-      if: |
-        contains(github.event.issue.labels.*.name, 'content') ||
-        contains(github.event.pull_request.labels.*.name, 'content')
+      if: github.event == 'issue' || github.event = 'pull_request'
       with:
         project: 'https://github.com/newrelic/docs-website/projects/3'
         column_name: 'Needs Triage'


### PR DESCRIPTION
This PR changes the logic to move ALL issues and PRS to the content project board per @austin-schaefer request.