### PR TITLE
Updated distributed tracing link on homepage so it points to the new …

### DIFF
--- a/src/data/homepage.yml
+++ b/src/data/homepage.yml
@@ -17,7 +17,7 @@ fso:
     - /docs/introduction-full-stack-observability
     - /docs/apm
     - /docs/browser
-    - /docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing
+    - /docs/distributed-tracing
     - /docs/infrastructure
     - /docs/logs/enable-logs/configure-logs-context/configure-logs-context-apm-agents
     - /docs/mobile-monitoring


### PR DESCRIPTION
…landing page for DT.

### Give us some context

In PR #1595, I created a new home page and quick start for distributed tracing. This is a follow up PR to change the link in the home page tile for distributed tracing. It should now point to the new landing page: /docs/distributed-tracing.

