### PR TITLE
Remove unneeded escape characters from NRQL function doc collapsers

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -1386,7 +1386,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-buckets"
-    title={<InlineCode>buckets(attribute, ceiling \[,number of buckets])</InlineCode>}
+    title={<InlineCode>buckets(attribute, ceiling [,number of buckets])</InlineCode>}
   >
     Use the `buckets()` function to aggregate data split up by a `FACET` clause into buckets based on ranges. You can bucket by any attribute that is stored as a numerical value in the New Relic database.
 
@@ -1448,7 +1448,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-count"
-    title={<InlineCode>count(\*)</InlineCode>}
+    title={<InlineCode>count(*)</InlineCode>}
   >
     Use the `count( )` function to return a count of available records. It takes a single argument; either `*`, an attribute, or a constant value. Currently, it follows typical SQL behavior and counts all records that have values for its argument.
 
@@ -1458,7 +1458,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="derivative"
-    title={<InlineCode>derivative(attribute \[,time interval])</InlineCode>}
+    title={<InlineCode>derivative(attribute [,time interval])</InlineCode>}
   >
     `derivative()` finds the rate of change for a given dataset. The rate of change is calculated using a linear least-squares regression to approximate the derivative. Since this calculation requires comparing more than one datapoint, if only one datapoint is included in the evaluation range, the calculation is indeterminate and won't work, resulting in a `null` value.
 
@@ -1656,7 +1656,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-histogram"
-    title={<InlineCode>histogram(attribute, ceiling \[,number of buckets])</InlineCode>}
+    title={<InlineCode>histogram(attribute, ceiling [,number of buckets])</InlineCode>}
   >
     Use the `histogram( )` function to generate histograms. It takes three arguments:
 
@@ -1842,7 +1842,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-percentile"
-    title={<InlineCode>percentile(attribute \[, percentile \[, ...]])</InlineCode>}
+    title={<InlineCode>percentile(attribute [, percentile [, ...]])</InlineCode>}
   >
     Use the `percentile( )` function to return an attribute's approximate value at a given percentile. It requires an attribute and can take any number of arguments representing percentile points. The `percentile()` function enables percentiles to displays with up to three digits after the decimal point, providing greater precision. Percentile thresholds may be specified as decimal values, but be aware that for most data sets, percentiles closer than 0.1 from each other will not be resolved.
 
@@ -1872,7 +1872,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="predictLinear"
-    title={<InlineCode>predictLinear(attribute, \[,time interval])</InlineCode>}
+    title={<InlineCode>predictLinear(attribute, [,time interval])</InlineCode>}
   >
     `predictLinear()` is an extension of the `derivative()` function. It uses a similar method of least-squares linear regression to predict the future values for a dataset.
 
@@ -1886,7 +1886,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-rate"
-    title={<InlineCode>rate(function(attribute) \[,time interval])</InlineCode>}
+    title={<InlineCode>rate(function(attribute) [,time interval])</InlineCode>}
   >
     Use the `rate( )` function to visualize the frequency or rate of a given query per time interval. For example, you might want to know the number of pageviews per minute over an hour-long period or the count of unique sessions on your site per hour over a day-long period.
 
@@ -1963,7 +1963,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-uniques"
-    title={<><InlineCode>uniques(attribute \[,limit]</InlineCode><InlineCode>)</InlineCode></>}
+    title={<><InlineCode>uniques(attribute [,limit]</InlineCode><InlineCode>)</InlineCode></>}
   >
     Use the `uniques( )` function to return a list of unique values recorded for an attribute over the time range specified. When used along with the `facet` clause, a list of unique attribute values will be returned per each facet value.
 


### PR DESCRIPTION
### Tell us why

As I was looking at [this NRQL doc](https://docs.newrelic.com/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/), I noticed some of the collapsers included a `\` before the optional arguments where `[` was used. I believe this was due to our migration process and something that we forgot to remove when moving it to the `title` attribute. This PR removes those stray `\` characters to provide better clarity so someone doesn't assume this is part of the NRQL itself.