### PR TITLE
Fixing typo in NRQL `tuple` description

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -1989,7 +1989,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
 
     <CollapserGroup>
       <Collapser title={<>Using <InlineCode>tuple</InlineCode></>}>
-        If you'd like to know the unique combinations of a handful of attributes, you can structure a query in the format `` SELECT unique(tuple(x, y, ... z)) ...` `` to get all the unique tuples of values, to maintain their relationship. In the following query, `tuple` is used on `index` and `cellName` together to find uniques where those two values occur in combination.
+        If you'd like to know the unique combinations of a handful of attributes, you can structure a query in the format `` SELECT uniques(tuple(x, y, ... z)) ...` `` to get all the unique tuples of values, to maintain their relationship. In the following query, `tuple` is used on `index` and `cellName` together to find uniques where those two values occur in combination.
 
         ```
         FROM NodeStatus SELECT uniques(tuple(index, cellName), 5)


### PR DESCRIPTION


<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

`unique` is not a function, but `uniques` is
