### PR TITLE
Fixed mangled link that was 404ing

### DIFF
--- a/src/content/docs/agents/java-agent/heroku/java-agent-heroku.mdx
+++ b/src/content/docs/agents/java-agent/heroku/java-agent-heroku.mdx
@@ -30,7 +30,7 @@ After you ensure that you [meet the requirements](#requirements), enable the New
 </Callout>
 
 1. Log in to your Heroku account.
-2. From the [APM Add-On Page](https://elements.heroku.com/addons/newrelic#planselector), select a subscription plan.
+2. From the [APM Add-On Page](https://elements.heroku.com/addons/newrelic#pricing), select a subscription plan.
 3. Select **Install New Relic APM**, and then select your target app from the dropdown.
 
 Installing the add-on automatically creates a New Relic account and configures access for Heroku servers.

--- a/src/content/docs/agents/java-agent/heroku/java-agent-heroku.mdx
+++ b/src/content/docs/agents/java-agent/heroku/java-agent-heroku.mdx
@@ -30,7 +30,7 @@ After you ensure that you [meet the requirements](#requirements), enable the New
 </Callout>
 
 1. Log in to your Heroku account.
-2. From the [APM Add-On Page](https://addons.heroku.com/newrelic), select a subscription plan.
+2. From the [APM Add-On Page](https://elements.heroku.com/addons/newrelic#planselector), select a subscription plan.
 3. Select **Install New Relic APM**, and then select your target app from the dropdown.
 
 Installing the add-on automatically creates a New Relic account and configures access for Heroku servers.

--- a/src/content/docs/agents/java-agent/heroku/java-agent-scala-heroku.mdx
+++ b/src/content/docs/agents/java-agent/heroku/java-agent-scala-heroku.mdx
@@ -29,7 +29,7 @@ After you ensure that you [meet the requirements](#requirements), enable the New
 </Callout>
 
 1. Log in to your Heroku account.
-2. From the [APM Add-On Page](https://elements.heroku.com/addons/newrelic#planselector), select a subscription plan.
+2. From the [APM Add-On Page](https://elements.heroku.com/addons/newrelic#pricing), select a subscription plan.
 3. Select **Install New Relic APM**, and then select your target app from the dropdown.
 
 Installing the add-on automatically creates a New Relic account and configures access for Heroku servers.

--- a/src/content/docs/agents/java-agent/heroku/java-agent-scala-heroku.mdx
+++ b/src/content/docs/agents/java-agent/heroku/java-agent-scala-heroku.mdx
@@ -29,7 +29,7 @@ After you ensure that you [meet the requirements](#requirements), enable the New
 </Callout>
 
 1. Log in to your Heroku account.
-2. From the [APM Add-On Page](https://addons.heroku.com/newrelic), select a subscription plan.
+2. From the [APM Add-On Page](https://elements.heroku.com/addons/newrelic#planselector), select a subscription plan.
 3. Select **Install New Relic APM**, and then select your target app from the dropdown.
 
 Installing the add-on automatically creates a New Relic account and configures access for Heroku servers.

--- a/src/content/docs/agents/nodejs-agent/hosting-services/nodejs-agent-heroku.mdx
+++ b/src/content/docs/agents/nodejs-agent/hosting-services/nodejs-agent-heroku.mdx
@@ -19,7 +19,7 @@ After deploying your Node.js app on Heroku, install the New Relic agent. Install
 
 To install the New Relic add-on through the [Heroku website's Add-on page for New Relic](https://addons.heroku.com/newrelic), you must be logged in to Heroku.
 
-1. From Heroku's Add-on page for New Relic, select the [appropriate subscription plan](https://addons.heroku.com/newrelic#plan_selector). Then run this toolbelt command:
+1. From Heroku's Add-on page for New Relic, select the [appropriate subscription plan](https://elements.heroku.com/addons/newrelic#planselector). Then run this toolbelt command:
 
    ```
    heroku addons:create newrelic:<var>$planlevel</var>

--- a/src/content/docs/agents/nodejs-agent/hosting-services/nodejs-agent-heroku.mdx
+++ b/src/content/docs/agents/nodejs-agent/hosting-services/nodejs-agent-heroku.mdx
@@ -19,7 +19,7 @@ After deploying your Node.js app on Heroku, install the New Relic agent. Install
 
 To install the New Relic add-on through the [Heroku website's Add-on page for New Relic](https://addons.heroku.com/newrelic), you must be logged in to Heroku.
 
-1. From Heroku's Add-on page for New Relic, select the [appropriate subscription plan](https://elements.heroku.com/addons/newrelic#planselector). Then run this toolbelt command:
+1. From Heroku's Add-on page for New Relic, select the [appropriate subscription plan](https://elements.heroku.com/addons/newrelic#pricing). Then run this toolbelt command:
 
    ```
    heroku addons:create newrelic:<var>$planlevel</var>

--- a/src/content/docs/agents/php-agent/advanced-installation/php-agent-heroku.mdx
+++ b/src/content/docs/agents/php-agent/advanced-installation/php-agent-heroku.mdx
@@ -27,7 +27,7 @@ After deploying your PHP app on Heroku, install our PHP agent:
   >
     To install the New Relic add-on through the Heroku website:
 
-    1. From the [New Relic Add-on Page](//addons.heroku.com/newrelic), select a subscription plan.
+    1. From the [New Relic Add-on Page](https://elements.heroku.com/addons/newrelic#planselector), select a subscription plan.
     2. From the **Select an app** dropdown, select your app.
     3. Give your application a [descriptive name](#naming) with this Heroku toolbelt command:
 
@@ -44,7 +44,7 @@ After deploying your PHP app on Heroku, install our PHP agent:
   >
     To install the New Relic add-on with Heroku toolbelt:
 
-    1. Via Heroku toolbelt, run the following command and substitute the [appropriate subscription plan](//addons.heroku.com/newrelic#plan_selector):
+    1. Via Heroku toolbelt, run the following command and substitute the [appropriate subscription plan](https://elements.heroku.com/addons/newrelic#planselector):
 
        ```
        heroku addons:create newrelic:<var>YOUR_PLAN_LEVEL</var>

--- a/src/content/docs/agents/php-agent/advanced-installation/php-agent-heroku.mdx
+++ b/src/content/docs/agents/php-agent/advanced-installation/php-agent-heroku.mdx
@@ -27,7 +27,7 @@ After deploying your PHP app on Heroku, install our PHP agent:
   >
     To install the New Relic add-on through the Heroku website:
 
-    1. From the [New Relic Add-on Page](https://elements.heroku.com/addons/newrelic#planselector), select a subscription plan.
+    1. From the [New Relic Add-on Page](https://elements.heroku.com/addons/newrelic#pricing), select a subscription plan.
     2. From the **Select an app** dropdown, select your app.
     3. Give your application a [descriptive name](#naming) with this Heroku toolbelt command:
 
@@ -44,7 +44,7 @@ After deploying your PHP app on Heroku, install our PHP agent:
   >
     To install the New Relic add-on with Heroku toolbelt:
 
-    1. Via Heroku toolbelt, run the following command and substitute the [appropriate subscription plan](https://elements.heroku.com/addons/newrelic#planselector):
+    1. Via Heroku toolbelt, run the following command and substitute the [appropriate subscription plan](https://elements.heroku.com/addons/newrelic#pricing):
 
        ```
        heroku addons:create newrelic:<var>YOUR_PLAN_LEVEL</var>

--- a/src/content/docs/agents/python-agent/hosting-services/python-agent-heroku.mdx
+++ b/src/content/docs/agents/python-agent/hosting-services/python-agent-heroku.mdx
@@ -29,7 +29,7 @@ After deploying your Python app on Heroku, install the Python agent:
   >
     To install the New Relic add-on through the Heroku website, you must be logged in to Heroku:
 
-    1. From [Heroku's Add-on page for New Relic](https://elements.heroku.com/addons/newrelic#planselector), select a subscription plan.
+    1. From [Heroku's Add-on page for New Relic](https://elements.heroku.com/addons/newrelic#pricing), select a subscription plan.
     2. From **Select an app**, select your New Relic app.
     3. Give your application a [descriptive name](/docs/apm/new-relic-apm/installation-configuration/name-your-application) with this Heroku toolbelt command:
 
@@ -46,7 +46,7 @@ After deploying your Python app on Heroku, install the Python agent:
   >
     To install the Python agent add-on with Heroku the toolbelt:
 
-    1. Run the following command, where `$planlevel` is the [appropriate subscription plan](https://elements.heroku.com/addons/newrelic#planselector):
+    1. Run the following command, where `$planlevel` is the [appropriate subscription plan](https://elements.heroku.com/addons/newrelic#pricing):
 
        ```
        heroku addons:create newrelic:<var>$planlevel</var>

--- a/src/content/docs/agents/python-agent/hosting-services/python-agent-heroku.mdx
+++ b/src/content/docs/agents/python-agent/hosting-services/python-agent-heroku.mdx
@@ -29,7 +29,7 @@ After deploying your Python app on Heroku, install the Python agent:
   >
     To install the New Relic add-on through the Heroku website, you must be logged in to Heroku:
 
-    1. From [Heroku's Add-on page for New Relic](https://addons.heroku.com/newrelic), select a subscription plan.
+    1. From [Heroku's Add-on page for New Relic](https://elements.heroku.com/addons/newrelic#planselector), select a subscription plan.
     2. From **Select an app**, select your New Relic app.
     3. Give your application a [descriptive name](/docs/apm/new-relic-apm/installation-configuration/name-your-application) with this Heroku toolbelt command:
 
@@ -46,7 +46,7 @@ After deploying your Python app on Heroku, install the Python agent:
   >
     To install the Python agent add-on with Heroku the toolbelt:
 
-    1. Run the following command, where `$planlevel` is the [appropriate subscription plan](https://addons.heroku.com/newrelic#plan_selector):
+    1. Run the following command, where `$planlevel` is the [appropriate subscription plan](https://elements.heroku.com/addons/newrelic#planselector):
 
        ```
        heroku addons:create newrelic:<var>$planlevel</var>

--- a/src/content/docs/agents/ruby-agent/installation/ruby-agent-heroku.mdx
+++ b/src/content/docs/agents/ruby-agent/installation/ruby-agent-heroku.mdx
@@ -23,7 +23,7 @@ After deploying your Ruby app on Heroku, install the New Relic agent:
   >
     To install the New Relic add-on through the Heroku website, you must be logged in to Heroku:
 
-    1. From [Heroku's Add-on page for New Relic](https://addons.heroku.com/newrelic), select a subscription plan.
+    1. From [Heroku's Add-on page for New Relic](https://elements.heroku.com/addons/newrelic#planselector), select a subscription plan.
     2. From **Select an app**, select your New Relic app.
     3. Give your application a [descriptive name](/docs/apm/new-relic-apm/installation-configuration/name-your-application) with this Heroku toolbelt command:
 
@@ -47,7 +47,7 @@ After deploying your Ruby app on Heroku, install the New Relic agent:
   >
     To install the New Relic add-on with the Heroku toolbelt:
 
-    1. Run the following toolbelt command, where `$planlevel` is the [appropriate subscription plan](https://addons.heroku.com/newrelic#plan_selector):
+    1. Run the following toolbelt command, where `$planlevel` is the [appropriate subscription plan](https://elements.heroku.com/addons/newrelic#planselector):
 
        ```
        heroku addons:create newrelic:<var>$planlevel</var>

--- a/src/content/docs/agents/ruby-agent/installation/ruby-agent-heroku.mdx
+++ b/src/content/docs/agents/ruby-agent/installation/ruby-agent-heroku.mdx
@@ -23,7 +23,7 @@ After deploying your Ruby app on Heroku, install the New Relic agent:
   >
     To install the New Relic add-on through the Heroku website, you must be logged in to Heroku:
 
-    1. From [Heroku's Add-on page for New Relic](https://elements.heroku.com/addons/newrelic#planselector), select a subscription plan.
+    1. From [Heroku's Add-on page for New Relic](https://elements.heroku.com/addons/newrelic#pricing), select a subscription plan.
     2. From **Select an app**, select your New Relic app.
     3. Give your application a [descriptive name](/docs/apm/new-relic-apm/installation-configuration/name-your-application) with this Heroku toolbelt command:
 
@@ -47,7 +47,7 @@ After deploying your Ruby app on Heroku, install the New Relic agent:
   >
     To install the New Relic add-on with the Heroku toolbelt:
 
-    1. Run the following toolbelt command, where `$planlevel` is the [appropriate subscription plan](https://elements.heroku.com/addons/newrelic#planselector):
+    1. Run the following toolbelt command, where `$planlevel` is the [appropriate subscription plan](https://elements.heroku.com/addons/newrelic#pricing):
 
        ```
        heroku addons:create newrelic:<var>$planlevel</var>


### PR DESCRIPTION
### Tell us why

Added correct [`https://elements.heroku.com/addons/newrelic`](https://elements.heroku.com/addons/newrelic) or [`https://elements.heroku.com/addons/newrelic#planselector`](https://elements.heroku.com/addons/newrelic#planselector) link in place of truncated `//addons.heroku.com/newrelic#plan_selector` in response to [https://github.com/newrelic/docs-website/issues/1441](https://github.com/newrelic/docs-website/issues/1441). 

### Anything else you'd like to share?

n/a

### Are you making a change to site code?

no
