### PR TITLE
add section to create-nrql-alert-conditions.mdx

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -142,7 +142,7 @@ SELECT function(attribute)
 
 ## Reformatting Incompatible NRQL [#reformatting]
 
-Some elements of NRQL used in charts don’t make sense in the streaming context of alerts. Here’s a list of the most common incompatible elements and suggestions for reformatting a NRQL Alert query to achieve the same effect.
+Some elements of NRQL used in charts don’t make sense in the streaming context of alerts. Here’s a list of the most common incompatible elements and suggestions for reformatting a NRQL alert query to achieve the same effect.
 
 <table>
   <thead>
@@ -165,7 +165,7 @@ Some elements of NRQL used in charts don’t make sense in the streaming context
       <td>
         Example:  ```SELECT percentile(largestContentfulPaint, 75) FROM PageViewTiming WHERE (appId = 837807) SINCE yesterday```
 
-        NRQL Alerting produces a never-ending stream of windowed query results, so the SINCE and UNTIL keywords to scope the query to a point in time are not compatible. As a convenience, we automatically strip SINCE and UNTIL from a query when creating a NRQL Alert Condition from the context of a chart.
+        NRQL Alerting produces a never-ending stream of windowed query results, so the `SINCE` and `UNTIL` keywords to scope the query to a point in time are not compatible. As a convenience, we automatically strip `SINCE` and `UNTIL` from a query when creating a NRQL Alert Condition from the context of a chart.
       </td>
     </tr>
 
@@ -175,7 +175,7 @@ Some elements of NRQL used in charts don’t make sense in the streaming context
       </td>
 
       <td>
-        In NRQL queries, the TIMESERIES clause is used to return data as a time series broken out by a specified period of time.
+        In NRQL queries, the `TIMESERIES` clause is used to return data as a time series broken out by a specified period of time.
 
         For NRQL alerts, the equivalent property of a signal is the aggregation window.
       </td>
@@ -212,7 +212,7 @@ Some elements of NRQL used in charts don’t make sense in the streaming context
       </td>
 
       <td>
-        The COMPARE WITH clause is used to compare the values for two different time ranges. This type of query is incompatible with NRQL alerting. We recommend using a [Baseline Alert Condition](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-baseline-alert-conditions/) to dynamically detect deviations for a particular signal.
+        The `COMPARE WITH` clause is used to compare the values for two different time ranges. This type of query is incompatible with NRQL alerting. We recommend using a [Baseline Alert Condition](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-baseline-alert-conditions/) to dynamically detect deviations for a particular signal.
 
       </td>
     </tr>
@@ -222,9 +222,9 @@ Some elements of NRQL used in charts don’t make sense in the streaming context
       </td>
 
       <td>
-        The SLIDE BY clause supports a feature known as sliding windows. With sliding windows,SLIDE BY data is gathered into "windows" of time that overlap with each other. These windows can help to smooth out line graphs with a lot of variation in cases where the rolling aggregate (such as a rolling mean) is more important than aggregates from narrow windows of time.
+        The `SLIDE BY` clause supports a feature known as sliding windows. With sliding windows, `SLIDE BY data is gathered into "windows" of time that overlap with each other. These windows can help to smooth out line graphs with a lot of variation in cases where the rolling aggregate (such as a rolling mean) is more important than aggregates from narrow windows of time.
 
-        Configuration of sliding windows is not currently supported in NRQL alerts.
+        Sliding windows are not currently supported in NRQL alerts.
       </td>
     </tr>
         <tr>

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -43,7 +43,7 @@ To create a NRQL alert condition for a policy:
 Here's the basic syntax for creating all NRQL alert conditions. The [`FACET` clause](#facet) is required for Outlier threshold types, optional for Static, and not allowed for Baseline.
 
 ```
