### PR TITLE
Doc 6691 fix 404s part 1

### DIFF
--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -319,7 +319,7 @@
     ]
   },
   {
-    "url": "/docs/synthetics/synthetic-monitoring/",
+    "url": "/docs/synthetics/synthetic-monitoring",
     "paths": [
       "/docs/new-relic-synthetics/new-relic-synthetics/miscellaneous",
       "/docs/synthetics/new-relic-synthetics/miscellaneous"
@@ -2031,7 +2031,7 @@
     ]
   },
   {
-    "url": "/docs/query-your-data/explore-query-data/new-relic-query-language",
+    "url": "/docs/query-your-data/explore-query-data",
     "paths": [
       "/docs/query-your-data/explore-query-data/nrql",
       "/docs/query-your-data/explore-query-data/nqrl",

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -697,7 +697,7 @@
     ]
   },
   {
-    "url": "/docs/infrastructure/new-relic-infrastructure/filter-group/",
+    "url": "/docs/infrastructure/manage-your-data/filter-group",
     "paths": [
       "/docs/infrastructure/new-relic-infrastructure/scope-filter",
       "/docs/infrastructure/new-relic-infrastructure/filter-group",
@@ -767,7 +767,7 @@
     ]
   },
   {
-    "url": "/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-alerts/",
+    "url": "/docs/alerts-applied-intelligence/rest-api-alerts/new-relic-alerts-rest-api",
     "paths": [
       "/docs/alerts/new-relic-alerts/rest-api-alerts",
       "/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api"
@@ -832,7 +832,7 @@
     ]
   },
   {
-    "url": "/docs/insights/use-insights-ui/manage-dashboards/set-time-range-insights-dashboards-charts",
+    "url": "/docs/insights/use-insights-ui/time-settings",
     "paths": [
       "/docs/insights/using-insights-ui/time-settings"
     ]
@@ -905,10 +905,9 @@
     ]
   },
   {
-    "url": "/docs/insights/use-insights-ui/manage-dashboards/export-insights-data-csv-file",
+    "url": "/docs/insights/use-insights-ui/export-data",
     "paths": [
-      "/docs/export-data",
-      "/docs/insights/use-insights-ui/export-data"
+      "/docs/export-data"
     ]
   },
   {
@@ -990,7 +989,7 @@
     ]
   },
   {
-    "url": "/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations",
+    "url": "/docs/infrastructure/integrations/types-integrations",
     "paths": [
       "/docs/infrastructure/integrations/integrations",
       "/docs/infrastructure/integrations-getting-started/integrations"
@@ -1554,7 +1553,7 @@
     ]
   },
   {
-    "url": "/docs/infrastructure/new-relic-infrastructure/troubleshooting",
+    "url": "/docs/infrastructure/infrastructure-monitoring-troubleshooting/troubleshoot-infrastructure",
     "paths": [
       "/docs/infrastructure/troubleshooting/infra-troubleshooting",
       "/docs/infrastructure/infrastructure-troubleshooting/infra-troubleshooting",
@@ -1715,7 +1714,7 @@
     ]
   },
   {
-    "url": "/docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/get-started/introduction-new-relic-cordova",
+    "url": "/docs/mobile-monitoring/new-relic-mobile-cordova/get-started",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/get-started"
     ]
