### PR TITLE
Add additional pre-condition for log4j1.x Usage

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/logs-context-java/java-configure-log4j-1x.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/logs-context-java/java-configure-log4j-1x.mdx
@@ -21,6 +21,7 @@ To use New Relic logs in context with Log4j 1.x, ensure your configuration meets
 * Java agent 5.6.0 or higher: [Install](/docs/agents/java-agent/installation/install-java-agent) or [update](/docs/agents/java-agent/installation/update-java-agent)
 * JVM argument [`-javaagent`](/docs/agents/java-agent/installation/include-java-agent-jvm-argument) enabled on the Java agent.
 * [Log4j 1.x](https://logging.apache.org/log4j/1.2/) package installed and working on the application.
+* log4j must be configured in code or via XML. Properties files are not supported because `AsyncAppender` instances can only be automatically configured via XML.
 
 ## Configure logs in context with log management [#configure-logs]
 


### PR DESCRIPTION
### Give us some context

I created an issue here:
https://github.com/newrelic/docs-website/issues/1805


The 2nd precondition listed on the extension project's readme wasn't included on the docs page.  It generated a support ticket.  This change just adds a bullet point for that missing precondition.
https://github.com/newrelic/java-log-extensions/tree/main/log4j1#preconditions
compare to
https://docs.newrelic.com/docs/logs/enable-log-management-new-relic/logs-context-java/java-configure-log4j-1x/#compatibility-requirements-log4j-1

### Are you making a change to site code?
no