### PR TITLE
Added table of contents example to the end of the path for the final …

### DIFF
--- a/src/content/docs/style-guide/article-templates/landing-page-template.mdx
+++ b/src/content/docs/style-guide/article-templates/landing-page-template.mdx
@@ -93,7 +93,7 @@ Here's an example:
 ```
 <ButtonLink
   role="button"
-  to="<var>INSERT_LINK_TO_DIRECTORY_WITH_ALL_THESE_DOCS</var>"
+  to="<var>INSERT_LINK_TO_DIRECTORY_WITH_ALL_THESE_DOCS/table-of-contents</var>"
   variant="normal"
 >
   View all <var>INSERT_YOUR_CATEGORY_HERE</var> docs
@@ -174,7 +174,7 @@ type: landingPage
 
 <ButtonLink
   role="button"
-  to="<var>INSERT_LINK_TO_DIRECTORY_WITH_ALL_THESE_DOCS</var>"
+  to="<var>INSERT_LINK_TO_DIRECTORY_WITH_ALL_THESE_DOCS/table-of-contents</var>"
   variant="normal"
 >
   View all <var>INSERT_YOUR_CATEGORY_HERE</var> docs


### PR DESCRIPTION
### Give us some context

The final button at the bottom of our landing page template has a link to all the docs, which displays a table of contents page. To load this page, you need to have "/table-of-contents" following the path for the button, or else the page won't load (it just takes you to the node you were on).

