### PR TITLE
Added a link to the open source repository

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
 const parse = require('rehype-parse');
+const fs = require('fs');
 const path = require('path');
 const unified = require('unified');
 const rehypeStringify = require('rehype-stringify');

--- a/src/content/docs/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
+++ b/src/content/docs/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
@@ -97,3 +97,13 @@ To set up the PHP agent and daemon in the same Docker container:
     * `YOUR_APPLICATION_NAME`: Replace with the your application name, in quotes.
   </Collapser>
 </CollapserGroup>
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/advanced-installation/install-new-relic-php-agent-gae-flexible-environment.mdx
+++ b/src/content/docs/agents/php-agent/advanced-installation/install-new-relic-php-agent-gae-flexible-environment.mdx
@@ -114,3 +114,13 @@ Use these resources to troubleshoot your GAE flex environment app:
   log_file_name: STDOUT
   ```
 * To view the logs, use the [Cloud Platform Console's Log Viewer](https://cloud.google.com/appengine/docs/flexible/php/writing-application-logs).
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/advanced-installation/php-agent-heroku.mdx
+++ b/src/content/docs/agents/php-agent/advanced-installation/php-agent-heroku.mdx
@@ -151,6 +151,7 @@ heroku config:set NEW_RELIC_LOG_LEVEL=verbosedebug
 
 Additional documentation resources include:
 
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
 * [Heroku Dev Center](//devcenter.heroku.com/articles/newrelic) (information on the Heroku site on installing New Relic)
 * [New Relic for PHP](/docs/agents/php-agent/getting-started/new-relic-php) (overview of the New Relic PHP agent)
 * [Using multiple names for an app](/docs/apm/new-relic-apm/installation-configuration/using-multiple-names-app) (advanced techniques to "roll up" data from multiple applications under a single name)

--- a/src/content/docs/agents/php-agent/advanced-installation/php-agent-installation-non-standard-php-advanced.mdx
+++ b/src/content/docs/agents/php-agent/advanced-installation/php-agent-installation-non-standard-php-advanced.mdx
@@ -187,3 +187,13 @@ If this process doesn't work for you, you can obtain the correct information fro
     ```
 
 Wait for 3 to 5 minutes for results to arrive in your [APM **Summary** page](/docs/applications-menu/applications-overview).
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/advanced-installation/silent-mode-install-script-advanced.mdx
+++ b/src/content/docs/agents/php-agent/advanced-installation/silent-mode-install-script-advanced.mdx
@@ -477,6 +477,7 @@ This is the list of environment variables you can set prior to invoking [`newrel
 
 Additional documentation resources include:
 
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
 * [The `newrelic-install` script](/docs/php/the-newrelic-install-script) (installing using the install script)
 * [New Relic for PHP](/docs/agents/php-agent/getting-started/new-relic-php) (overview of PHP agent features, installation, and configuration)
 * [PHP agent installation: non-standard PHP](/docs/php/php-agent-installation-non-standard-php) (installing on a non-standard PHP configuration)

--- a/src/content/docs/agents/php-agent/advanced-installation/starting-php-daemon-advanced.mdx
+++ b/src/content/docs/agents/php-agent/advanced-installation/starting-php-daemon-advanced.mdx
@@ -69,3 +69,13 @@ If you want to use this external startup method:
 2. Edit `/etc/newrelic/newrelic.cfg` and adjust any required values.
 3. Execute `/etc/init.d/newrelic-daemon restart`.
 4. Restart your web server or PHP process manager in order to pick up the new settings.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/advanced-installation/uninstalling-php-agent.mdx
+++ b/src/content/docs/agents/php-agent/advanced-installation/uninstalling-php-agent.mdx
@@ -110,5 +110,6 @@ To uninstall the PHP agent from your system:
 
 Additional documentation resources include:
 
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
 * [The newrelic-install script](/docs/agents/php-agent/installation/newrelic-install-script) (steps for using the install script to install and uninstall the agent)
 * [Remove apps from New Relic](/docs/apm/new-relic-apm/maintenance/remove-applications-from-new-relic-ui) (steps to remove an app from showing up in your New Relic account)

--- a/src/content/docs/agents/php-agent/advanced-installation/use-newrelic-install-script-php.mdx
+++ b/src/content/docs/agents/php-agent/advanced-installation/use-newrelic-install-script-php.mdx
@@ -228,3 +228,13 @@ You can uninstall New Relic but keep valuable config files (useful when upgradin
     </Callout>
   </Collapser>
 </CollapserGroup>
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/api-guides/guide-using-php-agent-api.mdx
+++ b/src/content/docs/agents/php-agent/api-guides/guide-using-php-agent-api.mdx
@@ -368,3 +368,13 @@ Use these methods to collect data about your app's connections to other apps or 
 ## Monitor specific browser pages [#browser]
 
 You can [install the browser agent](/docs/browser/new-relic-browser/installation/install-new-relic-browser-agent) by automatically adding it to your pages or by deploying it on specific pages by copying and pasting our JavaScript snippet. You can also control the browser agent by using APM agent API calls. For more information, see [Browser monitoring and the PHP agent](/docs/agents/php-agent/features/new-relic-browser-php-agent).
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/attributes/attribute-examples.mdx
+++ b/src/content/docs/agents/php-agent/attributes/attribute-examples.mdx
@@ -130,6 +130,7 @@ browser_monitoring: food.fruit.banana, food.fruit.apple
 
 Additional documentation resources include:
 
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
 * [Agent attributes](/docs/features/agent-attributes) (types, destinations, and limits for attributes used by New Relic agents)
 * [PHP agent attributes](/docs/php/php-agent-attributes) (PHP-specific attributes available as of version 4.9)
 * [Enabling and disabling attributes](/docs/php/php-agent-enabling-and-disabling-attributes) (properties, rules, and backwards compatibility information for PHP agent attributes)

--- a/src/content/docs/agents/php-agent/attributes/enable-or-disable-attributes.mdx
+++ b/src/content/docs/agents/php-agent/attributes/enable-or-disable-attributes.mdx
@@ -826,3 +826,13 @@ The following properties have been deprecated. Switch to the new attributes conf
     </tr>
   </tbody>
 </table>
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/attributes/php-agent-attributes.mdx
+++ b/src/content/docs/agents/php-agent/attributes/php-agent-attributes.mdx
@@ -235,3 +235,13 @@ To change which attributes are sent to New Relic [destinations](/docs/apm/other-
 ## Upgrading the PHP agent [#upgrading]
 
 When upgrading to PHP agent **4.9** or higher, upgrade your configuration file. For more information about deprecated properties, see [Enabling and disabling attributes](/docs/php/php-agent-enabling-and-disabling-attributes#deprecated).
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/configuration/name-your-php-application.mdx
+++ b/src/content/docs/agents/php-agent/configuration/name-your-php-application.mdx
@@ -44,3 +44,13 @@ For PHP, you can set up to three application names. The primary application name
     ```
   </Collapser>
 </CollapserGroup>
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -3374,3 +3374,13 @@ This section lists the remaining newrelic.ini settings.
     Enables the detection of frameworks and libraries when preloading is enabled. Preloading was introduced in PHP version 7.4. `newrelic.preload_framework_library_detection` will only take effect when `opcache.preload` is set in the `php.ini` file.
   </Collapser>
 </CollapserGroup>
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/configuration/php-directory-ini-settings.mdx
+++ b/src/content/docs/agents/php-agent/configuration/php-directory-ini-settings.mdx
@@ -271,3 +271,13 @@ This will report to two New Relic applications: "Virtual Host 1" and "All Virtua
 <Callout variant="important">
   This feature is only available in versions 2.4 or higher of the PHP agent.
 </Callout>
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/configuration/proxy-daemon-newreliccfg-settings.mdx
+++ b/src/content/docs/agents/php-agent/configuration/proxy-daemon-newreliccfg-settings.mdx
@@ -259,3 +259,13 @@ A sample daemon configuration file was created during installation. To manually 
     Can be set on the command line using the daemon `--auditlog` option. Setting this value on the command line will override the value set in `newrelic.cfg`
   </Collapser>
 </CollapserGroup>
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/features/browser-monitoring-php-agent.mdx
+++ b/src/content/docs/agents/php-agent/features/browser-monitoring-php-agent.mdx
@@ -121,3 +121,13 @@ Once you enable browser monitoring and generate traffic for your app, data will 
 For how to disable browser monitoring with the PHP agent config, see [Browser monitoring config option](/docs/agents/php-agent/configuration/php-agent-configuration#inivar-autorum).
 
 For how to use the API to disable browser monitoring, see [`newrelic_disable_autorum()`](/docs/agents/php-agent/php-agent-api/newrelic_disable_autorum).
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/features/distributed-tracing-php-agent.mdx
+++ b/src/content/docs/agents/php-agent/features/distributed-tracing-php-agent.mdx
@@ -284,3 +284,13 @@ For more information about using manual instrumentation to get more detail or to
 ## Command line PHP programs [#command-line]
 
 PHP programs run from the PHP command line are always sampled by the agent's distributed tracer. Depending on the programs you run, these processes could see an over-representation in your collection of distributed traces. In these situations, you can opt to disable command line instrumentation by using the [`per-directory newrelic.enabled`](https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-configuration) setting in your `newrelic.ini files`.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/features/multiple-accounts.mdx
+++ b/src/content/docs/agents/php-agent/features/multiple-accounts.mdx
@@ -53,6 +53,8 @@ Set this as early in the transaction process as possible; otherwise the transact
 
 ## For more help [#more_help]
 
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+
 Additional documentation resources include:
 
 * [The PHP API](/docs/php/the-php-api) (the PHP API reference)

--- a/src/content/docs/agents/php-agent/features/php-custom-instrumentation.mdx
+++ b/src/content/docs/agents/php-agent/features/php-custom-instrumentation.mdx
@@ -43,6 +43,8 @@ Beyond that setting, agent API calls can control transactions and add custom ins
 
 ## For more help [#more_help]
 
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+
 Additional documentation resources include:
 
 * [Custom instrumentation](/docs/features/custom-instrumentation) (Overview of custom instrumentation)

--- a/src/content/docs/agents/php-agent/features/recording-deployments-using-php-script.mdx
+++ b/src/content/docs/agents/php-agent/features/recording-deployments-using-php-script.mdx
@@ -108,6 +108,8 @@ if ($error) {
 
 ## For more help [#more_help]
 
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+
 Additional documentation resources include:
 
 * [**Deployments** page](/docs/apm/applications-menu/events/deployments-page) (recent deployments and their impact on your end user and app server's Apdex scores, response times, throughput, and errors)

--- a/src/content/docs/agents/php-agent/frameworks-libraries/analyze-phpunit-test-data-new-relic.mdx
+++ b/src/content/docs/agents/php-agent/frameworks-libraries/analyze-phpunit-test-data-new-relic.mdx
@@ -420,6 +420,8 @@ SELECT host, name, testSuiteName, duration * 1000 AS 'duration (ms)', outcome, a
 
 ## For more help [#more_help]
 
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+
 Additional documentation resources include:
 
 * [Building dashboards](https://docs.newrelic.com/docs/insights/new-relic-insights/managing-dashboards-data/building-insights-dashboards) (how to build and view customized dashboards)

--- a/src/content/docs/agents/php-agent/frameworks-libraries/aws-elastic-beanstalk-installation-php.mdx
+++ b/src/content/docs/agents/php-agent/frameworks-libraries/aws-elastic-beanstalk-installation-php.mdx
@@ -51,6 +51,8 @@ After a successful setup, it can take up to fifteen minutes before metrics begin
 
 ## For more help [#more_help]
 
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+
 Additional documentation resources include:
 
 * [Elastic Beanstalk documentation](http://docs.amazonwebservices.com/elasticbeanstalk/latest/gsg/ "Link opens in a new window") (Amazon documentation for Elastic Beanstalk)

--- a/src/content/docs/agents/php-agent/frameworks-libraries/drupal-specific-functionality.mdx
+++ b/src/content/docs/agents/php-agent/frameworks-libraries/drupal-specific-functionality.mdx
@@ -39,3 +39,13 @@ In this situation, manual instrumentation provides a better opportunity to captu
 ## Cron tasks [#cron]
 
 Drupal supports periodically executing tasks to perform routine maintenance or similar work on behalf of installed Drupal modules. These tasks can be run without any manual involvement beyond the initial configuration. Commonly, these are referred to as [cron tasks](https://drupal.org/cron "Link opens in a new window"). Starting in version 4.3, the New Relic PHP agent detects the execution of these tasks and automatically marks them as [background transactions](/docs/features/monitoring-background-processes#ui) regardless of how they were started.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/frameworks-libraries/guzzle.mdx
+++ b/src/content/docs/agents/php-agent/frameworks-libraries/guzzle.mdx
@@ -67,3 +67,13 @@ To disable Guzzle support:
 
 1. Add `newrelic.guzzle.enabled = false` to your `newrelic.ini` file.
 2. [Restart your web server](https://docs.newrelic.com/docs/agents/php-agent/troubleshooting/why-when-restart-your-web-server-php) (Apache, Nginx, PHP-FPM, etc.).
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/frameworks-libraries/magento-specific-functionality.mdx
+++ b/src/content/docs/agents/php-agent/frameworks-libraries/magento-specific-functionality.mdx
@@ -72,3 +72,13 @@ If an interceptor is registered for `Magento\Framework\App\FrontControllerInterf
 ## Escape automatic transaction naming [#problems]
 
 If automatic transaction naming is not useful, you can override the PHP agent's automatic transaction naming by using the [`newrelic_name_transaction()`](/docs/agents/php-agent/configuration/php-agent-api#api-name-wt) API function.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/frameworks-libraries/php-frameworks-integrate-support-new-relic.mdx
+++ b/src/content/docs/agents/php-agent/frameworks-libraries/php-frameworks-integrate-support-new-relic.mdx
@@ -198,3 +198,13 @@ For page load timing (sometimes referred to as real user monitoring or RUM), ins
     ```
   </Collapser>
 </CollapserGroup>
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/frameworks-libraries/predis-library-php.mdx
+++ b/src/content/docs/agents/php-agent/frameworks-libraries/predis-library-php.mdx
@@ -16,3 +16,13 @@ New Relic added support for the Predis library in PHP agent [release 4.22](/docs
 The agent instruments standard calls to a `Predis\Client` object or to a pipeline. Any commands sent via a pipeline will be grouped and treated as a single command metric named `pipeline` rather than the individual commands.
 
 The PHP agent does not support calls to the `executeRaw` or `transaction` methods, PubSub, monitor, or similar. These will not be instrumented.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/frameworks-libraries/wordpress-specific-functionality.mdx
+++ b/src/content/docs/agents/php-agent/frameworks-libraries/wordpress-specific-functionality.mdx
@@ -35,3 +35,13 @@ By integrating your WordPress application with APM, you can view performance dir
 Signing up for a New Relic account and adding [browser monitoring](/docs/browser/new-relic-browser/getting-started/introduction-new-relic-browser) to your WordPress site is fast and easy with the [browser monitoring plugin for WordPress](https://wordpress.org/plugins/rt-newrelic-browser/). The plugin and our browser monitoring do not require the special access required to install our PHP agent.
 
 This makes them generally compatible with **all** WordPress hosting providers. In addition, the WordPress plugin is supported by the authors and the WordPress community.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/getting-started/apm-agent-security-php.mdx
+++ b/src/content/docs/agents/php-agent/getting-started/apm-agent-security-php.mdx
@@ -164,3 +164,13 @@ If you need different security settings than default or high security mode, you 
     </tr>
   </tbody>
 </table>
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/getting-started/introduction-new-relic-php.mdx
+++ b/src/content/docs/agents/php-agent/getting-started/introduction-new-relic-php.mdx
@@ -149,7 +149,7 @@ If you encounter issues with the PHP agent, see our [full list of troubleshootin
 
 If you need more help, check out these support and learning resources:
 
-* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our open source repository.
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
 * Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
 * Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
 * Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.

--- a/src/content/docs/agents/php-agent/getting-started/introduction-new-relic-php.mdx
+++ b/src/content/docs/agents/php-agent/getting-started/introduction-new-relic-php.mdx
@@ -144,3 +144,13 @@ If you encounter issues with the PHP agent, see our [full list of troubleshootin
 * [Determining permissions requirements](/docs/agents/php-agent/troubleshooting/determining-permissions-requirements)
 * [INI settings not taking effect immediately](/docs/agents/php-agent/troubleshooting/ini-settings-not-taking-effect-immediately)
 * [Why and when to restart your web server (PHP)](/docs/agents/php-agent/troubleshooting/why-when-restart-your-web-server-php)
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/getting-started/new-relic-daemon-processes.mdx
+++ b/src/content/docs/agents/php-agent/getting-started/new-relic-daemon-processes.mdx
@@ -114,3 +114,13 @@ The following methods can be used to kill the daemon:
   ```
   kill `cat /var/run/newrelic-daemon.pid`
   ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -544,3 +544,13 @@ The PHP agent integrates with other New Relic features to give you end-to-end vi
     </tr>
   </tbody>
 </table>
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/installation/install-php-agent-shared-hosting-service.mdx
+++ b/src/content/docs/agents/php-agent/installation/install-php-agent-shared-hosting-service.mdx
@@ -46,6 +46,7 @@ To help ensure that your application can integrate successfully with New Relic:
 
 Additional documentation resources include:
 
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
 * [How to speed up WordPress in 7 easy steps](http://blog.newrelic.com/?p=12218) and [WordPress performance optimization](http:/blog.newrelic.com/?p=12339) (blog posts about WordPress integration with New Relic)
 * [Finding help](/docs/accounts-partnerships/education/finding-help/finding-help) (resources available through the online Help Center)
 * [The New Relic user interface](/docs/apm/new-relic-apm/getting-started/new-relic-user-interface) (overview of how to use the UI)

--- a/src/content/docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos.mdx
+++ b/src/content/docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos.mdx
@@ -123,3 +123,13 @@ Even though the package name for the PHP agent refers to PHP 5, the package work
    ```
 5. Restart your web server (Apache, NGINX, PHP-FPM, etc.).
 6. Generate traffic to your application, and wait a few minutes for it to send data to New Relic. Then, [check your app's performance in New Relic](/docs/apm/applications-menu/monitoring/apm-overview-page).
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/installation/php-agent-installation-overview.mdx
+++ b/src/content/docs/agents/php-agent/installation/php-agent-installation-overview.mdx
@@ -99,3 +99,13 @@ Installation procedures may be different for admins who install the PHP agent th
 * [Other partnership installation procedures](https://docs.newrelic.com/docs/accounts-partnerships/partnerships/partner-based-installation/log-install-new-relic-partners)
 
 Not all partners support PHP agents.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/installation/php-agent-installation-tar-file.mdx
+++ b/src/content/docs/agents/php-agent/installation/php-agent-installation-tar-file.mdx
@@ -52,3 +52,13 @@ With tar file installation, the steps for first time installation and for updati
 5. Change the default [application name](/docs/site/naming-your-application) to a meaningful name.
 6. Restart your web server (Apache, Nginx, PHP-FPM, etc.).
 7. Wait a few minutes for your application to send data, then [check your app's performance in the New Relic UI](/docs/apm/applications-menu/monitoring/apm-overview-page).
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
+++ b/src/content/docs/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
@@ -331,3 +331,13 @@ For example, you can run these commands to preseed your app name and license key
 echo newrelic-php5 newrelic-php5/application-name string "<var>My App Name</var>" | debconf-set-selections
 echo newrelic-php5 newrelic-php5/license-key string "<var>YOUR_LICENSE_KEY</var>" | debconf-set-selections
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/installation/update-php-agent.mdx
+++ b/src/content/docs/agents/php-agent/installation/update-php-agent.mdx
@@ -260,3 +260,13 @@ To update the PHP agent:
 ## Troubleshooting after update [#troubleshoot]
 
 If you updated PHP and the agent stopped working or reporting data, follow the [troubleshooting procedures](/docs/agents/php-agent/troubleshooting/agent-stops-working-after-updating-php).
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_add_custom_parameter.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_add_custom_parameter.mdx
@@ -97,3 +97,13 @@ if (extension_loaded('newrelic')) { // Ensure PHP agent is available
 ```
 
 \-->
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_add_custom_tracer.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_add_custom_tracer.mdx
@@ -121,3 +121,13 @@ namespace {
     }
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_background_job.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_background_job.mdx
@@ -84,3 +84,13 @@ function example() {
     <var>...</var>
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_capture_params.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_capture_params.mdx
@@ -88,3 +88,13 @@ function example() {
     <var>...</var>
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_disable_autorum.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_disable_autorum.mdx
@@ -50,3 +50,13 @@ function example() {
     <var>...</var>
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_end_of_transaction.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_end_of_transaction.mdx
@@ -50,3 +50,13 @@ function example() {
     <var>... //streaming data</var>
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_end_transaction.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_end_transaction.mdx
@@ -95,3 +95,13 @@ function example() {
     <var>... // this code is ignored</var>
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_get_browser_timing_footer.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_get_browser_timing_footer.mdx
@@ -80,3 +80,13 @@ function example(){
     }
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_get_browser_timing_header.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_get_browser_timing_header.mdx
@@ -76,3 +76,13 @@ function example(){
     }
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_ignore_apdex.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_ignore_apdex.mdx
@@ -39,3 +39,13 @@ function example() {
     <var>...</var>
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_ignore_transaction.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_ignore_transaction.mdx
@@ -39,3 +39,13 @@ function example() {
     <var>...</var>
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_name_transaction.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_name_transaction.mdx
@@ -89,3 +89,13 @@ function example() {
 ### MVC framework naming [#mvc-example]
 
 In MVC frameworks, one good option is to use the `newrelic_name_transaction()` call where your request is routed and name your transaction with a Controller/Action format.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_notice_error.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_notice_error.mdx
@@ -292,3 +292,13 @@ function example_error_handler($errno, $errstr, $errfile = null, $errline = null
     //Add your code here.
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_record_custom_event.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_record_custom_event.mdx
@@ -84,3 +84,13 @@ if (extension_loaded('newrelic')) { // Ensure PHP agent is available
     newrelic_record_custom_event("WidgetSale", array("color"=>"red", "weight"=>12.5));
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_record_datastore_segment.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_record_datastore_segment.mdx
@@ -248,3 +248,13 @@ $result = newrelic_record_datastore_segment(function () use ($stmt) {
     'query'        => $query,
 ));
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_set_appname.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_set_appname.mdx
@@ -192,3 +192,13 @@ function example() {
     <var>...</var>
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_set_user_attributes.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_set_user_attributes.mdx
@@ -108,3 +108,13 @@ function example() {
     }
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelic_start_transaction.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelic_start_transaction.mdx
@@ -104,3 +104,13 @@ function example() {
     <var>...</var>
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtraceheaders.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtraceheaders.mdx
@@ -94,3 +94,13 @@ Returns `True` if the headers were accepted successfully, otherwise returns `Fal
 ## Examples
 
 For examples of how and when to use this API method, see the documentation to [manually instrument applications and services](https://docs.newrelic.com/docs/agents/php-agent/features/distributed-tracing-php#manual).
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtracepayload-php-agent-api.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtracepayload-php-agent-api.mdx
@@ -74,3 +74,13 @@ Requires PHP agent [version 8.4 or higher](https://docs.newrelic.com/docs/releas
 ## Examples
 
 For examples of how and when to use this API method, see the documentation to [manually instrument applications and services](https://docs.newrelic.com/docs/agents/php-agent/features/distributed-tracing-php#manual).
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtracepayloadhttpsafe-php-agent-api.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelicacceptdistributedtracepayloadhttpsafe-php-agent-api.mdx
@@ -106,3 +106,13 @@ Returns `true` to indicate success, or `false` if an error occurs.
 ## Examples
 
 For examples of how and when to use this API method, see the documentation to [manually instrument applications and services](https://docs.newrelic.com/docs/agents/php-agent/features/distributed-tracing-php#manual).
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelicaddcustomspanparameter-php-agent-api.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelicaddcustomspanparameter-php-agent-api.mdx
@@ -97,3 +97,13 @@ if (extension_loaded('newrelic')) { // Ensure PHP agent is available
 ```
 
 \-->
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newreliccreatedistributedtracepayload-php-agent-api.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newreliccreatedistributedtracepayload-php-agent-api.mdx
@@ -52,3 +52,14 @@ $payload = newrelic_create_distributed_trace_payload();// renders the payload as
 ## Examples
 
 For examples of how and when to use this API method, see the documentation to [manually instrument applications and services](https://docs.newrelic.com/docs/agents/php-agent/features/distributed-tracing-php#manual).
+
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newreliccustommetric-php-agent-api.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newreliccustommetric-php-agent-api.mdx
@@ -93,3 +93,13 @@ function example() {
     }
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelicgetlinkingmetadata.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelicgetlinkingmetadata.mdx
@@ -38,3 +38,13 @@ if (extension_loaded('newrelic')) {
   $payload = json_encode($linking_md);
 }
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelicgettracemetadata.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelicgettracemetadata.mdx
@@ -57,3 +57,13 @@ function make_http_request($url) {
 
 $status = make_http_request("zipkin-consumer.example");
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelicinsertdistributedtraceheaders.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelicinsertdistributedtraceheaders.mdx
@@ -63,3 +63,13 @@ When Distributed Tracing is enabled, `newrelic_insert_distributed_trace_headers`
 ## Examples
 
 For examples of how and when to use this API method, see the documentation to [manually instrument applications and services](https://docs.newrelic.com/docs/agents/php-agent/features/distributed-tracing-php#manual).
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/php-agent-api/newrelicissampled.mdx
+++ b/src/content/docs/agents/php-agent/php-agent-api/newrelicissampled.mdx
@@ -54,3 +54,13 @@ function make_http_request($url) {
 
 $status = make_http_request("zipkin-consumer.example");
 ```
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/agent-stops-working-after-updating-php.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/agent-stops-working-after-updating-php.mdx
@@ -24,3 +24,13 @@ If you are using a package manager (for example, `apt-get upgrade`) to update PH
 1. Restart your web server (Apache, Nginx, PHP-FPM, etc.).
 2. Wait five minutes to see if the agent starts reporting.
 3. If the agent is still not reporting, [verify the daemon setup](/docs/agents/php-agent/troubleshooting/verifying-php-daemon). If it is set to start in external mode, you must [manually start the daemon](/docs/agents/php-agent/advanced-installation/starting-php-daemon-advanced#daemon-external) for the agent to start reporting.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/checking-loaded-configuration-files-directory.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/checking-loaded-configuration-files-directory.mdx
@@ -29,3 +29,13 @@ If `newrelic.ini` is not the name of your configuration file, check that the fil
 <figcaption>
   **Sample phpinfo() showing top of page**: Verify that the configuration file is being read by checking the top section for the **Configuration File Path**, the **Loaded Configuration Files** and the **Addition .ini files parsed** locations if data does not appear on your APM **Summary** page within a few minutes after configuration and restarting your webserver and PHP.
 </figcaption>
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/data-stops-reporting-while-using-selinux.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/data-stops-reporting-while-using-selinux.mdx
@@ -79,3 +79,13 @@ In some cases, SELinux can prevent the daemon from starting altogether. [Verifyi
 SELinux is a security software designed to limit the communication of processes on your environment. SELinux is a powerful tool in server security. As such, you should implement and configure it to suit your own server environment.
 
 New Relic does not influence decisions on how to configure your server security or processes you allow to run. We are not responsible for security decisions for your software. You should review your configuration settings to make sure they comply with your own security policies before implementing.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/data-stops-reporting.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/data-stops-reporting.mdx
@@ -36,3 +36,13 @@ When the PHP agent is in an idle state, **two** transactions must occur before i
 
 * The first transaction wakes up the daemon and re-establishes the connection to New Relic.
 * The second transaction reports data to New Relic.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/determine-permissions-requirements-php.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/determine-permissions-requirements-php.mdx
@@ -28,3 +28,13 @@ Running the agent does not require root access. The agent does need read/write a
 * [A file in which to store the agent's log files](/docs/php/php-agent-phpini-settings#inivar-daemon-logfile)
 * [A file in which to store the agent's socket endpoint](/docs/php/php-agent-phpini-settings#inivar-daemon-port)
 * [A file in which to record the agent's process ID](/docs/php/php-agent-phpini-settings#inivar-daemon-pidfile)
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/first-php-transaction-not-reported.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/first-php-transaction-not-reported.mdx
@@ -27,3 +27,13 @@ This is expected behavior. When the [PHP daemon](/docs/agents/php-agent/getting-
 ## Cause
 
 This is expected behavior by the PHP daemon, which initially requires two transactions to be reported.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/generating-logs-troubleshooting-php.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/generating-logs-troubleshooting-php.mdx
@@ -35,3 +35,13 @@ Monitoring your New Relic logs may help diagnose the problem. The New Relic PHP 
 <Callout variant="caution">
   Watch the size of your log files. Depending on your application, they can grow very quickly.
 </Callout>
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/ini-settings-not-taking-effect-immediately.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/ini-settings-not-taking-effect-immediately.mdx
@@ -25,3 +25,13 @@ When your web server (Apache, Nginx, PHP-FPM, etc.) first starts up and initiali
 Apache then creates a pool of "worker" processes to deal with requests. These worker processes inherit the settings set during initialization. You have no way of knowing exactly which worker process will deal with a given request. When you make INI file changes, there may still be hundreds of worker processes left with the old settings, and the main Apache process itself (which will periodically kill existing and spawn new worker processes) also has the original INI settings.
 
 Until you restart your Apache server, most changes to your INI files will go unnoticed. The only exception is if you use PHP's "per-directory" setting mechanism using `.htaccess` files. Such settings are rare.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/missing-php-module.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/missing-php-module.mdx
@@ -37,3 +37,13 @@ If `newrelic.so` file is not present in your extensions directory, either:
 <figcaption>
   **Sample phpinfo FIle, Core section**: Check the directory specified by **extension_dir** and verify that `newrelic.so` is present, If data does not appear on your [APM **Summary** page](/docs/apm/applications-menu/monitoring/apm-overview-page) within a few minutes after configuring and restarting your webserver and PHP.
 </figcaption>
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/no-data-appears-php.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/no-data-appears-php.mdx
@@ -134,3 +134,13 @@ If no data appears after you generate traffic to your app and wait at least five
     </tr>
   </tbody>
 </table>
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/php-agent-not-reporting-errors.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/php-agent-not-reporting-errors.mdx
@@ -35,3 +35,13 @@ PHP handles errors with its own default handler. Many third party handlers, such
 The PHP agent has its own error handler that relies on PHP capturing the error. Since only one handler can handle an error, the agent does not see errors that were already handled by the third party handler before it could get captured by PHP.
 
 Additionally, some errors (for example: 404 errors) often occur at the web server level, which means that PHP is never involved and the error is never captured by the agent. If PHP is used to handle 404 errors, use the [`newrelic_notice_error()` API call](/docs/agents/php-agent/php-agent-api/newrelic_notice_error) to manually instrument those errors.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/php-installation-fails-os-x-1011-el-capitan.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/php-installation-fails-os-x-1011-el-capitan.mdx
@@ -66,3 +66,13 @@ There are many articles available on the web that describe SIP and the steps for
 PHP agent installation requires the daemon program to be installed in `/usr/bin` and the extension module in `/usr/lib`. However, those directories have `R-X` permissions, which means the daemon cannot be installed by normal means.
 
 Apple's System Integrity Protection, SIP, prevents the modification of permissions on these directories even when logged in as root, admin or via a sudo privileged account. This also applies in situations where the PHP `bin` is self-contained (for example, MAMP).
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/protocol-mismatch-error.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/protocol-mismatch-error.mdx
@@ -27,3 +27,13 @@ You see errors in your daemon log file after upgrading your agent like this:`pro
 The only reason for this error is that your agent and daemon are out of sync with each other. The daemon and the actual agent (the PHP extension) are a very tightly coupled pair, and the daemon will only accept connections and commands from an agent that matches it.
 
 Sometimes the upgrade process will fail to kill the old daemon correctly and you may still have old daemon processes running. Frequently, this error is caused by not restarting your web server after an upgrade. If the daemon was upgraded correctly, but your web server still contains older agents, you will see this error. The error itself points to which one is out of date.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/submitting-troubleshooting-results-php.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/submitting-troubleshooting-results-php.mdx
@@ -30,3 +30,13 @@ When working with a New Relic Technical Support engineer, provide the following 
   <?php phpinfo(); ?>
   ```
 * Your [agent and daemon log files](/docs/php/php-kb-105)
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/threaded-apache-worker-mpms.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/threaded-apache-worker-mpms.mdx
@@ -21,3 +21,13 @@ The New Relic PHP agent does not support any Apache multi-processing model (MPM)
 The PHP language development team [discourages the use of a threaded MPM with Apache](http://www.php.net/manual/en/install.unix.apache2.php "Link opens in a new window"), and we have chosen not to implement support for threaded MPMs in the PHP agent for similar stability reasons. This includes the **worker** and **event** MPMs.
 
 If the default, non-threaded **prefork** MPM is unsuitable for your needs for performance reasons, we suggest using **mod_fcgid** and **php-fpm** to use PHP via FastCGI instead.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/transactions-named-indexphp-or-unknown.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/transactions-named-indexphp-or-unknown.mdx
@@ -31,3 +31,13 @@ if (extension_loaded ('newrelic')) {
 ## Cause
 
 New Relic probably cannot accurately detect or hook into your specific framework. This often occurs because the supported framework's default dispatching method has been modified (often by a plugin) or is no longer being used. If that happens, New Relic may not be able to detect or hook into the framework's dispatcher, and it will not be able to provide a meaningful transaction naming structure.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/troubleshoot-php-agent-instance-count.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/troubleshoot-php-agent-instance-count.mdx
@@ -22,3 +22,13 @@ Each server listed on the **Summary** page includes the number of instances; for
 The number of instances will increase if command line, background, or external processes are running. The number also may be influenced by heavy throughput. For example, an Apache server may be configured to grow the connection pool to accommodate the increased load.
 
 A difference in the expected values between servers may reflect background tasks being run on one server but not the other. An unexpected count also may indicate a misconfigured load balancer.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/uninstrumented-time-traces.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/uninstrumented-time-traces.mdx
@@ -27,3 +27,13 @@ The second, and most common reason, is when a function:
 * Either is an internal function or is a function provided by an external module
 
 In this situation, the most frequent culprits are functions that send large blocks of data or large files to users. If the user is on a slow connection, sending small files (small images for example) could take a long time due to simple network latency. Since no internal or C extension functions are instrumented, the PHP agent has no one to "blame" the time spent on, and this appears in a transaction trace as uninstrumented time.
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/using-phpinfo-verify-php.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/using-phpinfo-verify-php.mdx
@@ -35,3 +35,13 @@ Use `phpinfo()` to verify that the agent was installed successfully:
 <figcaption>
   **Sample `phpinfo()` File**: If data does not appear on your New Relic [APM **Summary** page](/docs/apm/applications-menu/monitoring/apm-overview-page) within a few minutes after configuring both the PHP agent and the proxy daemon, check the New Relic section of your phpinfo() file to verify that New Relic is installed.
 </figcaption>
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/verifying-php-daemon.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/verifying-php-daemon.mdx
@@ -34,3 +34,13 @@ Verify that the daemon is running correctly:
 
    * [Agent mode startup](/docs/agents/php-agent/advanced-installation/starting-php-daemon-advanced#daemon-external) (default)
    * [External mode startup](/docs/agents/php-agent/advanced-installation/starting-php-daemon-advanced#daemon-autostart) (advanced)
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/troubleshooting/why-when-restart-your-web-server-php.mdx
+++ b/src/content/docs/agents/php-agent/troubleshooting/why-when-restart-your-web-server-php.mdx
@@ -68,3 +68,13 @@ You must restart your web server when:
     ```
   </Collapser>
 </CollapserGroup>
+
+## For more help
+
+If you need more help, check out these support and learning resources:
+
+* Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
+* Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
+* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.


### PR DESCRIPTION
This is a bit of a proof of concept. 

We definitely want to link to our other New Relic open source repositories, but adding a link to the For more help section would be a lot of manual labor. Worth chatting about.