### PR TITLE
Fix broken build due to missing tags

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/fluentd-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/fluentd-plugin-log-forwarding.mdx
@@ -179,7 +179,7 @@ By default the Fluentd plugin forwards logs to New Relic's US endpoint: `https:/
        </match>
        ```
    </Collapser>
-
+ </CollapserGroup>
 
 <CollapserGroup>
      <Collapser
@@ -216,6 +216,7 @@ By default the Fluentd plugin forwards logs to New Relic's US endpoint: `https:/
        </match>
        ```
    </Collapser>
+ </CollapserGroup>
 
 ## Test the Fluentd plugin [#test-plugin]
 


### PR DESCRIPTION
Build was broken due to some missing collapser tags, this fixes them.