### PR TITLE
Removing logging dependecies that are not needed anymore from docs

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
@@ -138,8 +138,7 @@ The log forwarding feature is compatible with the following operating systems:
 To use the log forwarder of the infrastructure agent, make sure you meet the following requirements:
 
 * Infrastructure agent version 1.11.4 or higher
-* OpenSSL library 1.1.0 or higher is required by `infra-agent` starting from v1.16.4. 
-* **Windows:** Install the [Microsoft Visual C++ Redistributable](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads): [x64](https://aka.ms/vs/16/release/vc_redist.x64.exe) or [x86](https://aka.ms/vs/16/release/vc_redist.x86.exe).
+* OpenSSL library 1.1.0 or higher is required by `infra-agent` starting from v1.16.4.
 
 The log forwarding feature is not supported on containerized agents.
 


### PR DESCRIPTION
Hi!

This PR removes some dependencies from the docs that are not needed anymore on the infra-agent for enable logging:

- Microsoft Visual C++ Redistributable is not needed anymore since version 1.12.4 for Windows.