### PR TITLE
Fix broken link in Tip callout

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/scripted-browser-examples.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/scripted-browser-examples.mdx
@@ -17,7 +17,7 @@ Using [scripted browsers](/docs/synthetics/new-relic-synthetics/scripting-monito
 For a detailed guide to all the available functions, see [Synthetic's scripted browser reference](/docs/synthetics/new-relic-synthetics/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050).
 
 <Callout variant="tip">
-  To view and share other scripted browser examples, check out the [synthetic scripts](https://discuss.newrelic.com/tags/c/support-products-agents/synthetics/synthetics-script) section of the New Relic Online Technical Community.
+  To view other scripted browser examples, check out the [Quickstarts Synthetics library](https://github.com/newrelic/quickstarts-synthetics-library) in New Relic’s Github repository. You may also view tips from New Relic support engineers in the [Level Up Relic Solutions](https://discuss.newrelic.com/search?q=Synthetics%20category%3A463) section of the New Relic Online Technical Community.
 </Callout>
 
 ## Monitor a URL [#advanced-url]


### PR DESCRIPTION
The Community Forum link in the Tip callout is no longer valid. Recommend linking to Quickstart Synthetics library and Level Up Relic Solutions.

<!-- Thanks for contributing to our docs! Your changes will help thousands of
New Relic users around the world. -->

<!-- Fill out this template to help us review your changes and route them to the
best team. See our [README.md](https://github.com/newrelic/docs-website/) for
information on how to contribute. -->

<!-- If you find any problems with our Japanese content pages, you can submit an issue. At this
time we aren't accepting Pull Requests on our Japanese content pages. -->

<!-- 日本語訳されたドキュメントに問題を見つけた場合は、issueを提出することができます。
issueをもとにドキュメントの改善に努めています。しかしながら、日本語訳のPRを直接マージする準備はまだできていないためご了承ください。-->

### Tell us why

Explain why you're proposing this change. If there's an existing GitHub issue
related to your change, please link to it.

### Anything else you'd like to share?

Add any context that will help us review your changes such as testing notes,
links to related docs, screenshots, etc.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.
