### PR TITLE
infrastructure agent 1.16.2 release notes

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1162.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1162.mdx
@@ -8,8 +8,11 @@ version: 1.16.2
 A new version of the agent has been released. Follow standard procedures to [update the Infrastructure agent](https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/update-or-uninstall/update-infrastructure-agent).  
 New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months.
 
-⚠️ We are releasing this version in a granular way. It means that we will release different asset type on different days (rpm, deb, msi, zip, targz, docker).
+<Callout variant="important">
+We're releasing this version in a granular way. This means that we will release different asset types on different days (RPM, DEB, MSI, zip, targz, Docker).
 This is required as we are releasing via our new open source build pipeline for the first time. Following releases will be done as usual, all assets at once.
+</Callout>
+
 
 ## Changed
 - `newrelic-fluent-bit-output` to [v1.4.1](https://github.com/newrelic/newrelic-fluent-bit-output/tree/1.4.1).

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1162.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1162.mdx
@@ -12,4 +12,4 @@ New Relic recommends that you upgrade the agent regularly and at a minimum every
 This is required as we are releasing via our new open source build pipeline for the first time. Following releases will be done as usual, all assets at once.
 
 ## Changed
-- Downgrade `newrelic-fluent-bit-output` to [v1.4.1](https://github.com/newrelic/newrelic-fluent-bit-output/tree/1.4.1).
+- `newrelic-fluent-bit-output` to [v1.4.1](https://github.com/newrelic/newrelic-fluent-bit-output/tree/1.4.1).

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1162.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1162.mdx
@@ -1,0 +1,15 @@
+---
+subject: Infrastructure agent
+releaseDate: '2021-04-06'
+version: 1.16.2
+---
+
+## Notes
+A new version of the agent has been released. Follow standard procedures to [update the Infrastructure agent](https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/update-or-uninstall/update-infrastructure-agent).  
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months.
+
+⚠️ We are releasing this version in a granular way. It means that we will release different asset type on different days (rpm, deb, msi, zip, targz, docker).
+This is required as we are releasing via our new open source build pipeline for the first time. Following releases will be done as usual, all assets at once.
+
+## Changed
+- Downgrade `newrelic-fluent-bit-output` to [v1.4.1](https://github.com/newrelic/newrelic-fluent-bit-output/tree/1.4.1).


### PR DESCRIPTION
* What problems does this PR solve?
This PR addresses new infrastructure agent release of version 1.16.2. This release is a bit special as we are doing it in a granular way. We may ask to update this page several times during the release process.
