### PR TITLE
link to CloudWatch docs for AWS namespace support

### DIFF
--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -175,6 +175,8 @@ Metrics received from AWS CloudWatch are stored in New Relic as [dimensional met
     * `aws.Region`
     * `aws.s3.BucketName`
 
+Current namespaces supported by AWS can be found in the [CloudWatch documentation website](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-services-cloudwatch-metrics.html).
+
 ## Query Experience, metric storage and mapping [#query-experience]
 
 Metrics coming from AWS CloudWatch are stored as dimensional metrics of type `summary` and can be [queried](/docs/telemetry-data-platform/get-data/apis/query-metric-data-type/) using [NRQL](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language/). 


### PR DESCRIPTION
### Give us some context

* What problems does this PR solve?
Adding a link to AWS documentation that shows users which AWS services and namespaces are currently supported

### Are you making a change to site code?

Nope 