### PR TITLE
Corrected Node and PHP links and removed URL prefixes in other links

### DIFF
--- a/src/content/docs/agents/manage-apm-agents/agent-data/agent-attributes.mdx
+++ b/src/content/docs/agents/manage-apm-agents/agent-data/agent-attributes.mdx
@@ -100,7 +100,7 @@ Collected attributes appear in these locations:
 
     <tr>
       <td>
-        [Span events](https://docs.newrelic.com/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing)
+        [Span events](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing)
       </td>
 
       <td>
@@ -108,19 +108,19 @@ Collected attributes appear in these locations:
 
         The following agents support the addition of custom user attributes to span events:
 
-        * [Java agent 5.13.0 and above](https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/java-agent-5130)
-        * [Go agent 3.6.0 and above](https://docs.newrelic.com/docs/release-notes/agent-release-notes/go-release-notes/go-agent-360)
-        * [.NET agent 8.25 and above](https://docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8252140)
-        * [Node agent 6.10.0 and above](https://docs.newrelic.com/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6100)
-        * [PHP agent 9.12.0.268 and above](https://docs/release-notes/agent-release-notes/php-release-notes/php-agent-9120268)
-        * [Python agent 5.8.0.136 and above](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-580136)
-        * [Ruby agent 6.8.0 and above](https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-680360)
+        * [Java agent 5.13.0 and above](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-5130)
+        * [Go agent 3.6.0 and above](/docs/release-notes/agent-release-notes/go-release-notes/go-agent-360)
+        * [.NET agent 8.25 and above](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8252140)
+        * [Node agent 6.10.0 and above](/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6-10-0/)
+        * [PHP agent 9.12.0.268 and above](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9120268)
+        * [Python agent 5.8.0.136 and above](/docs/release-notes/agent-release-notes/python-release-notes/python-agent-580136)
+        * [Ruby agent 6.8.0 and above](/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-680360)
       </td>
     </tr>
 
     <tr>
       <td>
-        [Transaction segments](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/transaction-trace-details)
+        [Transaction segments](/docs/apm/transactions/transaction-traces/transaction-trace-details)
       </td>
 
       <td>


### PR DESCRIPTION
This request came from an internal contributor who pointed out that we had two broken links. While I was in the neighborhood, I removed a bunch of absolute path prefixes, too.