### PR TITLE
Reverting back to the opensource bot token

### DIFF
--- a/.github/workflows/update-whats-new-ids.yml
+++ b/.github/workflows/update-whats-new-ids.yml
@@ -42,7 +42,7 @@ jobs:
         id: disable-branch-protection
         uses: actions/github-script@v1
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview
           script: |
             const result = await github.repos.updateBranchProtection({
@@ -62,7 +62,7 @@ jobs:
         if: steps.commit-changes.outputs.commit == 'true'
         uses: ad-m/github-push-action@v0.6.0
         with:
-          github_token: ${{ secrets.GH_TOKEN }}
+          github_token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
           branch: develop
 
       - name: Re-enable branch protection
@@ -70,7 +70,7 @@ jobs:
         if: always()
         uses: actions/github-script@v1
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview
           script: |
             const result = await github.repos.updateBranchProtection({


### PR DESCRIPTION
## Description
We recently attempted to update the Github tokens used in our workflows (#2037 and #2030). It turns out that the original token we had in place may have been accurate, but the bot user didn't have the right _permission_ in the repository. Since neither of the token updates we did yesterday worked, I'm reverting those updates and will explore giving the bot the correct permissions.
