### PR TITLE
Remove link to install unsupported agent (forward-your-logs-using-infrastructure-agent.mdx)

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
@@ -162,12 +162,6 @@ To use the following links, make sure you are logged to your New Relic account.
   />
 
   <TechTile
-    name="Container (Docker)"
-    to="/docs/infrastructure/new-relic-infrastructure/data-instrumentation/monitor-containers-underlying-hosts-coreos"
-    icon={<img src={dockerLogoCrop} alt="Docker"/>}
-  />
-
-  <TechTile
     name="Debian"
     to="https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJzZXR1cC1uZXJkbGV0LnNldHVwLW9zIiwiZGF0YVNvdXJjZSI6IkRFQklBTiJ9"
     icon={<img src={debian} alt="Debian"/>}


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

The documentation says:

> The log forwarding feature is not supported on containerized agents.

However in the next section, it provides a link to instructions on how to install the containerized agent. 

This is confusing so I've removed the link.

### Are you making a change to site code?

No

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.