### PR TITLE
Removed redirect from original pricing plan to new pricing plan

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing.mdx
@@ -8,7 +8,6 @@ translate:
   - jp
 metaDescription: How the New Relic One pricing plan and billing calculations work.
 redirects:
-  - /docs/accounts/original-accounts-billing/product-pricing/product-based-pricing
   - /docs/new-relic-one-pricing-billing
   - /docs/accounts/accounts-billing/new-relic-one-pricing-users/new-relic-one-pricing-billing
   - /docs/accounts/accounts-billing/new-relic-one-pricing-users/pricing-billing


### PR DESCRIPTION
"The following link won't work and it doesn't seem to be possible to view the old documentation 
https://docs.newrelic.com/docs/accounts/original-accounts-billing/product-pricing/product-based-pricing/"

This seems to be another redirect issue on the pricing pages. The link should take you to the original product based pricing page, but it instead redirects you to the NR1 pricing page.  I scanned through them and this should be the last of the fixes. 