### PR TITLE
Fixed layer link

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
@@ -22,7 +22,7 @@ the latest Lambda APIs with those older runtimes. Integration for older runtimes
 is possible.
 
 Python and NodeJS are by far the most popular languages in the Lambda ecosystem. The
-[New Relic Lambda Layers](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-using-lambda-layer)
+[New Relic Lambda Layers](https://layers.newrelic-external.com/)
 for Node and Python include the very latest New Relic Agent version, and provide rich instrumentation with minimal
 configuration, right out of the box.
 


### PR DESCRIPTION
As mentioned in #documentation, https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-using-lambda-layer/ is not working and needs to be replaced by https://layers.newrelic-external.com/.

Tested locally.