### PR TITLE
Fix anchor in Go attributes documentation

### DIFF
--- a/src/content/docs/agents/go-agent/instrumentation/go-agent-attributes.mdx
+++ b/src/content/docs/agents/go-agent/instrumentation/go-agent-attributes.mdx
@@ -302,7 +302,7 @@ The Go agent receives the following [default attributes](/docs/agents/manage-apm
   </Collapser>
 </CollapserGroup>
 
-## Span and segment attributes [#attributes]
+## Span and segment attributes [#span-and-segment-attributes]
 
 If you have [Go agent v2.6.0 or higher](https://docs.newrelic.com/docs/release-notes/agent-release-notes/go-release-notes), you can configure attributes on spans and segments. The Go agent receives the following [default attributes](/docs/agents/manage-apm-agents/agent-metrics/agent-attributes) from your app. These attributes are only found on span events and transaction trace segments. You can adjust these default settings and [turn attributes on or off](#change-attribute-destination) for certain destinations.
 


### PR DESCRIPTION
This anchor was a duplicate of the one above it. I've adjusted the name so it'll link to the correct section.