### PR TITLE
Fix Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   create-release:
     name: Create Github release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
   create-release:


### PR DESCRIPTION
## Description
The workflow for creating a new Github release was failing due to a missing env variable. By setting `GITHUB_TOKEN`, the `gh` command line utility should have proper authentication to read merges and create tags / releases.

## Related Issue(s)
* Closes #1829 