### PR TITLE
Fix: Reset any filtered attribute when changing data type / data source filters

### DIFF
--- a/src/components/DataDictionaryFilter.js
+++ b/src/components/DataDictionaryFilter.js
@@ -73,6 +73,7 @@ const DataDictionaryFilter = ({ location, events }) => {
             setFormState((state) => ({
               ...state,
               event: null,
+              attribute: null,
               dataSource: value,
             }));
           }}

--- a/src/components/DataDictionaryFilter.js
+++ b/src/components/DataDictionaryFilter.js
@@ -93,7 +93,11 @@ const DataDictionaryFilter = ({ location, events }) => {
           onChange={(e) => {
             const { value } = e.target;
 
-            setFormState((state) => ({ ...state, event: value }));
+            setFormState((state) => ({
+              ...state,
+              event: value,
+              attribute: null,
+            }));
           }}
         >
           <option value="">All</option>


### PR DESCRIPTION
## Description

Fixes issue where if you filter on an attribute (via query param OR by selecting it in the right menu), then change the Data Type or Data Source filters, the filtered attribute isn't cleared and remains in state / query params. I'm pretty sure we always want to clear any filtered attribute when changing to a different Data Type / Data Source.

## Screenshots
Current behavior

https://user-images.githubusercontent.com/2952843/116760489-e2970200-a9c9-11eb-9af2-dca0dd4a4b12.mov

PR behavior

https://user-images.githubusercontent.com/2952843/116760568-1e31cc00-a9ca-11eb-9b4f-d6e1f4b301d9.mov

