### PR TITLE
Publish a release when merging into `main`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,40 @@
-# name: Release
+name: Release
 
-# on:
-#   pull_request:
-#     types:
-#       - closed
-#     branches:
-#       - main
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
 
-# jobs:
-#   newrelic:
-#     name: New Relic deployment marker
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Set release version from tag
-#         run: echo "RELEASE_VERSION=${{ GITHUB_REF:10 }}" >> $GITHUB_ENV
+jobs:
+  create-release:
+    name: Create Github release
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.get-tag.outputs.tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-#       - name: Create New Relic deployment marker
-#         uses: newrelic/deployment-marker-action@v1
-#         with:
-#           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
-#           accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
-#           applicationId: ${{ secrets.NEW_RELIC_APPLICATION_ID }}
-#           revision: ${{ env.RELEASE_VERSION }}
+      - name: Get release tag
+        id: get-tag
+        run: |
+          MERGES=$(gh pr list -B main -s closed -L 9999 | wc -L | awk '{print $1}')
+          echo "::set-output name=tag::release-$MERGES"
+
+      - name: Create release
+        run: gh release create ${{ steps.get-tag.outputs.tag }}
+
+  newrelic:
+    name: New Relic deployment marker
+    runs-on: ubuntu-latest
+    needs: create-release
+    steps:
+      - name: Create New Relic deployment marker
+        uses: newrelic/deployment-marker-action@v1
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+          applicationId: ${{ secrets.NEW_RELIC_APPLICATION_ID }}
+          revision: ${{ needs.create-release.outputs.tag }}


### PR DESCRIPTION
## Description
Adds an action that will fire whenever a PR is merged into `main` that does the following:
1. Gets the number of PRs merged into the `main` branch.
2. Creates a release tagged with the #.
3. Sends a deployment marker to New Relic (with the new tag name).

## Reviewer Notes
I opted to do _all_ merges into `main` rather than the merges since we launched the site. This number is fairly arbitrary and I thought it would be best to simplify our workflow. Since the site has been open source from the very begining, starting the count from the first merge makes sense.

Along the same lines, I decided to reach for `gh` rather than running `git` commands. Unfortunately, I wasn't able to test these commands using _act_, but I've run them all locally and I can confirm that they work.

## Related Issue(s)
* Closes #1049
* Closes #1410