### PR TITLE
chore: changed Trace API link

### DIFF
--- a/src/content/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing.mdx
@@ -44,7 +44,7 @@ To start setting up Infinite Tracing, and to see specific requirements, see the 
 
 * Our [language agents](/docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing)
 * Our [integrations for third-party telemetry tools](/docs/integrations/open-source-telemetry-integrations)
-* Our [Trace API](/docs/understand-dependencies/distributed-tracing/trace-api)
+* Our [Trace API](https://docs.newrelic.com/docs/distributed-tracing/trace-api/introduction-trace-api/)
 
 ## Configure Infinite Tracing [#configure]
 


### PR DESCRIPTION
This link was leading to a `404`

