### PR TITLE
Rank homepage integrations in alpha order

### DIFF
--- a/src/data/homepage.yml
+++ b/src/data/homepage.yml
@@ -47,6 +47,14 @@ security:
 integrations:
   - title: Back-end, front-end, and mobile applications
     tiles:
+      - name: Android
+        icon: logo-android-color
+        link: /docs/mobile-monitoring/new-relic-mobile-android/get-started/introduction-new-relic-mobile-android
+
+      - name: Browser (JavaScript)
+        icon: logo-javascript
+        link: /docs/browser
+
       - name: C SDK
         icon: logo-c
         link: /docs/agents/c-sdk
@@ -54,6 +62,10 @@ integrations:
       - name: Go
         icon: logo-go
         link: /docs/agents/go-agent
+
+      - name: iOS
+        icon: logo-apple-color
+        link: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/introduction-new-relic-mobile-ios
 
       - name: Java
         icon: logo-java
@@ -79,24 +91,16 @@ integrations:
         icon: logo-ruby
         link: /docs/agents/ruby-agent
 
-      - name: Android
-        icon: logo-android-color
-        link: /docs/mobile-monitoring/new-relic-mobile-android/get-started/introduction-new-relic-mobile-android
-
-      - name: iOS
-        icon: logo-apple-color
-        link: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/introduction-new-relic-mobile-ios
-
-      - name: Browser
-        icon: logo-javascript
-        link: /docs/browser
-
       - name: Synthetics
         icon: logo-newrelic
         link: /docs/synthetics
 
   - title: Infrastructure and cloud platforms
     tiles:
+      - name: Apache
+        icon: logo-apache
+        link: /docs/integrations/host-integrations/host-integrations-list/apache-monitoring-integration
+
       - name: AWS
         icon: logo-aws
         link: /docs/integrations/amazon-integrations
@@ -109,25 +113,17 @@ integrations:
         icon: logo-gcloud
         link: /docs/integrations/google-cloud-platform-integrations
 
-      - name: Linux
-        icon: logo-linux
-        link: /docs/infrastructure/install-configure-manage-infrastructure/linux-installation/install-infrastructure-linux-using-package-manager
-
-      - name: Windows
-        icon: logo-windows
-        link: /docs/infrastructure/install-configure-manage-infrastructure/windows-installation/install-infrastructure-windows-server-using-msi-installer
+      - name: Kafka
+        icon: logo-kafka
+        link: /docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration
 
       - name: Kubernetes
         icon: logo-kubernetes
         link: /docs/integrations/kubernetes-integration/get-started/introduction-kubernetes-integration
 
-      - name: Apache
-        icon: logo-apache
-        link: /docs/integrations/host-integrations/host-integrations-list/apache-monitoring-integration
-
-      - name: Kafka
-        icon: logo-kafka
-        link: /docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration
+      - name: Linux
+        icon: logo-linux
+        link: /docs/infrastructure/install-configure-manage-infrastructure/linux-installation/install-infrastructure-linux-using-package-manager
 
       - name: Microsoft SQL
         icon: logo-mssql
@@ -152,6 +148,10 @@ integrations:
       - name: Redis
         icon: logo-redis
         link: /docs/integrations/host-integrations/host-integrations-list/redis-monitoring-integration
+
+      - name: Windows
+        icon: logo-windows
+        link: /docs/infrastructure/install-configure-manage-infrastructure/windows-installation/install-infrastructure-windows-server-using-msi-installer
 
   - title: Open-source monitoring systems
     tiles:


### PR DESCRIPTION
Note for reviewer: Please pull down and test locally, since this change affects the homepage.

### Give us some context

* The order of the integrations tiles on the homepage were intended to reflect importance
* There are so many tiles, though, that the order isn't intuitive to the reader
* This PR switches order for each section to simple alpha order

**Before**:

![image](https://user-images.githubusercontent.com/55203603/118052383-799f7a80-b337-11eb-9b58-678a57b56fb2.png)

**After**:

![image](https://user-images.githubusercontent.com/55203603/118052395-802df200-b337-11eb-82d8-d83c06d0952a.png)