### PR TITLE
Fixes 'whats new' link on release note template page.

### DIFF
--- a/src/content/docs/style-guide/article-templates/create-release-notes.mdx
+++ b/src/content/docs/style-guide/article-templates/create-release-notes.mdx
@@ -10,7 +10,7 @@ redirects:
 ---
 
 <Callout variant="tip">
-  This page is for release notes for downloadable software. For product announcements, see [What's new style guidelines](/docs/style-guide/writing-guidelines/whats-new-style-guidelines).
+  This page is for release notes for downloadable software. For product announcements, see [What's new style guidelines](/docs/style-guide/article-templates/whats-new-style-guidelines/).
 </Callout>
 
 To add either type of release note to the site:


### PR DESCRIPTION
Fixes the broken "What's new style guidelines" link at the top of the 'create-relase-notes' page.

Current link 404s.