### PR TITLE
Corrected "last_value"  for API and borrowed descriptions from the UI doc.

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names.mdx
@@ -146,9 +146,11 @@ Not every field listed in this glossary is required for every condition type. Th
     id="fill_option"
     title="fill_option"
   >
-    For sporadic data, you can avoid false alerts by filling the gaps (empty windows) with synthetic data. The default is `None`.
+    For sporadic data, you can avoid false alerts by filling the gaps (empty windows) with synthetic data. 
 
-    The other values are `Last known value` and `Custom static value`.
+    * `none`: (Default) Use this if you don’t want to take any action on empty aggregation windows. On evaluation, an empty aggregation window will reset the threshold duration timer. For example, if a condition says that all aggregation windows must have data points above the threshold for 5 minutes, and 1 of the 5 aggregation windows is empty, then the condition won’t be in violation.
+    * `static`: Use this if you’d like to insert a custom static value into the empty aggregation windows before they’re evaluated. This option has an additional, required parameter of fillValue (as named in the API) that specifies what static value should be used. This defaults to 0.
+    * `last_value`: Use this to insert the last seen value before evaluation occurs. We maintain the state of the last seen value for 2 hours.
 
     In the UI, under **Advanced signal settings**, this is the **Fill data gaps with** field.
   </Collapser>

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names.mdx
@@ -149,7 +149,7 @@ Not every field listed in this glossary is required for every condition type. Th
     For sporadic data, you can avoid false alerts by filling the gaps (empty windows) with synthetic data. 
 
     * `none`: (Default) Use this if you don’t want to take any action on empty aggregation windows. On evaluation, an empty aggregation window will reset the threshold duration timer. For example, if a condition says that all aggregation windows must have data points above the threshold for 5 minutes, and 1 of the 5 aggregation windows is empty, then the condition won’t be in violation.
-    * `static`: Use this if you’d like to insert a custom static value into the empty aggregation windows before they’re evaluated. This option has an additional, required parameter of fillValue (as named in the API) that specifies what static value should be used. This defaults to 0.
+    * `static`: Use this if you’d like to insert a custom static value into the empty aggregation windows before they’re evaluated. This option has an additional, required parameter of `fillValue` that specifies what static value should be used. This defaults to 0.
     * `last_value`: Use this to insert the last seen value before evaluation occurs. We maintain the state of the last seen value for 2 hours.
 
     In the UI, under **Advanced signal settings**, this is the **Fill data gaps with** field.


### PR DESCRIPTION
Here's the problem this fixes: The docs incorrectly state that the `fill_option` field requires  "Last known value” but  API Explorer throws an error.

I checked with the hero in alerts and confirmed that this is incorrect. At the hero's suggestion, I borrowed the descriptions for these fields from the [UI doc](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/#data-gaps).

I got a sign-off from the hero in alerts for my proposed revision.

I could use a formatting review.