### PR TITLE
Added a redirect from observability solutions that got dropped.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
 const parse = require('rehype-parse');
+const fs = require('fs');
 const path = require('path');
 const unified = require('unified');
 const rehypeStringify = require('rehype-stringify');

--- a/src/content/docs/distributed-tracing/index.mdx
+++ b/src/content/docs/distributed-tracing/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: Distributed tracing
 type: landingPage
+redirects:
+  - /docs/full-stack-observability/monitor-everything/observability-solutions/distributed-tracing
 ---
 
 <LandingPageHero>


### PR DESCRIPTION
When I made a new landing page for distributed tracing, I didn't add this redirect from the observability solutions navigation tree. So, this should fix the navigation tree that has a redirect to distributed tracing.

To test this, go to Full-Stack-Observability > Observer everything > Observability solutions > Distributed tracing. 