### PR TITLE
Small edit to account ID doc, correcting wrongness

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/account-id.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/account-id.mdx
@@ -13,11 +13,13 @@ redirects:
   - /docs/accounts/install-new-relic/account-setup/account-id
 ---
 
-Some New Relic functions require use of your account ID. Your account ID is the ID number we assign to your New Relic account. Note that some New Relic organizations will have multiple accounts with a master/sub-account structure.
+Some New Relic procedures require use of your account ID (for example, some API calls). Your account ID is the ID number we assign to your New Relic account. Note that some New Relic organizations will contain multiple accounts.
 
-Options for finding an account ID:
+Options for finding your account ID:
 
-* If you have a single account: From [one.newrelic.com](https://one.newrelic.com), click the [account dropdown](/docs/using-new-relic/welcome-new-relic/get-started/glossary#account-dropdown) and then select **Account settings**. Next, select **API keys** located on the left-hand side. The account ID is displayed on the API keys page.
-* If your organization has multiple accounts: From [one.newrelic.com](https://one.newrelic.com), select **Explorer** and use the account selector dropdown near the top of the page.
+* If your organization has multiple accounts: From [one.newrelic.com](https://one.newrelic.com), use the account selector dropdown near the top of the page to switch between accounts and see their IDs.
+* There are other options, depending on which [account/user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models) you're on: 
+  * Original user model: Click the [account dropdown](/docs/using-new-relic/welcome-new-relic/get-started/glossary#account-dropdown), click **Account settings**, and then click **API keys**. The account ID is displayed there.
+  * New Relic One user model: Click the [account dropdown](/docs/using-new-relic/welcome-new-relic/get-started/glossary#account-dropdown) and then click **Administration**. Click **Organization and access** and then **Accounts** to see account IDs.
 
 For more on how account access works, see [Factors affecting access](/docs/new-relic-one/use-new-relic-one/core-concepts/cross-account-features-security-new-relic-one).


### PR DESCRIPTION
Realized this doc didn't have right instructions for users on New Relic One (v2) user model. 