### PR TITLE
Restore "Single page apps" to left navigation panel

### DIFF
--- a/src/content/docs/browser/index.mdx
+++ b/src/content/docs/browser/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Browser monitoring
+title: Browser
 type: landingPage
 tags:
   - Browser

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -322,6 +322,7 @@ pages:
             path: /docs/apm/new-relic-apm/maintenance/record-monitor-deployments
   - title: Browser 
     path: /docs/browser
+    pages:
       - title: Browser monitoring
         pages:
           - title: Get started

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -512,7 +512,7 @@ pages:
                 path: /docs/browser/single-page-app-monitoring/use-spa-data/view-spa-data-browser-ui
               - title: SPA data collection
                 path: /docs/browser/single-page-app-monitoring/use-spa-data/spa-data-collection
-              - title: Browser/SPA NRQL query examples
+              - title: Query SPA data in New Relic
                 path: /docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/browserspa-nrql-query-examples
               - title: Use SPA API
                 path: /docs/browser/single-page-app-monitoring/use-spa-data/use-spa-api  

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -320,180 +320,205 @@ pages:
             path: /docs/apm/new-relic-apm/maintenance/remove-applications-new-relic
           - title: Record and monitor deployments
             path: /docs/apm/new-relic-apm/maintenance/record-monitor-deployments
-  - title: Browser monitoring
+  - title: Browser 
     path: /docs/browser
-    pages:
-      - title: Getting started
+      - title: Browser monitoring
         pages:
