### PR TITLE
Update new-relic-infrastructure-agent-1170.mdx

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1170.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1170.mdx
@@ -10,5 +10,5 @@ A new version of the agent has been released. Follow standard procedures to [upd
 New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months.
 
 ## Changed
-- `nri-docker` to [v1.6.0](https://github.com/newrelic/nri-docker/releases/tag/v1.6.0).
+- `nri-docker` to [v1.6.0](https://github.com/newrelic/nri-docker/releases/tag/v1.6.0). New memory and storage metrics added. `memoryUsageBytes` and `memoryUsageLimitPercent` calculation has changed. Please refer to this [product update post](https://discuss.newrelic.com/t/docker-containers-memory-metric-updates/147224) and [nri-docker release notes](https://github.com/newrelic/nri-docker/releases/edit/v1.6.0) for more information.
 - `nri-winservices` to [v0.2.0-beta](https://github.com/newrelic/nri-winservices/releases/tag/v0.2.0-beta).


### PR DESCRIPTION
Update infrastructure agent 1.17.0 release notes to reflect change in nri-docker.