### PR TITLE
Add Heroku Log Streaming and Syslog

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/enable-log-management-new-relic.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/enable-log-management-new-relic.mdx
@@ -58,6 +58,8 @@ You can use any of these solutions to forward your logs to New Relic:
 * [Fluentd plugin](/docs/enable-new-relic-logs-fluentd)
 * [Logstash plugin](/docs/enable-new-relic-logs-logstash)
 * [Vector plugin](/docs/logs/enable-new-relic-logs/1-enable-logs/vector-plugin-logs)
+* [Heroku Log Streaming](https://docs.newrelic.com/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/heroku-log-forwarding/)
+* [Syslog TCP Endpoint](https://docs.newrelic.com/docs/logs/log-management/log-api/use-tcp-endpoint-forward-logs-new-relic/)
 
 ### Enable using the Logs API [#enable-api]
 


### PR DESCRIPTION
Heroku log streaming and the syslog TCP endpoint were missing from the list of available log forwarding solutions.