### PR TITLE
Enabling related resources

### DIFF
--- a/.github/workflows/build-with-swiftype-content.yml
+++ b/.github/workflows/build-with-swiftype-content.yml
@@ -2,10 +2,8 @@ name: Build with Swiftype content
 
 on:
   workflow_dispatch:
-  # TODO: Figure out the schedule we want this to run on. For now, we'll run
-  # this on demand
-  # schedule:
-  #   - cron: '0 0 * * *' # start of every day
+  schedule:
+    - conr: '0 0 * 0 1,4 *' # start of the day on Monday and Thursday
 
 env:
   BOT_NAME: nr-opensource-bot

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,6 +8,7 @@ const getAgentName = require('./src/utils/getAgentName');
 
 const siteUrl = 'https://docs.newrelic.com';
 const dataDictionaryPath = `${__dirname}/src/data-dictionary`;
+const additionalLocales = ['jp'];
 const quote = (str) => `"${str}"`;
 
 const autoLinkHeaders = {
@@ -56,7 +57,7 @@ module.exports = {
         },
         i18n: {
           translationsPath: `${__dirname}/src/i18n/translations`,
-          additionalLocales: ['jp'],
+          additionalLocales,
         },
         prism: {
           languages: [
@@ -76,6 +77,7 @@ module.exports = {
             resultsPath: `${__dirname}/src/data/swiftype-resources.json`,
             engineKey: 'Ad9HfGjDw4GRkcmJjUut',
             refetch: Boolean(process.env.BUILD_RELATED_CONTENT),
+            limit: 3,
             filter: ({ node }) => {
               if (node.internal.type !== 'Mdx') {
                 return false;
@@ -106,6 +108,11 @@ module.exports = {
             getParams: ({ node }) => {
               const { tags, title } = node.frontmatter;
 
+              const locale = slug && slug.split('/')[0];
+              const postfix = additionalLocales.includes(locale)
+                ? `-${locale}`
+                : '';
+
               return {
                 q: tags ? tags.map(quote).join(' OR ') : title,
                 search_fields: {
@@ -113,7 +120,11 @@ module.exports = {
                 },
                 filters: {
                   page: {
-                    type: ['!blog', '!forum'],
+                    type: [
+                      `docs${postfix}`,
+                      `developer${postfix}`,
+                      `opensource${postfix}`,
+                    ],
                     document_type: [
                       '!views_page_menu',
                       '!term_page_api_menu',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -105,7 +105,7 @@ module.exports = {
                 includedTypes.includes(frontmatter.type)
               );
             },
-            getParams: ({ node }) => {
+            getParams: ({ node, slug }) => {
               const { tags, title } = node.frontmatter;
 
               const locale = slug && slug.split('/')[0];


### PR DESCRIPTION
## Description
Enables the "Build with swiftype" workflow to run twice a week and ensures that we're only showing related resources for the same language.

[Here](https://github.com/newrelic/docs-website/runs/2282202029?check_suite_focus=true) is an example of a successuful run of this workflow. I've also run this a few times on my machine (with one page, some pages, and all pages). I haven't run into any issues from _Swiftype_ so I think this work is...ready?

## Related Issue(s)
* Closes #1353

## Screenshot(s)
![Screen Shot 2021-04-06 at 4 42 36 PM](https://user-images.githubusercontent.com/1946433/113791120-cd46f480-96f7-11eb-9b67-195fab6b8d2d.png)
