### PR TITLE
Fix indentation for Java yaml infinite_tracing config

### DIFF
--- a/src/content/docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing.mdx
+++ b/src/content/docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing.mdx
@@ -632,15 +632,15 @@ Distributed tracing is enabled through configuration settings. Review the follow
               ```
               distributed_tracing:
                   enabled: true
-                infinite_tracing:
-                  trace_observer:
-                    host: <a href="/docs/understand-dependencies/distributed-tracing/infinite-tracing/set-trace-observer#ui-endpoints"><var>"YOUR_TRACE_OBSERVER_HOST"</var></a>
+              infinite_tracing:
+                trace_observer:
+                  host: <a href="/docs/understand-dependencies/distributed-tracing/infinite-tracing/set-trace-observer#ui-endpoints"><var>"YOUR_TRACE_OBSERVER_HOST"</var></a>
               ```
             * Java system property:
 
               ```
               -Dnewrelic.config.distributed_tracing.enabled=true
-              -Dnewrelic.config.infinite_tracing.trace_observer.host=<var>"YOUR_TRACE_OBSERVER_HOST"</var>
+              -Dnewrelic.config.infinite_tracing.trace_observer.host=<a href="/docs/understand-dependencies/distributed-tracing/infinite-tracing/set-trace-observer#ui-endpoints"><var>"YOUR_TRACE_OBSERVER_HOST"</var></a>
               ```
             * Environment variable:
 


### PR DESCRIPTION
Indentation was wrong for the `infinite_tracing` config yaml example which made it look like it was supposed to be nested under the `distributed_tracing` config stanza.