### PR TITLE
fix: RightRail rendering list items with the same href

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/alert-custom-violation-descriptions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/alert-custom-violation-descriptions.mdx
@@ -134,7 +134,7 @@ mutation {
 * For Infrastructure monitoring conditions, you can create the custom violation description when [creating an Infrastructure monitoring alert condition](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/infrastructure-alerts-add-edit-or-view-host-alert-information).
 * To learn about how to structure a custom violation description, see the [example template](#example) and the [attribute/tag instructions](#attributes-tags).
 
-## Mentioning users or notifying channel in Slack [#create-description-nrql]
+## Mentioning users or notifying channel in Slack [#mention-in-slack]
 
 When creating a description that you know will be sent to [Slack](/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts#slack), you may wish to **@mention** a user or generate a channel-wide notification (e.g. **@here** or **@channel**). To achieve this, simply include the User ID or a channel-wide notification in the description surrounded by `<` and `>` characters.
 


### PR DESCRIPTION
The `Mentioning users...` section had the same `href` as `Create description...NRQL` , so just edited the reference in the md page

