### PR TITLE
Update large-number-false-positive-security-vulnerabilities.mdx

### DIFF
--- a/src/content/docs/agents/java-agent/troubleshooting/large-number-false-positive-security-vulnerabilities.mdx
+++ b/src/content/docs/agents/java-agent/troubleshooting/large-number-false-positive-security-vulnerabilities.mdx
@@ -11,9 +11,14 @@ tags:
 
 When a security scan is performed, it reports back with a high number of false positive security vulnerabilities.
 
-## Solution
+## Cause
 
-Supress the false positives with:
+The security scan flagged the `.jar` files as vulnerable due to the class and method names we use to identify sources for instrumentation. However, our instrumentation code is not part of the vulnerable libraries and the vulnerable libraries do not exist in our `.jar` files, which contain only New Relic code.
+
+## Solution
+Suppress the false positive warnings coming from the `instrumentation` package in the newrelic.jar in whatever way the scanning tool you are using provides.
+
+For example, false positives discovered by the `DependencyCheck` project here: https://github.com/jeremylong/DependencyCheck can be suppressed with:
 
 ```
 <suppress>
@@ -22,7 +27,5 @@ Supress the false positives with:
     <cpe regex="true">.*
 </suppress>
 ```
+Consult your security scan vendor for the appropriate configuration to suppress false positives.
 
-## Cause
-
-The security scan flagged the `.jar` files as vulnerable due to the class and method names we use to identify sources for instrumentation. However, our instrumentation code is not part of the vulnerable libraries and the vulnerable libraries do not exist in our `.jar` files, which contain only New Relic code.

--- a/src/content/docs/agents/java-agent/troubleshooting/large-number-false-positive-security-vulnerabilities.mdx
+++ b/src/content/docs/agents/java-agent/troubleshooting/large-number-false-positive-security-vulnerabilities.mdx
@@ -13,12 +13,12 @@ When a security scan is performed, it reports back with a high number of false p
 
 ## Cause
 
-The security scan flagged the `.jar` files as vulnerable due to the class and method names we use to identify sources for instrumentation. However, our instrumentation code is not part of the vulnerable libraries and the vulnerable libraries do not exist in our `.jar` files, which contain only New Relic code.
+The security scan flagged the jar files as vulnerable due to the class and method names we use to identify sources for instrumentation. However, the jar files only contain New Relic instrumentation code.
 
 ## Solution
-Suppress the false positive warnings coming from the `instrumentation` package in the newrelic.jar in whatever way the scanning tool you are using provides.
+Suppress the false positive warnings coming from the `instrumentation` package in the newrelic.jar with your scanning tool.
 
-For example, false positives discovered by the `DependencyCheck` project here: https://github.com/jeremylong/DependencyCheck can be suppressed with:
+For example, false positives discovered by the `DependencyCheck` project at [github.com/jeremylong/DependencyCheck](https://github.com/jeremylong/DependencyCheck) can be suppressed with:
 
 ```
 <suppress>


### PR DESCRIPTION


### Give us some context

This doc previously provided a very specific solution for a single vendor security scan.  The doc demonstrated how to suppress false positives for the single vendor.

However, this information about false positives applies across many security scan vendors.  I updated this to be a more generic reference point for when customers see alarming security scan violations coming from the java agent. This is a common question, so the answer should be more generic.  I left the previous instruction for suppression as an example of how one might need to go about doing such a thing. 



