### PR TITLE
Fix to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,26 +23,24 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: '0'
-        
+
       - name: Get release tag
         id: get-tag
         run: |
           MERGES=$(gh pr list -B main -s merged --search "closed:>2021-02-28" -L 9999 | wc -l | awk '{print $1}')
           echo "::set-output name=tag::release-$MERGES"
-          
+
       - name: Get last release
         id: get-last-tag
         run: |
           LAST=$(gh release list -L 1 | awk '{print $1}')
           echo "::set-output name=last::$LAST"
-          
+
       - name: Get release notes
         id: get-release-notes
         run: |
           NOTES=$(git log ${{ steps.get-last-tag.outputs.last }}..HEAD --pretty="@%an - %b (%s)[%h]" --merges | sed -e 's!Merge pull request !!')
           echo "::set-output name=notes::$NOTES"
-          
-      
 
       - name: Create release
-        run: gh release create ${{ steps.get-tag.outputs.tag }} -t ${{ steps.get-tag.outputs.tag }} -n ${{ steps.get-release-notes.outputs.notes }}
+        run: gh release create ${{ steps.get-tag.outputs.tag }} -t ${{ steps.get-tag.outputs.tag }} -n "${{ steps.get-release-notes.outputs.notes }}"


### PR DESCRIPTION
## Description

Surrounds the `-n` option in `gh release create` with quotes to avoid `Unexpected token (` errors.

## Related
https://github.com/newrelic/docs-website/runs/2660281252?check_suite_focus=true