### PR TITLE
chore: removed deployment marker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,16 +28,3 @@ jobs:
 
       - name: Create release
         run: gh release create ${{ steps.get-tag.outputs.tag }} -t ${{ steps.get-tag.outputs.tag }}
-
-  newrelic:
-    name: New Relic deployment marker
-    runs-on: ubuntu-latest
-    needs: create-release
-    steps:
-      - name: Create New Relic deployment marker
-        uses: newrelic/deployment-marker-action@v1
-        with:
-          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
-          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
-          applicationId: ${{ secrets.NEW_RELIC_APPLICATION_ID }}
-          revision: ${{ needs.create-release.outputs.tag }}


### PR DESCRIPTION
This PR removes the new relic deployment marker as it doesn't work for non-APM applications. 