### PR TITLE
Add ssl-checker to supported 3rd party modules

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/manage-monitor-runtimes.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/manage-monitor-runtimes.mdx
@@ -363,6 +363,7 @@ Here are monitor version details for all [monitor types](/docs/synthetics/new-re
       * [request](https://www.npmjs.com/package/request) 2.88.0
       * [should](https://github.com/shouldjs/should.js) 13.2.3
       * [ssh2-sftp-client](https://www.npmjs.com/package/ssh2-sftp-client) 5.3.1
+      * [ssl-checker](https://github.com/dyaa/ssl-checker) 2.0.5
       * [text-encoding](https://www.npmjs.com/package/text-encoding) 0.7.0
       * [thrift](https://www.npmjs.com/package/thrift) 0.11.0
       * [tough-cookie](https://github.com/SalesforceEng/tough-cookie) 3.0.0


### PR DESCRIPTION
Adds ssl-checker to list of supported 3rd party modules for latest Synthetic Monitor Version

<!-- Thanks for contributing to our docs! Your changes will help thousands of
New Relic users around the world. -->

<!-- Fill out this template to help us review your changes and route them to the
best team. See our [README.md](https://github.com/newrelic/docs-website/) for
information on how to contribute. -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Tell us why

The Synthetics Runtime will be adding support for a new 3rd party module for the latest runtime, so we'd like to disclose that package in our documentation

### Anything else you'd like to share?

<img width="976" alt="SSL Checker Support in Synthetics" src="https://user-images.githubusercontent.com/72999039/112904575-ff27dd80-909d-11eb-9492-914d9105d393.png">

### Are you making a change to site code?

N/A
