### PR TITLE
Fix issue/PR triage when they are open

### DIFF
--- a/.github/workflows/issue-pr-triage.yml
+++ b/.github/workflows/issue-pr-triage.yml
@@ -16,14 +16,14 @@ jobs:
     steps:
     - name: Triages NEW issues and NEW pull requests to the Content Project
       uses: srggrs/assign-one-project-github-action@1.2.0
-      if: github.event == 'issue' || github.event = 'pull_request'
+      if: github.event.action == 'opened'
       with:
         project: 'https://github.com/newrelic/docs-website/projects/3'
         column_name: 'Needs Triage'
 
   localization_project:
     runs-on: ubuntu-latest
-    name: Triages to Localization Project
+    name: Triage to Localization Project
     steps:
     - name: Triages NEW issues and NEW pull requests to the Localization Project
       uses: srggrs/assign-one-project-github-action@1.2.0


### PR DESCRIPTION
### Tell us why

Turns out `github.event` is a reference to an object, so the workflow was not run correctly for new issues/PRs. Since we only want to run the action on NEW PRs and issues, this simplifies the condition to only run on the `opened` action regardless of whether it is an issue or PR. This should fix the issue triage.
