### PR TITLE
Second kafka pr for issue 1123

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
@@ -1277,8 +1277,57 @@ Troubleshooting tips:
   >
     Ensure that `zookeeper_path` is set correctly in the [configuration file](#config).
   </Collapser>
+
+  <Collapser
+    id="jmx-connection-errors"
+    title="JMX connection errors"
+  >
+    The Kafka integration uses a JMX helper tool called nrjmx to retrieve JMX metrics from brokers, consumers, and producers. JMX needs to be enabled and configured on all brokers in the cluster. Also, firewalls need to be tuned to allow connections from the host running the integration to the brokers over the JMX port.
+
+    To check whether JMX is correctly configured, run the following command for each broker from the machine running the Kafka integration. Replace the highlighted <var>PORT</var>, <var>USERNAME</var>, and <var>PASSWORD</var> tokens with the corresponding JMX settings for the brokers:
+
+    ```
+    $ echo ":" | nrjmx -hostname <var>HOSTNAME</var> -port <var>PORT</var> -v -username <var>USERNAME</var> -password <var>PASSWORD</var>    
+    ```
+
+    The command should generate the output showing a long series of metrics without any errors.
+
+  </Collapser>
+
+    <Collapser
+    id="kerberos-authentication"
+    title="Kerberos authentication failing"
+  >
+    The integration might show an error like the following:
+
+    ```
+    KRB Error: (6) KDC_ERR_C_PRINCIPAL_UNKNOWN Client not found in Kerberos database
+    ```
+
+    Check the keytab with kinit command. Replace the highlighted fields with your values:
+
+    ```
+    $ kinit -k -t <var>KEY_TAB_PATH</var> <var>USERNAME</var>
+    ```
+
+    If the username/keytab combination is correct, the command above should finish without printing any errors.
+
+    Check the realm using klist command:
+
+    ```
+    $ klist |grep "Default principal:"
+    ```
+
+    You should see something like this:
+
+    ```
+    Default principal: johndoe@a_realm_name
+    ```
+
+    Check that the printed user name and realm match the `sasl_gssapi_realm` and `sasl_gssapi_username` parameters in the integration configuration.
+  </Collapser>
 </CollapserGroup>
 
 ## Check the source code [#source-code]
 
-This integration is open source software. That means you can [browse its source code](https://github.com/newrelic/nri-kafka "Link opens in a new window.") and send improvements, or create your own fork and build it.
+This integration is open source software. That means you can [browse its source code](https://github.com/newrelic/nri-kafka "Link opens in a new window.") and send improvements or create your own fork and build it.

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
@@ -1282,16 +1282,14 @@ Troubleshooting tips:
     id="jmx-connection-errors"
     title="JMX connection errors"
   >
-    The Kafka integration uses a JMX helper tool called nrjmx to retrieve JMX metrics from brokers, consumers, and producers. JMX needs to be enabled and configured on all brokers in the cluster. Also, firewalls need to be tuned to allow connections from the host running the integration to the brokers over the JMX port.
+    The Kafka integration uses a JMX helper tool called `nrjmx` to retrieve JMX metrics from brokers, consumers, and producers. JMX needs to be enabled and configured on all brokers in the cluster. Also, firewalls need to be tuned to allow connections from the host running the integration to the brokers over the JMX port.
 
     To check whether JMX is correctly configured, run the following command for each broker from the machine running the Kafka integration. Replace the highlighted <var>PORT</var>, <var>USERNAME</var>, and <var>PASSWORD</var> tokens with the corresponding JMX settings for the brokers:
 
     ```
     $ echo ":" | nrjmx -hostname <var>HOSTNAME</var> -port <var>PORT</var> -v -username <var>USERNAME</var> -password <var>PASSWORD</var>    
     ```
-
     The command should generate the output showing a long series of metrics without any errors.
-
   </Collapser>
 
     <Collapser


### PR DESCRIPTION
### Tell us why

The migration from Drupal had dropped several changes in the Kafka doc. In a previous [PR] (https://github.com/newrelic/docs-website/pull/1388), I had restored the missing "preparation" section that was missing, but I overlooked two troubleshooting sections further down in the document. 

This PR is to restore those two troubleshooting sections:
* JMX connection errors
* Kerberos authentication failing

Closes #1123  
