### PR TITLE
Bump theme version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "^2.0.0-next.8",
     "@mdx-js/react": "^2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "^1.36.0",
+    "@newrelic/gatsby-theme-newrelic": "^1.37.0",
     "@splitsoftware/splitio-react": "^1.2.0",
     "babel-jest": "^26.3.0",
     "common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2222,10 +2222,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^1.36.0":
-  version "1.36.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.36.0.tgz#c31e268543db00bd1f1b982087da56d24e4d1d75"
-  integrity sha512-wT3TkzuY70hbS5GkTlwpgI93inqWZbj1iHlbrGfE9hWGnAt8AWh1uds7RqXiWX9RsgNA1btagxI+0RUcoXrawQ==
+"@newrelic/gatsby-theme-newrelic@^1.37.0":
+  version "1.37.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.37.0.tgz#3082429fc8815712abe53f1bea84b2333da0daf5"
+  integrity sha512-+3cfCZZFqz4J5kKo46q05w0t9aUcorfDntNXdtAiDe87FsgtKueV2SAWAGlEyfw4picJypTwIeVoPRsOeMCDhA==
   dependencies:
     "@elastic/react-search-ui" "^1.4.1"
     "@elastic/react-search-ui-views" "^1.4.1"


### PR DESCRIPTION
## Description

Bumps theme version to start using collapser links and searching localized pages.

## Related issues / PRs
Closes #1476 

## Screenshot(s)

<img width="1912" alt="2021-03-22_11-29-49" src="https://user-images.githubusercontent.com/2952843/112040244-37f60e80-8b02-11eb-90bf-fea6cce419c4.png">

<img width="1912" alt="2021-03-22_11-30-24" src="https://user-images.githubusercontent.com/2952843/112040270-3e848600-8b02-11eb-9d87-9f75653358ca.png">
