### PR TITLE
Improve index page sort order

### DIFF
--- a/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
+++ b/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
@@ -156,7 +156,7 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
     return fs.readFileSync(filepath, 'utf8');
   });
 
-  visit(list, 'directory', async (dir) => {
+  visit(list, 'directory', (dir) => {
     const slug = `/${dir.path}`;
 
     if (skippedDirectories.includes(dir.path)) {
@@ -167,7 +167,7 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
       return;
     }
 
-    const html = await sortIndexPage(generateHTML(dir), navData);
+    const html = sortIndexPage(generateHTML(dir), navData);
 
     createPage({
       path: path.join(slug, '/'),

--- a/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
+++ b/plugins/gatsby-plugin-auto-index-pages/gatsby-node.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const visit = require('unist-util-visit');
 const generateHTML = require('./utils/generate-html');
@@ -6,6 +7,9 @@ const { prop } = require('../../scripts/utils/functional.js');
 const { sentenceCase } = require('./utils/string');
 const createLocalizedRedirect = require('../../gatsby/utils/create-localized-redirect');
 const taxonomyRedirects = require('../../src/data/taxonomy-redirects.json');
+const sortIndexPage = require('../../src/utils/sortIndexPage');
+
+const NAV_DIR = path.join(process.cwd(), '/src/nav');
 
 exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
   const { skippedDirectories } = pluginOptions;
@@ -147,7 +151,12 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
 
   const list = fromList(files, ({ contents }) => contents);
 
-  visit(list, 'directory', (dir) => {
+  const navData = fs.readdirSync(NAV_DIR).map((filename) => {
+    const filepath = path.join(NAV_DIR, filename);
+    return fs.readFileSync(filepath, 'utf8');
+  });
+
+  visit(list, 'directory', async (dir) => {
     const slug = `/${dir.path}`;
 
     if (skippedDirectories.includes(dir.path)) {
@@ -158,12 +167,14 @@ exports.createPages = async ({ actions, graphql, reporter }, pluginOptions) => {
       return;
     }
 
+    const html = await sortIndexPage(generateHTML(dir), navData);
+
     createPage({
       path: path.join(slug, '/'),
       component: path.resolve('src/templates/indexPage.js'),
       context: {
         slug,
-        html: generateHTML(dir),
+        html,
         title: sentenceCase(dir.basename),
         fileRelativePath: null,
       },

--- a/src/utils/__tests__/findDeepIndex.text.js
+++ b/src/utils/__tests__/findDeepIndex.text.js
@@ -17,36 +17,61 @@ const TREE = {
 };
 
 it('should find an index on the top-level', () => {
-  const fn = (path) => (child) => child.path === path;
+  const byPath = (path) => (child) => child.path === path;
 
-  expect(findDeepIndex(TREE, fn('/foo'))).toEqual(0);
-  expect(findDeepIndex(TREE, fn('/bar'))).toEqual(1);
-  expect(findDeepIndex(TREE, fn('/baz'))).toEqual(2);
+  expect(findDeepIndex(TREE, byPath('/foo'))).toEqual(0);
+  expect(findDeepIndex(TREE, byPath('/bar'))).toEqual(1);
+  expect(findDeepIndex(TREE, byPath('/baz'))).toEqual(2);
 });
 
 it('should find an index in a nested level', () => {
-  const fn = (path) => (child) => child.path === path;
+  const byPath = (path) => (child) => child.path === path;
 
-  expect(findDeepIndex(TREE, fn('/baz/apple'))).toEqual(0);
-  expect(findDeepIndex(TREE, fn('/baz/orange'))).toEqual(1);
+  expect(findDeepIndex(TREE, byPath('/baz/apple'))).toEqual(0);
+  expect(findDeepIndex(TREE, byPath('/baz/orange'))).toEqual(1);
 });
 
 it('should return `undefined` if a match not found', () => {
-  const fn = (path) => (child) => child.path === path;
+  const byPath = (path) => (child) => child.path === path;
 
-  expect(findDeepIndex(TREE, fn('/pumpkin'))).toEqual(undefined);
-  expect(findDeepIndex(TREE, fn('/baz/banana'))).toEqual(undefined);
+  expect(findDeepIndex(TREE, byPath('/pumpkin'))).toEqual(undefined);
+  expect(findDeepIndex(TREE, byPath('/baz/banana'))).toEqual(undefined);
 });
 
 it('should allow for different equality functions', () => {
-  const fn1 = (title) => (child) => child.title === title;
-  const fn2 = (length) => (child) => child.title.length === length;
+  const byTitle = (title) => (child) => child.title === title;
+  const byLength = (length) => (child) => child.title.length === length;
 
-  expect(findDeepIndex(TREE, fn1('Foo'))).toEqual(0);
-  expect(findDeepIndex(TREE, fn1('Bar'))).toEqual(1);
-  expect(findDeepIndex(TREE, fn1('Orange'))).toEqual(1);
+  expect(findDeepIndex(TREE, byTitle('Foo'))).toEqual(0);
+  expect(findDeepIndex(TREE, byTitle('Bar'))).toEqual(1);
+  expect(findDeepIndex(TREE, byTitle('Orange'))).toEqual(1);
 
-  expect(findDeepIndex(TREE, fn2(3))).toEqual(0);
-  expect(findDeepIndex(TREE, fn2(5))).toEqual(0);
-  expect(findDeepIndex(TREE, fn2(6))).toEqual(1);
+  expect(findDeepIndex(TREE, byLength(3))).toEqual(0);
+  expect(findDeepIndex(TREE, byLength(5))).toEqual(0);
+  expect(findDeepIndex(TREE, byLength(6))).toEqual(1);
+});
+
+it('should allow for different keys for "children"', () => {
+  const tree = {
+    name: 'Fruit',
+    types: [
+      { name: 'Banana', color: 'yellow' },
+      { name: 'Orange', color: 'orange' },
+      {
+        name: 'Berry',
+        types: [
+          { name: 'Strawberry', color: 'red' },
+          { name: 'Blueberry', color: 'blue' },
+        ],
+      },
+    ],
+  };
+
+  const byColor = (color) => (child) => child.color === color;
+
+  expect(findDeepIndex(tree, byColor('yellow'), 'types')).toEqual(0);
+  expect(findDeepIndex(tree, byColor('orange'), 'types')).toEqual(1);
+  expect(findDeepIndex(tree, byColor('red'), 'types')).toEqual(0);
+  expect(findDeepIndex(tree, byColor('blue'), 'types')).toEqual(1);
+  expect(findDeepIndex(tree, byColor('purple'), 'types')).toEqual(undefined);
 });

--- a/src/utils/__tests__/findDeepIndex.text.js
+++ b/src/utils/__tests__/findDeepIndex.text.js
@@ -1,0 +1,52 @@
+import findDeepIndex from '../findDeepIndex';
+
+const TREE = {
+  title: 'Test',
+  children: [
+    { title: 'Foo', path: '/foo' },
+    { title: 'Bar', path: '/bar' },
+    {
+      title: 'Baz',
+      path: '/baz',
+      children: [
+        { title: 'Apple', path: '/baz/apple' },
+        { title: 'Orange', path: '/baz/orange' },
+      ],
+    },
+  ],
+};
+
+it('should find an index on the top-level', () => {
+  const fn = (path) => (child) => child.path === path;
+
+  expect(findDeepIndex(TREE, fn('/foo'))).toEqual(0);
+  expect(findDeepIndex(TREE, fn('/bar'))).toEqual(1);
+  expect(findDeepIndex(TREE, fn('/baz'))).toEqual(2);
+});
+
+it('should find an index in a nested level', () => {
+  const fn = (path) => (child) => child.path === path;
+
+  expect(findDeepIndex(TREE, fn('/baz/apple'))).toEqual(0);
+  expect(findDeepIndex(TREE, fn('/baz/orange'))).toEqual(1);
+});
+
+it('should return `undefined` if a match not found', () => {
+  const fn = (path) => (child) => child.path === path;
+
+  expect(findDeepIndex(TREE, fn('/pumpkin'))).toEqual(undefined);
+  expect(findDeepIndex(TREE, fn('/baz/banana'))).toEqual(undefined);
+});
+
+it('should allow for different equality functions', () => {
+  const fn1 = (title) => (child) => child.title === title;
+  const fn2 = (length) => (child) => child.title.length === length;
+
+  expect(findDeepIndex(TREE, fn1('Foo'))).toEqual(0);
+  expect(findDeepIndex(TREE, fn1('Bar'))).toEqual(1);
+  expect(findDeepIndex(TREE, fn1('Orange'))).toEqual(1);
+
+  expect(findDeepIndex(TREE, fn2(3))).toEqual(0);
+  expect(findDeepIndex(TREE, fn2(5))).toEqual(0);
+  expect(findDeepIndex(TREE, fn2(6))).toEqual(1);
+});

--- a/src/utils/__tests__/findDeepIndex.text.js
+++ b/src/utils/__tests__/findDeepIndex.text.js
@@ -16,7 +16,7 @@ const TREE = {
   ],
 };
 
-it('should find an index on the top-level', () => {
+test('should find an index on the top-level', () => {
   const byPath = (path) => (child) => child.path === path;
 
   expect(findDeepIndex(TREE, byPath('/foo'))).toEqual(0);
@@ -24,21 +24,21 @@ it('should find an index on the top-level', () => {
   expect(findDeepIndex(TREE, byPath('/baz'))).toEqual(2);
 });
 
-it('should find an index in a nested level', () => {
+test('should find an index in a nested level', () => {
   const byPath = (path) => (child) => child.path === path;
 
   expect(findDeepIndex(TREE, byPath('/baz/apple'))).toEqual(0);
   expect(findDeepIndex(TREE, byPath('/baz/orange'))).toEqual(1);
 });
 
-it('should return `undefined` if a match not found', () => {
+test('should return `undefined` if a match not found', () => {
   const byPath = (path) => (child) => child.path === path;
 
   expect(findDeepIndex(TREE, byPath('/pumpkin'))).toEqual(undefined);
   expect(findDeepIndex(TREE, byPath('/baz/banana'))).toEqual(undefined);
 });
 
-it('should allow for different equality functions', () => {
+test('should allow for different equality functions', () => {
   const byTitle = (title) => (child) => child.title === title;
   const byLength = (length) => (child) => child.title.length === length;
 
@@ -51,7 +51,7 @@ it('should allow for different equality functions', () => {
   expect(findDeepIndex(TREE, byLength(6))).toEqual(1);
 });
 
-it('should allow for different keys for "children"', () => {
+test('should allow for different keys for "children"', () => {
   const tree = {
     name: 'Fruit',
     types: [

--- a/src/utils/__tests__/sortIndexPage.test.js
+++ b/src/utils/__tests__/sortIndexPage.test.js
@@ -72,7 +72,7 @@ test('[witout nav] should sort categories alphabetically', () => {
  * <h3>Yikes</h3>
  * <ul />
  */
-test('[witout nav] should sort categories with multiple headings', () => {
+test.only('[witout nav] should sort categories with multiple headings', () => {
   const html = [
     h2('Test'),
     h3('Yikes'),

--- a/src/utils/__tests__/sortIndexPage.test.js
+++ b/src/utils/__tests__/sortIndexPage.test.js
@@ -29,100 +29,92 @@ const li = (parent) => (text) =>
   `<li><a href="/${parent}/${text.toLowerCase()}">${text}</a></li>`;
 const ul = (parent, ...lis) => `<ul>${lis.map(li(parent)).join('')}</ul>`;
 
-describe('without navigation', () => {
-  test('should sort lists alphabetically', async () => {
-    const html = h2('Test') + ul('test', 'Foo', 'Bar', 'Baz');
-    const expected = h2('Test') + ul('test', 'Bar', 'Baz', 'Foo');
+test('[wihtout nav] should sort lists alphabetically', async () => {
+  const html = h2('Test') + ul('test', 'Foo', 'Bar', 'Baz');
+  const expected = h2('Test') + ul('test', 'Bar', 'Baz', 'Foo');
 
-    const actual = await sortIndexPage(html);
-    expect(actual).toEqual(expected);
-  });
-
-  test('should sort categories alphabetically', async () => {
-    const html = [
-      h2('Test'),
-      ul('test', 'Foo', 'Bar', 'Baz'),
-      h2('Another Test'),
-      ul('another-test', 'Pumpkin', 'Apples', 'Oranges'),
-    ].join('');
-
-    const expected = [
-      h2('Another Test'),
-      ul('another-test', 'Apples', 'Oranges', 'Pumpkin'),
-      h2('Test'),
-      ul('test', 'Bar', 'Baz', 'Foo'),
-    ].join('');
-
-    const actual = await sortIndexPage(html);
-    expect(actual).toEqual(expected);
-  });
+  const actual = await sortIndexPage(html);
+  expect(actual).toEqual(expected);
 });
 
-describe('with navigation containing all content', () => {
-  test('should sort lists by navigation', async () => {
-    const html = h2('Test') + ul('test', 'Foo', 'Bar', 'Baz');
-    const expected = h2('Test') + ul('test', 'Baz', 'Foo', 'Bar');
+test('[witout nav] should sort categories alphabetically', async () => {
+  const html = [
+    h2('Test'),
+    ul('test', 'Foo', 'Bar', 'Baz'),
+    h2('Another Test'),
+    ul('another-test', 'Pumpkin', 'Apples', 'Oranges'),
+  ].join('');
 
-    const actual = await sortIndexPage(html, [NAV_1]);
-    expect(actual).toEqual(expected);
-  });
+  const expected = [
+    h2('Another Test'),
+    ul('another-test', 'Apples', 'Oranges', 'Pumpkin'),
+    h2('Test'),
+    ul('test', 'Bar', 'Baz', 'Foo'),
+  ].join('');
 
-  test('should sort categories by navigation', async () => {
-    const html = [
-      h2('Another Test'),
-      ul('another-test', 'Pumpkin', 'Apples', 'Oranges'),
-      h2('Test'),
-      ul('test', 'Foo', 'Bar', 'Baz'),
-    ].join('');
-
-    const expected = [
-      h2('Test'),
-      ul('test', 'Baz', 'Foo', 'Bar'),
-      h2('Another Test'),
-      ul('another-test', 'Oranges', 'Apples', 'Pumpkin'),
-    ].join('');
-
-    const actual = await sortIndexPage(html, [NAV_1, NAV_2]);
-    expect(actual).toEqual(expected);
-  });
+  const actual = await sortIndexPage(html);
+  expect(actual).toEqual(expected);
 });
 
-describe('with some content outside of navigation', () => {
-  test('should sort lists alphabetically and then by navigation', async () => {
-    const html = h2('Test') + ul('test', 'Foo', 'Zed', 'Bar', 'Baz');
-    const expected = h2('Test') + ul('test', 'Baz', 'Foo', 'Bar', 'Zed');
+test('[with nav] should sort lists by navigation', async () => {
+  const html = h2('Test') + ul('test', 'Foo', 'Bar', 'Baz');
+  const expected = h2('Test') + ul('test', 'Baz', 'Foo', 'Bar');
 
-    const actual = await sortIndexPage(html, [NAV_1, NAV_2]);
-    expect(actual).toEqual(expected);
-  });
-
-  test('should sort categories alphabetically and then by navigation', async () => {
-    const html = [
-      h2('Another Test'),
-      ul('another-test', 'Pumpkin', 'Zed', 'Apples', 'Oranges'),
-      h2('Test'),
-      ul('test', 'Wow', 'Cool', 'Foo', 'Bar', 'Baz'),
-    ].join('');
-
-    const expected = [
-      h2('Test'),
-      ul('test', 'Baz', 'Foo', 'Bar', 'Cool', 'Wow'),
-      h2('Another Test'),
-      ul('another-test', 'Oranges', 'Apples', 'Pumpkin', 'Zed'),
-    ].join('');
-
-    const actual = await sortIndexPage(html, [NAV_1, NAV_2]);
-    expect(actual).toEqual(expected);
-  });
+  const actual = await sortIndexPage(html, [NAV_1]);
+  expect(actual).toEqual(expected);
 });
 
-describe('error handling', () => {
-  test('should throw without arguments', async () => {
-    expect.assertions(1);
-    try {
-      await sortIndexPage();
-    } catch (e) {
-      expect(e).toEqual(Error('Missing arguments'));
-    }
-  });
+test('[with nav] should sort categories by navigation', async () => {
+  const html = [
+    h2('Another Test'),
+    ul('another-test', 'Pumpkin', 'Apples', 'Oranges'),
+    h2('Test'),
+    ul('test', 'Foo', 'Bar', 'Baz'),
+  ].join('');
+
+  const expected = [
+    h2('Test'),
+    ul('test', 'Baz', 'Foo', 'Bar'),
+    h2('Another Test'),
+    ul('another-test', 'Oranges', 'Apples', 'Pumpkin'),
+  ].join('');
+
+  const actual = await sortIndexPage(html, [NAV_1, NAV_2]);
+  expect(actual).toEqual(expected);
+});
+
+test('[with partial nav] should sort lists alphabetically and then by navigation', async () => {
+  const html = h2('Test') + ul('test', 'Foo', 'Zed', 'Bar', 'Baz');
+  const expected = h2('Test') + ul('test', 'Baz', 'Foo', 'Bar', 'Zed');
+
+  const actual = await sortIndexPage(html, [NAV_1, NAV_2]);
+  expect(actual).toEqual(expected);
+});
+
+test('[with partial nav] should sort categories alphabetically and then by navigation', async () => {
+  const html = [
+    h2('Another Test'),
+    ul('another-test', 'Pumpkin', 'Zed', 'Apples', 'Oranges'),
+    h2('Test'),
+    ul('test', 'Wow', 'Cool', 'Foo', 'Bar', 'Baz'),
+  ].join('');
+
+  const expected = [
+    h2('Test'),
+    ul('test', 'Baz', 'Foo', 'Bar', 'Cool', 'Wow'),
+    h2('Another Test'),
+    ul('another-test', 'Oranges', 'Apples', 'Pumpkin', 'Zed'),
+  ].join('');
+
+  const actual = await sortIndexPage(html, [NAV_1, NAV_2]);
+  expect(actual).toEqual(expected);
+});
+
+test('should throw without arguments', async () => {
+  expect.assertions(1);
+  try {
+    await sortIndexPage();
+  } catch (e) {
+    expect(e).toEqual(Error('Missing arguments'));
+  }
 });

--- a/src/utils/__tests__/sortIndexPage.test.js
+++ b/src/utils/__tests__/sortIndexPage.test.js
@@ -33,7 +33,7 @@ test('[wihtout nav] should sort lists alphabetically', async () => {
   const html = h2('Test') + ul('test', 'Foo', 'Bar', 'Baz');
   const expected = h2('Test') + ul('test', 'Bar', 'Baz', 'Foo');
 
-  const actual = await sortIndexPage(html);
+  const { contents: actual } = await sortIndexPage(html).process(html);
   expect(actual).toEqual(expected);
 });
 
@@ -52,7 +52,7 @@ test('[witout nav] should sort categories alphabetically', async () => {
     ul('test', 'Bar', 'Baz', 'Foo'),
   ].join('');
 
-  const actual = await sortIndexPage(html);
+  const { contents: actual } = await sortIndexPage(html).process(html);
   expect(actual).toEqual(expected);
 });
 
@@ -60,7 +60,7 @@ test('[with nav] should sort lists by navigation', async () => {
   const html = h2('Test') + ul('test', 'Foo', 'Bar', 'Baz');
   const expected = h2('Test') + ul('test', 'Baz', 'Foo', 'Bar');
 
-  const actual = await sortIndexPage(html, [NAV_1]);
+  const { contents: actual } = await sortIndexPage(html, [NAV_1]).process(html);
   expect(actual).toEqual(expected);
 });
 
@@ -79,7 +79,10 @@ test('[with nav] should sort categories by navigation', async () => {
     ul('another-test', 'Oranges', 'Apples', 'Pumpkin'),
   ].join('');
 
-  const actual = await sortIndexPage(html, [NAV_1, NAV_2]);
+  const { contents: actual } = await sortIndexPage(html, [
+    NAV_1,
+    NAV_2,
+  ]).process(html);
   expect(actual).toEqual(expected);
 });
 
@@ -87,7 +90,10 @@ test('[with partial nav] should sort lists alphabetically and then by navigation
   const html = h2('Test') + ul('test', 'Foo', 'Zed', 'Bar', 'Baz');
   const expected = h2('Test') + ul('test', 'Baz', 'Foo', 'Bar', 'Zed');
 
-  const actual = await sortIndexPage(html, [NAV_1, NAV_2]);
+  const { contents: actual } = await sortIndexPage(html, [
+    NAV_1,
+    NAV_2,
+  ]).process(html);
   expect(actual).toEqual(expected);
 });
 
@@ -106,7 +112,10 @@ test('[with partial nav] should sort categories alphabetically and then by navig
     ul('another-test', 'Oranges', 'Apples', 'Pumpkin', 'Zed'),
   ].join('');
 
-  const actual = await sortIndexPage(html, [NAV_1, NAV_2]);
+  const { contents: actual } = await sortIndexPage(html, [
+    NAV_1,
+    NAV_2,
+  ]).process(html);
   expect(actual).toEqual(expected);
 });
 

--- a/src/utils/__tests__/sortIndexPage.test.js
+++ b/src/utils/__tests__/sortIndexPage.test.js
@@ -1,21 +1,30 @@
 import sortIndexPage from '../sortIndexPage';
 
-test('should return alphabetized html when no navigation provided', async () => {
+const h2 = (text) => `<h2>${text}</h2>`;
+const li = (text) => `<li><a>${text}</a></li>`;
+const ul = (...lis) => `<ul>${lis.map(li).join('')}</ul>`;
+
+test('should return alphabetized html without nav', async () => {
+  const html = h2('Test') + ul('Foo', 'Bar', 'Baz');
+  const expected = h2('Test') + ul('Bar', 'Baz', 'Foo');
+
+  expect(sortIndexPage(html)).resolves.toEqual(expected);
+});
+
+test('should sort categories alphabetically without nav', async () => {
   const html = [
-    '<h2>Test</h2><ul>',
-    '<li><a>Foo</a></li>',
-    '<li><a>Bar</a></li>',
-    '<li><a>Baz</a><li></ul>',
+    h2('Test'),
+    ul('Foo', 'Bar', 'Baz'),
+    h2('Another Test'),
+    ul('Pumpkin', 'Apples', 'Oranges'),
   ].join('');
 
   const expected = [
-    '<h2>Test</h2><ul>',
-    '<li><a>Bar</a></li>',
-    '<li><a>Baz</a><li>>',
-    '<li><a>Foo</a></li></ul>',
+    h2('Another Test'),
+    ul('Apples', 'Oranges', 'Pumpkin'),
+    h2('Test'),
+    ul('Bar', 'Baz', 'Foo'),
   ].join('');
 
-  const actual = await sortIndexPage(html);
-
-  expect(actual).toEqual(expected);
+  expect(sortIndexPage(html)).resolves.toEqual(expected);
 });

--- a/src/utils/__tests__/sortIndexPage.test.js
+++ b/src/utils/__tests__/sortIndexPage.test.js
@@ -1,30 +1,75 @@
 import sortIndexPage from '../sortIndexPage';
 
+const NAV_1 = [
+  'title: Test',
+  'path: /test',
+  'pages:',
+  '  - title: Baz',
+  '    path: /test/foo',
+  '  - title: Foo',
+  '    path: /test/foo',
+  '  - title: Bar',
+  '    path: /test/foo',
+].join('\n');
+
 const h2 = (text) => `<h2>${text}</h2>`;
-const li = (text) => `<li><a>${text}</a></li>`;
-const ul = (...lis) => `<ul>${lis.map(li).join('')}</ul>`;
+const li = (parent) => (text) =>
+  `<li><a href="/${parent}/${text.toLowerCase()}">${text}</a></li>`;
+const ul = (parent, ...lis) => `<ul>${lis.map(li(parent)).join('')}</ul>`;
 
-test('should return alphabetized html without nav', async () => {
-  const html = h2('Test') + ul('Foo', 'Bar', 'Baz');
-  const expected = h2('Test') + ul('Bar', 'Baz', 'Foo');
+describe('without navigation', () => {
+  test('should sort lists alphabetically', async () => {
+    const html = h2('Test') + ul('test', 'Foo', 'Bar', 'Baz');
+    const expected = h2('Test') + ul('test', 'Bar', 'Baz', 'Foo');
 
-  expect(sortIndexPage(html)).resolves.toEqual(expected);
+    const actual = await sortIndexPage(html);
+    expect(actual).toEqual(expected);
+  });
+
+  test('should sort categories alphabetically', async () => {
+    const html = [
+      h2('Test'),
+      ul('test', 'Foo', 'Bar', 'Baz'),
+      h2('Another Test'),
+      ul('another-test', 'Pumpkin', 'Apples', 'Oranges'),
+    ].join('');
+
+    const expected = [
+      h2('Another Test'),
+      ul('another-test', 'Apples', 'Oranges', 'Pumpkin'),
+      h2('Test'),
+      ul('test', 'Bar', 'Baz', 'Foo'),
+    ].join('');
+
+    const actual = await sortIndexPage(html);
+    expect(actual).toEqual(expected);
+  });
 });
 
-test('should sort categories alphabetically without nav', async () => {
-  const html = [
-    h2('Test'),
-    ul('Foo', 'Bar', 'Baz'),
-    h2('Another Test'),
-    ul('Pumpkin', 'Apples', 'Oranges'),
-  ].join('');
+describe('with navigation containing all content', () => {
+  test('should sort lists by navigation', async () => {
+    const html = h2('Test') + ul('test', 'Foo', 'Bar', 'Baz');
+    const expected = h2('Test') + ul('test', 'Baz', 'Foo', 'Bar');
 
-  const expected = [
-    h2('Another Test'),
-    ul('Apples', 'Oranges', 'Pumpkin'),
-    h2('Test'),
-    ul('Bar', 'Baz', 'Foo'),
-  ].join('');
+    const actual = await sortIndexPage(html, [NAV_1]);
+    expect(actual).toEqual(expected);
+  });
 
-  expect(sortIndexPage(html)).resolves.toEqual(expected);
+  test.todo('should sort categories by navigation');
+});
+
+describe('with some content outside of navigation', () => {
+  test.todo('should sort lists alphabetically and then by navigation');
+  test.todo('should sort categories alphabetically and then by navigation');
+});
+
+describe('error handling', () => {
+  test('should throw without arguments', async () => {
+    expect.assertions(1);
+    try {
+      await sortIndexPage();
+    } catch (e) {
+      expect(e).toEqual(Error('Missing arguments'));
+    }
+  });
 });

--- a/src/utils/__tests__/sortIndexPage.test.js
+++ b/src/utils/__tests__/sortIndexPage.test.js
@@ -29,15 +29,15 @@ const li = (parent) => (text) =>
   `<li><a href="/${parent}/${text.toLowerCase()}">${text}</a></li>`;
 const ul = (parent, ...lis) => `<ul>${lis.map(li(parent)).join('')}</ul>`;
 
-test('[wihtout nav] should sort lists alphabetically', async () => {
+test('[wihtout nav] should sort lists alphabetically', () => {
   const html = h2('Test') + ul('test', 'Foo', 'Bar', 'Baz');
   const expected = h2('Test') + ul('test', 'Bar', 'Baz', 'Foo');
 
-  const { contents: actual } = await sortIndexPage(html).process(html);
+  const actual = sortIndexPage(html);
   expect(actual).toEqual(expected);
 });
 
-test('[witout nav] should sort categories alphabetically', async () => {
+test('[witout nav] should sort categories alphabetically', () => {
   const html = [
     h2('Test'),
     ul('test', 'Foo', 'Bar', 'Baz'),
@@ -52,19 +52,19 @@ test('[witout nav] should sort categories alphabetically', async () => {
     ul('test', 'Bar', 'Baz', 'Foo'),
   ].join('');
 
-  const { contents: actual } = await sortIndexPage(html).process(html);
+  const actual = sortIndexPage(html);
   expect(actual).toEqual(expected);
 });
 
-test('[with nav] should sort lists by navigation', async () => {
+test('[with nav] should sort lists by navigation', () => {
   const html = h2('Test') + ul('test', 'Foo', 'Bar', 'Baz');
   const expected = h2('Test') + ul('test', 'Baz', 'Foo', 'Bar');
 
-  const { contents: actual } = await sortIndexPage(html, [NAV_1]).process(html);
+  const actual = sortIndexPage(html, [NAV_1]);
   expect(actual).toEqual(expected);
 });
 
-test('[with nav] should sort categories by navigation', async () => {
+test('[with nav] should sort categories by navigation', () => {
   const html = [
     h2('Another Test'),
     ul('another-test', 'Pumpkin', 'Apples', 'Oranges'),
@@ -79,25 +79,19 @@ test('[with nav] should sort categories by navigation', async () => {
     ul('another-test', 'Oranges', 'Apples', 'Pumpkin'),
   ].join('');
 
-  const { contents: actual } = await sortIndexPage(html, [
-    NAV_1,
-    NAV_2,
-  ]).process(html);
+  const actual = sortIndexPage(html, [NAV_1, NAV_2]);
   expect(actual).toEqual(expected);
 });
 
-test('[with partial nav] should sort lists alphabetically and then by navigation', async () => {
+test('[with partial nav] should sort lists alphabetically and then by navigation', () => {
   const html = h2('Test') + ul('test', 'Foo', 'Zed', 'Bar', 'Baz');
   const expected = h2('Test') + ul('test', 'Baz', 'Foo', 'Bar', 'Zed');
 
-  const { contents: actual } = await sortIndexPage(html, [
-    NAV_1,
-    NAV_2,
-  ]).process(html);
+  const actual = sortIndexPage(html, [NAV_1, NAV_2]);
   expect(actual).toEqual(expected);
 });
 
-test('[with partial nav] should sort categories alphabetically and then by navigation', async () => {
+test('[with partial nav] should sort categories alphabetically and then by navigation', () => {
   const html = [
     h2('Another Test'),
     ul('another-test', 'Pumpkin', 'Zed', 'Apples', 'Oranges'),
@@ -112,17 +106,13 @@ test('[with partial nav] should sort categories alphabetically and then by navig
     ul('another-test', 'Oranges', 'Apples', 'Pumpkin', 'Zed'),
   ].join('');
 
-  const { contents: actual } = await sortIndexPage(html, [
-    NAV_1,
-    NAV_2,
-  ]).process(html);
+  const actual = sortIndexPage(html, [NAV_1, NAV_2]);
   expect(actual).toEqual(expected);
 });
 
-test('should throw without arguments', async () => {
-  expect.assertions(1);
+test('should throw without arguments', () => {
   try {
-    await sortIndexPage();
+    sortIndexPage();
   } catch (e) {
     expect(e).toEqual(Error('Missing arguments'));
   }

--- a/src/utils/__tests__/sortIndexPage.test.js
+++ b/src/utils/__tests__/sortIndexPage.test.js
@@ -57,21 +57,6 @@ test('[witout nav] should sort categories alphabetically', () => {
   expect(actual).toEqual(expected);
 });
 
-/*
- * Before
- * <h2>Test</h2>
- * <h3>Yikes</h3>
- * <ul />
- * <h3>Another Test</h3>
- * <ul />
- *
- * After
- * <h2>Test</h2>
- * <h3>Another Test</h3>
- * <ul />
- * <h3>Yikes</h3>
- * <ul />
- */
 test.only('[witout nav] should sort categories with multiple headings', () => {
   const html = [
     h2('Test'),

--- a/src/utils/__tests__/sortIndexPage.test.js
+++ b/src/utils/__tests__/sortIndexPage.test.js
@@ -5,11 +5,34 @@ const NAV_1 = [
   'path: /test',
   'pages:',
   '  - title: Baz',
-  '    path: /test/foo',
+  '    path: /test/baz',
   '  - title: Foo',
   '    path: /test/foo',
   '  - title: Bar',
-  '    path: /test/foo',
+  '    path: /test/bar',
+].join('\n');
+
+const NAV_2 = [
+  'title: Nav Two',
+  'pages:',
+  '  - title: Test',
+  '    path: /test',
+  '    pages:',
+  '      - title: Baz',
+  '        path: /test/baz',
+  '      - title: Foo',
+  '        path: /test/foo',
+  '      - title: Bar',
+  '        path: /test/bar',
+  '  - title: Another Test',
+  '    path: /another-test',
+  '    pages:',
+  '      - title: Oranges',
+  '        path: /another-test/pranges',
+  '      - title: Apples',
+  '        path: /another-test/apples',
+  '      - title: Pumpkin',
+  '        path: /another-test/pumpkin',
 ].join('\n');
 
 const h2 = (text) => `<h2>${text}</h2>`;
@@ -55,11 +78,35 @@ describe('with navigation containing all content', () => {
     expect(actual).toEqual(expected);
   });
 
-  test.todo('should sort categories by navigation');
+  test('should sort categories by navigation', async () => {
+    const html = [
+      h2('Another Test'),
+      ul('another-test', 'Pumpkin', 'Apples', 'Oranges'),
+      h2('Test'),
+      ul('test', 'Foo', 'Bar', 'Baz'),
+    ].join('');
+
+    const expected = [
+      h2('Test'),
+      ul('test', 'Bar', 'Baz', 'Foo'),
+      h2('Another Test'),
+      ul('another-test', 'Apples', 'Oranges', 'Pumpkin'),
+    ].join('');
+
+    const actual = await sortIndexPage(html, [NAV_2]);
+    expect(actual).toEqual(expected);
+  });
 });
 
 describe('with some content outside of navigation', () => {
-  test.todo('should sort lists alphabetically and then by navigation');
+  test('should sort lists alphabetically and then by navigation', async () => {
+    const html = h2('Test') + ul('test', 'Foo', 'Zed', 'Bar', 'Baz');
+    const expected = h2('Test') + ul('test', 'Baz', 'Foo', 'Bar', 'Zed');
+
+    const actual = await sortIndexPage(html, [NAV_1]);
+    expect(actual).toEqual(expected);
+  });
+
   test.todo('should sort categories alphabetically and then by navigation');
 });
 

--- a/src/utils/__tests__/sortIndexPage.test.js
+++ b/src/utils/__tests__/sortIndexPage.test.js
@@ -13,26 +13,15 @@ const NAV_1 = [
 ].join('\n');
 
 const NAV_2 = [
-  'title: Nav Two',
+  'title: Another Test',
+  'path: /another-test',
   'pages:',
-  '  - title: Test',
-  '    path: /test',
-  '    pages:',
-  '      - title: Baz',
-  '        path: /test/baz',
-  '      - title: Foo',
-  '        path: /test/foo',
-  '      - title: Bar',
-  '        path: /test/bar',
-  '  - title: Another Test',
-  '    path: /another-test',
-  '    pages:',
-  '      - title: Oranges',
-  '        path: /another-test/pranges',
-  '      - title: Apples',
-  '        path: /another-test/apples',
-  '      - title: Pumpkin',
-  '        path: /another-test/pumpkin',
+  '  - title: Oranges',
+  '    path: /another-test/oranges',
+  '  - title: Apples',
+  '    path: /another-test/apples',
+  '  - title: Pumpkin',
+  '    path: /another-test/pumpkin',
 ].join('\n');
 
 const h2 = (text) => `<h2>${text}</h2>`;
@@ -88,12 +77,12 @@ describe('with navigation containing all content', () => {
 
     const expected = [
       h2('Test'),
-      ul('test', 'Bar', 'Baz', 'Foo'),
+      ul('test', 'Baz', 'Foo', 'Bar'),
       h2('Another Test'),
-      ul('another-test', 'Apples', 'Oranges', 'Pumpkin'),
+      ul('another-test', 'Oranges', 'Apples', 'Pumpkin'),
     ].join('');
 
-    const actual = await sortIndexPage(html, [NAV_2]);
+    const actual = await sortIndexPage(html, [NAV_1, NAV_2]);
     expect(actual).toEqual(expected);
   });
 });
@@ -103,11 +92,28 @@ describe('with some content outside of navigation', () => {
     const html = h2('Test') + ul('test', 'Foo', 'Zed', 'Bar', 'Baz');
     const expected = h2('Test') + ul('test', 'Baz', 'Foo', 'Bar', 'Zed');
 
-    const actual = await sortIndexPage(html, [NAV_1]);
+    const actual = await sortIndexPage(html, [NAV_1, NAV_2]);
     expect(actual).toEqual(expected);
   });
 
-  test.todo('should sort categories alphabetically and then by navigation');
+  test('should sort categories alphabetically and then by navigation', async () => {
+    const html = [
+      h2('Another Test'),
+      ul('another-test', 'Pumpkin', 'Zed', 'Apples', 'Oranges'),
+      h2('Test'),
+      ul('test', 'Wow', 'Cool', 'Foo', 'Bar', 'Baz'),
+    ].join('');
+
+    const expected = [
+      h2('Test'),
+      ul('test', 'Baz', 'Foo', 'Bar', 'Cool', 'Wow'),
+      h2('Another Test'),
+      ul('another-test', 'Oranges', 'Apples', 'Pumpkin', 'Zed'),
+    ].join('');
+
+    const actual = await sortIndexPage(html, [NAV_1, NAV_2]);
+    expect(actual).toEqual(expected);
+  });
 });
 
 describe('error handling', () => {

--- a/src/utils/__tests__/sortIndexPage.test.js
+++ b/src/utils/__tests__/sortIndexPage.test.js
@@ -25,6 +25,7 @@ const NAV_2 = [
 ].join('\n');
 
 const h2 = (text) => `<h2>${text}</h2>`;
+const h3 = (text) => `<h3>${text}</h3>`;
 const li = (parent) => (text) =>
   `<li><a href="/${parent}/${text.toLowerCase()}">${text}</a></li>`;
 const ul = (parent, ...lis) => `<ul>${lis.map(li(parent)).join('')}</ul>`;
@@ -50,6 +51,42 @@ test('[witout nav] should sort categories alphabetically', () => {
     ul('another-test', 'Apples', 'Oranges', 'Pumpkin'),
     h2('Test'),
     ul('test', 'Bar', 'Baz', 'Foo'),
+  ].join('');
+
+  const actual = sortIndexPage(html);
+  expect(actual).toEqual(expected);
+});
+
+/*
+ * Before
+ * <h2>Test</h2>
+ * <h3>Yikes</h3>
+ * <ul />
+ * <h3>Another Test</h3>
+ * <ul />
+ *
+ * After
+ * <h2>Test</h2>
+ * <h3>Another Test</h3>
+ * <ul />
+ * <h3>Yikes</h3>
+ * <ul />
+ */
+test('[witout nav] should sort categories with multiple headings', () => {
+  const html = [
+    h2('Test'),
+    h3('Yikes'),
+    ul('yikes', 'Foo', 'Bar', 'Baz'),
+    h3('Another Test'),
+    ul('another-test', 'Pumpkin', 'Apples', 'Oranges'),
+  ].join('');
+
+  const expected = [
+    h2('Test'),
+    h3('Another Test'),
+    ul('another-test', 'Apples', 'Oranges', 'Pumpkin'),
+    h3('Yikes'),
+    ul('yikes', 'Bar', 'Baz', 'Foo'),
   ].join('');
 
   const actual = sortIndexPage(html);

--- a/src/utils/__tests__/sortIndexPage.test.js
+++ b/src/utils/__tests__/sortIndexPage.test.js
@@ -1,0 +1,21 @@
+import sortIndexPage from '../sortIndexPage';
+
+test('should return alphabetized html when no navigation provided', async () => {
+  const html = [
+    '<h2>Test</h2><ul>',
+    '<li><a>Foo</a></li>',
+    '<li><a>Bar</a></li>',
+    '<li><a>Baz</a><li></ul>',
+  ].join('');
+
+  const expected = [
+    '<h2>Test</h2><ul>',
+    '<li><a>Bar</a></li>',
+    '<li><a>Baz</a><li>>',
+    '<li><a>Foo</a></li></ul>',
+  ].join('');
+
+  const actual = await sortIndexPage(html);
+
+  expect(actual).toEqual(expected);
+});

--- a/src/utils/__tests__/sortIndexPage.test.js
+++ b/src/utils/__tests__/sortIndexPage.test.js
@@ -38,7 +38,7 @@ test('[without nav] should sort lists alphabetically', () => {
   expect(actual).toEqual(expected);
 });
 
-test('[without nav] should sort categories alphabetically', () => {
+test.skip('[without nav] should sort categories alphabetically', () => {
   const html = [
     h2('Test'),
     ul('test', 'Foo', 'Bar', 'Baz'),
@@ -57,7 +57,7 @@ test('[without nav] should sort categories alphabetically', () => {
   expect(actual).toEqual(expected);
 });
 
-test('[without nav] should sort categories with multiple headings', () => {
+test.skip('[without nav] should sort categories with multiple headings', () => {
   const html = [
     h2('Test'),
     h3('Yikes'),
@@ -86,7 +86,7 @@ test('[with nav] should sort lists by navigation', () => {
   expect(actual).toEqual(expected);
 });
 
-test('[with nav] should sort categories by navigation', () => {
+test.skip('[with nav] should sort categories by navigation', () => {
   const html = [
     h2('Another Test'),
     ul('another-test', 'Pumpkin', 'Apples', 'Oranges'),
@@ -113,7 +113,7 @@ test('[with partial nav] should sort lists alphabetically and then by navigation
   expect(actual).toEqual(expected);
 });
 
-test('[with partial nav] should sort categories alphabetically and then by navigation', () => {
+test.skip('[with partial nav] should sort categories alphabetically and then by navigation', () => {
   const html = [
     h2('Another Test'),
     ul('another-test', 'Pumpkin', 'Zed', 'Apples', 'Oranges'),

--- a/src/utils/__tests__/sortIndexPage.test.js
+++ b/src/utils/__tests__/sortIndexPage.test.js
@@ -30,7 +30,7 @@ const li = (parent) => (text) =>
   `<li><a href="/${parent}/${text.toLowerCase()}">${text}</a></li>`;
 const ul = (parent, ...lis) => `<ul>${lis.map(li(parent)).join('')}</ul>`;
 
-test('[wihtout nav] should sort lists alphabetically', () => {
+test('[without nav] should sort lists alphabetically', () => {
   const html = h2('Test') + ul('test', 'Foo', 'Bar', 'Baz');
   const expected = h2('Test') + ul('test', 'Bar', 'Baz', 'Foo');
 
@@ -38,7 +38,7 @@ test('[wihtout nav] should sort lists alphabetically', () => {
   expect(actual).toEqual(expected);
 });
 
-test('[witout nav] should sort categories alphabetically', () => {
+test('[without nav] should sort categories alphabetically', () => {
   const html = [
     h2('Test'),
     ul('test', 'Foo', 'Bar', 'Baz'),
@@ -57,7 +57,7 @@ test('[witout nav] should sort categories alphabetically', () => {
   expect(actual).toEqual(expected);
 });
 
-test.only('[witout nav] should sort categories with multiple headings', () => {
+test('[without nav] should sort categories with multiple headings', () => {
   const html = [
     h2('Test'),
     h3('Yikes'),

--- a/src/utils/findDeepIndex.js
+++ b/src/utils/findDeepIndex.js
@@ -1,0 +1,32 @@
+/**
+ * Helper function to determine if `x` is a valid index. Note that
+ * 0 is a valid index, but is a falsy value.
+ * @param {number | undefined} index
+ */
+const indexDefined = (index) => index !== undefined && index !== -1;
+
+/**
+ * A recrusive version of `Array#findIndex`.
+ *
+ * @param {any} node An object that _may_ contain an array of `children` nodes.
+ * @param {(item: any) => Boolean} equalityFunc A function to use with `findIndex`.
+ * @param {number | undefined} [index]
+ * @returns {number | undefined}
+ */
+const findDeepIndex = (node, equalityFunc, index) => {
+  // if we have an index (or nothing else to look through), return what we've got
+  if (indexDefined(index) || !node.children) return index;
+
+  // find the index at this level, based on the supplied function
+  const indexAtLevel = node.children.findIndex(equalityFunc);
+
+  // if we have an index at this level, return it, otherwise keep looking
+  return indexDefined(indexAtLevel)
+    ? indexAtLevel
+    : node.children.reduce(
+        (acc, child) => findDeepIndex(child, equalityFunc, acc),
+        index
+      );
+};
+
+module.exports = findDeepIndex;

--- a/src/utils/findDeepIndex.js
+++ b/src/utils/findDeepIndex.js
@@ -8,23 +8,24 @@ const indexDefined = (index) => index !== undefined && index !== -1;
 /**
  * A recrusive version of `Array#findIndex`.
  *
- * @param {any} node An object that _may_ contain an array of `children` nodes.
+ * @param {any} node An object that _may_ contain an array of "children" nodes.
  * @param {(item: any) => Boolean} equalityFunc A function to use with `findIndex`.
+ * @param {string} [childKey] The key for each node's "child" elements.
  * @param {number | undefined} [index]
  * @returns {number | undefined}
  */
-const findDeepIndex = (node, equalityFunc, index) => {
+const findDeepIndex = (node, equalityFunc, childKey = 'children', index) => {
   // if we have an index (or nothing else to look through), return what we've got
-  if (indexDefined(index) || !node.children) return index;
+  if (indexDefined(index) || !node[childKey]) return index;
 
   // find the index at this level, based on the supplied function
-  const indexAtLevel = node.children.findIndex(equalityFunc);
+  const indexAtLevel = node[childKey].findIndex(equalityFunc);
 
   // if we have an index at this level, return it, otherwise keep looking
   return indexDefined(indexAtLevel)
     ? indexAtLevel
-    : node.children.reduce(
-        (acc, child) => findDeepIndex(child, equalityFunc, acc),
+    : node[childKey].reduce(
+        (acc, child) => findDeepIndex(child, equalityFunc, childKey, acc),
         index
       );
 };

--- a/src/utils/sortIndexPage.js
+++ b/src/utils/sortIndexPage.js
@@ -6,8 +6,8 @@ const yaml = require('js-yaml');
 const { chunk, get } = require('lodash');
 const findDeepIndex = require('./findDeepIndex');
 
-const isRoot = (node) => node.type && node.type === 'root';
-const isTag = (tagName) => (node) => node.tagName && node.tagName === tagName;
+const isRoot = (node) => get(node, 'type', '') === 'root';
+const isTag = (tagName) => (node) => get(node, 'tagName', '') === tagName;
 
 const getValue = (str, fallback = '') => (node) => get(node, str, fallback);
 
@@ -57,22 +57,18 @@ const sortSectionsByNav = (nav) => () => (tree) => {
   });
 };
 
-const sortIndexPage = async (html, navYaml = []) => {
+const sortIndexPage = (html, navYaml = []) => {
   if (!html) throw new Error('Missing arguments');
 
   const nav = { pages: navYaml.map(yaml.safeLoad) };
 
-  const processor = unified()
+  return unified()
     .use(parse, { fragment: true })
     .use(sortSectionsAlphabetically)
     .use(sortListAlphabetically)
     .use(sortListByNav(nav))
     .use(sortSectionsByNav(nav))
     .use(stringify);
-
-  const { contents } = await processor.process(html);
-
-  return contents;
 };
 
 module.exports = sortIndexPage;

--- a/src/utils/sortIndexPage.js
+++ b/src/utils/sortIndexPage.js
@@ -3,24 +3,25 @@ const visit = require('unist-util-visit');
 const parse = require('rehype-parse');
 const stringify = require('rehype-stringify');
 const yaml = require('js-yaml');
-const { chunk, curry, get, takeWhile } = require('lodash');
+// const { chunk, curry, get, takeWhile } = require('lodash');
+const { curry, get } = require('lodash');
 const findDeepIndex = require('./findDeepIndex');
 
-const isRoot = (node) => get(node, 'type', '') === 'root';
+// const isRoot = (node) => get(node, 'type', '') === 'root';
 const isTag = curry((tagName, node) => get(node, 'tagName', '') === tagName);
 
-const isRootOrSection = (node) => isRoot(node) || isTag('section', node);
+// const isRootOrSection = (node) => isRoot(node) || isTag('section', node);
 
 const getValue = (str, fallback = '') => (node) => get(node, str, fallback);
 
 const getTextFromLi = getValue('children[0].children[0].value');
 const getLinkFromLi = getValue('children[0].properties.href');
-const getTextFromH = getValue('children[0].value');
+// const getTextFromH = getValue('children[0].value');
 
-const isHeading = (node) => /h[1-9]/.test(get(node, 'tagName', ''));
+// const isHeading = (node) => /h[1-9]/.test(get(node, 'tagName', ''));
 
 const findByPath = (node) => ({ path }) => getLinkFromLi(node) === path;
-const findByTitle = (node) => ({ title }) => getTextFromH(node) === title;
+// const findByTitle = (node) => ({ title }) => getTextFromH(node) === title;
 
 /**
  * Groups sections together. A section is a heading tag (e.g. <h3>) followed
@@ -33,6 +34,7 @@ const findByTitle = (node) => ({ title }) => getTextFromH(node) === title;
  *
  * @note this might not work with deeply nested sections.
  */
+/*
 const groupBySection = () => (tree) => {
   const section = { type: 'element', tagName: 'section', properties: {} };
 
@@ -61,6 +63,7 @@ const groupBySection = () => (tree) => {
     }
   });
 };
+*/
 
 const sortListAlphabetically = () => (tree) => {
   visit(tree, isTag('ul'), (node) => {
@@ -70,6 +73,7 @@ const sortListAlphabetically = () => (tree) => {
   });
 };
 
+/*
 const sortSectionsAlphabetically = () => (tree) => {
   visit(tree, isRootOrSection, (node) => {
     node.children = chunk(node.children, 2)
@@ -77,6 +81,7 @@ const sortSectionsAlphabetically = () => (tree) => {
       .reduce((acc, subsection) => [...acc, ...subsection], []);
   });
 };
+*/
 
 const sortListByNav = (nav) => () => (tree) => {
   visit(tree, isTag('ul'), (node) => {
@@ -89,6 +94,7 @@ const sortListByNav = (nav) => () => (tree) => {
   });
 };
 
+/*
 const sortSectionsByNav = (nav) => () => (tree) => {
   visit(tree, isRootOrSection, (node) => {
     node.children = chunk(node.children, 2)
@@ -110,6 +116,7 @@ const removeSections = () => (tree) => {
     }, []);
   });
 };
+*/
 
 /**
  * Returns a processor that can be used to update the sort order of an
@@ -129,12 +136,12 @@ const sortIndexPage = (html, navYaml = []) => {
 
   const { contents } = unified()
     .use(parse, { fragment: true })
-    .use(groupBySection)
-    .use(sortSectionsAlphabetically)
+    // .use(groupBySection)
+    // .use(sortSectionsAlphabetically)
     .use(sortListAlphabetically)
     .use(sortListByNav(nav))
-    .use(sortSectionsByNav(nav))
-    .use(removeSections)
+    // .use(sortSectionsByNav(nav))
+    // .use(removeSections)
     .use(stringify)
     .processSync(html);
 

--- a/src/utils/sortIndexPage.js
+++ b/src/utils/sortIndexPage.js
@@ -57,18 +57,32 @@ const sortSectionsByNav = (nav) => () => (tree) => {
   });
 };
 
+/**
+ * Returns a processor that can be used to update the sort order of an
+ * auto-generated index page.
+ *
+ * @example
+ * const { contents } = await sortIndexPage(nav).process(html);
+ *
+ * @param {string} html The input HTML.
+ * @param {string[]} [navYaml] An array of YAML file contents.
+ * @returns {string} The updated HTML.
+ */
 const sortIndexPage = (html, navYaml = []) => {
   if (!html) throw new Error('Missing arguments');
 
   const nav = { pages: navYaml.map(yaml.safeLoad) };
 
-  return unified()
+  const { contents } = unified()
     .use(parse, { fragment: true })
     .use(sortSectionsAlphabetically)
     .use(sortListAlphabetically)
     .use(sortListByNav(nav))
     .use(sortSectionsByNav(nav))
-    .use(stringify);
+    .use(stringify)
+    .processSync(html);
+
+  return contents;
 };
 
 module.exports = sortIndexPage;

--- a/src/utils/sortIndexPage.js
+++ b/src/utils/sortIndexPage.js
@@ -2,22 +2,38 @@ const unified = require('unified');
 const visit = require('unist-util-visit');
 const parse = require('rehype-parse');
 const stringify = require('rehype-stringify');
-const { get } = require('lodash');
+const { chunk, get } = require('lodash');
 
+const isRoot = (node) => node.type === 'root';
 const isTag = (tagName) => (node) => node.tagName === tagName;
 
 // Assumes <li><a>Text</a></li>
-const getTextFromLi = (node) => get(node, 'children[0].children[0].value');
+const getTextFromLi = (node) => get(node, 'children[0].children[0].value', '');
 
-const sortAlphabetically = () => (tree) => {
+const getTextFromH2 = (node) => get(node, 'children[0].value', '');
+
+const sortLisAlphabetically = () => (tree) => {
   visit(tree, isTag('ul'), (node) => {
-    node.chilren = node.children.sort((a, b) => {
-      return getTextFromLi(a) - getTextFromLi(b);
-    });
+    node.chilren = node.children.sort((a, b) =>
+      getTextFromLi(a).localeCompare(getTextFromLi(b))
+    );
   });
 };
 
-const processor = unified().use(parse).use(sortAlphabetically).use(stringify);
+// Assumes <h2 /><ul /><h2 /><ul />
+const sortSectionsAlphabetically = () => (tree) => {
+  visit(tree, isRoot, (node) => {
+    node.children = chunk(node.children, 2)
+      .sort((a, b) => getTextFromH2(a[0]).localeCompare(getTextFromH2(b[0])))
+      .reduce((acc, section) => [...acc, ...section], []);
+  });
+};
+
+const processor = unified()
+  .use(parse, { fragment: true })
+  .use(sortSectionsAlphabetically)
+  .use(sortLisAlphabetically)
+  .use(stringify);
 
 const sortIndexPage = async (html, nav) => {
   const { contents } = await processor.process(html);

--- a/src/utils/sortIndexPage.js
+++ b/src/utils/sortIndexPage.js
@@ -6,8 +6,8 @@ const yaml = require('js-yaml');
 const { chunk, get } = require('lodash');
 const findDeepIndex = require('./findDeepIndex');
 
-const isRoot = (node) => node.type === 'root';
-const isTag = (tagName) => (node) => node.tagName === tagName;
+const isRoot = (node) => node.type && node.type === 'root';
+const isTag = (tagName) => (node) => node.tagName && node.tagName === tagName;
 
 const getValue = (str, fallback = '') => (node) => get(node, str, fallback);
 

--- a/src/utils/sortIndexPage.js
+++ b/src/utils/sortIndexPage.js
@@ -26,6 +26,8 @@ const sortListAlphabetically = () => (tree) => {
   });
 };
 
+// NOTE: this assumes <h2><ul>...
+// This would fail with <h2><h3><ul>...
 const sortSectionsAlphabetically = () => (tree) => {
   visit(tree, isRoot, (node) => {
     node.children = chunk(node.children, 2)
@@ -75,10 +77,12 @@ const sortIndexPage = (html, navYaml = []) => {
 
   const { contents } = unified()
     .use(parse, { fragment: true })
-    .use(sortSectionsAlphabetically)
+    // TODO: break into a hierarchy that reflects heading level
+    .use(sortSectionsAlphabetically) // TODO: update this
     .use(sortListAlphabetically)
     .use(sortListByNav(nav))
-    .use(sortSectionsByNav(nav))
+    .use(sortSectionsByNav(nav)) // TODO: update this
+    // TODO: flaten the tree into the format it was at the start
     .use(stringify)
     .processSync(html);
 

--- a/src/utils/sortIndexPage.js
+++ b/src/utils/sortIndexPage.js
@@ -1,0 +1,28 @@
+const unified = require('unified');
+const visit = require('unist-util-visit');
+const parse = require('rehype-parse');
+const stringify = require('rehype-stringify');
+const { get } = require('lodash');
+
+const isTag = (tagName) => (node) => node.tagName === tagName;
+
+// Assumes <li><a>Text</a></li>
+const getTextFromLi = (node) => get(node, 'children[0].children[0].value');
+
+const sortAlphabetically = () => (tree) => {
+  visit(tree, isTag('ul'), (node) => {
+    node.chilren = node.children.sort((a, b) => {
+      return getTextFromLi(a) - getTextFromLi(b);
+    });
+  });
+};
+
+const processor = unified().use(parse).use(sortAlphabetically).use(stringify);
+
+const sortIndexPage = async (html, nav) => {
+  const { contents } = await processor.process(html);
+
+  return contents;
+};
+
+module.exports = sortIndexPage;


### PR DESCRIPTION
## Description
Improves the sort order of our automatically generated index pages by applying the following updates (in order):

1. Sort the sections alphabetically (by section title)
2. Sort the links within the section alphabetically (by title)
3. Sort the sections by their relative position in the site navigation
4. Sort the links within the section by their relative position in the navigation

For steps 3 and 4, we're using the first navigation file that the script finds that includes the link (in the event that there are multiple nav configuration files).

## Reviewer Notes
I'm creating a draft PR in case I'm unable to wrap up the work. I've taken a TDD approach to solving the issue, since there are multiple edge cases that I wanted to ensure we caught. Here is my current progress:

* [x] Sort links alphabetically
* [x] Sort links by nav
* [ ] ~~Sort sections alphabetically~~
* [ ] ~~Sort sections by nav~~

## Related Issue(s)
* Closes #566

## Screenshot(s)
**Before**
![Screen Shot 2021-04-26 at 11 12 13 AM](https://user-images.githubusercontent.com/1946433/116130656-578fd200-a680-11eb-9b79-5864361863c7.png)

**After**
![Screen Shot 2021-04-26 at 11 11 22 AM](https://user-images.githubusercontent.com/1946433/116130678-5ced1c80-a680-11eb-9f14-07bd5f47568c.png)
