### PR TITLE
Trying to remove apdex references

### DIFF
--- a/src/content/docs/browser/browser-monitoring/getting-started/browser-summary-page.mdx
+++ b/src/content/docs/browser/browser-monitoring/getting-started/browser-summary-page.mdx
@@ -4,7 +4,7 @@ tags:
   - Browser
   - Browser monitoring
   - Getting started
-metaDescription: 'New Relic Browser''s Overview page displays a summary of your app''s browser-side performance, including page load timing, throughput, and Apdex charts.'
+metaDescription: 'New Relic Browser''s Overview page displays a summary of your app''s browser-side performance, including page load timing, and throughput charts.'
 redirects:
   - /docs/new-relic-browser/browser-overview
   - /docs/browser/new-relic-browser/dashboard-details/browser-overview-dashboard
@@ -35,7 +35,6 @@ To view a summary of browser performance for an app:
 The Summary page includes:
 
 * [Web transactions chart](#page_load)
-* [Apdex score chart](#apdex-chart)
 * [Throughput chart](#throughput-chart)
 * For Browser Pro: Charts for [JavaScript errors, AJAX response time, and browser session traces](#other-charts)
 
@@ -152,22 +151,6 @@ The **Web transactions** chart is the main chart on the Summary page. It shows a
       <tbody>
         <tr>
           <td>
-            Find deployments, outages, Apdex settings changes
-          </td>
-
-          <td>
-            Review the areas on the chart that indicate events and changes:
-
-            * Black vertical bar: Apdex settings have changed
-            * Blue vertical bar: Deployment
-            * Yellow or red area: This indicates alert thresholds have been violated.
-
-            To view additional details, mouse over the vertical bar.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
             Change chart data format
           </td>
 
@@ -205,55 +188,6 @@ The **Web transactions** chart is the main chart on the Summary page. It shows a
   </Collapser>
 </CollapserGroup>
 
-## Apdex chart
-
-The **Apdex** chart displays the end-user [Apdex](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction) for the selected time range and the average values for that period. For Browser apps also monitored by [APM](/docs/apm/new-relic-apm/getting-started/welcome-new-relic-apm), the chart also includes app server Apdex data.
-
-<Callout variant="tip">
-  The Apdex chart does not use SPA data: it only uses standard page view timing.
-</Callout>
-
-Other functions of this chart include:
-
-<table>
-  <thead>
-    <tr>
-      <th width={200}>
-        **If you want to...**
-      </th>
-
-      <th>
-        **Do this...**
-      </th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td>
-        Switch between Browser and APM
-      </td>
-
-      <td>
-        For Browser apps also monitored by [APM](/docs/apm/new-relic-apm/getting-started/welcome-new-relic-apm):
-
-        * To view the app's **Summary** page: Select the **App server** link.
-        * To return to the Browser **Summary** page: From the APM **Summary** page, select the **Browser** link.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        View [Apdex](/docs/apm/new-relic-apm/apdex/viewing-your-apdex-score) thresholds
-      </td>
-
-      <td>
-        Mouse over the <Icon name="fe-help-circle"/>
-        icon beside the **Apdex** chart title to see what Apdex thresholds you have set for both Browser and (if applicable) APM.
-      </td>
-    </tr>
-  </tbody>
-</table>
 
 ## Throughput chart
 


### PR DESCRIPTION
This is an interim fix to remove references to the depreciated Apdex chart, but the page will need more edits to update screenshots and add references to newer functionality. 