### PR TITLE
Infra agent support for arm64

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -24,7 +24,7 @@ The infrastructure agent supports only x86 processor architectures:
 
 * **Linux**: 64-bit architecture (also requires 64-bit package manager and dependencies)
 * **Windows**: both 32 and 64-bit architectures
-* **ARM**: [AWS Graviton 2 processor](https://aws.amazon.com/ec2/graviton/) (using the [tarball setup instructions](https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/linux-installation/install-infrastructure-linux-using-package-manager#custom-setups-tarball)). Support is limited to infrastructure monitoring. Integrations, such as log forwarding, may not work as expected.
+* **ARM**: arm64 architecture including [AWS Graviton 2 processor](https://aws.amazon.com/ec2/graviton/) is supported on compatible linux operating sytems. Built-in log forwarding and on-host integrations are not yet available.
 
 ## Operating systems
 
@@ -139,7 +139,7 @@ The infrastructure agent supports these operating systems:
 </table>
 
 <Callout variant="important">
-  Operating systems are not supported beyond end-of-life.
+  Operating systems are not supported beyond manufacturer end-of-life.
 </Callout>
 
 <Callout variant="tip">

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -264,6 +264,9 @@ To install the infrastructure monitoring agent in Linux, follow these instructio
        ```
        printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt buster main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
+       <Callout variant="tip">
+         Use [arch=arm64] to installing on ARM architectures
+       </Callout>
      </Collapser>
 
      <Collapser
@@ -299,22 +302,25 @@ To install the infrastructure monitoring agent in Linux, follow these instructio
        ```
        printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt focal main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
+       <Callout variant="tip">
+         Use [arch=arm64] to install on ARM architectures such us AWS Graviton
+       </Callout>
      </Collapser>
 
      <Collapser
        id="amazon-linux-repository"
        title={<><img src={amazonLinux} title="amazon linux.png" alt="amazon linux.png" style={{ height: '32px', width: '32px', verticalAlign: 'middle' }}/> Amazon Linux</>}
      >
-       **Amazon Linux**
-
-       ```
-       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64/newrelic-infra.repo
-       ```
-
-       **Amazon Linux 2**
+       **Amazon Linux 2 (x86)**
 
        ```
        sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/7/x86_64/newrelic-infra.repo
+       ```
+
+       **Amazon Linux 2 (arm64)**
+
+       ```
+       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/7/aarch64/newrelic-infra.repo
        ```
      </Collapser>
 
@@ -322,28 +328,21 @@ To install the infrastructure monitoring agent in Linux, follow these instructio
        id="centos-rhel-repository"
        title={<><img src={centosIcon} title="centos icon" alt="centos icon" style={{ height: '32px', width: '32px', verticalAlign: 'middle' }}/> CentOS / <img src={redHatNew2} title="redhat icon" alt="redhat icon" style={{ height: '32px', width: '32px', verticalAlign: 'middle' }}/> RHEL</>}
      >
-       **RHEL 5.x**
-
-       ```
-       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/5/x86_64/newrelic-infra.repo
-       ```
-
-       **RHEL 6.x**
-
-       ```
-       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64/newrelic-infra.repo
-       ```
-
-       **CentOS 7.x, RHEL 7.x**
-
+       **CentOS 7.x, RHEL 7.x (x86)**
        ```
        sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/7/x86_64/newrelic-infra.repo
        ```
-
-       **CentOS 8.x, RHEL 8.x**
-
+       **CentOS 7.x, RHEL 7.x (arm64)**
+       ```
+       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/7/aarch64/newrelic-infra.repo
+       ```
+       **CentOS 8.x, RHEL 8.x (x86)**
        ```
        sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/8/x86_64/newrelic-infra.repo
+       ```
+       **CentOS 8.x, RHEL 8.x (arm64)**
+       ```
+       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/8/aarch64/newrelic-infra.repo
        ```
      </Collapser>
 
@@ -351,34 +350,47 @@ To install the infrastructure monitoring agent in Linux, follow these instructio
        id="amazon-linux-repository"
        title={<><img src={suseIcon} title="suse icon" alt="suse icon" style={{ height: '32px', width: '32px', verticalAlign: 'middle' }}/> SLES</>}
      >
-       **SLES 11.4**
-
-       ```
-       sudo curl -o /etc/zypp/repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/zypp/sles/11.4/x86_64/newrelic-infra.repo
-       ```
-
-       **SLES 12.1**
+       **SLES 12.1 (x86)**
 
        ```
        sudo curl -o /etc/zypp/repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/zypp/sles/12.1/x86_64/newrelic-infra.repo
        ```
+       **SLES 12.1 (ARM)**
 
-       **SLES 12.2**
+       ```
+       sudo curl -o /etc/zypp/repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/zypp/sles/12.1/aarch64/newrelic-infra.repo
+       ```
+       **SLES 12.2 (x86)**
 
        ```
        sudo curl -o /etc/zypp/repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/zypp/sles/12.2/x86_64/newrelic-infra.repo
        ```
+       **SLES 12.2 (ARM)**
 
-       **SLES 12.3**
+       ```
+       sudo curl -o /etc/zypp/repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/zypp/sles/12.2/aarch64/newrelic-infra.repo
+       ```
+
+       **SLES 12.3 (x86)**
 
        ```
        sudo curl -o /etc/zypp/repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/zypp/sles/12.3/x86_64/newrelic-infra.repo
        ```
+       **SLES 12.3 (ARM)**
 
-       **SLES 12.4**
+       ```
+       sudo curl -o /etc/zypp/repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/zypp/sles/12.3/aarch64/newrelic-infra.repo
+       ```
+
+       **SLES 12.4 (x86)**
 
        ```
        sudo curl -o /etc/zypp/repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/zypp/sles/12.4/x86_64/newrelic-infra.repo
+       ```
+       **SLES 12.4 (ARM)**
+
+       ```
+       sudo curl -o /etc/zypp/repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/zypp/sles/12.4/aarch64/newrelic-infra.repo
        ```
      </Collapser>
    </CollapserGroup>

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -265,7 +265,7 @@ To install the infrastructure monitoring agent in Linux, follow these instructio
        printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt buster main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
        <Callout variant="tip">
-         Use [arch=arm64] to install on ARM architectures such us AWS Graviton
+         Use [arch=arm64] to install on ARM architectures such us AWS Graviton.
        </Callout>
      </Collapser>
 
@@ -303,7 +303,7 @@ To install the infrastructure monitoring agent in Linux, follow these instructio
        printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt focal main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
        <Callout variant="tip">
-         Use [arch=arm64] to install on ARM architectures such us AWS Graviton
+         Use [arch=arm64] to install on ARM architectures such us AWS Graviton.
        </Callout>
      </Collapser>
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -265,7 +265,7 @@ To install the infrastructure monitoring agent in Linux, follow these instructio
        printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt buster main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
        <Callout variant="tip">
-         Use [arch=arm64] to installing on ARM architectures
+         Use [arch=arm64] to install on ARM architectures such us AWS Graviton
        </Callout>
      </Collapser>
 

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -278,6 +278,9 @@ Please consider the following when migrating from poll-based integrations:
 * Entities in New Relic Explorer might be duplicated for up to 24 hours.
 * The AWS CloudWatch Metric Streams integration only collects metrics. Integrations such as AWS Health, AWS Billing, and AWS CloudTrail collect additional instrumentation that's not available for metric streams. In order to continue collecting that additional data, keep those enabled as polling integrations.
 
+### Data ingested
+AWS CloudWatch Metric Streams makes all metrics available as soon as they are published to AWS CloudWatch from the different services (for most namespaces, metrics are published once per minute). For customers collecting metrics at the default polling rate of 5 minutes, this difference in interval might result in more data being ingested. See recommendations in [manage data](#manage-data) to refine data being collected.
+
 ## Troubleshooting [#troubleshooting]
 
 ### No metrics or errors appear on New Relic [#no-metrics-appear]

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -278,9 +278,6 @@ Please consider the following when migrating from poll-based integrations:
 * Entities in New Relic Explorer might be duplicated for up to 24 hours.
 * The AWS CloudWatch Metric Streams integration only collects metrics. Integrations such as AWS Health, AWS Billing, and AWS CloudTrail collect additional instrumentation that's not available for metric streams. In order to continue collecting that additional data, keep those enabled as polling integrations.
 
-### Data ingested
-AWS CloudWatch Metric Streams makes all metrics available as soon as they are published to AWS CloudWatch from the different services (for most namespaces, metrics are published once per minute). For customers collecting metrics at the default polling rate of 5 minutes, this difference in interval might result in more data being ingested. See recommendations in [manage data](#manage-data) to refine data being collected.
-
 ## Troubleshooting [#troubleshooting]
 
 ### No metrics or errors appear on New Relic [#no-metrics-appear]


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* Infrastructure agent will be available for arm64 machines with standard linux package setup.
* This PR updates the manual installation steps and support matrix to explain arm64 support.
* Support is limited to infra-agent and few additional integrations (no log-fwd, no OHIs at the moment). 

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.