### PR TITLE
chore: fixing Trace API link

### DIFF
--- a/src/content/docs/telemetry-data-platform/get-started/introduction-new-relic-data-ingest-apis-sdks.mdx
+++ b/src/content/docs/telemetry-data-platform/get-started/introduction-new-relic-data-ingest-apis-sdks.mdx
@@ -36,7 +36,7 @@ If our [more curated solutions](#integrations) don't work for you, our open sour
 
 If our more curated solutions don't work for you, we also have data-ingest APIs:
 
-* [Trace API](/docs/understand-dependencies/distributed-tracing/trace-api)
+* [Trace API](/docs/telemetry-data-platform/get-data/apis/introduction-trace-api/)
 * [Event API](/docs/insights/insights-data-sources/custom-data/introduction-event-api)
 * [Metric API](/docs/telemetry-data-platform/ingest-manage-data/ingest-apis/introduction-metric-api/)
 * [Log API](/docs/logs/new-relic-logs/log-api/introduction-log-api)


### PR DESCRIPTION
Linked to a `404`

