### PR TITLE
Update Mobile event attribute definitions

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,5 @@
-const parse = require('rehype-parse');
 const fs = require('fs');
+const parse = require('rehype-parse');
 const path = require('path');
 const unified = require('unified');
 const rehypeStringify = require('rehype-stringify');

--- a/src/data-dictionary/events/MobileCrash/appToken.md
+++ b/src/data-dictionary/events/MobileCrash/appToken.md
@@ -5,4 +5,4 @@ events:
   - MobileCrash
 ---
 
-The mobile application licence token.
+The mobile application license token.

--- a/src/data-dictionary/events/MobileCrash/appToken.md
+++ b/src/data-dictionary/events/MobileCrash/appToken.md
@@ -1,0 +1,8 @@
+---
+name: appToken
+type: attribute
+events:
+  - MobileCrash
+---
+
+The mobile application licence token.

--- a/src/data-dictionary/events/MobileCrash/buildId.md
+++ b/src/data-dictionary/events/MobileCrash/buildId.md
@@ -1,8 +1,0 @@
----
-name: buildId
-type: attribute
-events:
-  - MobileCrash
----
-
-The mobile app build version number.

--- a/src/data-dictionary/events/MobileCrash/buildId.md
+++ b/src/data-dictionary/events/MobileCrash/buildId.md
@@ -1,0 +1,8 @@
+---
+name: buildId
+type: attribute
+events:
+  - MobileCrash
+---
+
+The mobile app build version number.

--- a/src/data-dictionary/events/MobileCrash/deviceName.md
+++ b/src/data-dictionary/events/MobileCrash/deviceName.md
@@ -5,4 +5,4 @@ events:
   - MobileCrash
 ---
 
-The name of the device.
+The device's name.

--- a/src/data-dictionary/events/MobileCrash/deviceName.md
+++ b/src/data-dictionary/events/MobileCrash/deviceName.md
@@ -1,0 +1,8 @@
+---
+name: deviceName
+type: attribute
+events:
+  - MobileCrash
+---
+
+The name of the device.

--- a/src/data-dictionary/events/MobileCrash/osBuild.md
+++ b/src/data-dictionary/events/MobileCrash/osBuild.md
@@ -3,6 +3,7 @@ name: osBuild
 type: attribute
 events:
   - MobileCrash
+  - MobileHandledException
 ---
 
 For Android only. The specific build of the Android OS.

--- a/src/data-dictionary/events/MobileCrash/platformVersion.md
+++ b/src/data-dictionary/events/MobileCrash/platformVersion.md
@@ -1,0 +1,8 @@
+---
+name: platform
+type: attribute
+events:
+  - MobileCrash
+---
+
+The version number of the New Relic Mobile agent running on the application. For example: 4.232.0.

--- a/src/data-dictionary/events/MobileCrash/platformVersion.md
+++ b/src/data-dictionary/events/MobileCrash/platformVersion.md
@@ -1,8 +1,0 @@
----
-name: platform
-type: attribute
-events:
-  - MobileCrash
----
-
-The version number of the New Relic Mobile agent running on the application. For example: 4.232.0.

--- a/src/data-dictionary/events/MobileHandledException/exceptionAppBuildUuid.md
+++ b/src/data-dictionary/events/MobileHandledException/exceptionAppBuildUuid.md
@@ -6,4 +6,4 @@ events:
   - MobileHandledException
 ---
 
-The build uuid for the application binary in which the exception was caught. 
+The build uuid of the application binary in which the exception was caught. 

--- a/src/data-dictionary/events/MobileHandledException/exceptionAppBuildUuid.md
+++ b/src/data-dictionary/events/MobileHandledException/exceptionAppBuildUuid.md
@@ -1,8 +1,9 @@
 ---
 name: exceptionAppBuildUuid
 type: attribute
+units: ID
 events:
   - MobileHandledException
 ---
 
-The build identifier (uuid) of the binary in which the exception was caught.
+The build uuid for the application binary in which the exception was caught. 

--- a/src/data-dictionary/events/MobileHandledException/exceptionCause.md
+++ b/src/data-dictionary/events/MobileHandledException/exceptionCause.md
@@ -5,4 +5,4 @@ events:
   - MobileHandledException
 ---
 
-The platform-specific cause of the exception.
+The unsymbolicated, platform-specific cause of the exception.

--- a/src/data-dictionary/events/MobileHandledException/exceptionLocationClass.md
+++ b/src/data-dictionary/events/MobileHandledException/exceptionLocationClass.md
@@ -5,4 +5,4 @@ events:
   - MobileHandledException
 ---
 
-Comes from the exception: The class that generated the exception.
+The class that generated the exception. Only present if symbolication succeeded.

--- a/src/data-dictionary/events/MobileHandledException/exceptionLocationFile.md
+++ b/src/data-dictionary/events/MobileHandledException/exceptionLocationFile.md
@@ -5,4 +5,4 @@ events:
   - MobileHandledException
 ---
 
-Comes from the exception: The file where the exception was generated.
+The class that generated the exception. Only present if symbolication succeeded.

--- a/src/data-dictionary/events/MobileHandledException/exceptionLocationLibraryOffset.md
+++ b/src/data-dictionary/events/MobileHandledException/exceptionLocationLibraryOffset.md
@@ -5,4 +5,4 @@ events:
   - MobileHandledException
 ---
 
-The library offset of the library that generated the exception. Only present if symbolication succeeded. XCFramework agent only.
+For XCFramework agent only. The library offset of the library that generated the exception. Only present if symbolication succeeded. 

--- a/src/data-dictionary/events/MobileHandledException/exceptionLocationLibraryOffset.md
+++ b/src/data-dictionary/events/MobileHandledException/exceptionLocationLibraryOffset.md
@@ -1,0 +1,8 @@
+---
+name: exceptionLocationLibraryOffset
+type: attribute
+events:
+  - MobileHandledException
+---
+
+The library offset of the library that generated the exception. Only present if symbolication succeeded. XCFramework agent only.

--- a/src/data-dictionary/events/MobileHandledException/exceptionLocationLine.md
+++ b/src/data-dictionary/events/MobileHandledException/exceptionLocationLine.md
@@ -5,4 +5,4 @@ events:
   - MobileHandledException
 ---
 
