### PR TITLE
Added missing redirect

### DIFF
--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -21,6 +21,7 @@ redirects:
   - /docs/apis/getting-started/intro-apis/understand-new-relic-api-keys
   - /docs/apis/get-started/intro-apis/understand-new-relic-api-keys
   - /docs/apis/get-started/intro-apis/types-new-relic-api-keys
+  - /docs/apis/get-started/intro-apis/new-relic-api-keys/
 ---
 
 New Relic has several different [APIs](/docs/apis/getting-started/intro-apis/introduction-new-relic-apis) that each require their own type of API key to use. This resource describes our API keys, what they're used for, and how to access them.


### PR DESCRIPTION
An internal contributor pointed out a google search result pointed to a 404. This PR adds a redirect for the page to this doc.