### PR TITLE
chore: adds release notes for Node.js agent v7.3.1.

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-3-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-3-1.mdx
@@ -7,12 +7,14 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
 ## Fixes
 
-* Fixed issue with 'new_promise_tracking' feature flag functionality where segments for ended transactions would get propagated in certain cases by promises that had no continuations scheduled (via await or manually).
+* Fixed issue with `new_promise_tracking` feature flag functionality where segments for ended transactions would get propagated in certain cases by promises that had no continuations scheduled (via await or manually).
 
-  If you are experiencing high overhead levels with your promise usage and the agent attached, we recommend testing your application with  'new_promise_tracking' set to true to see if overhead is reduced. You'll also want to verify your data is still being captured correctly in case it falls into a known or unknown limitation of this approach.  **NOTE: chaining of promise continuations onto an already resolved promise across an async hop (scheduled timer) will result in state-loss with this new functionality turned on. This is a less-common use-case but worth considering with your applications.**
+  If you are experiencing high overhead levels with your promise usage and the agent attached, we recommend testing your application with  `new_promise_tracking` set to true to see if overhead is reduced. You'll also want to verify your data is still being captured correctly in case it falls into a known or unknown limitation of this approach.  
+  
+  **NOTE: With this new functionality turned on, chaining of promise continuations onto an already resolved promise across an async hop (scheduled timer) will result in state-loss. This is a less-common use-case but worth considering with your applications.**
 
 <Callout variant="important">
-**Deprecation Warning:** The certificate bundle automatically included by New Relic when using the 'certificates' configuration (commonly with proxies) will be disabled by default in the next major version. This is currently targeted for sometime in May. The bundle will be fully removed in later major versions. We recommend testing with the 'certificate_bundle' feature flag set to `false` to determine if you will need to modify your environment or setup your own appropriate bundle. Example configuration: `feature_flag: { certificate_bundle: false }`.
+**Deprecation Warning:** The certificate bundle automatically included by New Relic when using the `certificates` configuration (commonly with proxies) will be disabled by default in the next major version. This is currently targeted for sometime in May. The bundle will be fully removed in later major versions. We recommend testing with the 'certificate_bundle' feature flag set to `false` to determine if you will need to modify your environment or setup your own appropriate bundle. Example configuration: `feature_flag: { certificate_bundle: false }`.
 </Callout>
 
 ### Support statement:

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-3-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-3-1.mdx
@@ -1,0 +1,20 @@
+---
+subject: Node.js agent
+releaseDate: '2021-04-14'
+version: 7.3.1
+downloadLink: 'https://www.npmjs.com/package/newrelic'
+---
+
+## Fixes
+
+* Fixed issue with 'new_promise_tracking' feature flag functionality where segments for ended transactions would get propagated in certain cases by promises that had no continuations scheduled (via await or manually).
+
+  If you are experiencing high overhead levels with your promise usage and the agent attached, we recommend testing your application with  'new_promise_tracking' set to true to see if overhead is reduced. You'll also want to verify your data is still being captured correctly in case it falls into a known or unknown limitation of this approach.  **NOTE: chaining of promise continuations onto an already resolved promise across an async hop (scheduled timer) will result in state-loss with this new functionality turned on. This is a less-common use-case but worth considering with your applications.**
+
+<Callout variant="important">
+**Deprecation Warning:** The certificate bundle automatically included by New Relic when using the 'certificates' configuration (commonly with proxies) will be disabled by default in the next major version. This is currently targeted for sometime in May. The bundle will be fully removed in later major versions. We recommend testing with the 'certificate_bundle' feature flag set to `false` to determine if you will need to modify your environment or setup your own appropriate bundle. Example configuration: `feature_flag: { certificate_bundle: false }`.
+</Callout>
+
+### Support statement:
+
+* New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach [end-of-life](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software).


### PR DESCRIPTION
Added release notes for the v7.3.1 release of the Node.js agent.

Did add a special call-out to highlight a part of the note that I've seen in other documentation. Assuming works on release notes as well.