### PR TITLE
Script for fetching all translated content (serialized)

### DIFF
--- a/scripts/actions/utils/handlers.js
+++ b/scripts/actions/utils/handlers.js
@@ -83,6 +83,10 @@ module.exports = {
     deserialize: deserializeComponent,
     serialize: serializeComponent,
   },
+  ButtonGroup: {
+    deserialize: deserializeComponent,
+    serialize: serializeComponent,
+  },
   Callout: {
     deserialize: deserializeComponent,
     serialize: (h, node) =>
@@ -131,6 +135,14 @@ module.exports = {
       serializeComponent(h, node, { textAttributes: ['title'] }),
   },
   LandingPageTileGrid: {
+    deserialize: deserializeComponent,
+    serialize: serializeComponent,
+  },
+  LandingPageHero: {
+    deserialize: deserializeComponent,
+    serialize: serializeComponent,
+  },
+  HeroContent: {
     deserialize: deserializeComponent,
     serialize: serializeComponent,
   },
@@ -229,5 +241,26 @@ module.exports = {
         identifyComponent: false,
         tagName: 'mark',
       }),
+  },
+  figcaption: {
+    deserialize: deserializeComponent,
+    serialize: serializeComponent,
+  },
+  dd: {
+    deserialize: deserializeComponent,
+    serialize: serializeComponent,
+  },
+  dt: {
+    deserialize: deserializeComponent,
+    serialize: serializeComponent,
+  },
+  img: {
+    deserialize: deserializeComponent,
+    serialize: (h, node) =>
+      serializeComponent(h, node, { textAttributes: ['alt'] }),
+  },
+  a: {
+    deserialize: deserializeComponent,
+    serialize: serializeComponent,
   },
 };

--- a/scripts/utils/migrate/get-serialized-i18n-content.js
+++ b/scripts/utils/migrate/get-serialized-i18n-content.js
@@ -1,0 +1,48 @@
+const path = require('path');
+const fs = require('fs');
+const serializeMDX = require('../../actions/serialize-mdx');
+
+const JP_DIR = 'src/i18n/content/jp/docs';
+const OUT_DIR = '~/Desktop';
+
+const pathJoin = (filepath) => (name) => path.join(filepath, name);
+const replace = (x, sub = '') => (str) => str.replace(x, sub);
+
+const isDirectory = (filepath) => fs.statSync(filepath).isDirectory();
+const isFile = (filepath) => fs.statSync(filepath).isFile();
+const isMdx = (filepath) => path.extname(filepath) === '.mdx';
+
+const getDirectories = (filepath) =>
+  fs.readdirSync(filepath).map(pathJoin(filepath)).filter(isDirectory);
+
+const getFiles = (filepath) =>
+  fs.readdirSync(filepath).map(pathJoin(filepath)).filter(isFile);
+
+const getFilesRecursively = (filepath) =>
+  getDirectories(filepath)
+    .flatMap(getFilesRecursively)
+    .reduce((acc, file) => [...acc, file], getFiles(filepath))
+    .filter(isMdx);
+
+const getContent = (filepath) =>
+  fs.readFileSync(path.join(process.cwd(), filepath));
+
+const serializeContent = async (filepaths) =>
+  Promise.all(filepaths.map(getContent).map(serializeMDX));
+
+const main = async () => {
+  try {
+    const jpFilePaths = getFilesRecursively(JP_DIR);
+    const enFilePaths = jpFilePaths.map(replace('i18n/content/jp', 'content'));
+
+    const serializedJPContent = await serializeContent(jpFilePaths);
+    const serializedEnContent = await serializeContent(enFilePaths);
+
+    // TODO: save
+  } catch (e) {
+    console.log('[!]', 'Unable to serialize content');
+    console.error(e);
+  }
+};
+
+main();

--- a/scripts/utils/migrate/get-serialized-i18n-content.js
+++ b/scripts/utils/migrate/get-serialized-i18n-content.js
@@ -25,10 +25,11 @@ const getFilesRecursively = (filepath) =>
     .reduce((acc, file) => [...acc, file], getFiles(filepath))
     .filter(isMdx);
 
-const getContent = (filepath) => fs.readFileSync(getFullPath(filepath));
+const getContent = (filepath) =>
+  fs.existsSync(filepath) ? fs.readFileSync(getFullPath(filepath)) : null;
 
 const serializeContent = async (filepaths) =>
-  Promise.all(filepaths.map(getContent).map(serializeMDX));
+  Promise.all(filepaths.map(getContent).filter(Boolean).map(serializeMDX));
 
 const writeFile = (filepaths, locale) => (content, index) => {
   const mdxFilepath = filepaths[index];


### PR DESCRIPTION
## Description
This PR adds a script that can be run to grab the serialized HTML version of all the MDX files that are being translated. Our translation vendor needed _all_ the files (EN and JP) to build up their database.

The serialization logic was already in place (it's how we send them content via GH Actions). While working on this, I found a few different components that didn't have methods for serializing / deserializing. I've added those as part of this PR, since they're needed for the script to run successfully.

## Related Issue(s)
* Relates to #995
