### PR TITLE
Doc 6677 - Improvements to NerdGraph intro and nav

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-alerts-policies.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-alerts-policies.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'NerdGraph API: Alerts policies '
+title: "NerdGraph tutorial: Alerts policies"
 tags:
   - Alerts and Applied Intelligence
   - New Relic Alerts

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-examples.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-examples.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'NerdGraph API: Examples '
+title: "Intro to using Alerts via NerdGraph API"
 tags:
   - Alerts and Applied Intelligence
   - New Relic Alerts

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'NerdGraph API: Loss of signal and gap filling'
+title: "NerdGraph tutorial: Loss of signal and gap filling"
 tags:
   - Alerts and Applied Intelligence
   - New Relic Alerts

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-nrql-condition-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-nrql-condition-alerts.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'NerdGraph API: NRQL condition alerts '
+title: "NerdGraph tutorial: NRQL condition alerts"
 tags:
   - Alerts and Applied Intelligence
   - New Relic Alerts

--- a/src/content/docs/apis/get-started/intro-apis/introduction-new-relic-apis.mdx
+++ b/src/content/docs/apis/get-started/intro-apis/introduction-new-relic-apis.mdx
@@ -72,13 +72,9 @@ This document provides examples and reference information for our API endpoints.
 
 ## NerdGraph (GraphQL) [#graphql]
 
-[NerdGraph](/docs/apis/graphql-api/getting-started/introduction-new-relic-graphql-api) is New Relic's GraphQL API, an efficient and flexible query language that lets you request exactly the data you need, without over-fetching or under-fetching. While typical REST APIs require loading from multiple URLs, NerdGraph calls get all the data you need in a single request. NerdGraph also makes it easier to evolve APIs over time and enables powerful developer tools.
+[NerdGraph](/docs/apis/graphql-api/getting-started/introduction-new-relic-graphql-api) is New Relic's GraphQL-format API, an efficient and flexible query language that lets you request exactly the data you need, without over-fetching or under-fetching. NerdGraph is the preferred API for querying New Relic data and making a range of feature configurations. 
 
