### PR TITLE
Fix broken data dictionary links in default events docs

### DIFF
--- a/src/content/docs/infrastructure/manage-your-data/data-instrumentation/default-infrastructure-monitoring-data.mdx
+++ b/src/content/docs/infrastructure/manage-your-data/data-instrumentation/default-infrastructure-monitoring-data.mdx
@@ -67,7 +67,7 @@ Select an event name in the following table to see its attributes.
   <tbody>
     <tr>
       <td>
-        [`SystemSample`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8407)
+        [`SystemSample`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8407&event=SystemSample)
       </td>
 
       <td>
@@ -77,7 +77,7 @@ Select an event name in the following table to see its attributes.
 
     <tr>
       <td>
-        [`ProcessSample`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8412)
+        [`ProcessSample`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8407&event=ProcessSample)
       </td>
 
       <td>
@@ -91,7 +91,7 @@ Select an event name in the following table to see its attributes.
 
     <tr>
       <td>
-        [`StorageSample`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8417)
+        [`StorageSample`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8407&event=StorageSample)
       </td>
 
       <td>
@@ -133,7 +133,7 @@ Select an event name in the following table to see its attributes.
 
     <tr>
       <td>
-        [`NetworkSample`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8422)
+        [`NetworkSample`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8407&event=NetworkSample)
       </td>
 
       <td>
@@ -143,7 +143,7 @@ Select an event name in the following table to see its attributes.
 
     <tr>
       <td>
-        [`ContainerSample`](/attribute-dictionary?attribute_name=&events_tids%5B0%5D=10181)
+        [`ContainerSample`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8407&event=ContainerSample)
       </td>
 
       <td>
@@ -153,7 +153,7 @@ Select an event name in the following table to see its attributes.
 
     <tr>
       <td>
-        [`InfrastructureEvent`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8402)
+        [`InfrastructureEvent`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8407&event=InfrastructureEvent)
       </td>
 
       <td>

--- a/src/content/docs/insights/event-data-sources/default-events/default-events-reported-new-relic-products.mdx
+++ b/src/content/docs/insights/event-data-sources/default-events/default-events-reported-new-relic-products.mdx
@@ -25,6 +25,7 @@ Learn more about the events reported by New Relic products:
 * [Infrastructure default events](/docs/infrastructure/manage-your-data/data-instrumentation/default-infrastructure-events)
 * [Mobile default events](/docs/insights/insights-data-sources/default-data/mobile-default-events-insights)
 * [Synthetics default events](/docs/insights/insights-data-sources/default-data/synthetics-default-events-insights)
+* [NrAuditEvent events](/docs/insights/event-data-sources/default-events/query-account-audit-logs-nrauditevent/) for understanding changes to your account
 
 Related documentation:
 

--- a/src/content/docs/insights/event-data-sources/default-events/events-reported-apm.mdx
+++ b/src/content/docs/insights/event-data-sources/default-events/events-reported-apm.mdx
@@ -43,7 +43,7 @@ redirects:
   <tbody>
     <tr>
       <td id="transaction-event">
-        [`Transaction`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8236)
+        [`Transaction`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8357&event=Transaction)
       </td>
 
       <td>
@@ -53,7 +53,7 @@ redirects:
 
     <tr>
       <td id="transactionerror-event">
-        [`TransactionError`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8241)
+        [`TransactionError`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8357&event=TransactionError)
       </td>
 
       <td>
@@ -63,7 +63,7 @@ redirects:
 
     <tr>
       <td id="span-event">
-        [`Span`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&field_data_source_tid%5B%5D=8332)
+        [`Span`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8357&event=Span)
       </td>
 
       <td>

--- a/src/content/docs/insights/event-data-sources/default-events/events-reported-browser-monitoring.mdx
+++ b/src/content/docs/insights/event-data-sources/default-events/events-reported-browser-monitoring.mdx
@@ -38,7 +38,7 @@ redirects:
   <tbody>
     <tr>
       <td>
-        [`PageView`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8302)
+        [`PageView`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8302&event=PageView)
       </td>
 
       <td>
@@ -48,7 +48,7 @@ redirects:
 
     <tr>
       <td>
