### PR TITLE
Update find-use-your-kubernetes-data.mdx

### DIFF
--- a/src/content/docs/integrations/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data.mdx
+++ b/src/content/docs/integrations/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data.mdx
@@ -980,15 +980,6 @@ Query the `K8sDeploymentSample` event for deployment data:
       </td>
     </tr>
 
-    <tr>
-      <td>
-        `updatedAt`
-      </td>
-
-      <td>
-        Timestamp of when the deployment was updated
-      </td>
-    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
The `updatedAt` attribute of the `K8sDeploymentSample` doesn't exists.

In the CHANGELOG for the Kubernetes integration there is an entry saying that it was renamed to `podsUpdated` which is already in the docs.

This change was made a long time ago for the 1.0.0-alpha3 release.

https://github.com/newrelic/nri-kubernetes/blob/main/CHANGELOG.md#100-alpha3

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.