### PR TITLE
Update compatibility-requirements-java-agent.mdx

### DIFF
--- a/src/content/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -28,6 +28,135 @@ Before you install the Java agent, ensure your system meets these requirements:
     <Callout variant="tip">
       The Java agent is compatible with any JVM-based language, including: Java, Scala, Kotlin, and Clojure. For instrumentation support for language-specific features, see the [Automatically instrumented frameworks and libraries](#auto-instrumented) section below.
     </Callout>
+    
+    
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: "200px" }}>
+            Java Version
+          </th>
+
+          <th>
+            Agent Support
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            Java 5
+          </td>
+
+          <td>
+            Agent v1.3.0 to v2.21.4
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Java 6
+          </td>
+
+          <td>
+            Agent v3.0.0 to v4.3.0
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Java 7
+          </td>
+
+          <td>
+            Agent v3.0.0 to current
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Java 8
+          </td>
+
+          <td>
+            Agent v3.10.0 to current
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Java 9
+          </td>
+
+          <td>
+            Agent v3.43.0 to current
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Java 10
+          </td>
+
+          <td>
+            Agent v4.4.0 to current
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Java 11
+          </td>
+
+          <td>
+            Agent v4.7.0 to current
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Java 12
+          </td>
+
+          <td>
+            Agent v4.12.0 to current
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Java 13
+          </td>
+
+          <td>
+            Agent v5.7.0 to current
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Java 14
+          </td>
+
+          <td>
+            Agent v5.11.0 to current
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Java 15
+          </td>
+
+          <td>
+            Agent v6.1.0 to current
+          </td>
+        </tr>
+
+      </tbody>
+    </table>
+
 
     Fully supported:
 

--- a/src/content/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -34,11 +34,11 @@ Before you install the Java agent, ensure your system meets these requirements:
       <thead>
         <tr>
           <th style={{ width: "200px" }}>
-            Java Version
+            Java version
           </th>
 
           <th>
-            Agent Support
+            Agent support
           </th>
         </tr>
       </thead>


### PR DESCRIPTION
Add Java version support table. Not sure if I got the formatting right in the PR but this is supposed to generate a table under the JVM `Collapser` such as the following:

| Java Version | Agent Support  |
|---|---|
|  Java 5 |  Agent v1.3.0 to v2.21.4 |  
|  Java 6 |  Agent v3.0.0 to v4.3.0 |  
|  Java 7 |  Agent v3.0.0 to current |  
|  Java 8 |  Agent v3.10.0 to current |  
|  Java 9 |  Agent v3.43.0 to current |  
|  Java 10 |  Agent v4.4.0 to current |  
|  Java 11 |  Agent v4.7.0 to current |  
|  Java 12 |  Agent v4.12.0 to current |  
|  Java 13 |  Agent v5.7.0 to current |  
|  Java 14 |  Agent v5.11.0 to current |  
|  Java 15 |  Agent v6.1.0 to current |  