### PR TITLE
Adjust Amplify build settings

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -9,9 +9,9 @@ frontend:
       commands:
         - |
           if [ "${AWS_BRANCH}" = "main" ]; then
-            GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true yarn run build:production --log-pages;
+            GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true yarn run build:production
           else
-            GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true yarn run build:staging --log-pages;
+            GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true yarn run build:staging
           fi
   artifacts:
     baseDirectory: public


### PR DESCRIPTION
## Description
Our builds are not getting deployed on AWS Amplify. Their engineering team suspects that this is due to our builds taking longer than an hour (presumably, we are given an authorization token that expires after an hour). This change was suggested as a possible way to help with the problem while they continue to look into the problem.
