### PR TITLE
Fixed broken link in trace observer step.

### DIFF
--- a/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
@@ -153,7 +153,7 @@ To set up a trace observer:
           </Callout>
      </Collapser>
    </CollapserGroup>
-6. (Optional) There are several ways to [configure Infinite Tracing](/docs/understand-dependencies/distributed-tracing/infinite-tracing). This configuration can wait until after you've completed the enable procedures.
+6. (Optional) There are several ways to [configure Infinite Tracing](/docs/distributed-tracing/infinite-tracing). This configuration can wait until after you've completed the enable procedures.
 7. This procedure is complete. Next, return to finish any remaining instructions for the tracing tool you started enabling:
 
    * [Language agents](/docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing#configure-agents)


### PR DESCRIPTION

### Give us some context

We had a broken link to a table of contents page in the trace observer instructions (step 6) in the following page:

https://docs.newrelic.com/docs/distributed-tracing/infinite-tracing/set-trace-observer/

