### PR TITLE
Update create-metrics-other-data-types.mdx

### DIFF
--- a/src/content/docs/telemetry-data-platform/ingest-manage-data/convert-data-metrics/create-metrics-other-data-types.mdx
+++ b/src/content/docs/telemetry-data-platform/ingest-manage-data/convert-data-metrics/create-metrics-other-data-types.mdx
@@ -49,7 +49,7 @@ The most important part of [creating a metrics rule](#overview-process) is const
    WHERE nr.entityType = 'HOST'
    ```
    
-   This example query uses `count` on a non-numeric field. 
+   This example query uses `count` on a non-numeric field: 
    ```
    FROM ProcessSample SELECT count(hostname) 
    WHERE hostname LIKE '%prod%'

--- a/src/content/docs/telemetry-data-platform/ingest-manage-data/convert-data-metrics/create-metrics-other-data-types.mdx
+++ b/src/content/docs/telemetry-data-platform/ingest-manage-data/convert-data-metrics/create-metrics-other-data-types.mdx
@@ -48,6 +48,18 @@ The most important part of [creating a metrics rule](#overview-process) is const
    FROM ProcessSample SELECT <mark>summary</mark>(ioTotalReadBytes) 
    WHERE nr.entityType = 'HOST'
    ```
+   
+   This example query uses `count` on a non-numeric field. 
+   ```
+   FROM ProcessSample SELECT count(hostname) 
+   WHERE hostname LIKE '%prod%'
+   ```
+   
+   For `summary` on a non-numeric field use `summary(1)`:
+   ```
+   FROM ProcessSample SELECT <mark>summary(1)</mark> 
+   WHERE hostname LIKE '%prod%'
+   ```
      <Callout variant="tip">
   For more detailed information on using these metric types in rules, see [Creating metric rules: requirements and tips](https://docs.newrelic.com/docs/telemetry-data-platform/ingest-manage-data/convert-data-metrics/creating-metric-rules-requirements-tips).
   </Callout>


### PR DESCRIPTION
Added an example of using Events to Metrics on a non-numeric field by using summary(1) instead of the summary(non-numeric_field) as the latter will return zeros and NULLs

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

Added a new example for E2M rules to demonstrate translating a **count(string)** function into a **summary()** metric by using **summary(1)** vs **summary(string)**. The latter will not return the desired results.

### Are you making a change to site code?

No site code changes