### PR TITLE
redirect fix to address documentation channel feedback

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language.mdx
@@ -70,7 +70,6 @@ redirects:
   - /docs/servers/rest-api-examples-v2/server-api-examples/delete-host-index-v2
   - /docs/servers/rest-api-examples-v2
   - /docs/servers/rest-api-examples-v2/server-api-examples
-  - /docs/apis/getting-started/intro-apis/introduction-new-relic-apis
   - /docs/rubicon/query-history
   - /docs/insights/query-history
   - /docs/insights/new-relic-insights/managing-dashboards-and-data/query-history


### PR DESCRIPTION
links to "Intro to APIs" were going to NRQL page. This removes the redirect to NRQL, to ensure people get to the proper API page.