### PR TITLE
chore: Update rest-api-calls-new-relic-infrastructure-alerts.mdx

### DIFF
--- a/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts.mdx
+++ b/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts.mdx
@@ -163,9 +163,7 @@ curl -v -X GET --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-starte
           "offset":0,
           "total":3
        },
-       "links":{
-          "next":"infra-api.newrelic.com/v2/alerts/conditions?limit=1\u0026offset=50\u0026policy_id=<var>111111</var>"
-       }
+       "links":{}
     }
     ```
   </Collapser>


### PR DESCRIPTION
Removing links value from JSON example. This is no longer supported

<!-- Thanks for contributing to our docs! Your changes will help thousands of
New Relic users around the world. -->

<!-- Fill out this template to help us review your changes and route them to the
best team. See our [README.md](https://github.com/newrelic/docs-website/) for
information on how to contribute. -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Tell us why

The links URL is no longer returned by the Infra Alert API

### Anything else you'd like to share?



### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.
