### PR TITLE
Revert token for swiftype workflow

### DIFF
--- a/.github/workflows/build-with-swiftype-content.yml
+++ b/.github/workflows/build-with-swiftype-content.yml
@@ -56,7 +56,7 @@ jobs:
         id: disable-branch-protection
         uses: actions/github-script@v1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview
           script: |
             const result = await github.repos.updateBranchProtection({
@@ -86,7 +86,7 @@ jobs:
         if: steps.commit-changes.outputs.commit == 'true'
         uses: ad-m/github-push-action@v0.6.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
           branch: main
 
       - name: Re-enable branch protection
@@ -94,7 +94,7 @@ jobs:
         if: always()
         uses: actions/github-script@v1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview
           script: |
             const result = await github.repos.updateBranchProtection({


### PR DESCRIPTION
## Description
Like we did in #2045, we'd like to keep using the `OPENSOURCE_BOT_TOKEN` for our workflows that require altering branch protection.
