### PR TITLE
docs: add infrastructure agent release notes for version 1.16.0

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1160.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1160.mdx
@@ -7,7 +7,13 @@ version: 1.16.0
 A new version of the agent has been released. Follow standard procedures to [update the Infrastructure agent](https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/update-or-uninstall/update-infrastructure-agent).  
 New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months.
 
+### Added
+* `newrelic/infrastructure` agent [docker image](https://hub.docker.com/r/newrelic/infrastructure/tags?page=1&ordering=last_updated&name=latest) is now published as multi-arch (amd64 and arm64) 
+
 ### Changed
-* A new version of `nri-docker` has being updated to [v1.4.3](https://github.com/newrelic/nri-docker/releases/tag/v1.4.3)
-* A new version of `fluent-bit` has being updated to [v1.4.4](https://github.com/newrelic/newrelic-fluent-bit-output/tree/v1.4.4)
-* A new version of `nri-flex` has being updated to [v1.4.0](https://github.com/newrelic/nri-flex/releases/tag/v1.4.0)
+* `nri-docker` built-in integration updated to [v1.4.3](https://github.com/newrelic/nri-docker/releases/tag/v1.4.3)
+* `fluent-bit` built-in integration updated to [v1.4.4](https://github.com/newrelic/newrelic-fluent-bit-output/tree/v1.4.4)
+* `nri-flex` built-in integration updated to [v1.4.0](https://github.com/newrelic/nri-flex/releases/tag/v1.4.0)
+
+### Deprecated
+* CentOS 5 & RHEL 5 `newrelic-infra` packages are no longer published (manufacturer EOL). Please check the [system requirements documentation](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent/) for an updated list of supported OS & platforms.

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1160.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1160.mdx
@@ -1,0 +1,13 @@
+---
+subject: Infrastructure agent
+releaseDate: '2021-03-23'
+version: 1.16.0
+---
+## Notes
+A new version of the agent has been released. Follow standard procedures to [update the Infrastructure agent](https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/update-or-uninstall/update-infrastructure-agent).  
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months.
+
+### Changed
+* A new version of `nri-docker` has being updated to [v1.4.3](https://github.com/newrelic/nri-docker/releases/tag/v1.4.3)
+* A new version of `fluent-bit` has being updated to [v1.4.4](https://github.com/newrelic/newrelic-fluent-bit-output/tree/v1.4.4)
+* A new version of `nri-flex` has being updated to [v1.4.0](https://github.com/newrelic/nri-flex/releases/tag/v1.4.0)

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1160.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1160.mdx
@@ -8,7 +8,7 @@ A new version of the agent has been released. Follow standard procedures to [upd
 New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months.
 
 ### Added
-* `newrelic/infrastructure` agent [docker image](https://hub.docker.com/r/newrelic/infrastructure/tags?page=1&ordering=last_updated&name=latest) is now published as multi-arch (amd64 and arm64) 
+* `newrelic/infrastructure` agent [docker image](https://hub.docker.com/r/newrelic/infrastructure/tags?page=1&ordering=last_updated&name=latest) is now published as multi-arch (amd64 and arm64). 
 
 ### Changed
 * `nri-docker` built-in integration updated to [v1.4.3](https://github.com/newrelic/nri-docker/releases/tag/v1.4.3)
@@ -16,4 +16,4 @@ New Relic recommends that you upgrade the agent regularly and at a minimum every
 * `nri-flex` built-in integration updated to [v1.4.0](https://github.com/newrelic/nri-flex/releases/tag/v1.4.0)
 
 ### Deprecated
-* CentOS 5 & RHEL 5 `newrelic-infra` packages are no longer published (manufacturer EOL). Please check the [system requirements documentation](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent/) for an updated list of supported OS & platforms.
+* CentOS 5 & RHEL 5 `newrelic-infra` packages are no longer published due to manufacturer end of life. Please check the [system requirements documentation](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent/) for an updated list of supported OS and platforms.

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1160.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1160.mdx
@@ -1,6 +1,6 @@
 ---
 subject: Infrastructure agent
-releaseDate: '2021-03-23'
+releaseDate: '2021-03-24'
 version: 1.16.0
 ---
 ## Notes


### PR DESCRIPTION
### Tell us why

We are planing to release a new version of newrelic infrastructure agent [1.16.0](https://github.com/newrelic/infrastructure-agent/releases/tag/1.16.0)
