### PR TITLE
Change contributing url to style guide

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,6 +33,7 @@ module.exports = {
     repository: 'https://github.com/newrelic/docs-website',
     siteUrl,
     branch: 'develop',
+    contributingUrl: 'https://docs.newrelic.com/docs/style-guide/writing-guidelines/create-edit-content/'
   },
   plugins: [
     'gatsby-plugin-react-helmet',


### PR DESCRIPTION
The `contribute` link in the right nav of the docs site currently links to `contributing.md`. 

This PR changes that link to point towards our content contribution style guide doc, since we migrated all the info in #1853.

