### PR TITLE
Add release notes for .NET Agent 8.39.1

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-83901.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-83901.mdx
@@ -1,0 +1,37 @@
+---
+subject: .NET agent
+releaseDate: '2021-03-17'
+version: 8.39.1.0
+downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+---
+
+### Fixes
+* Fixes issue [#22](https://github.com/newrelic/newrelic-dotnet-agent/issues/22): Agent causes exception when distributed tracing is enabled in ASP.NET Core applications that use the RequestLocalization middleware in a Linux environment. ([#493](https://github.com/newrelic/newrelic-dotnet-agent/pull/493))
+* Fixes issue [#267](https://github.com/newrelic/newrelic-dotnet-agent/issues/267): On Linux, the profiler fails to parse config files that start with a UTF-8 byte-order-mark (BOM). ([#492](https://github.com/newrelic/newrelic-dotnet-agent/pull/492))
+* Fixes issue [#464](https://github.com/newrelic/newrelic-dotnet-agent/issues/464): Distributed tracing over RabbitMQ does not work with `RabbitMQ.Client` versions 6.x+ ([#466](https://github.com/newrelic/newrelic-dotnet-agent/pull/466))
+* Fixes issue [#169](https://github.com/newrelic/newrelic-dotnet-agent/issues/169): Profiler should be able to match method parameters from XML that contain a space. ([#461](https://github.com/newrelic/newrelic-dotnet-agent/pull/461))
+
+
+### Checksums
+| File | SHA - 256  Hash |
+| ---| ---|
+| newrelic-agent-win-8.39.1.0-scriptable-installer.zip | 0F027A061D2C1B26D3883EEB8C02BA35D202EA3FA4DDE302CC4D3B4357669183 |
+| newrelic-agent-win-x64-8.39.1.0.msi | 9C1015503869C46CE98086AE4065C356E1457FB4F37FE89A8A17B2B2D2543949 |
+| newrelic-agent-win-x64-8.39.1.0.zip | 483A43F2520431F88EC9A3DA7DB4B355B59CE662B45943E5E88B00814641ED2E |
+| newrelic-agent-win-x86-8.39.1.0.msi | 76E65F8FB8F9F104CA70B869D3D483824DAE6098AB44D8408B863838000DB538 |
+| newrelic-agent-win-x86-8.39.1.0.zip | 7B3A2E853484EACECE81C2CB0E47CBA3F6CDE0E77D4A706DC89DAE4112456E93 |
+| newrelic-netcore20-agent-8.39.1.0-1.x86_64.rpm | 82CDA137B03578A944E2D6FB2372380EF3E89615EAB7752A68ABB5D6529CB19C |
+| newrelic-netcore20-agent-win-8.39.1.0-scriptable-installer.zip | E1DED942CAC48E2AA50A979410CB386696B4A0B1A0FCB1001E35D6EA4F444F05 |
+| newrelic-netcore20-agent-win-x64-8.39.1.0.zip | FC5C031BCBC2AE4167F15DDF34467F510CEB990CAF1841E3FA13A1082FE67769 |
+| newrelic-netcore20-agent-win-x86-8.39.1.0.zip | 73079032BFFADCAD0F7678516E5AF03F75DDB37E5E9F08AD51CC306EECD28F42 |
+| newrelic-netcore20-agent_8.39.1.0_amd64.deb | B18497FE20DC9ED1BC8F81715FD3BD3AEFB70459B5654BF23A5FA359A131A8D7 |
+| newrelic-netcore20-agent_8.39.1.0_amd64.tar.gz | 78154716CAD11D0D4D380C59746E24B2D0F3A120E885E382A9C0CBCDD4533A3D |
+
+### Support statement
+
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [.NET Agent 8.14.222.0](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8142220).
+
+### Upgrading
+
+* Follow standard procedures to [update the .NET agent](/docs/agents/net-agent/installation-configuration/update-net-agent).
+* If you are upgrading from a particularly old agent, review the list of major changes and procedures to [upgrade legacy .NET agents](/docs/agents/net-agent/troubleshooting/upgrade-legacy-net-agents).


### PR DESCRIPTION
### Tell us why

Adding release notes for .NET Agent version 8.39.1.
