### PR TITLE
Update enable-serverless-monitoring-using-lambda-layer.mdx

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-using-lambda-layer.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-using-lambda-layer.mdx
@@ -41,15 +41,13 @@ For Node.js and Python, the layer contains the New Relic agent code, and a wrapp
 To enable serverless monitoring using our Lambda layer, you need the following:
 
 * [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured using `aws configure`.
-* Python version 3.3 or higher installed.
-* [newrelic-lambda CLI](https://github.com/newrelic/newrelic-lambda-cli#installation), which you can install by running `pip install newrelic-lambda-cli`.
+* [Python](https://www.python.org/downloads/) version 3.3 or higher installed.
+* [newrelic-lambda CLI](https://github.com/newrelic/newrelic-lambda-cli#installation), which you can install by running `pip3 install newrelic-lambda-cli`.
 * A New Relic account. You must be an admin, or have the **Infrastructure manager** [add-on role](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model#add-on).
 * A [user key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#personal-api-key).
 * An AWS account with permissions for creating IAM resources, managed secrets, and Lambdas. You also need permissions for creating CloudFormation stacks and S3 buckets.
 
-Note that you may need to use `pip3` instead of `pip` if your system uses Python 2 by default.
-
-## Enable serverless monitoring [#enable-erverless-monitoring]
+## Enable serverless monitoring [#enable-serverless-monitoring]
 
 There are a few things that have to happen to let New Relic gather telemetry from your Lambda functions.
 
@@ -66,7 +64,6 @@ When all the [requirements](#requirements) are in place, link your AWS account w
 
 ```
 newrelic-lambda integrations install --nr-account-id <var><a href="/docs/accounts/accounts-billing/account-setup/account-id">YOUR_NR_ACCOUNT_ID</a></var> \
-    --linked-account-name <var>YOUR_LINKED_ACCOUNT_NAME</var> \
     --nr-api-key <var><a href="https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key">YOUR_NEW_RELIC_USER_KEY</a></var>
 ```
 
@@ -108,7 +105,7 @@ We recommend trying out our example code for the following languages:
 
 Each example contains instructions, sample code, and a deploy script to get started. After you've gotten the example to work for you, you can clean up by deleting the CloudFormation stack, using either the AWS Console, or the AWS CLI: `aws cloudformation delete-stack --stack-name <stack-name>`
 
-Our examples are based on the AWS SAM CLI. There are other tools available for managing and deploying Lambda functions. New Relic offers a plugin for the Serverless Framework, and the CLI can modify your existing Lambda functions to add instrumentation. You can integrate the necessary Lambda layer and function permission using whatever AWS resource management tool you choose.
+Our examples are based on the AWS SAM CLI. There are other tools available for managing and deploying Lambda functions. New Relic offers a [plugin for the Serverless Framework](https://github.com/newrelic/serverless-newrelic-lambda-layers), and the CLI can modify your existing Lambda functions to add instrumentation. You can integrate the necessary Lambda layer and function permission using whatever AWS resource management tool you choose.
 
 ## Troubleshooting
 


### PR DESCRIPTION
* `pip3` is pretty much universal at this point, so this removes the `pip` command in favor of the `pip3` one
* Adds a link to download/install Python
* Removes the `--link-account-name` argument as it is not required and there is a sensible default
* Added link to the Serverless plugin

<!-- Thanks for contributing to our docs! Your changes will help thousands of
New Relic users around the world. -->

<!-- Fill out this template to help us review your changes and route them to the
best team. See our [README.md](https://github.com/newrelic/docs-website/) for
information on how to contribute. -->

<!-- If you find any problems with our Japanese content pages, you can submit an issue. At this
time we aren't accepting Pull Requests on our Japanese content pages. -->

<!-- 日本語訳されたドキュメントに問題を見つけた場合は、issueを提出することができます。
issueをもとにドキュメントの改善に努めています。しかしながら、日本語訳のPRを直接マージする準備はまだできていないためご了承ください。-->

### Tell us why

Explain why you're proposing this change. If there's an existing GitHub issue
related to your change, please link to it.

### Anything else you'd like to share?

Add any context that will help us review your changes such as testing notes,
links to related docs, screenshots, etc.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.
