### PR TITLE
[DO NOT MERGE] Add html to json for attribute defs

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -449,14 +449,17 @@ module.exports = {
                 node.definition && node.definition.rawMarkdownBody.trim(),
               dataSources: node.dataSources,
               attributes: node.childrenDataDictionaryAttribute.map(
-                (attribute) => ({
-                  name: attribute.name,
-                  definition: attribute.definition.rawMarkdownBody.trim(),
-                  definitionHtml: htmlParser.runSync(
+                (attribute) => {
+                  const parsedHtml = htmlParser.runSync(
                     attribute.definition.htmlAst
-                  ),
-                  units: attribute.units,
-                })
+                  );
+                  return {
+                    name: attribute.name,
+                    definition: attribute.definition.rawMarkdownBody.trim(),
+                    definitionHtml: htmlParser.stringify(parsedHtml),
+                    units: attribute.units,
+                  };
+                }
               ),
             };
           }),


### PR DESCRIPTION
## Description

Adds a field in attribute definition JSON that contains the HTML string for attribute definitions. This is consumed by data dictionary service. The data dictionary supports an optional format param for HTML, but it's not functional. Second part of this is to update data dictionary to store this field for each attribute and add resolver for HTML format.