### PR TITLE
Need to correct run command for ECS

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/monitor-services-running-amazon-ecs.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/monitor-services-running-amazon-ecs.mdx
@@ -90,9 +90,10 @@ Here are instructions for changing EC2 launch configuration (taken from [Amazon 
          - newrelic-infra
          - nri-*
        runcmd:
+         - [ yum, install, newrelic-infra, -y ]
          - [ systemctl, daemon-reload ]
-         - [ systemctl, enable, newrelic-infra ]
-         - [ systemctl, start, --no-block, newrelic-infra ]
+         - [ systemctl, enable, newrelic-infra.service ]
+         - [ systemctl, start, --no-block, newrelic-infra.service ]
 
        --MIMEBOUNDARY
        Content-Transfer-Encoding: 7bit
@@ -147,9 +148,10 @@ Here are instructions for changing EC2 launch configuration (taken from [Amazon 
          - newrelic-infra
          - nri-*
        runcmd:
+         - [ yum, install, newrelic-infra, -y ]
          - [ systemctl, daemon-reload ]
-         - [ systemctl, enable, newrelic-infra ]
-         - [ systemctl, start, --no-block, newrelic-infra ]
+         - [ systemctl, enable, newrelic-infra.service ]
+         - [ systemctl, start, --no-block, newrelic-infra.service ]
 
        --MIMEBOUNDARY
        Content-Transfer-Encoding: 7bit


### PR DESCRIPTION
Here is the request from GitHub issue 2461:

The suggested userdata snippets on Step 1, subsection 6 (both snippets) don't install the agent.

Specifically this section:

runcmd:
  - [ systemctl, daemon-reload ]
  - [ systemctl, enable, newrelic-infra ]
  - [ systemctl, start, --no-block, newrelic-infra ]
Should be:

runcmd:
  - [ yum, install, newrelic-infra, -y ]
  - [ systemctl, daemon-reload ]
  - [ systemctl, enable, newrelic-infra.service ]
  - [ systemctl, start, --no-block, newrelic-infra.service ]
For both "CentOS 7, RHEL 7, Amazon Linux 2" and "For CentOS 6, RHEL 6, Amazon Linux 1" snippets

Then in Step 2, we never mention that you need to add a runcmd to install the desired integration. Using the nginx example that the doc is currently using, it should say to add the following to the runcmd section:

  - [ yum, install, nri-nginx, -y ]
So the full runcmd section would be:

runcmd:
  - [ yum, install, newrelic-infra, -y ]
  - [ yum, install, nri-nginx, -y ]
  - [ systemctl, daemon-reload ]
  - [ systemctl, enable, newrelic-infra.service ]
  - [ systemctl, start, --no-block, newrelic-infra.service ]