### PR TITLE
Fix 'Filter' spelling

### DIFF
--- a/src/data-dictionary/events/DistributedTraceSummary/newRelic.traceFiler.type.md
+++ b/src/data-dictionary/events/DistributedTraceSummary/newRelic.traceFiler.type.md
@@ -1,9 +1,0 @@
----
-name: newRelic.traceFiler.type
-type: attribute
-events:
-  - DistributedTraceSummary
-  - Span
----
-
-The name of the trace filter used by the Infinite Tracing trace observer to select this trace.

--- a/src/data-dictionary/events/DistributedTraceSummary/newRelic.traceFilter.type.md
+++ b/src/data-dictionary/events/DistributedTraceSummary/newRelic.traceFilter.type.md
@@ -1,0 +1,9 @@
+---
+name: newRelic.traceFilter.type
+type: attribute
+events:
+  - DistributedTraceSummary
+  - Span
+---
+
+The name of the trace filter used by the Infinite Tracing trace observer to select this trace.


### PR DESCRIPTION
Original version is missing a 't'. Changed 'newRelic.traceFiler.type' to 'newRelic.traceFilter.type'. 

Example of span JSON data including this attribute:

` "events": [
        {
          "category": "generic",
          "duration.ms": 1.7349720001220703,
          "entity.guid": "MTU2NDk3OXxBUE18QVBQTElDQVRJT058OTQ1NzIwMTE4",
          "entity.name": "My application (Development)",
          "entityGuid": "MTU2NDk3OXxBUE18QVBQTElDQVRJT058OTQ1NzIwMTE4",
          "id": "b31939a4a3bb8b36",
          "name": "View/layouts/application/Rendering",
          "newRelic.ingestPoint": "api.infiniteTracing",
          "newRelic.traceFilter.type": "random",
          "parent.id": "14b94d4d9a9c3f69",
          "priority": 0.855915,
          "service.name": "My application (Development)",
          "timestamp": 1620941516809,
          "trace.id": "ecfad11074c88453423a4d1c691322dc",
          "transactionId": "dc044101e165800b",
          "type": "Span"
        },`


As this involves a file name change, will be following up with @hero in the #documentation channel

Lindsey Baker
DT TSE