### PR TITLE
Remove unorthodox use of <mark> in inline text

### DIFF
--- a/src/content/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one.mdx
@@ -28,7 +28,7 @@ To access New Relic One:
 
 ## A more consistent and unified platform [#platform]
 
-Before our release of New Relic One, our platform was separated into various products, like APM, Browser, and Mobile. With our move to New Relic One, you can view and interact with all the data from across your entire system more easily. <mark>For more information, see our [New Relic One transition guide](/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-one-transition-guide-july-2020).</mark>
+Before our release of New Relic One, our platform was separated into various products, like APM, Browser, and Mobile. With our move to New Relic One, you can view and interact with all the data from across your entire system more easily. For more information, see our [New Relic One transition guide](/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-one-transition-guide-july-2020).
 
 ## Quickly understand context [#context]
 


### PR DESCRIPTION
Mark is meant for code https://docs.newrelic.com/docs/style-guide/writing-guidelines/code-formatting-guidelines-var-mark/