-Comes from the exception: The line number where the exception was generated.
+Comes from the exception: The line number where the exception was generated. Only present if symbolication succeeded. 

--- a/src/data-dictionary/events/MobileHandledException/exceptionLocationMethod.md
+++ b/src/data-dictionary/events/MobileHandledException/exceptionLocationMethod.md
@@ -5,4 +5,4 @@ events:
   - MobileHandledException
 ---
 
-Comes from the exception: The method that generated the exception..
+The method that generated the exception. Only present if symbolication succeeded.

--- a/src/data-dictionary/events/MobileHandledException/exceptionMessage.md
+++ b/src/data-dictionary/events/MobileHandledException/exceptionMessage.md
@@ -5,4 +5,4 @@ events:
   - MobileHandledException
 ---
 
-The unsymbolicated message that comes from the exception. The message can be user-generated or a generic system message. For Android, the Throwable message.
+The unsymbolicated message from the exception. It can be user-generated or a generic system message. For Android, this is the Throwable message.

--- a/src/data-dictionary/events/MobileHandledException/exceptionMessage.md
+++ b/src/data-dictionary/events/MobileHandledException/exceptionMessage.md
@@ -5,4 +5,4 @@ events:
   - MobileHandledException
 ---
 
-Message associated with the exception. For Android, the Throwable message. An exception message comes from the exception. The message can be user-generated or a generic system message such as Null pointer.
+The unsymbolicated message that comes from the exception. The message can be user-generated or a generic system message. For Android, the Throwable message.

--- a/src/data-dictionary/events/MobileHandledException/exceptionName.md
+++ b/src/data-dictionary/events/MobileHandledException/exceptionName.md
@@ -5,4 +5,4 @@ events:
   - MobileHandledException
 ---
 
-The unsymbolicated expection type.
+The unsymbolicated exception type.

--- a/src/data-dictionary/events/MobileHandledException/exceptionName.md
+++ b/src/data-dictionary/events/MobileHandledException/exceptionName.md
@@ -5,4 +5,4 @@ events:
   - MobileHandledException
 ---
 
-The potentially symbolicated or deobfuscated exception type.
+The unsymbolicated expection type.

--- a/src/data-dictionary/events/MobileHandledException/fingerprint.md
+++ b/src/data-dictionary/events/MobileHandledException/fingerprint.md
@@ -1,0 +1,9 @@
+---
+name: fingerprint
+type: attribute
+units: ID
+events:
+  - MobileHandledException
+---
+
+The New Relic-generated identifier used to group like exceptions.

--- a/src/data-dictionary/events/MobileHandledException/handledExceptionUuid.md
+++ b/src/data-dictionary/events/MobileHandledException/handledExceptionUuid.md
@@ -6,4 +6,4 @@ events:
   - MobileHandledException
 ---
 
-The unique ID of\ the exception event.
+The unique ID of the exception event.

--- a/src/data-dictionary/events/MobileHandledException/handledExceptionUuid.md
+++ b/src/data-dictionary/events/MobileHandledException/handledExceptionUuid.md
@@ -1,0 +1,9 @@
+---
+name: handledExceptionUuid
+type: attribute
+units: ID
+events:
+  - MobileHandledException
+---
+
+The unique ID for the exception event.

--- a/src/data-dictionary/events/MobileHandledException/handledExceptionUuid.md
+++ b/src/data-dictionary/events/MobileHandledException/handledExceptionUuid.md
@@ -6,4 +6,4 @@ events:
   - MobileHandledException
 ---
 
-The unique ID for the exception event.
+The unique ID of\ the exception event.

--- a/src/data-dictionary/events/MobileHandledException/libraryName.md
+++ b/src/data-dictionary/events/MobileHandledException/libraryName.md
@@ -1,0 +1,8 @@
+---
+name: libraryName
+type: attribute
+events:
+  - MobileHandledException
+---
+
+The library name where the exception was generated. XCFramework agent only.

--- a/src/data-dictionary/events/MobileHandledException/libraryName.md
+++ b/src/data-dictionary/events/MobileHandledException/libraryName.md
@@ -5,4 +5,4 @@ events:
   - MobileHandledException
 ---
 
-The library name where the exception was generated. XCFramework agent only.
+For XCFramework agent only. The library name where the exception was generated. 

--- a/src/data-dictionary/events/MobileHandledException/libraryStartAddr.md
+++ b/src/data-dictionary/events/MobileHandledException/libraryStartAddr.md
@@ -5,4 +5,4 @@ events:
   - MobileHandledException
 ---
 
-The library start address where the exception was generated. XCFramework agent only.
+For XCFramework agent only. The library start address where the exception was generated.

--- a/src/data-dictionary/events/MobileHandledException/libraryStartAddr.md
+++ b/src/data-dictionary/events/MobileHandledException/libraryStartAddr.md
@@ -1,0 +1,8 @@
+---
+name: libraryStartAddr
+type: attribute
+events:
+  - MobileHandledException
+---
+
+The library start address where the exception was generated. XCFramework agent only.

--- a/src/data-dictionary/events/MobileHandledException/occurrenceTimestamp.md
+++ b/src/data-dictionary/events/MobileHandledException/occurrenceTimestamp.md
@@ -1,0 +1,8 @@
+---
+name: occurrenceTimestamp
+type: attribute
+events:
+  - MobileHandledException
+---
+
+Epoch timestamp of the agent-reported timestamp of the handled exception.

--- a/src/data-dictionary/events/MobileHandledException/occurrenceTimestamp.md
+++ b/src/data-dictionary/events/MobileHandledException/occurrenceTimestamp.md
@@ -5,4 +5,4 @@ events:
   - MobileHandledException
 ---
 
-Epoch timestamp of the agent-reported timestamp of the handled exception.
+Agent-reported epoch timestamp of the handled exception.

--- a/src/data-dictionary/events/MobileHandledException/osBuild.md
+++ b/src/data-dictionary/events/MobileHandledException/osBuild.md
@@ -1,0 +1,8 @@
+---
+name: osBuild
+type: attribute
+events:
+  - MobileHandledException
+---
+
+The OS build identifier as reported by the device. 

