### PR TITLE
fix: lock down to-vfile version

### DIFF
--- a/.github/workflows/update-whats-new-ids.yml
+++ b/.github/workflows/update-whats-new-ids.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 12
 
       - name: Install dependencies
-        run: yarn add vfile-glob to-vfile
+        run: yarn add vfile-glob@1.0.0 to-vfile@6.1.0
 
       - name: Generate new IDs
         run: yarn run generate-whatsnew-ids


### PR DESCRIPTION
# Summary
The latest version of `to-vfile` converts it to a ESM module, we are not ready for that update. This PR pins the version to 6.1.0.