### PR TITLE
 Add minor updates to python agent 6.4.0 release notes.

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60400157.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60400157.mdx
@@ -63,7 +63,7 @@ The agent can be installed using easy_install/pip/distribute via the [Python Pac
 
 * **RuntimeInstrumentationError crash removed**
 
-  Crashes occurred when a RuntimeInstrumentationError was reached, indicating a potential problem with existing instrumentation. The exception is now caught and replaced with error level log messages to avoid crashing applications.
+  Crashes occurred when a `RuntimeInstrumentationError` was reached, indicating a potential problem with existing instrumentation. The exception is now caught and replaced with error level log messages to avoid crashing applications.
 
 * **SQLite instrumentation consumes generator objects passed to `executemany`**
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60400157.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60400157.mdx
@@ -1,11 +1,10 @@
 ---
 subject: Python agent
-releaseDate: '2021-05-21'
+releaseDate: '2021-05-25'
 version: 6.4.0.157
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 ---
 
-**NOTE: Server-side configuration for the new settings described here is not yet released, but will be shortly.**
 
 ## Notes
 
@@ -28,7 +27,7 @@ The agent can be installed using easy_install/pip/distribute via the [Python Pac
 * **Added new `notice_error` API**
 
   This new API falls much more in line with [other language agents](/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected/#error-collection).
-  
+
   It also includes [expected errors](/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected/#expected) functionality and a status code parameter.
 
   To see all changes, view the [documentation](/docs/agents/python-agent/python-agent-api/noticeerror-python-agent-api/) for this API.
@@ -54,7 +53,7 @@ The agent can be installed using easy_install/pip/distribute via the [Python Pac
 
 * **`error_collector.ignore_status_codes` is now configurable in server-side configuration**
 
-    Previously this setting was only available in the config file, but is now available via server-side configuartion.
+    Previously this setting was only available in the config file, but is now available via server-side configuration.
 
 ## Bug Fixes
 
@@ -64,7 +63,7 @@ The agent can be installed using easy_install/pip/distribute via the [Python Pac
 
 * **RuntimeInstrumentationError crash removed**
 
-  Crashes ocurred when a RuntimeInstrumentationError was reached, indicating a potential problem with existing instrumentation. The exception is now caught and replaced with error level log messages to avoid crashing applications.
+  Crashes occurred when a RuntimeInstrumentationError was reached, indicating a potential problem with existing instrumentation. The exception is now caught and replaced with error level log messages to avoid crashing applications.
 
 * **SQLite instrumentation consumes generator objects passed to `executemany`**
 


### PR DESCRIPTION
### Give us some context

* What problems does this PR solve?
Our original release notes included a note about server side configuration not being released which is no longer applicable. This PR removes that note and fixes a few additional typos.

