### PR TITLE
Added a redirect to a broken what's new link

### DIFF
--- a/src/content/docs/full-stack-observability/observe-everything/get-started/new-relic-guided-install-overview.mdx
+++ b/src/content/docs/full-stack-observability/observe-everything/get-started/new-relic-guided-install-overview.mdx
@@ -4,7 +4,9 @@ tags:
   - Full-Stack Observability
   - Observe everything
   - Get started
-metaDescription: Our guided installation is a single command that you can use to discover and start monitoring integrations on your system. 
+metaDescription: Our guided installation is a single command that you can use to discover and start monitoring integrations on your system.
+redirects:
+  - /docs/new-relic-guided-install-overview
 ---
 
 Instrument your systems and send telemetry data to New Relic with guided install. Our guided install creates a customized CLI command for your environment that downloads and installs the New Relic CLI and the infrastructure agent. 

--- a/src/content/whats-new/2021/03/guided-java-net.md
+++ b/src/content/whats-new/2021/03/guided-java-net.md
@@ -7,8 +7,6 @@ learnMoreLink: 'https://docs.newrelic.com/docs/new-relic-guided-install-overview
 ---
 We’ve made it simple to set up APM (Java and .NET) using our recently-launched guided installation flow, so you can instrument your systems and start analyzing your telemetry data in 5 minutes - no instrumentation expertise required.
 ​
-
 Our guided install creates a customized CLI command for your environment and the systems you want to instrument. And starting today, we now support Java and .NET APM agents. So no more reading through documentation and manual configuration. Just run guided install, and we’ll take care of the rest!
-​
 
 Get started by selecting **Add more data** and then choosing **Guided install**.


### PR DESCRIPTION
This March 31 what's new post had an invalid URL. I added a redirect for it.