### PR TITLE
Update required permissions for GCP

### DIFF
--- a/src/content/docs/integrations/google-cloud-platform-integrations/get-started/integrations-custom-roles.mdx
+++ b/src/content/docs/integrations/google-cloud-platform-integrations/get-started/integrations-custom-roles.mdx
@@ -40,6 +40,7 @@ To customize your role you need to:
     All integrations need the following permission:
 
     * `monitoring.timeSeries.list`
+    * `service.usage.use`
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
For monitoring GCP Cloud Integrations we now require new permission that is required to monitor all services