### PR TITLE
docs: add logstash max retries configuration

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/logstash-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/logstash-plugin-log-forwarding.mdx
@@ -118,6 +118,20 @@ Once you have [installed](#logstash-plugin) and [configured](#configure-plugin) 
         EU endpoint: `https://log-api.eu.newrelic.com/log/v1`
       </td>
     </tr>
+    
+    <tr>
+      <td>
+        `max_retries`
+      </td>
+
+      <td>
+        Maximum number attempts to retry to send a message. If set to 0, no re-attempts will be made.
+      </td>
+
+      <td>
+        3
+      </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
### Give us some context
`logstash-pluing` v1.2.0 introduce a new setting to configure max retries when ingesting logs to NR. I'm adding this information on our public doc.