### PR TITLE
Redirecting the taxonomy for two files - Azure and GCP

### DIFF
--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -2442,5 +2442,17 @@
     "paths": [
       "/docs/full-stack-observability/instrument-everything/get-started-new-relic-instrumentation"
     ]
+  },
+  {
+    "url": "/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-functions-monitoring-integration/",
+    "paths": [
+      "/docs/serverless-function-monitoring/google-cloud-functions-monitoring/get-started"
+    ]
+  },
+  {
+    "url": "/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-functions-monitoring-integration",
+    "paths": [
+      "/docs/serverless-function-monitoring/azure-functions-monitoring/get-started"
+    ]
   }
 ]

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -2557,18 +2557,18 @@ pages:
             pages:
               - title: Troubleshoot Lambda monitoring
                 path: /docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda
-          - title: Azure functions monitoring
+      - title: Azure functions monitoring
+        pages:
+          - title: Get started
+            path: /docs/serverless-function-monitoring/azure-functions-monitoring/get-started
             pages:
-              - title: Get started
-                path: /docs/serverless-function-monitoring/azure-functions-monitoring/get-started
-                pages:
               - title: Azure Functions monitoring integration
                 path: /docs/serverless-function-monitoring/azure-functions-monitoring/get-started/azure-functions-monitoring-integration
-              - title: Google Cloud Functions monitoring
+      - title: Google Cloud Functions monitoring
+        pages:
+          - title: Get started
+            path: /docs/serverless-function-monitoring/google-cloud-functions-monitoring/get-started
             pages:
-              - title: Get started
-                path: /docs/serverless-function-monitoring/google-cloud-functions-monitoring/get-started
-                pages:
               - title: Google Cloud Functions monitoring integration
                 path: /docs/serverless-function-monitoring/google-cloud-functions-monitoring/get-started/google-cloud-functions-monitoring-integration
   - title: Synthetic monitoring

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -2557,18 +2557,18 @@ pages:
             pages:
               - title: Troubleshoot Lambda monitoring
                 path: /docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda
-      - title: Azure functions monitoring
-        pages:
-          - title: Get started
-            path: /docs/serverless-function-monitoring/azure-functions-monitoring/get-started
+          - title: Azure functions monitoring
             pages:
+              - title: Get started
+                path: /docs/serverless-function-monitoring/azure-functions-monitoring/get-started
+                pages:
               - title: Azure Functions monitoring integration
                 path: /docs/serverless-function-monitoring/azure-functions-monitoring/get-started/azure-functions-monitoring-integration
-      - title: Google Cloud Functions monitoring
-        pages:
-          - title: Get started
-            path: /docs/serverless-function-monitoring/google-cloud-functions-monitoring/get-started
+              - title: Google Cloud Functions monitoring
             pages:
+              - title: Get started
+                path: /docs/serverless-function-monitoring/google-cloud-functions-monitoring/get-started
+                pages:
               - title: Google Cloud Functions monitoring integration
                 path: /docs/serverless-function-monitoring/google-cloud-functions-monitoring/get-started/google-cloud-functions-monitoring-integration
   - title: Synthetic monitoring


### PR DESCRIPTION
Per notification in the documentation channel that these were broken.