### PR TITLE
fix: increase fetch-depth of action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
         
       - name: Get release tag
         id: get-tag


### PR DESCRIPTION
This is so that the `Get release notes` step can pull data on more than 1 commit

