### PR TITLE
Replaced link for reserved words

### DIFF
--- a/src/content/docs/agents/java-agent/attributes/java-agent-attributes.mdx
+++ b/src/content/docs/agents/java-agent/attributes/java-agent-attributes.mdx
@@ -108,7 +108,7 @@ In addition to the [default APM attributes](/docs/insights/new-relic-insights/de
     * Browser events: Disabled
 
     <Callout variant="important">
-      Before creating custom attributes, review New Relic's list of [reserved terms used by NRQL](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words). Otherwise, you might get some unexpected results.
+      Before creating custom attributes, review New Relic's list of [reserved terms used by NRQL](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words). Otherwise, you might get some unexpected results.
     </Callout>
   </Collapser>
 
@@ -121,7 +121,7 @@ In addition to the [default APM attributes](/docs/insights/new-relic-insights/de
     These attributes are added to span events, which can be found in the [distributed tracing UI](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works#trace-structure) or directly queried in the [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder).
 
     <Callout variant="important">
-      Before creating custom attributes, review New Relic's list of [reserved terms used by NRQL](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words). Otherwise, you might get unexpected results.
+      Before creating custom attributes, review New Relic's list of [reserved terms used by NRQL](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words). Otherwise, you might get unexpected results.
     </Callout>
   </Collapser>
 

--- a/src/content/docs/agents/net-agent/net-agent-api/addcustomparameter-net-agent-api.mdx
+++ b/src/content/docs/agents/net-agent/net-agent-api/addcustomparameter-net-agent-api.mdx
@@ -40,7 +40,7 @@ Custom attributes can be used to add more detail and context to [errors](/docs/a
 For more information, see [.NET agent attributes](/docs/agents/net-agent/attributes/net-agent-attributes).
 
 <Callout variant="important">
-  If you want to use your custom parameters or attributes, avoid using any of the [reserved terms used by NRQL](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words).
+  If you want to use your custom parameters or attributes, avoid using any of the [reserved terms used by NRQL](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
 </Callout>
 
 ## Parameters

--- a/src/content/docs/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -538,7 +538,7 @@ New Relic's Node.js agent includes additional API calls.
     </CollapserGroup>
 
     <Callout variant="caution">
-      If you want to use your custom attributes, avoid using any of the [reserved terms used by NRQL](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words) when naming them.
+      If you want to use your custom attributes, avoid using any of the [reserved terms used by NRQL](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words) when naming them.
     </Callout>
   </Collapser>
 
@@ -565,7 +565,7 @@ New Relic's Node.js agent includes additional API calls.
     </CollapserGroup>
 
     <Callout variant="caution">
-      If you want to use your custom attributes, avoid using any of the [reserved terms used by NRQL](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words) when naming them.
+      If you want to use your custom attributes, avoid using any of the [reserved terms used by NRQL](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words) when naming them.
     </Callout>
   </Collapser>
 
@@ -588,7 +588,7 @@ New Relic's Node.js agent includes additional API calls.
     </Callout>
 
     <Callout variant="caution">
-      If you want to use your custom span attributes, avoid using any of the [reserved terms used by NRQL](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words) when naming them.
+      If you want to use your custom span attributes, avoid using any of the [reserved terms used by NRQL](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words) when naming them.
     </Callout>
   </Collapser>
 
@@ -616,7 +616,7 @@ New Relic's Node.js agent includes additional API calls.
     </Callout>
 
     <Callout variant="caution">
-      If you want to use your custom span attributes, avoid using any of the [reserved terms used by NRQL](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words) when naming them.
+      If you want to use your custom span attributes, avoid using any of the [reserved terms used by NRQL](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words) when naming them.
     </Callout>
   </Collapser>
 

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_add_custom_parameter.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_add_custom_parameter.mdx
@@ -32,7 +32,7 @@ Add a [custom attribute](/docs/agents/manage-apm-agents/agent-data/collect-custo
 </Callout>
 
 <Callout variant="important">
-  If you want to use your custom attributes, avoid using any of the [reserved terms used by NRQL](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words).
+  If you want to use your custom attributes, avoid using any of the [reserved terms used by NRQL](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
 </Callout>
 
 ## Parameters

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelicaddcustomspanparameter-php-agent-api.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelicaddcustomspanparameter-php-agent-api.mdx
@@ -32,7 +32,7 @@ Add a [custom attribute](/docs/agents/manage-apm-agents/agent-data/collect-custo
 </Callout>
 
 <Callout variant="important">
-  If you want to use your custom attributes, avoid using any of the [reserved terms used by NRQL](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words).
+  If you want to use your custom attributes, avoid using any of the [reserved terms used by NRQL](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
 </Callout>
 
 ## Parameters

--- a/src/content/docs/agents/python-agent/attributes/python-agent-attributes.mdx
+++ b/src/content/docs/agents/python-agent/attributes/python-agent-attributes.mdx
@@ -713,7 +713,7 @@ Defaults:
 * Page views (browser monitoring): Disabled
 
 <Callout variant="important">
-  Before creating custom attributes, review our list of [reserved terms](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words). Otherwise, unexpected results might occur.
+  Before creating custom attributes, review our list of [reserved terms](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words). Otherwise, unexpected results might occur.
 </Callout>
 
 ## Add custom attributes to exceptions [#adding_error_attributes]

--- a/src/content/docs/agents/python-agent/python-agent-api/addcustomparameter-python-agent-api.mdx
+++ b/src/content/docs/agents/python-agent/python-agent-api/addcustomparameter-python-agent-api.mdx
@@ -26,7 +26,7 @@ This call records a [custom attribute](/docs/accounts-partnerships/education/get
 Attributes may be found in APM if the transaction is associated with an error or if a transaction trace is generated for that transaction. Attributes can also be found and queried in New Relic One.
 
 <Callout variant="important">
-  Before you create custom attributes, review our list of [reserved terms used by NRQL](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words).
+  Before you create custom attributes, review our list of [reserved terms used by NRQL](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
 </Callout>
 
 ## Parameters

--- a/src/content/docs/agents/python-agent/python-agent-api/addcustomparameters-python-agent-api.mdx
+++ b/src/content/docs/agents/python-agent/python-agent-api/addcustomparameters-python-agent-api.mdx
@@ -24,7 +24,7 @@ This call records one or more [custom attributes](/docs/accounts-partnerships/ed
 Attributes may be found in APM if the transaction is associated with an error or if a transaction trace is generated for that transaction. Attributes can also be found and queried in New Relic One.
 
 <Callout variant="important">
-  Before you create custom attributes, review our list of [reserved terms used by NRQL](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words).
+  Before you create custom attributes, review our list of [reserved terms used by NRQL](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
 </Callout>
 
 ## Parameters

--- a/src/content/docs/agents/python-agent/python-agent-api/addcustomspanattribute-python-agent-api.mdx
+++ b/src/content/docs/agents/python-agent/python-agent-api/addcustomspanattribute-python-agent-api.mdx
@@ -24,7 +24,7 @@ This call records a [custom attribute](/docs/accounts-partnerships/education/get
 Attributes may be found in Distributed Tracing or in APM if a transaction trace is created by the parent transaction. Attributes can also be [found and queried](/docs/query-your-data/explore-query-data/explore-data/introduction-querying-new-relic-data) in New Relic One.
 
 <Callout variant="important">
-  Before you create custom attributes, review our list of [reserved terms used by NRQL](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words).
+  Before you create custom attributes, review our list of [reserved terms used by NRQL](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
 </Callout>
 
 ## Parameters

--- a/src/content/docs/agents/python-agent/python-agent-api/recordcustomevent-python-agent-api.mdx
+++ b/src/content/docs/agents/python-agent/python-agent-api/recordcustomevent-python-agent-api.mdx
@@ -28,7 +28,7 @@ Python agent version 2.60.0.46 or higher.
 This records a custom [event](/docs/data-analysis/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data#event-data) that can be viewed and queried in New Relic One. If you want to use this outside of the context of a monitored transaction, use the application parameter.
 
 <Callout variant="important">
-  For limits and restrictions on `event_type` and `params`, see [Limits and restricted characters](/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-new-relic-apm-agents#limits) and [Reserved words](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words).
+  For limits and restrictions on `event_type` and `params`, see [Limits and restricted characters](/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-new-relic-apm-agents#limits) and [Reserved words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
 </Callout>
 
 ## Parameters

--- a/src/content/docs/agents/ruby-agent/attributes/ruby-agent-attributes.mdx
+++ b/src/content/docs/agents/ruby-agent/attributes/ruby-agent-attributes.mdx
@@ -98,7 +98,7 @@ To capture additional custom attributes from your application, use `NewRelic::Ag
 * Page views (browser monitoring): Disabled
 
 <Callout variant="caution">
-  If you want to use your custom parameters or attributes in Insights, avoid using any of the [reserved terms used by NRQL](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words) for naming them.
+  If you want to use your custom parameters or attributes in Insights, avoid using any of the [reserved terms used by NRQL](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words) for naming them.
 </Callout>
 
 ## Upgrading the Ruby agent [#upgrading]

--- a/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action.mdx
@@ -58,7 +58,7 @@ This API call sends a Browser [`PageAction` event](/docs/insights/explore-data/c
       <td>
         Required. Name or category of the action. Reports to New Relic One as the `actionName` attribute.
 
-        Avoid using [reserved NRQL words](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words) when you name the attribute or value.
+        Avoid using [reserved NRQL words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words) when you name the attribute or value.
       </td>
     </tr>
 
@@ -72,7 +72,7 @@ This API call sends a Browser [`PageAction` event](/docs/insights/explore-data/c
       <td>
         Optional. JSON object with one or more key/value pairs. For example: `{key:"value"}`. The key will report to New Relic One as its own PageAction attribute with the specified values.
 
-        Avoid using [reserved NRQL words](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words) when you name the attribute/value.
+        Avoid using [reserved NRQL words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words) when you name the attribute/value.
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/insights/event-data-sources/custom-events/apm-report-custom-events-attributes.mdx
+++ b/src/content/docs/insights/event-data-sources/custom-events/apm-report-custom-events-attributes.mdx
@@ -55,7 +55,7 @@ When creating your own custom events and attributes, follow data requirements fo
 
 * [Size limits](/docs/insights/explore-data/custom-attributes/requirements-custom-attributes)
 * [Attribute types](/docs/insights/explore-data/custom-attributes/requirements-custom-attributes)
-* [Reserved words](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words)
+* [Reserved words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words)
 
 <CollapserGroup>
   <Collapser
@@ -86,7 +86,7 @@ When creating your own custom events and attributes, follow data requirements fo
     NewRelic.getAgent().getInsights().recordCustomEvent("<var>MyCustomEvent</var>", <var>eventAttributes</var>);
     ```
 
-    The first argument defines the name of your event type, and the second argument is a map with the attributes for your custom event. Event attributes must be strings or numbers. Ensure you limit the number of unique event type names that you create, and do not generate these names dynamically. For restrictions on event type names, see our documentation about [limits and restricted characters](/docs/insights/explore-data/custom-attributes/requirements-custom-attributes) and [NRQL reserved words](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words).
+    The first argument defines the name of your event type, and the second argument is a map with the attributes for your custom event. Event attributes must be strings or numbers. Ensure you limit the number of unique event type names that you create, and do not generate these names dynamically. For restrictions on event type names, see our documentation about [limits and restricted characters](/docs/insights/explore-data/custom-attributes/requirements-custom-attributes) and [NRQL reserved words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
 
     You can change the maximum number of events recorded by the Java agent via a configuration parameter in `newrelic.yml`.
 
@@ -126,7 +126,7 @@ When creating your own custom events and attributes, follow data requirements fo
     NewRelic.Api.Agent.NewRelic.RecordCustomEvent('MyCustomEvent', eventAttributes);
     ```
 
-    The first argument defines the name of your event type, and the second argument is an IEnumerable with the attributes for your custom event. Ensure you limit the number of unique event type names that you create, and do not generate these names dynamically. For restrictions on event type names, see our documentation about [limits and restricted characters](/docs/insights/explore-data/custom-attributes/requirements-custom-attributes) and [NRQL reserved words](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words).
+    The first argument defines the name of your event type, and the second argument is an IEnumerable with the attributes for your custom event. Ensure you limit the number of unique event type names that you create, and do not generate these names dynamically. For restrictions on event type names, see our documentation about [limits and restricted characters](/docs/insights/explore-data/custom-attributes/requirements-custom-attributes) and [NRQL reserved words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
 
     You can then add [custom attributes](/docs/agents/manage-apm-agents/agent-data/collect-custom-attributes#net-att) for your .NET app.
 
@@ -144,7 +144,7 @@ When creating your own custom events and attributes, follow data requirements fo
     recordCustomEvent(<var>eventType</var>, <var>attributes</var>)
     ```
 
-    Use recordCustomEvent to record an event-based metric, usually associated with a particular duration. The eventType must be an alphanumeric string less than 255 characters. The attributes must be an object of key and value pairs. The keys must be shorter than 255 characters, and the values must be string, number, or boolean. For restrictions on event type names, see our documentation about [limits and restricted characters](/docs/insights/explore-data/custom-attributes/requirements-custom-attributes) and [NRQL reserved words](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words).
+    Use recordCustomEvent to record an event-based metric, usually associated with a particular duration. The eventType must be an alphanumeric string less than 255 characters. The attributes must be an object of key and value pairs. The keys must be shorter than 255 characters, and the values must be string, number, or boolean. For restrictions on event type names, see our documentation about [limits and restricted characters](/docs/insights/explore-data/custom-attributes/requirements-custom-attributes) and [NRQL reserved words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
 
     You can then add [custom attributes](/docs/apm/other-features/attributes/collecting-custom-attributes#nodejs-att) for your Node.js app.
 
@@ -162,7 +162,7 @@ When creating your own custom events and attributes, follow data requirements fo
     newrelic_record_custom_event("<var>WidgetSale</var>", array("<var>color</var>"=>"<var>red</var>", "<var>weight</var>"=><var>12.5</var>));
     ```
 
-    The first argument defines the name of your event type, and the second argument is an array with the attributes for your custom event. Ensure you limit the number of unique event type names that you create, and do not generate these names dynamically. For restrictions on event type names, see our documentation about [limits and restricted characters](/docs/insights/explore-data/custom-attributes/requirements-custom-attributes) and [NRQL reserved words](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words).
+    The first argument defines the name of your event type, and the second argument is an array with the attributes for your custom event. Ensure you limit the number of unique event type names that you create, and do not generate these names dynamically. For restrictions on event type names, see our documentation about [limits and restricted characters](/docs/insights/explore-data/custom-attributes/requirements-custom-attributes) and [NRQL reserved words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
 
     By default, the maximum number of custom events recorded per minute is 10,000. This setting cannot be changed.
 
@@ -182,7 +182,7 @@ When creating your own custom events and attributes, follow data requirements fo
     newrelic.agent.<mark>record_custom_event</mark>(event_type, params, application=None)
     ```
 
-    The `event_type` defines the name (or type) of the custom event. Attributes of the custom event should be passed in as a dictionary via the `params` keyword argument. Ensure you limit the number of unique event type names that you create, and do not generate these names dynamically. For limits and restrictions on `event_type` and `params`, see our documentation about [limits and restricted characters](/docs/insights/explore-data/custom-attributes/requirements-custom-attributes) and [reserved words](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words)
+    The `event_type` defines the name (or type) of the custom event. Attributes of the custom event should be passed in as a dictionary via the `params` keyword argument. Ensure you limit the number of unique event type names that you create, and do not generate these names dynamically. For limits and restrictions on `event_type` and `params`, see our documentation about [limits and restricted characters](/docs/insights/explore-data/custom-attributes/requirements-custom-attributes) and [reserved words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words)
 
     If called outside of the context of a monitored web request or background task, the call will be ignored unless the `application` keyword argument is provided and an application object corresponding to the application against which the exception should be recorded is provided. A suitable application object can be obtained using the `newrelic.agent.application()` function.
 
@@ -202,7 +202,7 @@ When creating your own custom events and attributes, follow data requirements fo
     ::NewRelic::Agent.record_custom_event('<var>WidgetSale</var>', <var>color</var>: '<var>red</var>', <var>weight</var>: <var>12.5</var>)
     ```
 
-    The first argument defines the name of your event type, and the second argument is a hash with the attributes for your custom event. Ensure you limit the number of unique event type names that you create, and do not generate these names dynamically. For restrictions on event type names, see our documentation about [limits and restricted characters](/docs/insights/explore-data/custom-attributes/requirements-custom-attributes) and [NRQL reserved words](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words).
+    The first argument defines the name of your event type, and the second argument is a hash with the attributes for your custom event. Ensure you limit the number of unique event type names that you create, and do not generate these names dynamically. For restrictions on event type names, see our documentation about [limits and restricted characters](/docs/insights/explore-data/custom-attributes/requirements-custom-attributes) and [NRQL reserved words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
 
     You can change the maximum number of events recorded by the Ruby agent via a configuration parameter in `newrelic.yml`:
 
@@ -229,4 +229,4 @@ See [Custom event data requirements](/docs/insights/insights-data-sources/custom
 
 ## Reserved words [#keywords]
 
-Before creating custom attributes, review New Relic's list of [reserved terms used by NRQL](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words). Otherwise unexpected results may occur.
+Before creating custom attributes, review New Relic's list of [reserved terms used by NRQL](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words). Otherwise unexpected results may occur.


### PR DESCRIPTION
As mentioned in #documentation, the link https://docs.newrelic.com/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-reserved-words/ no longer works.

I've started a sweep to replace it for https://docs.newrelic.com/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words. I want to double check with @barbnewrelic this is the right doc before I finish the sweep, I've changed 3 instances so far.