### PR TITLE
Edit branch protection reenablement

### DIFF
--- a/.github/workflows/update-whats-new-ids.yml
+++ b/.github/workflows/update-whats-new-ids.yml
@@ -85,7 +85,7 @@ jobs:
                 users: [],
                 teams: ['developer-enablement']
               },
-              enforce_admins: false,
+              enforce_admins: null,
               required_pull_request_reviews: {
                 dismiss_stale_reviews: true,
                 required_approving_review_count: 1

--- a/.github/workflows/update-whats-new-ids.yml
+++ b/.github/workflows/update-whats-new-ids.yml
@@ -85,7 +85,7 @@ jobs:
                 users: [],
                 teams: ['developer-enablement']
               },
-              enforce_admins: true,
+              enforce_admins: false,
               required_pull_request_reviews: {
                 dismiss_stale_reviews: true,
                 required_approving_review_count: 1


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

This workflow disables and reenables branch protection. Previously it was setting enforce_admins to true which was turning on branch protection for admins when we'd agreed not to enforce that. This corrects it to false
