### PR TITLE
Add documentation for PHP 9.17 release

### DIFF
--- a/src/content/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -16,7 +16,7 @@ Before you [install](/docs/agents/php-agent/installation) New Relic for PHP, mak
 New Relic supports PHP versions 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, and 8.0.
 
 <Callout variant="important">
-  Compatibility note: when PHP 8.0 detects the New Relic agent, it will disable Just-In-Time compilation.
+  Compatibility note: When PHP 8.0 detects the New Relic agent, it disables Just-In-Time compilation.
 </Callout>
 
 <Callout variant="important">
@@ -230,11 +230,11 @@ Supported PHP frameworks include:
 </table>
 
 <Callout variant="important">
-  Joomla 3.x is not supported on PHP 8
+  Joomla 3.x is not supported on PHP 8.
 </Callout>
 
 <Callout variant="important">
-  As of PHP agent version 9.17, the following frameworks or framework versions are no longer supported and may be removed from future agent builds.
+  As of PHP agent version 9.17, the following frameworks or framework versions are no longer supported and may be removed from future agent builds:
   * Cake PHP 1.x
   * Joomla 1.5, 1.6, and 2.x
   * Kohana

--- a/src/content/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -13,7 +13,7 @@ Before you [install](/docs/agents/php-agent/installation) New Relic for PHP, mak
 
 ## PHP releases [#php-release]
 
-New Relic supports PHP versions 5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, and 8.0.
+New Relic supports PHP versions 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, and 8.0.
 
 <Callout variant="important">
   Compatibility note: when PHP 8.0 detects the New Relic agent, it will disable Just-In-Time compilation.

--- a/src/content/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -13,7 +13,11 @@ Before you [install](/docs/agents/php-agent/installation) New Relic for PHP, mak
 
 ## PHP releases [#php-release]
 
-New Relic supports PHP versions 5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4.
+New Relic supports PHP versions 5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, and 8.0.
+
+<Callout variant="important">
+  Compatibility note: when PHP 8.0 detects the New Relic agent, it will disable Just-In-Time compilation.
+</Callout>
 
 <Callout variant="important">
   As of January 2021, we will discontinue support for PHP 5.3 and PHP 5.4. For more information, see our [PHP agent release notes v9.15.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293) and our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-across-browser-php-python-mobile-and-android-agents/123951).
