### PR TITLE
Removed redirect preventing access to a doc in the left nav

### DIFF
--- a/src/content/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring.mdx
+++ b/src/content/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring.mdx
@@ -5,8 +5,6 @@ tags:
   - Kubernetes integration
   - Installation
 metaDescription: How to configure control plane monitoring for your Kubernetes integration with New Relic.
-redirects:
-  - /docs/integrations/kubernetes-integration/installation/configure-kubernetes-proxy
 ---
 
 [New Relic](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/getting-started/introduction-new-relic-infrastructure) provides [Control Plane](http://kubernetes.io/docs/concepts/#kubernetes-control-plane) support for your Kubernetes integration, allowing you to monitor and collect metrics from your cluster's Control Plane components. That data can then be found in New Relic and used to [create queries and charts](/docs/using-new-relic/data/understand-data/query-new-relic-data).


### PR DESCRIPTION
Closes #2375.

This redirect was preventing access to the Configure Kubernetes with a proxy doc in the left nav. I removed it.