### PR TITLE
Fixing the restoration of API do taxonomy

### DIFF
--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -132,7 +132,7 @@ pages:
           - title: API Explorer v2
             pages:
               - title: Introduction to New Relic's REST API Explorer
-                path: /docs/apis/rest-api-v2/api-explorer-v2/introduction-new-relics-rest-api-expl
+                path: /docs/apis/rest-api-v2/api-explorer-v2/introduction-new-relics-rest-api-explorer
               - title: Use the API Explorerorer
                 path: /docs/apis/rest-api-v2/api-explorer-v2/use-api-explorer
               - title: Retrieve metric timeslice data for your app (Explorer)
@@ -213,3 +213,28 @@ pages:
                 path: /docs/apis/rest-api-v2/troubleshooting/301-response-rest-api-calls
               - title: 500 error when starting the API Explorer
                 path: /docs/apis/rest-api-v2/troubleshooting/500-error-when-starting-api-explorer
+      - title: Synthetics REST API
+        pages:
+          - title: Monitor examples
+            pages:
+              - title: Manage synthetic monitors via REST API
+                path: /docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api
+              - title: Payload attributes for the Synthetics REST API
+                path: /docs/apis/synthetics-rest-api/monitor-examples/payload-attributes-synthetics-rest-api
+              - title: Synthetics REST API version 1 (deprecated)
+                path: /docs/synthetics/new-relic-synthetics/synthetics-api/synthetics-rest-api-version-1
+          - title: Label examples
+            pages:
+              - title: Add labels/tags to synthetic monitors (deprecated)
+                path: /docs/apis/synthetics-rest-api/label-examples/use-synthetics-label-apis
+          - title: Secure credentials examples
+            pages:
+              - title: Use synthetic monitoring secure credentials APIs
+                path: /docs/apis/synthetics-rest-api/secure-credentials-examples/use-synthetics-secure-credentials-apis
+      - title: REST API v1 deprecated
+        pages:
+          - title: New Relic REST API v1
+            pages:
+              - title: Working with the New Relic REST API (v1) (deprecated)
+                path: /docs/apis/rest-api-v1-deprecated/new-relic-rest-api-v1/working-new-relic-rest-api-v1-deprecated
+      

--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -172,7 +172,7 @@ pages:
               - title: Get host memory used for an application
                 path: /docs/apis/rest-api-v2/application-examples-v2/get-host-memory-used-application
               - title: Get average CPU usage per host for an app
-                path: /docs/apis/rest-api-v2/application-examples-v2/get-average-cpu-usage-host-a
+                path: /docs/apis/rest-api-v2/application-examples-v2/get-average-cpu-usage-host-app
               - title: Get average throughput for an app (v2)
                 path: /docs/apis/rest-api-v2/application-examples-v2/get-average-throughput-app-v2
               - title: Get web transaction time data (v2)

--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -59,10 +59,157 @@ pages:
       - title: 'Troubleshoot: Metric API'
         path: /docs/telemetry-data-platform/get-data/apis/troubleshoot-nrintegrationerror-events
   - title: APIs
+    path: /docs/apis
     pages:
-      - title: Intro to APIs
+      - title: Get started
         pages:
