### PR TITLE
chore: add missing permission in EMR

### DIFF
--- a/src/content/docs/integrations/amazon-integrations/get-started/integrations-managed-policies.mdx
+++ b/src/content/docs/integrations/amazon-integrations/get-started/integrations-managed-policies.mdx
@@ -476,6 +476,7 @@ The following permissions are used by New Relic to retrieve data for specific AW
     * `elasticmapreduce:ListClusters`
     * `elasticmapreduce:DescribeCluster`
     * `elasticmapreduce:ListInstanceGroups`
+    * `elasticmapreduce:ListInstanceFleets`
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
### Tell us why

Users of Cloud integrations have to add the permission `emr:ListInstanceFleets` to work as expected. 
