### PR TITLE
fix: newrelic-fluent-bit-output released version

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1161.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1161.mdx
@@ -12,5 +12,5 @@ New Relic recommends that you upgrade the agent regularly and at a minimum every
 - [#357](https://github.com/newrelic/infrastructure-agent/issues/357) An issue with the agent update that disabled `newrelic-infra-service` and remain the agent stopped.
 
 ## Changed
-- downgrade `newrelic-fluent-bit-output` to [v1.4.0](https://github.com/newrelic/newrelic-fluent-bit-output/tree/1.4.0)
+- Downgrade `newrelic-fluent-bit-output` to [v1.4.0](https://github.com/newrelic/newrelic-fluent-bit-output/tree/1.4.0).
 - `newrelic/infrastructure` agent [docker image](https://hub.docker.com/r/newrelic/infrastructure/tags?page=1&ordering=last_updated&name=latest) only for amd64.

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1161.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1161.mdx
@@ -12,5 +12,5 @@ New Relic recommends that you upgrade the agent regularly and at a minimum every
 - [#357](https://github.com/newrelic/infrastructure-agent/issues/357) An issue with the agent update that disabled `newrelic-infra-service` and remain the agent stopped.
 
 ## Changed
-- downgrade `fluent-bit` to [v1.4.1](https://github.com/newrelic/newrelic-fluent-bit-output/tree/1.4.1)
+- downgrade `newrelic-fluent-bit-output` to [v1.4.0](https://github.com/newrelic/newrelic-fluent-bit-output/tree/1.4.0)
 - `newrelic/infrastructure` agent [docker image](https://hub.docker.com/r/newrelic/infrastructure/tags?page=1&ordering=last_updated&name=latest) only for amd64.


### PR DESCRIPTION
### Tell us why
* `newrelic-fluent-bit-output` included in the last released agent was with wrong version.
