### PR TITLE
chore: bump gatsby to 3.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "common-tags": "^1.8.0",
     "date-fns": "^2.17.0",
     "front-matter": "^4.0.2",
-    "gatsby": "^3.5.0",
+    "gatsby": "^3.5.1",
     "gatsby-image": "^3.3.0",
     "gatsby-plugin-gatsby-cloud": "^2.5.0",
     "gatsby-plugin-json-output": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6618,9 +6618,9 @@ electron-to-chromium@^1.3.621:
   integrity sha512-CsLk/r0C9dAzVPa9QF74HIXduxaucsaRfqiOYvIv2PRhvyC6EOqc/KbpgToQuDVgPf3sNAFZi3iBu4vpGOwGag==
 
 electron-to-chromium@^1.3.723:
-  version "1.3.728"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.728.tgz#dbedd6373f595ae10a13d146b66bece4c1afa5bd"
-  integrity sha512-SHv4ziXruBpb1Nz4aTuqEHBYi/9GNCJMYIJgDEXrp/2V01nFXMNFUTli5Z85f5ivSkioLilQatqBYFB44wNJrA==
+  version "1.3.732"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.732.tgz#2a07a8d61f74f2084b6f6bf2a908605a7a0b2d8d"
+  integrity sha512-qKD5Pbq+QMk4nea4lMuncUMhpEiQwaJyCW7MrvissnRcBDENhVfDmAqQYRQ3X525oTzhar9Zh1cK0L2d1UKYcw==
 
 emittery@^0.7.1:
   version "0.7.1"
@@ -8764,10 +8764,10 @@ gatsby-transformer-yaml@^3.3.0:
     lodash "^4.17.21"
     unist-util-select "^1.5.0"
 
-gatsby@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-3.5.0.tgz#a0e7dd4310c585120d8b1782a3d1f8a3272b580e"
-  integrity sha512-xQXHC89ybLCYPWA0TTsY6my8mLCrtH2M/UKOrXaiU7DeNwLb7pLYJ915lo+Dtjj5yu43zMuLL/+jIDLm3FiOmQ==
+gatsby@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-3.5.1.tgz#f32a1d01ac1cdda4ff431c25985a1da9d04ebf1d"
+  integrity sha512-wmhU5dsm2Is/aFgNyxjnuVMNK1chP0Kg5cS15JWAk593xk/hUj0i/lomirNmzvl+2Yk2LC8KZ0M/8OM4cocrKg==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/core" "^7.12.3"
@@ -19251,9 +19251,9 @@ webpack-virtual-modules@^0.3.2:
     debug "^3.0.0"
 
 webpack@^5.35.0:
-  version "5.37.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.37.0.tgz#2ab00f613faf494504eb2beef278dab7493cc39d"
-  integrity sha512-yvdhgcI6QkQkDe1hINBAJ1UNevqNGTVaCkD2SSJcB8rcrNNl922RI8i2DXUAuNfANoxwsiXXEA4ZPZI9q2oGLA==
+  version "5.37.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.37.1.tgz#2deb5acd350583c1ab9338471f323381b0b0c14b"
+  integrity sha512-btZjGy/hSjCAAVHw+cKG+L0M+rstlyxbO2C+BOTaQ5/XAnxkDrP5sVbqWhXgo4pL3X2dcOib6rqCP20Zr9PLow==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.47"


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?

Fixes unexpected 404 network requests when prefetching and preloading resources for redirected pages

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

For example page ( `/docs/agents/c-sdk/`):

Before:
![Screenshot 2021-05-19 at 17 00 38](https://user-images.githubusercontent.com/419821/118835970-c1884980-b8c3-11eb-86f1-5c8f9f393815.png)

After:
![Screenshot 2021-05-19 at 16 59 55](https://user-images.githubusercontent.com/419821/118835978-c3520d00-b8c3-11eb-9bc0-71342ee0a56c.png)

Remaining 404 responses are not related to redirects - those 2 on this page are for:
 1) The link to image (`![c-sdk-transactions1-crop.png](./images/c-sdk-transactions1-crop_1.png "c-sdk-transactions1-crop.png")`) that seems to try to use `gatsby-link` for link (didn't investigate this part yet)
 2) this one is actually valid 404 - there's link that point to not existing page that also doesn't have redirect (`/docs/insights/using-insights-ui/getting-started/introduction-new-relic-insights`)

* If your issue relates to an existing GitHub issue, please link to it.

Related to https://github.com/newrelic/docs-website/issues/1874 (not closing it just yet, because there are few more 404 requests happening)

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.