### PR TITLE
Fix: Include inlineCode elements in release notes excerpts

### DIFF
--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -183,7 +183,15 @@ export const pageQuery = graphql`
 `;
 
 const getBestGuessExcerpt = (mdxAST) => {
-  const textTypes = ['paragraph', 'list', 'listItem', 'text', 'root', 'link'];
+  const textTypes = [
+    'paragraph',
+    'list',
+    'listItem',
+    'text',
+    'root',
+    'link',
+    'inlineCode',
+  ];
   const ast = filter(mdxAST, (node) => textTypes.includes(node.type));
 
   return toString(


### PR DESCRIPTION
## Description
Includes `inlineCode` node type to include in an agent's release note landing page excerpt. These excerpts are plain text, so the inline code style won't be used. But this at least preserves some important context in the excerpt.

## Related issues
- Resolves #1793 

## Example
[Java agent 6.4.2 excerpt](http://localhost:8000/docs/release-notes/agent-release-notes/java-release-notes/)

## Screenshot
<img width="1731" alt="Screen Shot 2021-04-13 at 09 27 16" src="https://user-images.githubusercontent.com/2952843/114588006-0d97fc80-9c3b-11eb-8c38-951887369652.png">
