### PR TITLE
Remove remaining rpm.newrelic.com pathing

### DIFF
--- a/src/content/docs/accounts/install-new-relic/partner-based-installation/heroku-install-new-relic-add.mdx
+++ b/src/content/docs/accounts/install-new-relic/partner-based-installation/heroku-install-new-relic-add.mdx
@@ -167,8 +167,8 @@ In accordance with the terms of New Relic's partnership with Heroku, customers w
   >
     To sign into or switch between your regular New Relic accounts:
 
-    1. Sign in to New Relic's login page at [newrelic.com/login](https://rpm.newrelic.com/login).
-    2. To switch from one regular New Relic account to another: Go to: **[account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown) > Switch account**, and select an account.
+    1. Sign in to New Relic at **[one.newrelic.com](https://one.newrelic.com)**.
+    2. To switch from one regular New Relic account to another: Go to: **[account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown) and select an account.
 
     If you sign in directly through New Relic, you will not see any of your New Relic add-on accounts from Heroku when you select **[account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown) > Switch account**.
   </Collapser>

--- a/src/content/docs/accounts/original-accounts-billing/original-data-retention/event-data-retention-original-pricing-plan.mdx
+++ b/src/content/docs/accounts/original-accounts-billing/original-data-retention/event-data-retention-original-pricing-plan.mdx
@@ -234,7 +234,7 @@ Requirements to use this feature:
     ![Flex retention is found in the account usage UI.](./images/Account_usage_flex-retention.png "Account_usage_flex-retention.png")
 
     <figcaption>
-      Go to **[rpm.newrelic.com](https://rpm.newrelic.com) > ([account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown)) > Account settings > Usage > Data management section**: you can view your current retention plans, modify them, and perform overrides, all in the UI.
+      Go to **[one.newrelic.com](https://one.newrelic.com) > ([account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown)) > Account settings > Usage > Data management section**: You can view your current retention plans, modify them, and perform overrides, all in the UI.
     </figcaption>
   </Collapser>
 

--- a/src/content/docs/agents/java-agent/index.mdx
+++ b/src/content/docs/agents/java-agent/index.mdx
@@ -22,7 +22,7 @@ redirects:
   ![View a summary of your Java app's performance with APM.](./images/Java_agent_landing_image.png "Java_agent_landing_image.png")
 
   <figcaption>
-    **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Overview**: After installing the Java agent, view a summary of your app's performance.
+    **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Overview**: After installing the Java agent, view a summary of your app's performance.
   </figcaption>
 </LandingPageHero>
 

--- a/src/content/docs/agents/manage-apm-agents/configuration/server-side-agent-configuration.mdx
+++ b/src/content/docs/agents/manage-apm-agents/configuration/server-side-agent-configuration.mdx
@@ -48,14 +48,8 @@ For more information about the hierarchy of settings, see the illustration for t
 
 The C SDK and PHP agent do not support server-side configuration. To enable server-side configuration settings for apps that use other New Relic agents:
 
-1. Go to **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Settings > Application > Server-side agent configuration**.
-
-   OR
-
-   Go to **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm)**. Next, from the [index of applications](/docs/apm/applications-menu/monitoring/view-your-applications-index), select the app's gear <Icon name="fe-settings"/>
-   icon, then select **View settings > Server-side agent configuration**.
-2. Set the **Server-side configuration enabled** toggle to **On**.
-3. Select **Save server-side configuration**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com)** and click **APM**.
+2. Click on your app. Then click **Settings > Application > Server-side agent configuration**.
 
 After you enable server-side configuration, you can view and change the available settings through the UI.
 
@@ -69,14 +63,8 @@ If you use server-side configuration, you must still include your `license_key` 
 
 The C SDK and PHP agent do not support server-side configuration. To view or change the available server-side configuration settings through the UI for apps that use other New Relic agents:
 
-1. Go to **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Settings > Application > Server-side agent configuration**.
-
-   OR
-
-   Go to **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm)**. Next, from the [index of applications](/docs/apm/applications-menu/monitoring/view-your-applications-index), select the app's gear <Icon name="fe-settings"/>
-   icon, then select **View settings > Server-side agent configuration**.
-2. View or change the available configuration settings for your agent.
-3. If you make changes, select **Save server-side configuration**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com)** and click **APM**.
+2. Click on your app. Then click **Settings > Application > Server-side agent configuration**.
 
 Once you set any of these options from the UI, they will override any conflicting options in the [agent's configuration file](#precedence).
 

--- a/src/content/docs/agents/manage-apm-agents/configuration/view-config-values-your-app.mdx
+++ b/src/content/docs/agents/manage-apm-agents/configuration/view-config-values-your-app.mdx
@@ -20,4 +20,4 @@ You need an easy way to get information about your application's configuration s
   **Owner**, **Admins**, or **Add-on managers**
 </Callout>
 
-If you do not want to view your configuration file itself, you can view the configuration settings in the APM UI, go to **[rpm.newrelic.com](https://rpm.newrelic.com) > (select an app) > Settings > Environment > Agent initialization**.
+If you do not want to view your configuration file itself, you can view the configuration settings in the APM UI, go to **[one.newrelic.com](https://one.newrelic.com)** and click **APM**. Click your app, then click **Settings > Environment > Agent initialization**.

--- a/src/content/docs/agents/manage-apm-agents/troubleshooting/get-environment-data-about-your-apm-app.mdx
+++ b/src/content/docs/agents/manage-apm-agents/troubleshooting/get-environment-data-about-your-apm-app.mdx
@@ -21,7 +21,7 @@ You need an easy way to get information about your application's environment, su
 
 ## Solution
 
-To see which services and settings apply to an agent, or to see which agent uses a specific service or setting, go to **[rpm.newrelic.com](https://rpm.newrelic.com) > (select an app) > Settings > Environment > Environment snapshot**.
+To see which services and settings apply to an agent, or to see which agent uses a specific service or setting, go to **[one.newrelic.com](https://one.newrelic.com)**. Click on your app in the list, then click **Settings > Environment > Environment snapshot**.
 
 The **Environment snapshot** page helps you connect payloads from agents that include environment data, so you have a sense of what monitoring data is recorded. This also helps you more easily identify discrepancies across your services, and determine what might need to be updated.
 
@@ -30,7 +30,7 @@ In the following example, the user mouses over the second agent on the list. Mos
 ![Screenshot showing how to troubleshoot apm agent.](/images/troubleshooting-apm-environment.png "troubleshooting-apm-environment.png")
 
 <figcaption>
-  **[rpm.newrelic.com](https://rpm.newrelic.com) > (select an app) > Settings > Environment > Environment snapshot:** To see specific settings that apply to an agent and its services, or to see which of a setting's values apply to specific agents, mouse over any agent or value.
+  **[one.newrelic.com](https://one.newrelic.com) > APM > Settings > Environment > Environment snapshot:** To see specific settings that apply to an agent and its services, or to see which of a setting's values apply to specific agents, mouse over any agent or value.
 </figcaption>
 
 Information on the **Environment snapshot** page depends on the APM agent you use. For example, apps using the Ruby agent show settings for gems, while apps using the Java agent show settings for jars.

--- a/src/content/docs/agents/net-agent/troubleshooting/profiler-conflicts.mdx
+++ b/src/content/docs/agents/net-agent/troubleshooting/profiler-conflicts.mdx
@@ -96,7 +96,7 @@ To avoid a profiler conflict, fully remove the other profiler from the environme
     id="registry-keys"
     title="3. Restore New Relic registry keys or environment variables."
   >
-    Once the conflicting profiler has been disabled, you still may need to restore the New Relic registry keys or, if using Instrument All, the [system-wide](https://docs.newrelic.com/docs/agents/net-agent/troubleshooting/profiler-conflicts#check-conflicts) [](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration#net-framework-env-variables) [environment](https://docs.newrelic.com/docs/agents/net-agent/troubleshooting/profiler-conflicts#check-conflicts) [](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration#net-framework-env-variables) [variables](https://docs.newrelic.com/docs/agents/net-agent/troubleshooting/profiler-conflicts#check-conflicts).
+    Once the conflicting profiler has been disabled, you still may need to restore the New Relic registry keys or, if using Instrument All, the [system-wide environment variables](/docs/agents/net-agent/troubleshooting/profiler-conflicts#check-conflicts).
 
     To resolve the profiler conflict for IIS applications, either re-run the installer and use the `Repair` feature, or restore the registry settings manually using PowerShell:
 

--- a/src/content/docs/agents/nodejs-agent/index.mdx
+++ b/src/content/docs/agents/nodejs-agent/index.mdx
@@ -24,7 +24,7 @@ redirects:
   ![View a summary of your Node.js app's performance with APM.](./images/APM_Node_landing-page_0.png "APM_Node_landing-page.png")
 
   <figcaption>
-    **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Overview:** The APM **Overview** page includes charts and tables showing your Node.js app's performance at a glance, plus links to end user performance in New Relic Browser, hosts monitored by New Relic Infrastructure, data analysis via New Relic Insights, and more.
+    **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Overview:** The APM **Overview** page includes charts and tables showing your Node.js app's performance at a glance, plus links to end user performance in New Relic Browser, hosts monitored by New Relic Infrastructure, data analysis via New Relic Insights, and more.
   </figcaption>
 </LandingPageHero>
 

--- a/src/content/docs/agents/ruby-agent/background-jobs/monitor-ruby-background-processes.mdx
+++ b/src/content/docs/agents/ruby-agent/background-jobs/monitor-ruby-background-processes.mdx
@@ -93,7 +93,7 @@ NewRelic::Agent.manual_start(:sync_startup => true)
 
 Using `require 'new_relic/agent'` will require the agent's code, and it will make sure the agent doesn't run until you manually start it.
 
-If the process is shorter than the agent [harvest cycle](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/glossary#harvest-cycle), you need to manually shut down the agent with [`::NewRelic::Agents.shutdown`](https://www.rubydoc.info/github/newrelic/rpm/NewRelic%2FAgent:shutdown) to ensure all queued data is sent.
+If the process is shorter than the agent [harvest cycle](/docs/using-new-relic/welcome-new-relic/get-started/glossary#harvest-cycle), you need to manually shut down the agent with [`::NewRelic::Agents.shutdown`](https://www.rubydoc.info/github/newrelic/rpm/NewRelic%2FAgent:shutdown) to ensure all queued data is sent.
 
 ## Configure newrelic.yml for background processes [#config_file]
 

--- a/src/content/docs/agents/ruby-agent/frameworks/mongo-instrumentation.mdx
+++ b/src/content/docs/agents/ruby-agent/frameworks/mongo-instrumentation.mdx
@@ -67,7 +67,7 @@ This summarizes the Ruby agent's support for gems by version.
       </td>
 
       <td>
-        Support for Mongoid 2/3/4 and Moped currently is available only via third-party gems. For links to the relevant projects, see the [plugin list](https://github.com/newrelic/rpm_contrib#new-relic-ruby-agent-plugins-seperate-projects "Link opens in a new window") on `rpm_contrib`.
+        Support for Mongoid 2/3/4 and Moped currently is available only via third-party gems. For links to the relevant projects, see the [plugin list](https://github.com/newrelic/rpm_contrib#new-relic-ruby-agent-plugins-seperate-projects) on `rpm_contrib`.
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/agents/ruby-agent/index.mdx
+++ b/src/content/docs/agents/ruby-agent/index.mdx
@@ -26,7 +26,7 @@ redirects:
   ![Ruby app's Overview in New Relic APM](./images/ruby-apm-app_0.png "Ruby app's Overview in New Relic APM")
 
   <figcaption>
-    **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Overview:** The APM **Overview** page includes charts and tables showing your Ruby app's performance at a glance, plus links to end user performance in New Relic Browser, hosts monitored by New Relic Infrastructure, data analysis via New Relic Insights, and more.
+    **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Overview:** The APM **Overview** page includes charts and tables showing your Ruby app's performance at a glance, plus links to end user performance in New Relic Browser, hosts monitored by New Relic Infrastructure, data analysis via New Relic Insights, and more.
   </figcaption>
 </LandingPageHero>
 

--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/filterable-geography-webpage-metrics-location.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/filterable-geography-webpage-metrics-location.mdx
@@ -34,12 +34,12 @@ Also, firewalls may have an impact on the geographical data collected about your
 ![New Relic Browser: Filterable Geography](./images/screen-browser-filter-geography.png "New Relic Browser: Filterable Geography")
 
 <figcaption>
-  **[rpm.newrelic.com/browser](https://rpm.newrelic.com/browser) > (select an app) > Browser app > Filterable Geography:** Here is an example of the map before drilling down into detailed information about London, England.
+  **[one.newrelic.com](https://one.newrelic.com) > Browser > (select an app) > Browser app > Filterable Geography:** Here is an example of the map before drilling down into detailed information about London, England.
 </figcaption>
 
 To view or sort the performance information by location:
 
-1. Go to **[rpm.newrelic.com/browser](https://rpm.newrelic.com/browser) > (select an app) > Filterable Geography**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com) > Browser > (select an app) > Filterable Geography**.
 2. Select the [type of performance data](#type) to view from the dropdown, or use the default **Average page load time**.
 3. To drill down to a [specific area](#functions), mouse over or select any area on the geographical map, or select any of the ten worst performing locations from the list to the right of the map.
 4. To view specific performance metrics, select any of the [attributes](#filter) below the funnel <Icon name="fe-filter"/>
@@ -140,7 +140,7 @@ Use any of New Relic's standard [user interface functions](/docs/accounts-partne
 ![Browser: Filterable Geography (London zoom)](./images/crop-filter-geo-london3.png "Browser: Filterable Geography (London zoom)")
 
 <figcaption>
-  **[rpm.newrelic.com/browser](https://rpm.newrelic.com/browser) > (select an app) > Browser app > Filterable Geography:** Here is an example of the map as you use filter and zoom tools to drill down into detailed information about London, England. Athough overall throughput for the area is good (green), the nearby yellow areas, and the smaller red and orange circles indicate nearby cities with varying levels of throughput problems, not the size of those cities.
+  **[one.newrelic.com](https://one.newrelic.com) > Browser > (select an app) > Browser app > Filterable Geography:** Here is an example of the map as you use filter and zoom tools to drill down into detailed information about London, England. Athough overall throughput for the area is good (green), the nearby yellow areas, and the smaller red and orange circles indicate nearby cities with varying levels of throughput problems, not the size of those cities.
 </figcaption>
 
 The Filterable Geography heat map identifies performance quality with color and with the size of circles.
@@ -220,7 +220,7 @@ The filtered results appear on the geographical map, where you can use any of th
   >
     In this example, your organization is preparing to renew a peering agreement with the owner of an autonomous system, called "My-ASN." You are concerned that continued outages and other connection issues are affecting customer satisfaction with your site, and you want to compare its performance with other ASNs. You have a New Relic Browser Pro account.
 
-    1. Go to **[rpm.newrelic.com/browser](https://rpm.newrelic.com/browser) > (select an app) > Filterable Geography**.
+    1. Go to **[one.newrelic.com](https://one.newrelic.com) > Browser > (select an app) > Filterable Geography**.
     2. From the performance type dropdown, select **Connection setup**.
     3. Select the funnel <Icon name="fe-filter"/>
        icon.
@@ -241,7 +241,7 @@ The filtered results appear on the geographical map, where you can use any of th
   >
     In this example, your organization has a special three-day sales promotion for an upcoming holiday. Your **holiday-merchandise** page has undergone major changes, including dozens of new images. You want to look for performance problems with page rendering on Android mobile devices during this sales period. You have a New Relic Browser Pro account.
 
-    1. Go to **[rpm.newrelic.com/browser](https://rpm.newrelic.com/browser) > (select an app) > Filterable Geography**.
+    1. Go to **[one.newrelic.com](https://one.newrelic.com) > Browser > (select an app) > Filterable Geography**.
     2. Use the [time picker](/docs/data-analysis/user-interface-functions/time-picker-setting-time-periods-view-data) to change the date range to the promotion period.
     3. From the performance type dropdown, select **Page rendering**.
     4. Select the funnel <Icon name="fe-filter"/>
@@ -262,7 +262,7 @@ Charts on the **Page load performance** and **Historical performance** tabs auto
 ![Browser Filterable Geography Comparative Performance charts](./images/crop-browser-filterable-geo-comparative.png "Browser Filterable Geography Comparative Performance charts")
 
 <figcaption>
-  **[rpm.newrelic.com/browser](https://rpm.newrelic.com/browser) > (select an app) > Browser app > Filterable Geography:** Charts on the **Page load performance** and **Historical performance** tabs automatically refresh with details for the selected location.
+  **[one.newrelic.com](https://one.newrelic.com) > Browser > (select an app) > Browser app > Filterable Geography:** Charts on the **Page load performance** and **Historical performance** tabs automatically refresh with details for the selected location.
 </figcaption>
 
 The **Page load performance** tab shows two charts. The **Average page load time** chart includes:

--- a/src/content/docs/csp-v2-host-install-browser-agent.mdx
+++ b/src/content/docs/csp-v2-host-install-browser-agent.mdx
@@ -95,7 +95,7 @@ Content-Security-Policy: default-src 'self' https://js-agent.newrelic.com https:
 
 To create and host a `.js` file, you must first copy the Browser agent's JavaScript snippet from the hosting app.
 
-1. Go to **[rpm.newrelic.com/browser](https://rpm.newrelic.com/browser)**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com)** and click **Browser**.
 2. From the list of Browser apps, select the app for which you want to self-host the Browser agent.
 3. Select **Settings > Application settings > Copy/paste JavaScript code**.
 4. Copy the Browser agent's JavaScript snippet.

--- a/src/content/docs/csp-v2-monitor-salesforce.mdx
+++ b/src/content/docs/csp-v2-monitor-salesforce.mdx
@@ -80,7 +80,7 @@ Follow the [Salesforce procedures](https://help.salesforce.com/articleView?id=cs
 
 To create and host a `.js` file, you must first copy the Browser agent's JavaScript snippet from the hosting app.
 
-1. Go to **[rpm.newrelic.com/browser](https://rpm.newrelic.com/browser)**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com)** and click **Browser**..
 2. From the list of Browser apps, select the app for which you want to self-host the Browser agent.
 3. Select **Settings > Application settings > Copy/paste JavaScript code**.
 4. Copy the Browser agent's JavaScript snippet.

--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent.mdx
@@ -177,5 +177,3 @@ After you've installed the infrastructure monitoring agent:
 * Install [on-host integrations](/docs/integrations/host-integrations/getting-started/introduction-host-integrations) (for example, for Apache or MySQL).
 * [Enable log forwarding using the infrastructure agent](/docs/logs/enable-new-relic-logs/1-enable-logs/forward-your-logs-using-new-relic-infrastructure).
 * Learn how to [manage the agent](/docs/infrastructure/install-infrastructure-agent/manage-your-agent).
-
-  [](/docs/logs/enable-new-relic-logs/1-enable-logs/forward-your-logs-using-new-relic-infrastructure)

--- a/src/content/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/uninstall-infrastructure-integrations.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/uninstall-infrastructure-integrations.mdx
@@ -98,7 +98,7 @@ To uninstall any of your integrations, follow the procedure corresponding to the
           <td>
             To disable services while keeping your Azure account linked to New Relic:
 
-            1. From [i](https://infra.newrelic.com)**[one.newrelic.com](http://one.newrelic.com) > Infrastructure** **> Azure > Manage services**.
+            1. Go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure > Manage services**.
             2. From your **Edit Azure account** page, clear the checkbox for each active service you want to disable.
             3. Save your changes.
           </td>

--- a/src/content/docs/instrumentation-editor-instrument-net-ui.mdx
+++ b/src/content/docs/instrumentation-editor-instrument-net-ui.mdx
@@ -69,7 +69,7 @@ To use the **Instrumentation** editor, you must meet the following requirements:
 ![APM Settings: .NET instrumentation](./images/net-instrumentation.png "APM Settings: .NET instrumentation")
 
 <figcaption>
-  **[rpm.newrelic.com](https://rpm.newrelic.com) > (select a .NET app) > Settings > Instrumentation:** The **Instrumentation** editor provides an easy way to view or edit your custom instrumentation in the UI. This XML example shows the assembly name, class name, and method name.
+  **[one.newrelic.com](https://one.newrelic.com) > APM > (select a .NET app) > Settings > Instrumentation:** The **Instrumentation** editor provides an easy way to view or edit your custom instrumentation in the UI. This XML example shows the assembly name, class name, and method name.
 </figcaption>
 
 <Callout variant="important">
@@ -78,7 +78,7 @@ To use the **Instrumentation** editor, you must meet the following requirements:
 
 To use the **Instrumentation** editor:
 
-1. Go to **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select a .NET app) > Settings > Instrumentation**.
+1. Go to [one.newrelic.com](https://one.newrelic.com) and click **APM**. Find your app, then click **Settings > Instrumentation**.
 2. Use the **Instrumentation** editor to provide XML using the same syntax as described for [editing local .xml instrumentation files](/docs/agents/net-agent/custom-instrumentation/create-transactions-xml-net) and [adding instrumentation detail.](/docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net) Use any of these options from the UI:
 
    * Type in XML code directly.

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/amazon-transit-gateway-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/amazon-transit-gateway-monitoring-integration.mdx
@@ -26,7 +26,7 @@ Default [polling](/docs/infrastructure/amazon-integrations/aws-integrations-list
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > AWS** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > AWS** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-appsync-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-appsync-monitoring-integration.mdx
@@ -26,7 +26,7 @@ Default [polling](/docs/infrastructure/amazon-integrations/aws-integrations-list
 
 ## Find and use data [#find-data]
 
-To find your integration data in Infrastructure, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > AWS** and select an integration.
+To find your integration data in Infrastructure, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > AWS** and select an integration.
 
 You can [query and explore your data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data) using this [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-athena-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-athena-monitoring-integration.mdx
@@ -26,7 +26,7 @@ Default [polling](/docs/infrastructure/amazon-integrations/aws-integrations-list
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to **[infrastructure.newrelic.com](https://infrastructure.newrelic.com/ "Link opens in a new window.") > AWS** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > AWS** and select an integration.
 
 You can [query and explore your data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data) using this [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-connect-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-connect-monitoring-integration.mdx
@@ -24,7 +24,7 @@ Default [polling](/docs/infrastructure/amazon-integrations/aws-integrations-list
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > AWS** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > AWS** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-direct-connect-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-direct-connect-monitoring-integration.mdx
@@ -26,7 +26,7 @@ Default [polling](/docs/infrastructure/amazon-integrations/aws-integrations-list
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > AWS** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > AWS** and select an integration.
 
 You can [query and explore your data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data) using the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-documentdb-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-documentdb-monitoring-integration.mdx
@@ -26,7 +26,7 @@ Default [polling](/docs/infrastructure/amazon-integrations/aws-integrations-list
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > AWS** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > AWS** and select an integration.
 
 You can [query and explore your data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data) using the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-elemental-mediaconvert-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-elemental-mediaconvert-monitoring-integration.mdx
@@ -26,7 +26,7 @@ Default [polling](/docs/infrastructure/amazon-integrations/aws-integrations-list
 
 ## Find and use data [#find-data]
 
-To find your integration data in Infrastructure, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > AWS** and select an integration.
+To find your integration data in Infrastructure, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > AWS** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-kinesis-data-analytics-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-kinesis-data-analytics-monitoring-integration.mdx
@@ -27,7 +27,7 @@ Default [polling](/docs/infrastructure/amazon-integrations/aws-integrations-list
 
 ## Find and use data [#find-data]
 
-To find your integration data in Infrastructure, go to **[infrastructure.newrelic.com](https://infrastructure.newrelic.com/ "Link opens in a new window.") > AWS** and select an integration.
+To find your integration data in Infrastructure, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > AWS** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-mq-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-mq-integration.mdx
@@ -26,7 +26,7 @@ Default [polling](/docs/infrastructure/amazon-integrations/aws-integrations-list
 
 ## View and query data [#find-data]
 
-To view your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > AWS** and select an integration.
+To view your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > AWS** and select an integration.
 
 You can [query and explore your data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data) using the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-neptune-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-neptune-monitoring-integration.mdx
@@ -26,7 +26,7 @@ Default [polling](/docs/infrastructure/amazon-integrations/aws-integrations-list
 
 ## View and use data [#find-data]
 
-To [view and use your integration data](https://docs.newrelic.com/docs/infrastructure/integrations/find-use-infrastructure-integration-data), go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > AWS** and select an integration.
+To [view and use your integration data](https://docs.newrelic.com/docs/infrastructure/integrations/find-use-infrastructure-integration-data), go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > AWS** and select an integration.
 
 You can [query and explore your data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data) using the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-step-functions-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-step-functions-monitoring-integration.mdx
@@ -26,7 +26,7 @@ Default [polling](/docs/infrastructure/amazon-integrations/aws-integrations-list
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > AWS** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > AWS** and select an integration.
 
 You can [query and explore your data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data) using the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-waf-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-waf-monitoring-integration.mdx
@@ -27,7 +27,7 @@ Default [polling](/docs/infrastructure/amazon-integrations/aws-integrations-list
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > AWS** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > AWS** and select an integration.
 
 You can [query and explore your data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data) using the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/amazon-integrations/get-started/connect-aws-govcloud-new-relic.mdx
+++ b/src/content/docs/integrations/amazon-integrations/get-started/connect-aws-govcloud-new-relic.mdx
@@ -50,7 +50,7 @@ Requirements include:
 To start receiving Amazon data with New Relic AWS integrations, connect your Amazon account to New Relic.
 
 1. Obtain [your credentials](#govcloud-credentials).
-2. Go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure** [](https://infrastructure.newrelic.com/) **> GovCloud**.
+2. Go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > GovCloud**.
 3. Click on **Add AWS GovCloud account**.
 4. Give your AWS account a name, provide the credentials to connect your account, and click **Submit**.
 5. Select the Amazon Web Services to be monitored with New Relic infrastructure integrations, then click **Save**.

--- a/src/content/docs/integrations/elastic-container-service-integration/get-started/introduction-amazon-ecs-integration.mdx
+++ b/src/content/docs/integrations/elastic-container-service-integration/get-started/introduction-amazon-ecs-integration.mdx
@@ -27,7 +27,7 @@ Our ECS integration reports and displays performance data from your [Amazon ECS]
 Features include:
 
 * View your data in pre-built dashboards for immediate insight into your ECS environment.
-* Create your own queries and charts in the [](/docs/insights) [query builder](/docs/chart-builder/use-chart-builder/get-started/introduction-chart-builder) from automatically reported data.
+* Create your own queries and charts in the [query builder](/docs/chart-builder/use-chart-builder/get-started/introduction-chart-builder) from automatically reported data.
 * Create [alert conditions](/docs/ecs-integration-recommended-alert-conditions) on ECS data.
 * Explore entities using the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer-view-performance-across-apps-services-hosts).
 

--- a/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataflow-monitoring-integration.mdx
+++ b/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataflow-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > GCP** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > GCP** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataproc-monitoring-integration.mdx
+++ b/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataproc-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > GCP** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > GCP** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-database-monitoring-integration.mdx
+++ b/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-database-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > GCP** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > GCP** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-hosting-monitoring-integration.mdx
+++ b/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-hosting-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > GCP** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > GCP** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-storage-monitoring-integration.mdx
+++ b/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-storage-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > GCP** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > GCP** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firestore-monitoring-integration.mdx
+++ b/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firestore-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > GCP** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > GCP** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-router-monitoring-integration.mdx
+++ b/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-router-monitoring-integration.mdx
@@ -26,7 +26,7 @@ Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > GCP** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > GCP** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-run-monitoring-integration.mdx
+++ b/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-run-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > GCP** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > GCP** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-compute-engine-monitoring-integration.mdx
+++ b/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-compute-engine-monitoring-integration.mdx
@@ -27,7 +27,7 @@ New Relic Infrastructure integrations query your GCP services according to a pol
 
 ## Find and use data [#find-data]
 
-After activating the integration and waiting a few minutes (based on the [polling frequency](#polling)), data will appear in the New Relic UI. To [find and use your data](https://docs.newrelic.com/docs/infrastructure/integrations/find-use-infrastructure-integration-data), including links to your dashboards and alert settings, go to **[infrastructure.newrelic.com](https://infrastructure.newrelic.com/) > GCP > (select an integration)**.
+After activating the integration and waiting a few minutes (based on the [polling frequency](#polling)), data will appear in the New Relic UI. To [find and use your data](https://docs.newrelic.com/docs/infrastructure/integrations/find-use-infrastructure-integration-data), including links to your dashboards and alert settings, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > GCP > (select an integration)**.
 
 ## Metric data [#metrics]
 

--- a/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-datastore-monitoring-integration.mdx
+++ b/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-datastore-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > GCP** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > GCP** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-direct-interconnect-monitoring-integration.mdx
+++ b/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-direct-interconnect-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > GCP** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > GCP** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-serverless-vpc-access-monitoring-integration.mdx
+++ b/src/content/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-serverless-vpc-access-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > GCP** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > GCP** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/f5-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/f5-monitoring-integration.mdx
@@ -164,7 +164,7 @@ For more about the general structure of on-host integration configuration, see [
 
 ## Find and use data [#find-and-use]
 
-To find your integration data, go to **[infrastructure.newrelic.com](https://infrastructure.newrelic.com) > Third-party services** and select one of the F5 BIG-IP integration links.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Third-party services** and select one of the F5 BIG-IP integration links.
 
 In [New Relic Insights](/docs/insights), F5 BIG-IP data is attached to the following Insights [event types](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#event):
 

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
@@ -237,7 +237,7 @@ For more about the general structure of on-host integration configuration, see [
 
 ## Find and use data [#find-and-use]
 
-To find your integration data in Infrastructure, go to **[infrastructure.newrelic.com](https://infrastructure.newrelic.com) > Third-party services** and select one of the Oracle Database integration links.
+To find your integration data in Infrastructure, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Third-party services** and select one of the Oracle Database integration links.
 
 Oracle Database data is attached to the following [event types](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#event):
 

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration.mdx
@@ -193,7 +193,7 @@ After [installation](#install) and [verification](#test-verify), you can further
 
 ## Find and use data [#find-and-use]
 
-To use your integration data in Infrastructure, go to **[infrastructure.newrelic.com](https://infrastructure.newrelic.com) > Third-party services** and select one of the StatsD integration links.
+To use your integration data in Infrastructure, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Third-party services** and select one of the StatsD integration links.
 
 In [New Relic Insights](/docs/insights), StatsD [integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data) is attached to the `MyorgApplicationSample` [event type](/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type) (assuming you've followed the [event naming conventions](#event-type)).
 

--- a/src/content/docs/integrations/infrastructure-integrations/cloud-integrations/configure-polling-frequency-data-collection-cloud-integrations.mdx
+++ b/src/content/docs/integrations/infrastructure-integrations/cloud-integrations/configure-polling-frequency-data-collection-cloud-integrations.mdx
@@ -44,7 +44,7 @@ The [polling frequency](/docs/infrastructure/amazon-integrations/aws-integration
 
 To change the polling frequency for a cloud integration:
 
-1. Go to [](http://one.newrelic.com) **[one.newrelic.com](http://one.newrelic.com) > Infrastructure**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure**.
 2. Select the tab that corresponds to your cloud service provider.
 3. Select **Configure** next to the integration.
 4. Use the dropdowns next to **Data polling interval every** to select how frequently you want New Relic to capture your cloud integration data.

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-application-gateway-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-application-gateway-monitoring-integration.mdx
@@ -26,7 +26,7 @@ Default [polling](/docs/infrastructure/microsoft-azure-integrations/getting-star
 
 ## Find and use data [#find-data]
 
-To find your integration data in Infrastructure, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > Azure** and select an integration.
+To find your integration data in Infrastructure, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-containers-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-containers-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/infrastructure/microsoft-azure-integrations/getting-star
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > Azure** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-cosmos-db-document-db-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-cosmos-db-document-db-monitoring-integration.mdx
@@ -65,7 +65,7 @@ Default [polling](/docs/infrastructure/microsoft-azure-integrations/azure-integr
 
 ## View and query data [#find-data]
 
-To view your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > Azure** and select the Cosmos DB Integration.
+To view your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure** and select the Cosmos DB Integration.
 
 You can [query and explore your data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data) using the following [event types](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-cost-management-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-cost-management-monitoring-integration.mdx
@@ -43,7 +43,7 @@ Default [polling](/docs/infrastructure/microsoft-azure-integrations/azure-integr
 
 To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure > Azure** and look for the integration.
 
-You can [query and explore your data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data) using the `AzureCostManagementSample` event [](/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type) type. The `provider` metadata value indicates how the daily cost is grouped:
+You can [query and explore your data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data) using the `AzureCostManagementSample` event type. The `provider` metadata value indicates how the daily cost is grouped:
 
 * `AzureCostLocation`: Costs are grouped by location.
 * `AzureCostService`: Costs are grouped by cloud service.

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-data-factory-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-data-factory-integration.mdx
@@ -30,7 +30,7 @@ Default [polling](/docs/infrastructure/microsoft-azure-integrations/getting-star
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > Azure** and select the **Data Factory** integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure** and select the **Data Factory** integration.
 
 Data is attached to the following [event types](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-database-mariadb-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-database-mariadb-monitoring-integration.mdx
@@ -36,7 +36,7 @@ You can change the polling frequency and filter data using [configuration option
 
 ## View and use data [#find-and-use]
 
-To [explore your integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data): Go to **[infrastructure.newrelic.com](https://infrastructure.newrelic.com/) > Azure > (select an integration)**.
+To [explore your integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data): Go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure > (select an integration)**.
 
 In New Relic, data about a single database is attached to the `AzureMariaDbServerSample` event type, with a provider value of `AzureMariaDbServer`.
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-database-mysql-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-database-mysql-monitoring-integration.mdx
@@ -36,7 +36,7 @@ New Relic queries your Azure Database services according to a default [polling](
 
 ## Find and use data [#find-and-use]
 
-To [explore your integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data), go [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/) > Azure > (select an integration)**.
+To [explore your integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data), go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure > (select an integration)**.
 
 Data about a single database is attached to the `AzureMySqlServerSample` event type, with a provider value of `AzureMySqlServer`.
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-event-hub-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-event-hub-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/infrastructure/microsoft-azure-integrations/getting-star
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > Azure** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-express-route-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-express-route-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/infrastructure/microsoft-azure-integrations/getting-star
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > Azure** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-firewalls-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-firewalls-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/infrastructure/microsoft-azure-integrations/getting-star
 
 ## Find and use data [#find-data]
 
-To find your integration data in Infrastructure, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > Azure** and select an integration.
+To find your integration data in Infrastructure, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-front-door-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-front-door-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/infrastructure/microsoft-azure-integrations/getting-star
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > Azure** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-key-vault-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-key-vault-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/infrastructure/microsoft-azure-integrations/getting-star
 
 ## Find and use data [#find-data]
 
-To find your integration data in Infrastructure, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > Azure** and select an integration.
+To find your integration data in Infrastructure, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-load-balancer-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-load-balancer-monitoring-integration.mdx
@@ -45,7 +45,7 @@ New Relic queries your Azure Load Balancer services according to a default [poll
 
 ## Find and use data [#find-and-use]
 
-To [explore your integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data), go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/) > Azure > (select an integration)**.
+To [explore your integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data), go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure > (select an integration)**.
 
 You can [query and explore your data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data) using the `AzureLoadBalancerSample` [event type](/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type), with a `provider` value of `AzureLoadBalancer`.
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-logic-apps-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-logic-apps-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/infrastructure/microsoft-azure-integrations/getting-star
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > Azure** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-machine-learning-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-machine-learning-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/infrastructure/microsoft-azure-integrations/getting-star
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > Azure** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure** and select an integration.
 
 You can [query and explore your data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data) using the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-sql-database-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-sql-database-monitoring-integration.mdx
@@ -38,7 +38,7 @@ New Relic queries your Azure Database services according to a default [polling](
 
 ## Find and use data [#find-and-use]
 
-To [explore your integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data), go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/) > Azure > (select an integration)**.
+To [explore your integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data), go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure > (select an integration)**.
 
 Data is organized like this:
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-storage-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-storage-monitoring-integration.mdx
@@ -40,7 +40,7 @@ For this reason, New Relic recommends starting with a conservative polling perio
 
 ## Find and use data [#find-data]
 
-To [explore your integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data), go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/) > Azure > (select an integration)**.
+To [explore your integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data), go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure > (select an integration)**.
 
 You can [query and explore your data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data) using the `AzureStorageAccountSample` [event type](/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type), with a `provider` value of `AzureStorageAccount`.
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-virtual-machine-scale-sets-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-virtual-machine-scale-sets-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Default [polling](/docs/integrations/microsoft-azure-integrations/getting-starte
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > Azure** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure** and select an integration.
 
 You can [query and explore your data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data) using the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-virtual-machines-scale-sets-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-virtual-machines-scale-sets-monitoring-integration.mdx
@@ -29,7 +29,7 @@ Default [polling](/docs/integrations/microsoft-azure-integrations/getting-starte
 
 ## Find and use data [#find-data]
 
-To find your integration data in Infrastructure, go to **[infrastructure.newrelic.com](https://infrastructure.newrelic.com/ "Link opens in a new window.") > Azure** and select an integration.
+To find your integration data in Infrastructure, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure** and select an integration.
 
 In [New Relic Insights](https://docs.newrelic.com/docs/insights), data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-vpn-gateway-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-vpn-gateway-integration.mdx
@@ -30,7 +30,7 @@ Default [polling](/docs/infrastructure/microsoft-azure-integrations/getting-star
 
 ## Find and use data [#find-data]
 
-To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure [](https://infrastructure.newrelic.com/ "Link opens in a new window.") > Azure** and select an integration.
+To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Azure** and select an integration.
 
 Data is attached to the following [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type):
 

--- a/src/content/docs/introduction-new-relic-mobile-unity.mdx
+++ b/src/content/docs/introduction-new-relic-mobile-unity.mdx
@@ -147,15 +147,6 @@ The Unity plugin includes iOS and Android agent files that will embed the approp
     title="Install the Unity plugin"
   >
     As part of the installation process, New Relic Mobile automatically generates an [application token](/docs/mobile-apps/viewing-your-application-token). This is a 40-character hexadecimal string for authenticating each mobile project you monitor in New Relic Mobile.
-
-    For Admins with existing New Relic accounts, follow these steps to install and configure your Unity application. (If you do not have a New Relic account, see [New Relic Mobile](/docs/mobile-apps/new-relic-for-mobile-apps).)
-
-    1. Go to **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile)**.
-    2. From the mobile apps index, select **Add a new app**.
-    3. From the **Get started** page, select **Unity** as the platform for mobile monitoring.
-    4. Type a name for your mobile project, then select **Continue**.
-
-    Continue with the procedures to configure the Unity plugin.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes.mdx
@@ -96,7 +96,7 @@ Resolved crashes include a banner identifying who resolved the crash and when. B
     ![New Relic Mobile Crash Analytics: Top 5 occurrences](./images/d0930crash-analytics.png "New Relic Mobile Crash Analytics: Top 5 occurrences")
 
     <figcaption>
-      **one[.newrelic.com](https://rpm.newrelic.com/mobile) > Mobile > (select an app) > Exceptions > Crash analysis:** Here is an example of the **Top 5 occurrences** chart filtered by the **Crash locations** group. Select any groups or filters to analyze your crash data any way you want.
+      **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Exceptions > Crash analysis:** Here is an example of the **Top 5 occurrences** chart filtered by the **Crash locations** group. Select any groups or filters to analyze your crash data any way you want.
     </figcaption>
   </Collapser>
 

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/find-build-uuids-unsymbolicated-crashes.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/find-build-uuids-unsymbolicated-crashes.mdx
@@ -23,7 +23,7 @@ An application may have more than one Build UUID, one attributed for each CPU ar
 
 New Relic crash reports also contain the Build UUID of the crashing application. To view the Build UUID:
 
-1. Go to **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Crashes > Crash Analysis**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com)** and click **Mobile** in the top nav. Then find your app and click **Crashes > Crash Analysis**.
 2. From the [**Crash list** table](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/view-mobile-app-crashes), select any row.
 3. From the selected crash report's [**Crash Details** page](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report#viewing), look for the `App Image Uuid` on the attribute list.
 

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/handled-exceptions-analyze-trends-prevent-crashes.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/handled-exceptions-analyze-trends-prevent-crashes.mdx
@@ -15,7 +15,7 @@ With New Relic Mobile's [**Handled exceptions**](/docs/mobile-monitoring/mobile-
 
 To get the most out of New Relic Mobile's **Handled exceptions** UI, use this basic workflow:
 
-1. Go to **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Exceptions > Handled exceptions**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Exceptions > Handled exceptions**.
 2. Use any of New Relic's [standard page functions](/docs/data-analysis/user-interface-functions/view-your-data/standard-page-functions) to drill down into detailed information; for example, zoom into any area of a chart.
 3. Look for obvious or general trends in the **Users affected** and **Sessions affected** [percentage charts](#percentage-charts).
 4. Adjust the types of exceptions shown by using [groups and filters](#groups-filters).
@@ -26,7 +26,7 @@ To get the most out of New Relic Mobile's **Handled exceptions** UI, use this ba
 ![Mobile Handled Exceptions](./images/mobile-handled-exceptions-ui.png "Mobile Handled Exceptions")
 
 <figcaption>
-  **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Exceptions > Handled exceptions:** As you explore the wealth of data in the charts and table, use groups and filters to discover patterns that help you determine the root cause of mobile app exceptions.
+  **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Exceptions > Handled exceptions:** As you explore the wealth of data in the charts and table, use groups and filters to discover patterns that help you determine the root cause of mobile app exceptions.
 </figcaption>
 
 ## Exception percentage charts [#percentage-charts]
@@ -47,7 +47,7 @@ To examine data in greater detail: Below any chart, select [**Expand chart**](#t
     ![Mobile Handled Exceptions: Percentage charts](./images/mobile-handled-exceptions-percentages.png "Mobile Handled Exceptions: Percentage charts")
 
     <figcaption>
-      **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Exceptions > Handled exceptions:** The percentage charts help you quickly see any unexpected spikes, dips, or patterns with exceptions in general.
+      **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Exceptions > Handled exceptions:** The percentage charts help you quickly see any unexpected spikes, dips, or patterns with exceptions in general.
     </figcaption>
   </Collapser>
 </CollapserGroup>
@@ -70,7 +70,7 @@ The currently selected filters appear at the top of the UI page. You can close t
     ![Mobile Handled Exceptions: Groups and filters](./images/mobile-handled-exceptions-groups.png "Mobile Handled Exceptions: Groups and filters")
 
     <figcaption>
-      **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Exceptions > Handled exceptions:** Group the data by attributes that matter to the most to you, then select one or more filters to help pinpoint specific causes behind the exceptions.
+      **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Exceptions > Handled exceptions:** Group the data by attributes that matter to the most to you, then select one or more filters to help pinpoint specific causes behind the exceptions.
     </figcaption>
   </Collapser>
 </CollapserGroup>
@@ -97,7 +97,7 @@ For example, you can group by `Exception Message`, filter to `timeout` message, 
     ![Mobile Handled Exceptions: Top 5 locations](./images/mobile-handled-exceptions-locations.png "Mobile Handled Exceptions: Top 5 locations")
 
     <figcaption>
-      **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Exceptions > Handled exceptions:** This example shows the **Expand chart** button and links to New Relic Insights, where you can query, create dashboards, and share the handled exceptions data.
+      **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Exceptions > Handled exceptions:** This example shows the **Expand chart** button and links to New Relic Insights, where you can query, create dashboards, and share the handled exceptions data.
     </figcaption>
   </Collapser>
 </CollapserGroup>
@@ -127,7 +127,7 @@ You can change the sort order or filter options to focus on just the types of ex
     ![Mobile Handled Exceptions: Locations table](./images/mobile-handled-exceptions-table.png "Mobile Handled Exceptions: Locations table")
 
     <figcaption>
-      **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Exceptions > Handled exceptions:** To continue to the handled exception's **Occurrences** page, select any row on the table.
+      **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Exceptions > Handled exceptions:** To continue to the handled exception's **Occurrences** page, select any row on the table.
     </figcaption>
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/handled-exceptions-occurrences.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/handled-exceptions-occurrences.mdx
@@ -16,7 +16,7 @@ After you use New Relic Mobile's [**Handled exceptions** page](/docs/mobile-moni
 
 To view details for each occurrence of a handled exception:
 
-1. Go to **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Exceptions > Handled exceptions**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Exceptions > Handled exceptions**.
 2. From the **Top 5 exception locations** table, select a handled exception on any row.
 
 The **Occurrences** page shows details about the selected exception, including breakdown data by device type or operating system, number of users affected, total occurrences for the selected time period, attributes, and more.
@@ -24,7 +24,7 @@ The **Occurrences** page shows details about the selected exception, including b
 ![Mobile Handled Exceptions: Occurrences](./images/mobile-handled-exceptions-occurrences.png "Mobile Handled Exceptions: Occurrences")
 
 <figcaption>
-  **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Exceptions > Handled exceptions > (select an exception) > Occurrences:** Use the thread details to further examine patterns in the stack trace for a handled exception.
+  **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Exceptions > Handled exceptions > (select an exception) > Occurrences:** Use the thread details to further examine patterns in the stack trace for a handled exception.
 </figcaption>
 
 <table>

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/introduction-mobile-handled-exceptions.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/introduction-mobile-handled-exceptions.mdx
@@ -23,7 +23,7 @@ By using handled exceptions with New Relic Mobile, you can identify and resolve 
 ![Mobile Handled Exceptions](./images/mobile-handled-exceptions-ui.png "Mobile Handled Exceptions")
 
 <figcaption>
-  **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Exceptions > Handled exceptions:** As you explore the wealth of data in the charts and table, use groups and filters to discover patterns that help you determine the root cause of mobile app exceptions.
+  **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Exceptions > Handled exceptions:** As you explore the wealth of data in the charts and table, use groups and filters to discover patterns that help you determine the root cause of mobile app exceptions.
 </figcaption>
 
 <table>

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/mobile-crash-event-trail.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/mobile-crash-event-trail.mdx
@@ -23,7 +23,7 @@ When a mobile app crashes and you don't know why, you can study what happened ri
 ![New Relic Mobile crash event trail ](./images/New-Relic-Mobile-crash-event-trail.png "Android-Insights-event-trail.jpg")
 
 <figcaption>
-  **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select a mobile app) > Crash analysis > (selected crash type) > Event trail**: The crash event trail shows the activity leading up to a mobile app crash.
+  **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select a mobile app) > Crash analysis > (selected crash type) > Event trail**: The crash event trail shows the activity leading up to a mobile app crash.
 </figcaption>
 
 The crash event trail shows all New Relic Mobile [event types](/docs/insights/explore-add-data/custom-events/insert-query-custom-mobile-app-events-attributes#event-definition) leading up to a crash. You can use New Relic Mobile's [iOS SDK](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/work-ios-sdk-api) or [Android SDK](/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordbreadcrumb) to create custom `MobileBreadcrumb` events that track whatever app activity you think would help you diagnose a crash.
@@ -36,7 +36,7 @@ For more about annotating crash event trails with custom data, see [Add custom d
 
 To use the New Relic Mobile crash event trail:
 
-1. Go to **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select a mobile app) > Crash analysis**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select a mobile app) > Crash analysis**.
 2. On the lower right side of the **Crash analysis** page, select a crash type.
 3. On the **Crash details** page, beside the stack trace, select **Event trail**.
 4. Study the events leading up to a crash type for clues to the reasons for the crash.

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/devices-page.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/devices-page.mdx
@@ -26,12 +26,12 @@ From here you can drill down into details by a specific model (for example, iPho
 ![screen mobile devices.png](./images/screen-mobile-devices_0.png "screen mobile devices.png")
 
 <figcaption>
-  **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > App > Devices:** Use this page to view, sort, or drill down into detailed information about the top five types of devices using your mobile app, including interaction and HTTP request times, error rates, and active users.
+  **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > App > Devices:** Use this page to view, sort, or drill down into detailed information about the top five types of devices using your mobile app, including interaction and HTTP request times, error rates, and active users.
 </figcaption>
 
 To view performance details about your users' mobile devices:
 
-1. Go to **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > App > Devices**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > App > Devices**.
 2. To select the mobile app versions or change the time period, use the **Versions** menu and [**time picker**](/docs/site/timepicker-setting-time-periods-to-view-data) below the New Relic menu bar.
 3. Optional: Select the **Sort by** and **Hide &lt; 1% throughput** options.
 4. To limit details to a specific device **type** (for example, iPad), select its name.
@@ -48,7 +48,7 @@ To drill down into detailed information, use any of New Relic's standard [user i
 ![screen mobile devices drilldown.png](./images/screen-mobile-devices-drilldown_0.png "screen mobile devices drilldown.png")
 
 <figcaption>
-  **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > App > Devices > (select a device)**: This page provides drill-down details for the selected device, including http response time, network failures, active sessions, and slowest transaction traces (if available).
+  **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > App > Devices > (select a device)**: This page provides drill-down details for the selected device, including http response time, network failures, active sessions, and slowest transaction traces (if available).
 </figcaption>
 
 ## For more help [#more_help]

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/carriers-page.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/carriers-page.mdx
@@ -19,7 +19,7 @@ The Carriers page for Mobile monitoring includes charts that show your users' wi
 ![Use this page to view, sort, or drill down into detailed information about your users' mobile carriers by response time impact, network failures, and active sessions.](./images/carriers.png "Mobile carriers")
 
 <figcaption>
-  **[one.newrelic.com](https://rpm.newrelic.com/mobile)> Mobile > (select an app) > Network > Carriers**: Use this page to view, sort, or drill down into detailed information about your users' mobile carriers by response time impact, network failures, and active sessions.
+  **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Network > Carriers**: Use this page to view, sort, or drill down into detailed information about your users' mobile carriers by response time impact, network failures, and active sessions.
 </figcaption>
 
 To view your users' mobile carriers:

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-requests-page.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-requests-page.mdx
@@ -164,7 +164,7 @@ Accounts that do not have an Enterprise-level subscription see a different **HTT
     ![screen http requests details.png](./images/screen-http-requests-details_0.png "screen http requests details.png")
 
     <figcaption>
-      **[one.newrelic.com](https://rpm.newrelic.com/mobile) > Mobile > (select an app) > Network > HTTP requests > (select a request):** Here is an example of a selected HTTP request for an app monitored by New Relic Mobile. To view details for the transaction, select **App server drill-down**.
+      **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Network > HTTP requests > (select a request):** Here is an example of a selected HTTP request for an app monitored by New Relic Mobile. To view details for the transaction, select **App server drill-down**.
     </figcaption>
 
     <table>

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/map-page-mobile-apps-deprecated.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/map-page-mobile-apps-deprecated.mdx
@@ -31,7 +31,7 @@ To view your mobile app and its related services as an architectural map, go to 
 
 If you need to use the deprecated mobile **Map** page, follow these steps:
 
-1. Go to **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Network > Map**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Network > Map**.
 2. To view [HTTP request details](/docs/mobile-monitoring-ui/http-requests-dashboard) for a service, select its name.
 3. To view details for [an app monitored by APM](/docs/applications-menu/applications-overview) that is related to the service, select the service's name below the associated hostname.
 4. To view throughput details as a chart, select the icon or the `cpm` bar below the service's name.

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/usage-pages/monthly-uniques-report.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/usage-pages/monthly-uniques-report.mdx
@@ -11,7 +11,7 @@ redirects:
   - /docs/mobile-monitoring/mobile-monitoring-ui/usage-dashboards/monthly-uniques-report
 ---
 
-New Relic Mobile includes a monthly report with a bar chart tracking the number of devices running your app for each month over the last year. To view the report: Go to **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Usage > Monthly uniques**.
+New Relic Mobile includes a monthly report with a bar chart tracking the number of devices running your app for each month over the last year. To view the report: Go to **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Usage > Monthly uniques**.
 
 ## Monthly uniques report details [#details]
 
@@ -20,7 +20,7 @@ To see the total number of unique devices for any month, mouse over the month's 
 ![screen mobile monthly uniques.png](./images/screen-mobile-monthly-uniques.png "screen mobile monthly uniques.png")
 
 <figcaption>
-  **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Usage > Monthly uniques:** This report provides a bar chart tracking the number of devices running your app for each month over the last year.
+  **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Usage > Monthly uniques:** This report provides a bar chart tracking the number of devices running your app for each month over the last year.
 </figcaption>
 
 Use any of New Relic's standard [user interface functions](/docs/accounts-partnerships/education/getting-started-new-relic/new-relic-user-interface) and [page functions](/docs/accounts-partnerships/education/getting-started-new-relic/standard-dashboard-features) to drill down into detailed information.

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/usage-pages/versions-analysis.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/usage-pages/versions-analysis.mdx
@@ -24,12 +24,12 @@ The **Versions** page also includes a table comparing each version by date creat
 ![screen versions.png](./images/screen-versions_0.png "screen versions.png")
 
 <figcaption>
-  **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Usage > Versions:** The **Versions** analysis includes color-coded charts of mobile app usage, plus a table that summarizes mobile app versions and their averages for memory, CPU, active users, and network RPM (requests per minute).
+  **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Usage > Versions:** The **Versions** analysis includes color-coded charts of mobile app usage, plus a table that summarizes mobile app versions and their averages for memory, CPU, active users, and network RPM (requests per minute).
 </figcaption>
 
 The **Versions** page provides a list of all versions of your app that have been detected, plus overview information on all versions active in the last seven days. To view the comparative analysis:
 
-1. Go to **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Usage > Versions**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Usage > Versions**.
 2. To select the time period, use the [**time picker**](/docs/site/timepicker-setting-time-periods-to-view-data) below the New Relic menu bar.
 3. Optional: Select the **Sort by** options.
 4. To view details only for a specific **version**, select its name.
@@ -41,7 +41,7 @@ The **Versions** page provides a list of all versions of your app that have been
 ![screen versions details.png](./images/screen-versions-details_0.png "screen versions details.png")
 
 <figcaption>
-  **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Usage > Versions > (selected version):** Here is an example of details for a selected version.
+  **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Usage > Versions > (selected version):** Here is an example of details for a selected version.
 </figcaption>
 
 The details page provides further insight into how the selected version compares to a reference version (a recent or popular version), and the average of other versions of your app. Time series show the comparison across error rate, response time, active sessions, and memory usage.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-sdk-api-guide.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-sdk-api-guide.mdx
@@ -32,7 +32,7 @@ New Relic Mobile's Android agent provides an SDK API to set up [custom instrumen
 Before using the Android SDK API:
 
 1. Review the [Android SDK API release notes](/docs/release-notes/mobile-release-notes/android-release-notes) to ensure you have your app instrumented with a current SDK for New Relic Mobile.
-2. Follow the **Add a new app** instructions in [rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile).
+2. Go to **[one.newrelic.com](https://one.newrelic.com)**, click **Add more data** and then follow the steps for Android.
 
 For more information, see the detailed [Android installation and configuration procedures](/docs/mobile-monitoring/new-relic-mobile-android/install-configure). If you need to support Android 2.2, see the [legacy Android agent SDK procedures](/docs/mobile-monitoring/mobile-monitoring-installation/android/installing-android-apps-android-22-support).
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/upgrade-new-relic-mobiles-android-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/upgrade-new-relic-mobiles-android-sdk.mdx
@@ -21,7 +21,7 @@ To ensure you have the most current version of New Relic Mobile, see the [Androi
 
 ## Upgrade from Android SDK versions 2 or 3 [#android_upgrade_2]
 
-If you have previously installed version 2 or 3 of the Android SDK for New Relic Mobile: Go to **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Settings > Upgrade.**
+If you have previously installed version 2 or 3 of the Android SDK for New Relic Mobile: Go to **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Settings > Upgrade.**
 
 ## Upgrade Android SDK version 1 [#android_upgrade_1]
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-sdk-api-guide.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-sdk-api-guide.mdx
@@ -29,7 +29,7 @@ Use the iOS SDK API for New Relic Mobile to [add custom data](/docs/mobile-monit
 
 ## Install the SDK [#installing]
 
-Ensure you have your app instrumented with the latest New Relic Mobile SDK by using the instructions at **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile)**.
+Ensure you have your app instrumented with the latest New Relic Mobile SDK by going to **[one.newrelic.com](https://one.newrelic.com) > Add more data** and following the instructions for iOS.
 
 This document contains the iOS SDK instrumentation requirements for:
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/upload-dsyms-bitcode-apps.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/upload-dsyms-bitcode-apps.mdx
@@ -45,7 +45,7 @@ If an app is missing a dSYM file, a few indicators are available in the New Reli
 
 You can easily upload your dSYM files directly form the New Relic Mobile UI. To upload your dSYM files:
 
-1. From [rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile), select your mobile application from the app index.
+1. Go to [one.newrelic.com](https://one.newrelic.com) and click **Mobile**. Then select your app from the list.
 2. View **Crash analysis**.
 3. Select a specific crash from the **Crash types** list.
 4. Click **Upload dSYM**. You can either drag and drop your dSYMs directly, or select the file form your computer.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk-v4.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk-v4.mdx
@@ -29,4 +29,4 @@ Before upgrading to agent version 4, you must identify which agent version your 
 
 ## Update the agent [#updating]
 
-After verifying and upgrading your agent version, follow standard [iOS installation and configuration](/docs/mobile-monitoring/mobile-monitoring-installation/getting-started/ios-installation-configuration) procedures, or go to **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Settings > Installation.**
+After verifying and upgrading your agent version, follow standard [iOS installation and configuration](/docs/mobile-monitoring/mobile-monitoring-installation/getting-started/ios-installation-configuration) procedures, or go to **[one.newrelic.com](https://one.newrelic.com)** and click **Add more data**.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -29,4 +29,4 @@ Admins: You must replace the earlier version of your iOS agent framework before 
 3. Drag **NewRelicAgent.framework** to the trash.
 4. Verify that the Xcode project highlights the reference to **NewRelicAgent.framework** in red.
 5. Right-click or control-click **NewRelicAgent.framework**, and select **Delete** to remove the obsolete reference from the project.
-6. Continue with the standard installation procedures for iOS app monitoring at **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (select an app) > Settings > Installation**.
+6. Continue with the standard installation procedures for iOS app monitoring at **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Settings > Installation**.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/tvos/tvos-installation-configuration.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/tvos/tvos-installation-configuration.mdx
@@ -25,7 +25,7 @@ As part of the installation process, New Relic Mobile automatically generates an
 
 For Admins with existing New Relic accounts, follow these steps to install and configure your application. (If you do not have a New Relic account, see [New Relic Mobile](/docs/mobile-apps/new-relic-for-mobile-apps).)
 
-1. Go to **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile)**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com)** and click **Mobile**.
 2. If applicable: From the Mobile Apps list, select <Icon name="fe-plus-circle"/>
    **Add a new app**
 3. From the Get Started page, select **tvOS** as the platform for mobile monitoring.
@@ -33,8 +33,8 @@ For Admins with existing New Relic accounts, follow these steps to install and c
 
 Continue with the steps to configure New Relic Mobile.
 
-* To complete the configuration process for a new mobile app later: Go to **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile)**, then select **See Instructions** next to your mobile app name.
-* To upgrade an existing tvOS installation: Go to **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (selected app) > Settings > Installation**.
+* To complete the configuration process for a new mobile app later: Go to **[one.newrelic.com](https://one.newrelic.com)** and click **Mobile**, then select **See Instructions** next to your mobile app name.
+* To upgrade an existing tvOS installation: Go to **[one.newrelic.com](https://one.newrelic.com) > Mobile > (selected app) > Settings > Installation**.
 
 ## Configuring your tvOS application [#configuration]
 
@@ -54,7 +54,7 @@ These procedures to configure your tvOS app also appear on the Get Started page 
    ```
 8. Clean and build your app, and then run it in the simulator or other device.
 
-Within a few minutes you will begin to see data for your iOS app: Go to **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile) > (selected app)**. If you don't, see [No data appears](/docs/mobile-monitoring/mobile-monitoring-installation/ios/no-data-appears-ios).
+Within a few minutes you will begin to see data for your iOS app: Go to **[one.newrelic.com](https://one.newrelic.com) > Mobile > (selected app)**. If you don't, see [No data appears](/docs/mobile-monitoring/mobile-monitoring-installation/ios/no-data-appears-ios).
 
 ## Executing a demo crash (optional) [#demo]
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/tvos/upgrading-new-relic-mobiles-tvos-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/tvos/upgrading-new-relic-mobiles-tvos-sdk.mdx
@@ -32,7 +32,7 @@ Admins: You must replace the earlier version of your tvOS agent framework before
 3. Drag **NewRelicAgentTVOS.framework** to the trash.
 4. Verify that the Xcode project highlights the reference to **NewRelicAgentTVOS.framework** in red.
 5. Right-click or control-click **NewRelicAgentTVOS.framework**, and select **Delete** to remove the obsolete reference from the project.
-6. Follow standard installation procedures for tvOS app monitoring at **[rpm.newrelic.com/mobile](https://rpm.newrelic.com/mobile)**.
+6. Follow standard installation procedures for tvOS app monitoring.
 
 ## For more help [#more_help]
 

--- a/src/content/docs/new-relic-partnerships/partner-integration-guide/getting-started/partnership-admin-console.mdx
+++ b/src/content/docs/new-relic-partnerships/partner-integration-guide/getting-started/partnership-admin-console.mdx
@@ -19,13 +19,13 @@ https://partner-admin-console.newrelic.com/accounts/<var><a href="/docs/accounts
 
 You can also access the console from the New Relic UI:
 
-1. Go to **[rpm.newrelic.com](https://rpm.newrelic.com) > [(account dropdown)](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown) > Account settings**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com) > [(account dropdown)](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown) > Account settings**.
 2. From the left menu bar, select **Partnerships**.
 
 ![crop-partnership-account-settings.png](./images/crop-partnership-owner-account-settings.png "crop-partnership-account-settings.png")
 
 <figcaption>
-  **[rpm.newrelic.com](https://rpm.newrelic.com) > [(account dropdown)](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown) > Account settings > Partnerships**: Partnership owners can access the Partnership Admin Console from their account settings in the New Relic UI.
+  **[one.newrelic.com](https://one.newrelic.com) > [(account dropdown)](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown) > Account settings > Partnerships**: Partnership owners can access the Partnership Admin Console from their account settings in the New Relic UI.
 </figcaption>
 
 ## Console components [#components]
@@ -57,7 +57,7 @@ Where the performance problems are caused by under capacity, these customers are
 
 ## View an arbitrary customer [#viewing-customer]
 
-To view activity of a customer that does not appear in any of the filtered views: Go to **[rpm.newrelic.com](https://rpm.newrelic.com) > [(account dropdown)](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown) > Switch accounts > Other accounts**.
+To view activity of a customer that does not appear in any of the filtered views: Go to **[one.newrelic.com](https://one.newrelic.com) > [(account dropdown)](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown) > Switch accounts > Other accounts**.
 
 New Relic will list all of the reporting accounts in the partnership. You can filter or search the list.
 

--- a/src/content/docs/new-relic-partnerships/partner-integration-guide/new-relic-products-features/partner-products-pricing-billing.mdx
+++ b/src/content/docs/new-relic-partnerships/partner-integration-guide/new-relic-products-features/partner-products-pricing-billing.mdx
@@ -40,7 +40,7 @@ New Relic supports the following billing options for partnerships.
 * All subscriptions commence and expire at midnight GMT.
 * For host-based subscriptions, fees are charged in advance for the month. Upgrade requests are honored immediately without any billing for partial use during the month. Downgrades take effect at the next payment date.
 
-To view New Relic account billing details and history from the user interface: From [**rpm.newrelic.com**](https://rpm.newrelic.com), select **([account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown)) > Account settings > Account > Billing**.
+To view New Relic account billing details and history from the user interface: From **[one.newrelic.com](https://one.newrelic.com)**, select **([account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown)) > Account settings > Account > Billing**.
 
 <table>
   <thead>

--- a/src/content/docs/new-relic-solutions/new-relic-solutions/cloud-adoption/modern-cloud-services.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-solutions/cloud-adoption/modern-cloud-services.mdx
@@ -62,7 +62,7 @@ To get started configuring cloud service integrations, link your cloud service p
     ![AWS EC2 dashboard example](./images/AWSEC2-Dashboard.png "AWS EC2 dashboard example")
 
     <figcaption>
-      **[infrastructure.newrelic.com](https://infrastructure.newrelic.com) > Integrations > Amazon Web Services**: View AWS EC2 data on the default dashboard for the AWS EC2 monitoring integration.
+      **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Integrations > Amazon Web Services**: View AWS EC2 data on the default dashboard for the AWS EC2 monitoring integration.
     </figcaption>
   </Collapser>
 
@@ -75,7 +75,7 @@ To get started configuring cloud service integrations, link your cloud service p
     ![Integrations - Azure dashboard](./images/screen-Azure-VM-dashboard.png "Integrations - Azure dashboard")
 
     <figcaption>
-      **[infrastructure.newrelic.com](https://infrastructure.newrelic.com) > Integrations > Microsoft Azure**: View Azure virtual machine data on the default dashboard for the Azure VMs monitoring integration.
+      **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Integrations > Microsoft Azure**: View Azure virtual machine data on the default dashboard for the Azure VMs monitoring integration.
     </figcaption>
   </Collapser>
 
@@ -88,7 +88,7 @@ To get started configuring cloud service integrations, link your cloud service p
     ![GCP dashboard example](./images/GCPComputeEngineDashboard.png "GCP dashboard example")
 
     <figcaption>
-      **[infrastructure.newrelic.com](https://infrastructure.newrelic.com) > Integrations > Google Cloud Platform**: View GCP Compute Engine data on the default dashboard for the GCP Compute Engine monitoring integration.
+      **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Integrations > Google Cloud Platform**: View GCP Compute Engine data on the default dashboard for the GCP Compute Engine monitoring integration.
     </figcaption>
   </Collapser>
 

--- a/src/content/docs/new-relic-solutions/new-relic-solutions/measure-devops-success/app-remediation-gather-performance-statistics.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-solutions/measure-devops-success/app-remediation-gather-performance-statistics.mdx
@@ -42,7 +42,7 @@ The default charts in New Relic tell a story about your application’s performa
 ![APM_transactions.png](./images/APM_transactions.png "APM_transactions.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Monitoring > Overview**
+  **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Monitoring > Overview**
 </figcaption>
 
 Additionally, the response time breakdown shows a spike in **Web external** (which indicates downstream dependencies). Since the spike seems to correlate with periods of higher throughput, we can then use the **Throughput** chart to analyze the problem in more detail.
@@ -54,7 +54,7 @@ Click and drag on a graph, to [drill into a focused time slice of performance da
 ![2018-05-31_15-17-28.png](./images/2018-05-31_15-17-28.png "2018-05-31_15-17-28.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Monitoring > Overview**
+  **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Monitoring > Overview**
 </figcaption>
 
 Here, it’s obvious that some part of **Web external**, which is an application or service called by our **Web portal** app, is likely the source of the issue.
@@ -72,7 +72,7 @@ In the following example, we see that **interceptor.ServletConfigInter...** has 
 ![2018-05-31_15-17-50.png](./images/2018-05-31_15-17-50.png "2018-05-31_15-17-50.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Monitoring > Overview**
+  **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Monitoring > Overview**
 </figcaption>
 
 In fact, it’s responsible for 99.9% of the app server time, which means we’re getting closer to identifying the culprit of our spike.
@@ -82,7 +82,7 @@ Here, we see the same spike from before, but the performance of the transaction 
 ![app_Performance_DevOps_Catalyst.png](./images/app_Performance_DevOps_Catalyst.png "app_Performance_DevOps_Catalyst.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Monitoring > Overview**
+  **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Monitoring > Overview**
 </figcaption>
 
 While the share of the response times for most components of this transaction remained stable, **GetPlansController** (in brown) spiked massively.
@@ -96,7 +96,7 @@ We identified that **GetPlansController** is consuming the vast majority of our 
 ![Trace_Details_DevOps_Catalyst.png](./images/Trace_Details_DevOps_Catalyst.png "Trace_Details_DevOps_Catalyst.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Monitoring > Overview**
+  **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Monitoring > Overview**
 </figcaption>
 
 [Trace details](https://docs.newrelic.com/docs/apm/transactions/transaction-traces/transaction-trace-details) shows an execution timeline of this transaction, and we see that **Plan Service** is the external transaction causing the issues—the red color-coding indicates the problem.
@@ -104,7 +104,7 @@ We identified that **GetPlansController** is consuming the vast majority of our 
 ![2018-05-31_15-18-15.png](./images/2018-05-31_15-18-15.png "2018-05-31_15-18-15.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Monitoring > Overview**
+  **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Monitoring > Overview**
 </figcaption>
 
 From this point, we can navigate to the Transactions summary page for **Plan Service**:
@@ -112,7 +112,7 @@ From this point, we can navigate to the Transactions summary page for **Plan Ser
 ![2018-05-31_15-18-36.png](./images/2018-05-31_15-18-36.png "2018-05-31_15-18-36.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Monitoring > Transactions**
+  **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Monitoring > Transactions**
 </figcaption>
 
 The breakdown of the **GetPlans** transaction shows that database calls, particularly **MySQL PlansTable select**, appear to be a significant portion of the overall response time. The **Breakdown table** further identifies the problem: the number of database calls per transaction is very high. Note again that it’s highlighted in red.
@@ -120,7 +120,7 @@ The breakdown of the **GetPlans** transaction shows that database calls, particu
 ![2018-05-31_15-18-47.png](./images/2018-05-31_15-18-47.png "2018-05-31_15-18-47.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Monitoring > Transactions**
+  **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Monitoring > Transactions**
 </figcaption>
 
 Once again, we can look at a transaction trace to find what might be causing these queries.
@@ -128,7 +128,7 @@ Once again, we can look at a transaction trace to find what might be causing the
 ![2018-05-31_15-18-59.png](./images/2018-05-31_15-18-59.png "2018-05-31_15-18-59.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Monitoring > Transactions**
+  **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Monitoring > Transactions**
 </figcaption>
 
 Finally we find that an extremely large number of select methods account for the majority of transaction time. We can now take steps to address this potential N+1 query problem.
@@ -144,7 +144,7 @@ For backend errors, go to APM, select **Error Analytics** in the left nav, and t
 ![New Relic APM Error Profiles](./images/apm-errors-profile.png "apm-errors-profile.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Error Analytics > Error Profile**
+  **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Error Analytics > Error Profile**
 </figcaption>
 
 As a quality customer experience increasingly relies on complex client-side logic, it’s important to quickly analyze and understand JavaScript errors. In New Relic Browser, select **JS errors** in left navigation menu. Expand the details about JavaScript errors by clicking on a attribute. In this case, we've expanded the transaction names that are related to the errors:
@@ -152,7 +152,7 @@ As a quality customer experience increasingly relies on complex client-side logi
 ![New Relic JS Error Profiles](./images/NRErrorprofilesJS.png "js-errors-profile.png")
 
 <figcaption>
-  **[rpm.newrelic.com/browser](https://rpm.newrelic.com/apm) > (select an app) > JS errors**
+  **[one.newrelic.com](https://one.newrelic.com) > Browser > (select an app) > JS errors**
 </figcaption>
 
 Roughly half of the errors come from `phone.jsp`, so that is the place to start investigating. Then determine if you can safely ignore the error, or if you should resolve the error with code edits and a new deployment, or provide communication about the issue to your customers.

--- a/src/content/docs/new-relic-solutions/new-relic-solutions/measure-devops-success/iterate-measure-impact-track-metrics-after-deployments.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-solutions/measure-devops-success/iterate-measure-impact-track-metrics-after-deployments.mdx
@@ -36,7 +36,7 @@ It’s important to track deployments and how the impact of the code and infrast
 ![APM_web-transaction-times_Catalyst.png](./images/APM_web-transaction-times_Catalyst.png "APM_web-transaction-times_Catalyst.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Monitoring > Overview**
+  **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Monitoring > Overview**
 </figcaption>
 
 APM also provides a chronological list of deployments of your application, and additional metrics, such as error rate and Apdex from the time of the deployment, are available as well.
@@ -44,7 +44,7 @@ APM also provides a chronological list of deployments of your application, and a
 ![APM_Deployments_Catalyst.png](./images/APM_Deployments_Catalyst.png "APM_Deployments_Catalyst.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Events > Deployments**
+  **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Events > Deployments**
 </figcaption>
 
 Tracking deployments is an invaluable way to determine the root cause of immediate, long-term, or gradual degradations in your application.

--- a/src/content/docs/new-relic-solutions/new-relic-solutions/measure-devops-success/resolve-dependency-risk-identify-analyze-potential-issues.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-solutions/measure-devops-success/resolve-dependency-risk-identify-analyze-potential-issues.mdx
@@ -26,7 +26,7 @@ New Relic recommends that you start by viewing the entire architecture using the
 ![service_maps_response_time.png](./images/service_maps_response_time.png "service_maps_response_time.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > Service Maps > App/Service list**
+  **[one.newrelic.com](https://one.newrelic.com) > Service Maps > App/Service list**
 </figcaption>
 
 This initial view shows all applications that are configured in your account. Applications that have violated a warning threshold are shown in yellow, and those with an active alert are shown in red. Healthy applications appear in green.
@@ -40,7 +40,7 @@ After looking at the architecture as a whole, review the applications that have 
 ![APM-service-maps-connect.png](./images/APM-service-maps-connect.png "APM-service-maps-connect.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > Service Maps > App/Service list**
+  **[one.newrelic.com](https://one.newrelic.com) > Service Maps > App/Service list**
 </figcaption>
 
 In this example, we’ve chosen **Tower-Chicago** from the **App/Services** list. All of the traffic being sent to **Tower-Chicago** is coming from **Proxy-East**. In this case, **Tower-Chicago** is showing 48.3 requests per minute, or 11.3% of the 426 requests per minute flowing through **Proxy-East**.
@@ -48,7 +48,7 @@ In this example, we’ve chosen **Tower-Chicago** from the **App/Services** list
 ![apm_service_maps_dependencies.png](./images/apm_service_maps_dependencies.png "apm_service_maps_dependencies.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > Service Maps > App/Service list**
+  **[one.newrelic.com](https://one.newrelic.com) > Service Maps > App/Service list**
 </figcaption>
 
 In most cases, the separate applications and services represented in service maps are created and maintained by separate teams. This exercise of walking through the dependencies of your architecture should involve representatives from each of those teams.
@@ -300,7 +300,7 @@ Service maps seamlessly integrate data from [New Relic Browser](https://docs.new
 ![apm-service-maps-browser-portal.png](./images/apm-service-maps-browser-portal.png "apm-service-maps-browser-portal.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > Service Maps**
+  **[one.newrelic.com](https://one.newrelic.com) > Service Maps**
 </figcaption>
 
 Use the service map view to drill into front-end dependencies, and execute a similar exercise to the one you executed for back-end dependencies. This exercise will again expose data to help you identify risk areas you should address and optimize. We recommend that you conduct the analysis with user interface (UI) teams so that you can also gather a complementary qualitative understanding of what the UI teams consider critical based on their experience. A ranking from the UI teams of the most critical dependency is a useful output of this work.

--- a/src/content/docs/new-relic-solutions/new-relic-solutions/optimize-your-cloud-native-environment/adopt-cloud-services.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-solutions/optimize-your-cloud-native-environment/adopt-cloud-services.mdx
@@ -59,7 +59,7 @@ To configure cloud service integrations, link your [Amazon Web Services (AWS)](h
     ![AWS EC2 dashboard example](./images/AWSEC2-Dashboard.png "AWS EC2 dashboard example")
 
     <figcaption>
-      **[infrastructure.newrelic.com](https://infrastructure.newrelic.com) > Integrations > Amazon Web Services**: View AWS EC2 data on the default dashboard for the AWS EC2 monitoring integration.
+      **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Integrations > Amazon Web Services**: View AWS EC2 data on the default dashboard for the AWS EC2 monitoring integration.
     </figcaption>
   </Collapser>
 
@@ -72,7 +72,7 @@ To configure cloud service integrations, link your [Amazon Web Services (AWS)](h
     ![Integrations - Azure dashboard](./images/screen-Azure-VM-dashboard.png "Integrations - Azure dashboard")
 
     <figcaption>
-      **[infrastructure.newrelic.com](https://infrastructure.newrelic.com) > Integrations > Microsoft Azure**: View Azure virtual machine data on the default dashboard for the Azure VMs monitoring integration.
+      **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Integrations > Microsoft Azure**: View Azure virtual machine data on the default dashboard for the Azure VMs monitoring integration.
     </figcaption>
   </Collapser>
 
@@ -85,7 +85,7 @@ To configure cloud service integrations, link your [Amazon Web Services (AWS)](h
     ![GCP dashboard example](./images/GCPComputeEngineDashboard.png "GCP dashboard example")
 
     <figcaption>
-      **[infrastructure.newrelic.com](https://infrastructure.newrelic.com) > Integrations > Google Cloud Platform**: View GCP Compute Engine data on the default dashboard for the GCP Compute Engine monitoring integration.
+      **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Integrations > Google Cloud Platform**: View GCP Compute Engine data on the default dashboard for the GCP Compute Engine monitoring integration.
     </figcaption>
   </Collapser>
 

--- a/src/content/docs/new-relic-solutions/new-relic-solutions/optimize-your-cloud-native-environment/iterate-measure-impact-track-metrics-after-deployments.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-solutions/optimize-your-cloud-native-environment/iterate-measure-impact-track-metrics-after-deployments.mdx
@@ -37,7 +37,7 @@ A deployment marker is an event indicating that a deployment happened, and it's 
 ![APM_web-transaction-times_Catalyst.png](./images/APM_web-transaction-times_Catalyst.png "APM_web-transaction-times_Catalyst.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Monitoring > Overview**
+  **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Monitoring > Overview**
 </figcaption>
 
 APM also provides a chronological list of deployments of your application. Additional metrics, such as error rate and Apdex from the time of the deployment, are available as well.
@@ -45,7 +45,7 @@ APM also provides a chronological list of deployments of your application. Addit
 ![APM_Deployments_Catalyst.png](./images/APM_Deployments_Catalyst.png "APM_Deployments_Catalyst.png")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Events > Deployments**
+  **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Events > Deployments**
 </figcaption>
 
 Tracking deployments is a valuable way to determine the root cause of immediate, long-term, or gradual degradations in your application.

--- a/src/content/docs/new-relic-solutions/new-relic-solutions/optimize-your-cloud-native-environment/iterate-measure-impact-track-metrics-after-deployments.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-solutions/optimize-your-cloud-native-environment/iterate-measure-impact-track-metrics-after-deployments.mdx
@@ -68,7 +68,7 @@ Similarly, infrastructure changes should also have as small a footprint as possi
 ![Infra_hosts_events.png](./images/Infra_hosts_events.png "Infra_hosts_events.png")
 
 <figcaption>
-  **[infrastructure.newrelic.com/apm](https://infrastructure.newrelic.com/apm) > Hosts**
+  **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Hosts**
 </figcaption>
 
 For cloud infrastructure changes or larger code changes, consider using a [blue/green deployment](https://martinfowler.com/bliki/BlueGreenDeployment.html) strategy. APM supports [multiple app names](https://docs.newrelic.com/docs/agents/manage-apm-agents/app-naming/use-multiple-names-app), which is a good fit for this model.

--- a/src/content/docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/refactor-your-applications.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-solutions/plan-your-cloud-adoption/refactor-your-applications.mdx
@@ -51,7 +51,7 @@ APM agents collect performance metrics about outbound calls to databases. In the
 ![Databases page in APM](./images/screen-databases_0.png "Databases page in APM")
 
 <figcaption>
-  **[rpm.newrelic.com/apm](https://rpm.newrelic.com/apm) > (select an app) > Monitoring > Databases**: Use this page to view and sort detailed information about database performance.
+  **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Monitoring > Databases**: Use this page to view and sort detailed information about database performance.
 </figcaption>
 
 ## 4. Refactor your applications [#refactor]

--- a/src/content/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards.mdx
@@ -56,7 +56,7 @@ With New Relic One dashboards you can customize and understand the data you coll
 Use dashboards to:
 
 * Drive insight with custom, high-density interactive visualizations with a consistent UI.
-* Chart all the [](/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type) events and attributes [](/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type) from everywhere across our platform. For more information, see our documentation on default [data collection](/docs/using-new-relic/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data).
+* Chart all the events and attributes from everywhere across our platform. For more information, see our documentation on default [data collection](/docs/using-new-relic/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data).
 * [Add custom attributes](/docs/insights/insights-data-sources/custom-data/add-custom-attributes-new-relic-apm-data) or [send custom event types](/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api) to most events in order to better understand your business, and see specific details about how your customers interact with your platform, such as page views, host transactions, etc.
 * [Manage your charts and dashboards](#get-started) easily using our quick-access CRUD menus and editing options.
 * Explore and contextualize data with [advanced tooltips and zoom-in functions](#key-visual-tools) to monitor what your systems are doing in real time.
@@ -190,7 +190,7 @@ Dashboards have three types of permissions:
 * **Public - Read only**: All users are able to see the dashboard, but only you have full rights to work with the dashboard. Other users can access the dashboard but are not able to edit or delete it, although they can clone it.
 * **Private**: Only you can see the dashboard.
 
-When you create a [](/docs/dashboards/explore-dashboards-index/explore-dashboards-index#create-dashboard) dashboard using the **Create a dashboard** button or by cloning another dashboard, it will have **Public - Read and write** rights by default. Access the new dashboard to change this setting.
+When you [create a dashboard](/docs/dashboards/explore-dashboards-index/explore-dashboards-index#create-dashboard) using the **Create a dashboard** button or by cloning another dashboard, it will have **Public - Read and write** rights by default. Access the new dashboard to change this setting.
 
 ## Organize your dashboards with tags [#filter-dashboards]
 

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-metrics-amazon-elasticache.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-metrics-amazon-elasticache.mdx
@@ -15,7 +15,6 @@ redirects:
   * [Azure Logic Apps](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-logic-apps-monitoring-integration)
   * [Azure Container](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-containers-monitoring-integration)
 
-  [](https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-containers-monitoring-integration)
 * New metrics will be gathered for all Amazon ElastiCache clusters and nodes:
   * `cpuCreditUsage`
   * `cpuCreditBalance`

--- a/src/content/docs/style-guide/quick-reference/ui-paths.mdx
+++ b/src/content/docs/style-guide/quick-reference/ui-paths.mdx
@@ -61,7 +61,7 @@ Our goal for UI paths is to make them easy to use and understand, preferably wri
 
         Here's one for a lengthier path, though this can usually be avoided by following our other guidelines:
 
-        Go to **[one.newrelic.com](https://rpm.newrelic.com/apm "Link opens in a new window.") > APM > (select an app) > Transactions > (select a transaction) > (select a transaction trace) > Trace details:**
+        Go to **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Transactions > (select a transaction) > (select a transaction trace) > Trace details:**
       </td>
     </tr>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/view-ping-monitor-results.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/view-ping-monitor-results.mdx
@@ -71,7 +71,7 @@ To access a complete list of **ping** monitor results:
 
       <td>
         1. Make sure you have [enabled Synthetic transaction traces](/docs/synthetics/new-relic-synthetics/using-monitors/collect-synthetic-transaction-traces) for the ping monitor you want to view.
-        2. Go to **[one.newrelic.com](https://synthetics.newrelic.com) > Explorer > Synthetic monitors > (select a ping monitor)**
+        2. Go to **[one.newrelic.com](one.newrelic.com) > Explorer > Synthetic monitors > (select a ping monitor)**.
         3. Hover over the **Timeline** and click **APM transaction trace**.
 
         **Selecting a transaction trace will also reveal more details in APM.**


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* Sweeping the site for remaining rpm.newrelic.com paths using this search
![image](https://user-images.githubusercontent.com/55203603/118198753-58598f80-b406-11eb-9a5b-c2e252c4fb6e.png)
* Also swept for infrastructure.newrelic.com paths
* Also did a couple of sweeps for various types of malformed paths I discovered while sweeping rpm

### Not fixed

* API explorer paths (rpm.newrelic.com/api/explore). These paths remain unchanged.
* Anything related to SAML/SSO (e.g. /docs-website/src/content/docs/accounts/accounts/saml-single-sign/saml-service-providers.mdx)
* Any content in /jp/
* Anything in release notes
* This alerts doc with major issues https://docs.newrelic.com/docs/apm/applications-menu/events/view-alert-history/