### PR TITLE
This makes it easier to copy and paste these API headers

### DIFF
--- a/src/content/docs/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -111,6 +111,10 @@ Here is a summary of the Request API calls for New Relic's Node.js agent.
     id="transaction"
     title={<InlineCode>newrelic.setTransactionName(name)</InlineCode>}
   >
+    ```
+    newrelic.setTransactionName(name)
+    ```
+
     Name the current request, following the [request naming requirements](#requirements). You can call this function anywhere within the context of an HTTP request handler, at any time after handling of the request has started, but before the request has finished. In general, if the request and response objects are in scope, you can set the name.
 
     Explicitly calling `newrelic.setTransactionName()` will override any names set by Express or Restify routes. Also, calls to `newrelic.setTransactionName()` and `newrelic.setControllerName()` will overwrite each other. The last one to run before the request ends wins.
@@ -120,6 +124,10 @@ Here is a summary of the Request API calls for New Relic's Node.js agent.
     id="controller"
     title={<InlineCode>newrelic.setControllerName(name, \[action])</InlineCode>}
   >
+```    
+newrelic.setControllerName(name, \[action])
+```
+
     Name the current request using a controller-style pattern, optionally including the current controller action. If the action is omitted, New Relic will include the HTTP method (GET, POST, etc.) as the action. The rules for when you can call `newrelic.setControllerName()` are the same as they are for `newrelic.setTransactionName()`, including the [request naming requirements](#requirements).
 
     Explicitly calling `newrelic.setControllerName()` will override any names set by Express or Restify routes. Also, calls to `newrelic.setTransactionName()` and `newrelic.setControllerName()` will overwrite each other. The last one to run before the request ends wins.
@@ -135,6 +143,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="instrument"
     title={<InlineCode>newrelic.instrument(moduleName, onRequire \[, onError])</InlineCode>}
   >
+    ```
+    newrelic.instrument(moduleName, onRequire \[, onError])
+    ```
+
     Sets an instrumentation callback for a specific module.
 
     The provided `onRequire` callback will be fired when the given module is loaded with `require`. The `moduleName` parameter should be the string that will be passed to `require`; for example, `'express'` or `'amqplib/callback_api'`. The optional `onError` callback is called if the `onRequire` parameters throws an error. This is useful for debugging your instrumentation.
@@ -152,6 +164,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="instrumentDatastore"
     title={<InlineCode>newrelic.instrumentDatastore(moduleName, onRequire \[, onError])</InlineCode>}
   >
+    ```
+    newrelic.instrumentDatastore(moduleName, onRequire \[, onError])
+    ```
+
     Sets an instrumentation callback for a datastore module.
 
     This method is just like [`newrelic.instrument()`](#instrument), except it provides a [datastore-specialized shim](https://newrelic.github.io/node-newrelic/docs/DatastoreShim.html). For more information, see New Relic's [Node.js datastore instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/docs/tutorial-Datastore-Simple.html).
@@ -161,6 +177,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="instrumentLoadedModule"
     title={<InlineCode>newrelic.instrumentLoadedModule(moduleName, moduleInstance)</InlineCode>}
   >
+    ```
+    newrelic.instrumentLoadedModule(moduleName, moduleInstance)
+    ```
+
     The `instrumentLoadedModule` method allows you to add stock instrumentation to specific modules in situations where it's impossible to have `require('newrelic');` as the first line of your app's main module.
 
     ```
@@ -186,6 +206,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="instrumentMessages"
     title={<InlineCode>newrelic.instrumentMessages(moduleName, onRequire \[, onError])</InlineCode>}
   >
+    ```
+    newrelic.instrumentMessages(moduleName, onRequire \[, onError])
+    ```
+
     Sets an instrumentation callback for a message service client module.
 
     This method is just like [`newrelic.instrument()`](#instrument), except it provides a [message-service-specialized shim](https://newrelic.github.io/node-newrelic/docs/MessageShim.html). For more information, see New Relic's [Node.js message service instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/docs/tutorial-Messaging-Simple.html).
@@ -195,6 +219,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="instrumentWebframework"
     title={<InlineCode>newrelic.instrumentWebframework(moduleName, onRequire \[, onError])</InlineCode>}
   >
+    ```
+    newrelic.instrumentWebframework(moduleName, onRequire \[, onError])
+    ```
+
     Sets an instrumentation callback for a web framework module.
 
     This method is just like [`newrelic.instrument()`](#instrument), except it provides a [web-framework-specialized shim](https://newrelic.github.io/node-newrelic/docs/WebFrameworkShim.html). For more information, see New Relic's [Node.js web framework instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/docs/tutorial-Webframework-Simple.html).
@@ -204,6 +232,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="startWebTransaction"
     title={<InlineCode>newrelic.startWebTransaction(url, handle)</InlineCode>}
   >
+    ```
+    newrelic.startWebTransaction(url, handle)
+    ```
+
     Instrument the specified web transaction. Using this API call, you can instrument transactions that New Relic [does not automatically detect](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation#web-txn).
 
     * The `url` defines the transaction name and needs to be static. Do not include variable data such as user ID.
@@ -220,6 +252,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="startBackgroundTransaction"
     title={<InlineCode>newrelic.startBackgroundTransaction(name, \[group], handle)</InlineCode>}
   >
+    ```
+    newrelic.startBackgroundTransaction(name, \[group], handle)
+    ```
+
     Instrument the specified background transaction. Using this API call, you can expand New Relic's instrumentation to [capture data from background transactions](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation#background-txn).
 
     * The `name` defines the transaction name and needs to be static. Do not include variable data such as user ID.
@@ -237,6 +273,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="getTransaction"
     title={<InlineCode>newrelic.getTransaction()</InlineCode>}
   >
+    ```
+    newrelic.getTransaction()
+    ```
+
     Returns a handle on the currently executing transaction. This handle can then be used to interact with a given transaction safely from any context. It is best used with `newrelic.startWebTransaction()` and `newrelic.startBackgroundTransaction()`.
 
     [Please refer to the transaction handle section for more details.](#transaction-handle-methods)
@@ -246,6 +286,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="endTransaction"
     title={<InlineCode>newrelic.endTransaction()</InlineCode>}
   >
+    ```
+    newrelic.endTransaction()
+    ```
+
     End the current [web](#createWebTransaction) or [background](#createBackgroundTransaction) custom transaction. This method requires being in the correct transaction context when called. This API call takes no arguments.
   </Collapser>
 
@@ -253,6 +297,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="startSegment"
     title={<InlineCode>newrelic.startSegment(name, record, handler, callback)</InlineCode>}
   >
+    ```
+    newrelic.startSegment(name, record, handler, callback)
+    ```
+
     Instrument a particular method to [improve visibility into a transaction](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation#expanding-instrumentation), or optionally turn it into a metric.
 
     * The `name` defines a name for the segment. This name will be visible in transaction traces and as a new metric in the New Relic UI.
@@ -273,6 +321,10 @@ Use these API calls to [record additional arbitrary metrics](/docs/agents/nodejs
     id="record_metric"
     title={<InlineCode>newrelic.recordMetric(name, value)</InlineCode>}
   >
+    ```
+    newrelic.recordMetric(name, value)
+    ```
+
     Use `recordMetric` to record an event-based metric, usually associated with a particular duration. The `name` must be a string following standard metric naming rules. The `value` will usually be a number, but it can also be an object.
 
     * When `value` is a numeric value, it should represent the magnitude of a measurement associated with an event; for example, the duration for a particular method call.
@@ -283,6 +335,10 @@ Use these API calls to [record additional arbitrary metrics](/docs/agents/nodejs
     id="increment_metric"
     title={<InlineCode>newrelic.incrementMetric(name, \[amount])</InlineCode>}
   >
+    ```
+    newrelic.incrementMetric(name, \[amount])
+    ```
+
     Use `incrementMetric` to update a metric that acts as a simple counter. The count of the selected metric will be incremented by the specified amount, defaulting to 1.
   </Collapser>
 </CollapserGroup>
@@ -296,6 +352,10 @@ Use these API calls to record additional events:
     id="record_custom_event"
     title={<InlineCode>newrelic.recordCustomEvent(eventType, attributes)</InlineCode>}
   >
+    ```
+    newrelic.recordCustomEvent(eventType, attributes)
+    ```
+
     Use `recordCustomEvent` to record an event-based metric, usually associated with a particular duration.
 
     * The `eventType` must be an alphanumeric string less than 255 characters.
@@ -332,6 +392,10 @@ Use these methods to interact directly with the current transaction:
     id="transaction-handle-end"
     title={<InlineCode>transactionHandle.end(\[callback])</InlineCode>}
   >
+    ```
+    transactionHandle.end(\[callback])
+    ```
+
     Use `transactionHandle.end` to end the transaction referenced by the handle instance.
 
     The `callback` is invoked when the transaction has fully ended. The finished transaction passed to the callback as the first argument.
@@ -341,6 +405,10 @@ Use these methods to interact directly with the current transaction:
     id="transaction-handle-ignore"
     title={<InlineCode>transactionHandle.ignore()</InlineCode>}
   >
+    ```
+    transactionHandle.ignore()
+    ```
+
     Use `transactionHandle.ignore` to ignore the transaction referenced by the handle instance.
   </Collapser>
 
@@ -348,6 +416,10 @@ Use these methods to interact directly with the current transaction:
     id="transaction-handle-insertDistributedTraceHeaders"
     title={<InlineCode>transactionHandle.insertDistributedTraceHeaders(headers)</InlineCode>}
   >
+    ```
+    transactionHandle.insertDistributedTraceHeaders(headers)
+    ```
+
     <Callout variant="important">
       This API requires [distributed tracing to be enabled](/docs/enable-distributed-tracing).
     </Callout>
@@ -383,6 +455,10 @@ Use these methods to interact directly with the current transaction:
     id="transaction-handle-acceptDistributedTraceHeaders"
     title={<InlineCode>transactionHandle.acceptDistributedTraceHeaders(transportType, headers)</InlineCode>}
   >
+    ```
+    transactionHandle.acceptDistributedTraceHeaders(transportType, headers)
+    ```
+
     <Callout variant="important">
       This API requires [distributed tracing to be enabled](/docs/enable-distributed-tracing).
     </Callout>
@@ -434,6 +510,10 @@ Use these methods to interact directly with the current transaction:
     id="transaction-handle-createDistributedTracePayload"
     title={<InlineCode>transactionHandle.createDistributedTracePayload()</InlineCode>}
   >
+    ```
+    transactionHandle.createDistributedTracePayload()
+    ```
+
     <Callout variant="caution">
       This method is deprecated and was removed in version 7.0.0! Please use `insertDistributedTraceHeaders.`
     </Callout>
@@ -494,6 +574,10 @@ Use these methods to interact directly with the current transaction:
     id="transaction-handle-acceptDistributedTracePayload"
     title={<InlineCode>transactionHandle.acceptDistributedTracePayload(payload)</InlineCode>}
   >
+    ```
+    transactionHandle.acceptDistributedTracePayload(payload)
+    ```
+
     <Callout variant="caution">
       This method is deprecated and was removed in version 7.0.0! Please use `acceptDistributedTraceHeaders.`
     </Callout>
@@ -511,6 +595,10 @@ Use these methods to interact directly with the current transaction:
     id="transaction-handle-isSampled"
     title={<InlineCode>transactionHandle.isSampled()</InlineCode>}
   >
+    ```
+    transactionHandle.isSampled()
+    ```
+
     Returns whether this trace is being sampled.
   </Collapser>
 </CollapserGroup>
@@ -524,6 +612,10 @@ New Relic's Node.js agent includes additional API calls.
     id="add-custom-attribute"
     title={<InlineCode>newrelic.addCustomAttribute(name, value)</InlineCode>}
   >
+    ```
+    newrelic.addCustomAttribute(name, value)
+    ```
+
     Set a custom attribute value to be displayed along with the transaction trace in the New Relic UI. This must be called within the context of a transaction so it has a place to set the custom attributes. Custom attributes will appear in New Relic APM's transaction trace detail view and in errors for the transaction.
 
     <CollapserGroup>
@@ -546,6 +638,10 @@ New Relic's Node.js agent includes additional API calls.
     id="add-custom-attributes"
     title={<InlineCode>newrelic.addCustomAttributes(attributes)</InlineCode>}
   >
+    ```
+    newrelic.addCustomAttributes(attributes)
+    ```
+
     Set multiple custom attribute values to be displayed along with the transaction trace in the New Relic UI. The attributes should be passed as a single object. This must be called within the context of a transaction so it has a place to set the custom attributes. Custom attributes will appear in the transaction trace detail view and in errors for the transaction.
 
     <CollapserGroup>
@@ -570,6 +666,10 @@ New Relic's Node.js agent includes additional API calls.
   </Collapser>
 
   <Collapser title={<InlineCode>newrelic.addCustomSpanAttribute(name, value)</InlineCode>}>
+    ```
+    newrelic.addCustomSpanAttribute(name, value)
+    ```
+
     Set a custom span attribute value to be displayed along with a transaction trace span in the New Relic UI. This must be called within the context of an active segment/span so it has a place to set the custom span attributes. Custom span attributes will appear in the Attributes section of the span detail view.
 
     <CollapserGroup>
@@ -593,6 +693,10 @@ New Relic's Node.js agent includes additional API calls.
   </Collapser>
 
   <Collapser title={<InlineCode>newrelic.addCustomSpanAttributes(attributes)</InlineCode>}>
+    ```
+    newrelic.addCustomSpanAttributes(attributes)
+    ```
+
     Set multiple custom span attribute values to be displayed along with the transaction trace spans in the New Relic UI. The attributes should be passed as a single object. This must be called within the context of an active segment/span so it has a place to set the custom span attributes. Custom span attributes will appear in the Attributes section of the span detail view.
 
     <CollapserGroup>
@@ -624,6 +728,10 @@ New Relic's Node.js agent includes additional API calls.
     id="browserTimingHeader"
     title={<InlineCode>newrelic.getBrowserTimingHeader()</InlineCode>}
   >
+    ```
+    newrelic.getBrowserTimingHeader()
+    ```
+
     Returns the HTML snippet to be inserted into the header of HTML pages to enable [New Relic Browser](/docs/agents/nodejs-agent/supported-features/page-load-timing-nodejs). The HTML will instruct the browser to fetch a small JavaScript file and start the page timer.
   </Collapser>
 
@@ -631,6 +739,10 @@ New Relic's Node.js agent includes additional API calls.
     id="ignore"
     title={<InlineCode>newrelic.setIgnoreTransaction(ignored)</InlineCode>}
   >
+    ```
+    newrelic.setIgnoreTransaction(ignored)
+    ```
+
     Tell the module whether or not to ignore a given request. This allows you to explicitly filter long-polling, irrelevant routes or requests you know will be time-consuming. This also allows you to gather metrics for requests that otherwise would be ignored.
 
     * To ignore the transaction, set the parameter to `true` will ignore the transaction.
@@ -646,6 +758,10 @@ New Relic's Node.js agent includes additional API calls.
     id="noticeError"
     title={<InlineCode>newrelic.noticeError(error, \[customParameters])</InlineCode>}
   >
+    ```
+    newrelic.noticeError(error, \[customParameters])
+    ```
+
     Use this call if your app is doing its own error handling with domains or try/catch clauses, but you want all of the information about how many errors are coming out of the app to be centrally managed. Unlike other Node.js calls, this can be used outside of route handlers, but it will have additional context if called from within transaction scope.
 
     <Callout variant="caution">
@@ -657,6 +773,10 @@ New Relic's Node.js agent includes additional API calls.
     id="shutdown"
     title={<InlineCode>newrelic.shutdown(\[options], callback)</InlineCode>}
   >
+    ```
+    newrelic.shutdown(\[options], callback)
+    ```
+
     Use this method to gracefully shut down the agent.
 
     `options`
@@ -677,6 +797,10 @@ New Relic's Node.js agent includes additional API calls.
     id="getLinkingMetadata"
     title={<InlineCode>newrelic.getLinkingMetadata()</InlineCode>}
   >
+    ```
+    newrelic.getLinkingMetadata()
+    ```
+
     Returns key/value pairs which can be used to link traces or entities.
 
     It will only contain items with meaningful values. For instance, if distributed tracing is disabled, `trace.id` will not be included.
@@ -686,6 +810,10 @@ New Relic's Node.js agent includes additional API calls.
     id="getTraceMetadata"
     title={<InlineCode>newrelic.getTraceMetadata()</InlineCode>}
   >
+    ```
+    newrelic.getTraceMetadata()
+    ```
+
     Returns and object containing the current trace ID and span ID.
 
     <Callout variant="important">
@@ -705,6 +833,7 @@ Here is the structure for rules in New Relic's Node.js agent.
     id="rules-name"
     title={<InlineCode>rules.name</InlineCode>}
   >
+
     A list of rules of the format `{pattern : "pattern", name : "name"}` for matching incoming request URLs to `pattern` and naming the matching New Relic transaction's `name`. This acts as a regex replace, where you can set the pattern either as a string, or as a JavaScript regular expression literal, and both pattern and name are required.
 
     When passing a regex as a string, escape backslashes, as the agent does not keep them when given as a string in a pattern. Define your configuration rules from the most specific to the most general, as the patterns will be evaluated in order and are terminal in nature. For more information, see the [naming guidelines](/docs/agents/nodejs-agent/installation-configuration/configuring-nodejs#rules).


### PR DESCRIPTION
A Docs hero request came in about how it's not possible to select the code methods for copy/pasting. I've added code boxes for these API headers in each of the collapser sections so it's possible in some fashion.