### PR TITLE
Adding a few redirects for Insights docs

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/create-widgets-dashboards-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/create-widgets-dashboards-api.mdx
@@ -7,6 +7,9 @@ tags:
 metaDescription: Use New Relic NerdGraph to add and configure dashboards.
 redirects:
   - /docs/apis/nerdgraph/examples/dashboards-api-widgets
+  - /docs/insights/insights-api/
+  - /docs/insights/event-data-sources/insights-api/
+  - /docs/insights/event-data-sources/insights-api/insights-dashboard-api/
 ---
 
 With the New Relic dashboards API you can use [NerdGraph](https://api.newrelic.com/graphiql) to build your [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards). This document explains the different types of widgets you can add to your dashboards, and how to create and get them using the API.


### PR DESCRIPTION
A few Insights docs are giving 404, this PR fixes those.

So far I'm redirecting Insights API related docs to https://docs.newrelic.com/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/