### PR TITLE
PHP agent 9.17.1 release notes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9171301.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9171301.mdx
@@ -1,0 +1,16 @@
+---
+subject: PHP agent
+releaseDate: '2021-04-28'
+version: 9.17.1.301
+downloadLink: 'https://download.newrelic.com/php_agent/archive/9.17.1.301'
+---
+
+## New Relic PHP Agent v9.17.1 ##
+
+### Bug Fixes ###
+* [Fixed](https://github.com/newrelic/newrelic-php-agent/pull/148) instances where the agent's `mysqli_commit` instrumentation returned a NULL instead of a boolean.
+* [Fixed](https://github.com/newrelic/newrelic-php-agent/pull/146) an issue where parameters were not passed by reference in the agent's pdo instrumentation. This caused a warning in PHP 8.
+* [Fixed](https://github.com/newrelic/newrelic-php-agent/issues/145) instances where an `Unknown PHP version: 8.0` error was occurring when installing on Debian and Ubuntu systems.
+
+### Support Statement ###
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [8.6.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-860238/).


### PR DESCRIPTION
This includes the release notes for PHP agent 9.17.1. The release is targeted for 4/28/21.