### PR TITLE
Enable automatic translation workflow

### DIFF
--- a/.github/workflows/check-translations-and-deserialize.yml
+++ b/.github/workflows/check-translations-and-deserialize.yml
@@ -2,10 +2,9 @@ name: Check status of translation jobs
 
 on:
   workflow_dispatch:
-  # TODO: uncomment when ready for this to run
-  # schedule:
-  # # 11am every day
-  # - cron: '0 11 * * *'
+  schedule:
+    # 12pm every day
+    - cron: '0 12 * * *'
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/send-content-to-translate.yml
+++ b/.github/workflows/send-content-to-translate.yml
@@ -2,9 +2,9 @@ name: Send content to be translated
 
 on:
   workflow_dispatch:
-  # schedule:
-  #   # 6pm every Thursday
-  #   - cron: '0 18 * * 4'
+  schedule:
+    # 1am every Thursday
+    - cron: '0 1 * * 4'
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Description
This PR enabled the translation workflows to run at regular intervals:
* Send content to be translated _every Thrusday at 1am_
* Check the status of translation queues _every day at 12pm_

The translation vendor user, project, and secret have already been upated in the "secrets" section of the repository.

## Reviewer Notes
I left the `workflow_dispatch` event so that we could manually trigger each action (just in case we want to manually send content sooner than Thursday).
