### PR TITLE
Corrected two PHP links based on pages I found in the old Drupal site.

### DIFF
--- a/src/content/docs/agents/php-agent/installation/php-agent-installation-tar-file.mdx
+++ b/src/content/docs/agents/php-agent/installation/php-agent-installation-tar-file.mdx
@@ -10,7 +10,7 @@ redirects:
   - /docs/php/php-agent-installation-tar-file
 ---
 
-You can install New Relic's PHP agent from compressed tar files on any supported platform. However, for Redhat or CentOS it is more common to use the [RPM package](php-agent-installation-redhat-and-centos). For Ubuntu or Debian it is more common to use the [Debian package](php-agent-installation-ubuntu-and-debian).
+You can install New Relic's PHP agent from compressed tar files on any supported platform. However, for Redhat or CentOS it is more common to use the [RPM package](/docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos/). For Ubuntu or Debian it is more common to use the [Debian package](/docs/agents/php-agent/installation/php-agent-installation-ubuntu-debian).
 
 <Callout variant="tip">
   To use PHP or any other agent, as well as the rest of our [observability platform](https://one.newrelic.com), join the New Relic family! [Sign up](https://newrelic.com/signup) to create your free account in only a few seconds. Then ingest up to 100GB of data for free each month. Forever.


### PR DESCRIPTION
This PR is based on this GitHub issue: #2740

Tell us what you need
https://docs.newrelic.com/php-agent-installation-redhat-and-centos/
URL is not available , getting 404 page not found

Anything else you'd like to share?
URL found on this page "https://docs.newrelic.com/docs/agents/php-agent/installation/php-agent-installation-tar-file/"
click on hyperlink "RPM Page" in the second line

Same is for "Debian package" hyperlink on "https://docs.newrelic.com/docs/agents/php-agent/installation/php-agent-installation-tar-file/"

hyperlink url : https://docs.newrelic.com/php-agent-installation-ubuntu-and-debian/

Doc information (don't delete this section)
https://docs.newrelic.com/php-agent-installation-redhat-and-centos/
OS: Windows 10
Browser: Chrome 90.0.4430.212
Device: Unknown