@@ -1947,7 +1946,7 @@
     ]
   },
   {
-    "url": "/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/kubernetes-plugin-log-forwarding",
+    "url": "/docs/integrations/kubernetes-integration/kubernetes-plugin-logs",
     "paths": [
       "/docs/integrations/kubernetes-integration/logs",
       "/docs/infrastructure-integrations/kubernetes-integration/logs"
@@ -2184,7 +2183,7 @@
     ]
   },
   {
-    "url": "/docs/full-stack-observability/instrument-everything/get-started-new-relic-instrumentation/introduction-new-relic-integrations",
+    "url": "/docs/full-stack-observability/instrument-everything/instrument-your-code-infrastructure",
     "paths": [
       "/docs/full-stack-observability/instrument-everything/instrument-applications-infrastructure"
     ]
@@ -2254,7 +2253,7 @@
     ]
   },
   {
-    "url": "/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/enable-log-management-new-relic",
+    "url": "/docs/logs/log-management/enable-logs",
     "paths": [
       "/docs/logs/new-relic-logs/enable-logs",
       "/docs/logs/log-monitoring/enable-logs"

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -58,7 +58,7 @@
     ]
   },
   {
-    "url": "/docs/agents/python-agent/web-frameworks",
+    "url": "/docs/agents/python-agent",
     "paths": [
       "/docs/python/python-web-frameworks",
       "/docs/agents/python-agent/web-frameworks/python-web-frameworks"
@@ -335,13 +335,13 @@
     ]
   },
   {
-    "url": "/docs/new-relic-only/drupal-configuration/drupal-methods",
+    "url": "/docs/style-guide",
     "paths": [
       "/docs/new-relic-only/drupal-configuration/drupal-methods-insights"
     ]
   },
   {
-    "url": "/docs/alerts/new-relic-alerts/get-started",
+    "url": "/docs/alerts-applied-intelligence",
     "paths": [
       "/docs/alerts/alert-policies-v3/getting-started",
       "/docs/alerts/new-relic-alerting/getting-started",
@@ -437,7 +437,7 @@
     ]
   },
   {
-    "url": "/docs/apis/rest-api-v2/",
+    "url": "/docs/apis/rest-api-v2",
     "paths": [
       "/docs/apm/apis/server-examples-v2"
     ]
@@ -534,7 +534,7 @@
     ]
   },
   {
-    "url": "/docs/infrastructure/infrastructure-monitoring-ui/infrastructure-ui",
+    "url": "/docs/infrastructure/table-of-contents",
     "paths": [
       "/docs/servers/servers-dashboards",
       "/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages",
@@ -606,7 +606,7 @@
     ]
   },
   {
-    "url": "/docs/mobile-monitoring/new-relic-mobile/troubleshoot",
+    "url": "/docs/mobile-monitoring/new-relic-mobile",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile/troubleshooting"
     ]
@@ -619,7 +619,7 @@
     ]
   },
   {
-    "url": "/docs/mobile-monitoring/mobile-monitoring-ui/miscellaneous",
+    "url": "/docs/mobile-monitoring/mobile-monitoring-ui",
     "paths": [
       "/docs/mobile-monitoring/mobile-monitoring-uii/miscellaneous"
     ]
@@ -650,7 +650,7 @@
     ]
   },
   {
-    "url": "/docs/release-notes/browser-release-notes",
+    "url": "/docs/release-notes",
     "paths": [
       "/docs/release-notes/browser-agent-release-notes",
       "/docs/release-notes/new-relic-browser-release-notes"
@@ -671,7 +671,7 @@
     ]
   },
   {
-    "url": "/docs/apm/transactions/browser-traces",
+    "url": "/docs/apm/transactions",
     "paths": [
       "/docs/apm/traces/browser-traces"
     ]
@@ -749,7 +749,7 @@
     ]
   },
   {
-    "url": "/docs/infrastructure/manage-your-data/share-charts",
+    "url": "/docs/infrastructure/manage-your-data",
     "paths": [
       "/docs/infrastructure/new-relic-infrastructure/share-charts",
       "/docs/infrastructure/config-management-tools/share-charts"
@@ -812,7 +812,7 @@
     ]
   },
   {
-    "url": "/docs/insights/insights-api/get-data",
+    "url": "/docs/insights/table-of-contents",
     "paths": [
       "/docs/insights/export-insights-data/insights-rest-api",
       "/docs/insights/export-insights-data/export-api",
@@ -872,7 +872,7 @@
     ]
   },
   {
-    "url": "/docs/mobile-monitoring/new-relic-mobile-cordova",
+    "url": "/docs/mobile-monitoring/table-of-contents",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile-cordova-phonegap"
     ]
