### PR TITLE
Restored lost preparation section that was dropped in the Gatsby migration

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
@@ -29,6 +29,69 @@ Before installing the integration, make sure that you meet the following require
 
 For Kafka running on Kubernetes, see [the Kubernetes requirements](http://docs.newrelic.com/docs/monitor-service-running-kubernetes#requirements).
 
+## Prepare for the installation [#prepare]
+
+Kafka is a complex piece of software that is built as a distributed system. For this reason, you’ll need to ensure that the integration can contact all the required hosts and services so the data is collected correctly.
+
+### Autodiscovery [#autodiscovery]
+
+Given the distributed nature of Kafka, the actual number and list of brokers is usually not fixed by the configuration, and it is instead quite dynamic. For this reason, the Kafka integration offers two mechanisms to perform automatic discovery of the list of brokers in the cluster: Bootstrap and Zookeeper. The mechanism you use depends on the setup of the Kafka cluster being monitored.
+
+#### Bootstrap [#bootstrap]
+
+With the bootstrap mechanism, the integration uses a bootstrap broker to perform the autodiscovery. This is a broker whose address is well known and that will be asked for any other brokers it is aware of. The integration needs to be able to contact this broker in the address provided in the bootstrap_broker_host parameter for bootstrap discovery to work.
+
+#### Zookeeper [#zookeeper]
+
+Alternatively, the Kafta integration can also talk to a Zookeeper server in order to obtain the list of brokers. To do this, the integration needs to be provided with the following:
+
+The list of Zookeeper hosts to contact (zookeeper_hosts).
+The proper authentication secrets to connect with the hosts.
+Together with the list of brokers it knows about, Zookeeper will also advertise which connection mechanisms are supported by each broker.
+
+You can configure the Kafka integration to try directly with one of these mechanisms with the preferred_listener parameter. If this parameter is not provided, the integration will try to contact the brokers with all the advertised configurations until one of them succeeds.
+
+<Callout variant="tip">
+
+The integration will use Zookeeper only for discovering brokers and will not retrieve metrics from it.
+</Callout>
+
+### Topic listing [#topic-listing]
+
+To correctly list the topics processed by the brokers, the integration needs to to contact brokers over the Kafka protocol. Depending on how the brokers are configured, this might require setting up SSL and/or SASL to match the broker configuration.
+
+### Broker monitoring (JMX) [#broker-monitoring]
+
+The Kafka integration queries JMX, a standard Java extension for exchanging metrics in Java applications. JMX is not enabled by default in Kafka brokers, and you need to enable it for metrics collection to work properly. JMX requires RMI to be enabled, and the RMI port needs to be set to the same port as JMX.
+
+You can configure JMX to use username/password authentication, as well as SSL. If such features have been enabled in the broker's JMX settings, you need to configure the integration accordingly.
+
+<Callout variant="important">
+
+We do not recommend enabling anonymous and/or unencrypted JMX/RMI access on public or untrusted network segments because this poses a big security risk.
+</Callout>
+
+### Producer/consumer monitoring (JMX) [#producer]
+
+Producers and consumers written in Java can also be monitored through the same mechanism (JMX). JMX needs to be enabled and configured on those applications where it is not enabled by default.
+
+Non-Java producers and consumers do not support JMX and are therefore not supported by the Kafka integration.
+
+### Connectivity requirements [#connectivity-requirements]
+
+As a summary, the integration needs to be configured and allowed to connect to:
+
+    * Hosts listed in zookeeper_hosts over the Zookeeper protocol, using the Zookeeper authentication mechanism (if autodiscover_strategy is set to zookeeper).
+    *Hosts defined in bootstrap_broker_host over the Kafka protocol, using the Kafka broker’s authentication/transport mechanisms (if autodiscover_strategy is set to bootstrap).
+    * All brokers in the cluster over the Kafka protocol and port, using the Kafka brokers' authentication/transport mechanisms.
+    * All brokers in the cluster over the JMX protocol and port, using the authentication/transport mechanisms specified in the JMX configuration of the brokers.
+    * All producers/consumers specified in producers and consumers over the JMX protocol and port, if you want producer/consumer monitoring. JMX settings for the consumer must be the same as for the brokers.
+    
+<Callout variant="important">
+
+For the cloud: By default, Security Groups (and their equivalents in other cloud providers) in AWS do not have the required ports open by default. JMX requires two ports in order to work: the JMX port and the RMI port. These can be set to the same value when configuring the JVM to enable JMX and must be open for the integration to be able to connect to and collect metrics from brokers.
+</Callout>
+
 ## Install and activate [#install]
 
 To install the Kafka integration, choose your setup:

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
@@ -45,8 +45,9 @@ With the bootstrap mechanism, the integration uses a bootstrap broker to perform
 
 Alternatively, the Kafta integration can also talk to a Zookeeper server in order to obtain the list of brokers. To do this, the integration needs to be provided with the following:
 
-The list of Zookeeper hosts to contact (zookeeper_hosts).
-The proper authentication secrets to connect with the hosts.
+* The list of Zookeeper hosts to contact (zookeeper_hosts).
+* The proper authentication secrets to connect with the hosts.
+
 Together with the list of brokers it knows about, Zookeeper will also advertise which connection mechanisms are supported by each broker.
 
 You can configure the Kafka integration to try directly with one of these mechanisms with the preferred_listener parameter. If this parameter is not provided, the integration will try to contact the brokers with all the advertised configurations until one of them succeeds.

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
@@ -82,15 +82,15 @@ Non-Java producers and consumers do not support JMX and are therefore not suppor
 
 As a summary, the integration needs to be configured and allowed to connect to:
 
-    * Hosts listed in zookeeper_hosts over the Zookeeper protocol, using the Zookeeper authentication mechanism (if autodiscover_strategy is set to zookeeper).
-    *Hosts defined in bootstrap_broker_host over the Kafka protocol, using the Kafka broker’s authentication/transport mechanisms (if autodiscover_strategy is set to bootstrap).
-    * All brokers in the cluster over the Kafka protocol and port, using the Kafka brokers' authentication/transport mechanisms.
-    * All brokers in the cluster over the JMX protocol and port, using the authentication/transport mechanisms specified in the JMX configuration of the brokers.
-    * All producers/consumers specified in producers and consumers over the JMX protocol and port, if you want producer/consumer monitoring. JMX settings for the consumer must be the same as for the brokers.
+* Hosts listed in `zookeeper_hosts` over the Zookeeper protocol, using the Zookeeper authentication mechanism (if `autodiscover_strategy` is set to `zookeeper`).
+* Hosts defined in `bootstrap_broker_host` over the Kafka protocol, using the Kafka broker’s authentication/transport mechanisms (if `autodiscover_strategy` is set to `bootstrap`).
+* All brokers in the cluster over the Kafka protocol and port, using the Kafka brokers' authentication/transport mechanisms.
+* All brokers in the cluster over the JMX protocol and port, using the authentication/transport mechanisms specified in the JMX configuration of the brokers.
+* All producers/consumers specified in producers and consumers over the JMX protocol and port, if you want producer/consumer monitoring. JMX settings for the consumer must be the same as for the brokers.
     
 <Callout variant="important">
 
-For the cloud: By default, Security Groups (and their equivalents in other cloud providers) in AWS do not have the required ports open by default. JMX requires two ports in order to work: the JMX port and the RMI port. These can be set to the same value when configuring the JVM to enable JMX and must be open for the integration to be able to connect to and collect metrics from brokers.
+**For the cloud:** By default, Security Groups (and their equivalents in other cloud providers) in AWS do not have the required ports open by default. JMX requires two ports in order to work: the JMX port and the RMI port. These can be set to the same value when configuring the JVM to enable JMX and **must** be open for the integration to be able to connect to and collect metrics from brokers.
 </Callout>
 
 ## Install and activate [#install]


### PR DESCRIPTION
### Tell us why

The Drupal to Gatsby migration left out the preparation section of the Kafka integration, which I just restored.

### Anything else you'd like to share?

This PR is related to GitHub issue https://github.com/newrelic/docs-website/issues/1123.

The review just needs to compare the content in this PR with the content here:

https://docs-dev.newrelic.com/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration#prepare-for-install