### PR TITLE
Resolve console error with Browser SPA page

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/save-browser-spa-api.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/save-browser-spa-api.mdx
@@ -37,6 +37,7 @@ This method returns the same API object created by `interaction()`, which is ass
 ## Examples
 
 ```
+/*
 window.addEventListener('scroll', () => {
     if (atBottomOfPage()) {
         newrelic.interaction() // Start monitoring this interaction.
@@ -45,4 +46,5 @@ window.addEventListener('scroll', () => {
         loadNextPage() // Start loading the next page.
     }
 })
+*/
 ```


### PR DESCRIPTION
## Description
This PR includes a temporary fix to a code block on one of our pages. For some reason, this one code block is being evaluated as valid JS. I was not able to determine _why_ this was happening, since no other javascript block behaves this way and I was unable to reproduce this effect elsewhere.

## Related Issue(s)
* Closes #1873