--- a/src/data-dictionary/events/MobileHandledException/osBuild.md
+++ b/src/data-dictionary/events/MobileHandledException/osBuild.md
@@ -1,8 +1,0 @@
----
-name: osBuild
-type: attribute
-events:
-  - MobileHandledException
----
-
-The OS build identifier as reported by the device. 

--- a/src/data-dictionary/events/MobileHandledException/runTime.md
+++ b/src/data-dictionary/events/MobileHandledException/runTime.md
@@ -1,0 +1,8 @@
+---
+name: runTime
+type: attribute
+events:
+  - MobileHandledException
+---
+
+The Android Runtime version where the exception was generated. Android agent only.

--- a/src/data-dictionary/events/MobileHandledException/runTime.md
+++ b/src/data-dictionary/events/MobileHandledException/runTime.md
@@ -6,4 +6,4 @@ events:
   - MobileCrash
 ---
 
-The Android Runtime version where the exception/crash was generated. Android agent only.
+For Android only. The Android Runtime version where the exception/crash was generated.

--- a/src/data-dictionary/events/MobileHandledException/runTime.md
+++ b/src/data-dictionary/events/MobileHandledException/runTime.md
@@ -3,6 +3,7 @@ name: runTime
 type: attribute
 events:
   - MobileHandledException
+  - MobileCrash
 ---
 
-The Android Runtime version where the exception was generated. Android agent only.
+The Android Runtime version where the exception/crash was generated. Android agent only.

--- a/src/data-dictionary/events/MobileHandledException/timestamp.md
+++ b/src/data-dictionary/events/MobileHandledException/timestamp.md
@@ -5,4 +5,4 @@ events:
   - MobileHandledException
 ---
 
-Epoch timestamp of the handled exception. This timestamp represents the time New Relic created the event if the occurrence timestamp of the exception is older than than two days or some other unexpected time.
+Epoch timestamp of the handled exception. This exception timestamp represents the time New Relic created the event, if it's older than two days or some other unexpected time.

--- a/src/data-dictionary/events/MobileHandledException/timestamp.md
+++ b/src/data-dictionary/events/MobileHandledException/timestamp.md
@@ -1,0 +1,8 @@
+---
+name: timestamp
+type: attribute
+events:
+  - MobileHandledException
+---
+
+Epoch timestamp of the handled exception. This timestamp represents the time New Relic created the event if the occurrence timestamp of the exception is older than than two days or some other unexpected time.

--- a/src/data-dictionary/events/MobileRequest/duration.md
+++ b/src/data-dictionary/events/MobileRequest/duration.md
@@ -7,4 +7,4 @@ events:
   - MobileRequestError
 ---
 
-Optional: The time to complete the request measured in fractional seconds.
+Optional: The time to complete the request, measured in fractional seconds.

--- a/src/data-dictionary/events/MobileRequest/duration.md
+++ b/src/data-dictionary/events/MobileRequest/duration.md
@@ -1,0 +1,10 @@
+---
+name: duration
+type: attribute
+units: seconds (s)
+events:
+  - MobileRequest
+  - MobileRequestError
+---
+
+Optional: The time to complete the request measured in fractional seconds.

--- a/src/data-dictionary/events/MobileRequest/lastInteraction.md
+++ b/src/data-dictionary/events/MobileRequest/lastInteraction.md
@@ -1,8 +1,0 @@
----
-name: lastInteraction
-type: attribute
-events:
-  - MobileRequest
----
-
-The last interaction before a crash/harvest event, if one is present, such as App Launch.

--- a/src/data-dictionary/events/MobileRequest/requestDomain.md
+++ b/src/data-dictionary/events/MobileRequest/requestDomain.md
@@ -3,6 +3,7 @@ name: requestDomain
 type: attribute
 events:
   - MobileRequest
+  - MobileRequestError
 ---
 
-The domain that the application attempted to access when the request occurred.
+The domain that the application attempted to access when the event occurred.

--- a/src/data-dictionary/events/MobileRequest/requestFingerprint.md
+++ b/src/data-dictionary/events/MobileRequest/requestFingerprint.md
@@ -1,0 +1,9 @@
+---
+name: requestFingerprint
+type: attribute
+units: ID
+events:
+  - MobileRequest
+---
+
+The New Relic-generated identifier used to group like request events.

--- a/src/data-dictionary/events/MobileRequest/requestMethod.md
+++ b/src/data-dictionary/events/MobileRequest/requestMethod.md
@@ -3,6 +3,7 @@ name: requestMethod
 type: attribute
 events:
   - MobileRequest
+  - MobileRequestError
 ---
 
-The REST method (GET, PUT, POST, etc.) that the application attempted when the request occurred.
+The REST method (GET, PUT, POST, etc.) that the application attempted when the event occurred.

--- a/src/data-dictionary/events/MobileRequest/requestPath.md
+++ b/src/data-dictionary/events/MobileRequest/requestPath.md
@@ -3,6 +3,7 @@ name: requestPath
 type: attribute
 events:
   - MobileRequest
+  - MobileRequestError
 ---
 
-The path that the application attempted to access when the request occurred.
+The path that the application attempted to access when the event occurred.

--- a/src/data-dictionary/events/MobileRequest/requestUrl.md
+++ b/src/data-dictionary/events/MobileRequest/requestUrl.md
@@ -3,6 +3,7 @@ name: requestUrl
 type: attribute
 events:
   - MobileRequest
+  - MobileRequestError
 ---
 
-The URL that the application attempted to access when the request occurred.
+The URL that the application attempted to access when the event occurred.

--- a/src/data-dictionary/events/MobileRequest/requestUuid.md
+++ b/src/data-dictionary/events/MobileRequest/requestUuid.md
@@ -1,9 +1,10 @@
 ---
-name: statusCode
+name: requestUuid
 type: attribute
+units: ID
 events:
   - MobileRequest
   - MobileRequestError
 ---
 
-Optional: The HTTP status code for the HTTP event.
+A unique identifer for the request event.

