### PR TITLE
This APM analytics redirect should fix a bunch of broken links

### DIFF
--- a/src/content/docs/apm/apm-ui-pages/error-analytics/errors-page-find-fix-verify-problems.mdx
+++ b/src/content/docs/apm/apm-ui-pages/error-analytics/errors-page-find-fix-verify-problems.mdx
@@ -24,6 +24,7 @@ redirects:
   - /docs/apm/applications-menu/error-analytics/introduction-error-analytics
   - /docs/apm/apm-ui-pages/error-analytics/error-analytics-explore-events-behind-errors
   - /docs/apm/apm-ui-pages/error-analytics/errors-page-explore-events-behind-errors
+  - /docs/apm/applications-menu/events/view-apm-error-analytics/
 ---
 
 With Errors in New Relic One, you can see the line of code that's causing a bad experience for your users, and get enough data to reproduce the issue so you can fix it. When you do, you’ll be able to confirm your fix is working in production.


### PR DESCRIPTION
This issue was raised in documentation. Evidently this redirect was missing. I found it over in Drupal.

You can test this redirect by going to these two pages:

* /docs/accounts/original-accounts-billing/product-based-pricing/overview-data-retention-components/#components-trace-data
* /docs/agents/ruby-agent/configuration/ruby-agent-configuration#disable_sinatra_auto_middleware