### PR TITLE
Updated "Script repository" link because it 404s

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050.mdx
@@ -1550,4 +1550,4 @@ Additional documentation resources include:
 
 * [Write scripted browsers](/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers) (how to build WebDriverJS scripts for multi-step monitoring)
 * [Scripted browser examples](/docs/synthetics/new-relic-synthetics/scripting-monitors/scripted-browser-examples) (example code for scripted browsers, including comments, with examples such as searching a website and waiting for results to load)
-* [Script repository in New Relic's Explorers Hub](https://discuss.newrelic.com/tags/c/support-products-agents/synthetics/synthetics-script) (example scripts tagged `synthetics-script`, created and shared by our online technical community)
+* [Script repository in New Relic's Explorers Hub](https://discuss.newrelic.com/search?q=tags%3Asyntheticsscript) (example scripts tagged `synthetics-script`, created and shared by our online technical community)


### PR DESCRIPTION
### Tell us why

Link https://discuss.newrelic.com/tags/c/support-products-agents/synthetics/synthetics-script is leading to a 404 not found page right now.

Replaced it with what seems like the equivalent.

### Anything else you'd like to share?

N/A

### Are you making a change to site code?

N/A