### PR TITLE
Fix erroneous info

### DIFF
--- a/src/content/whats-new/2020/10/alerting-loss-signal-detection-configurable-gap-filling-strategies.md
+++ b/src/content/whats-new/2020/10/alerting-loss-signal-detection-configurable-gap-filling-strategies.md
@@ -12,6 +12,6 @@ To see if it’s simply a delay in signal or something worse, you can now config
 
 We know that not all signals or time series that are being monitored have a consistent flow of data points. Because New Relic evaluates incoming data in specific windows of time, in many cases, the telemetry signals you send to New Relic can have gaps, meaning that some time windows will not have data. You now have the option to implement multiple strategies for how those gaps should be filled–sometimes called extrapolation strategies–including setting a static value, using the previously detected value, or not doing anything.
 
-When editing a NRQL Alert Condition, you can configure loss of signal detection and gap filling under **Condition settings > Advanced signal settings**.
+When editing a NRQL Alert Condition, you can configure loss of signal detection under **Condition settings > Set your condition thresholds** and gap filling under **Condition settings > Fine-tune advanced signal settings**.
 
 ![Animated gif showing condition settings.](./images/whats_up_signal_loss.gif "whats_up_signal_loss.gif")


### PR DESCRIPTION
Fixed erroneous instructions on where to go to find Gap Filling and Loss of Signal

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.