--- a/src/data-dictionary/events/MobileRequestError/lastInteraction.md
+++ b/src/data-dictionary/events/MobileRequestError/lastInteraction.md
@@ -1,8 +1,0 @@
----
-name: lastInteraction
-type: attribute
-events:
-  - MobileRequestError
----
-
-The last interaction before a crash/harvest event, if one is present, such as App Launch.

--- a/src/data-dictionary/events/MobileRequestError/requestDomain.md
+++ b/src/data-dictionary/events/MobileRequestError/requestDomain.md
@@ -1,8 +1,0 @@
----
-name: requestDomain
-type: attribute
-events:
-  - MobileRequestError
----
-
-The domain that the application attempted to access when the error occurred.

--- a/src/data-dictionary/events/MobileRequestError/requestErrorFingerprint.md
+++ b/src/data-dictionary/events/MobileRequestError/requestErrorFingerprint.md
@@ -1,0 +1,9 @@
+---
+name: requestErrorFingerprint
+type: attribute
+units: ID
+events:
+  - MobileRequestError
+---
+
+The New Relic-generated identifier used to group like request error events.

--- a/src/data-dictionary/events/MobileRequestError/requestMethod.md
+++ b/src/data-dictionary/events/MobileRequestError/requestMethod.md
@@ -1,8 +1,0 @@
----
-name: requestMethod
-type: attribute
-events:
-  - MobileRequestError
----
-
-The REST method (GET, PUT, POST, etc.) that the application attempted when the error occurred.

--- a/src/data-dictionary/events/MobileRequestError/requestPath.md
+++ b/src/data-dictionary/events/MobileRequestError/requestPath.md
@@ -1,8 +1,0 @@
----
-name: requestPath
-type: attribute
-events:
-  - MobileRequestError
----
-
-The path that the application attempted to access when the error occurred.

--- a/src/data-dictionary/events/MobileRequestError/requestUrl.md
+++ b/src/data-dictionary/events/MobileRequestError/requestUrl.md
@@ -1,8 +1,0 @@
----
-name: requestUrl
-type: attribute
-events:
-  - MobileRequestError
----
-
-The URL that the application attempted to access when the error occurred.

--- a/src/data-dictionary/events/MobileRequestError/statusCode.md
+++ b/src/data-dictionary/events/MobileRequestError/statusCode.md
@@ -1,8 +1,0 @@
----
-name: statusCode
-type: attribute
-events:
-  - MobileRequestError
----
-
-If the error is an HTTPError, New Relic will record the statusCode of that error. You can facet on any statusCode or query for codes you're interested in.

--- a/src/data-dictionary/events/MobileSession/appBuild.md
+++ b/src/data-dictionary/events/MobileSession/appBuild.md
@@ -4,6 +4,7 @@ type: attribute
 events:
   - MobileSession
   - MobileHandledException
+  - MobileCrash
 ---
 
 Indicates the technical build number of the app binary. As a developer, you can use this attribute to see identify specific builds of your app.

--- a/src/data-dictionary/events/MobileSession/appBuild.md
+++ b/src/data-dictionary/events/MobileSession/appBuild.md
@@ -3,6 +3,7 @@ name: appBuild
 type: attribute
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
-Indicates the technical build number of the binary that crashed. As a developer, you can use this attribute to see exactly which build of your app crashed.
+Indicates the technical build number of the app binary. As a developer, you can use this attribute to see identify specific builds of your app.

--- a/src/data-dictionary/events/MobileSession/appBuild.md
+++ b/src/data-dictionary/events/MobileSession/appBuild.md
@@ -9,4 +9,4 @@ events:
   - MobileRequestError
 ---
 
-Indicates the technical build number of the app binary. As a developer, you can use this attribute to see identify specific builds of your app.
+Indicates the technical build number of the app binary. As a developer, you can use this attribute to identify specific builds of your app.

--- a/src/data-dictionary/events/MobileSession/appBuild.md
+++ b/src/data-dictionary/events/MobileSession/appBuild.md
@@ -5,6 +5,8 @@ events:
   - MobileSession
   - MobileHandledException
   - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 Indicates the technical build number of the app binary. As a developer, you can use this attribute to see identify specific builds of your app.

--- a/src/data-dictionary/events/MobileSession/appId.md
+++ b/src/data-dictionary/events/MobileSession/appId.md
@@ -4,6 +4,7 @@ type: attribute
 units: ID
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
 A unique identifier for a monitored app, based on the app token. For example: 35091.

--- a/src/data-dictionary/events/MobileSession/appId.md
+++ b/src/data-dictionary/events/MobileSession/appId.md
@@ -6,6 +6,8 @@ events:
   - MobileSession
   - MobileHandledException
   - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 A unique identifier for a monitored app, based on the app token. For example: 35091.

--- a/src/data-dictionary/events/MobileSession/appId.md
+++ b/src/data-dictionary/events/MobileSession/appId.md
@@ -5,6 +5,7 @@ units: ID
 events:
   - MobileSession
   - MobileHandledException
+  - MobileCrash
 ---
 
 A unique identifier for a monitored app, based on the app token. For example: 35091.

--- a/src/data-dictionary/events/MobileSession/appName.md
+++ b/src/data-dictionary/events/MobileSession/appName.md
@@ -4,6 +4,7 @@ type: attribute
 events:
   - MobileSession
   - MobileHandledException
+  - MobileCrash
 ---
 
 The name of the monitored app. For example: My Mobile App - iOS.

--- a/src/data-dictionary/events/MobileSession/appName.md
+++ b/src/data-dictionary/events/MobileSession/appName.md
@@ -3,6 +3,7 @@ name: appName
 type: attribute
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
 The name of the monitored app. For example: My Mobile App - iOS.

--- a/src/data-dictionary/events/MobileSession/appName.md
+++ b/src/data-dictionary/events/MobileSession/appName.md
@@ -5,6 +5,8 @@ events:
   - MobileSession
   - MobileHandledException
   - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The name of the monitored app. For example: My Mobile App - iOS.

--- a/src/data-dictionary/events/MobileSession/appVersion.md
+++ b/src/data-dictionary/events/MobileSession/appVersion.md
@@ -4,6 +4,7 @@ type: attribute
 events:
   - MobileSession
   - MobileHandledException
