### PR TITLE
Per GitHub issue 1664, updated code snippet.

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-agent-configuration-feature-flags.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-agent-configuration-feature-flags.mdx
@@ -30,7 +30,7 @@ All settings, including the call to invoke the agent, are called in the `onCreat
   ```
   NewRelic.withApplicationToken(<NEW_RELIC_TOKEN>)
           <mark>.withDefaultInteractions(false)</mark>
-          <mark>.withCrashReporting(true)</mark>
+          <mark>.withCrashReportingEnabled(true)</mark>
           .start(this.getApplication());
   ```
 


### PR DESCRIPTION
### Give us some context

A contributor mentioned in issue 1664 that there was a an incorrect API:

"withCrashReporting(true)" needed to be replaced by "withCrashReportingEnabled(true)"

I confirmed this with an SME.

closes #1664