-SELECT function(attribute) 
+SELECT function(attribute)
 	FROM Event
 	WHERE attribute [comparison] [AND|OR ...]
 ```
@@ -139,6 +139,108 @@ SELECT function(attribute)
     </tr>
   </tbody>
 </table>
+
+## Reformatting Incompatible NRQL [#reformatting]
+
+Some elements of NRQL used in charts don’t make sense in the streaming context of alerts. Here’s a list of the most common incompatible elements and suggestions for reformatting a NRQL Alert query to achieve the same effect.
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "300px" }}>
+        **Clause**
+      </th>
+
+      <th>
+        **Notes**
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `SINCE` and `UNTIL`
+      </td>
+      <td>
+        Example:  ```SELECT percentile(largestContentfulPaint, 75) FROM PageViewTiming WHERE (appId = 837807) SINCE yesterday```
+
+        NRQL Alerting produces a never-ending stream of windowed query results, so the SINCE and UNTIL keywords to scope the query to a point in time are not compatible. As a convenience, we automatically strip SINCE and UNTIL from a query when creating a NRQL Alert Condition from the context of a chart.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `TIMESERIES`
+      </td>
+
+      <td>
+        In NRQL queries, the TIMESERIES clause is used to return data as a time series broken out by a specified period of time.
+
+        For NRQL alerts, the equivalent property of a signal is the aggregation window.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Multiple Aggregation Functions
+      </td>
+
+      <td>
+        Each alert condition can only target a single aggregated stream of data.  To alert on multiple streams simultaneously, you’ll need to decompose them into individual conditions within the same policy.
+
+        Original Query:
+        ```
+        SELECT count(foo), average(bar), max(baz) from Transaction
+        ```
+
+        Decomposed:
+        ```
+        SELECT count(foo) from Transaction
+
+        SELECT average(bar)  from Transaction
+
+        SELECT max(baz) from Transaction
+        ```
+
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `COMPARE WITH`
+      </td>
+
+      <td>
+        The COMPARE WITH clause is used to compare the values for two different time ranges. This type of query is incompatible with NRQL alerting. We recommend using a [Baseline Alert Condition](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-baseline-alert-conditions/) to dynamically detect deviations for a particular signal.
+
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `SLIDE BY`
+      </td>
+
+      <td>
+        The SLIDE BY clause supports a feature known as sliding windows. With sliding windows,SLIDE BY data is gathered into "windows" of time that overlap with each other. These windows can help to smooth out line graphs with a lot of variation in cases where the rolling aggregate (such as a rolling mean) is more important than aggregates from narrow windows of time.
+
+        Configuration of sliding windows is not currently supported in NRQL alerts.
+      </td>
+    </tr>
+        <tr>
+      <td>
+        `LIMIT`
+      </td>
+
+      <td>
+        In NRQL queries, the LIMIT clause is used to control the amount of data a query returns, either the maximum number of facet values returned by FACET queries or the maximum number of items returned by SELECT * queries.
+
+        LIMIT is not compatible with NRQL alerting: evaluation is always performed on the full result set.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 
 ## NRQL alert threshold examples [#examples]
 
@@ -319,7 +421,7 @@ Here are some tips for creating and using a NRQL condition:
 
     <tr>
       <td>
-        Lost signal threshold  
+        Lost signal threshold
         (loss of signal detection)
       </td>
 
@@ -423,7 +525,7 @@ When you create a NRQL alert, you can choose from different types of thresholds:
 
     <tr>
       <td>
-        [Baseline](/docs/alerts/new-relic-alerts/defining-conditions/create-baseline-alert-conditions)  
+        [Baseline](/docs/alerts/new-relic-alerts/defining-conditions/create-baseline-alert-conditions)
         (Dynamic)
       </td>
 
@@ -476,7 +578,7 @@ Loss of signal settings include a time duration and two possible actions.
   * Expiration duration is a timer that starts and resets when we receive a data point in the streaming alerts pipeline. If we don't receive another data point before your 'expiration time' expires, we consider that signal to be lost. This can be because no data is being sent to New Relic or the `WHERE` clause of your NRQL query is filtering that data out before it is streamed to the alerts pipeline.
   * The loss of signal expiration time is independent of the threshold duration and triggers as soon as the timer expires.
   * The maximum expiration duration is 48 hours. This is helpful when monitoring for the execution of infrequent jobs. The minimum is 30 seconds, but we recommend using at least 3-5 minutes.
-* **Loss of signal actions**  
+* **Loss of signal actions**
   Once a signal is considered lost, you can close open violations, open new violations, or both.
   * Close all current open violations: This closes all open violations that are related to a specific signal. It won't necessarily close all violations for a condition. If you're alerting on an ephemeral service, or on a sporadic signal, you'll want to choose this action to ensure that violations are closed properly. The GraphQL node name for this is ["closeViolationsOnExpiration](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling)"
   * Open new violations: This will open a new violation when the signal is considered lost. These violations will indicate that they are due to a loss of signal. Based on your incident preferences, this should trigger a notification. The graphQL node name for this [is "openViolationOnExpiration](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling)"
@@ -542,6 +644,6 @@ Gap filling lets you customize the values to use when your signals don't have an
 Options for editing data gap settings:
 
 * In the NRQL conditions UI, go to **Condition settings** > **Advanced signal settings** > **fill data gaps with** and choose an option.
-* If using our [Nerdgraph API](/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling) (preferred), this node is located at:  
+* If using our [Nerdgraph API](/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling) (preferred), this node is located at:
   `actor : account : alerts : nrqlCondition : signal : fillOption | fillValue`
 * NerdGraph is the preferred API but if you are using our REST API, you can find this setting in the REST API explorer under the **"signal"** section of [the Alert NRQL conditions API](https://rpm.newrelic.com/api/explore/alerts_nrql_conditions/list).

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -163,7 +163,11 @@ Some elements of NRQL used in charts don’t make sense in the streaming context
         `SINCE` and `UNTIL`
       </td>
       <td>
-        Example:  ```SELECT percentile(largestContentfulPaint, 75) FROM PageViewTiming WHERE (appId = 837807) SINCE yesterday```
+        Example:  
+        
+        ```
+        SELECT percentile(largestContentfulPaint, 75) FROM PageViewTiming WHERE (appId = 837807) SINCE yesterday
+        ```
 
         NRQL Alerting produces a never-ending stream of windowed query results, so the `SINCE` and `UNTIL` keywords to scope the query to a point in time are not compatible. As a convenience, we automatically strip `SINCE` and `UNTIL` from a query when creating a NRQL Alert Condition from the context of a chart.
       </td>
@@ -212,7 +216,7 @@ Some elements of NRQL used in charts don’t make sense in the streaming context
       </td>
 
       <td>
-        The `COMPARE WITH` clause is used to compare the values for two different time ranges. This type of query is incompatible with NRQL alerting. We recommend using a [Baseline Alert Condition](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-baseline-alert-conditions/) to dynamically detect deviations for a particular signal.
+        The `COMPARE WITH` clause is used to compare the values for two different time ranges. This type of query is incompatible with NRQL alerting. We recommend using a [Baseline Alert Condition](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-baseline-alert-conditions) to dynamically detect deviations for a particular signal.
 
       </td>
     </tr>
@@ -222,7 +226,7 @@ Some elements of NRQL used in charts don’t make sense in the streaming context
       </td>
 
       <td>
-        The `SLIDE BY` clause supports a feature known as sliding windows. With sliding windows, `SLIDE BY data is gathered into "windows" of time that overlap with each other. These windows can help to smooth out line graphs with a lot of variation in cases where the rolling aggregate (such as a rolling mean) is more important than aggregates from narrow windows of time.
+        The `SLIDE BY` clause supports a feature known as sliding windows. With sliding windows, `SLIDE BY` data is gathered into "windows" of time that overlap with each other. These windows can help to smooth out line graphs with a lot of variation in cases where the rolling aggregate (such as a rolling mean) is more important than aggregates from narrow windows of time.
 
         Sliding windows are not currently supported in NRQL alerts.
       </td>
