### PR TITLE
fix: Corrects NRQL query and adds evaulation clarification

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-users/usage-queries-alerts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-users/usage-queries-alerts.mdx
@@ -80,7 +80,7 @@ Here are some data usage query examples:
     id="month-cost"
     title="Month-to-date estimated data cost"
   >
-    This query shows the estimated cost of your ingested data:
+    This query shows the estimated cost of your ingested data for the current month:
 
     ```
     FROM NrMTDConsumption SELECT latest(estimatedCost) 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-users/usage-queries-alerts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-users/usage-queries-alerts.mdx
@@ -153,7 +153,7 @@ Here are some user-related query examples. For details on how users are counted,
 To help [manage your billable data](/docs/telemetry-data-platform/get-data-new-relic/manage-data/manage-your-data), you can set alerts to notify you of unexpected increases in usage. To learn about how to create alerts, see [Alert workflow](/docs/alerts/new-relic-alerts/getting-started/new-relic-alerts-concepts-workflow#workflow).
 
 <Callout variant="caution">
-  Usage and consumption data are published every hour.  When creating alert conditions, [Condition Thresholds](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/#signal-loss) and [Evaluation offset](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions#h2-evaluation-offset) should be set to 60 minutes or your conditions may not trigger.
+  Usage and consumption data are published every hour.  For this reason, when creating alert conditions, [condition thresholds](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/#signal-loss) and [evaluation offset](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions#h2-evaluation-offset) should be set to 60 minutes or your conditions may not trigger.
 </Callout>
 
 Here are some NRQL alert condition examples. For attribute definitions, see [Attributes](#attributes).

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-users/usage-queries-alerts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-users/usage-queries-alerts.mdx
@@ -84,7 +84,7 @@ Here are some data usage query examples:
 
     ```
     FROM NrMTDConsumption SELECT latest(estimatedCost) 
-       WHERE productLine = 'DataPlatform' SINCE this month
+       WHERE productLine = 'DataPlatform'
     ```
   </Collapser>
 </CollapserGroup>
@@ -153,7 +153,7 @@ Here are some user-related query examples. For details on how users are counted,
 To help [manage your billable data](/docs/telemetry-data-platform/get-data-new-relic/manage-data/manage-your-data), you can set alerts to notify you of unexpected increases in usage. To learn about how to create alerts, see [Alert workflow](/docs/alerts/new-relic-alerts/getting-started/new-relic-alerts-concepts-workflow#workflow).
 
 <Callout variant="caution">
-  When creating alert conditions, you should set the [Evaluation offset](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions#h2-evaluation-offset) value to 60 minutes or your conditions may not trigger.
+  Usage and consumption data are published every hour.  When creating alert conditions, [Condition Thresholds](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/#signal-loss) and [Evaluation offset](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions#h2-evaluation-offset) should be set to 60 minutes or your conditions may not trigger.
 </Callout>
 
 Here are some NRQL alert condition examples. For attribute definitions, see [Attributes](#attributes).


### PR DESCRIPTION
This PR updates the language of the usage alerting page:
* Removes invalid `SINCE` clause from NRQL example
* Clarifies time window language to outline relationship to hourly usage/consumption events