### PR TITLE
fix: error in cron configuration

### DIFF
--- a/.github/workflows/build-with-swiftype-content.yml
+++ b/.github/workflows/build-with-swiftype-content.yml
@@ -3,7 +3,7 @@ name: Build with Swiftype content
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * 0 1,4 *' # start of the day on Monday and Thursday
+    - cron: '0 0 * * 1,4' # start of the day on Monday and Thursday
 
 env:
   BOT_NAME: nr-opensource-bot


### PR DESCRIPTION
workflow is failing due to invalid cron syntax. should be good now.

Resolves #1773 