### PR TITLE
fix: change data type for swiftype title

### DIFF
--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -53,7 +53,7 @@ const DocsSiteSeo = ({
       <meta
         className="swiftype"
         name="title"
-        data-type="text"
+        data-type="string"
         content={title}
       />
     )}


### PR DESCRIPTION
Looks like swiftype may not have liked the data type. I _think_ it should be a string instead of text