### PR TITLE
Add mapping tables plus real examples in insights api migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # docs.newrelic.com
 
-Welcome! 👋  This is the repo for the `NEW` New Relic Docs site. This repo contains all the Docs website source code and Markdown source files we use to build our Docs site: `docs.newrelic.com`.
+W        :elcome! 👋  This is the repo for the `NEW` New Relic Docs site. This repo contains all the Docs website source code and Markdown source files we use to build our Docs site: `docs.newrelic.com`.
 
 Read on to learn more about who we are and how you can contribute to the New Relic Docs site.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # docs.newrelic.com
 
-W        :elcome! 👋  This is the repo for the `NEW` New Relic Docs site. This repo contains all the Docs website source code and Markdown source files we use to build our Docs site: `docs.newrelic.com`.
+Welcome! 👋  This is the repo for the `NEW` New Relic Docs site. This repo contains all the Docs website source code and Markdown source files we use to build our Docs site: `docs.newrelic.com`.
 
 Read on to learn more about who we are and how you can contribute to the New Relic Docs site.
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,5 @@
-const parse = require('rehype-parse');
 const fs = require('fs');
+const parse = require('rehype-parse');
 const path = require('path');
 const unified = require('unified');
 const rehypeStringify = require('rehype-stringify');

--- a/src/content/docs/apis/insights-apis/insights-dashboard-api.mdx
+++ b/src/content/docs/apis/insights-apis/insights-dashboard-api.mdx
@@ -14,9 +14,11 @@ redirects:
 
 The Insights Dashboard API allows you to create and manage dashboards. 
 
-## Requirements [#requirements]
+<Callout variant="important">
+  **Note that this API is deprecated.** We built a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that would help you adapting to the new dashboards API. For UI instructions, see [Dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/). 
+</Callout>
 
-**Note that this API is deprecated.** To use an API to create and manage dashboards, we recommend using [NerdGraph](/docs/apis/nerdgraph/examples/create-widgets-dashboards-api). For UI instructions, see [Dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/). 
+## Requirements [#requirements]
 
 If your account hosts data in the EU data center, ensure you're using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
 

--- a/src/content/docs/apis/insights-apis/insights-dashboard-api.mdx
+++ b/src/content/docs/apis/insights-apis/insights-dashboard-api.mdx
@@ -15,7 +15,7 @@ redirects:
 The Insights Dashboard API allows you to create and manage dashboards. 
 
 <Callout variant="important">
-  **Note that this API is deprecated.** We built a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that would help you adapting to the new dashboards API. For UI instructions, see [Dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/). 
+  **Note that this API is deprecated.** We have a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that will help you transition to the new dashboards API. For instructions on using the UI, see [Dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/). 
 </Callout>
 
 ## Requirements [#requirements]

--- a/src/content/docs/apis/insights-apis/insights-dashboard-api.mdx
+++ b/src/content/docs/apis/insights-apis/insights-dashboard-api.mdx
@@ -15,7 +15,7 @@ redirects:
 The Insights Dashboard API allows you to create and manage dashboards. 
 
 <Callout variant="important">
-  **Note that this API is deprecated.** We have a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that will help you transition to using the new API. For instructions on using the UI, see [Dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/). 
+  **Note that this API is deprecated.** We have a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) to help you transition to using the new API. For instructions on using the UI, see [Dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/). 
 </Callout>
 
 ## Requirements [#requirements]

--- a/src/content/docs/apis/insights-apis/insights-dashboard-api.mdx
+++ b/src/content/docs/apis/insights-apis/insights-dashboard-api.mdx
@@ -15,7 +15,7 @@ redirects:
 The Insights Dashboard API allows you to create and manage dashboards. 
 
 <Callout variant="important">
-  **Note that this API is deprecated.** We have a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that will help you transition to the new dashboards API. For instructions on using the UI, see [Dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/). 
+  **Note that this API is deprecated.** We have a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that will help you transition to using the new API. For instructions on using the UI, see [Dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/). 
 </Callout>
 
 ## Requirements [#requirements]

