### PR TITLE
Added line explaining buffer period between release notes PR and public build

### DIFF
--- a/src/content/docs/style-guide/article-templates/create-release-notes.mdx
+++ b/src/content/docs/style-guide/article-templates/create-release-notes.mdx
@@ -23,3 +23,4 @@ Review the recommended [best practices for New Relic release notes](https://nerd
 
 A Tech Docs hero will review your release note content and approve your pull request to get it published.
 
+If release notes are blockers for your team, please be aware that release note pull requests may take a few hours to appear on the docs site after merging. 

--- a/src/content/docs/style-guide/article-templates/create-release-notes.mdx
+++ b/src/content/docs/style-guide/article-templates/create-release-notes.mdx
@@ -23,4 +23,4 @@ Review the recommended [best practices for New Relic release notes](https://nerd
 
 A Tech Docs hero will review your release note content and approve your pull request to get it published.
 
-If release notes are blockers for your team, please be aware that release note pull requests may take a few hours to appear on the docs site after merging. 
+We only build and deploy the site a few times a day, and currently builds can take a few hours to complete. If your release is time-sensitive, ensure you've planned for enough time to get the docs live. 


### PR DESCRIPTION
Quick addition stating that release note PRs might take a few hours to render on the docs site. Added since release notes are blockers for some teams. 