### PR TITLE
Updating guided install instructions

### DIFF
--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -74,9 +74,11 @@ To stream CloudWatch metrics to New Relic you need to create Kinesis Data Fireho
 
 ### Guided setup using CloudFormation [#setup-cloudformation]
 
-First, you need to link each of your AWS accounts with your New Relic account. To do so, follow the instructions in the AWS UI. 
+First, you need to link each of your AWS accounts with your New Relic account. To do so: 
+* Go to **[one.newrelic.com](https://one.newrelic.com/) > Infrastructure > AWS**, click on **Add an AWS account**, then on **Use metric streams**, and follow the steps.
+* You may [automate this step with NerdGraph](/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial/#link-aws). 
 
-Next, set up the metric stream using the [CloudFormation template](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https://nr-downloads-main.s3.amazonaws.com/cloud_integrations/aws/cloudformation/MetricStreams_CloudFormation.yml&stackName=NewRelic-Metric-Stream&param_NewRelicDatacenter=US) we provide in our UI. 
+Next, set up the metric stream using the [CloudFormation template](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https://nr-downloads-main.s3.amazonaws.com/cloud_integrations/aws/cloudformation/MetricStreams_CloudFormation.yml&stackName=NewRelic-Metric-Stream&param_NewRelicDatacenter=US) we provide in the last step of our UI. 
 
 ### Manual setup using AWS Console, API, or calls
 

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -72,9 +72,11 @@ To stream CloudWatch metrics to New Relic you need to create Kinesis Data Fireho
 * If you manage multiple regions within those accounts, then each region needs to be configured with a different Kinesis Data Firehose pointing to New Relic.
 * You will typically map one or many AWS accounts to a single New Relic account.
 
-### Automated setup using CloudFormation [#setup-cloudformation]
+### Guided setup using CloudFormation [#setup-cloudformation]
 
-We provide a [CloudFormation template](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https://nr-downloads-main.s3.amazonaws.com/cloud_integrations/aws/cloudformation/MetricStreams_CloudFormation.yml&stackName=NewRelic-Metric-Stream&param_NewRelicDatacenter=US) that automates this process. This needs to be applied to each AWS account and region you want to monitor in New Relic. 
+First, you need to link each of your AWS accounts with your New Relic account. To do so, follow the instructions in the AWS UI. 
+
+Next, set up the metric stream using the [CloudFormation template](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https://nr-downloads-main.s3.amazonaws.com/cloud_integrations/aws/cloudformation/MetricStreams_CloudFormation.yml&stackName=NewRelic-Metric-Stream&param_NewRelicDatacenter=US) we provide in our UI. 
 
 ### Manual setup using AWS Console, API, or calls
 


### PR DESCRIPTION
As reported in #2177, the guided install instructions for AWS Metric Streams are misleading. Synching with @josemore 
 and updating doc accordingly.
