### PR TITLE
Link image to original

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -245,7 +245,7 @@ module.exports = {
             resolve: 'gatsby-remark-images',
             options: {
               maxWidth: 850,
-              linkImagesToOriginal: false,
+              linkImagesToOriginal: true,
               backgroundColor: 'transparent',
               disableBgImageOnAlpha: true,
             },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -292,7 +292,7 @@ module.exports = {
             resolve: 'gatsby-remark-images',
             options: {
               maxWidth: 1200,
-              linkImagesToOriginal: false,
+              linkImagesToOriginal: true,
               backgroundColor: 'transparent',
               disableBgImageOnAlpha: true,
             },


### PR DESCRIPTION
## Description

Makes images in `.md` and `.mdx` files link to their original file so they can be viewed in original resolution / size. GIFs not supported in this work.

## Review notes
* check JSON endpoints that include HTML to ensure it won't cause any issues rendering in NR1 (what's new, NR1 Help XP, translation serialization)

## Examples
* [What's New post](https://pr-2001.d1vx4w5vgyla4s.amplifyapp.com/whats-new/2021/04/log-part/)
* [MDX page with image](https://pr-2001.d1vx4w5vgyla4s.amplifyapp.com/docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-guide/)

## Related issues
* short term fix for https://github.com/newrelic/docs-website/issues/850