### PR TITLE
Remove link for a section that's not in doc

### DIFF
--- a/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -204,7 +204,6 @@ NEWRELIC_PROFILER_LOG_DIRECTORY=<var>path\to\agent\directory</var> (not configur
 
 Use these options to setup and configure your agent via the newrelic.config file. The New Relic .NET agent supports the following categories of setup options:
 
-* [Multiple applications](#multiple)
 * [Configuration element](#configuration)
 * [Service element](#service)
 * [Obscuring key element](#obscuring-key)


### PR DESCRIPTION
We were alerted to this by a notice in the documentation channel.