### PR TITLE
Adds release note naming convention note.

### DIFF
--- a/src/content/docs/style-guide/article-templates/create-release-notes.mdx
+++ b/src/content/docs/style-guide/article-templates/create-release-notes.mdx
@@ -16,12 +16,12 @@ redirects:
 To add either type of release note to the site:
 
 1. Find the most recent release note for your agent and make a copy of it.
-2. Use the established filenaming convention to name the new file. (see note below)
+2. Use the established filenaming convention to name the new file (see note below).
 3. Fill in the **subject**, **releaseDate**, **version**, and/or **watermark** fields.
 4. Write the content for your new release note, following the established pattern.
 5. Commit your changes and submit a pull request.
 
-> File Naming Note: To avoid potential naming conflicts, it is recommended to use a '-' to separate version parts in your file name. This may differ from your current convention. For example: Node.js agent v7.2.0 would result in the name: 'node-agent-7-2-0'.
+> File naming note: To avoid potential naming conflicts, we recommended to use a '-' to separate version parts in your file name, which may differ from your current convention. For example: Node.js agent v7.2.0 would result in the name: 'node-agent-7-2-0'.
 
 A Tech Docs hero will review your release note content and approve your pull request to get it published.
 

--- a/src/content/docs/style-guide/article-templates/create-release-notes.mdx
+++ b/src/content/docs/style-guide/article-templates/create-release-notes.mdx
@@ -16,11 +16,13 @@ redirects:
 To add either type of release note to the site:
 
 1. Find the most recent release note for your agent and make a copy of it.
-2. Use the established filenaming convention to name the new file.
+2. Use the established filenaming convention to name the new file. (see note below)
 3. Fill in the **subject**, **releaseDate**, **version**, and/or **watermark** fields.
 4. Write the content for your new release note, following the established pattern.
 5. Commit your changes and submit a pull request.
 
+> File Naming Note: To avoid potential naming conflicts, it is recommended to use a '-' to separate version parts in your file name. This may differ from your current convention. For example: Node.js agent v7.2.0 would result in the name: 'node-agent-7-2-0'.
+
 A Tech Docs hero will review your release note content and approve your pull request to get it published.
 
-We only build and deploy the site a few times a day, and currently builds can take a few hours to complete. If your release is time-sensitive, ensure you've planned for enough time to get the docs live. 
+We only build and deploy the site a few times a day, and currently builds can take a few hours to complete. If your release is time-sensitive, ensure you've planned for enough time to get the docs live.


### PR DESCRIPTION
Adding  a note per internal conversation [here](https://newrelic.slack.com/archives/C119L74HL/p1616620102034800?thread_ts=1616615375.033200&cid=C119L74HL) and external conversation here: https://github.com/newrelic/docs-website/issues/1255.

The note didn't really seem like it should be a super special callout like tips/warnings/etc. so I just used a quote formatting but y'all may decide you want styled different or not at all. Also, open to language or general changes too if you'd like approached a different way.