### PR TITLE
Add in ios mobile app release note 3.72.0

### DIFF
--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3720.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3720.mdx
@@ -1,0 +1,20 @@
+---
+subject: Mobile app for iOS
+releaseDate: '2021-05-10'
+version: 3.72.0
+downloadLink: 'https://apps.apple.com/app/id594038638'
+---
+
+### Notes
+
+Now featuring a global left navigation on iPad, with an explorer for all your entities.
+
+### New features
+
+* Added in an entity explorer page on iPad that supports Infrastructure integrations, along with a lot of other types of entities
+* Added in a global left navigation bar on iPad, to allow you to quickly access Home, Explorer, Dashboards, Alerts, and Query from anywhere
+* Renamed integration reported services to OpenTelemetry services
+
+### Fixes
+
+* Fixed an issue when opening dashboard universal links


### PR DESCRIPTION
Add in the latest release of the New Relic for iOS mobile app, version 3.72.0.