### PR TITLE
Removed broken RSS feed link

### DIFF
--- a/src/content/docs/security/security-privacy/information-security/security-bulletins.mdx
+++ b/src/content/docs/security/security-privacy/information-security/security-bulletins.mdx
@@ -18,7 +18,7 @@ This document contains important information regarding security vulnerabilities 
 
 ## Get security notifications [#notifications]
 
-To receive notifications for future advisories, select the **Watching** option in our Explorers Hub's [Security notifications community channel](https://discuss.newrelic.com/c/security-notifications) to receive email alerts.
+Select the **Watching** option in our Explorers Hub's [Security notifications community channel](https://discuss.newrelic.com/c/security-notifications) to receive email alerts.
 
 ## APM
 

--- a/src/content/docs/security/security-privacy/information-security/security-bulletins.mdx
+++ b/src/content/docs/security/security-privacy/information-security/security-bulletins.mdx
@@ -18,11 +18,7 @@ This document contains important information regarding security vulnerabilities 
 
 ## Get security notifications [#notifications]
 
-To receive notifications for future advisories, use either of these options:
-
-* Select New Relic's [<Icon style={{color: '#EE6F2E'}} name="fe-rss"/>
-  ](/docs/accounts-partnerships/accounts/security-bulletins/feed "RSS feed link") [RSS feed](/docs/accounts-partnerships/accounts/security-bulletins/feed "RSS feed link").
-* Select the **Watching** option in our Explorers Hub's [Security notifications community channel](https://discuss.newrelic.com/c/security-notifications) to receive email alerts.
+To receive notifications for future advisories, select the **Watching** option in our Explorers Hub's [Security notifications community channel](https://discuss.newrelic.com/c/security-notifications) to receive email alerts.
 
 ## APM
 


### PR DESCRIPTION
Just a very small edit to remove a bullet linking to RSS feed, which is not currently supported. No peer or tech review needed. 