### PR TITLE
Fixed COMPARE WITH description

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -172,7 +172,7 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
 
     `COMPARE WITH` requires a `SINCE` or `UNTIL` statement. The time specified by `COMPARE WITH` is relative to the time specified by `SINCE` or `UNTIL`. For example, `SINCE 1 day ago COMPARE WITH 1 day ago` compares yesterday with the day before.
 
-    The time range for the`COMPARE WITH` value is always the same as that specified by `SINCE` or `UNTIL`. For example, `SINCE 2 hours ago COMPARE WITH 4 hours ago` might compare 3:00pm through 5:00pm against 1:00 through 3:00pm.
+    The time range for the`COMPARE WITH` value is always the same as that specified by `SINCE` or `UNTIL`. For example, `SINCE 2 hours ago COMPARE WITH 4 hours ago` might compare 3:00pm through 5:00pm against 11:00am through 1:00pm.
 
     `COMPARE WITH` can be formatted as either a line chart or a billboard:
 


### PR DESCRIPTION
The section incorrectly specified that comparing data starting 3pm with 'four hours ago' would compare against 1pm data. The timing is actually relative to the SINCE clause, so the data being compared would be from four hours before 3pm (i.e. 11am).

<!-- Thanks for contributing to our docs! Your changes will help thousands of
New Relic users around the world. -->

<!-- Fill out this template to help us review your changes and route them to the
best team. See our [README.md](https://github.com/newrelic/docs-website/) for
information on how to contribute. -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Tell us why

Explain why you're proposing this change. If there's an existing GitHub issue
related to your change, please link to it.

### Anything else you'd like to share?

Add any context that will help us review your changes such as testing notes,
links to related docs, screenshots, etc.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.
