### PR TITLE
Set swiftype type via theme's updated SEO component

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "^2.0.0-next.8",
     "@mdx-js/react": "^2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "^1.35.2",
+    "@newrelic/gatsby-theme-newrelic": "^1.36.0",
     "@splitsoftware/splitio-react": "^1.2.0",
     "babel-jest": "^26.3.0",
     "common-tags": "^1.8.0",

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -8,12 +8,6 @@ const METADATA = [
     name: 'google-site-verification',
     content: 'eT8TSNhvMuDmAtqbtq5jygZKVkhDmz565fYQ3DVop4g',
   },
-  {
-    className: 'swiftype',
-    name: 'type',
-    'data-type': 'enum',
-    content: 'docs',
-  },
 ];
 
 const DocsSiteSeo = ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2222,10 +2222,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^1.35.2":
-  version "1.35.2"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.35.2.tgz#adce818e0aad0f4f1b719710c49b0b16ac644c22"
-  integrity sha512-sCi1nZCN121JVtay4dDYaxvRHK+ScSBad+4UzoOZhXNVoiPpnr7LXr1YMddecBzy5H7cacRbHG4DcOlZg8ilUw==
+"@newrelic/gatsby-theme-newrelic@^1.36.0":
+  version "1.36.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.36.0.tgz#c31e268543db00bd1f1b982087da56d24e4d1d75"
+  integrity sha512-wT3TkzuY70hbS5GkTlwpgI93inqWZbj1iHlbrGfE9hWGnAt8AWh1uds7RqXiWX9RsgNA1btagxI+0RUcoXrawQ==
   dependencies:
     "@elastic/react-search-ui" "^1.4.1"
     "@elastic/react-search-ui-views" "^1.4.1"


### PR DESCRIPTION
## Description
Bumps theme version to use updated `<SEO>` theme component that sets swiftype meta tag based on `siteMetadata.siteUrl`. Supports setting separate `type` value for localized pages.

## Related issues
- https://github.com/newrelic/docs-website/issues/1204