### PR TITLE
Adds documentation for DEBUG_LOGGING_ENABLED environment variable configuration in aws-log-ingestion lambda

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/aws-lambda-sending-cloudwatch-logs.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/aws-lambda-sending-cloudwatch-logs.mdx
@@ -51,6 +51,20 @@ Complete the following:
      <tbody>
        <tr>
          <td>
+           `DEBUG_LOGGING_ENABLED`
+         </td>
+
+         <td>
+           A boolean to determine if you want to output debug messages in the CloudWatch console. **Optional**.
+         </td>
+
+         <td>
+           To turn on debug logs, set this to `true`. By default, it is `false`.
+         </td>
+       </tr>
+       
+       <tr>
+         <td>
            `LICENSE_KEY`
          </td>
 


### PR DESCRIPTION
### Give us some context

* What problems does this PR solve?
It adds a missing configuration field for the `aws-log-ingestion` lambda, which allows the customer to run it in debug mode.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
The PR should be self-explanatory as it explains what is this config field for.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.