### PR TITLE
chore: japanese message on PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,21 +2,27 @@
 New Relic users around the world. -->
 
 <!-- Fill out this template to help us review your changes and route them to the
-best team. See our [README.md](https://github.com/newrelic/docs-website/) for 
+best team. See our [README.md](https://github.com/newrelic/docs-website/) for
 information on how to contribute. -->
+
+<!-- If you find any problems with our Japanese content pages, you can submit an issue. At this
+time we aren't accepting Pull Requests on our Japanese content pages. -->
+
+<!-- 日本語訳されたドキュメントに問題を見つけた場合は、issueを提出することができます。
+issueをもとにドキュメントの改善に努めています。しかしながら、日本語訳のPRを直接マージする準備はまだできていないためご了承ください。-->
 
 ### Tell us why
 
-Explain why you're proposing this change. If there's an existing GitHub issue 
+Explain why you're proposing this change. If there's an existing GitHub issue
 related to your change, please link to it.
 
 ### Anything else you'd like to share?
 
 Add any context that will help us review your changes such as testing notes,
-links to related docs, screenshots, etc. 
+links to related docs, screenshots, etc.
 
 ### Are you making a change to site code?
 
 If you're changing site code (rather than the content of a doc), please follow
-[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/) 
+[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
 in your commit messages and pull request title.


### PR DESCRIPTION
This PR adds a message in Japanese as a markdown comment explaining we don't accept PRs for Japanese content at this time. 