### PR TITLE
Update link in ios-agent-700.mdx

### DIFF
--- a/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
+++ b/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
@@ -4,8 +4,8 @@ const fromList = require('./utils/unist-fs-util-from-list');
 const generateHTML = require('./utils/generate-html');
 const { prop } = require('../../scripts/utils/functional.js');
 const { sentenceCase } = require('./utils/string');
-const taxonomyRedirects = require('../../src/data/taxonomy-redirects.json');
 const createLocalizedRedirect = require('../../gatsby/utils/create-localized-redirect');
+const taxonomyRedirects = require('../../src/data/taxonomy-redirects.json');
 
 exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
   const { skippedDirectories } = pluginOptions;

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-700.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-700.mdx
@@ -7,4 +7,4 @@ downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agen
 
 ### Notes
 
-The New Relic iOS agent is now deprecated. Please refer to the New Relic [XCFramework Agent](https://docs.newrelic.com/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-700) for iOS support.
+The New Relic iOS agent is now deprecated. Please refer to the New Relic [XCFramework Agent](https://docs.newrelic.com/docs/release-notes/mobile-release-notes/xcframework-release-notes/) for iOS support.


### PR DESCRIPTION
Link should point to the parent release notes page, not a specific (first) version

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve? prevents users from downloading incorrect version of XCFramework agent or from having to take extra steps to get to the most recent version
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.