-          - title: Intro to browser monitoring
-            path: /docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring
-          - title: Compatibility and requirements
-            path: /docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring
-          - title: Browser agent release notes
-            path: /docs/browser/new-relic-browser/getting-started/browser-agent-release-notes
-          - title: Browser apps index
-            path: /docs/browser/new-relic-browser/getting-started/browser-apps-index
-          - title: Browser Summary page
-            path: /docs/browser/browser-monitoring/getting-started/browser-summary-page
-      - title: Guides
-        pages:
-          - title: Browser API and SPA API guide
-            path: /docs/browser/new-relic-browser/guides/guide-using-browser-spa-apis
-          - title: Browser monitoring best practices guide
-            path: /docs/browser/browser-monitoring/guides/browser-monitoring-best-practices-guide
-      - title: Installation
-        pages:
-          - title: Install Browser
-            path: /docs/browser/browser-monitoring/installation/install-browser-monitoring-agent
-          - title: Update the Browser agent
-            path: /docs/browser/new-relic-browser/installation/update-browser-agent
-          - title: Disable Browser monitoring
-            path: /docs/browser/new-relic-browser/installation/disable-browser-monitoring
-          - title: Delete apps from Browser
-            path: /docs/browser/new-relic-browser/installation/delete-apps-new-relic-browser
-          - title: Install Browser for AMP
-            path: /docs/browser/new-relic-browser/installation/monitor-amp-pages-new-relic-browser
-      - title: Configuration
-        pages:
-          - title: 'Browser Apdex, countries'
-            path: /docs/browser/new-relic-browser/configuration/browser-settings-ui-options-apdex-geography
-          - title: Privacy settings
-            path: /docs/browser/browser-monitoring/configuration/privacy-settings
-          - title: Rename Browser apps
-            path: /docs/browser/new-relic-browser/configuration/rename-browser-apps
-          - title: Domain settings
-            path: /docs/browser/new-relic-browser/configuration/monitor-or-block-specific-domains-subdomains
-          - title: Metrics by URL patterns
-            path: /docs/browser/new-relic-browser/configuration/group-browser-metrics-urls
-          - title: License key and app ID
-            path: /docs/browser/browser-monitoring/configuration/browser-license-key-app-id
-          - title: Alerts in Browser
-            path: /docs/browser/new-relic-browser/configuration/view-browser-apps-alert-information
-      - title: Browser agent and SPA API
-        path: /docs/browser/new-relic-browser/browser-agent-spa-api
-        pages:
-          - title: View all methods
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/view-all-methods
-          - title: addPageAction
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action
-          - title: addRelease
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/add-release
-          - title: addToTrace
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/addtotrace-browser-agent-api
-          - title: finished
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/finished
-          - title: noticeError
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/noticeerror-browser-agent-api
-          - title: setCustomAttribute
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/setcustomattribute-browser-agent-api
-          - title: setErrorHandler
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/set-error-handler
-          - title: setPageViewName
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/setpageviewname-browser-agent-api
-          - title: 'SPA: actionText'
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/actiontext-browser-spa-api
-          - title: 'SPA: interaction'
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/interaction-browser-spa-api
-          - title: 'SPA: createTracer'
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/createtracer-browser-spa-api
-          - title: 'SPA: end'
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/end-browser-spa-api
-          - title: 'SPA: getContext'
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/getcontext-browser-spa-api
-          - title: 'SPA: ignore'
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/ignore-browser-spa-api
-          - title: 'SPA: onEnd'
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/spa-on-end
-          - title: 'SPA: save'
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/save-browser-spa-api
-          - title: 'SPA: setAttribute'
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/setattribute-browser-spa-api
-          - title: 'SPA: setCurrentRouteName'
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/setcurrentroutename-browser-spa-api
-          - title: 'SPA: setName'
-            path: /docs/browser/new-relic-browser/browser-agent-spa-api/setname-browser-spa-api
-      - title: Page load timing resources
-        pages:
-          - title: Page load timing process
-            path: /docs/browser/new-relic-browser/page-load-timing-resources/page-load-timing-process
-          - title: PageViewTiming event
-            path: /docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details
-          - title: Instrumentation for browser monitoring
-            path: /docs/browser/new-relic-browser/page-load-timing-resources/instrumentation-browser-monitoring
-          - title: Comparative charting
-            path: /docs/browser/new-relic-browser/page-load-timing-resources/compare-page-load-performance-browser-synthetics
-          - title: New Relic cookies used by Browser
-            path: /docs/browser/browser-monitoring/page-load-timing-resources/new-relic-cookies-used-browser
-          - title: Navigation start time unknown
-            path: /docs/browser/new-relic-browser/page-load-timing-resources/navigation-start-time-unknown
-          - title: Session cookies
-            path: /docs/browser/browser-monitoring/page-load-timing-resources/cookie-collection-session-tracking
-          - title: Cached pages
-            path: /docs/browser/new-relic-browser/page-load-timing-resources/cached-pages
-      - title: Browser Pro features
-        pages:
-          - title: SPA monitoring
-            path: /docs/browser/new-relic-browser/browser-pro-features/spa-monitoring
-          - title: AJAX page
-            path: /docs/browser/browser-monitoring/browser-pro-features/ajax-page-identify-time-consuming-calls
-          - title: JS errors page
-            path: /docs/browser/new-relic-browser/browser-pro-features/javascript-errors-page-detect-analyze-errors
-          - title: Error profiles
-            path: /docs/browser/new-relic-browser/browser-pro-features/browser-error-profiles-find-error-causes
-          - title: Session traces page
-            path: /docs/browser/browser-monitoring/browser-pro-features/session-traces-explore-webpages-life-cycle
-          - title: Filterable Geography page
-            path: /docs/browser/new-relic-browser/browser-pro-features/filterable-geography-webpage-metrics-location
-          - title: Browser data in distributed tracing
-            path: /docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing
-          - title: Upload source maps
-            path: /docs/browser/browser-monitoring/browser-pro-features/upload-source-maps-un-minify-js-errors
-          - title: Source map API
-            path: /docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-api
-      - title: Additional standard features
-        pages:
-          - title: Page views page
-            path: /docs/browser/new-relic-browser/additional-standard-features/page-views-examine-page-performance
-          - title: Browsers page
-            path: /docs/browser/new-relic-browser/additional-standard-features/browsers-problem-patterns-type-or-platform
-          - title: Geography page
-            path: /docs/browser/new-relic-browser/additional-standard-features/browser-geography-webpage-performance-location
-      - title: Performance quality
-        pages:
-          - title: Security for Browser
-            path: /docs/browser/new-relic-browser/performance-quality/security-browser-monitoring
-          - title: Browser monitoring and performance impact
-            path: /docs/browser/new-relic-browser/performance-quality/browser-monitoring-performance-impact
-          - title: Browser monitoring and SEO
-            path: /docs/browser/new-relic-browser/performance-quality/browser-monitoring-search-engine-optimization
-      - title: Troubleshooting
-        pages:
-          - title: Troubleshooting installation
-            path: /docs/browser/browser-monitoring/troubleshooting/troubleshoot-your-browser-monitoring-installation
-          - title: Data doesn't match other tools
-            path: /docs/browser/new-relic-browser/troubleshooting/browser-data-doesnt-match-other-analytics-tools
-          - title: View detailed error logs
-            path: /docs/browser/new-relic-browser/troubleshooting/view-detailed-error-logs-browser
-          - title: AJAX data collection
-            path: /docs/browser/new-relic-browser/troubleshooting/troubleshoot-ajax-data-collection
-          - title: Session trace collection
-            path: /docs/browser/new-relic-browser/troubleshooting/troubleshooting-session-trace-collection
-          - title: AngularJS errors do not appear
-            path: /docs/browser/new-relic-browser/troubleshooting/angularjs-errors-do-not-appear
-          - title: Accelerated mobile pages (AMP)
-            path: /docs/browser/new-relic-browser/troubleshooting/google-amp-validator-fails-due-3rd-party-script
-          - title: HAR data collection
-            path: /docs/browser/new-relic-browser/troubleshooting/get-browser-side-troubleshooting-details-har-file
-          - title: Not seeing specific page names
-            path: /docs/browser/new-relic-browser/troubleshooting/not-seeing-specific-page-or-endpoint-names-browser-data
-          - title: JavaScript injection causes problems
-            path: /docs/browser/new-relic-browser/troubleshooting/browser-javascript-injection-causes-problems-page
-          - title: JS errors missing traces
-            path: /docs/browser/new-relic-browser/troubleshooting/third-party-js-errors-missing-stack-traces
-          - title: RPM higher than PPM
-            path: /docs/browser/new-relic-browser/troubleshooting/app-server-requests-greatly-outnumber-browser-pageview-transactions
-          - title: AJAX call fails with a CORS redirect error message
-            path: /docs/browser/new-relic-browser/troubleshooting/ajax-call-fails-cors-redirect-error-message
+          - title: Get started
+            pages:
+              - title: Intro to browser monitoring
+                path: /docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring
+              - title: Compatibility and requirements
+                path: /docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring
+              - title: Browser agent release notes
+                path: /docs/browser/new-relic-browser/getting-started/browser-agent-release-notes
+              - title: Browser apps index
+                path: /docs/browser/new-relic-browser/getting-started/browser-apps-index
+              - title: Browser Summary page
+                path: /docs/browser/browser-monitoring/getting-started/browser-summary-page
+          - title: Guides
+            pages:
+              - title: Browser API and SPA API guide
+                path: /docs/browser/new-relic-browser/guides/guide-using-browser-spa-apis
+              - title: Browser monitoring best practices guide
+                path: /docs/browser/browser-monitoring/guides/browser-monitoring-best-practices-guide
+          - title: Installation
+            pages:
+              - title: Install Browser
+                path: /docs/browser/browser-monitoring/installation/install-browser-monitoring-agent
+              - title: Update the Browser agent
+                path: /docs/browser/new-relic-browser/installation/update-browser-agent
+              - title: Disable Browser monitoring
+                path: /docs/browser/new-relic-browser/installation/disable-browser-monitoring
+              - title: Delete apps from Browser
+                path: /docs/browser/new-relic-browser/installation/delete-apps-new-relic-browser
+              - title: Install Browser for AMP
+                path: /docs/browser/new-relic-browser/installation/monitor-amp-pages-new-relic-browser
+          - title: Configuration
+            pages:
+              - title: 'Browser Apdex, countries'
+                path: /docs/browser/new-relic-browser/configuration/browser-settings-ui-options-apdex-geography
+              - title: Privacy settings
+                path: /docs/browser/browser-monitoring/configuration/privacy-settings
+              - title: Rename Browser apps
+                path: /docs/browser/new-relic-browser/configuration/rename-browser-apps
+              - title: Domain settings
+                path: /docs/browser/new-relic-browser/configuration/monitor-or-block-specific-domains-subdomains
+              - title: Metrics by URL patterns
+                path: /docs/browser/new-relic-browser/configuration/group-browser-metrics-urls
+              - title: License key and app ID
+                path: /docs/browser/browser-monitoring/configuration/browser-license-key-app-id
+              - title: Alerts in Browser
+                path: /docs/browser/new-relic-browser/configuration/view-browser-apps-alert-information
+          - title: Browser agent and SPA API
+            path: /docs/browser/new-relic-browser/browser-agent-spa-api
+            pages:
+              - title: View all methods
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/view-all-methods
+              - title: addPageAction
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action
+              - title: addRelease
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/add-release
+              - title: addToTrace
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/addtotrace-browser-agent-api
+              - title: finished
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/finished
+              - title: noticeError
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/noticeerror-browser-agent-api
+              - title: setCustomAttribute
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/setcustomattribute-browser-agent-api
+              - title: setErrorHandler
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/set-error-handler
+              - title: setPageViewName
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/setpageviewname-browser-agent-api
+              - title: 'SPA: actionText'
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/actiontext-browser-spa-api
+              - title: 'SPA: interaction'
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/interaction-browser-spa-api
+              - title: 'SPA: createTracer'
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/createtracer-browser-spa-api
+              - title: 'SPA: end'
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/end-browser-spa-api
+              - title: 'SPA: getContext'
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/getcontext-browser-spa-api
+              - title: 'SPA: ignore'
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/ignore-browser-spa-api
+              - title: 'SPA: onEnd'
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/spa-on-end
+              - title: 'SPA: save'
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/save-browser-spa-api
+              - title: 'SPA: setAttribute'
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/setattribute-browser-spa-api
+              - title: 'SPA: setCurrentRouteName'
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/setcurrentroutename-browser-spa-api
+              - title: 'SPA: setName'
+                path: /docs/browser/new-relic-browser/browser-agent-spa-api/setname-browser-spa-api
+          - title: Page load timing resources
+            pages:
+              - title: Page load timing process
+                path: /docs/browser/new-relic-browser/page-load-timing-resources/page-load-timing-process
+              - title: PageViewTiming event
+                path: /docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details
+              - title: Instrumentation for browser monitoring
+                path: /docs/browser/new-relic-browser/page-load-timing-resources/instrumentation-browser-monitoring
+              - title: Comparative charting
+                path: /docs/browser/new-relic-browser/page-load-timing-resources/compare-page-load-performance-browser-synthetics
+              - title: New Relic cookies used by Browser
+                path: /docs/browser/browser-monitoring/page-load-timing-resources/new-relic-cookies-used-browser
+              - title: Navigation start time unknown
+                path: /docs/browser/new-relic-browser/page-load-timing-resources/navigation-start-time-unknown
+              - title: Session cookies
+                path: /docs/browser/browser-monitoring/page-load-timing-resources/cookie-collection-session-tracking
+              - title: Cached pages
+                path: /docs/browser/new-relic-browser/page-load-timing-resources/cached-pages
+          - title: Browser Pro features
+            pages:
+              - title: SPA monitoring
+                path: /docs/browser/new-relic-browser/browser-pro-features/spa-monitoring
+              - title: AJAX page
+                path: /docs/browser/browser-monitoring/browser-pro-features/ajax-page-identify-time-consuming-calls
+              - title: JS errors page
+                path: /docs/browser/new-relic-browser/browser-pro-features/javascript-errors-page-detect-analyze-errors
+              - title: Error profiles
+                path: /docs/browser/new-relic-browser/browser-pro-features/browser-error-profiles-find-error-causes
+              - title: Session traces page
+                path: /docs/browser/browser-monitoring/browser-pro-features/session-traces-explore-webpages-life-cycle
+              - title: Filterable Geography page
+                path: /docs/browser/new-relic-browser/browser-pro-features/filterable-geography-webpage-metrics-location
+              - title: Browser data in distributed tracing
+                path: /docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing
+              - title: Upload source maps
+                path: /docs/browser/browser-monitoring/browser-pro-features/upload-source-maps-un-minify-js-errors
+              - title: Source map API
+                path: /docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-api
+          - title: Additional standard features
+            pages:
+              - title: Page views page
+                path: /docs/browser/new-relic-browser/additional-standard-features/page-views-examine-page-performance
+              - title: Browsers page
+                path: /docs/browser/new-relic-browser/additional-standard-features/browsers-problem-patterns-type-or-platform
+              - title: Geography page
+                path: /docs/browser/new-relic-browser/additional-standard-features/browser-geography-webpage-performance-location
+          - title: Performance quality
+            pages:
+              - title: Security for Browser
+                path: /docs/browser/new-relic-browser/performance-quality/security-browser-monitoring
+              - title: Browser monitoring and performance impact
+                path: /docs/browser/new-relic-browser/performance-quality/browser-monitoring-performance-impact
+              - title: Browser monitoring and SEO
+                path: /docs/browser/new-relic-browser/performance-quality/browser-monitoring-search-engine-optimization
+          - title: Troubleshooting
+            pages:
+              - title: Troubleshooting installation
+                path: /docs/browser/browser-monitoring/troubleshooting/troubleshoot-your-browser-monitoring-installation
+              - title: Data doesn't match other tools
+                path: /docs/browser/new-relic-browser/troubleshooting/browser-data-doesnt-match-other-analytics-tools
+              - title: View detailed error logs
+                path: /docs/browser/new-relic-browser/troubleshooting/view-detailed-error-logs-browser
+              - title: AJAX data collection
+                path: /docs/browser/new-relic-browser/troubleshooting/troubleshoot-ajax-data-collection
+              - title: Session trace collection
+                path: /docs/browser/new-relic-browser/troubleshooting/troubleshooting-session-trace-collection
+              - title: AngularJS errors do not appear
+                path: /docs/browser/new-relic-browser/troubleshooting/angularjs-errors-do-not-appear
+              - title: Accelerated mobile pages (AMP)
+                path: /docs/browser/new-relic-browser/troubleshooting/google-amp-validator-fails-due-3rd-party-script
+              - title: HAR data collection
+                path: /docs/browser/new-relic-browser/troubleshooting/get-browser-side-troubleshooting-details-har-file
+              - title: Not seeing specific page names
+                path: /docs/browser/new-relic-browser/troubleshooting/not-seeing-specific-page-or-endpoint-names-browser-data
+              - title: JavaScript injection causes problems
+                path: /docs/browser/new-relic-browser/troubleshooting/browser-javascript-injection-causes-problems-page
+              - title: JS errors missing traces
+                path: /docs/browser/new-relic-browser/troubleshooting/third-party-js-errors-missing-stack-traces
+              - title: RPM higher than PPM
+                path: /docs/browser/new-relic-browser/troubleshooting/app-server-requests-greatly-outnumber-browser-pageview-transactions
+              - title: AJAX call fails with a CORS redirect error message
+                path: /docs/browser/new-relic-browser/troubleshooting/ajax-call-fails-cors-redirect-error-message
+      - title: Single page app monitoring   
+        pages: 
+          - title: Get started 
+            pages: 
+              - title: Introduction to Single Page App monitoring
+                path: /docs/browser/single-page-app-monitoring/get-started/introduction-single-page-app-monitoring
+              - title: SPA compatibility and requirements
+                path: /docs/browser/single-page-app-monitoring/get-started/spa-compatibility-requirements
+              - title: Install Single Page App monitoring
+                path: /docs/browser/single-page-app-monitoring/get-started/install-single-page-app-monitoring
+          - title: Use SPA data
+            pages: 
+              - title: View SPA data in Browser UI
+                path: /docs/browser/single-page-app-monitoring/use-spa-data/view-spa-data-browser-ui
+              - title: SPA data collection
+                path: /docs/browser/single-page-app-monitoring/use-spa-data/spa-data-collection
+              - title: Browser/SPA NRQL query examples
+                path: /docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/browserspa-nrql-query-examples
+              - title: Use SPA API
+                path: /docs/browser/single-page-app-monitoring/use-spa-data/use-spa-api  
+          - title: Troubleshooting
+            pages:
+              - title: Missing route changes with SPA agent
+                path: /docs/browser/single-page-app-monitoring/troubleshooting/missing-route-changes-spa-agent   
   - title: Infrastructure monitoring
     path: /docs/infrastructure
     pages:


### PR DESCRIPTION
### Tell us why

In the migration from Drupal to Gatsby, the docs related to single-page apps were not included in the left navigation. Evidently, the migration just moved navigation sub-category item " Browser monitoring." 

### Anything else you'd like to share?

To fix this, I moved the navigation category "Browser monitoring" down one level and created a sibling category of "Single page app monitoring." I then created the main navigation node for these related topics as "Browser" and is a sibling to other main topics, such as APM and Logs.

The one thing that doesn't quite match Drupal is that when you go to "View all Browser docs," you'll see that I had to rename the landing page from "Browser monitoring" to just "Browser" to avoid two stacked, identical headers on that TOC page. So, the new browser landing page now just says "Browser"; I hope that is OK!

You can compare this with Drupal at https://docs-dev.newrelic.com/docs/browser