### PR TITLE
Update mysql-monitoring-integration.mdx

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration.mdx
@@ -104,6 +104,9 @@ To install the MySQL integration, follow the instructions for your environment:
        ```
        sudo mysql -e "GRANT REPLICATION CLIENT ON *.* TO 'newrelic'@'localhost';"
        ```
+       3. Change the directory to the integration's folder.
+
+       ```
        cd /etc/newrelic-infra/integrations.d
        ```
     4. Copy the sample configuration file:

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration.mdx
@@ -104,7 +104,7 @@ To install the MySQL integration, follow the instructions for your environment:
        ```
        sudo mysql -e "GRANT REPLICATION CLIENT ON *.* TO 'newrelic'@'localhost';"
        ```
-       3. Change the directory to the integration's folder.
+    3. Change the directory to the integration's folder.
 
        ```
        cd /etc/newrelic-infra/integrations.d

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration.mdx
@@ -91,17 +91,18 @@ To install the MySQL integration, follow the instructions for your environment:
     title="Linux"
   >
     1. Follow the instructions for [installing an integration](/docs/install-integrations-package), using the file name `nri-mysql`.
-    2. From the command line, create a user with [replication privileges](https://dev.mysql.com/doc/refman/5.7/en/privileges-provided.html#priv_replication-client):
+    2. From the command line, create a user with [select](https://dev.mysql.com/doc/refman/5.7/en/privileges-provided.html#priv_select) and [replication](https://dev.mysql.com/doc/refman/5.7/en/privileges-provided.html#priv_replication-client) privileges:
 
        ```
-       sudo mysql -e "CREATE USER 'newrelic'@'localhost' IDENTIFIED BY '<var>YOUR_SELECTED_PASSWORD</var>';"
+       sudo mysql -e "CREATE USER 'newrelic'@'localhost' IDENTIFIED BY '<var>YOUR_SELECTED_PASSWORD</var>' WITH MAX_USER_CONNECTIONS 5;"
+       ```
+       
+       ```
+       sudo mysql -e "GRANT SELECT ON *.* TO 'newrelic'@'localhost';"
        ```
 
        ```
-       sudo mysql -e "GRANT REPLICATION CLIENT ON *.* TO 'newrelic'@'localhost' WITH MAX_USER_CONNECTIONS 5;"
-       ```
-    3. Change the directory to the integration's folder.
-
+       sudo mysql -e "GRANT REPLICATION CLIENT ON *.* TO 'newrelic'@'localhost';"
        ```
        cd /etc/newrelic-infra/integrations.d
        ```


### PR DESCRIPTION
Documentation was missing one of the permissions (SELECT) to allow the integration to work without errors.

### Give us some context

* Permissions missing on the mysql integration.
