### PR TITLE
Update gitignore path to swiftype-resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,4 +77,4 @@ yarn-error.log
 
 .vscode
 
-./src/data/swiftype-resources.json
+src/data/swiftype-resources.json


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

Since changing the swiftype resource fetch process we want to gitignore the file created on build and not check it in (it's too large anyway). seems it wasn't actually getting ignored so this alters the path to the file