### PR TITLE
chore: Move getField examples into the collapser

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -1639,9 +1639,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
         </tr>
       </tbody>
     </table>
-  </Collapser>
 
-  <dd>
     Examples:
 
     ```
@@ -1651,7 +1649,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
     ```
     SELECT sum(mySummary) from Metric where getField(mySummary, count) > 10
     ```
-  </dd>
+  </Collapser>
 
   <Collapser
     className="freq-link"


### PR DESCRIPTION
### Tell us why

The `getField` section on the [NRQL functions doc](https://docs.newrelic.com/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#func-get-field) contained examples that are not captured inside of the collapser (see screenshot). This PR moves the examples into the collapser after the table.

### Anything else you'd like to share?

<img width="1036" alt="Screen Shot 2021-03-10 at 3 12 00 PM" src="https://user-images.githubusercontent.com/565661/110710582-fafd5400-81b2-11eb-9a42-abde859e2d31.png">