--- a/src/content/docs/apis/nerdgraph/examples/create-widgets-dashboards-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/create-widgets-dashboards-api.mdx
@@ -15,7 +15,7 @@ redirects:
 With the New Relic dashboards API you can use [NerdGraph](https://api.newrelic.com/graphiql) to build your [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards). This document explains the different types of widgets you can add to your dashboards, and how to create and get them using the API.
 
 <Callout variant="tip">
-  To learn how to create a dashboard using this API, see [the dashboardCreate mutation](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph#dashboard-create).
+  If you were using the old Insights API, we built a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that would help you adapting to the new dashboards API.
 </Callout>
 
 ## Widget schema and types [#widget-schema]

--- a/src/content/docs/apis/nerdgraph/examples/create-widgets-dashboards-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/create-widgets-dashboards-api.mdx
@@ -15,7 +15,7 @@ redirects:
 With the New Relic dashboards API you can use [NerdGraph](https://api.newrelic.com/graphiql) to build your [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards). This document explains the different types of widgets you can add to your dashboards, and how to create and get them using the API.
 
 <Callout variant="tip">
-  If you're using the original Insights API, that is now deprecated. We have a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that helps you transition to the new dashboards API.
+  If you're using the deprecated Insights Dashboard API, we have a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that helps you transition to using the new API.
 </Callout>
 
 ## Widget schema and types [#widget-schema]

--- a/src/content/docs/apis/nerdgraph/examples/create-widgets-dashboards-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/create-widgets-dashboards-api.mdx
@@ -15,7 +15,7 @@ redirects:
 With the New Relic dashboards API you can use [NerdGraph](https://api.newrelic.com/graphiql) to build your [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards). This document explains the different types of widgets you can add to your dashboards, and how to create and get them using the API.
 
 <Callout variant="tip">
-  If you were using the old Insights API, we built a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that would help you adapting to the new dashboards API.
+  If you're using the original Insights API, that is now deprecated. We have a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that helps you transition to the new dashboards API.
 </Callout>
 
 ## Widget schema and types [#widget-schema]

--- a/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
@@ -133,7 +133,7 @@ Dashboards
 * [Create dashboards](/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/)      
 * [Export dashboards to other accounts](/docs/apis/nerdgraph/examples/export-import-dashboards-using-api/)
 * [Export dashboards as files](/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api/)
-
+* [Migrate from Insights Dashboard API to NerdGraph](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/)
       </td>
     </tr>
 

--- a/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph.mdx
@@ -1,23 +1,26 @@
 ---
-title: 'Dashboards API migration: from Insights API to Nerdgraph'
-tags:
-  - New Relic One
-  - Use New Relic One
-  - Core concepts
+title: 'Dashboard API migration: from Insights API to NerdGraph'
 ---
 
-In case you haven’t heard, NerdGraph is [New Relic’s unified API in a GraphQL](https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) flavor. The new dashboards API follows this unified approach and is exposed through [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) for user consumption.
+The [Insights Dashboard API](/docs/apis/insights-apis/insights-dashboard-api/) is deprecated, but you can use [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) (our GraphQL API) to create and configure dashboards. 
 
 ## Why a new dashboards API? [#why-new-api]
 
-[Dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards) in New Relic embrace the [entity concept](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic) and are now an entity in New Relic’s entity ecosystem. Dashboards can now connect with any other type of entity for better observability solutions, which opens the door to endless opportunities.
+Our Insights product, which was a way to query data and create charts and dashboards, has been deprecated and its set of features moved over to be a core part of the [New Relic One platform](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one/). To learn more about this transition and new features, see the [Insights to New Relic One migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/transition-new-relic-one-insights/). 
 
-At the same time, we have built new features for dashboards:
+The Insights Dashboard API will be deprecated in July of 2021. Until then, if you are using Insights Dashboard API, you should attempt to switch over to using NerdGraph. Some details on this deprecation:
 
-* [All New Relic One dashboards are structured in pages, known as Data Apps in Insights](/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard#)
-* [Multiple queries from different accounts within the same widget](/docs/query-your-data/explore-query-data/query-builder/use-advanced-nrql-mode-query-data)
-* [Facet linking](/docs/query-your-data/explore-query-data/dashboards/filter-new-relic-one-dashboards-facets)
-* [Facet linking with support for cases](/docs/query-your-data/explore-query-data/dashboards/filter-new-relic-one-dashboards-facets#)
+* You can continue to use your Insights insert API key with the Dashboards API, or you can create a new user API key (read more about [API keys](/docs/apis/get-started/intro-apis/new-relic-api-keys/)). 
+* Every user who wants to use NerdGraph needs their own user API key.
+* The REST API for Insights queries is **not** affected by this change and won't be deprecated. For more information about which key to use with our APIs, see our documentation about .
+
+When using NerdGraph, it helps to understand that Our [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards) now rely on the concept of [entities](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic). They report data from entities (monitored apps and hosts and services) and they are also themselves entities.  
+
+## Starting out with NerdGraph [#starting-out]
+
+If you're new to NerdGraph and GraphQL, you may want to first read the [Introduction to NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/) and some of [Create dashboards with NerdGraph](/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/).
+
+The NerdGraph API explorer is located at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
 
 ## Operations mapping table [#operations-mapping-table]
 
@@ -25,11 +28,11 @@ The table below maps every Insights API operation to the new dashboards API.
 
 | Insights API operation  | Nergraph API query/mutation  | Notes  |
 |---|---|---|
-| List (GET)      | [entitySearch()](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/#entitysearch)           | View a paginated list of dashboards that match the filter |
-| Show (GET)      | [entity()](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/#entityquery)                  | View an existing dashboard given its entity guid |
-| Create (POST)   | [dashboardCreate()](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/#dashboard-create)    | Create a new dashboard  |
-| Update (PUT)    | [dashboardUpdate()](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/#dashboard-update)    | Update an existing dashboard given its entity guid  |
-| Delete (DELETE) | [dashboardDelete()](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/#dashboard-delete)    | Delete an existing dashboard given its entity guid  |
+| List (GET)      | [entitySearch()](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/#entitysearch)           | View a paginated list of dashboards that match the filter. |
+| Show (GET)      | [entity()](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/#entityquery)                  | View an existing dashboard given its entity guid. |
+| Create (POST)   | [dashboardCreate()](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/#dashboard-create)    | Create a new dashboard.  |
+| Update (PUT)    | [dashboardUpdate()](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/#dashboard-update)    | Update an existing dashboard given its entity guid.  |
+| Delete (DELETE) | [dashboardDelete()](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/#dashboard-delete)    | Delete an existing dashboard given its entity guid.  |
 
 
 ## Dashboard properties mapping table [#dashboard-properties-mapping-table]
@@ -40,7 +43,7 @@ The table below maps dashboard properties from the Insights API to the new dashb
 
 | Insights API dashboard property  | Nergraph API dashboard property  | Notes  |
 |---|---|---|
-| id                    | guid        | Id of the New Relid entity the dashboard now represents |
+| id                    | guid        | ID of the New Relid entity the dashboard now represents |
 | createdAt             | createdAt   | |
 | updatedAt             | updatedAt   | |
 | title                 | name        | |
@@ -70,7 +73,7 @@ The table below maps widget properties from the Insights API to the new dashboar
 | data                                  | configuration + rawConfiguration  | |
 
 <Callout variant="tip">
-  See [this doc](/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/) to learn how to build every type of widget.
+  To learn how to build every type of widget, see [Create dashboard widgets](/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/).
 </Callout>
 
 ## Visualizations mapping table [#visualization-mapping-table]
@@ -110,7 +113,7 @@ We have simplified our widget visualizations by grouping the ones that were in f
 
 ## Examples: from REST endpoints to GraphQL queries/mutations [#from-rest-to-mutation]
 
-One of the main benefits from a GraphQL API is that it provides a complete and understandable description of the APIs' data. By using [NerdGraph GraphiQL explorer](https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer), you can discover GraphQL types and fields, along with a brief explanation.
+One of the main benefits of NerdGraph being a GraphQL-format API is that it provides a complete and understandable description of the APIs' data. By using the [NerdGraph API explorer](https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer), you can discover GraphQL types and fields, along with a brief explanation.
 
 We want to facilitate your migration from the [Insights API](/docs/apis/insights-apis/insights-dashboard-api/) to the new New Relic One dashboards API. Find below some examples that illustrate how the old REST endpoints map to the new GraphQL queries or mutations.
 

--- a/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph.mdx
@@ -6,11 +6,11 @@ tags:
   - Core concepts
 ---
 
-In case you haven’t heard, NerdGraph is [New Relic’s unified API in a GraphQL](https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) flavor. The [new dashboards API](/docs/apis/nerdgraph/examples/create-widgets-dashboards-api) follows this unified approach and is exposed through [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) for user consumption.
+In case you haven’t heard, NerdGraph is [New Relic’s unified API in a GraphQL](https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) flavor. The new dashboards API follows this unified approach and is exposed through [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) for user consumption.
 
 ## Why a new dashboards API? [#why-new-api]
 
-[Dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards) in New Relic embrace the [entity concept](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic) and are now an entity in New Relic’s entity ecosystem. Dashboards can now connect with any other type of entity for better observability solutions, which opens the door to endless opportunities we would like you to benefit from.
+[Dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards) in New Relic embrace the [entity concept](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic) and are now an entity in New Relic’s entity ecosystem. Dashboards can now connect with any other type of entity for better observability solutions, which opens the door to endless opportunities.
 
 At the same time, we have built new features for dashboards:
 
@@ -19,221 +19,509 @@ At the same time, we have built new features for dashboards:
 * [Facet linking](/docs/query-your-data/explore-query-data/dashboards/filter-new-relic-one-dashboards-facets)
 * [Facet linking with support for cases](/docs/query-your-data/explore-query-data/dashboards/filter-new-relic-one-dashboards-facets#)
 
-## From REST endpoints to GraphQL queries/mutations [#from-rest-to-mutation]
+## Operations mapping table [#operations-mapping-table]
+
+The table below maps every Insights API operation to the new dashboards API.
+
+| Insights API operation  | Nergraph API query/mutation  | Notes  |
+|---|---|---|
+| List (GET)      | [entitySearch()](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/#entitysearch)           | View a paginated list of dashboards that match the filter |
+| Show (GET)      | [entity()](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/#entityquery)                  | View an existing dashboard given its entity guid |
+| Create (POST)   | [dashboardCreate()](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/#dashboard-create)    | Create a new dashboard  |
+| Update (PUT)    | [dashboardUpdate()](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/#dashboard-update)    | Update an existing dashboard given its entity guid  |
+| Delete (DELETE) | [dashboardDelete()](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/#dashboard-delete)    | Delete an existing dashboard given its entity guid  |
+
+
+## Dashboard properties mapping table [#dashboard-properties-mapping-table]
+
+For more information about all the fields in the new dashboards GraphQL schema, have a look at [NerdGraph's GraphiQL explorer](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer).
+
+The table below maps dashboard properties from the Insights API to the new dashboards API.
+
+| Insights API dashboard property  | Nergraph API dashboard property  | Notes  |
+|---|---|---|
+| id                    | guid        | Id of the New Relid entity the dashboard now represents |
+| createdAt             | createdAt   | |
+| updatedAt             | updatedAt   | |
+| title                 | name        | |
+| editable              | [permissions](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/#dashboards-permissions) | `editable` and `visibility` merged in the same concept |
+| visibility            | [permissions](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/#dashboards-permissions) | `editable` and `visibility` merged in the same concept |
+| description           | description | |
+| metadata              | -           | No need of versioning in GraphQL APIs |
+| icon                  | -           | Not translated to New Relic One |
+| grid_column_count     | -           | 12 column dashboards by default in New Relic One |
+| filter                | -           | Not translated to New Relic One yet |
+
+## Widget properties mapping table [#widget-properties-mapping-table]
+
+For more information about all the fields in the new dashboards GraphQL schema, have a look at [NerdGraph's GraphiQL explorer](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer).
+
+The table below maps widget properties from the Insights API to the new dashboards API.
+
+| Insights API dashboard property  | Nergraph API dashboard property  | Notes  |
+|---|---|---|
+| id                                    | id                                | |
+| account_id                            | -                                 | Translated into widget configuration for those that require one |
+| visualization                         | visualization                     | |
+| presentation.title                    | title                             | |
+| presentation.drilldown_dashboard_id   | linkedEntities                    | Used to link a widget to a dashboard for the [facet linking](/docs/query-your-data/explore-query-data/dashboards/filter-new-relic-one-dashboards-facets) feature |
+| presentation.notes                    | -                                 | Not translated to New Relic One yet |
+| layout                                | layout                            | |
+| data                                  | configuration + rawConfiguration  | |
+
+<Callout variant="tip">
+  See [this doc](/docs/apis/nerdgraph/examples/create-widgets-dashboards-api/) to learn how to build every type of widget.
+</Callout>
+
+## Visualizations mapping table [#visualization-mapping-table]
+
+We have simplified our widget visualizations by grouping the ones that were in fact the same but obtained through different types of queries. For instance, a line widget is plotted the same way regardless of the type of query: old `line_chart` vs `comparison_line_chart` in Insights.
+
+| Insights API visualization  | Nergraph API visualization  |
+|---|---|---|
+|uniques_list|viz.table|
+|single_event|viz.table|
+|facet_table|viz.table|
+|event_table|viz.table|
+|faceted_area_chart|viz.area|
+|predefined_metric_chart.application_breakdown|viz.area|
+|predefined_metric_chart.scope_breakdown|viz.area|
+|predefined_metric_chart.browser_breakdown|viz.area|
+|predefined_metric_chart.background_breakdown|viz.area|
+|predefined_metric_chart.solr_breakdown|viz.area|
+|predefined_metric_chart.gc_runs_breakdown|viz.area|
+|facet_bar_chart|viz.bar|
+|billboard|viz.billboard|
+|attribute_sheet|viz.billboard|
+|billboard_comparison|viz.billboard|
+|gauge|viz.bullet|
+|event_feed|viz.event-feed|
+|funnel|viz.funnel|
+|heatmap|viz.heatmap|
+|histogram|viz.histogram|
+|inventory|infra.inventory|
+|raw_json|viz.json|
+|line_chart|viz.line|
+|comparison_line_chart|viz.line|
+|faceted_line_chart|viz.line|
+|metric_line_chart|viz.line|
+|markdown|viz.markdown|
+|facet_pie_chart|viz.pie|
+
+## Examples: from REST endpoints to GraphQL queries/mutations [#from-rest-to-mutation]
 
 One of the main benefits from a GraphQL API is that it provides a complete and understandable description of the APIs' data. By using [NerdGraph GraphiQL explorer](https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer), you can discover GraphQL types and fields, along with a brief explanation.
 
-We want to facilitate your migration from the [Insights API](/docs/insights/insights-api) to the new New Relic One dashboards API. Find below some examples that illustrate how the old REST endpoints map to the new GraphQL queries or mutations.
+We want to facilitate your migration from the [Insights API](/docs/apis/insights-apis/insights-dashboard-api/) to the new New Relic One dashboards API. Find below some examples that illustrate how the old REST endpoints map to the new GraphQL queries or mutations.
 
 ### List (GET) -> entitySearch query [#entitysearch]
 
 Dashboards in New Relic One embrace the concept of entity. They are now another entity in New Relic’s entity ecosystem.
 
-* You can list all the dashboard entities you have access to:
+Try it out using the [NerdGraph GraphiQL explorer](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer).
 
-```
-{
-  actor {
-    entitySearch(queryBuilder: {type: DASHBOARD}) {
-      results {
-        entities {
-          ... on DashboardEntityOutline {
-            guid
-            name
-            accountId
+<CollapserGroup>
+  <Collapser
+    id="list-all-dashboards"
+    title="List all dashboard entities you have access to"
+  >
+    ```
+      {
+        actor {
+          entitySearch(queryBuilder: {type: DASHBOARD}) {
+            results {
+              entities {
+                ... on DashboardEntityOutline {
+                  guid
+                  name
+                  accountId
+                }
+              }
+            }
           }
         }
       }
-    }
-  }
-}
-```
+    ```
+  </Collapser>
 
-* You can list all the dashboards by name:
-
-```
-{
-  actor {
-    entitySearch(queryBuilder: {name: "<var>My dashboard</var>"}) {
-      results {
-        entities {
-          ... on DashboardEntityOutline {
-            guid
-            name
-            accountId
+  <Collapser
+    id="list-dashboards-by-name"
+    title="List all dashboards by name"
+  >
+    ```
+      {
+        actor {
+          entitySearch(queryBuilder: {name: "<var>My dashboard</var>"}) {
+            results {
+              entities {
+                ... on DashboardEntityOutline {
+                  guid
+                  name
+                  accountId
+                }
+              }
+            }
           }
         }
       }
-    }
-  }
-}
-```
+    ```
+  </Collapser>
 
-* You can list all the dashboards by the creator’s email:
-
-```
-{
-  actor {
-    entitySearch(queryBuilder: {type: DASHBOARD, tags: {key: "<var>createdBy</var>", value: "<var>email@domain.com</var>"}}) {
-      results {
-        entities {
-          ... on DashboardEntityOutline {
-            guid
-            name
-            accountId
+  <Collapser
+    id="list-dashboards-by-email"
+    title="List all dashboards by creator’s email"
+  >
+    ```
+      {
+        actor {
+          entitySearch(queryBuilder: {type: DASHBOARD, tags: {key: "<var>createdBy</var>", value: "<var>email@domain.com</var>"}}) {
+            results {
+              entities {
+                ... on DashboardEntityOutline {
+                  guid
+                  name
+                  accountId
+                }
+              }
+            }
           }
         }
       }
-    }
-  }
-}
-```
+    ```
+  </Collapser>
 
-* You can list all the dashboards by the creator’s userId:
-
-```
-{
-  actor {
-    entitySearch(query: "type = '<var>DASHBOARD</var>' and ownerId = "<var>2357322</var>") {
-      results {
-        entities {
-          ... on DashboardEntityOutline {
-            guid
-            name
-            accountId
+  <Collapser
+    id="list-dashboards-by-user-id"
+    title="List all dashboards by creator’s user id"
+  >
+    ```
+      {
+        actor {
+          entitySearch(query: "type ='<var>DASHBOARD</var>' and ownerId = '<var>2357322</var>'") {
+            results {
+              entities {
+                ... on DashboardEntityOutline {
+                  guid
+                  name
+                  accountId
+                }
+              }
+            }
           }
         }
       }
-    }
-  }
-}
-```
+    ```
+  </Collapser>
+</CollapserGroup>
 
 ### Show (GET) -> entity query [#entityquery]
 
-In order to get information on a dashboard, all you need is to provide its unique entity identifier or entity GUID. Then you can access all the dashboard properties that you are interested in by adding them in the GraphQL query.
+In order to get information on a dashboard, all you need is to provide its unique entity identifier or entity guid. Then you can access all the dashboard properties that you are interested in by adding them in the GraphQL query.
 
-In the example below we are only interested in the entity GUID and the name of our dashboard.
+Try it out using the [NerdGraph GraphiQL explorer](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer).
 
-```
-{
-  actor {
-    entity(guid: "<var>MY_DASHBOARD_GUID</var>") {
-      ... on DashboardEntity {
-        guid
-        name
+<CollapserGroup>
+  <Collapser
+    id="get-dashboard"
+    title="Get dashboard info given its entity guid"
+  >
+    ```
+      {
+        actor {
+          entity(guid: "<var>MY_DASHBOARD_GUID</var>") {
+            ... on DashboardEntity {
+              guid
+              accountId
+              name
+              createdAt
+              updatedAt
+              permissions
+              description
+              owner { email userId }
+              pages {
+                guid
+                name
+                createdAt
+                updatedAt
+                description
+                owner { email userId }
+                widgets {
+                  id
+                  visualization { id }
+                  title
+                  layout { row column height width }
+                  rawConfiguration
+                  linkedEntities { guid }
+                }
+              }
+            }
+          }
+        }
       }
-    }
-  }
-}
-```
+    ```
+  </Collapser>
+</CollapserGroup>
 
 ### Create (POST) -> dashboardCreate mutation [#dashboard-create]
 
 Operations that mutate the state of the system are mutations in GraphQL APIs. You can create a dashboard by providing the required input for the `dashboardCreate` mutation. Although GraphQL APIs aim to be self-explanatory, Nerdgraph docs can help you with some information about the fields, like the doc about [how to build dashboard widgets](/docs/apis/nerdgraph/examples/create-widgets-dashboards-api).
 
-The example below is not complete but can give you an understanding of how the mutation looks like. Try it out using the [NerdGraph GraphiQL explorer](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer).
+Try it out using the [NerdGraph GraphiQL explorer](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer).
 
-```
-mutation {
-  dashboardCreate(
-    accountId: 1, 
-    dashboard: {
-      name: "<var>My dashboard</var>",  
-      pages: [
-        {
-          name: "<var>Errors page</var>", 
-          widgets: {}
+<CollapserGroup>
+  <Collapser
+    id="create-dashboard"
+    title="Create dashboard with two pages and two widgets per page"
+  >
+    ```
+      mutation {
+        dashboardCreate(accountId: <var>1</var>, dashboard: {
+          name: "My awesome dashboard",
+          permissions: PUBLIC_READ_WRITE,
+          pages: [{
+            name: "My first page",
+            widgets: [{
+              visualization: { id: "viz.markdown" },
+              title: "My markdown widget",
+              layout: {
+                row: 1,
+                column: 1,
+                width: 4,
+                height: 3
+              },
+              rawConfiguration: {
+                text: "#My markdown"
+              }
+            }, {
+              visualization: { id: "viz.line" },
+              title: "My line widget",
+              layout: {
+                row: 1,
+                column: 5,
+                width: 4,
+                height: 3
+              },
+              rawConfiguration: {
+                nrqlQueries: [{
+                  accountId: 1,
+                  query: "SELECT count(*) FROM Transaction FACET appName TIMESERIES"
+                }]
+              }
+            }]
+          }, {
+            name: "My second page",
+            widgets: [{
+              visualization: { id: "viz.billboard" },
+              title: "My billboard widget with thresholds",
+              layout: {
+                row: 1,
+                column: 1,
+                width: 4,
+                height: 3
+              },
+              rawConfiguration: {
+                nrqlQueries: [{
+                  accountId: 1,
+                  query: "SELECT count(*) FROM Transaction"
+                }],
+                thresholds: [{
+                  alertSeverity: WARNING,
+                  value: 650
+                }, {
+                  alertSeverity: CRITICAL,
+                  value: 1500
+                }]
+              }
+            }, {
+              visualization: { id: "viz.table" },
+              title: "My table widget",
+              layout: {
+                row: 1,
+                column: 5,
+                width: 4,
+                height: 3
+              },
+              rawConfiguration: {
+                nrqlQueries: [{
+                  query: "SELECT * FROM Transaction",
+                  accountId: 1
+                }]
+              }
+            }]
+          }]
+        }) {
+          errors {
+            description
+            type
+          }
+          entityResult {
+            guid
+            accountId
+            name
+            createdAt
+            updatedAt
+            permissions
+            description
+            owner { email userId }
+            pages {
+              guid
+              name
+              createdAt
+              updatedAt
+              description
+              owner { email userId }
+              widgets {
+                id
+                visualization { id }
+                title
+                layout { row column height width }
+                rawConfiguration
+                linkedEntities { guid }
+              }
+            }
+          }
         }
-        {
-          name: "<var>Logs page</var>", 
-          widgets: {}
-        }
-      ], 
-      permissions: PUBLIC_READ_ONLY
-    }) {
-    entityResult {
-      name
-      guid
-      updatedAt
-      createdAt
-    }
-    errors {
-      description
-      type
-    }
-  }
-}
-```
+      }
+    ```
+  </Collapser>
+</CollapserGroup>
 
 ### Update (PUT) -> dashboardUpdate mutation [#dashboard-update]
 
-The `dashboardUpdate` mutation allows you to update an existing dashboard by providing the existing dashboard GUID and the new configuration. Similarly to creating a dashboard, the mutation tries to be self-explanatory, but you can look up the doc about [how to build dashboard widgets](/docs/apis/nerdgraph/examples/create-widgets-dashboards-api).
+The `dashboardUpdate` mutation allows you to update an existing dashboard by providing the existing dashboard guid and the new configuration. Similarly to creating a dashboard, the mutation tries to be self-explanatory, but you can look up the doc about [how to build dashboard widgets](/docs/apis/nerdgraph/examples/create-widgets-dashboards-api).
 
-The example is not complete but it can give you an understanding of how the mutation looks like. Try it out using the NerdGraph GraphiQL explorer.
+Try it out using the [NerdGraph GraphiQL explorer](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer).
 
-```
-mutation {
-  dashboardUpdate( 
-    guid: "<var>MY_EXISTING_DASHBOARD_GUID</var>",
-    dashboard: {
-      name: "<var>My dashboard</var>",  
-      pages: [
-        {
-          name: "<var>Errors page</var>", 
-          widgets: {}
+<CollapserGroup>
+  <Collapser
+    id="update-dashboard"
+    title="Update previously created dashboard to 1 page and 1 widget per page"
+  >
+    ```
+      mutation {
+        dashboardUpdate(guid: "<var>MY_DASHBOARD_GUID</var>" dashboard: {
+          name: "My awesome dashboard",
+          permissions: PUBLIC_READ_WRITE,
+          pages: [{
+            name: "My first page",
+            widgets: [{
+              visualization: { id: "viz.line" },
+              title: "My line widget",
+              layout: {
+                row: 1,
+                column: 1,
+                width: 4,
+                height: 3
+              },
+              rawConfiguration: {
+                nrqlQueries: [{
+                  accountId: 1,
+                  query: "SELECT count(*) FROM Transaction FACET appName TIMESERIES"
+                }]
+              }
+            }]
+          }, {
+            name: "My second page",
+            widgets: [{
+              visualization: { id: "viz.table" },
+              title: "My table widget",
+              layout: {
+                row: 1,
+                column: 1,
+                width: 4,
+                height: 3
+              },
+              rawConfiguration: {
+                nrqlQueries: [{
+                  query: "SELECT * FROM Transaction",
+                  accountId: 1
+                }]
+              }
+            }]
+          }]
+        }) {
+          errors {
+            description
+            type
+          }
+          entityResult {
+            guid
+            accountId
+            name
+            createdAt
+            updatedAt
+            permissions
+            description
+            owner { email userId }
+            pages {
+              guid
+              name
+              createdAt
+              updatedAt
+              description
+              owner { email userId }
+              widgets {
+                id
+                visualization { id }
+                title
+                layout { row column height width }
+                rawConfiguration
+                linkedEntities { guid }
+              }
+            }
+          }
         }
-        {
-          name: "<var>Logs page</var>", 
-          widgets: {}
-        }
-      ], 
-      permissions: PUBLIC_READ_ONLY
-    }) {
-    entityResult {
-      name
-      guid
-      updatedAt
-      createdAt
-    }
-    errors {
-      description
-      type
-    }
-  }
-}
-```
+      }
+    ```
+  </Collapser>
+</CollapserGroup>
 
 ### Delete (DELETE) -> dashboardDelete mutation [#dashboard-delete]
 
-The `dashboardDelete` mutation allows you to delete an existing dashboard by providing its entity GUID.
+The `dashboardDelete` mutation allows you to delete an existing dashboard by providing its entity guid.
 
-```
-mutation {
-  dashboardDelete {
-    status
-    errors {
-      type
-      description
-    }
-  }
-}
-```
+Try it out using the [NerdGraph GraphiQL explorer](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer).
+
+<CollapserGroup>
+  <Collapser
+    id="delete-dashboard"
+    title="Delete previously created dashboard"
+  >
+    ```
+      mutation {
+        dashboardDelete(guid:"<var>MY_DASHBOARD_GUID</var>") {
+          status
+          errors {
+            type
+            description
+          }
+        }
+      }
+    ```
+  </Collapser>
+</CollapserGroup>
 
 ### Errors as first class citizens [#errors-first-class]
 
 As you might have noticed, all dashboard mutations offer you a way to ask for errors when being executed. This means that you can perform your dashboard mutations and check the response in order to detect potential issues. Every error has a type and a description to help you identify what’s the source of the problem.
 
-```
-mutation {
-  dashboardMutation(guid: "<var>MY_EXISTING_DASHBOARD_GUID</var>") {
-    mutationResult {
-      result
-    }
-    errors {
-      description
-      type
-    }
-  }
-}
-```
+<CollapserGroup>
+  <Collapser
+    id="errors-first-class"
+    title="Errors as part of every mutation response"
+  >
+    ```
+      mutation {
+        dashboardMutation(guid: "<var>MY_EXISTING_DASHBOARD_GUID</var>") {
+          mutationResult {
+            result
+          }
+          errors {
+            description
+            type
+          }
+        }
+      }
+    ```
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/transition-new-relic-one-insights.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/transition-new-relic-one-insights.mdx
@@ -36,7 +36,7 @@ With New Relic One, you get:
 * **Ability to query many accounts from the same widget**: New Relic One lets you query across all your associated accounts in one place. 
 * **Better querying and charting experiences:** Query access is available globally, no matter where you are in New Relic One. This includes a ["basic" query mode](/docs/chart-builder/use-chart-builder/choose-data/use-basic-mode-specify-data) that doesn't require knowledge of [NRQL](/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql).
 * **Improved query experience:** You can query both the [`Metric` data type](/docs/data-ingest-apis/get-data-new-relic/metric-api/view-query-you-metric-data) and [metric timeslice data](/docs/query-data/nrql-new-relic-query-language/nrql-query-tutorials/query-metric-timeslice-data-nrql).
-* **Easy customization:** Every visualization now has the query accessible. You can augment any curated chart just by changing the NRQL.
+* **Easy customization:** Every visualization now has the query accessible. You can augment any curated chart just by changing the NRQL query.
 
 ### Improved visualizations [#dashboard-options]
 

--- a/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/transition-new-relic-one-insights.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/transition-new-relic-one-insights.mdx
@@ -13,7 +13,7 @@ redirects:
 ---
 
 <Callout variant="important">
-  As of April 12, 2021, we are upgrading Insights to an improved web and mobile experience! All of your Insights URLs will be redirected automatically to the corresponding [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards) in New Relic One. For more details about this migration and how you can easily plan for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-insights-upgrade-to-nr1-dashboards/127823).
+  As of April 12, 2021, we're upgrading Insights to an improved web and mobile experience! All of your Insights URLs will be redirected automatically to the corresponding [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards) in New Relic One. For more details about this migration and how you can easily plan for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-insights-upgrade-to-nr1-dashboards/127823).
 </Callout>
 
 Released in 2014, New Relic Insights was our original way to create custom queries, charts, and dashboards. With [New Relic One](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one), we have modernized the experience for you to access, analyze, and visualize your data. New Relic One offers an improved charts and dashboards experience, and it provides a platform where we can more rapidly bring new innovations to you.
@@ -24,6 +24,32 @@ This transition guide can help you understand:
 * Why it's easy to transition to New Relic One
 * What to know and considerations when you make the switch
 * How to get the most out of using New Relic One
+
+## Features [#features]
+
+You can scroll down to the transition details, but first here are some features we've added that show how New Relic One dashboards are a clear improvement over Insights dashboards.  
+
+### Improved query abilities [#queries]
+
+With New Relic One, you get:
+
+* **Ability to query many accounts from the same widget**: New Relic One lets you query across all your associated accounts in one place. 
+* **Better querying and charting experiences:** Query access is available globally, no matter where you are in New Relic One. This includes a ["basic" query mode](/docs/chart-builder/use-chart-builder/choose-data/use-basic-mode-specify-data) that doesn't require knowledge of [NRQL](/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql).
+* **Improved query experience:** You can query both the [`Metric` data type](/docs/data-ingest-apis/get-data-new-relic/metric-api/view-query-you-metric-data) and [metric timeslice data](/docs/query-data/nrql-new-relic-query-language/nrql-query-tutorials/query-metric-timeslice-data-nrql).
+* **Easy customization:** Every visualization now has the query accessible. You can augment any curated chart just by changing the NRQL.
+
+### Improved visualizations [#dashboard-options]
+
+Not only can you select a wide range of visualization options, you can also add more to your dashboards:
+
+* **Better display options:** Make your data easier to understand by using visualizations other than dense, line-heavy charts. New Relic One also offers a better [TV mode](/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard#dash-visual-tv).
+* **Facet linking**: You can filter your dashboards by faceted attributes, making your dashboards more interactive and easy to use. There's also [support for cases](/docs/query-your-data/explore-query-data/dashboards/filter-new-relic-one-dashboards-facets/#facet-linking-cases). [Learn more](/docs/query-your-data/explore-query-data/dashboards/filter-new-relic-one-dashboards-facets).
+* **More charts or widgets in an area:** Insights restricted you to a 3-across limit. Now you can display up to 12 across your dashboard, providing increased data density along with improved tooltips and tracking across charts.
+* **Easier creation of multi-page dashboards:** Insights referred to these as [data apps](/docs/dashboards/new-relic-one-dashboards/manage-your-dashboard/create-dashboards-have-multiple-pages). Your Insights data apps are preserved as multi-page dashboards in New Relic One.
+* **Chart consistency and flexibility:** Dashboards include facet color consistency across widgets and faster loading times for more performant dashboards. Also, you can add any chart type to a dashboard in New Relic One!
+
+The New Relic Insights UI has served our users well for many years, but it's time to give you an even better experience. Join us and make the switch to New Relic One!
+
 
 ## Steps for a successful transition [#switch]
 
@@ -91,17 +117,7 @@ The transition to New Relic One has two parts: the UI and mobile app experience 
       </td>
 
       <td>
-        The Insights API to create dashboards will be deprecated and replaced with the new Dashboards API as of July 2021. We encourage you to start exploring the capabilities of the [Dashboards API in NerdGraph](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph) now!
-
-        * You can continue to use your Insights insert API key with the Dashboards API, or you can create a new user API key.
-        * Every user who wants to query with the NerdGraph API will need their own user API key.
-
-        The REST API for Insights queries is not affected by this change and will not be deprecated. For more information about which key to use with our APIs, see our documentation about [API keys](/docs/apis/get-started/intro-apis/new-relic-api-keys/).
-
-      ![Insights API keys](./images/insights-API-keys.gif "insights-API-keys.gif")
-
-      <figcaption> Easily access your insert and query API keys by going to **[one.newrelic.com](https://one.newrelic.com/)** > More > Manage Insights Data> API Keys </figcaption> 
-
+        In July of 2021, the Insights Dashboard API will be deprecated and replaced with NerdGraph functionality. For more on this change, and tips on how to migrate, see [NerdGraph API for dashboards](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph). 
       </td>
     </tr>
 
@@ -130,34 +146,3 @@ The transition to New Relic One has two parts: the UI and mobile app experience 
     </tr>
   </tbody>
 </table>
-
-## Get started with New Relic One [#features]
-
-New Relic One dashboards are an improvement to the Insights experience. New Relic One has all the dashboard and charting features that Insights has, and more!
-
-![New Relic One dashboard example](./images/new-relic-one-dashboard-example_1.png "new-relic-one-dashboard-example.png")
-
-<figcaption>
-  [one.newrelic.com](https://one.newrelic.com/) > Dashboards: New Relic One offers a better querying and charting experience than Insights.
-</figcaption>
-
-Switching to New Relic One is easy and seamless. All of the dashboards you previously created in Insights are automatically available in New Relic One.
-
-### Query anything [#queries]
-
-With New Relic One, you get:
-
-* **Better querying and charting experiences:** Query access is available globally, no matter where you are in New Relic One. This includes a ["basic" query mode](/docs/chart-builder/use-chart-builder/choose-data/use-basic-mode-specify-data) that doesn't require knowledge of [NRQL](/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql).
-* **Improved query experience:** You can query both the [`Metric` data type](/docs/data-ingest-apis/get-data-new-relic/metric-api/view-query-you-metric-data) and [metric timeslice data](/docs/query-data/nrql-new-relic-query-language/nrql-query-tutorials/query-metric-timeslice-data-nrql).
-* **Easy customization:** Every visualization now has the query accessible. You can augment any curated chart just by changing the NRQL.
-
-### Visualize more data [#dashboard-options]
-
-Not only can you select a wide range of visualization options, you can also add more to your dashboards:
-
-* **Better display options:** Make your data easier to understand by using visualizations other than dense, line-heavy charts. New Relic One also offers a better [TV mode](/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard#dash-visual-tv).
-* **More charts or widgets across dashboards:** Insights restricted you to a 3-across limit. Now you can display up to 12 across your dashboard, providing increased data density along with improved tooltips and tracking across charts.
-* **Easier creation of multi-page dashboards:** Insights referred to these as [data apps](/docs/dashboards/new-relic-one-dashboards/manage-your-dashboard/create-dashboards-have-multiple-pages). Your Insights data apps are preserved as multi-page dashboards in New Relic One.
-* **Chart consistency and flexibility:** Dashboards include facet color consistency across widgets and faster loading times for more performant dashboards. Also, you can add any chart type to a dashboard in New Relic One!
-
-The New Relic Insights UI has served our users well for many years, but it's time to give you an even better experience. Join us and make the switch to New Relic One!

--- a/src/content/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards.mdx
@@ -57,18 +57,18 @@ Use dashboards to:
 
 * Drive insight with custom, high-density interactive visualizations with a consistent UI.
 * View dashboards across your organization using [cross-account search](/docs/new-relic-one/use-new-relic-one/core-concepts/cross-account-features-security).
-* Chart all the events and attributes from everywhere across our platform. For more information, see our documentation on default [data collection](/docs/using-new-relic/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data).
+* Chart all the events and attributes from everywhere across our platform. For more information, see [Data collection](/docs/using-new-relic/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data).  
 * [Add custom attributes](/docs/insights/insights-data-sources/custom-data/add-custom-attributes-new-relic-apm-data) or [send custom event types](/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api) to most events in order to better understand your business, and see specific details about how your customers interact with your platform, such as page views, host transactions, etc.
 * [Manage your charts and dashboards](#get-started) easily using our quick-access CRUD menus and editing options.
 * Explore and contextualize data with [advanced tooltips and zoom-in functions](#key-visual-tools) to monitor what your systems are doing in real time.
-* Search your dashboards for attributes and metrics.
+* Search your dashboards for attributes and metrics.  
 * [Send data](/docs/insights/insights-data-sources/custom-data/report-custom-event-data) to your dashboards using our APIs.
 
-### Transitioning from Insights [#dashboards-full-experience]
+## Transitioning from Insights [#dashboards-full-experience]
 
 Switching to using New Relic One dashboards from our deprecated Insights dashboards? See [our transition guide](/docs/transition-new-relic-one-dashboards-insights).
 
-If you're using the original Insights Dashboard API, we have have a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that will help you transition to using the new API.
+If you're using the Insights Dashboard API, we have have a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that will help you transition to using the new API.
 
 ## Get started with dashboards [#get-started]
 

--- a/src/content/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards.mdx
@@ -45,10 +45,6 @@ Envision your data as a complex system of roads: you need to navigate the signs 
 
 ![dashboards_intro.png](./images/dashboards_intro.png "dashboards_intro.png")
 
-<Callout variant="important">
-  If you are new to New Relic One and were using the old Insights API, we built a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that will help you adapting to the new dashboards API.
-</Callout>
-
 <Callout variant="tip">
   To use dashboards and the rest of our [observability platform](http://one.newrelic.com), join the New Relic family! [Sign up](https://newrelic.com/signup) to create your free account in only a few seconds. Then ingest up to 100GB of data for free each month. Forever.
 </Callout>
@@ -60,6 +56,7 @@ With New Relic One dashboards you can customize and understand the data you coll
 Use dashboards to:
 
 * Drive insight with custom, high-density interactive visualizations with a consistent UI.
+* View dashboards across your organization using [cross-account search](/docs/new-relic-one/use-new-relic-one/core-concepts/cross-account-features-security).
 * Chart all the events and attributes from everywhere across our platform. For more information, see our documentation on default [data collection](/docs/using-new-relic/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data).
 * [Add custom attributes](/docs/insights/insights-data-sources/custom-data/add-custom-attributes-new-relic-apm-data) or [send custom event types](/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api) to most events in order to better understand your business, and see specific details about how your customers interact with your platform, such as page views, host transactions, etc.
 * [Manage your charts and dashboards](#get-started) easily using our quick-access CRUD menus and editing options.
@@ -67,13 +64,11 @@ Use dashboards to:
 * Search your dashboards for attributes and metrics.
 * [Send data](/docs/insights/insights-data-sources/custom-data/report-custom-event-data) to your dashboards using our APIs.
 
-### See your dashboards across all New Relic [#dashboards-full-experience]
+### Transitioning from Insights [#dashboards-full-experience]
 
-New Relic One dashboards have full **backwards compatibility** with the original New Relic platform, so any dashboard you have created in Insights will be automatically available in dashboards from day one. Reciprocally, when you add a new dashboard, it is also created in Insights. No further action is needed. With New Relic One you can also view dashboards across your organization using [cross-account search](/docs/new-relic-one/use-new-relic-one/core-concepts/cross-account-features-security).
+Switching to using New Relic One dashboards from our deprecated Insights dashboards? See [our transition guide](/docs/transition-new-relic-one-dashboards-insights).
 
-<Callout variant="tip">
-  Switching to New Relic One from Insights? See [our transition guide](/docs/transition-new-relic-one-dashboards-insights).
-</Callout>
+If you're using the original Insights Dashboard API, we have have a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that will help you transition to using the new API.
 
 ## Get started with dashboards [#get-started]
 

--- a/src/content/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards.mdx
@@ -45,6 +45,10 @@ Envision your data as a complex system of roads: you need to navigate the signs 
 
 ![dashboards_intro.png](./images/dashboards_intro.png "dashboards_intro.png")
 
+<Callout variant="important">
+  If you are new to New Relic One and were using the old Insights API, we built a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that will help you adapting to the new dashboards API.
+</Callout>
+
 <Callout variant="tip">
   To use dashboards and the rest of our [observability platform](http://one.newrelic.com), join the New Relic family! [Sign up](https://newrelic.com/signup) to create your free account in only a few seconds. Then ingest up to 100GB of data for free each month. Forever.
 </Callout>

--- a/src/nav/new-relic-one.yml
+++ b/src/nav/new-relic-one.yml
@@ -42,7 +42,7 @@ pages:
             path: /docs/new-relic-one/use-new-relic-one/workloads/workload-status-configuration
           - title: Workload status views and notifications
             path: /docs/new-relic-one/use-new-relic-one/workloads/workload-status-views-notifications
-      - title: Build New Relic One 
+      - title: Build on New Relic One 
         pages:
           - title: Build a custom New Relic One integration
             path: /docs/new-relic-one/use-new-relic-one/build-new-relic-one/build-custom-new-relic-one-application            


### PR DESCRIPTION
### What

* Adding some mapping tables in the Insights API -> NR1 dashboards API migration doc
  * Also updating the new dashboards API examples so people can copy/paste and start playing around
* Adding some callouts to drive people to the migration doc in case they are coming from Insights

### Why?

* In the context of the Insights dashboards API being EOLed soon, help Insights API users migrate to the new dashboards API

![image](https://user-images.githubusercontent.com/12070491/118675110-a3a2e200-b7fa-11eb-99ef-2f71efda64c6.png)

![image](https://user-images.githubusercontent.com/12070491/118675160-aac9f000-b7fa-11eb-93cf-696e7d7412a8.png)

![image](https://user-images.githubusercontent.com/12070491/118675311-caf9af00-b7fa-11eb-80eb-8a4c15ca69cb.png)