@@ -240,7 +244,6 @@ Some elements of NRQL used in charts don’t make sense in the streaming context
     </tr>
   </tbody>
 </table>
-
 
 ## NRQL alert threshold examples [#examples]
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -140,7 +140,7 @@ SELECT function(attribute)
   </tbody>
 </table>
 
-## Reformatting Incompatible NRQL [#reformatting]
+## Reformatting incompatible NRQL [#reformatting]
 
 Some elements of NRQL used in charts don’t make sense in the streaming context of alerts. Here’s a list of the most common incompatible elements and suggestions for reformatting a NRQL alert query to achieve the same effect.
 
@@ -202,7 +202,7 @@ Some elements of NRQL used in charts don’t make sense in the streaming context
         ```
         SELECT count(foo) from Transaction
 
-        SELECT average(bar)  from Transaction
+        SELECT average(bar) from Transaction
 
         SELECT max(baz) from Transaction
         ```


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! Your changes will help thousands of
New Relic users around the world. -->

<!-- Fill out this template to help us review your changes and route them to the
best team. See our [README.md](https://github.com/newrelic/docs-website/) for
information on how to contribute. -->

<!-- If you find any problems with our Japanese content pages, you can submit an issue. At this
time we aren't accepting Pull Requests on our Japanese content pages. -->

<!-- 日本語訳されたドキュメントに問題を見つけた場合は、issueを提出することができます。
issueをもとにドキュメントの改善に努めています。しかしながら、日本語訳のPRを直接マージする準備はまだできていないためご了承ください。-->

### Tell us why
When the ability to create a NRQL alert directly from a chart is released, some elements of NRQL that worked in the charting context won't be appropriate for creating an alert condition. This PR adds a section that covers the most common disallowed elements and how to achieve the same effect in an alerting context.

### Anything else you'd like to share?

We're planning to link to this from the error message in the Alerts Condition Builder UI when SINCE, UNTIL, etc are entered into the query field. SEE NR Jira AINTER-7731 for details.


### Are you making a change to site code?
No, just text