### PR TITLE
Links now point to lists

### DIFF
--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -628,15 +628,15 @@ pages:
           - title: Intro to integrations
             path: /docs/infrastructure/integrations/types-integrations/intro-integrations
           - title: Amazon/AWS integrations
-            path: /docs/infrastructure/integrations/integrations/amazonaws-integrations-0
+            path: /docs/integrations/amazon-integrations/aws-integrations-list
           - title: Azure integrations
-            path: /docs/infrastructure/integrations/integrations/azure-integrations
+            path: /docs/integrations/microsoft-azure-integrations/azure-integrations-list
           - title: Google Cloud integrations
-            path: /docs/infrastructure/integrations/types-integrations/google-cloud-integrations
+            path: /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list
           - title: Kubernetes integration
             path: /docs/infrastructure/integrations/types-integrations/introduction-kubernetes-integration
           - title: On-host integrations
-            path: /docs/infrastructure/integrations-getting-started/integrations/host-integrations
+            path: /docs/integrations/host-integrations/host-integrations-list
           - title: Integrations SDK
             path: /docs/infrastructure/integrations/types-integrations/integrations-sdk
       - title: Infrastructure Integrations SDK


### PR DESCRIPTION
Closes #1276 . This PR changes the links under Types of Integrations to point towards the relevant lists. 