-New Relic provides a powerful GraphQL tool to explore the API with embedded schema definitions. To get started, go to **[api.newrelic.com/graphiql](https://api.newrelic.com/graphiql)**.
-
-<Callout variant="tip">
-  For sample queries and mutations, use our [NerdGraph tutorials](/docs/apis/graphql-api/tutorials).
-</Callout>
+To get started, see [Introduction to NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph).
 
 ## REST APIs by capability [#product-apis]
 

--- a/src/content/docs/apis/nerdgraph/examples/configure-infinite-tracing-graphql.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/configure-infinite-tracing-graphql.mdx
@@ -1,5 +1,5 @@
 ---
-title: Configure Infinite Tracing with GraphQL
+title: "NerdGraph tutorial: Configure Infinite Tracing"
 tags:
   - APIs
   - NerdGraph

--- a/src/content/docs/apis/nerdgraph/examples/create-widgets-dashboards-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/create-widgets-dashboards-api.mdx
@@ -4,7 +4,7 @@ tags:
   - APIs
   - NerdGraph
   - Examples
-metaDescription: 'Use New Relic''s Insights Dashboard API with the API Explorer to list, create, read, update and delete new or existing Insights dashboards.'
+metaDescription: Use New Relic NerdGraph to add and configure dashboards.
 redirects:
   - /docs/apis/nerdgraph/examples/dashboards-api-widgets
 ---

--- a/src/content/docs/apis/nerdgraph/examples/create-widgets-dashboards-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/create-widgets-dashboards-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: Create widgets with the Dashboards API
+title: "NerdGraph tutorial: Create dashboards"
 tags:
   - APIs
   - NerdGraph

--- a/src/content/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: NerdGraph tutorial: Export dashboards as files"
+title: "NerdGraph tutorial: Export dashboards as files"
 tags:
   - APIs
   - NerdGraph

--- a/src/content/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: Export dashboards as PDF/PNG using the API
+title: NerdGraph tutorial: Export dashboards as files"
 tags:
   - APIs
   - NerdGraph

--- a/src/content/docs/apis/nerdgraph/examples/export-import-dashboards-using-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/export-import-dashboards-using-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: Export and import dashboards using the API
+title: "NerdGraph tutorial: Move dashboards to other accounts"
 tags:
   - APIs
   - NerdGraph

--- a/src/content/docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial.mdx
@@ -1,5 +1,5 @@
 ---
-title: Golden metrics for entities NerdGraph API tutorial
+title: "NerdGraph tutorial: View and configure an entity's golden metrics"
 tags:
   - APIs
   - NerdGraph

--- a/src/content/docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial.mdx
@@ -4,7 +4,7 @@ tags:
   - APIs
   - NerdGraph
   - Examples
-metaDescription: Use New Relic's NerdGraph (our GraphQL API) to query or override golden metrics and tags.
+metaDescription: Use New Relic NerdGraph (our GraphQL API) to query or override golden metrics and tags.
 ---
 
 **Golden metrics** and **golden tags** are bits of information about an [entity](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic) that we consider to be the most important for that entity. We use this information to display a brief overview of an entity across all New Relic. You can see and contribute to the standard definitions of the golden metrics and tags in this [public repository](https://github.com/newrelic-experimental/entity-synthesis-definitions#golden-tags).

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial.mdx
@@ -4,7 +4,7 @@ tags:
   - APIs
   - NerdGraph
   - Examples
-metaDescription: Use New Relic's NerdGraph (our GraphQL API) to query your New Relic Infrastructure cloud integration data.
+metaDescription: Use New Relic NerdGraph (our GraphQL API) to query your New Relic Infrastructure cloud integration data.
 redirects:
   - /docs/cloud-integration-graphql-examples
   - /docs/cloud-integration-new-relic-graphql-api-examples

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial.mdx
@@ -1,5 +1,5 @@
 ---
-title: NerdGraph cloud integrations API tutorial
+title: "NerdGraph tutorial: Configure cloud integrations"
 tags:
   - APIs
   - NerdGraph

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-distributed-trace-data-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-distributed-trace-data-tutorial.mdx
@@ -1,5 +1,5 @@
 ---
-title: NerdGraph distributed trace data tutorial
+title: "NerdGraph tutorial: Viewing distributed trace details"
 tags:
   - APIs
   - NerdGraph

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-distributed-trace-data-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-distributed-trace-data-tutorial.mdx
@@ -4,7 +4,7 @@ tags:
   - APIs
   - NerdGraph
   - Examples
-metaDescription: Use New Relic's NerdGraph (our GraphQL API) to query your distributed trace data.
+metaDescription: Use New Relic NerdGraph (our GraphQL API) to query your distributed trace data.
 redirects:
   - /docs/apis/graphql-api/tutorials/query-distributed-trace-data-using-graphql-api
   - /docs/apis/graphql-api/tutorials/nerdgraph-graphiql-distributed-trace-data-tutorial

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
@@ -4,7 +4,7 @@ tags:
   - APIs
   - NerdGraph
   - Examples
-metaDescription: 'Use New Relic''s NerdGraph (our GraphQL API) to query your monitored entities (applications, hosts, etc.)'
+metaDescription: "Use New Relic's NerdGraph (our GraphQL API) to query your monitored entities (applications, hosts, etc.)"
 redirects:
   - /docs/use-new-relic-graphql-api-query-entities
   - /docs/apis/graphql-api/tutorials/use-new-relic-graphql-api-query-entities

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
@@ -1,5 +1,5 @@
 ---
-title: NerdGraph entities API tutorial
+title: NerdGraph tutorial: Working with entities
 tags:
   - APIs
   - NerdGraph
@@ -12,12 +12,7 @@ redirects:
   - /docs/apis/nerdgraph/tutorials/nerdgraph-graphiql-entities-api-tutorial
 ---
 
-To query data with [New Relic's NerdGraph](/docs/introduction-new-relic-graphql), we use the concept of an [entity](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic). An entity provides unified access to all the things you monitor with New Relic, including but not limited to:
-
-* Applications monitored by [APM](/docs/apm/new-relic-apm/getting-started/introduction-new-relic-apm).
-* Cloud integrations, services, and hosts monitored by [infrastructure monitoring](/docs/infrastructure/new-relic-infrastructure/get-started/introduction-new-relic-infrastructure).
-
-To view entity details in the our UI, use the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer) in [New Relic One](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one).
+With [NerdGraph](/docs/introduction-new-relic-graphql), you can query details about your monitored entities. 
 
 <Callout variant="important">
   To work with an entity's golden metrics and tags, see the golden metrics [API tutorial](/docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial).
@@ -25,15 +20,24 @@ To view entity details in the our UI, use the [New Relic Explorer](/docs/new-rel
 
 ## Entity definition [#definition]
 
-Each [entity](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic) has similar traits:
+Entities are an important New Relic concept. Basically, an entity is anything we monitor, including but not limited to: 
 
-* A unique entity GUID identifies it.
-* It exists over a span of time, even if it's a short period.
-* It provides a useful entry point for exploring data about specific metrics and events, or for contextualizing data related to other entities.
+* Applications monitored by [APM](/docs/apm/new-relic-apm/getting-started/introduction-new-relic-apm).
+* Cloud integrations, services, and hosts monitored by our [infrastructure monitoring](/docs/infrastructure/new-relic-infrastructure/get-started/introduction-new-relic-infrastructure).
 
-## Requirements
+[Learn more about how we define "entity."](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic)
 
-All you need is a [user key](/docs/apis/getting-started/intro-apis/understand-new-relic-api-keys#user-api-key).
+To view entity details in the UI, you can use the [Explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer).
+
+When working with entities in NerdGraph, it can help to understand some important traits they have:
+
+* A unique entity GUID identifies an entity.
+* An entity exists over a span of time, even if it's a short period.
+* An entity provides a useful entry point for exploring data about specific metrics and events, or for contextualizing data related to other entities.
+
+## Requirements [#requirements]
+
+You need a [user key](/docs/apis/getting-started/intro-apis/understand-new-relic-api-keys#user-api-key).
 
 ## Search for entities [#search-entity]
 

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
@@ -1,10 +1,10 @@
 ---
-title: NerdGraph tutorial: Working with entities
+title: "NerdGraph tutorial: View entity data"
 tags:
   - APIs
   - NerdGraph
   - Examples
-metaDescription: "Use New Relic's NerdGraph (our GraphQL API) to query your monitored entities (applications, hosts, etc.)"
+metaDescription: Use New Relic NerdGraph (our GraphQL API) to query your monitored entities (applications, hosts, etc.)
 redirects:
   - /docs/use-new-relic-graphql-api-query-entities
   - /docs/apis/graphql-api/tutorials/use-new-relic-graphql-api-query-entities

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial.mdx
@@ -1,5 +1,5 @@
 ---
-title: NerdGraph NRQL tutorial
+title: "NerdGraph tutorial: Query your data using NRQL"
 tags:
   - APIs
   - NerdGraph

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial.mdx
@@ -1,5 +1,5 @@
 ---
-title: NerdGraph relationships API tutorial
+title: "NerdGraph tutorial: Understand entity relationships and dependencies"
 tags:
   - APIs
   - NerdGraph

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial.mdx
@@ -1,5 +1,5 @@
 ---
-title: NerdGraph tagging API tutorial
+title: "NerdGraph tutorial: View and add tags"
 tags:
   - APIs
   - NerdGraph

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial.mdx
@@ -4,7 +4,7 @@ tags:
   - APIs
   - NerdGraph
   - Examples
-metaDescription: Use New Relic's NerdGraph (our GraphQL API) to manage tags attached to your entities.
+metaDescription: Use New Relic NerdGraph (our GraphQL API) to manage tags attached to your entities.
 redirects:
   - /docs/new-relic-only/tech-writer-style-guide/article-templates/graphql-tagging-api-tutorial
   - /docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial

--- a/src/content/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use NerdGraph to manage license keys and user keys
+title: "NerdGraph tutorial: Manage license keys and user keys"
 tags:
   - APIs
   - NerdGraph

--- a/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
@@ -1,12 +1,12 @@
 ---
-title: Introduction to New Relic NerdGraph
+title: Introduction to New Relic NerdGraph, our GraphQL API
 tags:
   - APIs
   - NerdGraph
   - Get started
 translate:
   - jp
-metaDescription: "NerdGraph is New Relic's GraphQL-format API, used to query data and do some product configurations."
+metaDescription: NerdGraph is New Relic's GraphQL-format API, used to query data and do some product configurations.
 redirects:
   - /docs/new-relic-graphql
   - /docs/introduction-new-relic-graphql
@@ -27,7 +27,7 @@ NerdGraph is our GraphQL-format API that lets you query New Relic data and confi
 New Relic has several [APIs](/docs/apis/get-started/intro-apis/introduction-new-relic-apis/). NerdGraph is our preferred API for querying New Relic data, and for performing some specific configurations ([learn more about features](#tutorials)). NerdGraph provides a single API interface for returning data from New Relic’s various APIs and microservices. Over time, other configuration capabilities available in our REST API will be added to NerdGraph. 
 
 <Callout variant="important">
-NerdGraph isn’t used for data ingest. For that, use our [data ingest APIs](/docs/apis/get-started/intro-apis/introduction-new-relic-apis/#data-type-apis. 
+NerdGraph isn’t used for data ingest. For that, use our [data ingest APIs](/docs/apis/get-started/intro-apis/introduction-new-relic-apis/#data-type-apis). 
 </Callout>
 
 NerdGraph is built using [GraphQL](https://graphql.org), which is an open source API format that allows you to request exactly the data needed, with no over-fetching or under-fetching. 
@@ -74,7 +74,7 @@ curl -X POST https://api.newrelic.com/graphql \
 NerdGraph functionality can be broken down into two main categories: 
 
 * **Querying New Relic data.** You can fetch data for a variety of purposes, including using it in a programmatic workflow, or building a [New Relic One app](https://developer.newrelic.com/build-apps) for custom data visualizations. 
-* **Configuring New Relic features.** There are a variety of configurations available and more will be added over time. You can do things like add tags, configure workloads, or customize “golden metrics.”
+* **Configuring New Relic features.** There are a variety of configurations available and more will be added over time. You can do things like add tags, configure workloads, or customize "golden metrics."
 
 You can use NerdGraph to return a wide range of New Relic data but we’ve created some tutorials for common use cases:  
 
@@ -238,7 +238,7 @@ The following are terms that originate with GraphQL (the API format NerdGraph us
 There are two classes of GraphQL operations: 
 
 * [Queries](https://graphql.org/learn/queries/) are basic requests used only to fetch data. These queries are not static, meaning that you can ask for more data or less data, depending on your needs. For each query, you can specify exactly what data you want to retrieve, as long as it is supported by the [schema](https://graphql.org/learn/schema/).
-* [Mutations](https://graphql.org/learn/queries/#mutations) are requests that perform an action, such as creating a resource or changing configuration. Mutations require the keyword `mutation`, as well as the `name of the mutation. 
+* [Mutations](https://graphql.org/learn/queries/#mutations) are requests that perform an action, such as creating a resource or changing configuration. Mutations require the keyword `mutation`, as well as the `name` of the mutation. 
 
       </td>
     </tr>
@@ -277,7 +277,7 @@ There are two classes of GraphQL operations:
   </tbody>
 </table>
 
-## Tips for querying with the GraphiQL explorer [#make-query]
+## Tips on using the GraphiQL explorer [#make-query]
 
 You can make queries with the [NerdGraph GraphiQL explorer](https://api.newrelic.com/graphiql). The explorer provides built-in schema definitions and features, including auto-complete and query validation.
 

--- a/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
@@ -24,10 +24,10 @@ NerdGraph is our GraphQL-format API that lets you query New Relic data and confi
 
 ## What is NerdGraph? [#overview]
 
-New Relic has several [APIs](/docs/apis/get-started/intro-apis/introduction-new-relic-apis/). NerdGraph is our preferred API for querying New Relic data, and for performing some specific configurations ([learn more about features](#tutorials)). NerdGraph provides a single API interface for returning data from New Relic’s various APIs and microservices. Over time, other configuration capabilities available in our REST API will be added to NerdGraph. 
+New Relic has several [APIs](/docs/apis/get-started/intro-apis/introduction-new-relic-apis/). NerdGraph is our preferred API for querying New Relic data, and for performing some specific configurations ([learn more about features](#tutorials)). NerdGraph provides a single API interface for returning data from New Relic’s various APIs and microservices. Over time, other configuration capabilities will be added to NerdGraph. 
 
 <Callout variant="important">
-NerdGraph isn’t used for data ingest. For that, use our [data ingest APIs](/docs/apis/get-started/intro-apis/introduction-new-relic-apis/#data-type-apis). 
+NerdGraph isn’t used for data ingest. For that, you'd use our [data ingest APIs](/docs/apis/get-started/intro-apis/introduction-new-relic-apis/#data-type-apis). 
 </Callout>
 
 NerdGraph is built using [GraphQL](https://graphql.org), which is an open source API format that allows you to request exactly the data needed, with no over-fetching or under-fetching. 

--- a/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
@@ -208,8 +208,6 @@ Partners and resellers</td>
 [Manage subscriptions](/docs/apis/nerdgraph/tutorials/provisions-your-subscriptions-nerdgraph/) (only for partners using [original pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans))      </td>
     </tr>
 
-
-
   </tbody>
 </table>
 
@@ -236,10 +234,8 @@ The following are terms that originate with GraphQL (the API format NerdGraph us
         Queries and mutations
       </td>
 
-      <td>
-
- 
-There are two classes of GraphQL operations: queries and mutations. 
+      <td> 
+There are two classes of GraphQL operations: 
 
 * [Queries](https://graphql.org/learn/queries/) are basic requests used only to fetch data. These queries are not static, meaning that you can ask for more data or less data, depending on your needs. For each query, you can specify exactly what data you want to retrieve, as long as it is supported by the [schema](https://graphql.org/learn/schema/).
 * [Mutations](https://graphql.org/learn/queries/#mutations) are requests that perform an action, such as creating a resource or changing configuration. Mutations require the keyword `mutation`, as well as the `name of the mutation. 

--- a/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
@@ -6,7 +6,7 @@ tags:
   - Get started
 translate:
   - jp
-metaDescription: New Relic's NerdGraph is our GraphQL API. Use it and our GraphiQL explorer to query data and do tasks.
+metaDescription: NerdGraph is New Relic's GraphQL-format API, used to query data and do some product configurations.
 redirects:
   - /docs/new-relic-graphql
   - /docs/introduction-new-relic-graphql
@@ -16,27 +16,49 @@ redirects:
   - /docs/apis/graphql-api/get-started/introduction-new-relic-nerdgraph
 ---
 
-NerdGraph is New Relic's [GraphQL](https://graphql.org/)-format API. Our NerdGraph is an efficient and flexible query language that lets you request exactly the data you need, without over-fetching or under-fetching. While typical REST APIs require loading from multiple URLs, NerdGraph calls get all the data you need in a single request. NerdGraph also makes it easier to evolve APIs over time and enables powerful developer tools.
+NerdGraph is our GraphQL-format API that lets you query New Relic data and configure some New Relic features.  
 
 <Callout variant="tip">
-  To use NerdGraph and APIs, as well as the rest of our [observability platform](https://one.newrelic.com), join the New Relic family! [Sign up](https://newrelic.com/signup) to create your free account in only a few seconds. Then ingest up to 100GB of data for free each month. Forever.
+  To use our APIs, or the rest of our [observability platform](https://one.newrelic.com), join the New Relic family! [Sign up](https://newrelic.com/signup) to create your free account in only a few seconds. Then ingest up to 100GB of data for free each month. Forever.
 </Callout>
 
-## Use the NerdGraph GraphiQL explorer [#explorer]
+## What is NerdGraph? [#overview]
 
-We have a GraphiQL explorer that lets you explore our schema, find definitions, and form calls. To use the explorer:
+New Relic has several [APIs](/docs/apis/get-started/intro-apis/introduction-new-relic-apis/). NerdGraph is our preferred API for querying New Relic data, and for performing some specific configurations ([learn more about features](#tutorials)). NerdGraph provides a single API interface for returning data from New Relic’s various APIs and microservices. Over time, other configuration capabilities available in our REST API will be added to NerdGraph. 
 
-1. You'll need a [New Relic user key](#authentication).
-2. Go to [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql) (if you have New Relic data in EU, use [api.eu.newrelic.com/graphiql](https://api.eu.newrelic.com/graphiql))
+<Callout variant="important">
+NerdGraph isn’t used for data ingest. For that, use our [data ingest APIs](/docs/apis/get-started/intro-apis/introduction-new-relic-apis/#data-type-apis. 
+</Callout>
+
+NerdGraph is built using [GraphQL](https://graphql.org), which is an open source API format that allows you to request exactly the data needed, with no over-fetching or under-fetching. 
+
+For a lesson in how to use NerdGraph, watch this 7-minute video: 
+
+<Video id="nPPQNS_AAIU" type="youtube" />
+
+Want to watch more video tutorials? Go to the New Relic University’s [Intro to NerdGraph](https://newrelic.wistia.com/medias/h9qfum9nh0). Or see the [online course on New Relic APIs](https://learn.newrelic.com/new-relic-apis).
+
+
+## Use the GraphiQL explorer [#explorer]
+
+To get started using GraphQL, we recommend playing around with our GraphiQL explorer (GraphiQL is an open source graphical interface for using GraphQL). You can use it to explore our data schema, to read built-in object definitions, and to build and execute queries. 
+ 
+To use GraphQL, you’ll need a user-specific New Relic API key called a user key. You can generate one or find an existing one from the GraphiQL explorer’s **API key** dropdown.  
+ 
+To find the GraphiQL explorer: 
+ 
+* If your New Relic account uses an [EU data center](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers), go to [api.eu.newrelic.com/graphiql](https://api.eu.newrelic.com/graphiql). 
+* Otherwise use [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
+
+For tips on how to build queries, see [Build queries](#make-query).
 
 ## Requirements and endpoints [#authentication]
 
-To use NerdGraph, you need a New Relic [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys).
+To use NerdGraph, you need a New Relic [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys), which can be generated and accessed from the [GraphiQL explorer](#explorer).
 
-NerdGraph endpoints:
-
+The endpoints are:
 * Main endpoint: `https://api.newrelic.com/graphql`
-* EU endpoint: For accounts with data in [EU data center](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers), use `https://api.eu.newrelic.com/graphql`.
+* Endpoint for accounts using EU data center: `https://api.eu.newrelic.com/graphql`
 
 To access the endpoint, use the following cURL command:
 
@@ -47,15 +69,21 @@ curl -X POST https://api.newrelic.com/graphql \
 -d '{ "query":  "{ requestContext { userId apiKey } }" } '
 ```
 
-## NerdGraph tutorials and examples [#tutorials]
+## What can you do with NerdGraph? [#tutorials]
 
-You can use NerdGraph to:
+NerdGraph functionality can be broken down into two main categories: 
+
+* **Querying New Relic data.** You can fetch data for a variety of purposes, including using it in a programmatic workflow, or building a [New Relic One app](https://developer.newrelic.com/build-apps) for custom data visualizations. 
+* **Configuring New Relic features.** There are a variety of configurations available and more will be added over time. You can do things like add tags, configure workloads, or customize “golden metrics.”
+
+You can use NerdGraph to return a wide range of New Relic data but we’ve created some tutorials for common use cases:  
+
 
 <table>
   <thead>
     <tr>
-      <th style={{ width: "340px" }}>
-        Functionality
+      <th style={{ width: "240px" }}>
+        Topic
       </th>
 
       <th>
@@ -67,102 +95,127 @@ You can use NerdGraph to:
   <tbody>
     <tr>
       <td>
-        Query all the [entities](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic) associated with your account.
+Your monitored entities
       </td>
 
       <td>
-        See the [entities tutorial](/docs/apis/graphql-api/tutorials/use-new-relic-graphql-api-query-entities).
+* [Get data about entities](/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial/) 
+* [Understand entity relationships and dependencies](/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial/) (used to build service maps)
+* [Query and configure "golden metrics"](/docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial/) (important entity metrics)
       </td>
     </tr>
 
     <tr>
       <td>
-        Query, create, and update [workloads](/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-one-workloads-isolate-resolve-incidents-faster) associated with your account.
+Querying data
       </td>
 
       <td>
-        See the [workloads tutorial](/docs/nerdgraph-workloads-tutorials).
+[Query using NRQL](/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial/) (our query language)
       </td>
     </tr>
 
     <tr>
       <td>
-        Create, manage, and add [tags](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor) to entities.
-      </td>
+Tags      </td>
 
       <td>
-        For more information and examples, see the [tagging tutorial](/docs/apis/graphql-api/tutorials/graphql-tagging-api-tutorial).
+[Add and manage tags](/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial/)
       </td>
     </tr>
 
     <tr>
       <td>
-        Query distributed tracing data.
+Dashboards
       </td>
 
       <td>
-        See the [trace data tutorial](/docs/apis/graphql-api/tutorials/query-distributed-trace-data-using-graphql-api).
+* [Create dashboards](/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/)      
+* [Export dashboards to other accounts](/docs/apis/nerdgraph/examples/export-import-dashboards-using-api/)
+* [Export dashboards as files](/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api/)
+
       </td>
     </tr>
 
     <tr>
       <td>
-        Fetch data when building a [New Relic One app](https://developer.newrelic.com/).
-      </td>
+Alerts      </td>
 
       <td>
-        See [New Relic One app data querying and mutations](https://developer.newrelic.com/build-tools/new-relic-one-applications/query-and-store-data).
+[See all alert-related tutorials](/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-nrql-condition-alerts/)      </td>
+    </tr>
+
+    <tr>
+      <td>
+Workloads      </td>
+
+      <td>
+[View and configure workloads](/docs/apis/nerdgraph/tutorials/nerdgraph-workloads-api-tutorials/)      </td>
+    </tr>
+
+    <tr>
+      <td>
+Manage keys      </td>
+
+      <td>
+[Create and manage keys](/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys/) (license keys used for data ingest, and user keys)
       </td>
     </tr>
 
     <tr>
       <td>
-        Understand upstream and downstream relationships with your services.
-      </td>
+Manage data      </td>
 
       <td>
-        See the [relationships tutorial](/docs/apis/graphql-api/tutorials/graphql-relationships-api-tutorial).
+* [Convert event data to metric data](/docs/telemetry-data-platform/ingest-manage-data/convert-data-metrics/analyze-monitor-data-trends-metrics)
+* [Drop data](/docs/accounts/accounts/data-management/drop-data-using-nerdgraph/)
       </td>
     </tr>
 
     <tr>
       <td>
-        Configure your New Relic cloud integrations.
-      </td>
+Distributed tracing      </td>
 
       <td>
-        See [cloud integration examples](/docs/cloud-integration-new-relic-graphql-api-examples).
+* [Query distributed tracing data](/docs/apis/nerdgraph/examples/nerdgraph-distributed-trace-data-tutorial/)
+* [Configure Infinite Tracing](/docs/apis/nerdgraph/examples/configure-infinite-tracing-graphql/) 
       </td>
     </tr>
 
     <tr>
       <td>
-        Query [event data](/docs/using-new-relic/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data#event-data) using NRQL.
-      </td>
+New Relic One apps  </td>
 
       <td>
-        See the [NRQL tutorial](/docs/use-new-relic-graphql-query-data-nrql).
+[Build a New Relic One app](https://developer.newrelic.com/explore-docs/query-and-store-data)
       </td>
     </tr>
 
     <tr>
       <td>
-        Watch video tutorials about NerdGraph.
-      </td>
+Cloud integrations (AWS, Azure, GCP)  </td>
 
       <td>
-        Go to the New Relic University tutorial [Intro to New Relic NerdGraph](https://newrelic.wistia.com/medias/h9qfum9nh0). Or, go to the full online course [New Relic APIs](https://learn.newrelic.com/new-relic-apis).
+[Configure cloud integrations](/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial/)
       </td>
     </tr>
+
+    <tr>
+      <td>
+Partners and resellers</td>
+
+      <td>
+[Manage subscriptions](/docs/apis/nerdgraph/tutorials/provisions-your-subscriptions-nerdgraph/) (only for partners using [original pricing plan](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#pricing-plans))      </td>
+    </tr>
+
+
+
   </tbody>
 </table>
 
 ## NerdGraph terminology [#terminology]
 
-The New Relic GraphQL server explicitly defines the graph structure of NerdGraph. The following keywords are common to all GraphQL servers. Use these keywords to help build and understand your own queries. In addition:
-
-* To understand how NerdGraph provides unified access to all the things you monitor with New Relic, see [NerdGraph entities](https://docs.newrelic.com/docs/use-new-relic-graphql-api-query-entities).
-* To understand schema definitions: From the [NerdGraph GraphiQL explorer](https://api.newrelic.com/graphiql), select **Docs**.
+The following are terms that originate with GraphQL (the API format NerdGraph uses). 
 
 <table>
   <thead>
@@ -180,21 +233,17 @@ The New Relic GraphQL server explicitly defines the graph structure of NerdGraph
   <tbody>
     <tr>
       <td>
-        Queries
+        Queries and mutations
       </td>
 
       <td>
-        [Queries](https://graphql.org/learn/queries/) are basic requests that are intended to only fetch data, without any additional actions. Queries in the NerdGraph GraphiQL explorer are not static, meaning that you can ask for more or less data depending on your needs. For each query, you can specify exactly what data you want to retrieve, as long as it is supported by the [schema](https://graphql.org/learn/schema/).
-      </td>
-    </tr>
 
-    <tr>
-      <td>
-        Mutations
-      </td>
+ 
+There are two classes of GraphQL operations: queries and mutations. 
 
-      <td>
-        [Mutations](https://graphql.org/learn/queries/#mutations) are requests that are intended to have additional actions, such as creating data or updating data on a server. Mutations require the keyword `mutation`, as well as the `name` of the mutation.
+* [Queries](https://graphql.org/learn/queries/) are basic requests used only to fetch data. These queries are not static, meaning that you can ask for more data or less data, depending on your needs. For each query, you can specify exactly what data you want to retrieve, as long as it is supported by the [schema](https://graphql.org/learn/schema/).
+* [Mutations](https://graphql.org/learn/queries/#mutations) are requests that perform an action, such as creating a resource or changing configuration. Mutations require the keyword `mutation`, as well as the `name of the mutation. 
+
       </td>
     </tr>
 
@@ -232,18 +281,14 @@ The New Relic GraphQL server explicitly defines the graph structure of NerdGraph
   </tbody>
 </table>
 
-## Make queries with the explorer [#make-query]
+## Tips for querying with the GraphiQL explorer [#make-query]
 
 You can make queries with the [NerdGraph GraphiQL explorer](https://api.newrelic.com/graphiql). The explorer provides built-in schema definitions and features, including auto-complete and query validation.
-
-In GraphQL, you ask for specific information in the graph structure of New Relic's data. You can follow the nodes of the graph to query exactly the data that you want.
-
-New fields are added seamlessly, and old fields can be marked as deprecated, which removes them from documentation and allows an eventual, graceful shutdown of that field.
 
 <CollapserGroup>
   <Collapser
     id="example-account-user"
-    title="Query account a New Relic user can access"
+    title="Query accounts a New Relic user can access"
   >
     You can query for the name of an account that an `actor` (a New Relic authorized user) has access to:
 
@@ -274,7 +319,7 @@ New fields are added seamlessly, and old fields can be marked as deprecated, whi
 
   <Collapser
     id="example-multiple-requests"
-    title="Query user, account, and NRQL in one NerdGraph GraphiQL request"
+    title="Query user, account, and NRQL in one request"
   >
     The graph structure shows its capabilities when queries become more complex. For example, you can query for user information, account information, and make a NRQL query with one request. With REST API, this would take three different requests to three different endpoints.
 

--- a/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
@@ -6,7 +6,7 @@ tags:
   - Get started
 translate:
   - jp
-metaDescription: NerdGraph is New Relic's GraphQL-format API, used to query data and do some product configurations.
+metaDescription: "NerdGraph is New Relic's GraphQL-format API, used to query data and do some product configurations."
 redirects:
   - /docs/new-relic-graphql
   - /docs/introduction-new-relic-graphql

--- a/src/content/docs/apis/nerdgraph/tutorials/nerdgraph-workloads-api-tutorials.mdx
+++ b/src/content/docs/apis/nerdgraph/tutorials/nerdgraph-workloads-api-tutorials.mdx
@@ -1,5 +1,5 @@
 ---
-title: NerdGraph workloads API tutorials
+title: "NerdGraph tutorial: View and manage workloads"
 tags:
   - APIs
   - NerdGraph

--- a/src/content/docs/apis/nerdgraph/tutorials/provisions-your-subscriptions-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/tutorials/provisions-your-subscriptions-nerdgraph.mdx
@@ -1,5 +1,5 @@
 ---
-title: Provisions partner subscriptions with NerdGraph
+title: "NerdGraph tutorial: Partner and reseller subscriptions"
 tags:
   - New Relic partnerships
   - Partnerships

--- a/src/nav/alerts-and-applied-intelligence.yml
+++ b/src/nav/alerts-and-applied-intelligence.yml
@@ -102,13 +102,13 @@ pages:
             path: /docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/delete-alert-notification-channels
       - title: Alerts and Nerdgraph
         pages:
+          - title: 'Intro to NerdGraph API and Alerts'
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-examples
+          - title: 'NerdGraph: Alerts policies'
+            path: /docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-alerts-policies
           - title: 'NerdGraph: NRQL conditions'
             path: /docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-nrql-condition-alerts
-          - title: 'NerdGraph API: Alerts policies'
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-alerts-policies
-          - title: 'NerdGraph API: Examples'
-            path: /docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-examples
-          - title: 'NerdGraph API: Loss of signal'
+          - title: 'NerdGraph: Loss of signal'
             path: /docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling
       - title: Infrastructure alerts
         pages:

--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -73,7 +73,7 @@ pages:
         pages:
           - title: Get started
             pages:
-              - title: Introduction to NerdGraph
+              - title: Introduction to NerdGraph (our GraphQL API)
                 path: /docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph
           - title: Tutorials
             pages:

--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -71,38 +71,38 @@ pages:
                 path: /docs/apis/get-started/intro-apis/new-relic-api-keys
       - title: Nerdgraph
         pages:
-          - title: Get Started
+          - title: Get started
             pages:
-              - title: Introduction to New Relic NerdGraph
+              - title: Introduction to NerdGraph
                 path: /docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph
-          - title: Examples
+          - title: Tutorials
             pages:
-              - title: NerdGraph NRQL tutorial
+              - title: NRQL tutorial 
                 path: /docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial
-              - title: Use NerdGraph to manage license keys and user keys
+              - title: Entity data tutorial
+                path: /docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial  
+              - title: Entity relationships tutorial
+                path: /docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial 
+              - title: Golden metrics tutorial
+                path: /docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial                                             
+              - title: Managing keys tutorial
                 path: /docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys
-              - title: NerdGraph tagging API tutorial
+              - title: Tagging tutorial
                 path: /docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial
-              - title: NerdGraph distributed trace data tutorial
+              - title: Distributed tracing tutorial
                 path: /docs/apis/nerdgraph/examples/nerdgraph-distributed-trace-data-tutorial
-              - title: NerdGraph entities API tutorial
-                path: /docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial
-              - title: Golden metrics for entities NerdGraph API tutorial 
-                path: /docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial
-              - title: NerdGraph workloads API tutorials
+              - title: Infinite Tracing tutorial
+                path: /docs/apis/nerdgraph/examples/configure-infinite-tracing-graphql                
+              - title: Workloads tutorial
                 path: /docs/apis/nerdgraph/tutorials/nerdgraph-workloads-api-tutorials
-              - title: NerdGraph cloud integrations API tutorial
+              - title: Cloud integration tutorial
                 path: /docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial
-              - title: NerdGraph relationships API tutorial
-                path: /docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial
-              - title: Create widgets with the Dashboards API
+              - title: Dashboard creation tutorial
                 path: /docs/apis/nerdgraph/examples/create-widgets-dashboards-api
-              - title: Export dashboards as PDF/PNG using the API
+              - title: Tutorial on exporting dashboards as files
                 path: /docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api
-              - title: Export and import dashboards using the API
+              - title: Tutorial on moving dashboards to other accounts
                 path: /docs/apis/nerdgraph/examples/export-import-dashboards-using-api
-              - title: Configure Infinite Tracing with GraphQL
-                path: /docs/apis/nerdgraph/examples/configure-infinite-tracing-graphql
       - title: REST API v2
         pages:
           - title: Get started

--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -103,6 +103,8 @@ pages:
                 path: /docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api
               - title: Tutorial on moving dashboards to other accounts
                 path: /docs/apis/nerdgraph/examples/export-import-dashboards-using-api
+              - title: See all NerdGraph tutorials
+                path: /docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/#tutorials
       - title: REST API v2
         pages:
           - title: Get started


### PR DESCRIPTION
Asking @rhetoric101 if he wants to do review on this. See jira for details. Basically overhauled the intro doc, making it easier to understand what NerdGraph is, and how it works, and using simpler, more direct language, and including a helpful video. I also added all the assorted NerdGraph tutorials in one place in the intro doc, because previously we didn't have the full list there (as they are a bit scattered throughout docs site). And I retitled all nerdgraph-related docs and changed their short titles to make them all more aligned. 