### PR TITLE
Update usage-queries-alerts.mdx

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-users/usage-queries-alerts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-users/usage-queries-alerts.mdx
@@ -152,8 +152,8 @@ Here are some user-related query examples. For details on how users are counted,
 
 To help [manage your billable data](/docs/telemetry-data-platform/get-data-new-relic/manage-data/manage-your-data), you can set alerts to notify you of unexpected increases in usage. To learn about how to create alerts, see [Alert workflow](/docs/alerts/new-relic-alerts/getting-started/new-relic-alerts-concepts-workflow#workflow).
 
-<Callout variant="tip">
-  When creating alert conditions, we recommend 60 minutes for the [Evaluation offset](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions#h2-evaluation-offset) value.
+<Callout variant="caution">
+  When creating alert conditions, you should set the [Evaluation offset](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions#h2-evaluation-offset) value to 60 minutes or your conditions may not trigger.
 </Callout>
 
 Here are some NRQL alert condition examples. For attribute definitions, see [Attributes](#attributes).


### PR DESCRIPTION
Updated callout about Evaluation Offset to caution level and explained that not doing this may cause conditions not to trigger.

<!-- Thanks for contributing to our docs! Your changes will help thousands of
New Relic users around the world. -->

<!-- Fill out this template to help us review your changes and route them to the
best team. See our [README.md](https://github.com/newrelic/docs-website/) for
information on how to contribute. -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Tell us why

The previous language around the Evaluation Offset (and level of the callout being set to Tip) did not strongly enough suggest that *not* doing this will cause alert conditions to not trigger. Added additional language stating this, and changed callout level from tip to caution.

### Anything else you'd like to share?

Based on my testing, leaving the evaluation offset at the default causes usage alerts to not trigger.

### Are you making a change to site code?

No.
