### PR TITLE
DOC-6579 Partnership API changes 

### DIFF
--- a/src/content/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api.mdx
+++ b/src/content/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: Partner API
+title: Intro to Partnership API
 tags:
   - New Relic partnerships
   - Partner integration guide
@@ -11,9 +11,28 @@ redirects:
   - /docs/accounts-partnerships/partner-integration-guide/partner-account-maintenance/partner-api
 ---
 
-New Relic offers a web service-based API through which partners can create, edit, upgrade, downgrade, and cancel New Relic accounts on behalf of their customers.
+Our Partnership API allows New Relic partners, and New Relic accounts set up as [customer partnerships](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions/#partnerships), to manage accounts, users, and subscription-related settings.
 
-## API functions [#functions]
+## Requirements [#requirements]
+
+The Partnership API can be used by two types of New Relic accounts: [partners](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions/#partnerships) (managed service providers, resellers) and [customer partnerships](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions/#partnerships) (larger customers who have been given access to our partnership account structure). 
+
+These docs are for version 2 of the Partner API. Earlier versions have been deprecated. If you have problems with an older integration, upgrade to version 2.
+
+Access to the partnership account structure and the Partnership ability requires prior setup and approval by New Relic representatives. Partnership API calls require authentication with both your partnership owner account's REST API key and your Partner ID.
+
+Accounts that are genuine New Relic partners (managed service providers, resellers) have no restrictions on using the API. Accounts set up as [customer partnerships](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions/#partnerships) have restrictions that follow. 
+
+### Customer partnership restrictions [#customer-restrictions]
+
+If your New Relic account is set up as a [customer partnership](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions/#partnerships), there are some restrictions in place for our newer pricing plan and user model:
+
+* **Pricing plan.** If you’re on [New Relic One pricing](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans), you can’t use the Partnership API's [subscription object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object/) or the [NerdGraph Provisioning API](/docs/apis/nerdgraph/tutorials/provisions-your-subscriptions-nerdgraph/), because those govern our [original pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans). 
+* **User model.** If your New Relic account has been converted to be entirely on the [New Relic One account/user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models), you can no longer use API calls that create or govern users on our [original user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models). This has two main impacts:  
+  * You can't use the [user object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object/) because it governs users on the original user model. You'd manage users with [these user management docs](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-managing-users/).
+  * You can use the [account object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object/) but you can't add users via the `users` field because that adds original user model users. You'd manage users with [these user management docs](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-managing-users/).
+
+## Things you can do with the API [#functions]
 
 The following functions are supported:
 
@@ -26,20 +45,24 @@ The following functions are supported:
 * Set primary admin
 * Show usage
 
-**User:**
+**Users:**
+
+For accounts with users on our [original user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models), you can:
 
 * Add user access to account
 * Remove user access from account
 
-**Subscription:** Change subscription terms
+**Subscription:** 
+
+For accounts on the [New Relic One pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans), you can change various subscription terms.
 
 ## Initial API call [#initial-call]
 
-The initial API call for all account-level interactions is to "create account." This call returns an xml record of the newly created account. Part of this record is the `account_id`. All of the other calls in the Partner API require the `account_id` as a parameter. Provision will need to be made by the partner to parse the returned xml extract, store the `account_id`, and associate it with the users' partner account record.
+The initial API call for all account-level interactions is to "create account." This call returns an xml record of the newly created account. Part of this record is the `account_id`. All of the other calls in the Partnership API require the `account_id` as a parameter. Provision will need to be made by the partner to parse the returned xml extract, store the `account_id`, and associate it with the users' partner account record.
 
 ## Password complexity and the API [#password]
 
-Starting with v2 of the Partner API, passwords passed as part of an account creation call will be required to meet the following complexity minimums:
+Starting with v2 of the Partnership API, passwords passed as part of an account creation call will be required to meet the following complexity minimums:
 
 * 8 to 50 characters in length
 * Only contain letters, numbers, or special characters

--- a/src/content/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api.mdx
+++ b/src/content/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api.mdx
@@ -46,31 +46,34 @@ Passwords passed for account creation have these requirements:
 * Must contain at least 1 letter
 * Must contain at least 1 number or special character
 
-## Things you can do with the API [#functions]
+## Things you can do [#functions]
 
-The following functions are supported:
+Here is an overview of the API's functionality. 
 
 **Account:**
 
-You can use the [account object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object/) to do the following: 
+The [account object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object/) is what you use to create and update accounts. You can do the following with it: 
 
 * Create new
 * Show
 * Update
 * Cancel
-* For some accounts: Set primary admin (see [requirements](#requirements)) 
 * Show usage
+* Set primary admin ([some accounts](#requirements))
+* Set subscription ([some accounts](#requirements))
+
+There is also a [sub-account object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-sub-account-object) for creating sub-accounts. 
 
 **Users:**
 
-If you [meet the requirements](#customer-restrictions), you can use the [user object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object/) to:
+Some organizations that [meet the requirements](#customer-restrictions) can use the [user object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object/) to:
 
 * Add user access to account
 * Remove user access from account
 
 **Subscription:** 
 
-If you [meet the requirements](#customer-restrictions), you can use the [subscription object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object/) to change various subscription terms.
+Organizations that [meet the requirements](#customer-restrictions) and are on our original product pricing plan can use the [subscription object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object/) to configure various subscription-related traits. 
 
 ## Get started [#get-started]
 

--- a/src/content/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api.mdx
+++ b/src/content/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api.mdx
@@ -19,7 +19,7 @@ The Partnership API can be used by two types of New Relic accounts: [partners](/
 
 These docs are for version 2 of the Partner API. Earlier versions have been deprecated. If you have problems with an older integration, upgrade to version 2.
 
-Access to the partnership account structure and the Partnership ability requires prior setup and approval by New Relic representatives. Partnership API calls require authentication with both your partnership owner account's REST API key and your Partner ID.
+Access to the partnership account structure and the Partnership API requires prior setup and approval by New Relic. Partnership API calls require authentication with both your partnership owner account's REST API key and your Partner ID.
 
 Accounts that are genuine New Relic partners (managed service providers, resellers) have no restrictions on using the API. Accounts set up as [customer partnerships](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions/#partnerships) have restrictions that follow. 
 
@@ -35,6 +35,16 @@ If your New Relic organization is set up as a [customer partnership](/docs/new-r
   * For the [account object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object/): you can't add users via the `users` field. Instead, you'd manage users with [these user management docs](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-managing-users/).
 
 To determine your pricing plan or account/user model, see [Overview of pricing and user model changes](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model).
+
+### Password requirements [#password]
+
+Passwords passed for account creation have these requirements: 
+
+* 8 to 50 characters in length
+* Only contain letters, numbers, or special characters
+* Cannot contain spaces
+* Must contain at least 1 letter
+* Must contain at least 1 number or special character
 
 ## Things you can do with the API [#functions]
 
@@ -53,32 +63,15 @@ You can use the [account object](/docs/new-relic-partnerships/partnerships/partn
 
 **Users:**
 
-For accounts with users on our [original user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models), you can use the [user object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object/) to:
+If you [meet the requirements](#customer-restrictions), you can use the [user object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object/) to:
 
 * Add user access to account
 * Remove user access from account
 
 **Subscription:** 
 
-For accounts on the [original pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans), you can use the [subscription object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object/) to change various subscription terms.
+If you [meet the requirements](#customer-restrictions), you can use the [subscription object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object/) to change various subscription terms.
 
-## Initial API call [#initial-call]
+## Get started [#get-started]
 
-The initial API call for all account-level interactions is to "create account." This call returns an xml record of the newly created account. Part of this record is the `account_id`. All of the other calls in the Partnership API require the `account_id` as a parameter. Provision will need to be made by the partner to parse the returned xml extract, store the `account_id`, and associate it with the users' partner account record.
-
-## Password complexity and the API [#password]
-
-Starting with v2 of the Partnership API, passwords passed as part of an account creation call will be required to meet the following complexity minimums:
-
-* 8 to 50 characters in length
-* Only contain letters, numbers, or special characters
-* Cannot contain spaces
-* Must contain at least 1 letter
-* Must contain at least 1 number or special character
-
-## For more help [#more_help]
-
-Additional documentation resources include:
-
-* [Partner API reference](/docs/accounts-partnerships/partnerships/partner-api) (detailed information about the API)
-* [Changing passwords and user preferences](/docs/accounts-partnerships/accounts/account-maintenance/changing-passwords-user-preferences#requirements) (New Relic's password requirements)
+To start using the Partnership API, see the [Partner API reference docs](/docs/accounts-partnerships/partnerships/partner-api). 

--- a/src/content/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api.mdx
+++ b/src/content/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api.mdx
@@ -25,12 +25,16 @@ Accounts that are genuine New Relic partners (managed service providers, reselle
 
 ### Customer partnership restrictions [#customer-restrictions]
 
-If your New Relic account is set up as a [customer partnership](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions/#partnerships), there are some restrictions in place for our newer pricing plan and user model:
+If your New Relic organization is set up as a [customer partnership](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions/#partnerships), there are some restrictions in place if your organization is on our newer [pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans) or our newer [account/user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models). Details:
 
-* **Pricing plan.** If you’re on [New Relic One pricing](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans), you can’t use the Partnership API's [subscription object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object/) or the [NerdGraph Provisioning API](/docs/apis/nerdgraph/tutorials/provisions-your-subscriptions-nerdgraph/), because those govern our [original pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans). 
-* **User model.** If your New Relic account has been converted to be entirely on the [New Relic One account/user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models), you can no longer use API calls that create or govern users on our [original user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models). This has two main impacts:  
-  * You can't use the [user object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object/) because it governs users on the original user model. You'd manage users with [these user management docs](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-managing-users/).
-  * You can use the [account object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object/) but you can't add users via the `users` field because that adds original user model users. You'd manage users with [these user management docs](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-managing-users/).
+* **Pricing plan.** If you’re on [New Relic One pricing](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans), you can't use API calls that govern our [original pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans). The API impacts are: 
+  * You can't use the [subscription object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object/)
+  * You can't use the [NerdGraph Provisioning API](/docs/apis/nerdgraph/tutorials/provisions-your-subscriptions-nerdgraph/). 
+* **User model.** If your New Relic account has been converted to be entirely on the [New Relic One account/user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models), you can no longer use API calls that create or govern users on our [original user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models). The API impacts are:  
+  * You can't use the [user object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object/). Instead, you'd manage users with [these user management docs](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-managing-users/).
+  * For the [account object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object/): you can't add users via the `users` field. Instead, you'd manage users with [these user management docs](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-managing-users/).
+
+To determine your pricing plan or account/user model, see [Overview of pricing and user model changes](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model).
 
 ## Things you can do with the API [#functions]
 
@@ -38,23 +42,25 @@ The following functions are supported:
 
 **Account:**
 
+You can use the [account object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object/) to do the following: 
+
 * Create new
 * Show
 * Update
 * Cancel
-* Set primary admin
+* For some accounts: Set primary admin (see [requirements](#requirements)) 
 * Show usage
 
 **Users:**
 
-For accounts with users on our [original user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models), you can:
+For accounts with users on our [original user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models), you can use the [user object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object/) to:
 
 * Add user access to account
 * Remove user access from account
 
 **Subscription:** 
 
-For accounts on the [New Relic One pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans), you can change various subscription terms.
+For accounts on the [original pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans), you can use the [subscription object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object/) to change various subscription terms.
 
 ## Initial API call [#initial-call]
 

--- a/src/content/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions.mdx
+++ b/src/content/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions.mdx
@@ -13,14 +13,16 @@ redirects:
   - /docs/accounts-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions
 ---
 
-Organizations with New Relic **partnership accounts** have access to an enhanced hierarchical way of organizing their master accounts and sub-accounts. This describes basic concepts and features available with a New Relic partnership.
+New Relic organizations set up as **partnership accounts** have access to an enhanced hierarchical way of organizing their account structure. 
 
 ## Partnerships with New Relic [#partnerships]
 
-There are two types of partnerships:
+There are two types of New Relic organizations that are able to use our partnership account structure and the Partnership API:
 
-* A **partnership**: A service provider who partners with New Relic in offering New Relic products to their customers. Heroku is one example of a New Relic partner.
-* A **customer partnership**: a New Relic customer with a large, complex account hierarchy that uses New Relic's partnership account structure. (New Relic contacts customers whose account structures would benefit from such a change.)
+* An actual **partnership**: A partnership refers to managed service providers or resellers, who offer New Relic products to their customers. Heroku is one example of such a New Relic partner.
+* A **customer partnership**: some of our larger organizations also make use of our partnership account structure. We call these customers "customer partnerships." 
+
+Use of our partnership account structure requires prior approval and set up by New Relic representatives. For customer partnerships, New Relic contacts organizations that would benefit from such a structure. 
 
 Partnerships are identified by a numeric [`PARTNER_ID`](/docs/accounts-partnerships/partnerships/partner-api/partner-api-reference). In some cases, a New Relic customer may have more than one partnership; for example, when one section of New Relic users must be managed differently from another.
 

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partner-api-reference.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partner-api-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: Partner API reference
+title: Partnership API reference
 tags:
   - New Relic partnerships
   - Partnerships
@@ -10,25 +10,23 @@ redirects:
   - /docs/accounts-partnerships/partnerships/partner-api/partner-api-reference
 ---
 
-All New Relic Partner API calls require authentication with both your partnership owner account's REST API key and your Partner ID. Otherwise, Partner API calls will be rejected.
+This doc explains technical details about using the Partnership API. For an introduction and requirements, first read [Intro to Partnership API](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/). 
 
-## Use Partner API v2 [#partner-api-v2]
+## Requirements [#requirements]
 
-The New Relic Partner API is organized around [REST](http://en.wikipedia.org/wiki/Representational_State_Transfer). This API is designed to have predictable, resource-oriented URLs and to use HTTP response codes to indicate API errors. The API uses the [JSON](http://www.json.org/ "Link opens in a new window") response format.
+All New Relic Partnership API calls require authentication with both your partnership owner account's REST API key and your Partner ID. Otherwise, Partner API calls will be rejected.
 
-<Callout variant="important">
-  This information is for version 2 of the Partner API. Earlier versions have been deprecated. If you have problems with an older integration, upgrade to version 2.
-</Callout>
+For other requirements, read [Intro to Partnership API](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/). 
 
-## Find your Partner API key [#the-api-key]
+## Find your Partnership API key [#the-api-key]
 
-The Partner API requires that you authenticate with the [REST API key](/docs/apis/getting-started/intro-apis/understand-new-relic-api-keys#rest-api) that is specific to your [partnership owner account](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions#partner-owner) (you cannot use the other [REST API keys](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key)).
+The Partnership API requires that you authenticate with the [REST API key](/docs/apis/getting-started/intro-apis/understand-new-relic-api-keys#rest-api) that is specific to your [partnership owner account](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions#partner-owner) (you cannot use the other [REST API keys](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key)).
 
-When using your Partner API key with calls to [REST API (v2)](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2) endpoints that require the use of an **Admin user's API key**, see [Admin user's API Key and partnerships](/docs/apis/rest-api-v2/requirements/admins-api-key-partnerships).
+When using your Partnership API key with calls to [REST API (v2)](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2) endpoints that require the use of an **Admin user's API key**, see [Admin user's API Key and partnerships](/docs/apis/rest-api-v2/requirements/admins-api-key-partnerships).
 
 ## Find your Partner ID [#partner-id]
 
-The Partner API also requires that you authenticate by providing a Partner ID specific to your partnership. This is unique from the [account ID](/docs/accounts/install-new-relic/account-setup/account-id) for your partnership owner account.
+The Partnership API also requires that you authenticate by providing a Partner ID specific to your partnership. This is unique from the [account ID](/docs/accounts/install-new-relic/account-setup/account-id) for your partnership owner account.
 
 To obtain your Partner ID, go to your [partner admin console](https://docs.newrelic.com/docs/accounts-partnerships/partner-integration-guide/getting-started/partnership-admin-console) and retrieve the partner ID number that is listed in your URL:
 
@@ -172,12 +170,3 @@ New Relic uses conventional HTTP response codes to indicate success or failure o
   </tbody>
 </table>
 
-## For more help [#more_help]
-
-Additional documentation resources include:
-
-* [Partner integration guide](/docs/partnerships/partner-integration-guide) (how to work with New Relic as a partner)
-* [Partnership API account object](/docs/accounts-partnerships/partnerships/partner-api/partner-api-account-object) (the primary JSON container object in the API)
-* [Partnership API user object](/docs/accounts-partnerships/partnerships/partner-api/partner-api-user-object) (defined as an array within the account object)
-* [Partnership API subscription object](/docs/accounts-partnerships/partnerships/partner-api/partner-api-subscription-object) (the level of service a customer purchases for one or more New Relic products)
-* [Partnership billing integration API](/docs/accounts-partnerships/partnerships/partner-api/partnership-billing-integration-api) (functions to replace a customer's existing subscription with a new one, or to update invoice information for New Relic partner accounts)

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partner-api-reference.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partner-api-reference.mdx
@@ -55,7 +55,7 @@ You must include the Partner ID as part of the base URL for the Partner API.
 
       <td>
         ```
-        https://rpm.newrelic.com/api/v2/partners/:PARTNER_ID:
+        https://rpm.newrelic.com/api/v2/partners/<var>PARTNER_ID</var>
         ```
       </td>
     </tr>
@@ -68,11 +68,11 @@ You must include the Partner ID as part of the base URL for the Partner API.
       <td>
         ```
         /accounts
-        /accounts/:ACCOUNT_ID
-        /accounts/:ACCOUNT_ID:/users
-        /accounts/:ACCOUNT_ID/users/:USER_ID
-        /accounts/:ACCOUNT_ID:/subscriptions
-        /accounts/:ACCOUNT_ID:/subscriptions/:SUBSCRIPTION_ID
+        /accounts/<var>ACCOUNT_ID</var>
+        /accounts/<var>ACCOUNT_ID</var>/users
+        /accounts/<var>ACCOUNT_ID</var>/users/<var>USER_ID</var>
+        /accounts/<var>ACCOUNT_ID</var>/subscriptions
+        /accounts/<var>ACCOUNT_ID</var>/subscriptions/<var>SUBSCRIPTION_ID</var>
         ```
       </td>
     </tr>
@@ -84,7 +84,7 @@ You must include the Partner ID as part of the base URL for the Partner API.
 
       <td>
         ```
-        https://rpm.newrelic.com/api/v2/partners/:PARTNER_ID:/accounts/:ACCOUNT_ID
+        https://rpm.newrelic.com/api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>ACCOUNT_ID</var>
         ```
       </td>
     </tr>

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partner-api-reference.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partner-api-reference.mdx
@@ -14,9 +14,7 @@ This doc explains technical details about using the Partnership API. For an intr
 
 ## Requirements [#requirements]
 
-All New Relic Partnership API calls require authentication with both your partnership owner account's REST API key and your Partner ID. Otherwise, Partner API calls will be rejected.
-
-For other requirements, read [Intro to Partnership API](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/). 
+For requirements, see [Intro to Partnership API](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/). 
 
 ## Find your Partnership API key [#the-api-key]
 
@@ -99,6 +97,10 @@ To authenticate to the Partner API when making an API call:
 
 1. Add a request header labeled **x-api-key** and set its value to your **Partner API key**.
 2. Include your **Partner ID** at the specified point in the request URI.
+
+## Notes for partners who manage New Relic accounts [#initial-call]
+
+For partners who manage New Relic accounts for their customers, the initial API call for all account-level interactions is to "create account." This call returns an xml record of the newly created account. Part of this record is the `account_id`. All of the other calls in the Partnership API require the `account_id` as a parameter. Provision will need to be made by the partner to parse the returned xml extract, store the `account_id`, and associate it with the users' partner account record.
 
 ## Errors [#api-errors]
 

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object.mdx
@@ -11,11 +11,11 @@ redirects:
   - /docs/accounts-partnerships/partnerships/partner-api/partnership-api-account-object
 ---
 
-Accounts are the basic administrative unit of the New Relic system. As a partner, use the account object with the [Partnership API](/docs/new-relic-partnerships/partnerships/partner-api/partner-api-reference) to manage your accounts. To create a sub-account, use the [sub-account](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-sub-account-object) object.
+This doc explains how to use the [Partnership API](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/) to manage accounts. For sub-accounts, you'd use the [sub-account](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-sub-account-object) object.
 
-<Callout variant="important">
-  This information is for version 2 of the Partnership API. Use v2 for all new integrations. Earlier versions have been deprecated. If you have problems with an older integration, upgrade to version 2.
-</Callout>
+## Requirements [#requirements]
+
+**Before using the Partnership API, first read [the requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).**
 
 ## Account object attributes [#account-attributes]
 
@@ -156,7 +156,7 @@ Here are the Partnership API account object's attributes.
 
   <Collapser
     id="attr-users"
-    title={<>users <strong>(REQUIRED to create an account)</strong></>}
+    title={<>users <strong>(REQUIRED for some accounts)</strong></>}
   >
     <table>
       <tbody>
@@ -182,12 +182,18 @@ Here are the Partnership API account object's attributes.
       </tbody>
     </table>
 
-    An array defining a list of users. When you first create the New Relic account, this field is required, and only one user can be defined: the account `Owner`. To add additional users, use the [Partnership API user object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object).
+    An array defining a list of users. There are some restrictions in place dependent on the status of your account: 
+
+* For [customer partnerships](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions/) who have switched to the [New Relic One user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models): do not define users. If you add users with this field, they will be ignored. Instead, to add users, you'd use [these user management procedures](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-managing-users/). 
+* For all other accounts, which have users on our [original user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models): When you first create an account, this field is required, and only one user can be defined: the account `Owner`. To add additional users, use the [Partnership API user object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object).
+
+For more about restrictions, read the [Requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
+
   </Collapser>
 
   <Collapser
     id="attr-subscriptions"
-    title={<>subscriptions <strong>(REQUIRED to create an account)</strong></>}
+    title={<>subscriptions <strong>(REQUIRED for some accounts)</strong></>}
   >
     <table>
       <tbody>
@@ -213,17 +219,22 @@ Here are the Partnership API account object's attributes.
       </tbody>
     </table>
 
-    An array defining a list of subscriptions. The subscriptions attribute is **required** for new accounts, but the array may be empty.
+    An array defining a list of subscriptions. There are some restrictions in place dependent on the status of your account: 
+    
+* For [customer partnerships](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions/) that have switched to the [New Relic One pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans), ignore this field because it applies to the original pricing plan, not yours. If you use this, it will be ignored. 
+* For all other accounts: You are on our [original product-based pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans). For you, the `subscriptions` attribute is **required** for new accounts, but the array may be empty.
 
-    If you provide an empty subscriptions array, the Partnership API creates accounts with the default New Relic product tiers for your partnership. To update subscription information, use the [Partnership API subscription object](/docs/partnerships/partner-api-subscription-object).
+More on using this attribute: 
 
-    To specify an empty JSON array, use this format:
+If you provide an empty subscriptions array, the Partnership API creates accounts with the default New Relic product tiers for your partnership. To update subscription information, use the [Partnership API subscription object](/docs/partnerships/partner-api-subscription-object).
 
-    ```
-    subscriptions: [  ]
-    ```
+To specify an empty JSON array, use this format:
 
-    Do not use `subscriptions: [ {} ]` to specify an empty array.
+```
+subscriptions: [  ]
+```
+
+Do not use `subscriptions: [ {} ]` to specify an empty array.
   </Collapser>
 </CollapserGroup>
 
@@ -319,7 +330,7 @@ Content-Type: application/json
 
 ## Status definitions [#account-status-definitions]
 
-When an account is created or listed with an API call, the account status is included automatically.
+When an account is created or listed with an API call, the account status is included automatically. Some of these statuses don't apply to all pricing plans. 
 
 <table>
   <thead>
@@ -439,7 +450,9 @@ When an account is created or listed with an API call, the account status is inc
 
 ## JSON example [#call-example]
 
-Here is an example of a JSON request and response using the Partnership API account object.
+Here is an example of a JSON request and response using the Partnership API account object. 
+
+**Note that this is just an example, and that for some accounts, the [`users` and `subscriptions` attributes](#account-attributes) are unnecessary and are ignored.**
 
 <CollapserGroup>
   <Collapser
@@ -552,7 +565,7 @@ Partnerships with more than 1000 accounts return a paginated response. To specif
 ?page=
 ```
 
-Here are examples of API calls using the Partnership API account object.
+Here are examples of API calls using the Partnership API account object. **Note that these are just examples, and that for some accounts, the [`users` and `subscriptions` attributes](#account-attributes) are unnecessary and are ignored.**
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object.mdx
@@ -810,7 +810,10 @@ Here's an example of creating an account for an organization on our original pri
 Here's an example of creating an account for an organization with our New Relic One pricing and our New Relic One account/user model. For more on restrictions, see [requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
 
     ```
-curl -X POST     -H 'x-api-key:customer_api_key'     -H 'Content-Type:application/json'     -d '{"account":{"name":"customer_account_name"}}'     https://staging.newrelic.com/api/v2/partners/customer_partner_id/accounts
+    curl -X POST \
+        -H 'x-api-key:customer_api_key'     
+        -H 'Content-Type:application/json'     
+        -d '{"account":{"name":"customer_account_name"}}' https://rpm.newrelic.com/api/v2/partners/customer_partner_id/accounts
     ```
 
   </Collapser>

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object.mdx
@@ -800,14 +800,14 @@ Here's an example of creating an account for an organization on our original pri
     }
     ```
 
-Here's an example of creating an account for an organization with our New Relic One pricing and our New Relic One account/user model. For more on restrictions on API use, see [requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
+Here's an example of creating an account for a [customer partnership](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions/) that is on our New Relic One pricing and our New Relic One account/user model. For more on restrictions on API use, see [requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
 
     ```
     curl -X POST \
         -H 'x-api-key:<var>PARTNER_ACCOUNT_KEY</var>'   \
         -H 'Content-Type:application/json'  \
         -d '{"account":{"name":"Sample account"}}' \
-        https://rpm.newrelic.com/api/v2/partners/customer_partner_id/accounts<var>PARTNER_ID</var>/accounts/
+        https://rpm.newrelic.com/api/v2/partners/<var>PARTNER_ID</var>/accounts/
     ```
 
   </Collapser>

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object.mdx
@@ -807,13 +807,14 @@ Here's an example of creating an account for an organization on our original pri
     title="Create (New Relic One pricing plan and account/user model)"
   >
 
-Here's an example of creating an account for an organization with our New Relic One pricing and our New Relic One account/user model. For more on restrictions, see [requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
+Here's an example of creating an account for an organization with our New Relic One pricing and our New Relic One account/user model. For more on restrictions on API use, see [requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
 
     ```
     curl -X POST \
-        -H 'x-api-key:customer_api_key'     
-        -H 'Content-Type:application/json'     
-        -d '{"account":{"name":"customer_account_name"}}' https://rpm.newrelic.com/api/v2/partners/customer_partner_id/accounts
+        -H 'x-api-key:<var>:PARTNER_ACCOUNT_KEY</var>'   \
+        -H 'Content-Type:application/json'  \
+        -d '{"account":{"name":"customer_account_name"}}' \
+        https://rpm.newrelic.com/api/v2/partners/customer_partner_id/accounts<var>:PARTNER_ID</var>/accounts/
     ```
 
   </Collapser>

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object.mdx
@@ -15,7 +15,7 @@ This doc explains how to use the [Partnership API](/docs/new-relic-partnerships/
 
 ## Requirements [#requirements]
 
-**Before using the Partnership API, first read [the requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).**
+**Before using the Partnership API, first read [the requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).** 
 
 ## Account object attributes [#account-attributes]
 
@@ -222,19 +222,19 @@ For more about restrictions, read the [Requirements](/docs/new-relic-partnership
     An array defining a list of subscriptions. There are some restrictions in place dependent on the status of your account: 
     
 * For [customer partnerships](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions/) that have switched to the [New Relic One pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans), ignore this field because it applies to the original pricing plan, not yours. If you use this, it will be ignored. 
-* For all other accounts: You are on our [original product-based pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans). For you, the `subscriptions` attribute is **required** for new accounts, but the array may be empty.
+* For all other accounts: You are on our [original product-based pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans). The `subscriptions` attribute is **required** for new accounts. If it is empty, default product tiers will be used. To update subscription information, use the [Partnership API subscription object](/docs/partnerships/partner-api-subscription-object).
 
-More on using this attribute: 
+<Callout variant="important">
+When creating an account with this object, it can take some time for some account settings to reflect the truth. This means that the returned response may initially show errors. For example, it may return a response showing you have `Lite` subscriptions when you do not. 
+</Callout>
 
-If you provide an empty subscriptions array, the Partnership API creates accounts with the default New Relic product tiers for your partnership. To update subscription information, use the [Partnership API subscription object](/docs/partnerships/partner-api-subscription-object).
-
-To specify an empty JSON array, use this format:
+To specify an empty JSON array, don't use `subscriptions: [ {} ]`. Instead, use this format:
 
 ```
 subscriptions: [  ]
 ```
 
-Do not use `subscriptions: [ {} ]` to specify an empty array.
+
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object.mdx
@@ -15,7 +15,7 @@ This doc explains how to use the [Partnership API](/docs/new-relic-partnerships/
 
 ## Requirements [#requirements]
 
-**Before using the Partnership API, first read [the requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).** 
+You may not be able to use some aspects of this object. **Before using, first read [the requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).** 
 
 ## Account object attributes [#account-attributes]
 
@@ -182,12 +182,12 @@ Here are the Partnership API account object's attributes.
       </tbody>
     </table>
 
-    An array defining a list of users. There are some restrictions in place dependent on the status of your account: 
+An array defining a list of users. There are some restrictions in place dependent on the status of your account: 
 
 * For [customer partnerships](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions/) who have switched to the [New Relic One user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models): do not define users. If you add users with this field, they will be ignored. Instead, to add users, you'd use [these user management procedures](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-managing-users/). 
 * For all other accounts, which have users on our [original user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models): When you first create an account, this field is required, and only one user can be defined: the account `Owner`. To add additional users, use the [Partnership API user object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object).
 
-For more about restrictions, read the [Requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
+For more on restrictions, read the [Requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
 
   </Collapser>
 
@@ -221,11 +221,11 @@ For more about restrictions, read the [Requirements](/docs/new-relic-partnership
 
     An array defining a list of subscriptions. There are some restrictions in place dependent on the status of your account: 
     
-* For [customer partnerships](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions/) that have switched to the [New Relic One pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans), ignore this field because it applies to the original pricing plan, not yours. If you use this, it will be ignored. 
+* For [customer partnerships](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions/) on our [New Relic One pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans): ignore this field because it applies to the original pricing plan, not yours. If you use this, it will be ignored. 
 * For all other accounts: You are on our [original product-based pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans). The `subscriptions` attribute is **required** for new accounts. If it is empty, default product tiers will be used. To update subscription information, use the [Partnership API subscription object](/docs/partnerships/partner-api-subscription-object).
 
 <Callout variant="important">
-When creating an account with this object, it can take some time for some account settings to reflect the truth. This means that the returned response may initially show errors. For example, it may return a response showing you have `Lite` subscriptions when you do not. 
+When creating an account with this object, it can take some time for the account settings to populate. This means that the returned response may initially show aspects that are not true (for example, it may return a response showing default `Lite` subscriptions). 
 </Callout>
 
 To specify an empty JSON array, don't use `subscriptions: [ {} ]`. Instead, use this format:
@@ -565,7 +565,7 @@ Partnerships with more than 1000 accounts return a paginated response. To specif
 ?page=
 ```
 
-Here are examples of API calls using the Partnership API account object. **Note that these are just examples, and that for some accounts, the [`users` and `subscriptions` attributes](#account-attributes) are unnecessary and are ignored.**
+Here are examples of calls using the Partnership API account object. **Note that these are examples, and that for some accounts, the [`users` and `subscriptions` attributes](#account-attributes) don't apply and will be ignored.**
 
 <CollapserGroup>
   <Collapser
@@ -726,9 +726,9 @@ Here are examples of API calls using the Partnership API account object. **Note 
 
   <Collapser
     id="example-create"
-    title="Create"
+    title="Create (original pricing plan and account/user model)"
   >
-    Request:
+Here's an example of creating an account for an organization on our original pricing plan and on our original user model. For an example call of creating an account for organizations with the newer models, see the [other Create example](#example-create-2). 
 
     ```
     curl -X POST \
@@ -799,7 +799,22 @@ Here are examples of API calls using the Partnership API account object. **Note 
       }
     }
     ```
+
   </Collapser>
+
+  <Collapser
+    id="example-create-2"
+    title="Create (New Relic One pricing plan and account/user model)"
+  >
+
+Here's an example of creating an account for an organization with our New Relic One pricing and our New Relic One account/user model. For more on restrictions, see [requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
+
+    ```
+curl -X POST     -H 'x-api-key:customer_api_key'     -H 'Content-Type:application/json'     -d '{"account":{"name":"customer_account_name"}}'     https://staging.newrelic.com/api/v2/partners/customer_partner_id/accounts
+    ```
+
+  </Collapser>
+
 
   <Collapser
     id="example-update"

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object.mdx
@@ -273,7 +273,7 @@ Content-Type: application/json
 
       <td>
         ```
-        GET /api/v2/partners/<var>:PARTNER_ID:</var>/accounts
+        GET /api/v2/partners/<var>PARTNER_ID</var>/accounts
         ```
       </td>
     </tr>
@@ -285,7 +285,7 @@ Content-Type: application/json
 
       <td>
         ```
-        GET /api/v2/partners/<var>:PARTNER_ID:</var>/accounts/<var>:ID</var>
+        GET /api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>:ID</var>
         ```
       </td>
     </tr>
@@ -297,7 +297,7 @@ Content-Type: application/json
 
       <td>
         ```
-        PUT /api/v2/partners/<var>:PARTNER_ID:</var>/accounts/<var>:ID</var>
+        PUT /api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>:ID</var>
         ```
       </td>
     </tr>
@@ -309,7 +309,7 @@ Content-Type: application/json
 
       <td>
         ```
-        POST /api/v2/partners/<var>:PARTNER_ID:</var>/accounts
+        POST /api/v2/partners/<var>PARTNER_ID</var>/accounts
         ```
       </td>
     </tr>
@@ -321,7 +321,7 @@ Content-Type: application/json
 
       <td>
         ```
-        DELETE /api/v2/partners/<var>:PARTNER_ID:</var>/accounts/<var>:ID</var>
+        DELETE /api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>:ID</var>
         ```
       </td>
     </tr>
@@ -576,9 +576,9 @@ Here are examples of calls using the Partnership API account object. **Note that
 
     ```
     curl -X GET \
-        -H 'x-api-key<var>:PARTNER_ACCOUNT_KEY</var>' \
+        -H 'x-api-key:<var>PARTNER_ACCOUNT_KEY</var>' \
         -H 'Content-Type:application/json' \
-        https://rpm.newrelic.com/api/v2/partners/<var>:PARTNER_ID</var>/accounts
+        https://rpm.newrelic.com/api/v2/partners/<var>PARTNER_ID</var>/accounts
     ```
 
     Response (line breaks are for readability):
@@ -656,9 +656,9 @@ Here are examples of calls using the Partnership API account object. **Note that
 
     ```
     curl -X GET \
-        -H 'x-api-key<var>:PARTNER_ACCOUNT_KEY</var>' \
+        -H 'x-api-key:<var>PARTNER_ACCOUNT_KEY</var>' \
         -H 'Content-Type:application/json' \
-        https://rpm.newrelic.com/api/v2/partners/<var>:PARTNER_ID</var>/accounts/<var>:ACCOUNT_ID</var>
+        https://rpm.newrelic.com/api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>ACCOUNT_ID</var>
     ```
 
     Response (line breaks are for readability):
@@ -726,16 +726,16 @@ Here are examples of calls using the Partnership API account object. **Note that
 
   <Collapser
     id="example-create"
-    title="Create (original pricing plan and account/user model)"
+    title="Create"
   >
-Here's an example of creating an account for an organization on our original pricing plan and on our original user model. For an example call of creating an account for organizations with the newer models, see the [other Create example](#example-create-2). 
+Here's an example of creating an account for an organization on our original pricing plan and on our original user model. For an example call of creating an account for organizations with the newer models, see the example after this one. 
 
     ```
     curl -X POST \
-        -H 'x-api-key<var>:PARTNER_ACCOUNT_KEY</var>' \
+        -H 'x-api-key:<var>PARTNER_ACCOUNT_KEY</var>' \
         -H 'Content-Type:application/json' \
         -d '{"account":{"name":"Sample Account", "users":[{"email":"sample_user@sample.org", "password":"XXXXXX", "first_name":"Sample", "last_name":"User", "role":"admin", "owner":"true"}],"subscriptions":[{"product_id": 4,"quantity": 10},{"product_id": 10,"quantity": 0}]}}' \
-        https://rpm.newrelic.com/api/v2/partners/<var>:PARTNER_ID</var>/accounts/
+        https://rpm.newrelic.com/api/v2/partners/<var>PARTNER_ID</var>/accounts/
     ```
 
     Response (line breaks are for readability):
@@ -800,21 +800,14 @@ Here's an example of creating an account for an organization on our original pri
     }
     ```
 
-  </Collapser>
-
-  <Collapser
-    id="example-create-2"
-    title="Create (New Relic One pricing plan and account/user model)"
-  >
-
 Here's an example of creating an account for an organization with our New Relic One pricing and our New Relic One account/user model. For more on restrictions on API use, see [requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
 
     ```
     curl -X POST \
-        -H 'x-api-key:<var>:PARTNER_ACCOUNT_KEY</var>'   \
+        -H 'x-api-key:<var>PARTNER_ACCOUNT_KEY</var>'   \
         -H 'Content-Type:application/json'  \
-        -d '{"account":{"name":"customer_account_name"}}' \
-        https://rpm.newrelic.com/api/v2/partners/customer_partner_id/accounts<var>:PARTNER_ID</var>/accounts/
+        -d '{"account":{"name":"Sample account"}}' \
+        https://rpm.newrelic.com/api/v2/partners/customer_partner_id/accounts<var>PARTNER_ID</var>/accounts/
     ```
 
   </Collapser>
@@ -830,10 +823,10 @@ Here's an example of creating an account for an organization with our New Relic 
 
     ```
     curl -X PUT \
-        -H 'x-api-key<var>:PARTNER_ACCOUNT_KEY</var>' \
+        -H 'x-api-key:<var>PARTNER_ACCOUNT_KEY</var>' \
         -H 'Content-Type:application/json' \
         -d '{"account":{"name":"Sample account name"}}' \
-        https://rpm.newrelic.com/api/v2/partners/<var>:PARTNER_ID</var>/accounts/<var>:ACCOUNT_ID</var>
+        https://rpm.newrelic.com/api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>ACCOUNT_ID</var>
     ```
 
     Response (line breaks are for readability):
@@ -907,9 +900,9 @@ Here's an example of creating an account for an organization with our New Relic 
 
     ```
     curl -X DELETE \
-        -H 'x-api-key<var>:PARTNER_ACCOUNT_KEY</var>' \
+        -H 'x-api-key:<var>PARTNER_ACCOUNT_KEY</var>' \
         -H 'Content-Type:application/json' \
-        https://rpm.newrelic.com/api/v2/partners/<var>:PARTNER_ID</var>/accounts/<var>:ACCOUNT_ID</var>
+        https://rpm.newrelic.com/api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>ACCOUNT_ID</var>
     ```
 
     Response: No response body.

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object.mdx
@@ -832,7 +832,7 @@ Here's an example of creating an account for an organization with our New Relic 
     curl -X PUT \
         -H 'x-api-key<var>:PARTNER_ACCOUNT_KEY</var>' \
         -H 'Content-Type:application/json' \
-        -d '{"account":{"name":"Account New Name"}}' \
+        -d '{"account":{"name":"Sample account name"}}' \
         https://rpm.newrelic.com/api/v2/partners/<var>:PARTNER_ID</var>/accounts/<var>:ACCOUNT_ID</var>
     ```
 

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-keys.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-keys.mdx
@@ -12,7 +12,11 @@ redirects:
   - /docs/new-relic-partnerships/partnerships/partner-api/understanding-keys
 ---
 
-Partnership API keys are used to authenticate calls with partnership accounts in New Relic. An important distinction in working with API keys is account versus partnership owner. The partnership owner is a special form of account that is used to manage data about the account.
+[Partnership API](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/) keys are used to authenticate calls with partnership accounts in New Relic. An important distinction in working with API keys is account versus partnership owner. The partnership owner is a special form of account that is used to manage data about the account.
+
+## Requirements [#requirements]
+
+For requirements, read [Intro to Partnership API](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/). 
 
 ## License key
 

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-sub-account-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-sub-account-object.mdx
@@ -13,7 +13,7 @@ This doc explains how to use the [Partnership API](/docs/new-relic-partnerships/
 
 ## Requirements [#requirements]
 
-**Before using the Partnership API, first read [the requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).**
+You may not have access to using this object. **Before using the Partnership API, first read [the requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).**
 
 ## Introduction to using sub-accounts [#overview]
 
@@ -27,7 +27,9 @@ Some notes about using the sub-account object:
 
 ## Sub-account object attributes [#account-attributes]
 
-Here are the Partnership API sub-account object's attributes.
+**Before using the Partnership API, first read [the requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).** 
+
+Here are the Partnership API sub-account object's attributes:
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-sub-account-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-sub-account-object.mdx
@@ -207,8 +207,8 @@ For some New Relic organizations, sub-accounts can also be created via the maste
 Here is the URL pattern to create sub-accounts. Notice that the Parent Account ID must be specified. If using this URL pattern, send the JSON object along with an HTTP header containing the [Partner API key](https://docs.newrelic.com/docs/new-relic-partnerships/partnerships/partner-api/partner-api-reference#the-api-key). For example:
 
 ```
-POST .../api/v2/partners/<var>:PARTNER_ID</var>/accounts/<var>:PARENT_ACCOUNT_ID</var>/sub_accounts​
-x-api-key: <var>:PARTNER_ACCOUNT_KEY</var>
+POST .../api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>PARENT_ACCOUNT_ID</var>/sub_accounts​
+x-api-key:<var>PARTNER_ACCOUNT_KEY</var>
 Content-Type: application/json
 
 <var>{ JSON data }</var>
@@ -235,7 +235,7 @@ Content-Type: application/json
 
       <td>
         ```
-        POST /api/v2/partners/<var>:PARTNER_ID</var>/accounts/<var>:PARENT_ACCOUNT_ID</var>/sub_accounts
+        POST /api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>PARENT_ACCOUNT_ID</var>/sub_accounts
         ```
       </td>
     </tr>
@@ -361,7 +361,7 @@ Here is an example of an API call using the Partnership API sub-account object.
     -H 'x-api-key:<var>PARTNER_ACCOUNT_KEY</var>' \
     -H 'Content-Type:application/json' \
     -d '{"sub_account":{"name":"Sample Sub-Account"}, "users":[{"email":"sample_user@sample.org", "password":"XXXXXX", "first_name":"Sample", "last_name":"User", "role":"admin", "owner":"true"}]}' \
-    https://rpm.newrelic.com/api/v2/partners/<var>:PARTNER_ID</var>/accounts/<var>:PARENT_ACCOUNT_ID</var>/sub_accounts
+    https://rpm.newrelic.com/api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>PARENT_ACCOUNT_ID</var>/sub_accounts
     ```
 
     Response (line breaks are for readability):

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-sub-account-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-sub-account-object.mdx
@@ -9,17 +9,21 @@ redirects:
   - /docs/new-relic-partnerships/partnerships/partner-api/partnership-api-sub-account-object-add-name-creating-not-managing
 ---
 
-Accounts are the basic administrative unit of the New Relic system. As a partner, use the sub-account object with the [Partnership API](/docs/new-relic-partnerships/partnerships/partner-api/partner-api-reference) to create [sub-accounts](/docs/accounts/install-new-relic/account-setup/manage-apps-or-users-sub-accounts).
+This doc explains how to use the [Partnership API](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/) to manage sub-accounts. For accounts, you'd use the [sub-account](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object) object. 
 
-* A parent account may have more than one associated sub_account, but every sub_account must correspond to one and only one parent account.
-* Every sub_account must have at least a primary_admin user.
-* You cannot create a sub_account without connecting it to an existing parent account and adding at least one user.
+## Requirements [#requirements]
 
-To manage existing master or sub-accounts, use the [Partnership API account object](https://docs.newrelic.com/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object).
+**Before using the Partnership API, first read [the requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).**
 
-<Callout variant="important">
-  This information is for version 2 of the Partnership API. Use v2 for all new integrations. Earlier versions have been deprecated. If you have problems with an older integration, upgrade to version 2.
-</Callout>
+## Introduction to using sub-accounts [#overview]
+
+Some notes about using the sub-account object:
+
+* To manage existing master accounts or existing sub-accounts, use the [Partnership API account object](https://docs.newrelic.com/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object).
+* A parent account may have more than one associated sub-account, but every sub-account must correspond to one and only one parent account.
+* Every sub-account must have at least a `primary_admin` user.
+* You cannot create a sub-account without connecting it to an existing parent account and adding at least one user.
+
 
 ## Sub-account object attributes [#account-attributes]
 
@@ -127,7 +131,7 @@ Here are the Partnership API sub-account object's attributes.
 
   <Collapser
     id="attr-users"
-    title="users (REQUIRED)"
+    title="users (REQUIRED for some accounts)"
   >
     <table>
       <tbody>
@@ -153,7 +157,13 @@ Here are the Partnership API sub-account object's attributes.
       </tbody>
     </table>
 
-    An array defining a list of users. When you create the sub-account, only one user can be defined: the account `Owner`. To add additional users, use the [Partnership API user object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object).
+An array defining a list of users. There are some restrictions in place dependent on the status of your account: 
+
+* For [customer partnerships](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions/) who have switched to the [New Relic One user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models): do not define users. If you add users with this field, they will be ignored. Instead, to add users, you'd use [these user management procedures](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-managing-users/). 
+* For all other accounts, which have users on our [original user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models): When you create the sub-account, you can define only one user: the account `Owner`. To add additional users, use the [Partnership API user object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object).
+
+For more about restrictions, read the [Requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
+
   </Collapser>
 
   <Collapser
@@ -188,7 +198,7 @@ Here are the Partnership API sub-account object's attributes.
   </Collapser>
 </CollapserGroup>
 
-Sub-accounts can also be created via the master account's [**Account settings** page](/docs/accounts/install-new-relic/account-setup/manage-apps-or-users-sub-accounts) in the New Relic UI.
+For some New Relic organizations, sub-accounts can also be created via the master account's [**Account settings** page](/docs/accounts/install-new-relic/account-setup/manage-apps-or-users-sub-accounts) in the New Relic UI.
 
 ## Sub-account API calls [#account-calls]
 
@@ -233,6 +243,9 @@ Content-Type: application/json
 ## JSON example [#account-status-definitions]
 
 Here is an example of a JSON request and response using the Partnership API sub-account object.
+
+**Note that this is just an example, and that for some accounts, the [`users` attribute](#account-attributes) is unnecessary and will be ignored.**
+
 
 <CollapserGroup>
   <Collapser
@@ -331,6 +344,9 @@ Here is an example of a JSON request and response using the Partnership API sub-
 
 Here is an example of an API call using the Partnership API sub-account object.
 
+**Note that this is just an example, and that for some accounts, the [`users` attribute](#account-attributes) is unnecessary and will be ignored.**
+
+
 <CollapserGroup>
   <Collapser
     id="example-create"
@@ -410,9 +426,3 @@ Here is an example of an API call using the Partnership API sub-account object.
     ```
   </Collapser>
 </CollapserGroup>
-
-## For more help [#more_help]
-
-* A parent account may have more than one associated sub_account, but every sub_account must correspond to one and only one parent account.
-* Every sub_account must have at least a primary_admin user.
-* You cannot create a sub_account without connecting it to an existing parent account and adding at least one user.

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object.mdx
@@ -672,8 +672,8 @@ Before using this, first read [Requirements](/docs/new-relic-partnerships/partne
 Here are the URL patterns for subscription-related API functions. If used, send them along with the JSON object and an HTTP header containing the [Partner API key](https://docs.newrelic.com/docs/accounts-partnerships/partnerships/partner-api/partner-api-reference#the-api-key). For example:
 
 ```
-GET .../api/v2/partners/:PARTNER_ID:/accounts/:ACCOUNT_ID/subscriptions
-x-api-key: :PARTNER_ACCOUNT_KEY:
+GET .../api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>ACCOUNT_ID</var>/subscriptions
+x-api-key:<var>PARTNER_ACCOUNT_KEY</var>
 Content-Type: application/json
 
 { JSON data }
@@ -700,7 +700,7 @@ Content-Type: application/json
 
       <td>
         ```
-        GET /api/v2/partners/:PARTNER_ID:/accounts/:ACCOUNT_ID:/subscriptions
+        GET /api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>ACCOUNT_ID</var>/subscriptions
         ```
       </td>
     </tr>
@@ -712,7 +712,7 @@ Content-Type: application/json
 
       <td>
         ```
-        GET /api/v2/partners/:PARTNER_ID:/accounts/:ACCOUNT_ID:/subscriptions/:ID
+        GET /api/v2/partners/<var>PARTNER_ID<var>/accounts/<var>ACCOUNT_ID</var>/subscriptions/<var>ID</var>
         ```
       </td>
     </tr>
@@ -724,7 +724,7 @@ Content-Type: application/json
 
       <td>
         ```
-        POST /api/v2/partners/:PARTNER_ID:/accounts/:ACCOUNT_ID:/subscriptions
+        POST /api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>ACCOUNT_ID</var>/subscriptions
         ```
       </td>
     </tr>
@@ -915,9 +915,9 @@ Here are API example requests and responses to list, show, create, and update [o
 
     ```
     curl -X GET \
-         -H 'x-api-key:PARTNER_ACCOUNT_KEY' \
+         -H 'x-api-key:<var>PARTNER_ACCOUNT_KEY</var>' \
          -H 'Content-Type:application/json' \
-         https://rpm.newrelic.com/api/v2/partners/:PARTNER_ID/accounts/<var>:ACCOUNT_ID</var>/subscriptions
+         https://rpm.newrelic.com/api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>ACCOUNT_ID</var>/subscriptions
     ```
 
     **Response:**
@@ -980,9 +980,9 @@ Here are API example requests and responses to list, show, create, and update [o
 
     ```
     curl -X GET \
-         -H 'x-api-key:PARTNER_ACCOUNT_KEY' \
+         -H 'x-api-key:<var>PARTNER_ACCOUNT_KEY</var>' \
          -H 'Content-Type:application/json' \
-         https://rpm.newrelic.com/api/v2/partners/<var>:PARTNER_ID</var>/accounts/<var>:ACCOUNT_ID</var>/subscriptions/<var>:SUBSCRIPTION_ID</var>
+         https://rpm.newrelic.com/api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>ACCOUNT_ID</var>/subscriptions/<var>SUBSCRIPTION_ID</var>
     ```
 
     **Response:**
@@ -1045,10 +1045,10 @@ Here are API example requests and responses to list, show, create, and update [o
 
     ```
     curl -X POST \
-         -H 'x-api-key:PARTNER_ACCOUNT_KEY' \
+         -H 'x-api-key:<var>PARTNER_ACCOUNT_KEY</var>' \
          -H 'Content-Type:application/json' \
          -d '{"subscriptions":[{"product_id":"1", "quantity":1}]}' \
-         https://rpm.newrelic.com/api/v2/partners/<var>:PARTNER_ID</var>/accounts/<var>:ACCOUNT_ID</var>/subscriptions
+         https://rpm.newrelic.com/api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>ACCOUNT_ID</var>/subscriptions
     ```
 
     **Response:**

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object.mdx
@@ -15,21 +15,22 @@ redirects:
   - /docs/accounts-partnerships/partnerships/partner-api/partnership-availability-monitoring-api
 ---
 
-A New Relic account has one or more subscriptions. A subscription is the level of service that a customer purchases. As a partner, use the subscription API to manage the New Relic product levels for your accounts.
+This doc explains how to use the [Partnership API](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/) to manage subscriptions for accounts on our [original pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans). 
 
-<Callout variant="important">
-  This information is for version 2 of the Partnership API. Use v2 for all new integrations. Earlier versions have been deprecated. If you have problems with an older integration, upgrade to v2.
-</Callout>
+## Requirements (#requirements)
 
-## Product subscriptions for an account [#product-subscriptions]
+You can use the subscription object only if you are on our original pricing plan. It doesn't support accounts that are on our New Relic One pricing plan. For more about this, read the [Partnership API requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
 
-The Partnership API does not allow you to upgrade or downgrade individual product subscriptions for an account. Instead, the API requires you to replace ([add](#example-create)) the configuration for **all** product subscriptions for the account.
+The Partnership API doesn't allow you to upgrade or downgrade individual product subscriptions for an account. Instead, the API requires you to replace ([add](#example-create)) the configuration for **all** product subscriptions for the account.
 
 If any product configurations are not included, the New Relic Partnership API provisions the account with the best free product type available. The API automatically selects the product level based on the configuration and custom pricing for the account's partnership.
 
+
 ## Subscription object attributes [#subscr-attributes]
 
-Here are the Partnership API subscription object's attributes.
+The subscription object only applies to accounts on our [original pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans). For more about this, see [Requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/). 
+
+Here are the Partnership API subscription object's attributes:
 
 <CollapserGroup>
   <Collapser
@@ -174,7 +175,9 @@ Here are the Partnership API subscription object's attributes.
 With each account creation call, you must supply at least one New Relic product type. The API only accepts the numeric `product_id` for the type.
 
 <Callout variant="important">
-  Creating subscriptions for Serverless, Logs, and Traces is not supported in the New Relic Partnership API. If your account has these subscriptions, any attempt to make changes will return an error. Please contact your account executive to modify subscriptions.
+Reminder that the subscription object only applies for accounts using our [original pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans). 
+    
+Also, creating subscriptions for Serverless, Logs, and Traces is not supported by the Partnership API. If your account has these subscriptions, any attempt to make changes will return an error. Please contact your account executive to modify subscriptions.
 </Callout>
 
 <Callout variant="important">
@@ -186,9 +189,9 @@ With each account creation call, you must supply at least one New Relic product 
     id="apm-product-mapping"
     title="APM"
   >
-    The number of allowable hosts per account and the data retention period vary by subscription level within [New Relic APM's pricing structure](http://newrelic.com/application-monitoring/pricing). For example, New Relic APM allows an unlimited number of allowable hosts for Lite accounts but only a 24-hour data retention period.
+    The number of allowable hosts per account and the data retention period vary by subscription level within New Relic APM's pricing structure. For example, New Relic APM allows an unlimited number of allowable hosts for Lite accounts but only a 24-hour data retention period.
 
-    In addition, pricing and data retention depend on whether you select [pricing plans based on hosts or compute units (CU)](/docs/accounts-partnerships/accounts/account-billing-usage/compute-unit-pricing-host-pricing). Use the product ID's **integer** format to identify the subscription level and type of plan.
+    In addition, pricing and data retention depend on whether you select pricing plans based on hosts or compute units (CU). Use the product ID's **integer** format to identify the subscription level and type of plan.
 
     <table>
       <thead>
@@ -296,7 +299,7 @@ With each account creation call, you must supply at least one New Relic product 
       </tbody>
     </table>
 
-    If you select [pricing plans based on compute units (CU)](https://newrelic.com/calculator), use these product ID **integer** formats to identify the subscription level and type of plan.
+    If you select pricing plans based on compute units (CU), use these product ID **integer** formats to identify the subscription level and type of plan.
 
     <table>
       <thead>
@@ -359,7 +362,7 @@ With each account creation call, you must supply at least one New Relic product 
     id="mobile-product-mapping"
     title="Mobile"
   >
-    [New Relic Mobile's pricing structure](http://newrelic.com/mobile-monitoring/pricing) allows 100,000 monthly active users per account at the Enterprise subscription level. Data retention varies by subscription level. Use the product ID's **integer** format to identify the subscription level.
+    New Relic Mobile's pricing structure allows 100,000 monthly active users per account at the Enterprise subscription level. Data retention varies by subscription level. Use the product ID's **integer** format to identify the subscription level.
 
     <table>
       <thead>
@@ -475,7 +478,7 @@ With each account creation call, you must supply at least one New Relic product 
     id="browser-product-mapping"
     title="Browser"
   >
-    [New Relic Browser's pricing structure](http://newrelic.com/browser-monitoring/pricing) allows an unlimited number of app users, regardless of subscription level. However, the number of allowable page views per month and the data retention period vary by subscription level. For example:
+    New Relic Browser's pricing structure allows an unlimited number of app users, regardless of subscription level. However, the number of allowable page views per month and the data retention period vary by subscription level. For example:
 
     * Lite accounts include an unlimited number of page views per month and 24-hour data retention.
     * Pro account pricing starts at 500,000 page views per month and three months data retention.
@@ -533,7 +536,7 @@ With each account creation call, you must supply at least one New Relic product 
     id="synthetics-product-mapping"
     title="Synthetics"
   >
-    With [New Relic Synthetics' pricing structure](http://newrelic.com/synthetics/pricing), the default number of allowable monitoring checks and the data retention period vary by subscription level. Use the product ID's **integer** format to identify the subscription level.
+    With New Relic Synthetics' pricing structure, the default number of allowable monitoring checks and the data retention period vary by subscription level. Use the product ID's **integer** format to identify the subscription level.
 
     <table>
       <thead>
@@ -590,9 +593,9 @@ With each account creation call, you must supply at least one New Relic product 
     id="infrastructure-product-mapping"
     title="Infrastructure"
   >
-    With [New Relic Infrastructure's pricing structure](https://newrelic.com/infrastructure), the default number of instances and the data retention period vary by subscription level. [Infrastructure events](/docs/infrastructure/new-relic-infrastructure/data-instrumentation/default-infrastructure-attributes-events) do not count against your New Relic Insights quota, even though you can query them in Insights.
+    With New Relic's Infrastructure pricing structure, the default number of instances and the data retention period vary by subscription level. [Infrastructure events](/docs/infrastructure/new-relic-infrastructure/data-instrumentation/default-infrastructure-attributes-events) do not count against your New Relic Insights quota, even though you can query them in Insights.
 
-    New Relic Infrastructure offers [pricing plans based on Compute Units (CU) only](https://newrelic.com/calculator). Use the product ID's **integer** format to identify the subscription level.
+    New Relic Infrastructure offers pricing plans based on Compute Units (CU) only. Use the product ID's **integer** format to identify the subscription level.
 
     <table>
       <thead>
@@ -728,7 +731,7 @@ Content-Type: application/json
 
 ## Subscription API examples [#examples]
 
-Here are examples of an API call to create a subscription and the JSON response listing subscriptions for the account.
+Here are examples of an API call to create an [original pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans) subscription and the JSON response listing subscriptions for the account.
 
 <CollapserGroup>
   <Collapser
@@ -807,7 +810,7 @@ Here are examples of an API call to create a subscription and the JSON response 
     id="subscription-state"
     title="Subscription status"
   >
-    Here are typical subscription status values that the API call may return.
+    Here are some [original pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans) subscription status values that the API call may return.
 
     <table>
       <thead>
@@ -899,7 +902,7 @@ Here are examples of an API call to create a subscription and the JSON response 
 
 ## API examples (v2)
 
-Here are API example requests and responses to list, show, create, and update partner subscriptions. Line breaks in responses are for readability. The actual responses appear as a continuous line.
+Here are API example requests and responses to list, show, create, and update [original pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans) subscriptions. Line breaks in responses are for readability. The actual responses appear as a continuous line.
 
 <CollapserGroup>
   <Collapser
@@ -1096,12 +1099,3 @@ Here are API example requests and responses to list, show, create, and update pa
     ```
   </Collapser>
 </CollapserGroup>
-
-## For more help [#more_help]
-
-Additional documentation resources include:
-
-* [Partner integration guide](/docs/accounts-partnerships/partner-integration-guide) (how to work with New Relic as a partner)
-* [Partnership API reference](/docs/accounts-partnerships/partnerships/partner-api/partner-api-reference) (overview of the Partner API)
-* [Partnership API account object](/docs/accounts-partnerships/partnerships/partner-api/partner-api-account-object) (the primary JSON container object in the API)
-* [Partnership API user object](/docs/accounts-partnerships/partnerships/partner-api/partner-api-user-object) (defined as an array within the account object)

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object.mdx
@@ -17,9 +17,9 @@ redirects:
 
 This doc explains how to use the [Partnership API](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/) to manage subscriptions for accounts on our [original pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans). 
 
-## Requirements (#requirements)
+## Requirements [#requirements]
 
-You can use the subscription object only if you're on our original pricing plan. It doesn't support accounts that are on our [New Relic One pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans). For more on this, read the [Partnership API requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
+You can use the subscription object only if you're on our original pricing plan. It doesn't support accounts on our [New Relic One pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans). For more on this, read the [Partnership API requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
 
 The Partnership API doesn't allow you to upgrade or downgrade individual product subscriptions for an account. Instead, the API requires you to replace ([add](#example-create)) the configuration for **all** product subscriptions for the account.
 
@@ -666,6 +666,8 @@ Also, creating subscriptions for Serverless, Logs, and Traces is not supported b
 </CollapserGroup>
 
 ## Subscription API calls [#user-calls]
+
+Before using this, first read [Requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/). 
 
 Here are the URL patterns for subscription-related API functions. If used, send them along with the JSON object and an HTTP header containing the [Partner API key](https://docs.newrelic.com/docs/accounts-partnerships/partnerships/partner-api/partner-api-reference#the-api-key). For example:
 

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-subscription-object.mdx
@@ -19,7 +19,7 @@ This doc explains how to use the [Partnership API](/docs/new-relic-partnerships/
 
 ## Requirements (#requirements)
 
-You can use the subscription object only if you are on our original pricing plan. It doesn't support accounts that are on our New Relic One pricing plan. For more about this, read the [Partnership API requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
+You can use the subscription object only if you're on our original pricing plan. It doesn't support accounts that are on our [New Relic One pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans). For more on this, read the [Partnership API requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
 
 The Partnership API doesn't allow you to upgrade or downgrade individual product subscriptions for an account. Instead, the API requires you to replace ([add](#example-create)) the configuration for **all** product subscriptions for the account.
 
@@ -28,9 +28,9 @@ If any product configurations are not included, the New Relic Partnership API pr
 
 ## Subscription object attributes [#subscr-attributes]
 
-The subscription object only applies to accounts on our [original pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans). For more about this, see [Requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/). 
+Before using this, first read [Requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/). 
 
-Here are the Partnership API subscription object's attributes:
+Here are the subscription object's attributes:
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object.mdx
@@ -93,13 +93,7 @@ This is the list of attributes in the user object. Ensure you assign the [**owne
 
     This attribute is **required** for new users.
 
-    The password for this user is ignored if the email address matches a pre-existing user record. As of Partnership API version 2, passwords passed as part of an account creation call must meet each of the following minimum requirements for complexity:
-
-    * Eight to 50 characters in length
-    * Only letters, numbers, or special characters (see [list of allowed special characters](#special-chars) below). Spaces are **not** allowed.
-    * At least one letter (a-z, A-Z)
-    * At least one number or special character (0-9)  
-      Special characters allowed include `~` `` ` `` `!` `@` `#` `$` `%` `^` `&` `*` `(` `)` `_` `-` `+` `=` `{` `[` `}` `]` `:` `;` `"` `'` `<` `,` `>` `.` `?` `/` `|` `\`
+    The password for this user is ignored if the email address matches a pre-existing user record. As of Partnership API version 2, passwords passed as part of an account creation call must meet the [requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
 
     <Callout variant="caution">
       Passwords passed as part of an account provisioning call that do not conform to this format will generate an error and cause the operation to fail.
@@ -246,8 +240,8 @@ This is the list of attributes in the user object. Ensure you assign the [**owne
 Here are the URL patterns for user-related API functions. If using this URL pattern, send an HTTP header containing the [Partner API key](https://docs.newrelic.com/docs/new-relic-partnerships/partnerships/partner-api/partner-api-reference#the-api-key) along with the JSON request body. For example:
 
 ```
-GET .../api/v2/partners/:PARTNER_ID:/accounts/:ID
-x-api-key: :PARTNER_ACCOUNT_KEY:
+GET .../api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>ID</var>
+x-api-key:<var>PARTNER_ACCOUNT_KEY</var>
 Content-Type: application/json
 
 { JSON data }
@@ -274,7 +268,7 @@ Content-Type: application/json
 
       <td>
         ```
-        GET /api/v2/partners/:PARTNER_ID:/accounts/:ACCOUNT_ID:/users
+        GET /api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>ACCOUNT_ID</var>/users
         ```
       </td>
     </tr>
@@ -286,7 +280,7 @@ Content-Type: application/json
 
       <td>
         ```
-        PUT /api/v2/partners/:PARTNER_ID:/accounts/:ACCOUNT_ID/users/:ID
+        PUT /api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>ACCOUNT_ID</var>/users/<var>ID</var>
         ```
       </td>
     </tr>
@@ -300,7 +294,7 @@ Content-Type: application/json
 
       <td>
         ```
-        POST /api/v2/partners/:PARTNER_ID:/accounts/:ACCOUNT_ID:/users
+        POST /api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>ACCOUNT_ID</var>/users
         ```
       </td>
     </tr>
@@ -314,7 +308,7 @@ Content-Type: application/json
 
       <td>
         ```
-        DELETE /api/v2/partners/:PARTNER_ID:/accounts/:ACCOUNT_ID:/users/:ID
+        DELETE /api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>ACCOUNT_ID</var>/users/<var>ID</var>
         ```
       </td>
     </tr>
@@ -394,9 +388,9 @@ Here are examples of API calls using the Partnership API user object.
 
     ```
     curl -X GET \
-        -H 'x-api-key:PARTNER_ACCOUNT_KEY' \
+        -H 'x-api-key:<var>PARTNER_ACCOUNT_KEY</var>' \
         -H 'Content-Type:application/json' \
-        https://rpm.newrelic.com/api/v2/partners/:PARTNER_ID/accounts/12345/users
+        https://rpm.newrelic.com/api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>12345</var>/users
     ```
 
     Response:
@@ -422,10 +416,10 @@ Here are examples of API calls using the Partnership API user object.
 
     ```
     curl -X POST \
-        -H 'x-api-key:PARTNER_ACCOUNT_KEY' \
+        -H 'x-api-key:<var>PARTNER_ACCOUNT_KEY</var>' \
         -H 'Content-Type:application/json' \
         -d '{"users":[{"email": "foobar@newrelic.com", "password":"password1", "first_name":"John", "last_name":"Doe", "role":"admin" }]}' \
-        https://rpm.newrelic.com/api/v2/partners/:PARTNER_ID/accounts/12345/users
+        https://rpm.newrelic.com/api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>12345</var>/users
     ```
 
     Response (line breaks are for readability):
@@ -444,10 +438,10 @@ Here are examples of API calls using the Partnership API user object.
 
     ```
     curl -X PUT \
-        -H 'x-api-key:PARTNER_ACCOUNT_KEY' \
+        -H 'x-api-key:<var>PARTNER_ACCOUNT_KEY</var>' \
         -H 'Content-Type:application/json' \
         -d '{"users":[{"role": "restricted"}]}' \
-        https://rpm.newrelic.com/api/v2/partners/:PARTNER_ID/accounts/12345/users/23456
+        https://rpm.newrelic.com/api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>12345</var>/users/<var>23456</var>
     ```
 
     Response (line breaks are for readability)
@@ -466,9 +460,9 @@ Here are examples of API calls using the Partnership API user object.
 
     ```
     curl -X DELETE \
-        -H 'x-api-key:PARTNER_ACCOUNT_KEY' \
+        -H 'x-api-key:<var>PARTNER_ACCOUNT_KEY</var>' \
         -H 'Content-Type:application/json' \
-        https://rpm.newrelic.com/api/v2/partners/:PARTNER_ID/accounts/12345/users/23456
+        https://rpm.newrelic.com/api/v2/partners/<var>PARTNER_ID</var>/accounts/<var>12345</var>/users/<var>23456</var>
     ```
 
     Response: No response body.

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object.mdx
@@ -13,7 +13,7 @@ redirects:
 
 This doc explains how to use the [Partnership API](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/) to add and manage users. 
 
-## Requirements (#requirements)
+## Requirements [#requirements]
 
 You can use the user object only if your organization has users on our original user model. **Before using the API, read the [Partnership API requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).**
 
@@ -322,6 +322,8 @@ Content-Type: application/json
 </table>
 
 ## User object JSON example [#call-example]
+
+**Before using this API, read the [Partnership API requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).**
 
 Here is an example of a JSON request and response using the Partnership API user object.
 

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object.mdx
@@ -15,7 +15,7 @@ This doc explains how to use the [Partnership API](/docs/new-relic-partnerships/
 
 ## Requirements (#requirements)
 
-You can use the user object only if your organization has users on our original user model. **Before using this object, please read the [Partnership API requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).**
+You can use the user object only if your organization has users on our original user model. **Before using the API, read the [Partnership API requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).**
 
 ## User object attributes [#user-attributes]
 

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object.mdx
@@ -11,13 +11,15 @@ redirects:
   - /docs/accounts-partnerships/partnerships/partner-api/partnership-api-user-object
 ---
 
-The Users entity stores customer information. One or more users can be associated with an account. In addition a specific user may be associated with multiple accounts.
+This doc explains how to use the [Partnership API](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/) to add and manage users. 
 
-<Callout variant="important">
-  This information is for version 2 of the Partnership API. Use v2 for all new integrations. Earlier versions have been deprecated. If you have problems with an older integration, upgrade to version 2.
-</Callout>
+## Requirements (#requirements)
+
+You can use the user object only if your organization has users on our original user model. **Before using this object, please read the [Partnership API requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).**
 
 ## User object attributes [#user-attributes]
+
+The user object stores customer information. One or more users can be associated with an account. In addition a specific user may be associated with multiple accounts.
 
 This is the list of attributes in the user object. Ensure you assign the [**owner**](#attr-owner) attribute to one user when creating a New Relic account.
 
@@ -471,11 +473,3 @@ Here are examples of API calls using the Partnership API user object.
   </Collapser>
 </CollapserGroup>
 
-## For more help [#more_help]
-
-Additional documentation resources include:
-
-* [Partner integration guide](/docs/accounts-partnerships/partner-integration-guide) (how to work with New Relic as a partner)
-* [Partnership API reference](/docs/partnerships/partner-api-account-object) (overview of the Partner API)
-* [Partnership API account object](/docs/partnerships/partner-api-account-object) (the primary JSON container object in the API)
-* [Partnership API subscription object](/docs/partnerships/partner-api-subscription-object) (defined as an array within the account object)

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-user-object.mdx
@@ -323,7 +323,7 @@ Content-Type: application/json
 
 ## User object JSON example [#call-example]
 
-**Before using this API, read the [Partnership API requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).**
+**Before using this API, read the [requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).**
 
 Here is an example of a JSON request and response using the Partnership API user object.
 

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-billing-integration-api.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-billing-integration-api.mdx
@@ -16,7 +16,7 @@ New Relic's [Partnership API](/docs/new-relic-partnerships/partner-integration-g
 
 For example, when customers of a New Relic reseller partner purchase a higher subscription level from New Relic's Sales team, New Relic replaces the old subscription with a new subscription. New Relic then uses the API to communicate this information to the partner.
 
-## Requirements 
+## Requirements [#requirements]
 
 **Before using this object, please read the [Partnership API requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).**
 

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-billing-integration-api.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/partnership-billing-integration-api.mdx
@@ -12,15 +12,13 @@ redirects:
   - /docs/accounts-partnerships/partnerships/partner-api/partnership-billing-integration-api
 ---
 
-New Relic's Partnership API includes functions to replace a customer's existing subscription with a new one, or to update invoice information for New Relic partner accounts. This is particularly useful for partners acting as resellers for New Relic accounts.
+New Relic's [Partnership API](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/) includes functionality for partners to replace a customer's existing subscription with a new one, or to update invoice information for New Relic partner accounts. This is particularly useful for partners acting as resellers or managed service providers of New Relic accounts.
 
 For example, when customers of a New Relic reseller partner purchase a higher subscription level from New Relic's Sales team, New Relic replaces the old subscription with a new subscription. New Relic then uses the API to communicate this information to the partner.
 
-<Callout variant="important">
-  This information is for version 2 of the Partnership API. Use v2 for all new integrations. Earlier versions have been deprecated. If you have problems with an older integration, upgrade to version 2.
-</Callout>
+## Requirements 
 
-## Contents [#qiklinks]
+**Before using this object, please read the [Partnership API requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).**
 
 ## Communication endpoint [#billing-communication]
 

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/product-buckets.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/product-buckets.mdx
@@ -10,6 +10,14 @@ redirects:
   - /docs/accounts-partnerships/partnerships/partner-api/product-buckets
 ---
 
+For partnership accounts on our original product pricing, you can use the [Partnership API](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/) for managing subscriptions. This doc explains some details for using the Browser, Synthetics, and Insights products. 
+
+## Requirements (#requirements)
+
+This doc applies only for partnership accounts on our original pricing plan. **Before using this API, please read the [Partnership API requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).**
+
+## Overview (#overview)
+
 When using the Partnership API for Insights, Browser, and Synthetics products, you must provide a valid [`quantity` value](/docs/accounts-partnerships/partnerships/partner-api/partner-api-subscription-object#attr-quantity). This indicates the number of [Insights Events](#h2_insights_events), [Browser PageViews](#h2_browser_page_views), and [Synthetics Checks](#h2_synthetics_checks) provisioned to that account.
 
 New Relic uses this "bucket" pricing structure based on the quantity value in order to offer discounts on large volume purchases. Be sure to select an available bucket value. Otherwise, the New Relic Partnership API will return an error response.
@@ -1063,11 +1071,3 @@ Here are the valid `quantity` values by New Relic product.
   </Collapser>
 </CollapserGroup>
 
-## For more help [#more_help]
-
-Additional documentation resources include:
-
-* [Partner integration guide](/docs/accounts-partnerships/partner-integration-guide) (how to work with New Relic as a partner)
-* [Partnership API reference](/docs/partnerships/partner-api-account-object) (overview of the Partner API)
-* [Partnership API account object](/docs/partnerships/partner-api-account-object) (the primary JSON container object in the API)
-* [Partnership API subscription object](/docs/partnerships/partner-api-subscription-object) (defined as an array within the account object)

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/product-buckets.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/product-buckets.mdx
@@ -12,7 +12,7 @@ redirects:
 
 For partnership accounts on our original product pricing, you can use the [Partnership API](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/) for managing subscriptions. This doc explains some details for using the Browser, Synthetics, and Insights products. 
 
-## Requirements (#requirements)
+## Requirements [#requirements]
 
 This doc applies only for partnership accounts on our original pricing plan. **Before using this API, please read the [Partnership API requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).**
 

--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/typical-integration-example.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/typical-integration-example.mdx
@@ -14,7 +14,7 @@ redirects:
 
 This provides the step-by-step details of a typical integration using the page widget and SSO.
 
-**Recommendation:** Start new projects by referring to [Getting started with API v2](/docs/apm/apis/requirements/new-relic-rest-api-v2-getting-started) and the [New Relic REST API v2 examples](/docs/apis/rest-api-v2). Also, begin migrating any of your API v1 scripts to their v2 equivalent.
+**Recommendation:** Start new projects by referring to [Getting started with API](/docs/apm/apis/requirements/new-relic-rest-api-v2-getting-started) and the [New Relic REST API v2 examples](/docs/apis/rest-api-v2). Also, begin migrating any of your API v1 scripts to their v2 equivalent.
 
 ## Account creation and value storage [#create-account]
 

--- a/src/nav/new-relic-partnerships.yml
+++ b/src/nav/new-relic-partnerships.yml
@@ -21,7 +21,7 @@ pages:
         pages:
           - title: Partnership accounts
             path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions
-          - title: Partner API
+          - title: Intro to Partner API
             path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api
           - title: Partner account access for administrators
             path: /docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-account-access-administrators


### PR DESCRIPTION
For release March 24 afternoon. 

This is regarding changes for the Partnership API that pertain to restrictions for customer partnerships on the New Relic One pricing plan or the New Relic One user model (so four total audiences of all combinations of those). It doesn't apply to true partners (aka resellers, managed service providers) just customer partnerships. Main scope of work: 

Edits in the 'Intro to Partnership API' doc: adding more info about requirements and restrictions. 
For every doc in this category: putting in prominent notes about reading requirements before use. 
Edits in the `account object` doc: putting in various callouts regarding the attributes that are restricted dependent on pricing plan or account/user model. The other two objects (users object and subscription object) will throw error messages if used by accounts that can't use it, so in that sense things are a lot simpler for them. That's not true of the 'account object', which may just ignore some calls and not throw error messages.

For more info, see Slack convo or jira. 
