### PR TITLE
Corrected two broken links to external sites.

### DIFF
--- a/src/content/docs/integrations/open-source-telemetry-integrations/opentelemetry/introduction-opentelemetry-new-relic.mdx
+++ b/src/content/docs/integrations/open-source-telemetry-integrations/opentelemetry/introduction-opentelemetry-new-relic.mdx
@@ -143,7 +143,7 @@ We recommend that you explore both New Relic and OpenTelemetry instrumentation o
 
 ### OpenTelemetry: A work in progress [#emerging-standard]
 
-OpenTelemetry is still an emerging standard, so your choices may be affected by what's available. You can check on the current state of the specification at the [OpenTelemetry site](https://opentelemetry.io/project-status/).
+OpenTelemetry is still an emerging standard, so your choices may be affected by what's available. You can check on the current state of the specification at the [OpenTelemetry site](https://opentelemetry.io/releases/).
 
 The current state of language-specific OpenTelemetry APIs and SDKs varies: some languages are still pre-alpha and may be missing instructions on how to instrument your service. Most languages have some implementation of traces that is sufficient to start sending data to New Relic. Check out this [table in GitHub](https://github.com/open-telemetry/opentelemetry-specification/blob/master/spec-compliance-matrix.md) that provides an overview of the state of OpenTelemetry specification compliance for each language.
 
@@ -167,7 +167,7 @@ If you are interested in tracing, we recommend that you instrument as many servi
 * If you want New Relic to analyze all your traces, configure tail-based sampling with New Relic Infinite Tracing, which reroutes traces to our cloud-based trace observer. The trace observer accepts all your traces and sorts through them to find useful ones. If you want to know more about this option, especially if you want to use it in the EU, see [Introduction to Infinite Tracing](/docs/understand-dependencies/distributed-tracing/infinite-tracing/introduction-infinite-tracing). While Infinite Tracing is not yet compatible with the native OTLP endpoint, it is still possible to configure tail-based sampling via the collector, for more information see [Tail Sampling Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor).
 
 <Callout variant="tip">
-  We discuss some variations on these basic approaches in our [OpenTelemetry architecture recipes](/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-architecture-recipes). For a detailed discussion about the architecture of OpenTelemetry itself, see our [blog](https://blog.newrelic.com/product-news/what-is-opentelemetry/).
+  We discuss some variations on these basic approaches in our [OpenTelemetry architecture recipes](/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-architecture-recipes). For a detailed discussion about the architecture of OpenTelemetry itself, see our [blog](https://newrelic.com/blog/best-practices/opentelemetry-opentracing-opencensus).
 </Callout>
 
 <Callout variant="important">


### PR DESCRIPTION
### Give us some context

This PR fixes two broken links to external sites from the OpenTelemetry introduction. 