### PR TITLE
Clarify use of pre-release OTLP endpoint

### DIFF
--- a/src/content/docs/integrations/open-source-telemetry-integrations/opentelemetry/introduction-opentelemetry-new-relic.mdx
+++ b/src/content/docs/integrations/open-source-telemetry-integrations/opentelemetry/introduction-opentelemetry-new-relic.mdx
@@ -159,19 +159,19 @@ APM agents offer detailed transaction trace visibility for individual services. 
 
 ## How OpenTelemetry works with New Relic [#how-it-works]
 
-Here are two basic ways you could set up OpenTelemetry with New Relic: use the OpenTelemetry collector (recommended), or use the native OTLP exporter (pre-release). Each approach assumes you set up instrumentation in your code, but they differ in how the data is gathered and sent to New Relic.
+Here are two basic ways you could set up OpenTelemetry with New Relic: use the OpenTelemetry collector (recommended), or use the native OTLP endpoint (pre-release). Each approach assumes you set up instrumentation in your code, but they differ in how the data is gathered and sent to New Relic.
 
 If you are interested in tracing, we recommend that you instrument as many services as you can so that you get the most benefit from distributed tracing. There are two main options for trace sampling:
 
-* Configure the head-based, native sampling in OpenTelemetry, which means OpenTelemetry samples traces before they are sent to New Relic. Head-based sampling doesn’t analyze all traces, but instead randomly samples traces up front before details about the completed traces are known. Both the OpenTelemetry collector and the native OTLP exporter support this option.
-* If you want New Relic to analyze all your traces, configure tail-based sampling with New Relic Infinite Tracing, which reroutes traces to our cloud-based trace observer. The trace observer accepts all your traces and sorts through them to find useful ones. If you want to know more about this option, especially if you want to use it in the EU, see [Introduction to Infinite Tracing](/docs/understand-dependencies/distributed-tracing/infinite-tracing/introduction-infinite-tracing). While Infinite Tracing is not yet compatible with the native OTLP exporter, it is still possible to configure tail-based sampling via the collector, for more information see [Tail Sampling Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor).
+* Configure the head-based, native sampling in OpenTelemetry, which means OpenTelemetry samples traces before they are sent to New Relic. Head-based sampling doesn’t analyze all traces, but instead randomly samples traces up front before details about the completed traces are known. Both the OpenTelemetry collector and the native OTLP endpoint support this option.
+* If you want New Relic to analyze all your traces, configure tail-based sampling with New Relic Infinite Tracing, which reroutes traces to our cloud-based trace observer. The trace observer accepts all your traces and sorts through them to find useful ones. If you want to know more about this option, especially if you want to use it in the EU, see [Introduction to Infinite Tracing](/docs/understand-dependencies/distributed-tracing/infinite-tracing/introduction-infinite-tracing). While Infinite Tracing is not yet compatible with the native OTLP endpoint, it is still possible to configure tail-based sampling via the collector, for more information see [Tail Sampling Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor).
 
 <Callout variant="tip">
   We discuss some variations on these basic approaches in our [OpenTelemetry architecture recipes](/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-architecture-recipes). For a detailed discussion about the architecture of OpenTelemetry itself, see our [blog](https://blog.newrelic.com/product-news/what-is-opentelemetry/).
 </Callout>
 
 <Callout variant="important">
-New Relic's language-specific exporters for OpenTelemetry are now deprecated in favor of the OpenTelemetry collector and native OTLP exporter options described here.
+New Relic's language-specific exporters for OpenTelemetry are now deprecated in favor of the OpenTelemetry collector and native OTLP endpoint options described here.
 </Callout>
 
 ### Collector (recommended) [#collector]
@@ -190,7 +190,7 @@ Here are some advantages of this approach:
 
 ### OTLP (pre-release) [#otlp]
 
-The example above uses a New Relic exporter, but we have a pre-release program if you want to try out the native OTLP exporter for sending your data to New Relic. You can either use the OTLP exporter with the OpenTelemetry collector, or send us data directly from your service. If you are interested, let us know by completing this [form](https://docs.google.com/forms/d/e/1FAIpQLSdIJVEAYaP7TXe9LmQA64yIObGvt-nOiz5kXYsjxLBbvut_1A/viewform).
+The example above uses a New Relic exporter, but we have a pre-release program if you want to try out the native OTLP endpoint for sending your data to New Relic. You can either use the OTLP exporter in the OpenTelemetry collector, or send us data directly from your service. If you are interested, let us know by completing this [form](https://docs.google.com/forms/d/e/1FAIpQLSdIJVEAYaP7TXe9LmQA64yIObGvt-nOiz5kXYsjxLBbvut_1A/viewform).
 
 Here are some advantages to operating without an OpenTelemetry collector:
 

--- a/src/content/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-architecture-recipes.mdx
+++ b/src/content/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-architecture-recipes.mdx
@@ -13,7 +13,7 @@ OpenTelemetry is powerful because of its flexibility, but this flexibility can b
 Use this recipe if you don’t want to add any vendor-specific code to your applications. As a best practice to maximize value and interoperability, we recommend the OpenTelemetry collector as the main ingredient of this recipe. The OpenTelemetry collector proxies data between instrumented code and backend services.
 
 <Callout variant="tip">
-We have a pre-release program that allows you to use the OTLP exporter in the collector. If you are interested, let us know by completing this [form](https://docs.google.com/forms/d/e/1FAIpQLSdIJVEAYaP7TXe9LmQA64yIObGvt-nOiz5kXYsjxLBbvut_1A/viewform).  
+We have a pre-release program that allows you to use the OTLP exporter in the OpenTelemetry collector. If you are interested, let us know by completing this [form](https://docs.google.com/forms/d/e/1FAIpQLSdIJVEAYaP7TXe9LmQA64yIObGvt-nOiz5kXYsjxLBbvut_1A/viewform).  
 </Callout>
 
 The OpenTelemetry collector has one or more pipelines. Each pipeline includes:

--- a/src/content/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start.mdx
+++ b/src/content/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start.mdx
@@ -54,17 +54,17 @@ Go to the repository for your language and follow the instructions to instrument
 Choose how you want to export your telemetry data to New Relic:
 
 * [Use the OpenTelemetry collector (recommended)](#collector)
-* [Use the native OTLP exporter (pre-release)](#otlp)
+* [Use the native OTLP endpoint (pre-release)](#otlp)
 
 You can use one or both of these approaches in your environment. We'll discuss some highlights of each approach here, but if you need more background, see [Introduction to OpenTelemetry](/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-exporter).
 
 If you are interested in tracing, there are two main options for trace sampling:
 
-* Configure the head-based, native sampling in OpenTelemetry, which means OpenTelemetry samples traces before they are sent to New Relic. Head-based sampling doesn’t analyze all traces, but instead randomly samples traces up front before details about the completed traces are known. Both the OpenTelemetry collector and the native OTLP exporter support this option.
-* If you want New Relic to analyze all your traces, configure tail-based sampling with New Relic Infinite Tracing, which reroutes traces to our cloud-based trace observer. The trace observer accepts all your traces and sorts through them to find useful ones. If you want to know more about this option, especially if you want to use it in the EU, see [Introduction to Infinite Tracing](/docs/understand-dependencies/distributed-tracing/infinite-tracing/introduction-infinite-tracing). While Infinite Tracing is not yet compatible with the native OTLP exporter, it is still possible to configure tail-based sampling via the collector, for more information see [Tail Sampling Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor).
+* Configure the head-based, native sampling in OpenTelemetry, which means OpenTelemetry samples traces before they are sent to New Relic. Head-based sampling doesn’t analyze all traces, but instead randomly samples traces up front before details about the completed traces are known. Both the OpenTelemetry collector and the native OTLP endpoint support this option.
+* If you want New Relic to analyze all your traces, configure tail-based sampling with New Relic Infinite Tracing, which reroutes traces to our cloud-based trace observer. The trace observer accepts all your traces and sorts through them to find useful ones. If you want to know more about this option, especially if you want to use it in the EU, see [Introduction to Infinite Tracing](/docs/understand-dependencies/distributed-tracing/infinite-tracing/introduction-infinite-tracing). While Infinite Tracing is not yet compatible with the native OTLP endpoint, it is still possible to configure tail-based sampling via the collector, for more information see [Tail Sampling Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor).
 
 <Callout variant="important">
-New Relic's language-specific exporters for OpenTelemetry are now deprecated in favor of the OpenTelemetry collector and native OTLP exporter options described here.
+New Relic's language-specific exporters for OpenTelemetry are now deprecated in favor of the OpenTelemetry collector and native OTLP endpoint options described here.
 </Callout>
 
 ### Use the OpenTelemetry collector (recommended) [#collector]
@@ -92,9 +92,9 @@ To use the collector:
    * [Swift](https://github.com/open-telemetry/opentelemetry-swift/tree/master/Sources/Exporters/OpenTelemetryProtocol)
    * [...Find additional OTLP language support in GitHub](https://github.com/open-telemetry)
 
-### Use the native OTLP exporter (pre-release) [#otlp]
+### Use the native OTLP endpoint (pre-release) [#otlp]
 
-The example above uses a New Relic exporter, but we have a pre-release program if you want to try out the native OTLP exporter for sending your data to New Relic. You can either use the OTLP exporter with the OpenTelemetry collector or send us data directly from your service. If you are interested, let us know by completing this [form](https://docs.google.com/forms/d/e/1FAIpQLSdIJVEAYaP7TXe9LmQA64yIObGvt-nOiz5kXYsjxLBbvut_1A/viewform).
+The example above uses a New Relic exporter, but we have a pre-release program if you want to try out the native OTLP endpoint for sending your data to New Relic. You can either use the OTLP exporter in the OpenTelemetry collector or send us data directly from your service. If you are interested, let us know by completing this [form](https://docs.google.com/forms/d/e/1FAIpQLSdIJVEAYaP7TXe9LmQA64yIObGvt-nOiz5kXYsjxLBbvut_1A/viewform).
 
 ## Step 4: View your data in the New Relic UI [#view-data]
 

--- a/src/content/docs/integrations/open-source-telemetry-integrations/troubleshooting/troubleshoot-opentelemetry-exporter.mdx
+++ b/src/content/docs/integrations/open-source-telemetry-integrations/troubleshooting/troubleshoot-opentelemetry-exporter.mdx
@@ -4,20 +4,20 @@ tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
-metaDescription: Troubleshooting tips for New Relic's OpenTelemetry exporters.
+metaDescription: Troubleshooting tips for New Relic's OpenTelemetry exporter.
 redirects:
   - /docs/integrations/open-source-telemetry-integrations/troubleshooting-opentelemetry
 ---
 
 [OpenTelemetry](http://opentelemetry.io) is an emerging standard for service-level instrumentation. Because it has not yet reached 1.0 for any language, the OpenTelemetry SDK, APIs, and instrumentation are subject to change.
 
-If you're using a [New Relic OpenTelemetry exporter](/docs/integrations/open-source-telemetry-integrations/open-source-telemetry-integration-list/new-relics-opentelemetry-integration), but you're not seeing the data you expect, this guide should help.
+If you're using [New Relic's OpenTelemetry exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/newrelicexporter), but you're not seeing the data you expect, this guide should help.
 
 OpenTelemetry currently supports two telemetry types: distributed traces and metrics. Through the New Relic UI, you can see your traces and metrics, as well as a view that focuses on errors. Learn more about how to [find your data](/docs/integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic).
 
 ## Install
 
-To send your data through the [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector), configure your OpenTelemetry SDK `service.name` as a resource and configure the SDK to send data to the collector. Then configure the collector with the [New Relic exporter for Go](https://github.com/newrelic/opentelemetry-exporter-go) with your Insert API key. Consult the [collector documentation](https://opentelemetry.io/docs/collector/about/) if you're having trouble sending data through the collector.
+To send your data through the [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector), configure your OpenTelemetry SDK `service.name` as a resource and configure the SDK to send data to the collector. Then configure the collector with the [New Relic exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/newrelicexporter) with your Insert API key. Consult the [collector documentation](https://opentelemetry.io/docs/collector/about/) if you're having trouble sending data through the collector.
 
 Once OpenTelemetry is configured with the API key and service name, you should be able to find your service in the [explorer](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer-view-performance-across-apps-services-hosts). Select your service to view its summary page.
 


### PR DESCRIPTION
A follow up from #1907.  For more details see DOC-6641. @rvanderwal-newrelic, please review!

This changes language around the pre-release to reference the OTLP endpoint, not the OTLP exporter, which is slightly ambiguous. In other places, I've tried to be more clear that we mean [the OTLP exporter in the OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter).