### PR TITLE
fix: set nri-jmx defaults for user and pass to empty string

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/jmx-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/jmx-monitoring-integration.mdx
@@ -127,15 +127,15 @@ Configuration options are below. For examples, see [Example config](#example-con
 
 This is where the host connection and collection file information is defined. This configuration accepts the following arguments. For an example, see [Host connection file example](#host-connection-example).
 
-* `collection_files`: A comma-separated list of full file paths to the metric collection definition files. For on-host install, the default JVM metrics collection file is at `/etc/newrelic-infra/integrations.d/jvm-metrics.yml`. Default value: `admin`.
+* `collection_files`: A comma-separated list of full file paths to the metric collection definition files. For on-host install, the default JVM metrics collection file is at `/etc/newrelic-infra/integrations.d/jvm-metrics.yml`.
 * Connection arguments:
   * `jmx_host`: the host JMX is running on. Default: `localhost`.
-  * `jmx_pass`: the password for the JMX connection. Default: `admin`.
+  * `jmx_pass`: the password for the JMX connection. Default: `""`.
   * `jmx_port`: the port JMX is running on. Default: `9999`.
   * `jmx_remote`: (JBoss specific) whether or not to use the JMX remote URL connection format, connection defaults to JBoss Domain-mode if `true`. Default: `false`.
   * `jmx_remote_jboss_standlone`: (JBoss specific) whether or not to use the JBoss standalone connection format, only relevant if `jmx_remote` is set. Default: `false`.
 * `connection_url:`: full JMX endpoint URL. This replaces all connection arguments (above) by providing all parameters on one line. Example: `"service:jmx:rmi:///jndi/rmi://localhost:7199/jmxrmi"` .
-* `jmx_user`: the username for the JMX connection. Default: `admin`.
+* `jmx_user`: the username for the JMX connection. Default: `""`.
 * `key_store`: the filepath of the keystore containing the JMX client's SSL certificate.
 * `key_store_password`: the password for the SSL key store.
 * `local_entity`: collect all metrics on the local entity. Only use when monitoring localhost. Default: `false`.


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! Your changes will help thousands of
New Relic users around the world. -->

<!-- Fill out this template to help us review your changes and route them to the
best team. See our [README.md](https://github.com/newrelic/docs-website/) for 
information on how to contribute. -->

### Tell us why

Defaults for user and pass for nri-jmx were rolled back to `""` in this PR [#57](https://github.com/newrelic/nri-jmx/pull/57)

### Anything else you'd like to share?

Add any context that will help us review your changes such as testing notes,
links to related docs, screenshots, etc. 

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/) 
in your commit messages and pull request title.