### PR TITLE
Add rename logic to getAgentName

### DIFF
--- a/src/utils/getAgentName.js
+++ b/src/utils/getAgentName.js
@@ -16,16 +16,28 @@ const AGENTS = [
   'sdk',
 ];
 
+// keeping the naming streamlined and in matching with previous data
+const RENAMES = { '.net': 'dotnet', node: 'nodejs' };
+
 /**
  * @param {string} subject The release note "subject" in frontmatter
  * @returns {string}
  */
-const getAgentName = (subject) =>
-  subject &&
-  AGENTS.find(
-    (agent) =>
-      subject.toLowerCase().includes(agent) &&
-      !subject.toLowerCase().includes('insights')
-  );
+
+const renameKeys = Object.keys(RENAMES);
+
+const getAgentName = (subject) => {
+  if (subject) {
+    const subjLowercase = subject.toLowerCase();
+    const agentName = AGENTS.find(
+      (agent) =>
+        subjLowercase.includes(agent) && !subjLowercase.includes('insights')
+    );
+
+    return agentName && renameKeys.includes(agentName)
+      ? RENAMES[agentName]
+      : agentName;
+  }
+};
 
 module.exports = getAgentName;

--- a/src/utils/getAgentName.js
+++ b/src/utils/getAgentName.js
@@ -24,8 +24,6 @@ const RENAMES = { '.net': 'dotnet', node: 'nodejs' };
  * @returns {string}
  */
 
-const renameKeys = Object.keys(RENAMES);
-
 const getAgentName = (subject) => {
   if (subject) {
     const subjLowercase = subject.toLowerCase();
@@ -34,9 +32,7 @@ const getAgentName = (subject) => {
         subjLowercase.includes(agent) && !subjLowercase.includes('insights')
     );
 
-    return agentName && renameKeys.includes(agentName)
-      ? RENAMES[agentName]
-      : agentName;
+    return RENAMES[agentName] || agentName;
   }
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! Your changes will help thousands of
New Relic users around the world. -->

<!-- Fill out this template to help us review your changes and route them to the
best team. See our [README.md](https://github.com/newrelic/docs-website/) for
information on how to contribute. -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Currently https://docs.newrelic.com/api/agent-release-notes.json outputs entries for both `nodejs` and `node` as well as `.net` and `dotnet`. This PR simplifies these entries and renames `.net` and `node` to `dotnet` and `nodejs`. This is in line with the naming used in a previous service