### PR TITLE
Add swiftype document_type to whats new page

### DIFF
--- a/src/pages/whats-new.js
+++ b/src/pages/whats-new.js
@@ -6,6 +6,7 @@ import { graphql } from 'gatsby';
 import { Layout, Link, useTranslation } from '@newrelic/gatsby-theme-newrelic';
 import Timeline from '../components/Timeline';
 import SEO from '../components/SEO';
+import { TYPES } from '../utils/constants';
 
 const WhatsNew = ({ data, location }) => {
   const now = useMemo(() => new Date(), []);
@@ -28,7 +29,11 @@ const WhatsNew = ({ data, location }) => {
 
   return (
     <>
-      <SEO location={location} title="What's new in New Relic" />
+      <SEO
+        location={location}
+        title="What's new in New Relic"
+        type={TYPES.WHATS_NEW}
+      />
       <div>
         <PageTitle
           css={css`

--- a/src/pages/whats-new.js
+++ b/src/pages/whats-new.js
@@ -32,7 +32,7 @@ const WhatsNew = ({ data, location }) => {
       <SEO
         location={location}
         title="What's new in New Relic"
-        type={TYPES.WHATS_NEW}
+        type={TYPES.WHATS_NEW_PAGE}
       />
       <div>
         <PageTitle

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -13,4 +13,5 @@ export const TYPES = {
   TABLE_OF_CONTENTS: 'views_page_menu',
   AUTO_INDEX_PAGE: 'views_page_menu',
   ATTRIBUTE_DICTIONARY: 'views_page_content',
+  WHATS_NEW: 'views_page_content',
 };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -13,5 +13,5 @@ export const TYPES = {
   TABLE_OF_CONTENTS: 'views_page_menu',
   AUTO_INDEX_PAGE: 'views_page_menu',
   ATTRIBUTE_DICTIONARY: 'views_page_content',
-  WHATS_NEW: 'views_page_content',
+  WHATS_NEW_PAGE: 'views_page_content',
 };


### PR DESCRIPTION
## Description

Adds a swiftype meta tag for `document_type` set to `views_page_content` (same as attribute dictionary) so we can apply some filtering for searches. Any page with dynamic content used this value in Drupal, so we want to match that for now. 

These kinds of pages tend to add noise to search results since they're dynamic and essentially list content. And the jp namespaced pages contain a lot of English content, so if users' searches match this page, they will see duplicate records (unless we update search UI to be a fully localized experience)

## Related issues / PRs
https://github.com/newrelic/docs-website/issues/1191