### PR TITLE
Remove unsupported Ubuntu 14 (EOL)

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -120,7 +120,7 @@ The infrastructure agent supports these operating systems:
       </td>
 
       <td>
-        [LTS](https://wiki.ubuntu.com/LTS) versions 14.04.x, 16.04.x, 18.04.x, 20.04.x
+        [LTS](https://wiki.ubuntu.com/LTS) versions 16.04.x, 18.04.x, 20.04.x
       </td>
     </tr>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
Ubuntu 14 is not supported anymore in the infrastructure agent. 
Ubuntu 14.04 has reached EOL in 2019.


### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.