### PR TITLE
Change obscure "epoch milliseconds" to "unix time"

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/proactive-detection/proactive-detection-applied-intelligence.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/proactive-detection/proactive-detection-applied-intelligence.mdx
@@ -405,7 +405,7 @@ Proactive Detection sends the event body in JSON format via HTTPS POST. The syst
       </td>
 
       <td>
-        The timestamp of the data point in [Unix time](https://en.wikipedia.org/wiki/Unix_time).  
+        The timestamp of the data point in [milliseconds since the Unix epoch](https://currentmillis.com/).
         Example: 1584366819000
       </td>
     </tr>

--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/proactive-detection/proactive-detection-applied-intelligence.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/proactive-detection/proactive-detection-applied-intelligence.mdx
@@ -405,7 +405,7 @@ Proactive Detection sends the event body in JSON format via HTTPS POST. The syst
       </td>
 
       <td>
-        The timestamp of the data point in epoch milliseconds.  
+        The timestamp of the data point in [Unix time](https://en.wikipedia.org/wiki/Unix_time).  
         Example: 1584366819000
       </td>
     </tr>

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-distributed-trace-data-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-distributed-trace-data-tutorial.mdx
@@ -81,7 +81,7 @@ Additional trace-level data:
       </td>
 
       <td>
-        Epoch milliseconds timestamp representing the trace's start time.
+        Unix timestamp representing the trace's start time.
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-distributed-trace-data-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-distributed-trace-data-tutorial.mdx
@@ -81,7 +81,7 @@ Additional trace-level data:
       </td>
 
       <td>
-        Unix timestamp representing the trace's start time.
+        The trace's start time in milliseconds since the Unix epoch](https://currentmillis.com/).
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/understand-dependencies/distributed-tracing/trace-api/report-new-relic-format-traces-trace-api.mdx
+++ b/src/content/docs/understand-dependencies/distributed-tracing/trace-api/report-new-relic-format-traces-trace-api.mdx
@@ -169,7 +169,7 @@ The Trace API JSON payload is an array of objects, with each object representing
       </td>
 
       <td>
-        Span start time in [Unix time](https://en.wikipedia.org/wiki/Unix_time).
+        Span start time in [milliseconds since the Unix epoch](https://currentmillis.com/).
       </td>
 
       <td>

--- a/src/content/docs/understand-dependencies/distributed-tracing/trace-api/report-new-relic-format-traces-trace-api.mdx
+++ b/src/content/docs/understand-dependencies/distributed-tracing/trace-api/report-new-relic-format-traces-trace-api.mdx
@@ -169,7 +169,7 @@ The Trace API JSON payload is an array of objects, with each object representing
       </td>
 
       <td>
-        Span start time in [Epoch milliseconds](https://currentmillis.com/).
+        Span start time in [Unix time](https://en.wikipedia.org/wiki/Unix_time).
       </td>
 
       <td>

--- a/src/data-dictionary/events/SyntheticCheck/timestamp.md
+++ b/src/data-dictionary/events/SyntheticCheck/timestamp.md
@@ -7,4 +7,4 @@ events:
   - SyntheticsPrivateLocationStatus
 ---
 
-The start time of the job in epoch milliseconds.
+The start time of the job in Unix time (milliseconds since the Unix epoch).

--- a/src/data-dictionary/events/SyntheticCheck/timestamp.md
+++ b/src/data-dictionary/events/SyntheticCheck/timestamp.md
@@ -7,4 +7,4 @@ events:
   - SyntheticsPrivateLocationStatus
 ---
 
-The start time of the job in Unix time (milliseconds since the Unix epoch).
+The start time of the job in milliseconds since the Unix epoch. (See https://currentmillis.com for an example.)

--- a/src/data-dictionary/events/TransactionError/timestamp.md
+++ b/src/data-dictionary/events/TransactionError/timestamp.md
@@ -6,4 +6,4 @@ events:
   - TransactionError
 ---
 
-The start time of the job in Unix time (milliseconds since the Unix epoch).
+The start time of the job in milliseconds since the Unix epoch. (See https://currentmillis.com for an example.)

--- a/src/data-dictionary/events/TransactionError/timestamp.md
+++ b/src/data-dictionary/events/TransactionError/timestamp.md
@@ -6,4 +6,4 @@ events:
   - TransactionError
 ---
 
-The start time of the job in epoch milliseconds.
+The start time of the job in Unix time (milliseconds since the Unix epoch).


### PR DESCRIPTION
[Unix time](https://en.wikipedia.org/wiki/Unix_time) is the most common usage.