### PR TITLE
GitHub issue 2157: Clarify service map functionality for Mobile distributed tracing.

### DIFF
--- a/src/content/docs/distributed-tracing/concepts/distributed-tracing-planning-guide.mdx
+++ b/src/content/docs/distributed-tracing/concepts/distributed-tracing-planning-guide.mdx
@@ -68,7 +68,7 @@ We may provide backward compatibility with some or all of the affected features 
   >
    APM-related impacts include:
 
-    * When distributed tracing is enabled for an APM-monitored entity, [service maps](/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps) will not show applications monitored by mobile.
+    * When distributed tracing is enabled for an APM-monitored entity, legacy [service maps](/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps) will not show applications monitored by mobile.
     * The [App server drill-down](/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-requests-page#details) feature of the legacy Mobile HTTP requests UI page is not available.
 
   </Collapser>

--- a/src/content/docs/distributed-tracing/concepts/distributed-tracing-planning-guide.mdx
+++ b/src/content/docs/distributed-tracing/concepts/distributed-tracing-planning-guide.mdx
@@ -69,7 +69,8 @@ We may provide backward compatibility with some or all of the affected features 
    APM-related impacts include:
 
     * When distributed tracing is enabled for an APM-monitored entity, [service maps](/docs/understand-dependencies/understand-system-dependencies/service-maps/introduction-service-maps) will not show applications monitored by mobile.
-    * The [App server drill-down](/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-requests-page#details) feature of the Mobile HTTP requests UI page is not available.
+    * The [App server drill-down](/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-requests-page#details) feature of the legacy Mobile HTTP requests UI page is not available.
+
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
It turns out that legacy service maps don't work with Mobile distributed tracing, so I inserted "legacy" to differentiate the type of service maps that don't work. 