### PR TITLE
feat: Update theme to include split(a/b) testing

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -72,6 +72,19 @@ module.exports = {
             'python',
           ],
         },
+        splitio: {
+          // Mocked features only used when in localhost mode
+          // https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#localhost-mode
+          features: {
+            free_account_button_color: {
+              treatment: 'off',
+            },
+          },
+          core: {
+            authorizationKey: process.env.SPLITIO_AUTH_KEY || 'localhost',
+          },
+          debug: false,
+        },
         relatedResources: {
           swiftype: {
             resultsPath: `${__dirname}/src/data/swiftype-resources.json`,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "^2.0.0-next.8",
     "@mdx-js/react": "^2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "^2.0.2",
+    "@newrelic/gatsby-theme-newrelic": "2.2.0",
     "@splitsoftware/splitio-react": "^1.2.4",
     "babel-jest": "^26.3.0",
     "common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2313,10 +2313,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-2.0.2.tgz#bdaff281932eca1907b752e264bf030e01968664"
-  integrity sha512-AddNtgCyh3I3ahmD5SFgIiiz55stzeCdTO3CtbPvHbdXGjdR+0EzkysUlV+WKLq23IWdxe21FM6uKoz+BdPiyw==
+"@newrelic/gatsby-theme-newrelic@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-2.2.0.tgz#9d0719c7084436354f5aab9112986aabd974e79f"
+  integrity sha512-0B3Mzs8KEm/p9aHE4pjyn2/u9tTFvd93X9TkZ5/JYeEKYTiLUvAg3CFPw+JWAP303lpGE7aoUsydFcLF91rAHw==
   dependencies:
     "@elastic/react-search-ui" "^1.5.1"
     "@elastic/react-search-ui-views" "^1.5.1"
@@ -8460,9 +8460,9 @@ gatsby-plugin-sharp@^3.3.0, gatsby-plugin-sharp@^3.3.1:
     uuid "3.4.0"
 
 gatsby-plugin-sitemap@^4.0.0-next.0:
-  version "4.0.0-next.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-4.0.0-next.0.tgz#23296d97120ed7cc8a7009e8834dfb204ac991c4"
-  integrity sha512-VDmnJKRwNqKnNvLWnSklGAzdU7xnwu+OQG1T3OM+bYdRFL8EtdSz4ADE5CVfGWFw0jahJ1eMOde2CDiaCcIMuQ==
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-4.0.0.tgz#65f2ef27362796ac145cec1d8dd05c790b50e1fc"
+  integrity sha512-+GxxKhB4Lm1AY+k9LfcnATF/LsUXiRHVwM3YDjzpB25WCGrGZGEgviZXiy4xb2BOZz0EoUkYZ9IDU9eNgAoHBQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     common-tags "^1.8.0"


### PR DESCRIPTION
# Summary
To enable splits, AKA A/B testing, a new button component has been added to the theme's header. This PR updates to that version of the theme and sets up the required configuration values.

Closes newrelic/gatsby-theme-newrelic/issues/356