### PR TITLE
Fix issue with collapser ID

### DIFF
--- a/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -510,7 +510,7 @@ The `service` element supports the following attributes:
   </Collapser>
 
   <Collapser
-    id="service-sendDataOnExitThreshold"
+    id="service-completeTransactionsOnThread"
     title="completeTransactionsOnThread"
   >
     <table>


### PR DESCRIPTION
### Tell us why

The `completeTransactionsOnThread` service config section could not be linked to because the collapser ID was incorrect.

