### PR TITLE
Add pie chart troubleshooting to pie chart section

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/use-charts/chart-types.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/use-charts/chart-types.mdx
@@ -541,7 +541,7 @@ SELECT uniqueCount(name) FROM Transaction
 
     You can add only one `FACET` in basic query mode. If you're using NRQL, you can use `FACET` to add up to 5 attributes, separated by commas, and also include the [`TIMESERIES`](/docs/insights/nrql-new-relic-query-language/nrql-reference/nrql-syntax-components-functions#sel-timeseries) function.
 
-    Pie charts are unavailable for the following [aggregator functions](/docs/insights/new-relic-insights/using-new-relic-query-language/nrql-reference#functions): `average`, `apdex`, `min`, `max`, `percentage`, and `percentile`. For `uniqueCount`, percentages [may add up to more than 100%.](/docs/insights/nrql-new-relic-query-language/troubleshooting/pie-chart-uniquecount-adds-more-100)
+    Pie charts are unavailable for the following [aggregator functions](/docs/insights/new-relic-insights/using-new-relic-query-language/nrql-reference#functions): `average`, `apdex`, `min`, `max`, `percentage`, and `percentile`. For `uniqueCount`, percentages [may add up to more than 100%](#pie-percentage-problem).
 
     <table>
       <tbody>
@@ -564,8 +564,16 @@ SELECT uniqueCount(name) FROM Transaction
             Present data that does not use values as they related to a whole, such as with line charts.
           </td>
         </tr>
+        
       </tbody>
     </table>
+
+### Pie chart percentage problem [#pie-percentage-problem]
+
+When using a pie chart with the [`uniqueCount`](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions#func-uniqueCount) aggregator function, the percentages can add up to more than 100%. This is because the attributes being uniquely counted may be present in multiple facets. For example, in the query `SELECT uniqueCount(user) FROM PageView FACET appName`, a single unique user may use multiple apps. Each of these users are included in the unique value for each of the appropriate facets (apps), but the total number of unique users won't change.
+
+To solve this, use a [bar chart](#widget-barchart) or [table](#widget-table) to provide a more accurate visualization of `uniqueCount` data.
+
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
When doing DOC-6819, Insights cat deprecation, realized I'd forgot to add back this 'pie chart percentage' doc into the pie chart section. 