### PR TITLE
Remove https prefix from bare URLs in link text

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/new-relic-license-key.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/new-relic-license-key.mdx
@@ -29,7 +29,7 @@ You can view the license key for your New Relic account in the [API keys page](h
 1. From the [account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown), select **Account settings**.
 2. Select **API keys** from the options at the side of the page.
 
-You can also get to the **API keys** page by navigating directly to [https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher).
+You can also get to the **API keys** page by navigating directly to [one.newrelic.com/launcher/api-keys-ui.api-keys-launcher](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher).
 
 From there, you can view and manage your license key as well as other [types of API keys](/docs/apis/get-started/intro-apis/types-new-relic-api-keys).
 

--- a/src/content/docs/accounts/accounts/automated-user-management/azure-ad-scimsso-application-configuration.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/azure-ad-scimsso-application-configuration.mdx
@@ -20,7 +20,7 @@ Before using this guide, read our [AUM requirements](/docs/assign-users-automate
 
 Azure AD provides an application gallery, which includes various integrations for Azure AD, including the ones that New Relic offers. Add the New Relic SCIM/SSO application to your list of applications.
 
-1. Go to the Azure Active Directory admin center, and sign in if necessary. [https://aad.portal.azure.com/](https://aad.portal.azure.com/)
+1. Go to the Azure Active Directory admin center, and sign in if necessary. [aad.portal.azure.com/](https://aad.portal.azure.com/)
 2. Click on **All services** in the left hand menu.
 3. In the main pane, click on **Enterprise applications**.
 4. Click on **+New Application**.

--- a/src/content/docs/accounts/install-new-relic/partner-based-installation/log-install-new-relic-partners.mdx
+++ b/src/content/docs/accounts/install-new-relic/partner-based-installation/log-install-new-relic-partners.mdx
@@ -97,7 +97,7 @@ These partners require specific login and deployment procedures for you to use y
   >
     To create an account through [Rackspace Cloud Tools](https://www.rackspace.com) and sign into New Relic, follow these basic procedures. For more information, see [Rackspace Cloud Load Balancer plugin](/docs/accounts-partnerships/accounts/install-new-relic/partner-based-installation/rackspace-cloud-load-balancer-plugin).
 
-    1. Log in to your CloudTools account at [https://cloudtools.rackspace.com/myapps](https://cloudtools.rackspace.com/myapps).
+    1. Log in to your CloudTools account at [cloudtools.rackspace.com/myapps](https://cloudtools.rackspace.com/myapps).
     2. From **Use Your Applications**, select **New Relic**.
     3. Select your agent language (Java, .NET, PHP, Python, Ruby), then follow the online instructions to complete the installation process.
     4. Wait for New Relic to begin collecting data for your app.
@@ -122,7 +122,7 @@ These partners require specific login and deployment procedures for you to use y
 
     To install the New Relic plugin for W3 Edge/Wordpress users:
 
-    1. Log in to your WordPress account at [https://wordpress.org/support/bb-login.php](https://wordpress.org/support/bb-login.php).
+    1. Log in to your WordPress account at [wordpress.org/support/bb-login.php](https://wordpress.org/support/bb-login.php).
     2. Follow [New Relic's instructions](https://docs.newrelic.com/docs/agents/php-agent/installation/wordpress-users-new-relic) to complete the installation process, or contact [W3TC support](http://wordpress.org/support/plugin/w3-total-cache) for assistance.
     3. Wait for New Relic to begin collecting data.
 

--- a/src/content/docs/accounts/install-new-relic/partner-based-installation/rackspace-cloud-load-balancer-plugin.mdx
+++ b/src/content/docs/accounts/install-new-relic/partner-based-installation/rackspace-cloud-load-balancer-plugin.mdx
@@ -53,7 +53,7 @@ bundle install -binstubs
 
 After the plugin installs successfully, you can select it in New Relic:
 
-1. Sign in to your New Relic account at [https://rpm.newrelic.com/login](https://rpm.newrelic.com/login).
+1. Sign in to your New Relic account at [rpm.newrelic.com/login](https://rpm.newrelic.com/login).
 2. From the New Relic UI, select the Rackspace Cloud Load Balancer icon.
 
 From here you can select load balancer(s), view traffic, configure alerts, and more.

--- a/src/content/docs/agents/go-agent/installation/install-new-relic-go.mdx
+++ b/src/content/docs/agents/go-agent/installation/install-new-relic-go.mdx
@@ -35,7 +35,7 @@ The Go agent requires Golang 1.7 or higher on Linux, macOS, or Windows. For more
 
 In order to install the Go agent, you need a [New Relic license key](/docs/accounts-partnerships/accounts/account-setup/license-key). Then, to install the agent:
 
-1. From [https://github.com/newrelic/go-agent](https://github.com/newrelic/go-agent), use your preferred process; for example:
+1. From [github.com/newrelic/go-agent](https://github.com/newrelic/go-agent), use your preferred process; for example:
 
    ```
    go get github.com/newrelic/go-agent

--- a/src/content/docs/agents/python-agent/installation/python-agent-admin-script-advanced-usage.mdx
+++ b/src/content/docs/agents/python-agent/installation/python-agent-admin-script-advanced-usage.mdx
@@ -54,7 +54,7 @@ By default the sample configuration file will be directed to standard output and
 
 When the sample agent configuration file is generated, only the license key option in the file is updated. You should still edit the file and make changes to `app_name` and `log_file` options as appropriate. For more information, see [Python agent installation](/docs/python/python-agent-installation).
 
-If you cannot run the `generate-config` command to produce the initial agent configuration file, you can download a sample configuration file from [https://download.newrelic.com/python_agent/release/newrelic.ini](https://download.newrelic.com/python_agent/release/newrelic.ini).
+If you cannot run the `generate-config` command to produce the initial agent configuration file, you can download a sample configuration file from [download.newrelic.com/python_agent/release/newrelic.ini](https://download.newrelic.com/python_agent/release/newrelic.ini).
 
 ## validate-config config_file \[log_file] [#validate-config]
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/muting-rules-suppress-notifications.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/muting-rules-suppress-notifications.mdx
@@ -218,7 +218,7 @@ A muting rule has the following fields and components:
 
         * `startTime`: The datetime stamp that represents when the muting rule starts. This is in local ISO 8601 format without an offset. Example: '2020-07-08T14:30:00'
         * `endTime`: The datetime stamp that represents when the muting rule ends. This is in local ISO 8601 format without an offset. Example: '2020-07-15T14:30:00'
-        * `timeZone`: The time zone that applies to the muting rule schedule. Example: 'America/Los_Angeles'. See [https://en.wikipedia.org/wiki/List_of_tz_database_time_zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+        * `timeZone`: The time zone that applies to the muting rule schedule. Example: 'America/Los_Angeles'. See [Wikipedia's list of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
         * repeat: The frequency the muting rule schedule repeats. If it does not repeat, use null. Options are DAILY, WEEKLY, MONTHLY.
         * endRepeat: The datetime stamp when the muting rule schedule stops repeating. This is in local ISO 8601 format without an offset. Example: '2020-07-10T15:00:00'. Note: Either `endRepeat` or `repeatCount` should be used to end a muting rule schedule. Both fields should not be provided together.
         * repeatCount: The number of times the muting rule schedule repeats. This includes the original schedule. For example, a `repeatCount` of 2 will recur one time. A `repeatCount` of 3 will recur two times. Note: Either `repeatCount` or `endRepeat` can be used to end a muting rule schedule. Both fields should not be provided together.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names.mdx
@@ -135,7 +135,7 @@ Not every field listed in this glossary is required for every condition type. Th
     id="external_service_url"
     title="external_service_url"
   >
-    This is the URL of the external service to be monitored. This string must **not** include the protocol. For example, use <var>example.com</var>, not <var>[https://example.com](https://example.com)</var>.
+    This is the URL of the external service to be monitored. This string must **not** include the protocol. For example, use `example.com`, not `https://example.com`.
 
     Used for:
 

--- a/src/content/docs/apis/nerdgraph/examples/configure-infinite-tracing-graphql.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/configure-infinite-tracing-graphql.mdx
@@ -26,7 +26,7 @@ As described in our [docs on the tail-based sampling algorithms](/docs/understan
 
 The following example shows you how to update the value from the default of 1%:
 
-1. Go to the NerdGraph GraphiQL explorer at [https://api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
+1. Go to the NerdGraph GraphiQL explorer at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
 2. Execute the following query to find the trace observer that contains the random sampler to modify:
 
    ```
@@ -163,7 +163,7 @@ Here's the response confirming the change:
 
 Here's how you can change the name of a trace observer:
 
-1. Go to the NerdGraph GraphiQL explorer at [https://api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
+1. Go to the NerdGraph GraphiQL explorer at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
 2. Find the trace observer whose name you'd like to update:
 
    ```

--- a/src/content/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api.mdx
@@ -22,7 +22,10 @@ If your dashboard has [a single page](/docs/dashboards/manage-your-dashboard/man
 1. Obtain the dashboard's GUID: Click the <Icon name="fe-info"/>
    icon by the dashboard's name to access the **See metadata and manage tags** modal and see the dashboard's GUID.
 2. Run the **dashboardCreateSnapshotURL** mutation in the [NerdGraphQL explorer](https://api.newrelic.com/graphiql) with the GUID as a parameter.
-3. Get the link to retrieve your dashboard as a PDF. The link looks similar to [https://gorgon.nr-assets.net/image/e0c22263-2d88-40bc-940a-b885dbc1d98d?...](https://gorgon.nr-assets.net/image/e0c22263-2d88-40bc-940a-b885dbc1d98d?format=PDF&width=2000&height=2000)
+3. Get the link to retrieve your dashboard as a PDF. The link looks similar to:
+```
+https://gorgon.nr-assets.net/image/e0c22263-2d88-40bc-940a-b885dbc1d98d?format=PDF&width=2000&height=2000
+```
 4. [Configure](#configure) the exported file, if necessary.
 
 ## Export multiple-page dashboards [#dash-multiple]
@@ -57,7 +60,13 @@ For dashboards with multiple pages, first you need to obtain the GUID for each i
 
 Edit the returned link to change the format of your export (PDF or PNG), or resize it.
 
-For example, if you obtain the link [https://gorgon.nr-assets.net/image/e0c22263-2d88-40bc-940a-b885dbc1d98d?...](https://gorgon.nr-assets.net/image/e0c22263-2d88-40bc-940a-b885dbc1d98d?format=)<mark>PDF</mark>&<mark>width=2000&height=2000</mark>
+For example, if you obtain the link:
+
+```
+https://gorgon.nr-assets.net/image/e0c22263-2d88-40bc-940a-b885dbc1d98d?format=<mark>PDF</mark>&<mark>width=2000&height=2000</mark>
+``` 
+
+You could:
 
 * Substitute `PDF` for `PNG` to get an image.
 * Modify the width and height fields to adjust the size to your needs. The maximum value is `2000`.

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial.mdx
@@ -33,7 +33,7 @@ Before querying cloud integration data with NerdGraph, ensure you have:
 
 To access the NerdGraph GraphiQL explorer:
 
-1. Go to [https://api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
+1. Go to [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
 2. Add any of the following examples.
 
 ## Query examples [#queries]

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-distributed-trace-data-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-distributed-trace-data-tutorial.mdx
@@ -17,7 +17,7 @@ You can use New Relic's [NerdGraph GraphiQL explorer](https://api.newrelic.com/g
 
 ## Trace metadata
 
-In addition to [span event and transaction event data](/docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works#trace-structure), we calculate additional metadata about the trace and its span relationships. To query this metadata, go to the NerdGraph GraphiQL explorer at [https://api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
+In addition to [span event and transaction event data](/docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works#trace-structure), we calculate additional metadata about the trace and its span relationships. To query this metadata, go to the NerdGraph GraphiQL explorer at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
 
 Additional trace-level data:
 

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial.mdx
@@ -14,13 +14,13 @@ redirects:
   - /docs/query-data/nrql-new-relic-query-language/query-tools/nrql-api-queries
 ---
 
-You can use the [New Relic NerdGraph GraphiQL explorer](/docs/introduction-new-relic-graphql) to make [New Relic Query Language (NRQL)](/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) queries. To learn how to construct these queries and see responses, go to the NerdGraph GraphiQL explorer at [https://api.newrelic.com/graphiql](https://api.newrelic.com/graphiql). This document explains some of the available functions for NRQL queries.
+You can use the [New Relic NerdGraph GraphiQL explorer](/docs/introduction-new-relic-graphql) to make [New Relic Query Language (NRQL)](/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) queries. To learn how to construct these queries and see responses, go to the NerdGraph GraphiQL explorer at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql). This document explains some of the available functions for NRQL queries.
 
 ## Basic NRQL queries with NerdGraph [#basic-queries]
 
 To make NRQL queries using NerdGraph:
 
-1. Go to the NerdGraph GraphiQL explorer at [https://api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
+1. Go to the NerdGraph GraphiQL explorer at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
 2. Pass the NRQL query as a string argument to the NRQL object, and include the `results` field in your NerdGraph query.
 
 For example, to get a count of all [transaction events](/docs/insights/insights-data-sources/default-data/apm-default-event-attributes-insights#transaction-event) in the last hour, use the following query:

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial.mdx
@@ -19,7 +19,7 @@ This doc explains how to use our NerdGraph API to add and manage tags. For a gui
 
 To construct these queries and see responses:
 
-1. Go to the NerdGraph GraphiQL explorer at [https://api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
+1. Go to the NerdGraph GraphiQL explorer at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
 2. Use [`entitySearch()`](/docs/apis/graphql-api/tutorials/use-new-relic-graphql-api-query-entities#search-entity) to find the entity and then fetch its tags.
 3. Use NerdGraph's tag API to read the existing tags and their values.
 
@@ -48,7 +48,7 @@ The actual values vary depending on your data. Use the [New Relic GraphiQL explo
 
 To add new tags for an entity:
 
-1. Go to the NerdGraph GraphiQL explorer at [https://api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
+1. Go to the NerdGraph GraphiQL explorer at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
 2. Use [`entitySearch()`](/docs/apis/graphql-api/tutorials/use-new-relic-graphql-api-query-entities#search-entity) to locate the GUID for the entity you want to tag.
 3. Use the `taggingAddTagsToEntity` mutation to add a tag with a value to the entity.
 
@@ -70,7 +70,7 @@ mutation {
 
 To delete a tag and all of its associated values from an entity:
 
-1. Go to the NerdGraph GraphiQL explorer at [https://api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
+1. Go to the NerdGraph GraphiQL explorer at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
 2. Use [`entitySearch()`](/docs/apis/graphql-api/tutorials/use-new-relic-graphql-api-query-entities#search-entity) to locate the GUID for the entity with the tag you want to remove.
 3. Use the `taggingDeleteTagFromEntity` mutation.
 
@@ -92,7 +92,7 @@ mutation {
 
 Instead of deleting an entire tag and all of its values, you can delete a single tag value.
 
-1. Go to the NerdGraph GraphiQL explorer at [https://api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
+1. Go to the NerdGraph GraphiQL explorer at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
 2. Use [`entitySearch()`](/docs/apis/graphql-api/tutorials/use-new-relic-graphql-api-query-entities#search-entity) to locate the GUID for the entity with the tag you want to remove.
 3. Use the `taggingDeleteTagValuesFromEntity` mutation.
 
@@ -116,7 +116,7 @@ Because `tagValues` is an array, you can delete multiple specific values from a 
 
 To replace the entity’s entire set of tags with the provided tag set:
 
-1. Go to the NerdGraph GraphiQL explorer at [https://api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
+1. Go to the NerdGraph GraphiQL explorer at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
 2. Use [`entitySearch()`](/docs/apis/graphql-api/tutorials/use-new-relic-graphql-api-query-entities#search-entity) to locate the GUID for the entity with the tag you want to remove.
 3. Use the `taggingReplaceTagsOnEntity` mutation.
 

--- a/src/content/docs/apis/rest-api-v2/api-explorer-v2/introduction-new-relics-rest-api-explorer.mdx
+++ b/src/content/docs/apis/rest-api-v2/api-explorer-v2/introduction-new-relics-rest-api-explorer.mdx
@@ -36,7 +36,7 @@ For information on API keys, see [REST API keys](/docs/apis/rest-api-v2/getting-
 ![This is an example of the API Explorer homepage](./images/API_explorer_main_page.png "API_explorer_main_page.png")
 
 <figcaption>
-  **[https://rpm.newrelic.com/api/explore](https://rpm.newrelic.com/api/explore)**: The New Relic API Explorer makes it easy to test and send requests for any API endpoint. After you select your account and your choice of functions for the type of API call (applications, browsers, users, etc.), the UI provides an interactive form to view requirements and test your parameter values.
+  **[rpm.newrelic.com/api/explore](https://rpm.newrelic.com/api/explore)**: The New Relic API Explorer makes it easy to test and send requests for any API endpoint. After you select your account and your choice of functions for the type of API call (applications, browsers, users, etc.), the UI provides an interactive form to view requirements and test your parameter values.
 </figcaption>
 
 ## Differences from API version 1 [#v1]

--- a/src/content/docs/browser/new-relic-browser/installation/update-browser-agent.mdx
+++ b/src/content/docs/browser/new-relic-browser/installation/update-browser-agent.mdx
@@ -25,7 +25,7 @@ The numbers that follow `nr-` are your current version. For example, `js-agent.n
 
 To verify the latest version of the Browser script loader:
 
-1. Go to [https://js-agent.newrelic.com/nr-loader-full-current.min.js](https://js-agent.newrelic.com/nr-loader-full-current.min.js) .
+1. Go to [js-agent.newrelic.com/nr-loader-full-current.min.js](https://js-agent.newrelic.com/nr-loader-full-current.min.js) .
 2. Search for `js-agent.newrelic.com/nr-`, then note the numbers that follow `nr-`.
 
 If the latest version number is higher than the number of the version you are currently running, update your Browser agent.

--- a/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
+++ b/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
@@ -246,7 +246,7 @@ This diagram shows several important concepts:
   * **External**. If a client span has any attributes prefixed with `http.` (like `http.url`) or has a child span in another process, it's categorized as an external span. This is a general category for any external calls that are not datastore queries.
 * **Trace duration**. A trace's total duration is determined by the length of time from the start of the earliest span to the completion of the last span.
 
-You can query span relationship data with the [NerdGraph GraphiQL explorer](/docs/apis/graphql-api/tutorials/query-distributed-trace-data-using-graphql-api) at [https://api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
+You can query span relationship data with the [NerdGraph GraphiQL explorer](/docs/apis/graphql-api/tutorials/query-distributed-trace-data-using-graphql-api) at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
 
 ## How trace data is stored [#trace-storage]
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent.mdx
@@ -97,7 +97,7 @@ If you used the default installation process, use your package manager to update
   >
     To manually update the infrastructure agent on Windows Server:
 
-    1. Download the latest .MSI installer image from [https://download.newrelic.com/infrastructure_agent/windows/386/newrelic-infra-386.msi](https://download.newrelic.com/infrastructure_agent/windows/386/newrelic-infra-386.msi)
+    1. Download the latest .MSI installer image from [download.newrelic.com/infrastructure_agent/windows/386/newrelic-infra-386.msi](https://download.newrelic.com/infrastructure_agent/windows/386/newrelic-infra-386.msi)
     2. Run the install script. To install from the Windows command prompt, run:
 
        ```
@@ -113,7 +113,7 @@ If you used the default installation process, use your package manager to update
   >
     To manually update the infrastructure agent on Windows Server:
 
-    1. Download the latest .MSI installer image from [https://download.newrelic.com/infrastructure_agent/windows/newrelic-infra.msi](https://download.newrelic.com/infrastructure_agent/windows/newrelic-infra.msi)
+    1. Download the latest .MSI installer image from [download.newrelic.com/infrastructure_agent/windows/newrelic-infra.msi](https://download.newrelic.com/infrastructure_agent/windows/newrelic-infra.msi)
     2. Run the install script. To install from the Windows command prompt, run:
 
        ```

--- a/src/content/docs/infrastructure/new-relic-infrastructure/troubleshooting/incorrect-host-name-reported.mdx
+++ b/src/content/docs/infrastructure/new-relic-infrastructure/troubleshooting/incorrect-host-name-reported.mdx
@@ -11,7 +11,7 @@ redirects:
 
 ## Problem
 
-The agent is working, but the \[New Relic Infrastructure monitoring UI]([https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-compute-page-measure-resource-usage](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-compute-page-measure-resource-usage)) shows the wrong hostname.
+The agent is working, but the [infrastructure monitoring UI](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-compute-page-measure-resource-usage) shows the wrong hostname.
 
 ## Solution
 

--- a/src/content/docs/instrumentation-editor-instrument-net-ui.mdx
+++ b/src/content/docs/instrumentation-editor-instrument-net-ui.mdx
@@ -78,7 +78,7 @@ To use the **Instrumentation** editor, you must meet the following requirements:
 
 To use the **Instrumentation** editor:
 
-1. Go to **[https://rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select a .NET app) > Settings > Instrumentation**.
+1. Go to **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select a .NET app) > Settings > Instrumentation**.
 2. Use the **Instrumentation** editor to provide XML using the same syntax as described for [editing local .xml instrumentation files](/docs/agents/net-agent/custom-instrumentation/create-transactions-xml-net) and [adding instrumentation detail.](/docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net) Use any of these options from the UI:
 
    * Type in XML code directly.

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-auto-scaling-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-auto-scaling-monitoring-integration.mdx
@@ -23,7 +23,7 @@ To enable this integration:
 
 To enable group metrics using the console:
 
-1. Open the Amazon EC2 console at [https://console.aws.amazon.com/ec2/](https://console.aws.amazon.com/ec2/).
+1. Open the Amazon EC2 console at [console.aws.amazon.com/ec2/](https://console.aws.amazon.com/ec2/).
 2. From the navigation pane, select **Auto Scaling Groups > (select your group)**.
 3. From the **Monitoring** tab, select **Auto Scaling Metrics > Enable Group Metrics Collection** or **Display > Auto Scaling**.
 

--- a/src/content/docs/integrations/grafana-integrations/set-configure/configure-new-relic-prometheus-data-source-grafana.mdx
+++ b/src/content/docs/integrations/grafana-integrations/set-configure/configure-new-relic-prometheus-data-source-grafana.mdx
@@ -33,8 +33,8 @@ Follow these steps to add New Relic as a Prometheus data source for Grafana. The
    * Off: this is not your default data source
    * On: this is your default data source
 6. Enter the correct **URL**:
-   * US: [https://prometheus-api.newrelic.com](https://prometheus-api.newrelic.com)
-   * EU: [https://prometheus-api.eu.newrelic.com](https://prometheus-api.eu.newrelic.com)
+   * US: [prometheus-api.newrelic.com](https://prometheus-api.newrelic.com)
+   * EU: [prometheus-api.eu.newrelic.com](https://prometheus-api.eu.newrelic.com)
 7. Under **Custom Headers**, select **Add Header**. Set the **Header** name to **X-Query-Key.** For the **Value**, enter to the Query key you created in step 1.
 8. Click **Save & Test**.
 

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
@@ -185,9 +185,12 @@ In the [install procedure](#install), you run `nri-statsd` with environment vari
 <Callout variant="tip">
   To ensure FedRAMP compliance when using the StatsD integration you must define the following endpoints in the custom configuration:
 
-  _address = '[https://gov-insights-collector.newrelic.com/v1/accounts/](https://gov-insights-collector.newrelic.com/v1/accounts/)$\_NR_ACCOUNT_ID_/events'\_
+  ```address = 'https://gov-insights-collector.newrelic.com/v1/accounts/  <var>$NR_ACCOUNT_ID</var>/events'
+  ```
 
-  _address-metrics = '[https://gov-infra-api.newrelic.com/metric/v1](https://gov-infra-api.newrelic.com/metric/v1)'_
+  ```
+  address-metrics = 'https://gov-infra-api.newrelic.com/metric/v1'
+  ```
 </Callout>
 
 Here are some examples of customizing configuration by overwriting the default configuration:

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
@@ -185,7 +185,8 @@ In the [install procedure](#install), you run `nri-statsd` with environment vari
 <Callout variant="tip">
   To ensure FedRAMP compliance when using the StatsD integration you must define the following endpoints in the custom configuration:
 
-  ```address = 'https://gov-insights-collector.newrelic.com/v1/accounts/  <var>$NR_ACCOUNT_ID</var>/events'
+  ```
+  address = 'https://gov-insights-collector.newrelic.com/v1/accounts/  <var>$NR_ACCOUNT_ID</var>/events'
   ```
 
   ```

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/vmware-vsphere-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/vmware-vsphere-monitoring-integration.mdx
@@ -90,7 +90,7 @@ To install the vSphere integration, choose your setup:
   >
     1. Download the `nri-vsphere` MSI installer image from:
 
-       [https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-vsphere/nri-vsphere-amd64.msi](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-vsphere/nri-vsphere-amd64.msi)
+       [download.newrelic.com/infrastructure_agent/windows/integrations/nri-vsphere/nri-vsphere-amd64.msi](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-vsphere/nri-vsphere-amd64.msi)
     2. To install from the Windows command prompt, run:
 
        ```

--- a/src/content/docs/integrations/kubernetes-integration/installation/kubernetes-integration-install-configure.mdx
+++ b/src/content/docs/integrations/kubernetes-integration/installation/kubernetes-integration-install-configure.mdx
@@ -73,7 +73,7 @@ Before starting our [automated installer](https://one.newrelic.com/launcher/k8s-
 
     Before starting our [automated installer](https://one.newrelic.com/launcher/k8s-cluster-explorer-nerdlet.cluster-explorer-launcher?pane=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsInBhdGgiOiJndWlkZWQiLCJlbnYiOiJrdWJlcm5ldGVzIiwiaW5pdGlhbEFjdGlvbkluZGV4IjpudWxsLCJhY3Rpb25JbmRleCI6MX0=) to deploy the Kubernetes integration on GKE, ensure you have sufficient permissions:
 
-    1. Go to [https://console.cloud.google.com/iam-admin/iam](https://console.cloud.google.com/iam-admin/iam) and find your username. Click **edit**.
+    1. Go to [console.cloud.google.com/iam-admin/iam](https://console.cloud.google.com/iam-admin/iam) and find your username. Click **edit**.
     2. Ensure you have permissions to create `Roles` and `ClusterRoles`: If you are not sure, add the **Kubernetes Engine Cluster Admin** role. If you cannot edit your user role, ask the owner of the GCP project to give you the necessary permissions.
     3. Ensure you have a `RoleBinding` that grants you the same permissions to create `Roles` and `ClusterRoles`:
 

--- a/src/content/docs/integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
+++ b/src/content/docs/integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
@@ -17,7 +17,7 @@ The New Relic explorer is a good place to get overview information about your ap
 
 To get started with the explorer:
 
-1. Open [https://one.newrelic.com](https://one.newrelic.com), and go to **explorer**.
+1. Open [one.newrelic.com](https://one.newrelic.com), and go to **explorer**.
 2. Using the filter bar at the top, narrow your searches:
    1. Limit results to OpenTelemetry entities with the following:
       ![Screen capture showing how to filter for OpenTelemetry.](./images/explorer_filter_1.png "explorer_filter_1.png")
@@ -39,7 +39,7 @@ When you access distributed tracing through the explorer, you are looking at tra
 For more ways to filter and analyze your spans, see our [distributed tracing UI](/docs/understand-dependencies/distributed-tracing/ui-data/understand-use-distributed-tracing-ui) page.
 
 <Callout variant="tip">
-  If you prefer to search traces across all New Relic accounts in your organization, you can go outside explorer: **[https://one.newrelic.com](https://one.newrelic.com) > Apps > Favorites > Distributed tracing.**
+  If you prefer to search traces across all New Relic accounts in your organization, you can go outside explorer: **[one.newrelic.com](https://one.newrelic.com) > Apps > Favorites > Distributed tracing.**
 </Callout>
 
 ### Transactions [#trx]

--- a/src/content/docs/mobile-apps/new-relic-mobile-apps/authentication-alerts/troubleshoot-sso-accounts-using-mobile-devices.mdx
+++ b/src/content/docs/mobile-apps/new-relic-mobile-apps/authentication-alerts/troubleshoot-sso-accounts-using-mobile-devices.mdx
@@ -26,7 +26,7 @@ You may not have a user name or password for New Relic because some SAML provide
 
 ## Errors after signing in [#sso-errors]
 
-If you see any errors after successfully signing in to your SSO provider with your mobile device, verify that you are able to sign in to [https://rpm.newrelic.com](https://rpm.newrelic.com) with a desktop web browser.
+If you see any errors after successfully signing in to your SSO provider with your mobile device, verify that you are able to sign in to [one.newrelic.com](https://one.newrelic.com) with a desktop web browser.
 
 * If no, contact your administrator.
 * If yes, get support at [support.newrelic.com](https://support.newrelic.com).

--- a/src/content/docs/mobile-apps/new-relic-mobile-apps/authentication-alerts/user-settings-authentication.mdx
+++ b/src/content/docs/mobile-apps/new-relic-mobile-apps/authentication-alerts/user-settings-authentication.mdx
@@ -84,7 +84,7 @@ Depending on your New Relic account, additional installation or authentication s
       <td>
         When you sign in to the New Relic mobile app, your session automatically redirects to your web browser. From there you can sign in to your New Relic SAML-SSO account.
 
-        If you see any errors when using SAML-SSO accounts on your mobile device, verify that you are able to sign in to [https://rpm.newrelic.com](https://rpm.newrelic.com) with a desktop web browser.
+        If you see any errors when using SAML-SSO accounts on your mobile device, verify that you are able to sign in to [one.newrelic.com](https://one.newrelic.com) with a desktop web browser.
 
         * If no, contact your administrator.
         * If yes, get support at [support.newrelic.com](https://support.newrelic.com).

--- a/src/content/docs/new-relic-partnerships/partner-integration-guide/getting-started/support-resources-new-relic-partners.mdx
+++ b/src/content/docs/new-relic-partnerships/partner-integration-guide/getting-started/support-resources-new-relic-partners.mdx
@@ -23,9 +23,9 @@ To obtain support for partner accounts, create a ticket at [support.newrelic.com
 
 ## Documentation [#docs]
 
-Documentation from [New Relic's Docs site](https://docs.newrelic.com/docs/) is an important resource for your support group when providing Level 1 support to your New Relic subscribers. Posting these links on your support pages is an effective way to encourage self help and reduce your support efforts.
+Documentation from [New Relic's Docs site](https://docs.newrelic.com) is an important resource for your support group when providing Level 1 support to your New Relic subscribers. Posting these links on your support pages is an effective way to encourage self help and reduce your support efforts.
 
-Top level entry point for New Relic documentation: [https://docs.newrelic.com/docs/](https://docs.newrelic.com/docs/). From here you can select information about New Relic products and features by category.
+Top level entry point for New Relic documentation: [docs.newrelic.com](https://docs.newrelic.com). From here you can select information about New Relic products and features by category.
 
 <Callout variant="tip">
   The Docs site includes a [Partnerships](/docs/accounts-partnerships/partnerships) category with information for New Relic partners and some partnership customers.

--- a/src/content/docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/optimize-your-cloud-spend.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/optimize-your-cloud-spend.mdx
@@ -38,28 +38,6 @@ Include charts for various Infrastructure metrics related to performance and usa
 
 You may also want to include charts that represent the application using this cloud infrastructure. In this way you can correlate the cloud infrastructure performance with that of the application. As you right-size your cloud infrastructure, you will want to monitor application performance to make sure you are achieving any targets.
 
-Here is an example of an Insights dashboard for cloud performance.
-
-<CollapserGroup>
-  <Collapser
-    id="data-by-performance"
-    title="Break out data by cloud performance and application metrics"
-  >
-    The following dashboard shows several charts that present key cloud infrastructure metrics and an associated application metric. Every one of these charts represents the result of a query.
-
-    \[Downs: Updated image based on New Relic One can be found at:  
-    [https://www.dropbox.com/s/rjq7tqrswxwtte9/Tutorial-Run-OptimizeCloudSpen...](https://www.dropbox.com/s/rjq7tqrswxwtte9/Tutorial-Run-OptimizeCloudSpend-image1.png)
-
-    Image caption: one.newrelic.com > Dashboards: Create dashboards that include both cloud infrastructure and application metrics.]
-
-    ![Cloud performance example AppX](./images/CloudPerformanceForAppX.png "Cloud performance example AppX")
-
-    <figcaption>
-      [**insights.newrelic.com**](https://insights.newrelic.com): Create dashboards that include both cloud infrastructure and application metrics.
-    </figcaption>
-  </Collapser>
-</CollapserGroup>
-
 ## 3. Configure the Amazon AWS integration [#configure-aws-integration]
 
 New Relic Infrastructure comes with several types of integrations, including [Amazon Web Services (AWS)](/docs/integrations/amazon-integrations/aws-integrations-list), [Microsoft Azure](/docs/integrations/microsoft-azure-integrations/azure-integrations-list), and [on-host integrations](/docs/integrations/host-integrations/host-integrations-list).
@@ -79,39 +57,6 @@ When creating **Budgets**, be sure to:
 ## 5. Add cloud spend and budget widgets to Insights dashboard [#spend-budget-widgets]
 
 [New Relic Insights](/docs/insights) is the product that you use to write powerful custom queries about your data, and then visualize the results in widgets that you collect on a dashboard. You can also feed the results of your Insights queries directly into [New Relic Alerts](https://docs.newrelic.com/docs/alerts/new-relic-alerts/getting-started/introduction-new-relic-alerts), where you can get notifications on any deviations that you specify.
-
-Here are some examples of ways to use Insights dashboards to visualize your AWS cloud spend data.
-
-<CollapserGroup>
-  <Collapser
-    id="data-by-budget"
-    title="Break out data by application and by AWS budget"
-  >
-    The following dashboard shows several widgets that present key information about an AWS budget vs. actual spending, with data broken out by an application AWS budget. Every one of these widgets represents the result of an Insights query, and the data in the supporting Insights tables is the data that our integration automatically receives from AWS.
-
-    \[Downs: Updated image based on New Relic One can be found at:
-
-    [https://www.dropbox.com/s/ecp5mrnkezh6hjh/Tutorial-Run-OptimizeCloudSpen...](https://www.dropbox.com/s/ecp5mrnkezh6hjh/Tutorial-Run-OptimizeCloudSpend-image2.png)
-
-    Image caption: one.newrelic.com > Dashboards: Add charts that include AWS cloud and budgets data.]
-
-    \[Downs: put this 'code' section below the image please.
-
-    Here is the query to create the Application X Cloud Cost budget chart in this dashboard example:
-
-    ```
-    SELECT latest(`provider.actualAmount`) as '$ Actual', latest(`provider.forecastedAmount`) as '$ Forecast', max(`provider.limitAmount`) as '$ Limit' FROM FinanceSample WHERE provider = 'BillingBudget' AND `provider.budgetName` = '<var>NAME_OF_YOUR_CLOUD_BUDGET</var>'
-    ```
-
-    ]
-
-    ![Cloud performance example AppXwSpend](./images/CloudPerformanceForAppXwSpend.png "Cloud performance example AppXwSpend")
-
-    <figcaption>
-      [**insights.newrelic.com**](https://insights.newrelic.com): Create dashboards that include AWS cloud and budgets.
-    </figcaption>
-  </Collapser>
-</CollapserGroup>
 
 ## 6. Create dashboards for every level of your organization [#create-dashboards]
 

--- a/src/content/docs/query-your-data/explore-query-data/dashboards/explore-public-api-performance-dashboard.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/explore-public-api-performance-dashboard.mdx
@@ -24,7 +24,7 @@ The dashboard works by showing real latencies experienced by an anonymized sampl
 
 If the Public API Performance dashboard isn't already visible in your UI, you can add it easily.
 
-1. Enable the dashboard from [https://one.newrelic.com/](https://one.newrelic.com/):
+1. Enable the dashboard from [one.newrelic.com/](https://one.newrelic.com/):
    * New customers: The dashboard is enabled by default and added to the favorites list for all new accounts.
    * Existing customers: If the dashboard hasn't already been enabled, you can add it by clicking your avatar and selecting **Add your data**.
 2. Click the **Public API Performance** tile to open the account selector, then click **Add and view pre-built dashboard**

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-370.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-370.mdx
@@ -9,5 +9,5 @@ downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.7.0'
 
 ### Changes
 
-* When `Config.Transport` is nil, no longer use the `http.DefaultTransport` when communicating with the New Relic backend. This addresses an issue with shared transports as described in [https://github.com/golang/go/issues/33006](https://github.com/golang/go/issues/33006).
+* When `Config.Transport` is nil, no longer use the `http.DefaultTransport` when communicating with the New Relic backend. This addresses an issue with shared transports as described in [golang/go#33006](https://github.com/golang/go/issues/33006).
 * If a timeout occurs when attempting to send data to the New Relic backend, instead of dropping the data, we save it and attempt to send it with the next harvest. Note [data retention limits](https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/apm-data-retention) still apply and the agent will still start to drop data when these limits are reached. We attempt to keep the highest priority events and traces.

--- a/src/content/docs/security/new-relic-security/security-bulletins/notification-apolloio-security-incident.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/notification-apolloio-security-incident.mdx
@@ -33,7 +33,7 @@ We are currently investigating who is impacted, but we believe that the vendorâ€
 
 **What happened?**
 
-New Relic was recently notified by Apollo.io that personal data that we shared with them in accordance with our Privacy Policy was exposed by a breach. We then started our investigation to learn more about the scope of the data involved. Our privacy policy is described further at: [https://newrelic.com/termsandconditions/privacy](https://newrelic.com/termsandconditions/privacy). New Relic did not sell the data to Apollo, but shared it solely to assist in providing services to New Relic.
+New Relic was recently notified by Apollo.io that personal data that we shared with them in accordance with our Privacy Policy was exposed by a breach. We then started our investigation to learn more about the scope of the data involved. Our privacy policy is described further at: [newrelic.com/termsandconditions/privacy](https://newrelic.com/termsandconditions/privacy). New Relic did not sell the data to Apollo, but shared it solely to assist in providing services to New Relic.
 
 **What data was compromised?**
 

--- a/src/content/docs/security/new-relic-security/security-bulletins/solarwinds-orion.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/solarwinds-orion.mdx
@@ -20,4 +20,4 @@ As a proactive measure, New Relic security has conducted a review of our process
 
 In accordance with our own vendor risk management program, New Relic has initiated communication with critical vendors to determine whether they use the SolarWinds product in any of the services they provide to us. Based on their response, New Relic will identify and take appropriate steps to mitigate the risk to our company and our customers.
 
-The security and privacy of our customers is our top priority, and we are continuing to follow the SolarWinds situation closely. We encourage customers with questions to contact us at [https://support.newrelic.com/](https://support.newrelic.com/).
+The security and privacy of our customers is our top priority, and we are continuing to follow the SolarWinds situation closely. We encourage customers with questions to contact us at [support.newrelic.com/](https://support.newrelic.com/).

--- a/src/content/docs/style-guide/writing-guidelines/code-formatting-guidelines-var-mark.mdx
+++ b/src/content/docs/style-guide/writing-guidelines/code-formatting-guidelines-var-mark.mdx
@@ -32,7 +32,7 @@ For some use cases, [highlighting](#highlighting) may be a better choice than a 
 Below are some general style recommendations for formatting user-specific `<var>` values. `<var>` tag formatting may vary based on language- or system-specific expectations, so be sure check the style used in the documentation section in question, and to ask relevant SMEs what they think of the style.
 
 * Account IDs and other IDs/#s: YOUR_ACCOUNT_ID, YOUR_API_CODE, etc. **This should be the general style used.**
-* URLs: [https://example.com](https://example.com), or maybe YOUR_URL
+* URLs: [example.com](https://example.com), or maybe YOUR_URL
 * Paths: PATH/TO/SOMETHING.exe or maybe PATH_TO_FILE
 * Emails: [datanerd@example.com](mailto:datanerd@example.com) or maybe YOUR_EMAIL
 * Bash variables for REST API code: Some `<var>` tagged code values on the docs site have the form $&#x7B;API_KEY}. This is a format used for variables in bash scripts, where users assign values to specific variable names and then call those variables later in the script by using the $VARIABLE_NAME. For more info, see this [explanation of bash variables](http://tldp.org/HOWTO/Bash-Prog-Intro-HOWTO-5.html).

--- a/src/content/docs/style-guide/writing-guidelines/hyperlinks.mdx
+++ b/src/content/docs/style-guide/writing-guidelines/hyperlinks.mdx
@@ -25,6 +25,7 @@ Follow these guidelines when writing text for hyperlinks:
 * **Location:** Include a clear, concise text label to identify where the link goes. Give extra context if you're linking to an external site. Why are you sending someone there?
 * **Click here:** Do not use "click here" or other meaningless link labels.
 * **"Link test:"** Read just the links, without the surrounding text. Can each stand alone as a clear description of where the link goes if that is all the user looks at on the page?
+* **Avoid URL prefixes:** If you're sending users to an address where you want to use the URL as the link text, drop the `https:` and `www.` prefixes from the link text. For example, [github.com](https://github.com) not [https://github.com/](https://github.com). Or [github.com/newrelic/docs-website](https://github.com/newrelic/docs-website/), not [https://github.com/newrelic/docs-website](https://github.com/newrelic/docs-website/).
 
 Take the link test for these three examples. The last is the best for readers looking for information on configuring PHP, because the link clearly identifies it, without having to read anything else on the page.
 

--- a/src/content/docs/style-guide/writing-guidelines/hyperlinks.mdx
+++ b/src/content/docs/style-guide/writing-guidelines/hyperlinks.mdx
@@ -79,7 +79,7 @@ Take the link test for these three examples. The last is the best for readers lo
 **Never include a hyperlink to the Support email address.** This prevents spam and ensures customers use the ticket submission form to create tickets so they receive the correct support priority. If you need to tell customers to contact support, use this instead:
 
 ```
-Get support at [https://support.newrelic.com](support.newrelic.com).
+Get support at [support.newrelic.com](support.newrelic.com).
 ```
 
 ## Docs site ("internal") links [#Hyperlinks-internal]

--- a/src/content/docs/using-new-relic/welcome-new-relic/get-started/glossary.mdx
+++ b/src/content/docs/using-new-relic/welcome-new-relic/get-started/glossary.mdx
@@ -707,7 +707,7 @@ A glossary of common terminology you may encounter.
   >
     [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) is our GraphQL API, an efficient and flexible query language that lets you request exactly the data you need, without over-fetching or under-fetching. NerdGraph calls get all the data you need in a single request. NerdGraph also makes it easier to evolve APIs over time and enables powerful developer tools.
 
-    You can use our [NerdGraph GraphiQL explorer](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer) to explore the schema and find definitions. With [valid New Relic API key](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#authentication), you can try it out yourself at [https://api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
+    You can use our [NerdGraph GraphiQL explorer](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer) to explore the schema and find definitions. With [valid New Relic API key](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#authentication), you can try it out yourself at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
### Give us some context

Per Slack conversation earlier today, we'd like link text for "bare" URLs to drop the https and www prefixes in most cases. 

Please test locally since this change affects a fairly large number of docs.

This PR:

* Sweeps the site for links like `[https://one.newrelic.com](https://one.newrelic.com)` and changes them to `[one.newrelic.com](https://one.newrelic.com)`
* Updates the style guide doc on hyperlinks
* Fixes a few malformed links that seem to have been created by the migration script

Notes:

* Did not remove from legal docs in case having the https there is helpful
* Did not remove from old release notes (low ROI)
* Used this vscode search to find offending links
![image](https://user-images.githubusercontent.com/55203603/118048700-7e613000-b331-11eb-8f34-e42242e05597.png)