@@ -22,6 +26,7 @@ New Relic supports PHP versions 5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4.
 * We recommend using a [supported release](http://php.net/supported-versions.php) of PHP, especially 7.3 and 7.4.
 * PHP 5.1 support was deprecated in release 4.0 of the agent, and removed in release 4.5.
 * PHP 5.2 support was deprecated in release 6.8 of the agent, and removed in release 7.0.
+* PHP 5.3 and PHP 5.4 support was deprecated in release 9.15 of the agent, and will be removed in a future release.
 
 ## Permissions
 
@@ -223,6 +228,10 @@ Supported PHP frameworks include:
     </tr>
   </tbody>
 </table>
+
+<Callout variant="important">
+  Joomla 3.x is not supported on PHP 8
+</Callout>
 
 The PHP agent's list of frameworks continues to grow. Even if the framework you are using is not listed here, the PHP agent may be able to provide you with useful information about your app.
 
@@ -551,6 +560,6 @@ If you need more help, check out these support and learning resources:
 
 * Suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
 * Browse the [Explorers Hub](https://discuss.newrelic.com/) to get help from the community and join in discussions.
-* Find [answers on our sites and learn how to use our support portal](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
-* Run [New Relic Diagnostics](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
-* Review New Relic's [data security](https://docs.newrelic.com/docs/security/) and [licenses](https://docs.newrelic.com/docs/licenses/) documentation.
+* Find [answers on our sites and learn how to use our support portal](/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/).
+* Run [New Relic Diagnostics](/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics/), our troubleshooting tool for Linux, Windows, and macOS.
+* Review New Relic's [data security](/docs/security/) and [licenses](/docs/licenses/) documentation.

--- a/src/content/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -233,6 +233,15 @@ Supported PHP frameworks include:
   Joomla 3.x is not supported on PHP 8
 </Callout>
 
+<Callout variant="important">
+  As of PHP agent version 9.17, the following frameworks or framework versions are no longer supported and may be removed from future agent builds.
+  * Cake PHP 1.x
+  * Joomla 1.5, 1.6, and 2.x
+  * Kohana
+  * Silex 1.x and 2.x
+  * Symfony 1.x and 2.x
+</Callout>
+
 The PHP agent's list of frameworks continues to grow. Even if the framework you are using is not listed here, the PHP agent may be able to provide you with useful information about your app.
 
 For more information, see [PHP frameworks: Integrating support for New Relic](/docs/php/framework-developers-integrated-support-for-new-relic). If you want to suggest support for other popular PHP frameworks, visit us at the [Explorers Hub](https://discuss.newrelic.com/tags/phpagent) and create a `Feature Idea`!

--- a/src/content/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -24,7 +24,7 @@ New Relic supports PHP versions 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, and 8.0.
 * PHP 5.2 support was deprecated in release 6.8 of the agent, and removed in release 7.0.
 * PHP 5.3 and PHP 5.4 support was deprecated in release [9.15](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293) of the agent, and removed in release [9.17](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9170300/).
 
-## Permissions
+## Permissions [#permissions]
 
 * Installation: Root access [is required](/docs/agents/php-agent/troubleshooting/determing-permissions-requirements) for most installations.
 * Running: Root access [is not required](/docs/agents/php-agent/troubleshooting/determing-permissions-requirements).
@@ -38,7 +38,7 @@ For any installation, you will need your New Relic [license key](/docs/subscript
 * Intel (and compatible) platforms only
 * Support for SSE2 instructions is required
 
-## Operating systems
+## Operating systems [#operating-systems]
 
 <Callout variant="important">
   The Windows operating system is not supported.
@@ -495,7 +495,7 @@ To request instance-level information from datastores currently not listed for y
 * HTTP
 * Laravel Queuing, available as an experimental feature in the [PHP Agent 6.6.0.169 release](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-660169), enabled by default since [PHP Agent 8.0.0.204](https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-800204).
 
-## Security requirements
+## Security requirements [#security]
 
 As a standard [security measure for data collection](/docs/accounts-partnerships/accounts/security/data-security), your app server must support SHA-2 (256-bit). SHA-1 is not supported.
 

--- a/src/content/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -19,14 +19,10 @@ New Relic supports PHP versions 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, and 8.0.
   Compatibility note: When PHP 8.0 detects the New Relic agent, it disables Just-In-Time compilation.
 </Callout>
 
-<Callout variant="important">
-  As of January 2021, we will discontinue support for PHP 5.3 and PHP 5.4. For more information, see our [PHP agent release notes v9.15.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293) and our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-across-browser-php-python-mobile-and-android-agents/123951).
-</Callout>
-
-* We recommend using a [supported release](http://php.net/supported-versions.php) of PHP, especially 7.3 and 7.4.
+* We recommend using a [supported release](http://php.net/supported-versions.php) of PHP, especially 7.3, 7.4, and 8.0.
 * PHP 5.1 support was deprecated in release 4.0 of the agent, and removed in release 4.5.
 * PHP 5.2 support was deprecated in release 6.8 of the agent, and removed in release 7.0.
-* PHP 5.3 and PHP 5.4 support was deprecated in release 9.15 of the agent, and will be removed in a future release.
+* PHP 5.3 and PHP 5.4 support was deprecated in release [9.15](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293) of the agent, and removed in release [9.17](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9170300/).
 
 ## Permissions
 

--- a/src/content/docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos.mdx
+++ b/src/content/docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos.mdx
@@ -21,7 +21,7 @@ Our PHP agent auto-instruments your code so you can start monitoring application
 
 ## Install the agent [#install]
 
-Even though the package name for the PHP agent refers to PHP 5, the package works for all [supported PHP versions](/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements#php-release), including PHP 7 versions.
+Even though the package name for the PHP agent refers to PHP 5, the package works for all [supported PHP versions](/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements#php-release), including PHP 8 versions.
 
 1. Make sure you have your [New Relic license key](/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements#license_key) accessible.
 2. Use either of the following ways to obtain the installation package:

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9170300.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9170300.mdx
@@ -5,7 +5,7 @@ version: 9.17.0.300
 downloadLink: 'https://download.newrelic.com/php_agent/archive/9.17.0.300'
 ---
 
-### End of Life Notices ###
+### End of life notices ###
 * This will be the last release in which ZTS builds are supported. In the future, ZTS builds may not be provided, and support may be completely pulled from the codebase.
 * New Relic no longer supports PHP 5.3 or PHP 5.4. New Relic highly encourages upgrading to a supported version of PHP. If you would like to continue running the New Relic PHP agent with PHP 5.3 or 5.4, we recommend using version 9.16 of the agent. However, please note that we can only offer limited support in this case.
 * Ubuntu LTS versions earlier than 14.04, Ubuntu non-LTS versions earlier than 19.04, and Debian versions earlier than 7 "wheezy" are no longer supported.
@@ -16,14 +16,14 @@ downloadLink: 'https://download.newrelic.com/php_agent/archive/9.17.0.300'
   * Silex 1.x and 2.x
   * Symfony 1.x and 2.x
 
-### New Features ###
+### New features ###
 * The agent now supports 64-bit PHP 8.0! Compatibility note: When PHP 8.0 detects the New Relic agent, it disables JIT.
 * `mysqli_commit` is now [instrumented](https://github.com/newrelic/newrelic-php-agent/pull/102).
 
-### Bug Fixes ###
+### Bug fixes ###
 * Fixed [a memory leak](https://github.com/newrelic/newrelic-php-agent/pull/123) that occurred when short lived segments throw exceptions.
-* Fixed [a build up](https://github.com/newrelic/newrelic-php-agent/pull/120) of duplicate Distributed Tracing headers that sometimes occurred when using `file_get_contents`.
+* Fixed [a build up](https://github.com/newrelic/newrelic-php-agent/pull/120) of duplicate distributed tracing headers that sometimes occurred when using `file_get_contents`.
 * Fixed an issue where Laravel Lumen transactions were [not being properly named](https://github.com/newrelic/newrelic-php-agent/pull/135). 
 
-### Support Statement ###
+### Support statement ###
 * New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [8.6.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-860238/).

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9170300.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9170300.mdx
@@ -6,10 +6,10 @@ downloadLink: 'https://download.newrelic.com/php_agent/archive/9.17.0.300'
 ---
 
 ### End of Life Notices ###
-* This will be the last release in which ZTS builds are supported. In the future, ZTS builds may not be provided and support may be completely pulled from the codebase.
-* New Relic no longer supports PHP 5.3 or PHP 5.4. New Relic highly encourages upgrading to a supported version of PHP. If you would like to continue running the New Relic PHP agent with PHP 5.3 or 5.4, we recommend using version 9.16 of the agent, however please note that we can only offer limited support in this case.
+* This will be the last release in which ZTS builds are supported. In the future, ZTS builds may not be provided, and support may be completely pulled from the codebase.
+* New Relic no longer supports PHP 5.3 or PHP 5.4. New Relic highly encourages upgrading to a supported version of PHP. If you would like to continue running the New Relic PHP agent with PHP 5.3 or 5.4, we recommend using version 9.16 of the agent. However, please note that we can only offer limited support in this case.
 * Ubuntu LTS versions earlier than 14.04, Ubuntu non-LTS versions earlier than 19.04, and Debian versions earlier than 7 "wheezy" are no longer supported.
-* The following frameworks or framework versions are no longer supported and may be removed from future agent builds.
+* The following frameworks or framework versions are no longer supported and may be removed from future agent builds:
   * Cake PHP 1.x
   * Joomla 1.5, 1.6, and 2.x
   * Kohana
@@ -17,7 +17,7 @@ downloadLink: 'https://download.newrelic.com/php_agent/archive/9.17.0.300'
   * Symfony 1.x and 2.x
 
 ### New Features ###
-* The agent now supports 64-bit PHP 8.0! Compatibility note: when PHP 8.0 detects the New Relic agent, it will disable JIT.
+* The agent now supports 64-bit PHP 8.0! Compatibility note: When PHP 8.0 detects the New Relic agent, it disables JIT.
 * `mysqli_commit` is now [instrumented](https://github.com/newrelic/newrelic-php-agent/pull/102).
 
 ### Bug Fixes ###

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9170300.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9170300.mdx
@@ -1,0 +1,29 @@
+---
+subject: PHP agent
+releaseDate: '2021-04-21'
+version: 9.17.0.300
+downloadLink: 'https://download.newrelic.com/php_agent/archive/9.17.0.300'
+---
+
+### End of Life Notices ###
+* This will be the last release in which ZTS builds are supported. In the future, ZTS builds may not be provided and support may be completely pulled from the codebase.
+* New Relic no longer supports PHP 5.3 or PHP 5.4. New Relic highly encourages upgrading to a supported version of PHP. If you would like to continue running the New Relic PHP agent with PHP 5.3 or 5.4, we recommend using version 9.16 of the agent, however please note that we can only offer limited support in this case.
+* Ubuntu LTS versions earlier than 14.04, Ubuntu non-LTS versions earlier than 19.04, and Debian versions earlier than 7 "wheezy" are no longer supported.
+* The following frameworks or framework versions are no longer supported and may be removed from future agent builds.
+  * Cake PHP 1.x
+  * Joomla 1.5, 1.6, and 2.x
+  * Kohana
+  * Silex 1.x and 2.x
+  * Symfony 1.x and 2.x
+
+### New Features ###
+* The agent now supports 64-bit PHP 8.0! Compatibility note: when PHP 8.0 detects the New Relic agent, it will disable JIT.
+* `mysqli_commit` is now [instrumented](https://github.com/newrelic/newrelic-php-agent/pull/102).
+
+### Bug Fixes ###
+* Fixed [a memory leak](https://github.com/newrelic/newrelic-php-agent/pull/123) that occurred when short lived segments throw exceptions.
+* Fixed [a build up](https://github.com/newrelic/newrelic-php-agent/pull/120) of duplicate Distributed Tracing headers that sometimes occurred when using `file_get_contents`.
+* Fixed an issue where Laravel Lumen transactions were [not being properly named](https://github.com/newrelic/newrelic-php-agent/pull/135). 
+
+### Support Statement ###
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [8.6.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-860238/).


### PR DESCRIPTION
READY for publication: Updating PHP agent documentation and release notes to reflect the PHP 9.17 release.