### PR TITLE
Fix taxonomy redirects

### DIFF
--- a/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
+++ b/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
@@ -135,9 +135,7 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
 
   const { nodes: locales } = allLocale;
 
-  const existingPaths = tableOfContentsNodes
-    .map(getSlug)
-    .concat(fileNodes.map(getSlug));
+  const existingPaths = tableOfContentsNodes.map(getSlug);
 
   const files = fileNodes.map((node) => ({
     basename: node.base,
@@ -153,7 +151,7 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
     if (skippedDirectories.includes(dir.path)) {
       return [visit.SKIP];
     }
-
+    // I think we want to just look at tableofcontents, not all filenodes
     if (existingPaths.includes(slug)) {
       return;
     }

--- a/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
+++ b/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
@@ -135,7 +135,9 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
 
   const { nodes: locales } = allLocale;
 
-  const existingPaths = tableOfContentsNodes.map(getSlug);
+  const existingPaths = tableOfContentsNodes
+    .map(getSlug)
+    .concat(fileNodes.map(getSlug));
 
   const files = fileNodes.map((node) => ({
     basename: node.base,

--- a/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
+++ b/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
@@ -151,7 +151,7 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
     if (skippedDirectories.includes(dir.path)) {
       return [visit.SKIP];
     }
-    // I think we want to just look at tableofcontents, not all filenodes
+
     if (existingPaths.includes(slug)) {
       return;
     }

--- a/plugins/gatsby-source-nav/gatsby-node.js
+++ b/plugins/gatsby-source-nav/gatsby-node.js
@@ -254,6 +254,29 @@ const groupBy = (arr, fn) =>
 const createNav = async ({ args, createNodeId, nodeModel, locales }) => {
   const { slug } = args;
 
+  const fileNode = await nodeModel.runQuery({
+    type: 'File',
+    query: {
+      filter: {
+        sourceInstanceName: { eq: 'markdown-pages' },
+        relativePath: { regex: '/docs/' },
+        childMdx: {
+          fields: {
+            slug: {
+              eq: slug
+                .replace(/\/table-of-contents$/, '')
+                .replace(new RegExp(`^\\/(${locales.join('|')})(?=\\/)`), ''),
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (fileNode === null) {
+    return null;
+  }
+
   const nav = nodeModel.getAllNodes({ type: 'NavYaml' }).find((nav) =>
     // table-of-contents pages should get the same nav as their landing page
     findPage(

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -59,7 +59,7 @@ const DocsSiteSeo = ({
 );
 
 DocsSiteSeo.propTypes = {
-  location: PropTypes.string.isRequired,
+  location: PropTypes.object.isRequired,
   title: PropTypes.string,
   description: PropTypes.string,
   type: PropTypes.string,

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -1153,7 +1153,7 @@
     ]
   },
   {
-    "url": "/docs/integrations/amazon-integrations/",
+    "url": "/docs/integrations/amazon-integrations",
     "paths": [
       "/docs/integrations/amazon-integrations/aws-integrations-list",
       "/docs/infrastructure/amazon-integrations/aws-integrations-list",

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "/docs/infrastructure/infrastructure-monitoring-troubleshooting",
+    "url": "/docs/infrastructure/infrastructure-troubleshooting",
     "paths": [
       "/docs/windows-server-monitoring/wsm-kb-100",
       "/docs/windows-server-monitoring/windows-server-monitor-known-issues",
@@ -28,7 +28,7 @@
       "/docs/servers/new-relic-servers-windows/troubleshooting",
       "/docs/infrastructure/troubleshooting-0",
       "/docs/infrastructure/troubleshooting",
-      "/docs/infrastructure/infrastructure-troubleshooting"
+      "/docs/infrastructure/infrastructure-monitoring-troubleshooting"
     ]
   },
   {

--- a/src/templates/indexPage.js
+++ b/src/templates/indexPage.js
@@ -10,7 +10,10 @@ import { TYPES } from '../utils/constants';
 
 const IndexPage = ({ data, pageContext, location }) => {
   const { nav } = data;
-  const { html, disableSwiftype } = pageContext;
+
+  const useIndexHtml = nav?.url !== location.pathname;
+
+  const { html, disableSwiftype, title: contextTitle } = pageContext;
   const title = nav ? nav.title : pageContext.title;
 
   return (
@@ -22,13 +25,14 @@ const IndexPage = ({ data, pageContext, location }) => {
         disableSwiftype={disableSwiftype}
       />
       <PageTitle>{title}</PageTitle>
+      {useIndexHtml && nav && <h2>{contextTitle}</h2>}
       <Layout.Content>
-        {nav ? (
-          <IndexContents nav={nav} />
-        ) : (
+        {useIndexHtml ? (
           <TableOfContentsContainer
             dangerouslySetInnerHTML={{ __html: html }}
           />
+        ) : (
+          <IndexContents nav={nav} />
         )}
       </Layout.Content>
     </>

--- a/src/templates/indexPage.js
+++ b/src/templates/indexPage.js
@@ -11,9 +11,7 @@ import { TYPES } from '../utils/constants';
 const IndexPage = ({ data, pageContext, location }) => {
   const { nav } = data;
 
-  const useIndexHtml = nav?.url !== location.pathname;
-
-  const { html, disableSwiftype, title: contextTitle } = pageContext;
+  const { html, disableSwiftype } = pageContext;
   const title = nav ? nav.title : pageContext.title;
 
   return (
@@ -25,14 +23,13 @@ const IndexPage = ({ data, pageContext, location }) => {
         disableSwiftype={disableSwiftype}
       />
       <PageTitle>{title}</PageTitle>
-      {useIndexHtml && nav && <h2>{contextTitle}</h2>}
       <Layout.Content>
-        {useIndexHtml ? (
+        {nav ? (
+          <IndexContents nav={nav} />
+        ) : (
           <TableOfContentsContainer
             dangerouslySetInnerHTML={{ __html: html }}
           />
-        ) : (
-          <IndexContents nav={nav} />
         )}
       </Layout.Content>
     </>


### PR DESCRIPTION
## Description

Originally it seemed like redirects were not working via `gatsby-plugin-auto-index-pages`, but the issue was a gotcha in the way we attach nav menus (loaded into gatsby via `nav/*.yml` files). This updates the logic when resolving which nav to add to a given page at a slug to not add one if the page is a programmatically generated page (not authored .mdx driving it)

### Cause
Every page has a `nav` object in its data via `MainLayout` query, which passes it a slug and either gets back a nav menu object based on one of the nav .yml files OR null. That's set via `gatsby-source-nav` via a resolver that looks for the slug in all the `NavYaml` data in graphql (which is loaded via nav .yml files). We do that to know what left nav menu to show so a user stays in context when clicking on links in a particular menu. The gotcha is if there are links in a nav .yml that are links to directory index pages, the script doesn't know that and adds the nav object. If that link is in more than one nav .yml, the first one it sees (which i think is alpha order) is the nav menu it attaches to the index.


### Fixes re: to the issue
This fixes some of the 404s listed in the issue this relates to. But there are many other links that 404. At quick glance some are caused by:
* links that do not have anything to resolve to (so there's no .mdx file, directory, page in Gatsby)
* paths in `taxonomy-redirects.json` with `docs/release-notes` and `whats-new` are intentionally excluded via the auto index plugin and thus redirects aren't created there (they can be created via frontmatter on index.mdx files in release notes subdirs)

The original scope of this PR was to not look at file nodes in addition to landing page nodes. Still unsure why we look at all file nodes and compare that to directory paths, but reverted that for now.

## Related issues / PRs
Closes #1460 