-          - title: New Relic APIs
-            path: /docs/apis/get-started/intro-apis/introduction-new-relic-apis
-          - title: API keys
-            path: /docs/apis/get-started/intro-apis/new-relic-api-keys
+          - title: Intro to APIs
+            pages:
+              - title: New Relic APIs
+                path: /docs/apis/get-started/intro-apis/introduction-new-relic-apis
+              - title: API keys
+                path: /docs/apis/get-started/intro-apis/new-relic-api-keys
+      - title: Nerdgraph
+        pages:
+          - title: Get Started
+            pages:
+              - title: Introduction to New Relic NerdGraph
+                path: /docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph
+          - title: Examples
+            pages:
+              - title: NerdGraph NRQL tutorial
+                path: /docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial
+              - title: Use NerdGraph to manage license keys and user keys
+                path: /docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys
+              - title: NerdGraph tagging API tutorial
+                path: /docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial
+              - title: NerdGraph distributed trace data tutorial
+                path: /docs/apis/nerdgraph/examples/nerdgraph-distributed-trace-data-tutorial
+              - title: NerdGraph entities API tutorial
+                path: /docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial
+              - title: Golden metrics for entities NerdGraph API tutorial 
+                path: /docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial
+              - title: NerdGraph workloads API tutorials
+                path: /docs/apis/nerdgraph/tutorials/nerdgraph-workloads-api-tutorials
+              - title: NerdGraph cloud integrations API tutorial
+                path: /docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial
+              - title: NerdGraph relationships API tutorial
+                path: /docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial
+              - title: Create widgets with the Dashboards API
+                path: /docs/apis/nerdgraph/examples/create-widgets-dashboards-api
+              - title: Export dashboards as PDF/PNG using the API
+                path: /docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api
+              - title: Export and import dashboards using the API
+                path: /docs/apis/nerdgraph/examples/export-import-dashboards-using-api
+              - title: Configure Infinite Tracing with GraphQL
+                path: /docs/apis/nerdgraph/examples/configure-infinite-tracing-graphql
+      - title: REST API v2
+        pages:
+          - title: Get started
+            pages: 
+              - title: Introduction to New Relic REST API (v2)
+                path: /docs/apis/rest-api-v2/get-started/introduction-new-relic-rest-api-v2
+              - title: New Relic partnership account authentication
+                path: /docs/apis/rest-api-v2/get-started/admin-users-api-key-partnerships
+              - title: List application ID, host ID, instance ID
+                path: /docs/apis/rest-api-v2/get-started/list-application-id-host-id-instance-id
+              - title: Get app and other IDs in New Relic One
+                path: /docs/apis/rest-api-v2/get-started/get-app-other-ids-new-relic-one
+          - title: Basic functions
+            pages:
+              - title: Pagination for API output
+                path: /docs/apis/rest-api-v2/basic-functions/pagination-api-output
+              - title: Specify a time range (v2)
+                path: /docs/apis/rest-api-v2/basic-functions/specify-time-range-v2
+              - title: Extract metric timeslice data
+                path: /docs/apis/rest-api-v2/basic-functions/extract-metric-timeslice-data
+              - title: Calculate average metric values (summarize)
+                path: /docs/apis/rest-api-v2/basic-functions/calculate-average-metric-values-summarize
+              - title: 'API overload protection: Handling 429 errors'
+                path: /docs/apis/rest-api-v2/basic-functions/api-overload-protection-handling-429-errors
+              - title: Set a custom user agent 
+                path: /docs/apis/rest-api-v2/basic-functions/set-custom-user-agent
+          - title: API Explorer v2
+            pages:
+              - title: Introduction to New Relic's REST API Explorer
+                path: /docs/apis/rest-api-v2/api-explorer-v2/introduction-new-relics-rest-api-expl
+              - title: Use the API Explorerorer
+                path: /docs/apis/rest-api-v2/api-explorer-v2/use-api-explorer
+              - title: Retrieve metric timeslice data for your app (Explorer)
+                path: /docs/apis/rest-api-v2/api-explorer-v2/retrieve-metric-timeslice-data-your-app-explorer
+          - title: Account admin and usage (v2)
+            pages:
+              - title: Listing users for your account
+                path: /docs/apis/rest-api-v2/account-examples-v2/listing-users-your-account
+              - title: Subscription usage APIs
+                path: /docs/apis/rest-api-v2/account-examples-v2/subscription-usage-apis
+          - title: Alerts examples (v2)
+            pages: 
+              - title: Alerts Rest API
+                path: /docs/apis/rest-api-v2/alert-examples-v2/rest-api-calls-new-relic-alerts
+              - title: Infrastructure alerting API
+                path: /docs/apis/rest-api-v2/alert-examples-v2/infrastructure-alerting-api
+          - title: Application examples (v2)
+            pages: 
+              - title: Recording deployments with the REST API (v2)
+                path: /docs/apis/rest-api-v2/application-examples-v2/recording-deployments-rest-api-v2
+              - title: List an app's host IDs and instance IDs
+                path: /docs/apis/rest-api-v2/application-examples-v2/application-reporting-health-status-v2
+              - title: List your app ID and metric timeslice data (v2)
+                path: /docs/apis/rest-api-v2/application-examples-v2/average-response-time-examples-v2
+              - title: Getting Apdex data for apps or browsers (v2)
+                path: /docs/apis/rest-api-v2/application-examples-v2/getting-apdex-data-apps-or-browsers-v2
+              - title: Summary data examples (v2)
+                path: /docs/apis/rest-api-v2/application-examples-v2/summary-data-examples-v2
+              - title: Average response time examples (v2)
+                path: /docs/apis/rest-api-v2/application-examples-v2/average-response-time-examples-v2
+              - title: Application error rate example (v2)
+                path: /docs/apis/rest-api-v2/application-examples-v2/application-error-rate-example-v2
+              - title: Application reporting and health status (v2)
+                path: /docs/apis/rest-api-v2/application-examples-v2/application-reporting-health-status-v2
+              - title: Change the alias for your application (v2)
+                path: /docs/apis/rest-api-v2/application-examples-v2/change-alias-your-application-v2
+              - title: Get host memory used for an application
+                path: /docs/apis/rest-api-v2/application-examples-v2/get-host-memory-used-application
+              - title: Get average CPU usage per host for an app
+                path: /docs/apis/rest-api-v2/application-examples-v2/get-average-cpu-usage-host-a
+              - title: Get average throughput for an app (v2)
+                path: /docs/apis/rest-api-v2/application-examples-v2/get-average-throughput-app-v2
+              - title: Get web transaction time data (v2)
+                path: /docs/apis/rest-api-v2/application-examples-v2/get-web-transaction-time-data-v2                                                      
+          - title: Browser examples (v2)
+            pages:
+              - title: Obtaining Browser (end user) page load time data (v2)
+                path: /docs/apis/rest-api-v2/browser-examples-v2/obtaining-browser-end-user-page-load-time-data-v2
+              - title: Average browser (end user) page throughput example (v2)
+                path: /docs/apis/rest-api-v2/browser-examples-v2/average-browser-end-user-page-throughput-example-v2
+              - title: Average browser page load time example (v2)
+                path: /docs/apis/rest-api-v2/browser-examples-v2/average-browser-page-load-time-example-v2
+              - title: Add or list Browser apps via API (v2)
+                path: /docs/apis/rest-api-v2/browser-examples-v2/add-or-list-browser-apps-api-v2
+          - title: Labels examples (v2)
+            pages:  
+              - title: Add, list, delete labels (deprecated)
+                path: /docs/apis/rest-api-v2/labels-examples-v2/create-labels-apps-v2
+          - title: Mobile examples (v2)
+            pages:
+              - title: Mobile crash count and crash rate example (v2)
+                path: /docs/apis/rest-api-v2/mobile-examples-v2/mobile-crash-count-crash-rate-example-v2
+          - title: Plugin examples (v2)
+            pages:
+              - title: Get a list of plugins (v2)
+                path: /docs/apis/rest-api-v2/plugin-examples-v2/get-list-plugins-v2
+              - title: Get individual plugin components (v2)
+                path: /docs/apis/rest-api-v2/plugin-examples-v2/get-individual-plugin-components-v2
+              - title: List multiple plugin components (v2)
+                path: /docs/apis/rest-api-v2/plugin-examples-v2/list-multiple-plugin-components-v2
+              - title: Listing metric timeslice data for plugin components (v2)
+                path: /docs/apis/rest-api-v2/plugin-examples-v2/listing-metrics-plugin-components-v2
+          - title: Troubleshooting
+            pages:
+              - title: 200 Status with API Explorer     
+                path: /docs/apis/rest-api-v2/troubleshooting/http-200-status-api-explorer
+              - title: 301 response for REST API calls
+                path: /docs/apis/rest-api-v2/troubleshooting/301-response-rest-api-calls
+              - title: 500 error when starting the API Explorer
+                path: /docs/apis/rest-api-v2/troubleshooting/500-error-when-starting-api-explorer


### PR DESCRIPTION
This restores the API category into the taxonomy. 

Please wait to review this until the Amplify preview is finished so we can test it easier! 