+  - MobileCrash
 ---
 
 The version number of the monitored app. For example: 2.2.9.

--- a/src/data-dictionary/events/MobileSession/appVersion.md
+++ b/src/data-dictionary/events/MobileSession/appVersion.md
@@ -5,6 +5,8 @@ events:
   - MobileSession
   - MobileHandledException
   - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The version number of the monitored app. For example: 2.2.9.

--- a/src/data-dictionary/events/MobileSession/appVersion.md
+++ b/src/data-dictionary/events/MobileSession/appVersion.md
@@ -3,6 +3,7 @@ name: appVersion
 type: attribute
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
 The version number of the monitored app. For example: 2.2.9.

--- a/src/data-dictionary/events/MobileSession/appVersionId.md
+++ b/src/data-dictionary/events/MobileSession/appVersionId.md
@@ -6,6 +6,8 @@ events:
   - MobileSession
   - MobileHandledException
   - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 An identifier for the specific version of the app. For example: 1713477.

--- a/src/data-dictionary/events/MobileSession/appVersionId.md
+++ b/src/data-dictionary/events/MobileSession/appVersionId.md
@@ -5,6 +5,7 @@ units: ID
 events:
   - MobileSession
   - MobileHandledException
+  - MobileCrash
 ---
 
 An identifier for the specific version of the app. For example: 1713477.

--- a/src/data-dictionary/events/MobileSession/appVersionId.md
+++ b/src/data-dictionary/events/MobileSession/appVersionId.md
@@ -4,6 +4,7 @@ type: attribute
 units: ID
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
 An identifier for the specific version of the app. For example: 1713477.

--- a/src/data-dictionary/events/MobileSession/asnOwner.md
+++ b/src/data-dictionary/events/MobileSession/asnOwner.md
@@ -4,6 +4,9 @@ type: attribute
 events:
   - MobileSession
   - MobileHandledException
+  - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The telecom owner of the ASN.

--- a/src/data-dictionary/events/MobileSession/asnOwner.md
+++ b/src/data-dictionary/events/MobileSession/asnOwner.md
@@ -3,6 +3,7 @@ name: asnOwner
 type: attribute
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
 The telecom owner of the ASN.

--- a/src/data-dictionary/events/MobileSession/bundleId.md
+++ b/src/data-dictionary/events/MobileSession/bundleId.md
@@ -4,6 +4,7 @@ type: attribute
 units: ID
 events:
   - MobileCrash
+  - MobileSession
 ---
 
 The unique string used to identify the application.

--- a/src/data-dictionary/events/MobileSession/carrier.md
+++ b/src/data-dictionary/events/MobileSession/carrier.md
@@ -3,6 +3,7 @@ name: carrier
 type: attribute
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
 The mobile network over which the app transferred data, such as wifi, Verizon, or Sprint.

--- a/src/data-dictionary/events/MobileSession/carrier.md
+++ b/src/data-dictionary/events/MobileSession/carrier.md
@@ -9,4 +9,4 @@ events:
   - MobileRequestError
 ---
 
-The mobile network over which the app transferred data, such as wifi, Verizon, or Sprint.
+The network over which the app transferred data, such as Wi-Fi, Verizon, or Sprint.

--- a/src/data-dictionary/events/MobileSession/carrier.md
+++ b/src/data-dictionary/events/MobileSession/carrier.md
@@ -4,6 +4,7 @@ type: attribute
 events:
   - MobileSession
   - MobileHandledException
+  - MobileCrash
 ---
 
 The mobile network over which the app transferred data, such as wifi, Verizon, or Sprint.

--- a/src/data-dictionary/events/MobileSession/carrier.md
+++ b/src/data-dictionary/events/MobileSession/carrier.md
@@ -5,6 +5,8 @@ events:
   - MobileSession
   - MobileHandledException
   - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The mobile network over which the app transferred data, such as wifi, Verizon, or Sprint.

--- a/src/data-dictionary/events/MobileSession/countryCode.md
+++ b/src/data-dictionary/events/MobileSession/countryCode.md
@@ -4,6 +4,8 @@ type: attribute
 events:
   - MobileSession
   - MobileHandledException
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The country from which the device ran the application. For a list of country codes, see ISO 3166-1 alpha-2. 

--- a/src/data-dictionary/events/MobileSession/countryCode.md
+++ b/src/data-dictionary/events/MobileSession/countryCode.md
@@ -1,0 +1,9 @@
+---
+name: countryCode
+type: attribute
+events:
+  - MobileSession
+  - MobileHandledException
+---
+
+The country from which the device ran the application. For a list of country codes, see ISO 3166-1 alpha-2. 

--- a/src/data-dictionary/events/MobileSession/device.md
+++ b/src/data-dictionary/events/MobileSession/device.md
@@ -4,6 +4,8 @@ type: attribute
 events:
   - MobileSession
   - MobileHandledException
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The specific type of the device: iPhone 8, iPad Pro, etc. Duplicate of `deviceType`.

--- a/src/data-dictionary/events/MobileSession/device.md
+++ b/src/data-dictionary/events/MobileSession/device.md
@@ -3,6 +3,7 @@ name: device
 type: attribute
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
-The specific type of the device: iPhone 8, iPad Pro, etc.
+The specific type of the device: iPhone 8, iPad Pro, etc. Duplicate of `deviceType`.

--- a/src/data-dictionary/events/MobileSession/deviceGroup.md
+++ b/src/data-dictionary/events/MobileSession/deviceGroup.md
@@ -3,6 +3,8 @@ name: deviceGroup
 type: attribute
 events:
   - MobileSession
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The category of the device, such as iPhone or Tablet.

--- a/src/data-dictionary/events/MobileSession/deviceManufacturer.md
+++ b/src/data-dictionary/events/MobileSession/deviceManufacturer.md
@@ -4,6 +4,9 @@ type: attribute
 events:
   - MobileSession
   - MobileCrash
+  - MobileHandledException
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The manufacturer of the device, such as Motorola or HTC.

--- a/src/data-dictionary/events/MobileSession/deviceManufacturer.md
+++ b/src/data-dictionary/events/MobileSession/deviceManufacturer.md
@@ -3,6 +3,7 @@ name: deviceManufacturer
 type: attribute
 events:
   - MobileSession
