### PR TITLE
fix: Increase watermark size

### DIFF
--- a/src/components/Watermark.js
+++ b/src/components/Watermark.js
@@ -8,7 +8,7 @@ const Watermark = ({ text }) => (
     css={css`
       position: fixed;
       color: #eeeeee;
-      font-size: 8rem;
+      font-size: 18rem;
       transform: rotate(-15deg);
       z-index: -1;
       top: calc(var(--global-header-height) + 8rem);


### PR DESCRIPTION
This is a quick-fix for #1599. This does not close it as we should also look into changing the colors/contrast, but it works as a stop-gap. 

This simply increases the size of the watermark font from `8rem` to `18rem`