### PR TITLE
Only run build in PR validation for merges to develop, not main

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build:
     name: Gatsby Build
-    if: github.ref == 'refs/heads/develop'
+    if: github.base_ref == 'develop'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   build:
     name: Gatsby Build
+    if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Tell us why

Currently we run a build on PRs merging into develop and again when releasing develop to main. The build from develop -> main is unnecessary and adds a lot of time to releases. This PR adjusts the action so the build job is only run on PRs to develop

Closes #1209