+  - MobileCrash
 ---
 
 The manufacturer of the device, such as Motorola or HTC.

--- a/src/data-dictionary/events/MobileSession/deviceModel.md
+++ b/src/data-dictionary/events/MobileSession/deviceModel.md
@@ -5,6 +5,8 @@ events:
   - MobileSession
   - MobileHandledException
   - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The model number of the device, such as XT1039 or SM-G900F.

--- a/src/data-dictionary/events/MobileSession/deviceModel.md
+++ b/src/data-dictionary/events/MobileSession/deviceModel.md
@@ -3,6 +3,7 @@ name: deviceModel
 type: attribute
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
 The model number of the device, such as XT1039 or SM-G900F.

--- a/src/data-dictionary/events/MobileSession/deviceModel.md
+++ b/src/data-dictionary/events/MobileSession/deviceModel.md
@@ -4,6 +4,7 @@ type: attribute
 events:
   - MobileSession
   - MobileHandledException
+  - MobileCrash
 ---
 
 The model number of the device, such as XT1039 or SM-G900F.

--- a/src/data-dictionary/events/MobileSession/deviceType.md
+++ b/src/data-dictionary/events/MobileSession/deviceType.md
@@ -4,6 +4,8 @@ type: attribute
 events:
   - MobileSession
   - MobileHandledException
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The specific type of device: iPhone 8, iPad Pro, etc. Duplication of `device`.

--- a/src/data-dictionary/events/MobileSession/deviceType.md
+++ b/src/data-dictionary/events/MobileSession/deviceType.md
@@ -8,4 +8,4 @@ events:
   - MobileRequestError
 ---
 
-The specific type of device: iPhone 8, iPad Pro, etc. Duplication of `device`.
+The specific type of device: iPhone 8, iPad Pro, etc. Duplicate of `device`.

--- a/src/data-dictionary/events/MobileSession/deviceType.md
+++ b/src/data-dictionary/events/MobileSession/deviceType.md
@@ -3,6 +3,7 @@ name: deviceType
 type: attribute
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
-The specific type of device: iPhone 8, iPad Pro, etc.
+The specific type of device: iPhone 8, iPad Pro, etc. Duplication of `device`.

--- a/src/data-dictionary/events/MobileSession/deviceUuid.md
+++ b/src/data-dictionary/events/MobileSession/deviceUuid.md
@@ -5,6 +5,7 @@ units: ID
 events:
   - MobileSession
   - MobileHandledException
+  - MobileCrash
 ---
 
 A unique identifier assigned by New Relic for a specific app on a particular device. It is only reset if a user deletes and then reinstalls the app. For example: B8B0BC30-0235-11E4-9191-0800200C9A66. Dupliate of `uuid`.

--- a/src/data-dictionary/events/MobileSession/deviceUuid.md
+++ b/src/data-dictionary/events/MobileSession/deviceUuid.md
@@ -4,6 +4,7 @@ type: attribute
 units: ID
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
-The specific UUID of the device assigned by New Relic, assigned at the time of app installation. It is only reset if a user deletes and then reinstalls the app.
+A unique identifier assigned by New Relic for a specific app on a particular device. It is only reset if a user deletes and then reinstalls the app. For example: B8B0BC30-0235-11E4-9191-0800200C9A66. Dupliate of `uuid`.

--- a/src/data-dictionary/events/MobileSession/deviceUuid.md
+++ b/src/data-dictionary/events/MobileSession/deviceUuid.md
@@ -6,6 +6,8 @@ events:
   - MobileSession
   - MobileHandledException
   - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
-A unique identifier assigned by New Relic for a specific app on a particular device. It is only reset if a user deletes and then reinstalls the app. For example: B8B0BC30-0235-11E4-9191-0800200C9A66. Dupliate of `uuid`.
+A unique identifier assigned at the time of app installation by New Relic. It is only reset if a user deletes and then reinstalls the app. For example: B8B0BC30-0235-11E4-9191-0800200C9A66. Dupliate of `uuid`.

--- a/src/data-dictionary/events/MobileSession/lastInteraction.md
+++ b/src/data-dictionary/events/MobileSession/lastInteraction.md
@@ -4,6 +4,7 @@ type: attribute
 events:
   - MobileSession
   - MobileHandledException
+  - MobileCrash
 ---
 
 The last interaction before a crash or harvest event, if one is present.

--- a/src/data-dictionary/events/MobileSession/lastInteraction.md
+++ b/src/data-dictionary/events/MobileSession/lastInteraction.md
@@ -5,6 +5,8 @@ events:
   - MobileSession
   - MobileHandledException
   - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The last interaction before a crash or harvest event, if one is present.

--- a/src/data-dictionary/events/MobileSession/lastInteraction.md
+++ b/src/data-dictionary/events/MobileSession/lastInteraction.md
@@ -3,6 +3,7 @@ name: lastInteraction
 type: attribute
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
-The last interaction before a crash/harvest event, if one is present, such as App Launch.
+The last interaction before a crash or harvest event, if one is present.

--- a/src/data-dictionary/events/MobileSession/memUsageMb.md
+++ b/src/data-dictionary/events/MobileSession/memUsageMb.md
@@ -5,6 +5,7 @@ units: megabytes (MB)
 events:
   - MobileSession
   - MobileHandledException
+  - MobileCrash
 ---
 
 The total amount of memory, in MB, used by the application. Updated every 60 seconds.

--- a/src/data-dictionary/events/MobileSession/memUsageMb.md
+++ b/src/data-dictionary/events/MobileSession/memUsageMb.md
@@ -4,6 +4,7 @@ type: attribute
 units: megabytes (MB)
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
 The total amount of memory, in MB, used by the application. Updated every 60 seconds.

--- a/src/data-dictionary/events/MobileSession/memUsageMb.md
+++ b/src/data-dictionary/events/MobileSession/memUsageMb.md
@@ -6,6 +6,8 @@ events:
   - MobileSession
   - MobileHandledException
   - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The total amount of memory, in MB, used by the application. Updated every 60 seconds.

