### PR TITLE
StatsD v1 integration EOL June 1st 2021

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration.mdx
@@ -15,7 +15,7 @@ redirects:
 Our StatsD integration lets you send data of your choosing to the New Relic platform, where it can be analyzed, used to create queries and custom charts, and used as a basis for [alert conditions](/docs/alerts).
 
 <Callout variant="important">
-  We have a [newer, improved StatsD integration version](/docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2).
+ Starting June 1st 2021, the StatsD v1 integration is no longer supported. Find more details [in this post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-across-synthetics-apm-java-php-infrastructure-mobile-agents-health-maps-statsd-and-legacy-dashboards/147982). We have a [newer, improved StatsD integration version](/docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2).
 </Callout>
 
 The diagram shows the basics of how the StatsD integration sends data to New Relic.


### PR DESCRIPTION
Added a note and link to the EOL communication for the StatsD v1 on-host integration. 
Customers should migrate to v2.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.