### PR TITLE
Fix warnings on hot reload

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -384,7 +384,7 @@ const createPageFromNode = (
 
   if (process.env.NODE_ENV === 'development' && !template) {
     createPage({
-      path: path.join(prefix, slug),
+      path: path.join(prefix, slug, '/'),
       component: path.resolve(TEMPLATE_DIR, 'dev/missingTemplate.js'),
       context: {
         ...context,
@@ -394,7 +394,7 @@ const createPageFromNode = (
     });
   } else {
     createPage({
-      path: path.join(prefix, slug),
+      path: path.join(prefix, slug, '/'),
       component: path.resolve(path.join(TEMPLATE_DIR, `${template}.js`)),
       context: {
         ...context,

--- a/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
+++ b/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
@@ -159,7 +159,7 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
     }
 
     createPage({
-      path: slug,
+      path: path.join(slug, '/'),
       component: path.resolve('src/templates/indexPage.js'),
       context: {
         slug,
@@ -226,7 +226,7 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
           child.data.fields.slug = localizedFileSlug;
         });
       createPage({
-        path: localizedSlug,
+        path: path.join(localizedSlug, '/'),
         component: path.resolve('src/templates/indexPage.js'),
         context: {
           slug: localizedSlug,
@@ -246,7 +246,7 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
     const slug = path.join(landingPageSlug, 'table-of-contents');
 
     createPage({
-      path: slug,
+      path: path.join(slug, '/'),
       component: path.resolve('src/templates/tableOfContents.js'),
       context: {
         fileRelativePath: null,
@@ -266,7 +266,7 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
         ) || node;
 
       createPage({
-        path: localizedSlug,
+        path: path.join(localizedSlug, '/'),
         component: path.resolve('src/templates/tableOfContents.js'),
         context: {
           fileRelativePath: null,


### PR DESCRIPTION
The warnings are due to us creating pages without trailing slashes in docs-website, then in the theme the trailing slash is added. When we do a hot reload, we recreate pages without trailing slashes (like before), which produces this produces the warning we see.

To remediate this, added trailing slashes to the places where we use createPage in docs-website and set the path of the page.

Resolves #1385