--- a/src/data-dictionary/events/MobileSession/newRelicAgent.md
+++ b/src/data-dictionary/events/MobileSession/newRelicAgent.md
@@ -5,4 +5,4 @@ events:
   - MobileSession
 ---
 
-The New Relic agent running on the application. For example: the iOSAgent or the androidAgent.
+The New Relic agent running on the application. For example: the iOSAgent or the androidAgent. 

--- a/src/data-dictionary/events/MobileSession/newRelicVersion.md
+++ b/src/data-dictionary/events/MobileSession/newRelicVersion.md
@@ -3,6 +3,7 @@ name: newRelicVersion
 type: attribute
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
-The version number of the agent running on the application. For example: 4.232.0.
+The version number of the agent running on the application. For example: 4.232.0.  Duplicate of `newRelicAgentVersion`.

--- a/src/data-dictionary/events/MobileSession/newRelicVersion.md
+++ b/src/data-dictionary/events/MobileSession/newRelicVersion.md
@@ -4,6 +4,7 @@ type: attribute
 events:
   - MobileSession
   - MobileHandledException
+  - MobileCrash
 ---
 
 The version number of the agent running on the application. For example: 4.232.0.  Duplicate of `newRelicAgentVersion`.

--- a/src/data-dictionary/events/MobileSession/newRelicVersion.md
+++ b/src/data-dictionary/events/MobileSession/newRelicVersion.md
@@ -5,6 +5,8 @@ events:
   - MobileSession
   - MobileHandledException
   - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The version number of the agent running on the application. For example: 4.232.0.  Duplicate of `newRelicAgentVersion`.

--- a/src/data-dictionary/events/MobileSession/osMajorVersion.md
+++ b/src/data-dictionary/events/MobileSession/osMajorVersion.md
@@ -3,6 +3,7 @@ name: osMajorVersion
 type: attribute
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
 The simplified version number of the app's host operating system, such as iOS 11, as compared to iOS 11.0.4.

--- a/src/data-dictionary/events/MobileSession/osMajorVersion.md
+++ b/src/data-dictionary/events/MobileSession/osMajorVersion.md
@@ -4,6 +4,7 @@ type: attribute
 events:
   - MobileSession
   - MobileHandledException
+  - MobileCrash
 ---
 
 The simplified version number of the app's host operating system, such as iOS 11, as compared to iOS 11.0.4.

--- a/src/data-dictionary/events/MobileSession/osMajorVersion.md
+++ b/src/data-dictionary/events/MobileSession/osMajorVersion.md
@@ -5,6 +5,8 @@ events:
   - MobileSession
   - MobileHandledException
   - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The simplified version number of the app's host operating system, such as iOS 11, as compared to iOS 11.0.4.

--- a/src/data-dictionary/events/MobileSession/osName.md
+++ b/src/data-dictionary/events/MobileSession/osName.md
@@ -3,7 +3,8 @@ name: osName
 type: attribute
 events:
   - MobileSession
-  - MobileHandledException  
+  - MobileHandledException
+  - MobileCrash
 ---
 
 The name of the app's host operating system, for example, iOS or Android.

--- a/src/data-dictionary/events/MobileSession/osName.md
+++ b/src/data-dictionary/events/MobileSession/osName.md
@@ -5,6 +5,8 @@ events:
   - MobileSession
   - MobileHandledException
   - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The name of the app's host operating system, for example, iOS or Android.

--- a/src/data-dictionary/events/MobileSession/osName.md
+++ b/src/data-dictionary/events/MobileSession/osName.md
@@ -3,6 +3,7 @@ name: osName
 type: attribute
 events:
   - MobileSession
+  - MobileHandledException  
 ---
 
 The name of the app's host operating system, for example, iOS or Android.

--- a/src/data-dictionary/events/MobileSession/osVersion.md
+++ b/src/data-dictionary/events/MobileSession/osVersion.md
@@ -3,6 +3,10 @@ name: osVersion
 type: attribute
 events:
   - MobileSession
+  - MobileHandledException
+  - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The exact version number of the app's host operating system, such as iOS 11.0.4, as compared to iOS 11.

--- a/src/data-dictionary/events/MobileSession/platform.md
+++ b/src/data-dictionary/events/MobileSession/platform.md
@@ -3,6 +3,7 @@ name: platform
 type: attribute
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
-The platform type of the New Relic Mobile agent, such as Android, iOS, or Cordova.
+The platform type of the New Relic Mobile agent, such as native or Cordova.

--- a/src/data-dictionary/events/MobileSession/platform.md
+++ b/src/data-dictionary/events/MobileSession/platform.md
@@ -5,6 +5,8 @@ events:
   - MobileSession
   - MobileHandledException
   - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The platform type of the New Relic Mobile agent, such as native or Cordova.

--- a/src/data-dictionary/events/MobileSession/platform.md
+++ b/src/data-dictionary/events/MobileSession/platform.md
@@ -4,6 +4,7 @@ type: attribute
 events:
   - MobileSession
   - MobileHandledException
+  - MobileCrash
 ---
 
 The platform type of the New Relic Mobile agent, such as native or Cordova.

--- a/src/data-dictionary/events/MobileSession/platformVersion.md
+++ b/src/data-dictionary/events/MobileSession/platformVersion.md
@@ -1,8 +1,0 @@
----
-name: platformVersion
-type: attribute
-events:
-  - MobileSession
----
-
-The version number of the New Relic Mobile agent running on the application. For example: 4.232.0.

--- a/src/data-dictionary/events/MobileSession/regionCode.md
+++ b/src/data-dictionary/events/MobileSession/regionCode.md
@@ -4,6 +4,8 @@ type: attribute
 events:
   - MobileSession
   - MobileHandledException
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The specific region within a country where the monitored app is located. In the United States, regions are states. The regionCode is based on IP address and may not always match your region.

--- a/src/data-dictionary/events/MobileSession/regionCode.md
+++ b/src/data-dictionary/events/MobileSession/regionCode.md
@@ -3,6 +3,7 @@ name: regionCode
 type: attribute
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
 The specific region within a country where the monitored app is located. In the United States, regions are states. The regionCode is based on IP address and may not always match your region.

