### PR TITLE
Use `type` instead of `contentType`

### DIFF
--- a/src/content/docs/style-guide/processes-procedures/use-content-types-text-formats.mdx
+++ b/src/content/docs/style-guide/processes-procedures/use-content-types-text-formats.mdx
@@ -47,8 +47,8 @@ Thr top of every doc begins with a set of metadata. Read on for more information
     </tr>
 
     <tr>
-      <td>contentType</td>
-      <td>For the **basicDoc** template, use **page**.</td>
+      <td>type</td>
+      <td>For the **basicDoc** template, use **page** or omit `type`. If omitted, the default `type` is `page` and the `basicDoc` template is used.</td>
 
     </tr>
 


### PR DESCRIPTION
## Description 

The frontmatter field is `type` and not `contentType`. Also, added brief info about default value if omitted from an .mdx file.

