### PR TITLE
Cut intro paragraph to just focus on content edits

### DIFF
--- a/src/content/docs/style-guide/writing-guidelines/create-edit-content.mdx
+++ b/src/content/docs/style-guide/writing-guidelines/create-edit-content.mdx
@@ -15,16 +15,6 @@ redirects:
   - /docs/new-relic-only/basic-style-guide/basic-style-guide/create-edit-content
 ---
 
-The Documentation Team and Developer Enablement Team at New Relic welcome your contributions to our site.
-
-There are several ways you can contribute:
-
-- If you'd like to to make code contributions follow [our code contribution guidelines](https://github.com/newrelic/docs-website/blob/develop/CONTRIBUTING.md).
-- If you wish to make documentation edits or add new
-  documentation, follow our guidelines below.
-
-## Grammar and style guidelines [#grammar-style]
-
 We welcome your contributions! And we don't want you to worry about style. When you edit a file, tech writers on our team review it for style, grammar, and formatting. That said, if you're curious about our style guidelines, you're welcome (but not obligated) [to take a look](/docs/style-guide/get-started/introduction-style-guide/).
 
 <Callout variant="important">
@@ -38,7 +28,7 @@ We welcome your contributions! And we don't want you to worry about style. When 
 
 ## Edit a doc [#edit-doc]
 
-If you see a minor problem in our documentation that you want to quickly fix, you can use Github to edit the file and submit your pull request. A member of the Tech Docs team will review your edit and publish your changes. We'll follow up with you if we have any questions.
+If you see a minor problem in our documentation that you want to quickly fix, you can use GitHub to edit the file and submit your pull request. A member of the Tech Docs team will review your edit and publish your changes. We'll follow up with you if we have any questions.
 
 <Callout variant="important">
   You need a GitHub account to edit docs. If you don’t have one, you can [create
@@ -88,7 +78,7 @@ Your cloned doc automatically inherits the original doc's frontmatter content. M
 
 If you are comfortable with deleting the page yourself, go for it. If not, ask us by:
 
-1. Filing a [Documentation Request](https://github.com/newrelic/docs-website/issues/new/choose), or contact the @hero in the #documentation channel.
+1. [File an issue in the docs-website repo](https://github.com/newrelic/docs-website/issues/new/choose), or contact the @hero in the #documentation channel if you're a New Relic employee.
 2. The Documentation Team will review the request to delete an existing documentation page.
 3. If the deletion is approved, the Docs team will delete the page.
 


### PR DESCRIPTION
### Give us some context

(This is from @austin-schaefer 's training account)

I believe cutting the intro here makes the info more accessible. The focus here is content, not code.