### PR TITLE
chore: Adjust gh cli command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get release tag
         id: get-tag
         run: |
-          MERGES=$(gh pr list -B main -s closed -L 9999 | wc -L | awk '{print $1}')
+          MERGES=$(gh pr list -B main -s merged --search "closed:>2021-02-28" -L 9999 | wc -l | awk '{print $1}')
           echo "::set-output name=tag::release-$MERGES"
 
       - name: Create release


### PR DESCRIPTION
### Give us some context

This PR swaps a flag used in our github release action which was previously causing an issue (using `wc` `-L` counts the length of the longest line while `-l` counts the number of lines ). also updates the release logic to only count merged PRs (not including every closed PR) and starts the count from march 1st