### PR TITLE
Use tag name for release name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           echo "::set-output name=tag::release-$MERGES"
 
       - name: Create release
-        run: gh release create ${{ steps.get-tag.outputs.tag }}
+        run: gh release create ${{ steps.get-tag.outputs.tag }} -t ${{ steps.get-tag.outputs.tag }}
 
   newrelic:
     name: New Relic deployment marker


### PR DESCRIPTION
## Description
Updates our release workflow so that the title of the release is the same as the version name. Without this, the release title was the last commit.

## Reviewer Notes
The last time the release workflow ran, [it failed](https://github.com/newrelic/docs-website/runs/2355397196?check_suite_focus=true). It doesn't look like this was an issue with our workflow, but rather an issue with Github actions (it never made it to our step). I'll monitor it :eyes:
