### PR TITLE
AWS metric stream integration: post-ga updates

### DIFF
--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -201,7 +201,6 @@ When we generate New Relic entities for a namespace you can expect to:
 [Lookout view](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-lookout-monitor-your-estate-glance/) in **Entity Explorer** is not compatible with entities created from the AWS Metric Streams integration at this time.
 </Callout>
 
-
 ## Set alert conditions [#set-alerts]
 You can create NRQL alert conditions on metrics from a metric stream. Make sure your filter limits data to metrics from the CloudWatch metric stream only. To do that, construct your queries like this:
 
@@ -227,10 +226,9 @@ The following query shows an example of tags being collected and queried as dime
 SELECT average(`aws.rds.CPUUtilization`) FROM Metric FACET `tags.mycustomtag` SINCE 30 MINUTES AGO TIMESERIES
 ```
 ## Metadata collection [#metadata-collection]
-Similarly as with custom tags, New Relic also pulls metadata information from relevant AWS services in order to decorate AWS CloudWatch metrics with enriched metadata collected from AWS Services APIs.
-This is an optional capability that's complementary to the CloudWatch metric streams integration. 
-The solution relies on [AWS Config](https://docs.aws.amazon.com/config/index.html) which might incur in additional costs in your AWS account. 
-AWS Config provides [granular controls](https://docs.aws.amazon.com/config/latest/developerguide/select-resources.html) to determine which services and resources are recorded. New Relic will only ingest metadata from the available resources in your AWS account.
+Similarly as with custom tags, New Relic also pulls metadata information from relevant AWS services in order to decorate AWS CloudWatch metrics with enriched metadata collected from AWS Services APIs. This is an optional capability that's complementary to the CloudWatch Metric Streams integration. 
+
+The solution relies on [AWS Config](https://docs.aws.amazon.com/config/index.html), which might incur in additional costs in your AWS account. AWS Config provides [granular controls](https://docs.aws.amazon.com/config/latest/developerguide/select-resources.html) to determine which services and resources are recorded. New Relic will only ingest metadata from the available resources in your AWS account.
 
 The following services / namespaces are supported:
 * EC2
@@ -241,22 +239,22 @@ The following services / namespaces are supported:
 
 We plan to add metadata from most used AWS services.
 
-## Curated dashboards
-A set of Dashboards for different AWS Services is available in the NR1 [Quickstarts app](https://newrelic.github.io/quickstarts-dashboard-library/#/). 
+## Curated dashboards [#curated-dashboards]
+A set of dashboards for different AWS Services is available in the New Relic One [Quickstarts app](https://newrelic.github.io/quickstarts-dashboard-library/#/). 
 
-### Get access to the Quickstarts App
-Follow these steps in order to browse and import the dashboards:
-1. Navigate to the "Apps" catalog in New Relic One. 
-2. Search and select the "Quickstarts" app. 
-3. Click on "Add this app" link (top-right corner).
-4. Select target accounts where the app needs to be enabled and confirm with "Update account" button.
+### Get access to the Quickstarts App [#access-quickstart]
+Follow these steps in order to browse and import dashboards:
+1. Navigate to the **Apps** catalog in New Relic One. 
+2. Search and select the **Quickstarts** app. 
+3. Click on the **Add this app** link in the top-right corner.
+4. To enable the app, select target accounts and confirm clicking the **Update account** button.
 5. If applicable, review and confirm the Terms and Conditions of Use.
-6. Note that it might take a few minutes until permissions are applied and the App is ready to be used. Once available, confirm app is enabled. 
+6. Note that it might take a few minutes until permissions are applied and the app is ready to be used. Once available, confirm the app is enabled. 
 The Quickstarts app will be listed in the Apps catalog.
 
-### Importing Dashboards from Quickstarts App
+### Import dashboards from Quickstarts App [#import-dashboards]
 Follow these steps in order to import any of the curated dashboards:
-1. Navigate to Apps and open the Quickstarts app.
+1. Navigate to **Apps** and open the Quickstarts app.
 2. Browse the AWS Dashboards. If you don't find a dashboard for your AWS service please submit your feedback on the top navigation bar or feel free to [contribute with your own dashboard](https://github.com/newrelic/quickstarts-dashboard-library/tree/main/library). 
 3. Select the dashboard, confirm the target account and initial dashboard name. 
 4. A copy of the dashboard should be imported in the target account. Additional customization is possible using any of the New Relic One dashboarding features.
@@ -280,17 +278,20 @@ New Relic and AWS teams are working together to offer more granular controls so 
   Metrics sent via AWS Metric Streams count against your Metric API limits for the New Relic account where data will be ingested.
 </Callout>
 
-## Migrating from poll-based AWS integrations
-When sending metrics via Metric Streams to New Relic, if the same metrics are being retrieved using the current poll-based integrations, metrics will be duplicated. For example, alerts and dashboards that use `sum` or `count` will return twice the actual number. This includes alerts and dashboards that use metrics that have a `.Sum` suffix.
+## Migrating from poll-based AWS integrations [#migrating-from-poll-integrations]
+When metrics are sent via Metric Streams to New Relic, if the same metrics are being retrieved using the current poll-based integrations, those metrics will be duplicated. For example, alerts and dashboards that use `sum` or `count` will return twice the actual number. This includes alerts and dashboards that use metrics that have a `.Sum` suffix.
 
 We recommend sending the data to a non-production New Relic account where you can safely do tests. If that is not an option, then AWS CloudWatch Metric Stream filters are available to include or exclude certain namespaces that can cause trouble.
 
 Alternatively, you can use filtering on queries to distinguish between metrics that come from Metric Streams and those that come through polling. All metrics coming from Metric Streams are tagged with `collector.name='cloudwatch-metric-streams'`.
 
-### Query, dashboard and alert considerations
+### Query, dashboard, and alert considerations [#considerations]
 AWS Metric Streams integration uses the Metric API to push metrics in the dimensional metric format.
-Poll-based integrations push metrics based on events (e.g. ComputeSample event) and will be migrated to dimensional metrics in the future.
-To assist in this transition, New Relic provides a mechanism (known as shimming) that transparently let customers write queries in any format and be processed as expected baseed on the source that's available (metrics or events). This mechanism works on both ways: events to metrics and viceversa. 
+
+Poll-based integrations push metrics based on events (for example, `ComputeSample` event), and will be migrated to dimensional metrics in the future.
+
+To assist in this transition, New Relic provides a mechanism (known as shimming) that transparently lets you write queries in any format. Then these queries are processed as expected based on the source that's available (metrics or events). This mechanism works both ways, from events to metrics, and viceversa. 
+
 Please consider the following when migrating from poll-based integrations:
 * Custom dashboards that use poll-based AWS integration events should work as expected. 
 * Alert conditions that use poll-based AWS events might need to be adapted with dimensional metric format. Use the NRQL source for the alert condition. 
@@ -345,8 +346,6 @@ You can see the state of the Metric Stream(s) in the Streams tab in the CloudWat
 * Stopped: The stream has been explicitly set to the halted state (not because of an error). This state is useful to temporarily stop the streaming of data without deleting the configuration.
 
 ### Errors in the Status Dashboard [#errors-status-dashboard]
-
-#### 
 
 New Relic relies on the AWS Config service to collect additional metadata from resources in order to enrich metrics received via CloudWatch Metric Stream.
 

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -87,7 +87,7 @@ We provide a [CloudFormation template](https://console.aws.amazon.com/cloudforma
     * Third-party service provider: New Relic - Metrics
     * New Relic configuration
       * HTTP endpoint URL (US Datacenter): `https://aws-api.newrelic.com/cloudwatch-metrics/v1`
-      * HTTP endpoint URL (EU Datacenter): `https://aws-api.newrelic.com/cloudwatch-metrics/v1`
+      * HTTP endpoint URL (EU Datacenter): `https://cloud-collector.eu01.nr-data.net/cloudwatch-metrics/v1`
       * API key: Enter your [license key](/docs/accounts/accounts-billing/account-setup/new-relic-license-key/)
       * Content encoding: `GZIP`
       * Retry duration: `60`

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -1,12 +1,12 @@
 ---
-title: Amazon Metric Stream integration
+title: Amazon CloudWatch Metric Streams integration
 tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
 ---
 
-New Relic currently provides independent [integrations with AWS](/docs/integrations/amazon-integrations/) to collect performance metrics and metadata for more than 50 AWS services. With the new AWS metric stream integration, you only need a **single service**, [AWS CloudWatch](https://aws.amazon.com/cloudwatch/), to gather all AWS metrics and custom namespaces and send them to New Relic.
+New Relic currently provides independent [integrations with AWS](/docs/integrations/amazon-integrations/) to collect performance metrics and metadata for more than 50 AWS services. With the new AWS Metric Streams integration, you only need a **single service**, [AWS CloudWatch](https://aws.amazon.com/cloudwatch/), to gather all AWS metrics and custom namespaces and send them to New Relic.
 
 ## Why does this matter? [#why-it-matters]
 
@@ -197,6 +197,11 @@ When we generate New Relic entities for a namespace you can expect to:
 * Get metrics and entities from that namespace decorated with AWS tags. Collecting AWS tags requires that you have given New Relic the `tag:GetResources` permission which is part of the setup process in the UI. AWS tags show in metrics as `tag.AWSTagName`; for example, if you have set a Team AWS tag on the resource, it will show as `tag.Team`.
 * Leverage all the built-in features that are part of the Explorer.
 
+<Callout variant="important">
+[Lookout view](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-lookout-monitor-your-estate-glance/) in **Entity Explorer** is not compatible with entities created from the AWS Metric Stream integration at this time.
+</Callout>
+
+
 ## Set alert conditions [#set-alerts]
 You can create NRQL alert conditions on metrics from a metric stream. Make sure your filter limits data to metrics from the CloudWatch metric stream only. To do that, construct your queries like this:
 
@@ -257,9 +262,9 @@ Follow these steps in order to import any of the curated dashboards:
 4. A copy of the dashboard should be imported in the target account. Additional customization is possible using any of the New Relic One dashboarding features.
 
 ## Manage your data [#manage-data]
-New Relic provides a [set of tools](/docs/telemetry-data-platform/ingest-manage-data/manage-data/manage-your-data/) to keep track of the data being ingested in your account. Go to **Manage your data** in the settings menu to see all details. Metrics ingested from AWS Metric Stream integrations are considered in the **Metric** bucket. 
+New Relic provides a [set of tools](/docs/telemetry-data-platform/ingest-manage-data/manage-data/manage-your-data/) to keep track of the data being ingested in your account. Go to **Manage your data** in the settings menu to see all details. Metrics ingested from AWS Metric Streams integrations are considered in the **Metric** bucket. 
 
-If you need a more granular view of the data you can use the `bytecountestimate()` function on Metric in order to estimate the data being ingested. For example, the following query represents data ingested from all metrics processed via AWS Metric Stream integration in the last 30 days (in bytes):
+If you need a more granular view of the data you can use the `bytecountestimate()` function on Metric in order to estimate the data being ingested. For example, the following query represents data ingested from all metrics processed via AWS Metric Streams integration in the last 30 days (in bytes):
 
 ```
 FROM Metric SELECT bytecountestimate() where collector.name='cloudwatch-metric-streams' since 30 day ago
@@ -271,7 +276,7 @@ We recommend the following actions to control the data being ingested:
 
 New Relic and AWS teams are working together to offer more granular controls so that filters can be applied based on tags and other attributes.  
 
-<Callout variant="note">
+<Callout variant="important">
   Metrics sent via AWS Metric Streams count against your Metric API limits for the New Relic account where data will be ingested.
 </Callout>
 
@@ -283,7 +288,7 @@ We recommend sending the data to a non-production New Relic account where you ca
 Alternatively, you can use filtering on queries to distinguish between metrics that come from Metric Streams and those that come through polling. All metrics coming from Metric Streams are tagged with `collector.name='cloudwatch-metric-streams'`.
 
 ### Query, dashboard and alert considerations
-AWS Metric Stream integration uses the Metric API to push metrics in the dimensional metric format.
+AWS Metric Streams integration uses the Metric API to push metrics in the dimensional metric format.
 Poll-based integrations push metrics based on events (e.g. ComputeSample event) and will be migrated to dimensional metrics in the future.
 To assist in this transition, New Relic provides a mechanism (known as shimming) that transparently let customers write queries in any format and be processed as expected baseed on the source that's available (metrics or events). This mechanism works on both ways: events to metrics and viceversa. 
 Please consider the following when migrating from poll-based integrations:
@@ -333,7 +338,7 @@ WHERE collector.name = 'cloudwatch-metric-streams'
 
 Remember that AWS fixes the maximum resolution for every metric reported in AWS CloudWatch (for example: 1 minute, 5 minutes, etc). 
 
-### AWS Metric Stream Operation [#metric-stream-operation]
+### AWS Metric Streams Operation [#metric-stream-operation]
 
 You can see the state of the Metric Stream(s) in the Streams tab in the CloudWatch console. In particular, a Metric Stream can be in one of two states: running or stopped.
 * Running: The stream is running correctly. Note that there may not be any metric data been streamed due to the configured filters. Although there is no data corresponding to the configured filters, the status of the Metric Stream can be running still.

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -1,12 +1,12 @@
 ---
-title: Amazon CloudWatch Metric Streams integration
+title: Amazon Metric Stream integration
 tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
 ---
 
-New Relic currently provides independent [integrations with AWS](/docs/integrations/amazon-integrations/) to collect performance metrics and metadata for more than 50 AWS services. With the new AWS metric streams integration, you only need a **single service**, [AWS CloudWatch](https://aws.amazon.com/cloudwatch/), to gather all AWS metrics and custom namespaces and send them to New Relic.
+New Relic currently provides independent [integrations with AWS](/docs/integrations/amazon-integrations/) to collect performance metrics and metadata for more than 50 AWS services. With the new AWS metric stream integration, you only need a **single service**, [AWS CloudWatch](https://aws.amazon.com/cloudwatch/), to gather all AWS metrics and custom namespaces and send them to New Relic.
 
 ## Why does this matter? [#why-it-matters]
 
@@ -62,13 +62,7 @@ Our current system, which relies on individual integrations, runs on a polling f
   </tbody>
 </table>
 
-## Set up a Metric Streams to send CloudWatch metrics to New Relic [#set-up-metric-streams]
-
-When sending metrics via Metric Streams to New Relic, if the same metrics are being retrieved using the current poll-based integrations, metrics will be duplicated. For example, alerts and dashboards that use `sum` or `count` will return twice the actual number. This includes alerts and dashboards that use metrics that have a `.Sum` suffix.
-
-We recommend sending the data to a non-production New Relic account where you can safely do tests. If that is not an option, then filter metric streams to include or exclude certain namespaces that can cause trouble.
-
-Alternatively, you can use filtering to distinguish between metrics that come from Metric Streams and those that come through polling. All metrics coming from Metric Streams are tagged with `collector.name='cloudwatch-metric-streams'`.
+## Set up a Metric Stream to send CloudWatch metrics to New Relic [#set-up-metric-stream]
 
 To stream CloudWatch metrics to New Relic you need to create Kinesis Data Firehose and point it to New Relic and then create a CloudWatch Metric Stream that sends metrics to that Firehose.
 
@@ -92,7 +86,8 @@ We provide a [CloudFormation template](https://console.aws.amazon.com/cloudforma
   * Ensure the following settings are defined:
     * Third-party service provider: New Relic - Metrics
     * New Relic configuration
-      * HTTP endpoint URL: `https://aws-api.newrelic.com/cloudwatch-metrics/v1`
+      * HTTP endpoint URL (US Datacenter): `https://aws-api.newrelic.com/cloudwatch-metrics/v1`
+      * HTTP endpoint URL (EU Datacenter): `https://aws-api.newrelic.com/cloudwatch-metrics/v1`
       * API key: Enter your [license key](/docs/accounts/accounts-billing/account-setup/new-relic-license-key/)
       * Content encoding: `GZIP`
       * Retry duration: `60`
@@ -202,11 +197,6 @@ When we generate New Relic entities for a namespace you can expect to:
 * Get metrics and entities from that namespace decorated with AWS tags. Collecting AWS tags requires that you have given New Relic the `tag:GetResources` permission which is part of the setup process in the UI. AWS tags show in metrics as `tag.AWSTagName`; for example, if you have set a Team AWS tag on the resource, it will show as `tag.Team`.
 * Leverage all the built-in features that are part of the Explorer.
 
-
-<Callout variant="important">
-[Lookout view](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-lookout-monitor-your-estate-glance/) in **Entity Explorer** is not compatible with entities created from the AWS Metric Stream integration at this time.
-</Callout>
-
 ## Set alert conditions [#set-alerts]
 You can create NRQL alert conditions on metrics from a metric stream. Make sure your filter limits data to metrics from the CloudWatch metric stream only. To do that, construct your queries like this:
 
@@ -233,6 +223,9 @@ SELECT average(`aws.rds.CPUUtilization`) FROM Metric FACET `tags.mycustomtag` SI
 ```
 ## Metadata collection [#metadata-collection]
 Similarly as with custom tags, New Relic also pulls metadata information from relevant AWS services in order to decorate AWS CloudWatch metrics with enriched metadata collected from AWS Services APIs.
+This is an optional capability that's complementary to the CloudWatch metric streams integration. 
+The solution relies on [AWS Config](https://docs.aws.amazon.com/config/index.html) which might incur in additional costs in your AWS account. 
+AWS Config provides [granular controls](https://docs.aws.amazon.com/config/latest/developerguide/select-resources.html) to determine which services and resources are recorded. New Relic will only ingest metadata from the available resources in your AWS account.
 
 The following services / namespaces are supported:
 * EC2
@@ -243,10 +236,30 @@ The following services / namespaces are supported:
 
 We plan to add metadata from most used AWS services.
 
-## Manage your data [#manage-data]
-New Relic provides a [set of tools](/docs/telemetry-data-platform/ingest-manage-data/manage-data/manage-your-data/) to keep track of the data being ingested in your account. Go to **Manage your data** in the settings menu to see all details. Metrics ingested from AWS Metric Streams integrations are considered in the **Metric** bucket. 
+## Curated dashboards
+A set of Dashboards for different AWS Services is available in the NR1 [Quickstarts app](https://newrelic.github.io/quickstarts-dashboard-library/#/). 
 
-If you need a more granular view of the data you can use the `bytecountestimate()` function on Metric in order to estimate the data being ingested. For example, the following query represents data ingested from all metrics processed via AWS Metric Streams integration in the last 30 days (in bytes):
+### Get access to the Quickstarts App
+Follow these steps in order to browse and import the dashboards:
+1. Navigate to the "Apps" catalog in New Relic One. 
+2. Search and select the "Quickstarts" app. 
+3. Click on "Add this app" link (top-right corner).
+4. Select target accounts where the app needs to be enabled and confirm with "Update account" button.
+5. If applicable, review and confirm the Terms and Conditions of Use.
+6. Note that it might take a few minutes until permissions are applied and the App is ready to be used. Once available, confirm app is enabled. 
+The Quickstarts app will be listed in the Apps catalog.
+
+### Importing Dashboards from Quickstarts App
+Follow these steps in order to import any of the curated dashboards:
+1. Navigate to Apps and open the Quickstarts app.
+2. Browse the AWS Dashboards. If you don't find a dashboard for your AWS service please submit your feedback on the top navigation bar or feel free to [contribute with your own dashboard](https://github.com/newrelic/quickstarts-dashboard-library/tree/main/library). 
+3. Select the dashboard, confirm the target account and initial dashboard name. 
+4. A copy of the dashboard should be imported in the target account. Additional customization is possible using any of the New Relic One dashboarding features.
+
+## Manage your data [#manage-data]
+New Relic provides a [set of tools](/docs/telemetry-data-platform/ingest-manage-data/manage-data/manage-your-data/) to keep track of the data being ingested in your account. Go to **Manage your data** in the settings menu to see all details. Metrics ingested from AWS Metric Stream integrations are considered in the **Metric** bucket. 
+
+If you need a more granular view of the data you can use the `bytecountestimate()` function on Metric in order to estimate the data being ingested. For example, the following query represents data ingested from all metrics processed via AWS Metric Stream integration in the last 30 days (in bytes):
 
 ```
 FROM Metric SELECT bytecountestimate() where collector.name='cloudwatch-metric-streams' since 30 day ago
@@ -254,19 +267,34 @@ FROM Metric SELECT bytecountestimate() where collector.name='cloudwatch-metric-s
 
 We recommend the following actions to control the data being ingested:
 * Make sure metric streams are enabled only on the AWS accounts and regions you want to monitor with New Relic.
-* Use the inclusion and exclusion filters in CloudWatch Metric Streams is order to select which services / namespaces are being collected.
+* Use the inclusion and exclusion filters in CloudWatch Metric Stream is order to select which services / namespaces are being collected.
 
 New Relic and AWS teams are working together to offer more granular controls so that filters can be applied based on tags and other attributes.  
 
-<Callout variant="important">
+<Callout variant="note">
   Metrics sent via AWS Metric Streams count against your Metric API limits for the New Relic account where data will be ingested.
 </Callout>
+
+## Migrating from poll-based AWS integrations
+When sending metrics via Metric Streams to New Relic, if the same metrics are being retrieved using the current poll-based integrations, metrics will be duplicated. For example, alerts and dashboards that use `sum` or `count` will return twice the actual number. This includes alerts and dashboards that use metrics that have a `.Sum` suffix.
+
+We recommend sending the data to a non-production New Relic account where you can safely do tests. If that is not an option, then AWS CloudWatch Metric Stream filters are available to include or exclude certain namespaces that can cause trouble.
+
+Alternatively, you can use filtering on queries to distinguish between metrics that come from Metric Streams and those that come through polling. All metrics coming from Metric Streams are tagged with `collector.name='cloudwatch-metric-streams'`.
+
+### Query, dashboard and alert considerations
+AWS Metric Stream integration uses the Metric API to push metrics in the dimensional metric format.
+Poll-based integrations push metrics based on events (e.g. ComputeSample event) and will be migrated to dimensional metrics in the future.
+To assist in this transition, New Relic provides a mechanism (known as shimming) that transparently let customers write queries in any format and be processed as expected baseed on the source that's available (metrics or events). This mechanism works on both ways: events to metrics and viceversa. 
+Please consider the following when migrating from poll-based integrations:
+* Custom dashboards that use poll-based AWS integration events should work as expected. 
+* Alert conditions that use poll-based AWS events might need to be adapted with dimensional metric format. Use the NRQL source for the alert condition. 
 
 ## Troubleshooting [#troubleshooting]
 
 ### No metrics or errors appear on New Relic [#no-metrics-appear]
 If you are not seeing data in New Relic once the AWS CloudWatch Metric Stream has been connected to AWS Kinesis Data Firehose, then follow the steps below to troubleshoot your configuration: 
-1. Check that the Metric Stream is in a state of Running via the AWS console or API. 
+1. Check that the Metric Stream is in a state of Running via the AWS console or API. Please refer to [AWS Troubleshooting docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-troubleshoot.html) for additional details.
 2. Check the Metric Stream metrics under AWS/CloudWatch/MetricStreams namespace. You will see a count of metric updates and errors per Metric Streams. This will indicate that the Metric Stream is successfully emitting data. 
 3. If you see errors, confirm the IAM role specified in the Metric Streams configuration grants the CloudWatch service principal permissions to write to it. 
 4. Check the Monitoring tab of the Kinesis Data Firehose in the Kinesis console to see if the Firehose is successfully receiving data. 
@@ -313,9 +341,11 @@ You can see the state of the Metric Stream(s) in the Streams tab in the CloudWat
 
 ### Errors in the Status Dashboard [#errors-status-dashboard]
 
+#### 
+
 New Relic relies on the AWS Config service to collect additional metadata from resources in order to enrich metrics received via CloudWatch Metric Stream.
 
-Make sure AWS Config is enabled in your AWS Account, and ensure the linked Role has the following inline policy created:
+Make sure AWS Config is enabled in your AWS Account, and ensure the linked Role has the following permission or inline policy created:
 
 ```
 {
@@ -329,4 +359,3 @@ Make sure AWS Config is enabled in your AWS Account, and ensure the linked Role 
     ]
 }
 ```
-

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -198,7 +198,7 @@ When we generate New Relic entities for a namespace you can expect to:
 * Leverage all the built-in features that are part of the Explorer.
 
 <Callout variant="important">
-[Lookout view](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-lookout-monitor-your-estate-glance/) in **Entity Explorer** is not compatible with entities created from the AWS Metric Stream integration at this time.
+[Lookout view](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-lookout-monitor-your-estate-glance/) in **Entity Explorer** is not compatible with entities created from the AWS Metric Streams integration at this time.
 </Callout>
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

We've been collecting feedback after the initial launch of the AWS CloudWatch Metric Streams integration. 
Changes:
- Add section to guide customers that want to migrate from polling integrations
- Add section explaining how to import Dashboards from Quickstarts
- Added formal named used by Amazon: AWS CloudWatch Metric Streams (plural)
- Considerations when using dimensional format vs events-based query format

### Are you making a change to site code?
No

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.