### PR TITLE
fix: for the translation action which was storing data so it now …

### DIFF
--- a/scripts/actions/add-files-to-translation-queue.js
+++ b/scripts/actions/add-files-to-translation-queue.js
@@ -80,7 +80,8 @@ const main = async () => {
   const key = { type: 'to_translate' };
 
   const queue = await loadFromDB(table, key);
-  const data = await getUpdatedQueue(url, queue);
+  const { locales } = queue.Item;
+  const data = await getUpdatedQueue(url, locales);
 
   await saveToTranslationQueue(key, 'set locales = :slugs', { ':slugs': data });
 

--- a/scripts/actions/add-files-to-translation-queue.js
+++ b/scripts/actions/add-files-to-translation-queue.js
@@ -50,7 +50,7 @@ const getUpdatedQueue = async (url, queue) => {
       .map(prop('filename'));
 
     const queueFiles =
-      Object.entries(queue).length === 0 ? Object.entries(queue) : [];
+      Object.entries(queue).length !== 0 ? Object.entries(queue) : [];
 
     return queueFiles
       .map(([locale, files]) => [
@@ -60,7 +60,7 @@ const getUpdatedQueue = async (url, queue) => {
       .reduce(
         (acc, [locale, filenames]) => ({
           ...acc,
-          [locale]: filenames.concat(acc[locale] || []),
+          [locale]: [...new Set(filenames.concat(acc[locale] || []))],
         }),
         addedMdxFiles
       );


### PR DESCRIPTION
Previously, the action that used this script would add data to our database, but in the process remove pre-existing data. With this change, data should now be appended (and no data should be lost) and duplicates are ignored.

Resolves #1733