@@ -1147,7 +1147,7 @@
     ]
   },
   {
-    "url": "/docs/new-relic-only/tech-writer-style-guide/miscellaneous",
+    "url": "/docs/style-guide",
     "paths": [
       "/docs/new-relic-only/advanced-style-guide/miscellaneous"
     ]
@@ -1307,7 +1307,7 @@
     "url": "/docs/integrations/google-cloud-platform-integrations",
     "paths": [
       "/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list",
-      "/https:/docs.newrelidocs/infrastructure/integrations/google-cloud-platform-integrations",
+      "/docs.newrelidocs/infrastructure/integrations/google-cloud-platform-integrations",
       "/docs/infrastructure/integrations/types-integrations/google-cloud-integrations",
       "/docs/infrastructure/new-relic-infrastructure/integrations/gcp-integrations",
       "/docs/kubernetes-integration/google-cloud-platform-integrations/gcp-integrations-list",
@@ -1446,7 +1446,7 @@
     ]
   },
   {
-    "url": "/docs/apis/insights-apis/get-started",
+    "url": "/docs/apis/get-started",
     "paths": [
       "/docs/apis/insights-apis/getting-started"
     ]
@@ -1733,7 +1733,7 @@
     ]
   },
   {
-    "url": "/docs/mobile-monitoring/new-relic-mobile-react-native",
+    "url": "/docs/mobile-monitoring",
     "paths": [
       "/docs/mobile-extensible-agent-toc",
       "/docs/mobile-react-native-agent-toc"
@@ -1860,7 +1860,7 @@
     ]
   },
   {
-    "url": "/docs/mobile-monitoring/new-relic-mobile-react-native/install-configure",
+    "url": "/docs/mobile-monitoring",
     "paths": [
       "/docs/install-configure"
     ]
@@ -2024,7 +2024,7 @@
     ]
   },
   {
-    "url": "/docs/query-your-data/nrql-new-relic-query-language/query-tools",
+    "url": "/docs/query-your-data",
     "paths": [
       "/docs/query-data/nrql-new-relic-query-language/query-tools",
       "/docs/explore-query-data/nrql-new-relic-query-language/query-tools"
@@ -2064,7 +2064,7 @@
     ]
   },
   {
-    "url": "/docs/accounts/accounts-billing/automated-user-management",
+    "url": "/docs/accounts/accounts-billing",
     "paths": [
       "/docs/accounts/accounts/automated-user-management"
     ]
@@ -2102,7 +2102,7 @@
     ]
   },
   {
-    "url": "/docs/alerts-applied-intelligence/rest-api-alerts",
+    "url": "/docs/alerts-applied-intelligence",
     "paths": [
       "/docs/alerts/rest-api-alerts"
     ]
@@ -2227,7 +2227,7 @@
     ]
   },
   {
-    "url": "/docs/infrastructure/infrastructure-monitoring/guides",
+    "url": "/docs/infrastructure/infrastructure-monitoring",
     "paths": [
       "/docs/infrastructure/new-relic-infrastructure/guides"
     ]
@@ -2353,7 +2353,7 @@
     ]
   },
   {
-    "url": "/docs/browser/browser-monitoring/miscellaneous",
+    "url": "/docs/browser/browser-monitoring",
     "paths": [
       "/docs/browser/new-relic-browser/miscellaneous"
     ]

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -923,7 +923,7 @@
     ]
   },
   {
-    "url": "/docs/insights/insights-api",
+    "url": "docs/insights/table-of-contents",
     "paths": [
       "/docs/insights/export-insights-data"
     ]
@@ -996,7 +996,7 @@
     ]
   },
   {
-    "url": "/docs/insights/use-insights-ui/troubleshooting",
+    "url": "/docs/insights/use-insights-ui/",
     "paths": [
       "/docs/insights/nrql-new-relic-query-language/troubleshooting",
       "/docs/troubleshooting"
@@ -1009,7 +1009,7 @@
     ]
   },
   {
-    "url": "/docs/new-relic-only/basic-style-guide/writing-guidelines",
+    "url": "/docs/style-guide",
     "paths": [
       "/docs/new-relic-only/basic-style-guide/basic-style-guide"
     ]
@@ -1105,7 +1105,7 @@
     ]
   },
   {
-    "url": "/docs/security/security-privacy/security-bulletins",
+    "url": "/docs/security/security-privacy",
     "paths": [
       "/docs/accounts-partnerships/accounts/security-bulletins",
       "/docs/accounts-partnerships/welcome-new-relic/security-bulletins",
@@ -1580,7 +1580,7 @@
     ]
   },
   {
-    "url": "/docs/infrastructure/infrastructure-monitoring-troubleshooting/troubleshoot-logs",
+    "url": "/docs/infrastructure/infrastructure-troubleshooting",
     "paths": [
       "/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infra-logs",
       "/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs"
@@ -1946,7 +1946,7 @@
     ]
   },
   {
-    "url": "/docs/integrations/kubernetes-integration/kubernetes-plugin-logs",
+    "url": "/docs/integrations/kubernetes-integration/",
     "paths": [
       "/docs/integrations/kubernetes-integration/logs",
       "/docs/infrastructure-integrations/kubernetes-integration/logs"
@@ -2183,7 +2183,7 @@
     ]
   },
   {
-    "url": "/docs/full-stack-observability/instrument-everything/instrument-your-code-infrastructure",
+    "url": "/docs/full-stack-observability/instrument-everything",
     "paths": [
       "/docs/full-stack-observability/instrument-everything/instrument-applications-infrastructure"
     ]
@@ -2253,7 +2253,7 @@
     ]
   },
   {
-    "url": "/docs/logs/log-management/enable-logs",
+    "url": "/docs/logs/log-management",
     "paths": [
       "/docs/logs/new-relic-logs/enable-logs",
       "/docs/logs/log-monitoring/enable-logs"
@@ -2280,7 +2280,7 @@
     ]
   },
   {
-    "url": "/docs/synthetics/synthetic-monitoring/guides",
+    "url": "/docs/synthetics/table-of-contents",
     "paths": [
       "/docs/synthetics/new-relic-synthetics/guides"
     ]
@@ -2444,7 +2444,7 @@
     ]
   },
   {
-    "url": "/docs/full-stack-observability/instrument-everything/get-started",
+    "url": "/docs/full-stack-observability/instrument-everything",
     "paths": [
       "/docs/full-stack-observability/instrument-everything/get-started-new-relic-instrumentation"
     ]

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -697,7 +697,7 @@
     ]
   },
   {
-    "url": "/docs/infrastructure/manage-your-data/filter-group",
+    "url": "/docs/infrastructure/new-relic-infrastructure/filter-group/",
     "paths": [
       "/docs/infrastructure/new-relic-infrastructure/scope-filter",
       "/docs/infrastructure/new-relic-infrastructure/filter-group",
@@ -767,7 +767,7 @@
     ]
   },
   {
-    "url": "/docs/alerts-applied-intelligence/rest-api-alerts/new-relic-alerts-rest-api",
+    "url": "/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-alerts/",
     "paths": [
       "/docs/alerts/new-relic-alerts/rest-api-alerts",
       "/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api"
@@ -832,7 +832,7 @@
     ]
   },
   {
-    "url": "/docs/insights/use-insights-ui/time-settings",
+    "url": "/docs/insights/use-insights-ui/manage-dashboards/set-time-range-insights-dashboards-charts",
     "paths": [
       "/docs/insights/using-insights-ui/time-settings"
     ]
@@ -905,9 +905,10 @@
     ]
   },
   {
-    "url": "/docs/insights/use-insights-ui/export-data",
+    "url": "/docs/insights/use-insights-ui/manage-dashboards/export-insights-data-csv-file",
     "paths": [
-      "/docs/export-data"
+      "/docs/export-data",
+      "/docs/insights/use-insights-ui/export-data"
     ]
   },
   {
@@ -989,7 +990,7 @@
     ]
   },
   {
-    "url": "/docs/infrastructure/integrations/types-integrations",
+    "url": "/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations",
     "paths": [
       "/docs/infrastructure/integrations/integrations",
       "/docs/infrastructure/integrations-getting-started/integrations"
@@ -1553,7 +1554,7 @@
     ]
   },
   {
-    "url": "/docs/infrastructure/infrastructure-monitoring-troubleshooting/troubleshoot-infrastructure",
+    "url": "/docs/infrastructure/new-relic-infrastructure/troubleshooting",
     "paths": [
       "/docs/infrastructure/troubleshooting/infra-troubleshooting",
       "/docs/infrastructure/infrastructure-troubleshooting/infra-troubleshooting",
@@ -1714,7 +1715,7 @@
     ]
   },
   {
-    "url": "/docs/mobile-monitoring/new-relic-mobile-cordova/get-started",
+    "url": "/docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/get-started/introduction-new-relic-cordova",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/get-started"
     ]
