### PR TITLE
Create whats new ID workflow

### DIFF
--- a/.github/workflows/build-with-swiftype-content.yml
+++ b/.github/workflows/build-with-swiftype-content.yml
@@ -107,7 +107,7 @@ jobs:
               },
               restrictions: {
                 users: [],
-                teams: ['site-squad']
+                teams: ['developer-enablement']
               },
               enforce_admins: true,
               required_pull_request_reviews: null

--- a/.github/workflows/update-whats-new-ids.yml
+++ b/.github/workflows/update-whats-new-ids.yml
@@ -1,0 +1,48 @@
+name: Update whats-new-ids
+
+on:
+  pull_request:
+    branches:
+      - main
+
+env:
+  BOT_NAME: nr-opensource-bot
+  BOT_EMAIL: opensource+bot@newrelic.com
+
+jobs:
+  update-whats-new-ids:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: develop
+
+      - name: Setup node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Install dependencies
+        run: yarn add vfile-glob to-vfile
+
+      - name: Generate new IDs
+        run: yarn run generate-whatsnew-ids
+
+      - name: Commit changes
+        id: commit-changes
+        run: |
+          git config --local user.email "${{ env.BOT_EMAIL }}"
+          git config --local user.name "${{ env.BOT_NAME }}"
+          git add ./src/data/whats-new-ids.json
+          git diff-index --quiet HEAD ./src/data/whats-new-ids.json || git commit -m 'chore(whats-new-ids): updated ids'
+          echo "::set-output name=commit::true"
+
+      # This pushes directly to develop which should get included in the release PR
+
+      - name: Push Commit
+        if: steps.commit-changes.outputs.commit == 'true'
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
+          branch: develop

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,4 @@
 const path = require('path');
-const vfileGlob = require('vfile-glob');
-const { read, write } = require('to-vfile');
 const { prop } = require('./scripts/utils/functional.js');
 const externalRedirects = require('./src/data/external-redirects.json');
 
@@ -17,44 +15,6 @@ const hasTrailingSlash = (pathname) =>
 
 const appendTrailingSlash = (pathname) =>
   pathname.endsWith('/') ? pathname : `${pathname}/`;
-
-exports.onPreBootstrap = async ({ reporter, store }) => {
-  reporter.info("generating what's new post IDs");
-  const { program } = store.getState();
-  const file = await read(
-    path.join(program.directory, 'src/data/whats-new-ids.json'),
-    'utf-8'
-  );
-
-  const data = JSON.parse(file.contents);
-  let largestID = Object.values(data).reduce(
-    (num, id) => Math.max(parseInt(id, 10), num),
-    0
-  );
-
-  return new Promise((resolve) => {
-    vfileGlob(
-      path.join(program.directory, 'src/content/whats-new/**/*.md')
-    ).subscribe({
-      next: (file) => {
-        const slug = file.path
-          .replace(/.*?src\/content/, '')
-          .replace('.md', '');
-
-        if (!data[slug]) {
-          data[slug] = String(++largestID);
-        }
-      },
-      complete: async () => {
-        file.contents = JSON.stringify(data, null, 2);
-
-        await write(file, 'utf-8');
-
-        resolve();
-      },
-    });
-  });
-};
 
 exports.onCreateNode = ({ node, getNode, actions }) => {
   const { createNodeField } = actions;
@@ -441,5 +401,3 @@ const getTemplate = (node) => {
       return { template: 'docPage' };
   }
 };
-
-const getFileRelativePath = (path) => path.replace(`${process.cwd()}/`, '');

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "build:production": "GATSBY_NEWRELIC_ENV=production yarn run build",
     "build:staging": "GATSBY_NEWRELIC_ENV=staging yarn run build",
     "build:related-content": "BUILD_RELATED_CONTENT=true yarn run build:production",
+    "generate-whatsnew-ids": "node scripts/actions/generate-whats-new-ids.js",
     "debug": "yarn develop --inspect-brk",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "start": "yarn develop",

--- a/scripts/actions/generate-whats-new-ids.js
+++ b/scripts/actions/generate-whats-new-ids.js
@@ -1,0 +1,35 @@
+const vfileGlob = require('vfile-glob');
+const { read, write } = require('to-vfile');
+
+const generateWhatsNewIds = async () => {
+  const file = await read('./src/data/whats-new-ids.json', 'utf-8');
+
+  const data = JSON.parse(file.contents);
+  let largestID = Object.values(data).reduce(
+    (num, id) => Math.max(parseInt(id, 10), num),
+    0
+  );
+
+  return new Promise((resolve) => {
+    vfileGlob('./src/content/whats-new/**/*.md').subscribe({
+      next: (file) => {
+        const slug = file.path
+          .replace(/.*?src\/content/, '')
+          .replace('.md', '');
+
+        if (!data[slug]) {
+          data[slug] = String(++largestID);
+        }
+      },
+      complete: async () => {
+        file.contents = JSON.stringify(data, null, 2);
+
+        await write(file, 'utf-8');
+
+        resolve();
+      },
+    });
+  });
+};
+
+generateWhatsNewIds();


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

This PR adds a workflow to generate whats new IDs used for the `https://docs.newrelic.com/api/nr1/content/nr1-announcements.json` endpoint. Previously we generated these during the build, which meant new IDs lived in memory until someone ran a local build and committed those changes. This will get rid of the process on build and run it in a workflow that occurs on PRs to main. This way new IDs should get committed as necessary on each release

Closes https://github.com/newrelic/docs-website/issues/1561
