### PR TITLE
Adding missing redirect

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data.mdx
@@ -10,6 +10,7 @@ redirects:
   - /docs/using-new-relic/data/understand-data/query-new-relic-data
   - /docs/query-your-data/explore-query-data/explore-data/introduction-querying-new-relic-data
   - /docs/query-your-data/explore-query-data/get-started/intro-querying  
+  - /docs/telemetry-data-platform/ingest-manage-data/understand-data/introduction-querying-new-relic-data/  
 ---
 
 You can query New Relic data in several ways, including [in the UI](#query-ui) or [via API](#query-apis).


### PR DESCRIPTION
Adding missing redirect to 'intro to querying data' doc