### PR TITLE
Restoring the original certification announcement for May 27th.

### DIFF
--- a/src/content/whats-new/2021/05/programmability-fs.md
+++ b/src/content/whats-new/2021/05/programmability-fs.md
@@ -1,0 +1,22 @@
+---
+title: 'New observability specialist certification for developers!'
+summary: 'Get certified in programmability with this certification course'
+releaseDate: '2021-05-27'
+learnMoreLink: 'https://newrelic.com/blog/nerd-life/observability-specialist-certification'
+getStartedLink: 'https://learn.newrelic.com/programmability-certification'
+---
+Are you looking to extend New Relic One capabilities? Want to build custom apps and request external data into the platform? Now, you can get recognized for your expertise in extending New Relic One so you can highlight your in-demand observability skill set to your organization!
+
+We designed the new programmability certification course for you—engineers and developers who already have a foundational knowledge of New Relic fundamentals—and want to validate your New Relic One expertise. 
+
+After completing this course, you’ll be able to create a New Relic One application from scratch, deploy custom visualizations for your dashboards, and more!
+
+Register for free [here](https://learn.newrelic.com/programmability-certification) or click **Get Started** above!
+
+Click **Learn more** to read the blog, or watch the latest Nerdlog episode below for more information:   
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Opq3a22xnFw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+Note: This certification program assumes you already have existing knowledge of [React](https://reactjs.org/docs/getting-started.html), [Git](https://guides.github.com/introduction/git-handbook/), and [GraphQL](https://graphql.org/).
+
+![Logo of observability specialist certification for developers](./images/programmability-certification.png "Logo of observability specialist certification for developers")


### PR DESCRIPTION
This PR is a follow up the the original 'What's new?" PR #2438 that I had to pull back. I had merged that too soon into develop yesterday, so I pulled it back. 

This PR re-stages this certification post to be released on May 27th. I left the original gif in develop so I only needed to re-publish this document.