### PR TITLE
Update fluentd doc layout and eu endpoint examples

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/fluentd-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/fluentd-plugin-log-forwarding.mdx
@@ -27,8 +27,8 @@ To enable log management with Fluentd:
 
 1. [Install](#fluentd-plugin) the Fluentd plugin.
 2. [Configure](#configure-plugin) the Fluentd plugin.
-3. [Test](#test-plugin) the Fluentd plugin.
-4. [Optional: Configure](#instrument-plugin) additional plugin attributes.
+3. Optional: [Configure EU Endpoint](#eu-configuration)
+4. [Test](#test-plugin) the Fluentd plugin.
 5. Generate some traffic and wait a few minutes, then [check your account](#find-data) for data.
 
 ## Install the Fluentd plugin [#fluentd-plugin]
@@ -61,7 +61,9 @@ To install the Fluentd plugin:
 
 ## Configure the Fluentd plugin [#configure-plugin]
 
-**NOTE**: If you're configuring Fluentd for the first time, you may find it helpful to review our collection of pre-built [configuration files](https://github.com/newrelic/newrelic-fluentd-output/tree/master/examples) addressing common use cases.
+<Callout variant="tip">
+  If you're configuring Fluentd for the first time, you may find it helpful to review our collection of pre-built [configuration files](https://github.com/newrelic/newrelic-fluentd-output/tree/master/examples) addressing common use cases.
+</Callout>
 
 To configure your Fluentd plugin:
 
@@ -138,6 +140,83 @@ To configure your Fluentd plugin:
    </CollapserGroup>
 2. Restart the Fluentd service to ensure your changes are applied.
 
+## Configure the Fluentd Plugin for EU accounts [#eu-configuration]
+
+By default the Fluentd plugin forwards logs to New Relic's US endpoint: `https://log-api.newrelic.com/log/v1`. If your account is on New Relic's [EU datacenter](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers/) then you will need to manually set the `base_uri` property to the EU endpoint. For example:
+
+<CollapserGroup>
+     <Collapser
+       id="insert-key-eu"
+       title="Add EU Endpoint to API key configuration"
+     >
+      Configure EU endpoint with the New Relic [Insert API key](/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#register):
+       
+      ```
+       #Tail one or more log files 
+       <source>
+         @type tail
+         <parse>
+           @type none
+         </parse>
+         path /path/to/file
+         tag example.service
+       </source>
+
+       #Add hostname and service_name to all events with "example.service" tag
+       <filter example.service>
+         @type record_transformer
+         <record>
+           service_name ${tag}
+           hostname "#{Socket.gethostname}"
+         </record>
+       </filter>
+
+       #Forward all events to New Relic EU Endpoint
+       <match **>
+         @type newrelic
+         api_key <var>YOUR_API_INSERT_KEY</var>
+         base_uri https://log-api.eu.newrelic.com/log/v1
+       </match>
+       ```
+   </Collapser>
+
+
+<CollapserGroup>
+     <Collapser
+       id="license-key-eu"
+       title="Add EU Endpoint to License key configuration"
+     > 
+      Configure EU Endpoint with the [New Relic license key](/docs/accounts/install-new-relic/account-setup/license-key):
+
+       ```
+       #Tail one or more log files 
+       <source>
+         @type tail
+         <parse>
+           @type none
+         </parse>
+         path /path/to/file
+         tag example.service
+       </source>
+
+       #Add hostname and service_name to all events with "example.service" tag
+       <filter example.service>
+         @type record_transformer
+         <record>
+           service_name ${tag}
+           hostname "#{Socket.gethostname}"
+         </record>
+       </filter>
+
+       #Forward all events to New Relic EU Endpoint
+       <match **>
+         @type newrelic
+         license_key <var>YOUR_LICENSE_KEY</var>
+         base_uri https://log-api.eu.newrelic.com/log/v1
+       </match>
+       ```
+   </Collapser>
+
 ## Test the Fluentd plugin [#test-plugin]
 
 To test if your Fluentd plugin is receiving input from a log file:
@@ -149,46 +228,6 @@ To test if your Fluentd plugin is receiving input from a log file:
    ```
 2. Search [New Relic Logs UI](https://one.newrelic.com/launcher/logger.log-launcher) for `test message`.
 
-## Optional configuration [#instrument-plugin]
-
-Once you have [installed](#fluentd-plugin) and [configured](#configure-plugin) the Fluentd plugin, you can use the following attributes to configure how the plugin sends data to New Relic:
-
-<table>
-  <thead>
-    <tr>
-      <th style={{ width: "200px" }}>
-        **Property**
-      </th>
-
-      <th>
-        **Description**
-      </th>
-
-      <th>
-        **Default value**
-      </th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td>
-        base_uri
-      </td>
-
-      <td>
-        The New Relic ingestion endpoint.
-      </td>
-
-      <td>
-        US endpoint: `https://log-api.newrelic.com/log/v1`  
-        EU endpoint: `https://log-api.eu.newrelic.com/log/v1`
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-For more information and examples, see [Example Configurations for Fluentd](https://github.com/newrelic/newrelic-fluentd-output/tree/master/examples).
 
 ## View log data [#find-data]
 


### PR DESCRIPTION
Setting the EU logging endpoint was listed as an optional configuration using the base_uri property. EU customers must manually set this to the EU endpoint to get logs from our Fluentd plugin. I used the collapsable examples in the previous config steps but with the base_uri value added to the <match **> tags. I figured adding the whole config would be better since EU customers will likely just copy and paste the whole code snippet.

We also mentioned the github examples twice, but the github examples do not show how or where to set the base_uri property in the fluentd config. I removed the second link to the example and put the first one in a "Tip" box prior to config to make it more noticeable.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.