### PR TITLE
increase and document nav nesting levels

### DIFF
--- a/src/content/docs/style-guide/processes-procedures/update-left-navigation-pane.mdx
+++ b/src/content/docs/style-guide/processes-procedures/update-left-navigation-pane.mdx
@@ -39,7 +39,9 @@ pages:
           - title: Use multiple names for an app
             path: /docs/agents/manage-apm-agents/app-naming/use-multiple-names-app
 ```
-**NOTE**: Navigation nesting is currently limited to a maximum of 6 levels deep. Please reach out to the engineering team if that is not enough.
+<Callout variant="tip">
+Navigation nesting is currently limited to a maximum of six levels deep. Please reach out to the engineering team if that is not enough.
+</Callout>
 
 ## Configuration file options
 

--- a/src/content/docs/style-guide/processes-procedures/update-left-navigation-pane.mdx
+++ b/src/content/docs/style-guide/processes-procedures/update-left-navigation-pane.mdx
@@ -39,6 +39,7 @@ pages:
           - title: Use multiple names for an app
             path: /docs/agents/manage-apm-agents/app-naming/use-multiple-names-app
 ```
+**NOTE**: Navigation nesting is currently limited to a maximum of 6 levels deep. Please reach out to the engineering team if that is not enough.
 
 ## Configuration file options
 

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -126,6 +126,9 @@ export const query = graphql`
               ...MainLayout_navPages
               pages {
                 ...MainLayout_navPages
+                pages {
+                  ...MainLayout_navPages
+                }
               }
             }
           }


### PR DESCRIPTION
# Summary
Allow nesting of up to 6 levels deep in the navigation and document it.
This is in preparation of work being done in https://github.com/newrelic/docs-website/pull/2119