### PR TITLE
Fixing release workflow (again)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   create-release:


### PR DESCRIPTION
## Description
A previous fix to the Github release workflow is [still failing](https://github.com/newrelic/docs-website/actions/runs/752715586). We think this is due to incorrect permissions with the `GH_TOKEN` provided. This PR updates the code to use `GITHUB_TOKEN` which [should be available](https://github.blog/2021-03-11-scripting-with-github-cli/#using-gh-in-github-actions) from the actions environment.

## Related Issue(s)
* Closes #1819 (hopefully)
