### PR TITLE
chore: adds release notes for Node agent v7.2.0.

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-2-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-2-0.mdx
@@ -1,0 +1,46 @@
+---
+subject: Node.js agent
+releaseDate: '2021-03-23'
+version: 7.2.0
+downloadLink: 'https://www.npmjs.com/package/newrelic'
+---
+
+## Improvements
+
+* The `NEW_RELIC_NO_CONFIG_FILE` environment variable is no longer needed to run the agent without a configuration file.
+
+  * If a configuration file is used with agent configuration environment variables, the environment variables will override the corresponding configuration file settings.
+
+* Added feature flag to allow disabling of certificate bundle usage.
+
+  **Deprecation Warning:** The certificate bundle included by New Relic will be disabled by default and then fully removed in later major versions. We recommend testing with the certificate_bundle feature flag set to `false` to determine if you will need to modify your environment or setup your own appropriate bundle. Example configuration: `feature_flag: { certificate_bundle: false }`.
+
+* Set distributed tracing to enabled in the `newrelic.js` template configuration file supplied with the agent.
+
+* Added module root to shim.require() logging to aid debugging.
+
+* Migrated from .npmignore to 'files' list in package.json to control which files are packaged.
+
+  Thank you to @JamesPeiris for the initial nudge via PR to move in this direction.
+
+* Converted remaining collector unit tests to use tap API.
+
+* Added linting to scripts in /bin folder.
+
+  Linting rules added are slightly more permissive than production rules and allow full ecma 8.
+
+* Added new developer documentation to /docs folder.
+
+  This information is ported over from private GHE wiki used prior to going open source. S/O @astorm for original versions of the function wrapping and module instrumentation docs.
+
+## Fixes
+
+* Fixed bug where applications with multiple names on a dynamically named host (UUID like) would have instances consolidated, losing per-host breakdowns.
+
+  Removed 'host' from agent 'identifier' override to prevent server safety mechanism from kicking in. Host will still be used to identify unique agent instances, so was unnecessary to include as part of the identifier. This also resulted in additional processing overhead on the back-end. The identifier override is still kept in place with multiple application names to continue to allow uniquely identifying instances on the same host with multiple application names where the first name may be identical. For example `app_name['myName', 'unique1']` and `app_name['myName', 'unique2']`. These names would consolidate down into a single instance on the same host without the identifier override.
+
+* Fixed bug where truncated http (external) or datastore segments would generate generic spans instead of appropriate http or datastore spans.
+
+### Support statement:
+
+* New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach [end-of-life](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software).


### PR DESCRIPTION
Added release note for Node agent v7.2.0 we just shipped.

**Please Note: this is testing out the naming strategy discussed in another GitHub issue to verify there are no issues and use going forward if works. as expected**

Please see discussion here: https://github.com/newrelic/docs-website/issues/1255

I don't have yard installed or I would have attempted to run locally.