--- a/src/data-dictionary/events/MobileSession/sessionCrashed.md
+++ b/src/data-dictionary/events/MobileSession/sessionCrashed.md
@@ -2,6 +2,7 @@
 name: sessionCrashed
 type: attribute
 events:
+  - MobileSession
   - MobileCrash
 ---
 

--- a/src/data-dictionary/events/MobileSession/sessionId.md
+++ b/src/data-dictionary/events/MobileSession/sessionId.md
@@ -6,6 +6,8 @@ events:
   - MobileSession
   - MobileHandledException
   - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 A unique identifier for a single user session. A new sessionId is created each time the app is brought into the foreground.

--- a/src/data-dictionary/events/MobileSession/sessionId.md
+++ b/src/data-dictionary/events/MobileSession/sessionId.md
@@ -4,6 +4,7 @@ type: attribute
 units: ID
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
 A unique identifier for a single user session. A new sessionId is created each time the app is brought into the foreground.

--- a/src/data-dictionary/events/MobileSession/sessionId.md
+++ b/src/data-dictionary/events/MobileSession/sessionId.md
@@ -5,6 +5,7 @@ units: ID
 events:
   - MobileSession
   - MobileHandledException
+  - MobileCrash
 ---
 
 A unique identifier for a single user session. A new sessionId is created each time the app is brought into the foreground.

--- a/src/data-dictionary/events/MobileSession/timestamp.md
+++ b/src/data-dictionary/events/MobileSession/timestamp.md
@@ -3,6 +3,8 @@ name: timestamp
 type: attribute
 events:
   - MobileSession
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The UTC epoch time at which an event began.

--- a/src/data-dictionary/events/MobileSession/uuid.md
+++ b/src/data-dictionary/events/MobileSession/uuid.md
@@ -4,6 +4,7 @@ type: attribute
 units: ID
 events:
   - MobileSession
+  - MobileHandledException
 ---
 
-A unique identifier for a specific app on a particular device. Also found in deviceUuid. Resets on reinstallation of the app. For example: B8B0BC30-0235-11E4-9191-0800200C9A66
+A unique identifier assigned by New Relic for a specific app on a particular device. It is only reset if a user deletes and then reinstalls the app. For example: B8B0BC30-0235-11E4-9191-0800200C9A66. Dupliate of `deviceUuid`.

--- a/src/data-dictionary/events/MobileSession/uuid.md
+++ b/src/data-dictionary/events/MobileSession/uuid.md
@@ -5,6 +5,7 @@ units: ID
 events:
   - MobileSession
   - MobileHandledException
+  - MobileCrash
 ---
 
 A unique identifier assigned by New Relic for a specific app on a particular device. It is only reset if a user deletes and then reinstalls the app. For example: B8B0BC30-0235-11E4-9191-0800200C9A66. Dupliate of `deviceUuid`.

--- a/src/data-dictionary/events/MobileSession/uuid.md
+++ b/src/data-dictionary/events/MobileSession/uuid.md
@@ -6,6 +6,8 @@ events:
   - MobileSession
   - MobileHandledException
   - MobileCrash
+  - MobileRequest
+  - MobileRequestError
 ---
 
 A unique identifier assigned by New Relic for a specific app on a particular device. It is only reset if a user deletes and then reinstalls the app. For example: B8B0BC30-0235-11E4-9191-0800200C9A66. Dupliate of `deviceUuid`.

--- a/src/data-dictionary/events/PageView/asn.md
+++ b/src/data-dictionary/events/PageView/asn.md
@@ -7,6 +7,8 @@ events:
   - BrowserInteraction
   - MobileSession
   - MobileHandledException
+  - MobileRequest
+  - MobileRequestError
   - AjaxRequest
   - BrowserTiming
   - Span

--- a/src/data-dictionary/events/PageView/asn.md
+++ b/src/data-dictionary/events/PageView/asn.md
@@ -6,6 +6,7 @@ events:
   - PageAction
   - BrowserInteraction
   - MobileSession
+  - MobileHandledException
   - AjaxRequest
   - BrowserTiming
   - Span

--- a/src/data-dictionary/events/PageView/city.md
+++ b/src/data-dictionary/events/PageView/city.md
@@ -8,8 +8,9 @@ events:
   - AjaxRequest
   - BrowserTiming
   - MobileSession
+  - MobileHandledException
   - PageViewTiming
   - JavaScriptError
 ---
 
-The city in which the PageView event occurred, such as Portland or Seattle.
+The city in which the event occurred, such as Portland or Seattle.

--- a/src/data-dictionary/events/PageView/countryCode.md
+++ b/src/data-dictionary/events/PageView/countryCode.md
@@ -7,7 +7,6 @@ events:
   - BrowserInteraction
   - AjaxRequest
   - BrowserTiming
-  - MobileSession
   - PageViewTiming
   - JavaScriptError
 ---

--- a/src/data-dictionary/events/Span/guid.md
+++ b/src/data-dictionary/events/Span/guid.md
@@ -4,6 +4,8 @@ type: attribute
 units: ID
 events:
   - Span
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The unique identifier for the segment. This is equivalent to spanID in OpenTracing semantics.

--- a/src/data-dictionary/events/Span/trace.id.md
+++ b/src/data-dictionary/events/Span/trace.id.md
@@ -7,6 +7,8 @@ events:
   - Transaction
   - TransactionError
   - DistributedTraceSummary
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The unique ID (a randomly generated string) used to identify a single request as it crosses inter- and intra- process boundaries. This ID allows the linking of spans in a distributed trace. Included when distributed tracing is enabled.

--- a/src/data-dictionary/events/Span/traceId.md
+++ b/src/data-dictionary/events/Span/traceId.md
@@ -6,6 +6,8 @@ events:
   - Span
   - AwsLambdaInvocation
   - AwsLambdaInvocationError
+  - MobileRequest
+  - MobileRequestError
 ---
 
 The unique ID (a randomly generated string) used to identify a single request as it crosses inter- and intra- process boundaries. This ID allows the linking of spans in a distributed trace. Included when distributed tracing is enabled.


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

These changes are to improve the documentation around Mobile event types and their attributes. Event docs updated include `MobileSession`,  `MobileCrash`, `MobileHandledException` and `MobileRequestError` types.
