### PR TITLE
Guided Install now enabled process monitoring

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -2560,7 +2560,7 @@ If the agent is running in a cloud instance, the agent will try to detect the cl
   >
     <Callout variant="important">
       Requires infrastructure agent version 1.12.0 or higher.
-      Accounts created before July 20, 2020 and/or infrastructure agents installed using the new Guided Install have this enabled by default.
+      Accounts created before July 20, 2020 and/or infrastructure agents installed using the new Guided Install have this variable enabled by default.
 
     </Callout>
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -2560,8 +2560,8 @@ If the agent is running in a cloud instance, the agent will try to detect the cl
   >
     <Callout variant="important">
       Requires infrastructure agent version 1.12.0 or higher.
+      Accounts created before July 20, 2020 and/or infrastructure agents installed using the new Guided Install have this enabled by default.
 
-      Accounts created before July 20, 2020 have this enabled by default.
     </Callout>
 
     Enables the sending of [process metrics](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8412) to New Relic.


### PR DESCRIPTION
Highlighting that enable_process_metrics is now enabled by default when using the Guided Install

<!-- Thanks for contributing to our docs! Your changes will help thousands of
New Relic users around the world. -->

<!-- Fill out this template to help us review your changes and route them to the
best team. See our [README.md](https://github.com/newrelic/docs-website/) for
information on how to contribute. -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Tell us why

The new Guided Install flow is setting enable_process_metric enabled by default. This helps new New Relic customers experience all NR1 features around process monitoring.

### Anything else you'd like to share?

Some customers asked if Guided Install is enabling process monitoring by default in the infrastructure agent. 

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.
