### PR TITLE
Update heroku-log-forwarding.mdx

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/heroku-log-forwarding.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/heroku-log-forwarding.mdx
@@ -7,13 +7,13 @@ tags:
 metaDescription: 'Send Heroku logs to New Relic'
 ---
 
-You can stream your Heroku logs to New Relic using Heroku's built-in [Logplex](https://devcenter.heroku.com/articles/logplex) router. Here we explain how to stream logs to New Relic using Heroku [syslog drains](https://devcenter.heroku.com/articles/log-drains#syslog-drains).
+You can stream your Heroku logs to New Relic using Heroku's built-in [Logplex](https://devcenter.heroku.com/articles/logplex) router. In this page we explain how to stream logs to New Relic using [Heroku Syslog drains](https://devcenter.heroku.com/articles/log-drains#syslog-drains).
 
 
 ## Requirements [#requirements]
 
 <Callout variant="important">
-Currently, our Heroku syslog endpoint only supports accounts in our [US data center](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers).
+Currently, our Heroku Syslog endpoint only supports accounts in our [US data center](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers).
 </Callout>
 
 Ensure the following before configuring log forwarding from Heroku:
@@ -21,15 +21,15 @@ Ensure the following before configuring log forwarding from Heroku:
 1. Your New Relic user account has the [Admin role](https://docs.newrelic.com/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model/#roles) assigned to it.
 2. The account you wish to send logs to has at least one [Insights Insert API Key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/new-relic-api-keys/#insights-insert-key) associated with it.
 
-## Create a Heroku syslog drain [#create-syslog-drain]
+## Create a Heroku Syslog drain [#create-syslog-drain]
 
 1. Download and install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli#download-and-install).
-2. Use the Heroku CLI to create a syslog drain and attach it to the application you want to stream logs from, replacing ```YOUR_APP_NAME``` with the name of your Heroku application. 
+2. Use the Heroku CLI to create a Syslog drain and attach it to the application you want to stream logs from, replacing ```YOUR_APP_NAME``` with the name of your Heroku application. 
   ```
   $ heroku drains:add syslog+tls://newrelic.syslog.nr-data.net:6515 -a <var>YOUR_APP_NAME</var>
   ```
 
-3. Run the following command and copy the Heroku syslog [drain token](https://devcenter.heroku.com/articles/log-drains#drain-tokens) from the ```token``` attribute:
+3. Run the following command and copy the Heroku Syslog [drain token](https://devcenter.heroku.com/articles/log-drains#drain-tokens) from the ```token``` attribute:
   ```
   $ heroku drains -a <var>YOUR_APP_NAME</var>--json
   ```
@@ -41,13 +41,13 @@ Ensure the following before configuring log forwarding from Heroku:
   "id": "906262a4-e151-45d2-b35a-a2dc0ea9e688",
   "token": "d.f14da5dc-106b-468d-b1bd-bed0ed9fa1e7",
   "updated_at": "2018-12-04T00:59:47Z",
-  "url": "syslog://logs.example.com"
+  "url": "syslog+tls://newrelic.syslog.nr-data.net:6515
  }
  ```
 
-## Register a Heroku syslog drain [#register-syslog]
+## Register a Heroku Syslog drain [#register-syslog]
 
-Next, you'll need to register your newly created Heroku syslog drain in New Relic:
+Next, you'll need to register your newly created Heroku Syslog drain in New Relic:
 
 1. Login to [New Relic Logs](https://one.newrelic.com/launcher/logger.log-launcher) and click **Add more data sources**.
 

--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/heroku-log-forwarding.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/heroku-log-forwarding.mdx
@@ -7,7 +7,7 @@ tags:
 metaDescription: 'Send Heroku logs to New Relic'
 ---
 
-You can stream your Heroku logs to New Relic using Heroku's built-in [Logplex](https://devcenter.heroku.com/articles/logplex) router. In this page we explain how to stream logs to New Relic using [Heroku Syslog drains](https://devcenter.heroku.com/articles/log-drains#syslog-drains).
+You can stream your Heroku logs to New Relic using Heroku's built-in [Logplex](https://devcenter.heroku.com/articles/logplex) router. In this page, we explain how to stream logs to New Relic using [Heroku Syslog drains](https://devcenter.heroku.com/articles/log-drains#syslog-drains).
 
 
 ## Requirements [#requirements]


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context
Only 2 changes: 
* A typo in Syslog (as far as I understand the S has to be uppercase). 
* In the example of a drain token should appear the NR Syslog endpoint with the Heroku port.

