### PR TITLE
Fix Android Agent v6.0.0 Release Notes Formatting

### DIFF
--- a/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-600.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-600.mdx
@@ -23,7 +23,8 @@ Build types or product flavors are excluded through the [New Relic Gradle plugin
 newrelic {
     // do not instrument these build variants
     excludeVariantInstrumentation("debug", "chocolateRelease")
-}```
+}
+```
 
 
 ###  Updated requirements


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! Your changes will help thousands of
New Relic users around the world. -->

<!-- Fill out this template to help us review your changes and route them to the
best team. See our [README.md](https://github.com/newrelic/docs-website/) for
information on how to contribute. -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Tell us why

The formatting of the release notes for the v6.0.0 Android agent is incorrect w/ respect to the code block for demonstrating the new build variant exclusion feature. It looks fine on the New Relic site, but the links do not work for the headers. 

### Anything else you'd like to share?

No

### Are you making a change to site code?

No
