### PR TITLE
Add "go forward" callout

### DIFF
--- a/src/content/docs/logs/log-management/ui-data/data-partitions.mdx
+++ b/src/content/docs/logs/log-management/ui-data/data-partitions.mdx
@@ -16,6 +16,10 @@ Data partitions also allow data to be mapped to an alternative, or â€œsecondaryâ
 
 Before you start creating partitions, make sure you have the right permissions and a partition plan.
 
+<Callout variant="important">
+Logs are routed to partitions during the ingestion process, before data is written to NRDB. Partition rules will not affect logs that were ingested prior to the rule's creation.
+</Callout>
+
 ### Required roles and permissions
 
 Users require an [Admin role](/docs/accounts/accounts-billing/new-relic-one-user-management/new-relic-one-user-model-understand-user-structure/) to create and modify partition rules. 


### PR DESCRIPTION
Data partitions is a "go forward" feature which does not affect logs that have already been written to NRDB. We've received a few customer inquiries on this point, updating the docs for clarity.