### PR TITLE
Adding an alerts section to the Limits docs

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-users/usage-queries-alerts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-users/usage-queries-alerts.mdx
@@ -150,7 +150,7 @@ Here are some user-related query examples. For details on how users are counted,
 
 ## Set usage alerts [#alerts]
 
-To help [manage your billable data](/docs/telemetry-data-platform/get-data-new-relic/manage-data/manage-your-data), you can set alerts to notify you of unexpected increases in usage. To learn about how to create alerts, see [Alert workflow](/docs/alerts/new-relic-alerts/getting-started/new-relic-alerts-concepts-workflow#workflow).
+To help [manage your billable data](/docs/telemetry-data-platform/get-data-new-relic/manage-data/manage-your-data), you can set alerts to notify you of unexpected increases in usage. Learn how to create alerts with [NRQL queries here](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/#create).
 
 <Callout variant="caution">
   When creating alert conditions, you should set the [Evaluation offset](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions#h2-evaluation-offset) value to 60 minutes or your conditions may not trigger.

--- a/src/content/docs/telemetry-data-platform/ingest-manage-data/manage-data/query-limits.mdx
+++ b/src/content/docs/telemetry-data-platform/ingest-manage-data/manage-data/query-limits.mdx
@@ -203,5 +203,55 @@ Attributes on `newrelic.resourceConsumption.impact`
 - `Impact` - A count of what is happening when resource has exceeded set limit, i.e dropped requests. 
 - `consumingAccountId` - The New Relic account where the resource is being consumed.
 
- 
+## Set alerts on resource metrics
+
+While building a dashboard to see all your limits is handy, being able to automate it is even better. You can set alerts on your limit metrics to provide updates on limits changes.
+
+<Callout variant="tip">
+Because we currently only have metrics on 1 minute time windows, setting TimeWindow = 1 minute, will cover them all. Eventually, we make more metrics available, you might want to set separate alerts for limits that are enforced by different time windows.
+</Callout>
+
+You can use the following NRQL queries to create alerts. Learn about creating alerts with [NRQL queries here](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/#create).
+
+<CollapserGroup>
+  <Collapser
+    className="freq-link"
+    id=""
+    title="Limits faceted by `LimitName` and scoped by `Timewindow`"
+  >
+```
+From Metric select (rate(sum(newrelic.resourceConsumption.currentValue), 1 minute)/latest(newrelic.resourceConsumption.limitValue))*100 facet limitName  limit 200
+```
+  </Collapser>
+  <Collapser
+    className="freq-link"
+    id=""
+    title="Alert on a single limit"
+  >
+```
+From Metric select (rate(sum(newrelic.resourceConsumption.currentValue), 1 minute)/latest(newrelic.resourceConsumption.limitValue))*100 where limitName = ‘my limit’  limit 200
+```
+  </Collapser>
+  <Collapser
+    className="freq-link"
+    id=""
+    title="Alert on limit impact faceted by `dataType`, `impact`, `resource`, and `reason`"
+  >
+```
+From Metric select rate(sum(newrelic.resourceConsumption.impact), 1 minute) facet dataType, impact, resource, reason   limit 200
+```
+  </Collapser>
+  <Collapser
+    className="freq-link"
+    id=""
+    title="Alert on impact of a single `dataType`"
+  >
+```
+From Metric select rate(sum(newrelic.resourceConsumption.impact), 1 minute) facet dataType, impact, resource, reason  WHERE dataType = ‘important things’  limit 200
+```
+  </Collapser>
+</CollapserGroup>
+
+
+
 


### PR DESCRIPTION
This PR adds an alert section to the Query limits doc, and adds a better link to the usage doc.