### PR TITLE
Disable deployment marker action until we've got versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,24 @@
-name: Release
+# name: Release
 
-on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - main
+# on:
+#   pull_request:
+#     types:
+#       - closed
+#     branches:
+#       - main
 
-jobs:
-  newrelic:
-    name: New Relic deployment marker
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set release version from tag
-        run: echo "RELEASE_VERSION=${{ GITHUB_REF:10 }}" >> $GITHUB_ENV
+# jobs:
+#   newrelic:
+#     name: New Relic deployment marker
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Set release version from tag
+#         run: echo "RELEASE_VERSION=${{ GITHUB_REF:10 }}" >> $GITHUB_ENV
 
-      - name: Create New Relic deployment marker
-        uses: newrelic/deployment-marker-action@v1
-        with:
-          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
-          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
-          applicationId: ${{ secrets.NEW_RELIC_APPLICATION_ID }}
-          revision: ${{ env.RELEASE_VERSION }}
+#       - name: Create New Relic deployment marker
+#         uses: newrelic/deployment-marker-action@v1
+#         with:
+#           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+#           accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+#           applicationId: ${{ secrets.NEW_RELIC_APPLICATION_ID }}
+#           revision: ${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
### Give us some context

Comments out the release workflow which depends on tags. We can uncomment this once we have some kind of versioning in place 

closes https://github.com/newrelic/docs-website/issues/1682