### PR TITLE
integrations/postgresql: fix typo in parameter name

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/postgresql-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/postgresql-monitoring-integration.mdx
@@ -172,8 +172,8 @@ The `all_data` command accepts the following arguments:
     ```
 * `pgbouncer`: collect `pgbouncer` metrics. Default: `false`.
 * `enable_ssl`: determines if SSL is enabled. If `true`, `ssl_cert_location` and `ssl_key_location` are required. Default: `false`.
-* `trust_server_certificates`: if `true`, the server certificate is not verified for SSL. If `false`, the server certificate identified in `ssl_root_cert_location` is verified. Default: `false`.
-* `ssl_root_cert_location`: absolute path to PEM-encoded root certificate file. Required if `trust_server_certificates` is `false`.
+* `trust_server_certificate`: if `true`, the server certificate is not verified for SSL. If `false`, the server certificate identified in `ssl_root_cert_location` is verified. Default: `false`.
+* `ssl_root_cert_location`: absolute path to PEM-encoded root certificate file. Required if `trust_server_certificate` is `false`.
 * `ssl_cert_location`: absolute path to PEM-encoded client certificate file. Required if `enable_ssl` is `true`.
 * `ssl_key_location`: absolute path to PEM-encoded client key file. Required if `enable_ssl` is `true`.
 * `timeout`: maximum wait for connection, in seconds. Set to `0` for no timeout. Default: `10`.


### PR DESCRIPTION

<!-- Thanks for contributing to our docs! Your changes will help thousands of
New Relic users around the world. -->

<!-- Fill out this template to help us review your changes and route them to the
best team. See our [README.md](https://github.com/newrelic/docs-website/) for
information on how to contribute. -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Tell us why

This PR fixes a typo in one postgresql argument name, as per the code:

https://github.com/newrelic/nri-postgresql/blob/23cb38f05efdec3dd39b4804ded1ef6a7f70f5c5/src/args/argument_list.go#L21