### PR TITLE
Updating the value types to match the MySQL documentation.

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration.mdx
@@ -1640,7 +1640,7 @@ Additional metrics captured when `extended_myisam_metrics` is enabled in the [co
 
 ### Extended slave cluster metrics [#slave]
 
-Additional metrics captured when the extended metrics flag is enabled in the [configuration file](#config) and the [`cluster.slaveRunning` metric](#slaverunning) is returning a value of `1`:
+Additional metrics captured when the extended metrics flag is enabled in the [configuration file](#config) and the [`cluster.slaveRunning` metric](#slaverunning) is returning a value of `1`. Check the [MySQL Documentation](https://dev.mysql.com/doc/refman/5.7/en/show-slave-status.html) for more details.
 
 <table>
   <thead>
@@ -1712,7 +1712,7 @@ Additional metrics captured when the extended metrics flag is enabled in the [co
       </td>
 
       <td>
-        Boolean: 0 or 1. Status of whether the I/O thread is started and has connected successfully to the master.
+        Status of whether the I/O thread is started and has connected successfully to the master. The values can be `Yes`, `No`, or `Connecting`.
       </td>
     </tr>
 
@@ -1722,7 +1722,7 @@ Additional metrics captured when the extended metrics flag is enabled in the [co
       </td>
 
       <td>
-        Boolean: 0 or 1. Status of whether the SQL thread is started.
+        Status of whether the SQL thread is started. The values can be `Yes` or `No`.
       </td>
     </tr>
 


### PR DESCRIPTION
## MySQL Integration Metric Values Incorrectly Labeled

The return values of some MySQL cluster status metrics resulted in `Yes`, `No`, or `Connecting` rather than documented `boolean` values. The PR addresses this documentation inconsistency and provides a reference to current documentation for the MySQL status command that provides the metrics.