### PR TITLE
Fix PageView and PageViewTiming links

### DIFF
--- a/src/content/docs/insights/event-data-sources/default-events/events-reported-browser-monitoring.mdx
+++ b/src/content/docs/insights/event-data-sources/default-events/events-reported-browser-monitoring.mdx
@@ -38,7 +38,7 @@ redirects:
   <tbody>
     <tr>
       <td>
-        [`PageView`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8302)
+        [`PageView`](https://docs.newrelic.com/attribute-dictionary/?event=PageView)
       </td>
 
       <td>
@@ -48,7 +48,7 @@ redirects:
 
     <tr>
       <td>
-        [`PageViewTiming`](https://docs.newrelic.com/attribute-dictionary/pageview?attribute_name=&events_tids%5B%5D=10061)
+        [`PageViewTiming`](https://docs.newrelic.com/attribute-dictionary/?event=PageViewTiming)
       </td>
 
       <td>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

<!--
### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.
-->

### Context

When accessing the links on the [Events reported by Browser Monitoring page](https://docs.newrelic.com/docs/insights/event-data-sources/default-events/events-reported-browser-monitoring/), several of the links (`PageView`, `PageViewTiming`, etc.) only go to the `AjaxRequest` event and not the correct event.

### Resolution

I could not find the proper `event_tids` to use, so I used the resolved URL for the specific event pages. I have only fixed the `PageView` and `PageViewTiming` events. 

This may not work for you all, but I thought I'd throw this out there.