### PR TITLE
Moved definition next to first mention of entities

### DIFF
--- a/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
@@ -13,7 +13,7 @@ redirects:
   - /docs/what-entity-new-relic
 ---
 
-New Relic monitoring is built around the concept of the **entity**. This document explains:
+New Relic monitoring is built around the concept of the **entity**. An entity is anything that reports data to New Relic. This document explains:
 
 * What entities are
 * How to find entity data
@@ -30,7 +30,7 @@ This conceptual definition of "entity" is important because New Relic's goal is 
 
 ## Find and explore entities [#find]
 
-An entity is anything that reports data to New Relic, so you'll find your entities wherever you see your data reporting in New Relic.
+You'll find your entities wherever you see your data reporting in New Relic.
 
 <Callout variant="tip">
   You can create new entity types to monitor any data source. Learn more about [entity synthesis](https://github.com/newrelic-experimental/entity-synthesis-definitions#entity-synthesis-definitions).


### PR DESCRIPTION
We have a great definition of "entity" but it seemed a little buried. I moved it next to the first mention of "entity".

