### PR TITLE
Add syntax highlighting and fix indentation on code block

### DIFF
--- a/src/content/docs/agents/ruby-agent/background-jobs/resque-instrumentation.mdx
+++ b/src/content/docs/agents/ruby-agent/background-jobs/resque-instrumentation.mdx
@@ -44,24 +44,24 @@ Resque versions before 1.23.1 do not allow hooks to be defined multiple times; t
 
 You may omit definitions for any hooks that you have no custom code for. They will be automatically installed by the agent in this case.
 
-```
+```ruby
 Resque.before_first_fork do
-      # ... your custom hook code ...
-      NewRelic::Agent.manual_start(:dispatcher   => :resque,
-                                   :sync_startup => true,
-                                   :start_channel_listener => true)
-    end
+  # ... your custom hook code ...
+  NewRelic::Agent.manual_start(:dispatcher => :resque,
+                               :sync_startup => true,
+                               :start_channel_listener => true)
+end
     
-    Resque.before_fork do |job|
-      # ... your custom hook code ...
-      NewRelic::Agent.register_report_channel(job.object_id)
-    end
+Resque.before_fork do |job|
+  # ... your custom hook code ...
+  NewRelic::Agent.register_report_channel(job.object_id)
+end
     
-    Resque.after_fork do |job|
-      # ... your custom hook code ...
-      NewRelic::Agent.after_fork(:report_to_channel => job.object_id,
-                                 :report_instance_busy => false)
-    end
+Resque.after_fork do |job|
+  # ... your custom hook code ...
+  NewRelic::Agent.after_fork(:report_to_channel => job.object_id,
+                             :report_instance_busy => false)
+end
 ```
 
 ## Deadlocking jobs [#deadlocks]


### PR DESCRIPTION
### Give us some context

While looking at [this doc](https://docs.newrelic.com/docs/agents/ruby-agent/background-jobs/resque-instrumentation/), I noticed the code block did not include syntax highlighting, and the indentation was pretty wonky. This PR updates the code block to add ruby syntax highlighting and fix the indentation.