@@ -1946,7 +1947,7 @@
     ]
   },
   {
-    "url": "/docs/integrations/kubernetes-integration/kubernetes-plugin-logs",
+    "url": "/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/kubernetes-plugin-log-forwarding",
     "paths": [
       "/docs/integrations/kubernetes-integration/logs",
       "/docs/infrastructure-integrations/kubernetes-integration/logs"
@@ -2183,7 +2184,7 @@
     ]
   },
   {
-    "url": "/docs/full-stack-observability/instrument-everything/instrument-your-code-infrastructure",
+    "url": "/docs/full-stack-observability/instrument-everything/get-started-new-relic-instrumentation/introduction-new-relic-integrations",
     "paths": [
       "/docs/full-stack-observability/instrument-everything/instrument-applications-infrastructure"
     ]
@@ -2253,7 +2254,7 @@
     ]
   },
   {
-    "url": "/docs/logs/log-management/enable-logs",
+    "url": "/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/enable-log-management-new-relic",
     "paths": [
       "/docs/logs/new-relic-logs/enable-logs",
       "/docs/logs/log-monitoring/enable-logs"

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -319,7 +319,7 @@
     ]
   },
   {
-    "url": "/docs/synthetics/synthetic-monitoring/miscellaneous",
+    "url": "/docs/synthetics/synthetic-monitoring/",
     "paths": [
       "/docs/new-relic-synthetics/new-relic-synthetics/miscellaneous",
       "/docs/synthetics/new-relic-synthetics/miscellaneous"
@@ -437,7 +437,7 @@
     ]
   },
   {
-    "url": "/docs/apis/rest-api-v2/server-examples-v2",
+    "url": "/docs/apis/rest-api-v2/",
     "paths": [
       "/docs/apm/apis/server-examples-v2"
     ]
@@ -697,7 +697,7 @@
     ]
   },
   {
-    "url": "/docs/infrastructure/manage-your-data/filter-group",
+    "url": "/docs/infrastructure/manage-your-data",
     "paths": [
       "/docs/infrastructure/new-relic-infrastructure/scope-filter",
       "/docs/infrastructure/new-relic-infrastructure/filter-group",
@@ -767,7 +767,7 @@
     ]
   },
   {
-    "url": "/docs/alerts-applied-intelligence/rest-api-alerts/new-relic-alerts-rest-api",
+    "url": "/docs/alerts-applied-intelligence/table-of-contents",
     "paths": [
       "/docs/alerts/new-relic-alerts/rest-api-alerts",
       "/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api"
@@ -832,7 +832,7 @@
     ]
   },
   {
-    "url": "/docs/insights/use-insights-ui/time-settings",
+    "url": "/docs/insights/use-insights-ui/",
     "paths": [
       "/docs/insights/using-insights-ui/time-settings"
     ]
@@ -989,7 +989,7 @@
     ]
   },
   {
-    "url": "/docs/infrastructure/integrations/types-integrations",
+    "url": "/docs/infrastructure/table-of-contents",
     "paths": [
       "/docs/infrastructure/integrations/integrations",
       "/docs/infrastructure/integrations-getting-started/integrations"
@@ -1296,7 +1296,7 @@
     ]
   },
   {
-    "url": "/docs/release-notes/platform-release-notes",
+    "url": "/docs/release-notes",
     "paths": [
       "/docs/release-notes/alerts-release-notes/new-relic-alerts-release-notes/20161115-support-mobile-crash-analysis",
       "/docs/release-notes/alerts-release-notes/new-relic-alerts-release-notes/20161007-more-pagination-search-permalinks",
@@ -1553,7 +1553,7 @@
     ]
   },
   {
-    "url": "/docs/infrastructure/infrastructure-monitoring-troubleshooting/troubleshoot-infrastructure",
+    "url": "/docs/infrastructure/infrastructure-troubleshooting",
     "paths": [
       "/docs/infrastructure/troubleshooting/infra-troubleshooting",
       "/docs/infrastructure/infrastructure-troubleshooting/infra-troubleshooting",
@@ -1714,7 +1714,7 @@
     ]
   },
   {
-    "url": "/docs/mobile-monitoring/new-relic-mobile-cordova/get-started",
+    "url": "/docs/mobile-monitoring/table-of-contents",
     "paths": [
       "/docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/get-started"
     ]

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -905,7 +905,7 @@
     ]
   },
   {
-    "url": "/docs/insights/use-insights-ui/export-data",
+    "url": "/docs/insights/use-insights-ui",
     "paths": [
       "/docs/export-data"
     ]
@@ -983,7 +983,7 @@
     ]
   },
   {
-    "url": "/docs/infrastructure/integrations",
+    "url": "/docs/infrastructure/table-of-contents",
     "paths": [
       "/docs/infrastructure/integrations-getting-started"
     ]
@@ -996,7 +996,7 @@
     ]
   },
   {
-    "url": "/docs/insights/use-insights-ui/",
+    "url": "/docs/insights/use-insights-ui",
     "paths": [
       "/docs/insights/nrql-new-relic-query-language/troubleshooting",
       "/docs/troubleshooting"
@@ -1058,7 +1058,7 @@
     ]
   },
   {
-    "url": "/docs/new-relic-partnerships/partner-integration-guide/partner-apis",
+    "url": "/docs/new-relic-partnerships/partner-integration-guide",
     "paths": [
       "/docs/accounts-partnerships/partner-integration-guide/partner-apis"
     ]
@@ -1076,7 +1076,7 @@
     ]
   },
   {
-    "url": "/docs/using-new-relic/welcome-new-relic/new-relic-university",
+    "url": "/docs/using-new-relic/welcome-new-relic",
     "paths": [
       "/docs/accounts-partnerships/education/new-relic-university",
       "/docs/accounts-partnerships/accounts/install-new-relic/new-relic-university",
@@ -1122,7 +1122,7 @@
     ]
   },
   {
-    "url": "/docs/new-relic-only/tech-writer-style-guide/api-writing-guidelines",
+    "url": "/docs/style-guide",
     "paths": [
       "/docs/new-relic-only/advanced-style-guide/writing-guidelines",
       "/docs/new-relic-only/tech-writer-style-guide/writing-guidelines"
@@ -1135,7 +1135,7 @@
     ]
   },
   {
-    "url": "/docs/new-relic-only/tech-writer-style-guide/design-specifications",
+    "url": "/docs/style-guide",
     "paths": [
       "/docs/new-relic-only/advanced-style-guide/design-specifications"
     ]
@@ -1390,7 +1390,7 @@
     ]
   },
   {
-    "url": "/docs/integrations/microsoft-azure-integrations/troubleshooting",
+    "url": "/docs/integrations/microsoft-azure-integrations",
     "paths": [
       "/docs/kubernetes-integration/microsoft-azure-integrations/troubleshooting",
       "/docs/infrastructure-integrations/microsoft-azure-integrations/troubleshooting"
@@ -1836,7 +1836,7 @@
     ]
   },
   {
-    "url": "/docs/logs/enable-log-management-new-relic/new-relic-logs",
+    "url": "/docs/logs/enable-log-management-new-relic",
     "paths": [
       "/docs/logs/enable-logs/new-relic-logs",
       "/docs/logs/enable-new-relic-logs/new-relic-logs",


### PR DESCRIPTION
### Give us some context

For doc-6691, I looked at lines 2-80 in the spreadsheet of 404 errors related to pages that don't have front matter redirects. These are handled in `taxononomy-redirects.json`. 

I corrected most of the entries, but I also inserted some questions in the spreadsheet.

