### PR TITLE
Add google tag manager config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -174,6 +174,13 @@ module.exports = {
             }),
           },
         },
+        googleTagManager: {
+          trackingId: 'UA-3047412-33',
+          src: 'https://www.googletagmanager.com/gtag/js',
+          options: {
+            anonymize_ip: true,
+          },
+        },
       },
     },
     {


### PR DESCRIPTION
## Description

Adds google tag manager config to start tracking via google when not using tessen.