### PR TITLE
Fix code block example to display a tag and not render html link

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action.mdx
@@ -29,8 +29,8 @@ Agent version [nr-593](https://docs.newrelic.com/docs/release-notes/new-relic-br
 
 This API call sends a Browser [`PageAction` event](/docs/insights/explore-data/custom-events/insert-browser-custom-events-attributes-insights-javascript-api) with your user-defined name and optional attributes to [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards), along with [several default attributes](/docs/insights/explore-data/attributes/browser-default-attributes-insights). This is useful to track any event that is not already tracked automatically by the Browser agent, such as clicking a **Subscribe** button or accessing a tutorial.
 
-* PageAction events are sent to New Relic One every 30 seconds, with a maximum of 60 events per 30-second harvest cycle, per browser.
-* After the 60-event limit is reached, additional events are not captured for that harvest cycle.
+- PageAction events are sent to New Relic One every 30 seconds, with a maximum of 60 events per 30-second harvest cycle, per browser.
+- After the 60-event limit is reached, additional events are not captured for that harvest cycle.
 
 ## Parameters
 
@@ -45,6 +45,7 @@ This API call sends a Browser [`PageAction` event](/docs/insights/explore-data/c
         Description
       </th>
     </tr>
+
   </thead>
 
   <tbody>
@@ -75,6 +76,7 @@ This API call sends a Browser [`PageAction` event](/docs/insights/explore-data/c
         Avoid using [reserved NRQL words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words) when you name the attribute/value.
       </td>
     </tr>
+
   </tbody>
 </table>
 
@@ -85,81 +87,84 @@ This API call sends a Browser [`PageAction` event](/docs/insights/explore-data/c
 <dd>
   This example records a PageAction event whenever a user selects the **Try Me** link. The event is recorded with an `actionName` of `clickedTryMe`:
 
-  ```
-  <a href="/demo" id="try-me">Try Me!</a>
-  <script>
-      document.getElementById('try-me').addEventListener('click',function (e) {
-          newrelic.addPageAction('clickedTryMe');
-      })
-  </script>
-  ```
+```
+< a href="/demo" id="try-me" >Try Me!< /a>
+<script>
+    document.getElementById('try-me').addEventListener('click',function (e) {
+        newrelic.addPageAction('clickedTryMe');
+    })
+</script>
+```
 
-  You can then query the number of times the **Try Me** button was clicked with the following NRQL query:
+You can then query the number of times the **Try Me** button was clicked with the following NRQL query:
 
-  ```
-  SELECT count(*) FROM PageAction WHERE actionName='clickedTryMe' SINCE 1 hour ago
-  ```
+```
+SELECT count(*) FROM PageAction WHERE actionName='clickedTryMe' SINCE 1 hour ago
+```
 
-  ### Record link clicks (jQuery) [#example-link-click-jquery]
+### Record link clicks (jQuery) [#example-link-click-jquery]
+
 </dd>
 
 <dd>
   This example sends a PageAction event when a user clicks on an element with the class `copy-text`. The `actionName` is `copy-text-button` and the value is reported as another attribute called `Result` that corresponds to methods named `success` and `error` that handle the outcome.
 
-  ```
-  $('.copy-text').click(function (){
-      var clipboard = new Clipboard ('.copy-text');
-      clipboard.on('success', function(event) {
-        // Do stuff
-        // Report data to New Relic One
-        if (typeof newrelic == 'object') {
-          newrelic.addPageAction('copy-text-button', {result: 'success'});
-        }
-      });
-      clipboard.on('error', function(event) {
-        // Do stuff
-        // Report data to New Relic One
-        if (typeof newrelic == 'object') {
-          newrelic.addPageAction('copy-text-button', {result: 'error'});
-        }
-      });
-  });
-  ```
+```
+$('.copy-text').click(function (){
+    var clipboard = new Clipboard ('.copy-text');
+    clipboard.on('success', function(event) {
+      // Do stuff
+      // Report data to New Relic One
+      if (typeof newrelic == 'object') {
+        newrelic.addPageAction('copy-text-button', {result: 'success'});
+      }
+    });
+    clipboard.on('error', function(event) {
+      // Do stuff
+      // Report data to New Relic One
+      if (typeof newrelic == 'object') {
+        newrelic.addPageAction('copy-text-button', {result: 'error'});
+      }
+    });
+});
+```
 
-  Then in the query builder, you can create a pie chart to see the breakdown of how many button clicks resulted in success versus error over the past 30 days:
+Then in the query builder, you can create a pie chart to see the breakdown of how many button clicks resulted in success versus error over the past 30 days:
 
-  ```
-  SELECT count(*) AS 'Clicks' FROM PageAction WHERE actionName = 'copy-text-button' FACET result SINCE 30 days ago
-  ```
+```
+SELECT count(*) AS 'Clicks' FROM PageAction WHERE actionName = 'copy-text-button' FACET result SINCE 30 days ago
+```
 
-  Or you can create a query to see what pages have the most copy button clicks in the last 30 days:
+Or you can create a query to see what pages have the most copy button clicks in the last 30 days:
 
-  ```
-  SELECT count(*) AS 'Clicks' FROM PageAction WHERE actionName = 'copy-text-button' FACET currentUrl SINCE 30 days ago
-  ```
+```
+SELECT count(*) AS 'Clicks' FROM PageAction WHERE actionName = 'copy-text-button' FACET currentUrl SINCE 30 days ago
+```
 
-  ### Capture form input [#example-form-input]
+### Capture form input [#example-form-input]
+
 </dd>
 
 <dd>
   This example captures user input (email addresses) from a form called **Signup**. The event is recorded with an `actionName` of `userSignup`:
 
-  ```
-  <form action="/signup" id="myform">
-     <input id="email" name="email">
-     <input type="submit" value="Signup">
-  </form>
-  <script type="text/javascript">
-      document.getElementById('myform').addEventListener('submit', function (e) {
-          var email = e.target.elements['email'].value;
-          newrelic.addPageAction('userSignup', {email: email});
-      })
-  </script>
-  ```
+```
+<form action="/signup" id="myform">
+   <input id="email" name="email">
+   <input type="submit" value="Signup">
+</form>
+<script type="text/javascript">
+    document.getElementById('myform').addEventListener('submit', function (e) {
+        var email = e.target.elements['email'].value;
+        newrelic.addPageAction('userSignup', {email: email});
+    })
+</script>
+```
 
-  You can then see the emails that you gathered with the following NRQL query:
+You can then see the emails that you gathered with the following NRQL query:
 
-  ```
-  SELECT uniques(email) FROM PageAction WHERE actionName='userSignup' SINCE 1 hour ago
-  ```
+```
+SELECT uniques(email) FROM PageAction WHERE actionName='userSignup' SINCE 1 hour ago
+```
+
 </dd>


### PR DESCRIPTION
## Description

Adds spaces to `<a>` tag in code block to prevent parsing and rendering as HTML link. This is supposed to be part of the example and not rendered as a link, like we do in other code blocks.

## Related issues
Closes https://github.com/newrelic/docs-website/issues/2193

## Example
The first example in this doc has a link that should just show the `<a>` code as is: http://localhost:8000/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action/#examples

## Screenshots
<img width="1534" alt="Screen Shot 2021-05-10 at 09 00 33" src="https://user-images.githubusercontent.com/2952843/117689411-93419600-b16e-11eb-8586-21bd874bc2f4.png">
