### PR TITLE
Update Helm chart URL to point to official New Relic Helm chart repo

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
@@ -394,7 +394,7 @@ To start the CPM, follow the applicable Docker or Kubernetes instructions.
        * If you are copying the charts for the first time:
 
          ```
-         helm repo add <var>YOUR_REPO_NAME</var> https://helm-charts.newrelic.com/charts
+         helm repo add <var>YOUR_REPO_NAME</var> https://helm-charts.newrelic.com
          ```
        * If you previously copied the Helm charts from the New Relic Helm repo, then get the latest:
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

We would like to start linking to the official NR Helm Chart repo for customers to retrieve the CPM (Containerized Private Minion) Helm charts. We're currently linking to a Synthetics owned Helm chart repo, but would like to start the process of deprecating it in favor of the official NR Helm chart repo found [here](https://github.com/newrelic/helm-charts).

### Are you making a change to site code?

No