### PR TITLE
Chart refresh rates 

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/use-charts/chart-refresh-rates.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/use-charts/chart-refresh-rates.mdx
@@ -1,6 +1,8 @@
 ---
 title: Chart refresh rates
 metaDescription: 'New Relic chart refresh rates.'
+redirects: 
+  - /docs/insights/use-insights-ui/manage-dashboards/insights-chart-refresh-intervals
 ---
 
 The refresh rate of New Relic charts is the range of the query's timeframe divided by 60. The maximum frequency with which queries can be refreshed is every 5 seconds. 

--- a/src/content/docs/query-your-data/explore-query-data/use-charts/chart-refresh-rates.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/use-charts/chart-refresh-rates.mdx
@@ -1,0 +1,16 @@
+---
+title: Chart refresh rates
+metaDescription: 'New Relic chart refresh rates.'
+---
+
+The refresh rate of New Relic charts is the range of the query's timeframe divided by 60. The maximum frequency with which queries can be refreshed is every 5 seconds. 
+
+For example:
+
+* A query with a 7-day time range would have a refresh rate of once every 2.8 hours.
+* A query with a 1-hour time range would have a refresh rate of once every 1 minute.
+
+For queries using `TIMESERIES`, the size of the `TIMESERIES` bucket is used as the refresh interval. For example:
+
+* `SELECT count(*) FROM PageView TIMESERIES 5 minutes` would refresh every 5 minutes.
+* `SELECT count(*) FROM PageView TIMESERIES 1 hour SINCE 1 day ago` would refresh every hour.

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries.mdx
@@ -4,7 +4,6 @@ metaDescription: "An explanation of the rate limits in place for New Relic's que
 redirects:
   - /docs/insights/use-insights-ui/manage-account-data/rate-limits-insights-requests
   - /docs/insights/use-insights-ui/manage-account-data/rate-limits-insights
-  - /docs/insights/use-insights-ui/manage-dashboards/insights-chart-refresh-intervals
 ---
 
 New Relic's query language, NRQL, has rate limits in place to ensure a high level of availability and reliability for all users. To understand the places NRQL can be used, see [Where is NRQL used?](/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql#where).

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries.mdx
@@ -77,16 +77,3 @@ The limit for total number of reported data types is 250 per account over a give
 
 This limit applies to all [NRQL-queryable data types](/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql#what-you-can-query). Because there aren't that many different data types reported by New Relic products and integrations, this will mainly be a limit on [custom events](/docs/insights/insights-data-sources/custom-data/send-custom-data-insights).
 
-## Refresh rates [#refresh]
-
-The refresh rate of UI charts is the range of the query's timeframe divided by 60. The maximum frequency with which queries can be refreshed is every 5 seconds. 
-
-For example:
-
-* A query with a 7-day time range would have a refresh rate of once every 2.8 hours.
-* A query with a 1-hour time range would have a refresh rate of once every 1 minute.
-
-For queries using `TIMESERIES`, the size of the `TIMESERIES` bucket is used as the refresh interval. For example:
-
-* `SELECT count(*) FROM PageView TIMESERIES 5 minutes` would refresh every 5 minutes.
-* `SELECT count(*) FROM PageView TIMESERIES 1 hour SINCE 1 day ago` would refresh every hour.

--- a/src/nav/new-relic-in-practice.yml
+++ b/src/nav/new-relic-in-practice.yml
@@ -174,6 +174,8 @@ pages:
                 path: /docs/query-your-data/explore-query-data/use-charts/use-your-charts
               - title: Chart types
                 path: /docs/query-your-data/explore-query-data/use-charts/chart-types
+              - title: Chart refresh rates
+                path: /docs/query-your-data/explore-query-data/use-charts/chart-refresh-rates
           - title: Dashboards
             path: /docs/query-your-data/explore-query-data/dashboards
             pages:


### PR DESCRIPTION
Moving content, related to changes made on recent jira DOC-6819 that I needed to follow up on. Moved 'Chart refresh rates' out of query limits doc and into its own doc. 