### PR TITLE
fixes link to certificate glossary term

### DIFF
--- a/src/content/docs/agents/java-agent/configuration/configuring-your-ssl-certificates.mdx
+++ b/src/content/docs/agents/java-agent/configuration/configuring-your-ssl-certificates.mdx
@@ -9,7 +9,7 @@ redirects:
   - /docs/java/configuring-ssl-certs
 ---
 
-To communicate with the New Relic collector over HTTPS, you need to have the proper [certificates](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#ssl-certificate) for trusted signers in the trust store on your app server. By default, most JREs contain a valid root certificate that allows the agent to connect to newrelic.com.
+To communicate with the New Relic collector over HTTPS, you need to have the proper [certificates](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/glossary/#ssl-certificate) for trusted signers in the trust store on your app server. By default, most JREs contain a valid root certificate that allows the agent to connect to newrelic.com.
 
 ## Java Agent versions 6.2.0+
 

--- a/src/content/docs/agents/java-agent/configuration/configuring-your-ssl-certificates.mdx
+++ b/src/content/docs/agents/java-agent/configuration/configuring-your-ssl-certificates.mdx
@@ -9,7 +9,7 @@ redirects:
   - /docs/java/configuring-ssl-certs
 ---
 
-To communicate with the New Relic collector over HTTPS, you need to have the proper [certificates](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/glossary/#ssl-certificate) for trusted signers in the trust store on your app server. By default, most JREs contain a valid root certificate that allows the agent to connect to newrelic.com.
+To communicate with the New Relic collector over HTTPS, you need to have the proper [certificates](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/glossary#ssl-certificate) for trusted signers in the trust store on your app server. By default, most JREs contain a valid root certificate that allows the agent to connect to newrelic.com.
 
 ## Java Agent versions 6.2.0+
 

--- a/src/content/docs/agents/java-agent/configuration/configuring-your-ssl-certificates.mdx
+++ b/src/content/docs/agents/java-agent/configuration/configuring-your-ssl-certificates.mdx
@@ -9,11 +9,11 @@ redirects:
   - /docs/java/configuring-ssl-certs
 ---
 
-To communicate with the New Relic collector over HTTPS, you need to have the proper [certificates](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/glossary#ssl-certificate) for trusted signers in the trust store on your app server. By default, most JREs contain a valid root certificate that allows the agent to connect to newrelic.com.
+To communicate with the New Relic collector over HTTPS, you need to have the proper [certificates](/docs/using-new-relic/welcome-new-relic/get-started/glossary#ssl-certificate) for trusted signers in the trust store on your app server. By default, most JREs contain a valid root certificate that allows the agent to connect to newrelic.com.
 
 ## Java Agent versions 6.2.0+
 
-Starting with Java agent version 6.2.0, the [use_private_ssl](https://docs.newrelic.com/docs/agents/java-agent/configuration/java-agent-configuration-config-file#use_private_ssl) configuration option has been reintroduced so you can use the SSL certificates that are bundled into the agent jar. The following bundled SSL certificates are valid for up to a year after release.
+Starting with Java agent version 6.2.0, the [use_private_ssl](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#use_private_ssl) configuration option has been reintroduced so you can use the SSL certificates that are bundled into the agent jar. The following bundled SSL certificates are valid for up to a year after release.
 
 ```
 META-INF/certs/eu-newrelic-com.pem
@@ -24,7 +24,7 @@ META-INF/certs/eu-newrelic-com.pem
 <Callout variant="important">
   The Java agent will begin logging a warning message upon application startup when there are less than three months before the bundled certificate expires.
 
-  When the bundled certificates expire, the Java agent will no longer be able to connect to New Relic and you must either update to the latest agent version or provide a valid certificate using the [ca_bundle_path](https://docs.newrelic.com/docs/agents/java-agent/configuration/java-agent-configuration-config-file#ca_config_bundle) configuration.
+  When the bundled certificates expire, the Java agent will no longer be able to connect to New Relic and you must either update to the latest agent version or provide a valid certificate using the [ca_bundle_path](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#ca_config_bundle) configuration.
 
   Users wishing to add the global certificate to their local trust store can download the [DigiCert Global Root CA](https://www.digicert.com/kb/digicert-root-certificates.htm) from DigiCert.
 </Callout>
@@ -47,16 +47,16 @@ Summary
 
 There are two configuration settings that determine what certs are used by the agent to establish a secure connection to New Relic. They are: `use_private_ssl` and `ca_bundle_path`. Here's how they work together:
 
-* **DEFAULT**: Neither configuration option (`ca_bundle_path`/`use_private_ssl`) is provided, because both are using default values. The agent will use the default SSL certificates bundled into the Java Development Kit (JDK). If these certificates aren't present or don't include certificates that trust New Relic, then the agent will not connect. You'll need to [merge valid certificates into your JDK certificate bundle](https://docs.newrelic.com/docs/agents/java-agent/troubleshooting/ssl-or-connection-errors-java).
+* **DEFAULT**: Neither configuration option (`ca_bundle_path`/`use_private_ssl`) is provided, because both are using default values. The agent will use the default SSL certificates bundled into the Java Development Kit (JDK). If these certificates aren't present or don't include certificates that trust New Relic, then the agent will not connect. You'll need to [merge valid certificates into your JDK certificate bundle](/docs/agents/java-agent/troubleshooting/ssl-or-connection-errors-java).
 * Only `use_private_ssl` is configured. The agent will use the SSL certificates that are bundled with it.
-* Only `ca_bundle_path` is configured. The agent will try to connect using the custom SSL certificates bundle at the configured path. If the configured custom certificate bundle doesn’t include certificates that trust New Relic, then the agent will not connect. You'll need to [merge valid certificates into your custom certificate bundle](https://docs.newrelic.com/docs/agents/java-agent/troubleshooting/ssl-or-connection-errors-java).
+* Only `ca_bundle_path` is configured. The agent will try to connect using the custom SSL certificates bundle at the configured path. If the configured custom certificate bundle doesn’t include certificates that trust New Relic, then the agent will not connect. You'll need to [merge valid certificates into your custom certificate bundle](/docs/agents/java-agent/troubleshooting/ssl-or-connection-errors-java).
 * Both `use_private_ssl` and `ca_bundle_path` are configured. The `ca_bundle_path` configuration setting takes precedence and the `use_private_ssl` config is ignored. This behavior is the same as only specifying `ca_bundle_path`.
 
 ## Java Agent versions 6.0.0/6.1.0
 
 Starting in 6.0.0, the Java agent no longer includes the `nrcert` global certificate chain. Users wishing to add the global certificate to their local trust store must download the [DigiCert Global Root CA](https://www.digicert.com/kb/digicert-root-certificates.htm) from DigiCert.
 
-Note: In versions 6.1.0+, the Java agent will use a bundled New Relic certificate that is valid for up to a year after release. Before the certificate expires, you must either update the agent to the latest version or provide a valid certificate using the [ca_bundle_path](https://docs.newrelic.com/docs/agents/java-agent/configuration/java-agent-configuration-config-file#ca_config_bundle) configuration.
+Note: In versions 6.1.0+, the Java agent will use a bundled New Relic certificate that is valid for up to a year after release. Before the certificate expires, you must either update the agent to the latest version or provide a valid certificate using the [ca_bundle_path](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#ca_config_bundle) configuration.
 
 <Callout variant="important">
   The Java agent will begin logging a warning message upon application startup when there are less than three months before the bundled certificate expires.


### PR DESCRIPTION
previous link was not navigating to the `SSL Certificate` term in the glossary

<!-- Thanks for contributing to our docs! Your changes will help thousands of
New Relic users around the world. -->

<!-- Fill out this template to help us review your changes and route them to the
best team. See our [README.md](https://github.com/newrelic/docs-website/) for 
information on how to contribute. -->

### Tell us why

Explain why you're proposing this change. If there's an existing GitHub issue 
related to your change, please link to it.

### Anything else you'd like to share?

Add any context that will help us review your changes such as testing notes,
links to related docs, screenshots, etc. 

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/) 
in your commit messages and pull request title.