### PR TITLE
APM apps/services can now be deleted from the UI

### DIFF
--- a/src/content/docs/apm/new-relic-apm/maintenance/remove-applications-new-relic.mdx
+++ b/src/content/docs/apm/new-relic-apm/maintenance/remove-applications-new-relic.mdx
@@ -53,7 +53,7 @@ Before removing an APM, browser, or mobile application from New Relic, stop the 
        * [**Python**](/docs/agents/python-agent/installation-configuration/python-agent-configuration#monitor_mode): Set `monitor_mode` to `false`.
        * [**Ruby**](/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration#agent_enabled): Set `agent_enabled` to `false`.
     2. [Restart the application server](https://github.com/newrelic/go-agent/blob/master/GUIDE.md#config-and-application) and wait up to ten minutes. Verify the color-coded [health status](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#health-status) for the app has turned to gray and is no longer reporting data.
-    3. To remove the APM application _and_ any browser applications linked to it, you have two options:
+    3. To remove the APM application and any browser applications linked to it, you have two options:
        * Click the **Delete application** button on the APM application/service's **Settings** page. Go to **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app/service) > Settings > Application**.
        * Or, call the [`/applications/delete`](https://rpm.newrelic.com/api/explore/applications/delete) endpoint of the New Relic REST API. For example:
 

--- a/src/content/docs/apm/new-relic-apm/maintenance/remove-applications-new-relic.mdx
+++ b/src/content/docs/apm/new-relic-apm/maintenance/remove-applications-new-relic.mdx
@@ -22,7 +22,7 @@ redirects:
   - /docs/browser/new-relic-browser/installation/delete-apps-new-relic-browser
 ---
 
-Applications are automatically removed from New Relic after 93 days without sending data to our platform. Key metrics will continue to be available via the [New Relic REST API](https://docs.newrelic.com/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2), with the application name remaining reserved.
+Applications are automatically removed from New Relic after 93 days without sending data to our platform. You can also remove an application using the UI, once it has stopped sending data. Key metrics will continue to be available via the [New Relic REST API](https://docs.newrelic.com/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2), with the application name remaining reserved.
 
 For more information, see [Inactive apps in New Relic One](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-feature-end-life-announcements-july-2020#inactive-apps) and our [data retention guidelines](https://docs.newrelic.com/docs/accounts/accounts/data-management/overview-data-retention-components#apm).
 
@@ -53,7 +53,9 @@ Before removing an APM, browser, or mobile application from New Relic, stop the 
        * [**Python**](/docs/agents/python-agent/installation-configuration/python-agent-configuration#monitor_mode): Set `monitor_mode` to `false`.
        * [**Ruby**](/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration#agent_enabled): Set `agent_enabled` to `false`.
     2. [Restart the application server](https://github.com/newrelic/go-agent/blob/master/GUIDE.md#config-and-application) and wait up to ten minutes. Verify the color-coded [health status](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#health-status) for the app has turned to gray and is no longer reporting data.
-    3. To remove the APM application and its browser applications, call the [`/applications/delete`](https://rpm.newrelic.com/api/explore/applications/delete) endpoint of the New Relic REST API. For example:
+    3. To remove the APM application _and_ any browser applications linked to it, you have two options:
+       * Click the **Delete application** button on the APM application/service's **Settings** page. Go to **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app/service) > Settings > Application**.
+       * Or, call the [`/applications/delete`](https://rpm.newrelic.com/api/explore/applications/delete) endpoint of the New Relic REST API. For example:
 
        ```
        curl -X DELETE 'https://api.newrelic.com/v2/applications/<a href="/docs/apis/rest-api-v2/application-examples-v2/list-your-app-id-metric-timeslice-data-v2"><var>YOUR_APP_ID</var></a>.json' \
@@ -70,21 +72,20 @@ Before removing an APM, browser, or mobile application from New Relic, stop the 
       <Callout variant="tip">
         If browser data continues to be reported, see our [suggestions](#browser-reporting) below.
       </Callout>
-    * If your browser application is linked to an APM application, deleting the APM application also removes the browser application. Call the [`/applications/delete`](https://rpm.newrelic.com/api/explore/applications/delete) endpoint like this:
-
-      ```
-      curl -X DELETE 'https://api.newrelic.com/v2/applications/<a href="/docs/apis/rest-api-v2/application-examples-v2/list-your-app-id-metric-timeslice-data-v2"><var>YOUR_APP_ID</var></a>.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/get-started/intro-apis/types-new-relic-api-keys#personal-api-key"><var>YOUR_API_KEY</var></a>' -i
-      ```
+    * Once your browser application has stopped reporting, you have two ways to remove it:
+       * If your browser application is linked to an APM application, deleting the APM application also removes the browser application. See the instructions for deleting an APM application/service above for details.
+       * Or, click the **Delete application** button on the browser application's **Application settings** page. Go to **[one.newrelic.com](https://one.newrelic.com) > Browser > (select an app) > Settings > Application settings **.
   </Collapser>
 
   <Collapser
     id="remove-mobile-apps"
     title="Mobile"
   >
-    Remove all references/dependencies to the New Relic's mobile SDK/frameworks, then rebuild the application. For more information, see the [iOS](/docs/mobile-monitoring/new-relic-mobile-ios/installation) and [Android](/docs/mobile-monitoring/new-relic-mobile-android/install-configure) install docs.
+    * Remove all references/dependencies to the New Relic's mobile SDK/frameworks, then rebuild the application. For more information, see the [iOS](/docs/mobile-monitoring/new-relic-mobile-ios/installation) and [Android](/docs/mobile-monitoring/new-relic-mobile-android/install-configure) install docs.
 
-    After 93 days, the application will be removed from New Relic.
+    * After 93 days, the application will be removed from New Relic.
+    * Or, once your mobile application has stopped reporting, you can also remove it manually:
+       * Click the **Delete application** button on the mobile application's **Settings** page. Go to **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Settings > Application **.
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
Describe how to delete an APM app using the UI (new capability as of May 18 or 19). Also describe the same process for Mobile and Browser apps, which has existed (undocumented) for longer.

Contact ralph@newrelic.com with any questions about timing deployment of this edit :)
