### PR TITLE
fix: referrer field not being sent on sign up

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "^2.0.0-next.8",
     "@mdx-js/react": "^2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "^2.0.0",
+    "@newrelic/gatsby-theme-newrelic": "^2.0.1",
     "@splitsoftware/splitio-react": "^1.2.4",
     "babel-jest": "^26.3.0",
     "common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2318,10 +2318,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-2.0.0.tgz#77c5d26d9c89390ef7996acdd6a4adf6107ff0d3"
-  integrity sha512-Jo8hvtsmCEflIt9z2YYwiP8rfOIf7iaGzE3PJYI1oFVmz8Qd/s1omjuUwQJssPUf1pdhcXSL79Ccg/yNvONsmw==
+"@newrelic/gatsby-theme-newrelic@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-2.0.1.tgz#44ff836e6b4d3430fdec528d6245ac55c0c00100"
+  integrity sha512-CQ7OLUMWJ2qUFmuJD8Yt3mUlXE2dSwEowfCSauoLPNyiFGtDariRd7IJThRagXbmz+8b+a96goJYxvkun+UOZQ==
   dependencies:
     "@elastic/react-search-ui" "^1.5.1"
     "@elastic/react-search-ui-views" "^1.5.1"


### PR DESCRIPTION
# Summary
Fixes a bug in the `gatsby-theme-newrelic` dependency where it wasn't sending the referral field to segment.

Partly closes https://github.com/newrelic/docs-website/issues/1816