### PR TITLE
K8s link fix

### DIFF
--- a/src/content/docs/integrations/kubernetes-integration/installation/kubernetes-integration-install-configure.mdx
+++ b/src/content/docs/integrations/kubernetes-integration/installation/kubernetes-integration-install-configure.mdx
@@ -529,7 +529,7 @@ The `config` object is used to populate the `configMap` that is mounted automati
 
 ### Using the automated installer [#update-installer]
 
-To update a Kubernetes integration installed with the (automated installer)[#installer], just run the installer again. It will always offer a manifest pointing to the last released version of the integration.
+To update a Kubernetes integration installed with the [automated installer](#installer), just run the installer again. It will always offer a manifest pointing to the last released version of the integration.
 
 ### Using helm [#update-helm]
 


### PR DESCRIPTION
### Tell us why

There was a minor, incorrect formatting issue on a link on the K8S installation page in the update section.  It entailed reversing the order of parens and square brackets in the markdown for the link text and in-page link.

### Anything else you'd like to share?

This fix was tested in my local environment.  Please see the below screen captures of rendered HTML before the fix in this PR and after.

#### Current Live Site (BEFORE fix in this PR)
<img width="1241" alt="Before Link Fix" src="https://user-images.githubusercontent.com/2396774/110573174-ccd33200-8128-11eb-9f34-48b38bc31094.png">

#### Local development version (AFTER fix in this PR)
<img width="1236" alt="After Link Fix" src="https://user-images.githubusercontent.com/2396774/110573182-d0ff4f80-8128-11eb-8ebf-1d6188823a94.png">


### Are you making a change to site code?

No, this is a simple content change