### PR TITLE
Add Java 7 eol link to agent 6.5.0 release notes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-650.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-650.mdx
@@ -25,6 +25,8 @@ support has been deprecated and this will be the last version of the agent compa
 
 If you are running Java 7, you may continue to use Java agent 6.5.0 or lower.
 
+For more information, see the [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-across-synthetics-apm-java-php-infrastructure-mobile-agents-health-maps-statsd-and-legacy-dashboards/147982).
+
 ### Support statement:
 * New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and
   performance benefits. Additionally, older releases will no longer be supported when they reach


### PR DESCRIPTION
### Give us some context
Adds a link in the Java Agent 6.5.0 release notes to the Explorer Hub post with info about Java 7 EoL.

### Are you making a change to site code?
No