### PR TITLE
Added Ruby Agent 7.0 Migration Guide

### DIFF
--- a/src/content/docs/agents/ruby-agent/getting-started/migration-7x-guide.mdx
+++ b/src/content/docs/agents/ruby-agent/getting-started/migration-7x-guide.mdx
@@ -1,45 +1,49 @@
-import { Callout } from '@newrelic/gatsby-theme-newrelic'
+---
+title: Ruby Agent 6.x to 7.x migration guide
+tags: 
+  - Agents
+  - Ruby agent
+  - Getting started
+---
+## Summary [#summary]
 
-# Ruby Agent 6.x to 7.x Migration Guide
+This guide covers the major changes between the 6.x and 7.x series of the Ruby Agent, issues that may be encountered while upgrading, and how to migrate successfully to version 7.x. 
 
-## Summary
+Main changes include:
+- [Support for Ruby 2.0 and 2.1 is dropped](#ruby-2-dropped).
+- [SSL Certificate Bundle is removed](#ssl-cet-removed).
+- [Several APIs that were deprecated in various 6.x releases are now removed](#deprecated-apis).
+- [Auto-instrumentation defaults to prepend over method chaining](#prepend-instrumentation).
+- [Auto-instrumentation gets consistent configuration attributes](#modernized-auto-instrumentation).
 
-This guide covers the major changes between 6.x and 7.x series of the Ruby Agent, issues that may be encountered in upgrading and how to migrate successfully to 7.x.
+See [Milestone for 7.0 Target Release](https://github.com/newrelic/newrelic-ruby-agent/pulls?q=is%3Apr+is%3Aopen+label%3Aversion%3A7.0.0) for more information.
 
-- Support for Ruby 2.0 and 2.1 dropped.
-- SSL Certificate Bundle is removed.
-- Several APIs that were deprecated in various 6.x releases are now removed.
-- Auto-Instrumentation defaults to prepend over method chaining.
-- Auto-Instrumentation gets Consistent Configuration Attributes.
-
-See: [Milestone for 7.0 Target Release](https://github.com/newrelic/newrelic-ruby-agent/pulls?q=is%3Apr+is%3Aopen+label%3Aversion%3A7.0.0)
-
-## Support for Ruby 2.0 and 2.1 Dropped
+## Support for Ruby 2.0 and 2.1 is dropped [#ruby-2-dropped]
 
 Ruby 2.0 and 2.1 were [EOL'd in February 2016](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/) and New Relic is following suit with dropping support for these versions in the 7.0 release. There are no known changes that would inherently prevent these versions from continuing to work, but we are no longer guaranteeing the Ruby agent continues to function without issues going forward. If you need Ruby 2.0 or 2.1, then continue to use 6.15.0, which is the last release published to support these Ruby versions.
 
-## SSL Certificate Bundle Removed
+## The SSL Certificate bundle is removed [#ssl-cert-removed]
 
 In the early days of Ruby (1.8, 1.9, etc.), integration with OpenSSL and making HTTPS connections was not well-handled. To ensure customers would be able to consistently make HTTPS connections to New Relic's Collector servers, a selection of SSL CA Certificates were bundled and distributed with the Ruby Agent. Over time, the Ruby ecosystem has stabilized and now supports system installed CA Certificates in a standard manner that largely obsoletes the need to bundle and distribute the certificate bundle. The vast majority of certificates bundled have expired or are nearing expiration, so we have decided to remove this dependency from the agent. If you're deploying a Ruby application and agent to a container or server that does not have CA certificates installed, you will need to ensure they're now installed for 7.0+ releases of the agent to make successful HTTPS connections to New Relic servers.
 
-Relevant Issue: [Remove cert bundle #478](https://github.com/newrelic/newrelic-ruby-agent/issues/478)
+For more information, see [Remove cert bundle #478](https://github.com/newrelic/newrelic-ruby-agent/issues/478).
 
 **Potential Issue:** If you're deploying to a host that does not have OpenSSL and system CA certificates installed, you may experience issues connecting to New Relic servers and experience loss of APM data.
 
-**Solution:** New Relic servers require HTTPS, which requires CA certificates to initiate successful connections. These may be installed, and depending on your host, in various ways. The following are helpful links for testing the readiness of your host and installing CA certificates:
+**Solution:** New Relic servers require HTTPS, which uses CA certificates to initiate successful connections. These may be installed, and depending on your host, in various ways. The following are helpful links for testing the readiness of your host and installing CA certificates:
 
 - [Troubleshooting SSL Certificate Errors](https://bundler.io/v2.0/guides/rubygems_tls_ssl_troubleshooting_guide.html#troubleshooting-certificate-errors)
 - [Automated SSL Check](https://bundler.io/v2.0/guides/rubygems_tls_ssl_troubleshooting_guide.html#automated-ssl-check)
 - [Installing CA Certificates](https://superuser.com/questions/437330/how-do-you-add-a-certificate-authority-ca-to-ubuntu/719047#719047)
 - [How to handle Certificates in Docker](https://serverfault.com/questions/975775/how-to-handle-certificates-in-dockerfile)
 
-If needed, the agent can be configured to use any CA bundle by giving the path to the CA bundle file via configuration: :ca\_bundle\_path. Please see [Custom SSL certificate for Ruby](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/custom-ssl-certificates-ruby/) for more info.
+If needed, the agent can be configured to use any CA bundle by giving the path to the CA bundle file via configuration: `:ca\_bundle\_path`. Please see [Custom SSL certificate for Ruby](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/custom-ssl-certificates-ruby/) for more info.
 
-## Deprecated API's and Configuration Attributes
+## Deprecated API's and configuration attributes [#deprecated-apis]
 
-All deprecated API's have replacement API's that expand scope or improve robustness of the deprecated API.
+All deprecated API's have replacement API's that either expand scope and/or improve robustness of the deprecated API.
 
-Relevant Pull Requests:
+Relevant Pull Requests are:
 
 - [Remove references to "whitelist" and "blacklist" in codebase #479](https://github.com/newrelic/newrelic-ruby-agent/issues/479)
 - [Remove deprecated ActiveRecord config options #480](https://github.com/newrelic/newrelic-ruby-agent/issues/480)
@@ -47,7 +51,7 @@ Relevant Pull Requests:
 - [Remove deprecated option from notice\_error API #597](https://github.com/newrelic/newrelic-ruby-agent/issues/597)
 - [Remove deprecated distributed trace API methods #598](https://github.com/newrelic/newrelic-ruby-agent/issues/598)
 
-### Black/White List
+### Denied and allowed lists enabled [#lists-enabled]
 
 **Potential Issue:** Black/White listed attributes no longer work.
 
@@ -58,7 +62,7 @@ Relevant Pull Requests:
 - :autostart.blacklisted\_rake\_tasks => :[autostart.denylisted\_rake\_tasks](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#autostart-denylisted_rake_tasks)
 - :strip\_exception\_messages.whitelist => :[strip\_exception\_messages.allowed\_classes](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#strip_exception_messages.allowed_classes)
 
-### Active Record
+### Active Record [#active-record]
 
 **Potential Issue:** Disabling older Active Record versions no longer works.
 
@@ -67,25 +71,76 @@ Relevant Pull Requests:
 - :disable\_active\_record\_4 => :[disable\_active\_record\_notifications](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#disable_active_record_notifications)
 - :disable\_active\_record\_5 => :[disable\_active\_record\_notifications](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#disable_active_record_notifications)
 
-### httpResponseCode
+### httpResponseCode [#http-response-code]
 
 **Potential Issue:** The attribute `httpResponseCode` no longer appears in UI in the traces reported.
 
 **Solution:**'httpResponseCode' was replaced with '[http.statusCode](https://docs.newrelic.com/docs/agents/ruby-agent/attributes/ruby-agent-attributes/#attributes)''.
 
-### Notice Error (trace\_only)
+### Notice Error (trace\_only) [#notice-error]
 
-**Potential Issue:** Passing the :trace\_only option to NewRelic::Agent.notice\_error no longer works
+**Potential Issue:** Passing the `:trace\_only` option to `NewRelic::Agent.notice\_error` no longer works.
 
-**Solution:** Replace :trace\_only with the :[expected](https://docs.newrelic.com/docs/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/) attribute.
+**Solution:** Replace `:trace\_only` with the `:[expected](https://docs.newrelic.com/docs/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/)` attribute.
 
-### Distributed Tracing APIs
+### Distributed Tracing APIs [#distributed-tracing-apis]
 
-**Potential Issue:** Errors are raised in application code while calling the api methods `create_distributed_trace_payload` and `accept_distributed_trace_payload`
+**Potential Issue:** Errors are raised in application code while calling the api methods `create_distributed_trace_payload` and `accept_distributed_trace_payload`.
 
 **Solution:** Instead, please see [insert\_distributed\_trace\_headers](https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent/DistributedTracing#insert_distributed_trace_headers-instance_method) and [accept\_distributed\_trace\_headers](https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent/DistributedTracing#accept_distributed_trace_headers-instance_method), respectively.
 
-## Modernized Auto-Instrumentation Strategy
+## Prepend instrumentation configuration [#prepend-instrumentation]
+
+Relevant Pull Request: [Prepend instrumentation #565](https://github.com/newrelic/newrelic-ruby-agent/pull/565).
+
+**Potential Issue:** The agent fails to initialize and start reporting data. A Stack level too deep error message is reported in the logs.
+
+**Solution:** Our configuration and dependency detection mechanism can now be controlled through configuration. By default all auto-instrumented gems/libraries are activated with the prepend strategy. The default configuration setting for these libraries in the absence of any settings appearing in the configuration file is "auto", which will pick the best strategy. In the case of a known conflict with prepend strategies, "auto" instructs the agent to fall back to method-chaining when such conflicts are detected. Below is a complete explanation of our changes to the configuration section for auto-instrumentation using sidekiq as an example.
+
+```
+instrumentation:
+
+    sidekiq: chain
+```
+
+<Callout variant="tip">
+    The use case for this is when an unknown gem is found to be conflicting. The user is able to revert to method-chaining to deal with the conflict until the agent can be updated to auto-detect and handle the conflict.
+</Callout>
+
+To disable instrumentation altogether:
+
+```
+instrumentation:
+
+    sidekiq: disable
+```
+
+In some cases, we may know specific gems conflict with prepend. To facilitate, we offer an auto config option (which is the default), which will automatically degrade to chain in such cases.
+
+The default setting in most cases is thus:
+
+```
+instrumentation:
+
+    sidekiq: auto
+```
+
+It's possible to force using prepend strategy by specifying it in the config like so:
+
+```
+instrumentation:
+
+    sidekiq: prepend
+```
+
+<Callout variant="tip">
+   The use case for this is when a newer version of the conflicting gem is released and it's known to no longer conflict with prepend strategy.
+</Callout>
+
+
+If you [find a conflict](https://github.com/newrelic/newrelic-ruby-agent/issues/510) between prepend and another gem in your application's Gemfile, we would highly appreciate opening an Issue or commenting on this gem so that we are aware and potentially work with gem authors to eliminate conflicts.
+
+## Modernized auto-instrumentation strategy [#modernized-auto-instrumentation]
 
 Ruby introduced prepend as a way to insert method definitions earlier into the method resolution stack in Ruby 2.0 (released in 2013) with the intent that prepend eliminates the need to do method-chaining as a means of patching original gem libraries' implementations with trace/observability logic.
 
@@ -99,53 +154,3 @@ In the past, we had only one way to auto-instrument for most gems and that was m
 
 With the modernization of our auto-instrumentation, we have also introduced new functionality in our dependency detection mechanism to identify conflicting external gems and automatically switch from prepend strategy to method-chaining. This means our users no longer have to depend on the maintainers of other gems to make changes to their gem libraries in order to facilitate using the Ruby agent in conjunction with those gems. However, we are not aware of such conflicts until our users report them to us, so only a few of our auto-instrumented libraries can auto-detect these conflicts and auto-switch to method-chaining strategies. We need your help to hear about these scenarios and to add auto-detection to future Ruby agent releases.
 
-## Prepend Instrumentation Configuration
-
-Relevant Pull Request: [Prepend instrumentation #565](https://github.com/newrelic/newrelic-ruby-agent/pull/565)
-
-**Potential Issue:** The agent fails to initialize and start reporting data. A Stack level too deep error message is reported in the logs.
-
-**Solution:** Our configuration and dependency detection mechanism can now be controlled through configuration. By default all auto-instrumented gems/libraries are activated with the prepend strategy and the default configuration setting for these libraries in the absence of any settings appearing in the configuration file is "auto" which will pick the best strategy. In the case of a known conflict with prepend strategies, "auto" instructs the agent to fall back to method-chaining when such conflicts are detected. Below is a complete explanation of our changes to the configuration section for auto-instrumentation using sidekiq as an example.
-
-```
-instrumentation:
-
-    sidekiq: chain
-```
-
-<Callout variant={Callout.VARIANT.TIP} title={null}>
-    The use case for this is for when an unknown gem is found to be conflicting. The user is able to revert to method-chaining to deal with the conflict until the agent can be updated to auto-detect and handle the conflict.
-</Callout>
-
-To disable instrumentation altogether:
-
-```
-instrumentation:
-
-    sidekiq: disable
-```
-
-In some cases, we may know specific gems conflict with prepend. To facilitate, we offer an auto config option (which is the default) which will automatically degrade to chain in such cases.
-
-The default setting in most cases is thus:
-
-```
-instrumentation:
-
-    sidekiq: auto
-```
-
-It is possible to force using prepend strategy by specifying it in the config like so:
-
-```
-instrumentation:
-
-    sidekiq: prepend
-```
-
-<Callout variant={Callout.VARIANT.TIP} title={null}>
-   The use case for this is for when a newer version of the conflicting gem is released and it's known to no longer conflict with prepend strategy.
-</Callout>
-
-
-If you [find a conflict](https://github.com/newrelic/newrelic-ruby-agent/issues/510) between Prepend and another gem in your application's Gemfile, we would highly appreciate opening an Issue or commenting on this one specific to this gem so that we are aware and potentially work with gem authors to eliminate conflicts.

--- a/src/content/docs/agents/ruby-agent/getting-started/migration-7x-guide.mdx
+++ b/src/content/docs/agents/ruby-agent/getting-started/migration-7x-guide.mdx
@@ -10,17 +10,17 @@ tags:
 This guide covers the major changes between the 6.x and 7.x series of the Ruby Agent, issues that may be encountered while upgrading, and how to migrate successfully to version 7.x. 
 
 Main changes include:
-- [Support for Ruby 2.0 and 2.1 is dropped](#ruby-2-dropped).
-- [SSL Certificate Bundle is removed](#ssl-cet-removed).
-- [Several APIs that were deprecated in various 6.x releases are now removed](#deprecated-apis).
-- [Auto-instrumentation defaults to prepend over method chaining](#prepend-instrumentation).
-- [Auto-instrumentation gets consistent configuration attributes](#modernized-auto-instrumentation).
+- [Support for Ruby 2.0 and 2.1 is dropped](#ruby-2-dropped)
+- [SSL Certificate Bundle is removed](#ssl-cert-removed)
+- [Several APIs that were deprecated in various 6.x releases are now removed](#deprecated-apis)
+- [Auto-instrumentation defaults to prepend over method chaining](#prepend-instrumentation)
+- [Auto-instrumentation gets consistent configuration attributes](#modernized-auto-instrumentation)
 
 See [Milestone for 7.0 Target Release](https://github.com/newrelic/newrelic-ruby-agent/pulls?q=is%3Apr+is%3Aopen+label%3Aversion%3A7.0.0) for more information.
 
 ## Support for Ruby 2.0 and 2.1 is dropped [#ruby-2-dropped]
 
-Ruby 2.0 and 2.1 were [EOL'd in February 2016](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/) and New Relic is following suit with dropping support for these versions in the 7.0 release. There are no known changes that would inherently prevent these versions from continuing to work, but we are no longer guaranteeing the Ruby agent continues to function without issues going forward. If you need Ruby 2.0 or 2.1, then continue to use 6.15.0, which is the last release published to support these Ruby versions.
+Ruby 2.0 and 2.1 reached [EOL in February 2016](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/) and New Relic is following suit with dropping support for these versions in the 7.0 release. There are no known changes that would inherently prevent these versions from continuing to work, but we are no longer guaranteeing the Ruby agent continues to function without issues going forward. If you need Ruby 2.0 or 2.1, then continue to use 6.15.0, which is the last release published to support these Ruby versions.
 
 ## The SSL Certificate bundle is removed [#ssl-cert-removed]
 
@@ -37,7 +37,7 @@ For more information, see [Remove cert bundle #478](https://github.com/newrelic/
 - [Installing CA Certificates](https://superuser.com/questions/437330/how-do-you-add-a-certificate-authority-ca-to-ubuntu/719047#719047)
 - [How to handle Certificates in Docker](https://serverfault.com/questions/975775/how-to-handle-certificates-in-dockerfile)
 
-If needed, the agent can be configured to use any CA bundle by giving the path to the CA bundle file via configuration: `:ca\_bundle\_path`. Please see [Custom SSL certificate for Ruby](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/custom-ssl-certificates-ruby/) for more info.
+If needed, the agent can be configured to use any CA bundle by giving the path to the CA bundle file via configuration: `:ca\_bundle\_path`. Please see [Custom SSL certificate for Ruby](/docs/agents/ruby-agent/configuration/custom-ssl-certificates-ruby/) for more info.
 
 ## Deprecated API's and configuration attributes [#deprecated-apis]
 
@@ -45,7 +45,7 @@ All deprecated API's have replacement API's that either expand scope and/or impr
 
 Relevant Pull Requests are:
 
-- [Remove references to "whitelist" and "blacklist" in codebase #479](https://github.com/newrelic/newrelic-ruby-agent/issues/479)
+- [Remove references to `whitelist` and `blacklist` in codebase #479](https://github.com/newrelic/newrelic-ruby-agent/issues/479)
 - [Remove deprecated ActiveRecord config options #480](https://github.com/newrelic/newrelic-ruby-agent/issues/480)
 - [Remove httpResponseCode attribute #481](https://github.com/newrelic/newrelic-ruby-agent/issues/481)
 - [Remove deprecated option from notice\_error API #597](https://github.com/newrelic/newrelic-ruby-agent/issues/597)
@@ -55,12 +55,12 @@ Relevant Pull Requests are:
 
 **Potential Issue:** Black/White listed attributes no longer work.
 
-**Solution** : Change "black" to "denied" and "white" to "allowed" in your configuration or environment variable settings.
+**Solution** : Change `black` to `denied` and `white` to `allowed` in your configuration or environment variable settings.
 
-- :autostart.blacklisted\_constants => :[autostart.denylisted\_constants](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#autostart-denylisted_constants)
-- :autostart.blacklisted\_executables => :[autostart.denylisted\_executables](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#autostart-denylisted_executables)
-- :autostart.blacklisted\_rake\_tasks => :[autostart.denylisted\_rake\_tasks](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#autostart-denylisted_rake_tasks)
-- :strip\_exception\_messages.whitelist => :[strip\_exception\_messages.allowed\_classes](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#strip_exception_messages.allowed_classes)
+- :autostart.blacklisted\_constants => :[autostart.denylisted\_constants](/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#autostart-denylisted_constants)
+- :autostart.blacklisted\_executables => :[autostart.denylisted\_executables](/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#autostart-denylisted_executables)
+- :autostart.blacklisted\_rake\_tasks => :[autostart.denylisted\_rake\_tasks](/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#autostart-denylisted_rake_tasks)
+- :strip\_exception\_messages.whitelist => :[strip\_exception\_messages.allowed\_classes](/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#strip_exception_messages-allowed_classes)
 
 ### Active Record [#active-record]
 
@@ -68,20 +68,20 @@ Relevant Pull Requests are:
 
 **Solution:** Change the following configuration settings:
 
-- :disable\_active\_record\_4 => :[disable\_active\_record\_notifications](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#disable_active_record_notifications)
-- :disable\_active\_record\_5 => :[disable\_active\_record\_notifications](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#disable_active_record_notifications)
+- :disable\_active\_record\_4 => :[disable\_active\_record\_notifications](/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#disable_active_record_notifications)
+- :disable\_active\_record\_5 => :[disable\_active\_record\_notifications](/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#disable_active_record_notifications)
 
 ### httpResponseCode [#http-response-code]
 
 **Potential Issue:** The attribute `httpResponseCode` no longer appears in UI in the traces reported.
 
-**Solution:**'httpResponseCode' was replaced with '[http.statusCode](https://docs.newrelic.com/docs/agents/ruby-agent/attributes/ruby-agent-attributes/#attributes)''.
+**Solution:** `httpResponseCode` was replaced with [`http.statusCode`](/docs/agents/ruby-agent/attributes/ruby-agent-attributes/#attributes).
 
 ### Notice Error (trace\_only) [#notice-error]
 
 **Potential Issue:** Passing the `:trace\_only` option to `NewRelic::Agent.notice\_error` no longer works.
 
-**Solution:** Replace `:trace\_only` with the `:[expected](https://docs.newrelic.com/docs/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/)` attribute.
+**Solution:** Replace `:trace\_only` with the `:[expected](/docs/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/)` attribute.
 
 ### Distributed Tracing APIs [#distributed-tracing-apis]
 
@@ -95,7 +95,7 @@ Relevant Pull Request: [Prepend instrumentation #565](https://github.com/newreli
 
 **Potential Issue:** The agent fails to initialize and start reporting data. A Stack level too deep error message is reported in the logs.
 
-**Solution:** Our configuration and dependency detection mechanism can now be controlled through configuration. By default all auto-instrumented gems/libraries are activated with the prepend strategy. The default configuration setting for these libraries in the absence of any settings appearing in the configuration file is "auto", which will pick the best strategy. In the case of a known conflict with prepend strategies, "auto" instructs the agent to fall back to method-chaining when such conflicts are detected. Below is a complete explanation of our changes to the configuration section for auto-instrumentation using sidekiq as an example.
+**Solution:** Our configuration and dependency detection mechanism can now be controlled through configuration. By default all auto-instrumented gems/libraries are activated with the prepend strategy. The default configuration setting for these libraries in the absence of any settings appearing in the configuration file is `auto`, which will pick the best strategy. In the case of a known conflict with prepend strategies, `auto` instructs the agent to fall back to method-chaining when such conflicts are detected. Below is a complete explanation of our changes to the configuration section for auto-instrumentation using sidekiq as an example.
 
 ```
 instrumentation:

--- a/src/content/docs/agents/ruby-agent/getting-started/migration-7x-guide.mdx
+++ b/src/content/docs/agents/ruby-agent/getting-started/migration-7x-guide.mdx
@@ -1,0 +1,151 @@
+import { Callout } from '@newrelic/gatsby-theme-newrelic'
+
+# Ruby Agent 6.x to 7.x Migration Guide
+
+## Summary
+
+This guide covers the major changes between 6.x and 7.x series of the Ruby Agent, issues that may be encountered in upgrading and how to migrate successfully to 7.x.
+
+- Support for Ruby 2.0 and 2.1 dropped.
+- SSL Certificate Bundle is removed.
+- Several APIs that were deprecated in various 6.x releases are now removed.
+- Auto-Instrumentation defaults to prepend over method chaining.
+- Auto-Instrumentation gets Consistent Configuration Attributes.
+
+See: [Milestone for 7.0 Target Release](https://github.com/newrelic/newrelic-ruby-agent/pulls?q=is%3Apr+is%3Aopen+label%3Aversion%3A7.0.0)
+
+## Support for Ruby 2.0 and 2.1 Dropped
+
+Ruby 2.0 and 2.1 were [EOL'd in February 2016](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/) and New Relic is following suit with dropping support for these versions in the 7.0 release. There are no known changes that would inherently prevent these versions from continuing to work, but we are no longer guaranteeing the Ruby agent continues to function without issues going forward. If you need Ruby 2.0 or 2.1, then continue to use 6.15.0, which is the last release published to support these Ruby versions.
+
+## SSL Certificate Bundle Removed
+
+In the early days of Ruby (1.8, 1.9, etc.), integration with OpenSSL and making HTTPS connections was not well-handled. To ensure customers would be able to consistently make HTTPS connections to New Relic's Collector servers, a selection of SSL CA Certificates were bundled and distributed with the Ruby Agent. Over time, the Ruby ecosystem has stabilized and now supports system installed CA Certificates in a standard manner that largely obsoletes the need to bundle and distribute the certificate bundle. The vast majority of certificates bundled have expired or are nearing expiration, so we have decided to remove this dependency from the agent. If you're deploying a Ruby application and agent to a container or server that does not have CA certificates installed, you will need to ensure they're now installed for 7.0+ releases of the agent to make successful HTTPS connections to New Relic servers.
+
+Relevant Issue: [Remove cert bundle #478](https://github.com/newrelic/newrelic-ruby-agent/issues/478)
+
+**Potential Issue:** If you're deploying to a host that does not have OpenSSL and system CA certificates installed, you may experience issues connecting to New Relic servers and experience loss of APM data.
+
+**Solution:** New Relic servers require HTTPS, which requires CA certificates to initiate successful connections. These may be installed, and depending on your host, in various ways. The following are helpful links for testing the readiness of your host and installing CA certificates:
+
+- [Troubleshooting SSL Certificate Errors](https://bundler.io/v2.0/guides/rubygems_tls_ssl_troubleshooting_guide.html#troubleshooting-certificate-errors)
+- [Automated SSL Check](https://bundler.io/v2.0/guides/rubygems_tls_ssl_troubleshooting_guide.html#automated-ssl-check)
+- [Installing CA Certificates](https://superuser.com/questions/437330/how-do-you-add-a-certificate-authority-ca-to-ubuntu/719047#719047)
+- [How to handle Certificates in Docker](https://serverfault.com/questions/975775/how-to-handle-certificates-in-dockerfile)
+
+If needed, the agent can be configured to use any CA bundle by giving the path to the CA bundle file via configuration: :ca\_bundle\_path. Please see [Custom SSL certificate for Ruby](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/custom-ssl-certificates-ruby/) for more info.
+
+## Deprecated API's and Configuration Attributes
+
+All deprecated API's have replacement API's that expand scope or improve robustness of the deprecated API.
+
+Relevant Pull Requests:
+
+- [Remove references to "whitelist" and "blacklist" in codebase #479](https://github.com/newrelic/newrelic-ruby-agent/issues/479)
+- [Remove deprecated ActiveRecord config options #480](https://github.com/newrelic/newrelic-ruby-agent/issues/480)
+- [Remove httpResponseCode attribute #481](https://github.com/newrelic/newrelic-ruby-agent/issues/481)
+- [Remove deprecated option from notice\_error API #597](https://github.com/newrelic/newrelic-ruby-agent/issues/597)
+- [Remove deprecated distributed trace API methods #598](https://github.com/newrelic/newrelic-ruby-agent/issues/598)
+
+### Black/White List
+
+**Potential Issue:** Black/White listed attributes no longer work.
+
+**Solution** : Change "black" to "denied" and "white" to "allowed" in your configuration or environment variable settings.
+
+- :autostart.blacklisted\_constants => :[autostart.denylisted\_constants](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#autostart-denylisted_constants)
+- :autostart.blacklisted\_executables => :[autostart.denylisted\_executables](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#autostart-denylisted_executables)
+- :autostart.blacklisted\_rake\_tasks => :[autostart.denylisted\_rake\_tasks](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#autostart-denylisted_rake_tasks)
+- :strip\_exception\_messages.whitelist => :[strip\_exception\_messages.allowed\_classes](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#strip_exception_messages.allowed_classes)
+
+### Active Record
+
+**Potential Issue:** Disabling older Active Record versions no longer works.
+
+**Solution:** Change the following configuration settings:
+
+- :disable\_active\_record\_4 => :[disable\_active\_record\_notifications](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#disable_active_record_notifications)
+- :disable\_active\_record\_5 => :[disable\_active\_record\_notifications](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#disable_active_record_notifications)
+
+### httpResponseCode
+
+**Potential Issue:** The attribute `httpResponseCode` no longer appears in UI in the traces reported.
+
+**Solution:**'httpResponseCode' was replaced with '[http.statusCode](https://docs.newrelic.com/docs/agents/ruby-agent/attributes/ruby-agent-attributes/#attributes)''.
+
+### Notice Error (trace\_only)
+
+**Potential Issue:** Passing the :trace\_only option to NewRelic::Agent.notice\_error no longer works
+
+**Solution:** Replace :trace\_only with the :[expected](https://docs.newrelic.com/docs/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/) attribute.
+
+### Distributed Tracing APIs
+
+**Potential Issue:** Errors are raised in application code while calling the api methods `create_distributed_trace_payload` and `accept_distributed_trace_payload`
+
+**Solution:** Instead, please see [insert\_distributed\_trace\_headers](https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent/DistributedTracing#insert_distributed_trace_headers-instance_method) and [accept\_distributed\_trace\_headers](https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent/DistributedTracing#accept_distributed_trace_headers-instance_method), respectively.
+
+## Modernized Auto-Instrumentation Strategy
+
+Ruby introduced prepend as a way to insert method definitions earlier into the method resolution stack in Ruby 2.0 (released in 2013) with the intent that prepend eliminates the need to do method-chaining as a means of patching original gem libraries' implementations with trace/observability logic.
+
+Mixing prepend with method-chaining (a.k.a. method\_alias monkey patching) can lead to a known stack level too deep scenario as described in [our blog post](https://blog.newrelic.com/engineering/ruby-agent-module-prepend-alias-method-chains/) on the topic.
+
+New Relic has previously updated many auto-instrumented libraries over the years to use prepend strategy. The 7.0 release makes prepend the default strategy of choice to auto-instrument over method-chaining, except when known scenarios exist that would lead to triggering stack level too deep errors. A best effort to identify conflicting external gems that would lead to this scenario was made, but there are bound to be others out in the wild that we have not identified.
+
+If you encounter stack level too deep errors, please help us identify the offending gems by filing an [issue on GitHub](https://github.com/newrelic/newrelic-ruby-agent/issues/new?assignees=&amp;labels=&amp;template=bug_report.md&amp;title=Stack+Level+Too+Deep+%5BCONFLICTING+GEM%5D) so we may detect and automatically fall back to method-chaining in such scenarios as well as encourage gem authors to update their method-chaining monkey patches to favor prepending over method-chaining. Many have already made the move or carry extra baggage in their gem libraries to allow their gems to co-exist peacefully with New Relic's former use of method-chaining. 7.0 makes prepend the default strategy of choice to auto-instrument.
+
+In the past, we had only one way to auto-instrument for most gems and that was method-chaining. With 7.0 release, we can instrument most gems using either method-chaining or prepend and our configuration of all auto-instrumented gems has been updated to reflect this.
+
+With the modernization of our auto-instrumentation, we have also introduced new functionality in our dependency detection mechanism to identify conflicting external gems and automatically switch from prepend strategy to method-chaining. This means our users no longer have to depend on the maintainers of other gems to make changes to their gem libraries in order to facilitate using the Ruby agent in conjunction with those gems. However, we are not aware of such conflicts until our users report them to us, so only a few of our auto-instrumented libraries can auto-detect these conflicts and auto-switch to method-chaining strategies. We need your help to hear about these scenarios and to add auto-detection to future Ruby agent releases.
+
+## Prepend Instrumentation Configuration
+
+Relevant Pull Request: [Prepend instrumentation #565](https://github.com/newrelic/newrelic-ruby-agent/pull/565)
+
+**Potential Issue:** The agent fails to initialize and start reporting data. A Stack level too deep error message is reported in the logs.
+
+**Solution:** Our configuration and dependency detection mechanism can now be controlled through configuration. By default all auto-instrumented gems/libraries are activated with the prepend strategy and the default configuration setting for these libraries in the absence of any settings appearing in the configuration file is "auto" which will pick the best strategy. In the case of a known conflict with prepend strategies, "auto" instructs the agent to fall back to method-chaining when such conflicts are detected. Below is a complete explanation of our changes to the configuration section for auto-instrumentation using sidekiq as an example.
+
+```
+instrumentation:
+
+    sidekiq: chain
+```
+
+<Callout variant={Callout.VARIANT.TIP} title={null}>
+    The use case for this is for when an unknown gem is found to be conflicting. The user is able to revert to method-chaining to deal with the conflict until the agent can be updated to auto-detect and handle the conflict.
+</Callout>
+
+To disable instrumentation altogether:
+
+```
+instrumentation:
+
+    sidekiq: disable
+```
+
+In some cases, we may know specific gems conflict with prepend. To facilitate, we offer an auto config option (which is the default) which will automatically degrade to chain in such cases.
+
+The default setting in most cases is thus:
+
+```
+instrumentation:
+
+    sidekiq: auto
+```
+
+It is possible to force using prepend strategy by specifying it in the config like so:
+
+```
+instrumentation:
+
+    sidekiq: prepend
+```
+
+<Callout variant={Callout.VARIANT.TIP} title={null}>
+   The use case for this is for when a newer version of the conflicting gem is released and it's known to no longer conflict with prepend strategy.
+</Callout>
+
+
+If you [find a conflict](https://github.com/newrelic/newrelic-ruby-agent/issues/510) between Prepend and another gem in your application's Gemfile, we would highly appreciate opening an Issue or commenting on this one specific to this gem so that we are aware and potentially work with gem authors to eliminate conflicts.

--- a/src/nav/agents.yml
+++ b/src/nav/agents.yml
@@ -1078,7 +1078,7 @@ pages:
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/current
           - title: Ruby release notes
             path: /docs/agents/ruby-agent/getting-started/ruby-release-notes
-          - title: Ruby agent 7x Migration Guide
+          - title: Ruby agent 7x migration guide
             path: /docs/agents/ruby-agent/getting-started/migration-7x-guide
       - title: Installation
         pages:

--- a/src/nav/agents.yml
+++ b/src/nav/agents.yml
@@ -1078,6 +1078,8 @@ pages:
             path: /docs/release-notes/agent-release-notes/ruby-release-notes/current
           - title: Ruby release notes
             path: /docs/agents/ruby-agent/getting-started/ruby-release-notes
+          - title: Ruby agent 7x Migration Guide
+            path: /docs/agents/ruby-agent/getting-started/migration-7x-guide
       - title: Installation
         pages:
           - title: Ruby agent installation


### PR DESCRIPTION
Added a new page 'Ruby Agent 6.x to 7.x Migration Guide' to help customer upgrade to version 7x.

<!-- Thanks for contributing to our docs! Your changes will help thousands of
New Relic users around the world. -->

<!-- Fill out this template to help us review your changes and route them to the
best team. See our [README.md](https://github.com/newrelic/docs-website/) for
information on how to contribute. -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Tell us why

This guide covers the major changes between 6.x and 7.x series of the Ruby Agent, issues that may be encountered in upgrading and how to migrate successfully to 7.x.

### Anything else you'd like to share?

Add any context that will help us review your changes such as testing notes,
links to related docs, screenshots, etc.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.