-        [`PageViewTiming`](https://docs.newrelic.com/attribute-dictionary/pageview?attribute_name=&events_tids%5B%5D=10061)
+        [`PageViewTiming`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8302&event=PageViewTiming)
       </td>
 
       <td>
@@ -60,7 +60,7 @@ redirects:
 
     <tr>
       <td>
-        [`PageAction`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8307)
+        [`PageAction`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8302&event=PageAction)
       </td>
 
       <td>
@@ -70,7 +70,7 @@ redirects:
 
     <tr>
       <td>
-        [`BrowserInteraction` (SPA)](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8312)
+        [`BrowserInteraction` (SPA)](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8302&event=BrowserInteraction)
       </td>
 
       <td>
@@ -80,7 +80,7 @@ redirects:
 
     <tr>
       <td>
-        [`AjaxRequest` (SPA](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8317))
+        [`AjaxRequest` (SPA](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8302&event=AjaxRequest))
       </td>
 
       <td>
@@ -90,7 +90,7 @@ redirects:
 
     <tr>
       <td>
-        [`BrowserTiming` (SPA)](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8322)
+        [`BrowserTiming` (SPA)](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8302&event=BrowserTiming)
       </td>
 
       <td>
@@ -100,7 +100,7 @@ redirects:
 
     <tr>
       <td>
-        [`JavaScriptError`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8327)
+        [`JavaScriptError`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8302&event=JavaScriptError)
       </td>
 
       <td>
@@ -110,7 +110,7 @@ redirects:
 
     <tr>
       <td>
-        [`Span`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8337)
+        [`Span`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8302&event=Span)
       </td>
 
       <td>

--- a/src/content/docs/insights/event-data-sources/default-events/events-reported-mobile-monitoring.mdx
+++ b/src/content/docs/insights/event-data-sources/default-events/events-reported-mobile-monitoring.mdx
@@ -42,7 +42,7 @@ redirects:
   <tbody>
     <tr>
       <td>
-        [`Mobile`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8347)
+        [`Mobile`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8357&event=Mobile)
       </td>
 
       <td>
@@ -62,7 +62,7 @@ redirects:
 
     <tr>
       <td>
-        [`MobileCrash`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8357)
+        [`MobileCrash`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8357&event=MobileCrash)
       </td>
 
       <td>
@@ -72,7 +72,7 @@ redirects:
 
     <tr>
       <td>
-        [`MobileHandledException`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8372)
+        [`MobileHandledException`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8357&event=MobileHandledException)
       </td>
 
       <td>
@@ -84,7 +84,7 @@ redirects:
 
     <tr>
       <td>
-        [`MobileRequest`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8367)
+        [`MobileRequest`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8367&event=MobileRequest)
       </td>
 
       <td>
@@ -103,7 +103,7 @@ redirects:
 
     <tr>
       <td>
-        [`MobileRequestError`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8362)
+        [`MobileRequestError`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8367&event=MobileRequestError)
       </td>
 
       <td>
@@ -115,7 +115,7 @@ redirects:
 
     <tr id="session-list">
       <td>
-        [`MobileSession`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8352)
+        [`MobileSession`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8367&event=MobileSession)
       </td>
 
       <td>

--- a/src/content/docs/insights/event-data-sources/default-events/events-reported-synthetic-monitoring.mdx
+++ b/src/content/docs/insights/event-data-sources/default-events/events-reported-synthetic-monitoring.mdx
@@ -38,7 +38,7 @@ redirects:
   <tbody>
     <tr>
       <td id="syntheticcheck-error">
-        [`SyntheticCheck`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8382)
+        [`SyntheticCheck`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8407&event=SyntheticCheck)
       </td>
 
       <td>
@@ -50,7 +50,7 @@ redirects:
 
     <tr>
       <td id="syntheticrequest">
-        [`SyntheticRequest`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8387)
+        [`SyntheticRequest`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8407&event=SyntheticRequest)
       </td>
 
       <td>
@@ -62,7 +62,7 @@ redirects:
 
     <tr>
       <td>
-        `SyntheticPrivateLocationStatus`
+        [`SyntheticPrivateLocationStatus`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8407&event=SyntheticsPrivateLocationStatus)
       </td>
 
       <td>
@@ -72,7 +72,7 @@ redirects:
 
     <tr>
       <td id="synthetic-private-minion">
-        [`SyntheticPrivateMinion`](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8392)
+        [`SyntheticPrivateMinion`](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8407&event=SyntheticsPrivateMinion)
       </td>
 
       <td>

--- a/src/content/docs/insights/event-data-sources/default-events/nrauditevent-event-data-query-examples.mdx
+++ b/src/content/docs/insights/event-data-sources/default-events/nrauditevent-event-data-query-examples.mdx
@@ -18,7 +18,7 @@ To view changes made in your New Relic account, you can query [`NrAuditEvent` ev
 
 The `NrAuditEvent` is created to record configuration changes made in our products. The data gathered for this event includes the type of account change, actor (user or API key) that made the change, a human-readable description of the action taken, and a timestamp for the change.
 
-To see all the attributes attached to this event, see [`NrAuditEvent`.](https://docs.newrelic.com/attribute-dictionary?attribute_name=&events_tids%5B%5D=8287)
+To see all the attributes attached to this event, see [`NrAuditEvent`.](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8287&event=NrAuditEvent)
 
 ## Example queries [#default-attributes]
 

--- a/src/content/docs/insights/event-data-sources/default-events/query-account-audit-logs-nrauditevent.mdx
+++ b/src/content/docs/insights/event-data-sources/default-events/query-account-audit-logs-nrauditevent.mdx
@@ -37,7 +37,7 @@ To track and view changes to your New Relic account:
    ```
    SELECT * from NrAuditEvent SINCE 1 day ago
    ```
-2. To customize your query, use any of the available [`NrAuditEvent` attributes](/attribute-dictionary?attribute_name=&events_tids%5B%5D=8287).
+2. To customize your query, use any of the available [`NrAuditEvent` attributes](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8287&event=NrAuditEvent).
 3. To be notified about account changes, create [NRQL conditions with New Relic Alerts](/docs/alerts/new-relic-alerts/defining-conditions/create-alert-conditions-nrql-queries).
 
 To query changes to another account or sub-account, select the account and run a separate NRQL query for that account.


### PR DESCRIPTION
Based on https://github.com/newrelic/docs-website/pull/1895, manually fixing broken links. But this is larger issue we need to create a jira for, because all data dictionary links, including specific attribute links, were broken in the migration. 