### PR TITLE
Fix formatting on schedulerSchedulingDurationSeconds_operation_OPERAT…

### DIFF
--- a/src/content/docs/integrations/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data.mdx
+++ b/src/content/docs/integrations/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data.mdx
@@ -2604,7 +2604,7 @@ Query the `K8sSchedulerSample` event in New Relic Insights to see Scheduler data
 
     <tr>
       <td>
-        s`chedulerSchedulingDurationSeconds_operation_OPERATION_sum`
+        `schedulerSchedulingDurationSeconds_operation_OPERATION_sum`
       </td>
 
       <td>


### PR DESCRIPTION
Just moving the `s` inside the backticks.