### PR TITLE
Changed section heading for clarification.

### DIFF
--- a/src/content/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -196,7 +196,7 @@ Before you install the Java agent, ensure your system meets these requirements:
   </Collapser>
 </CollapserGroup>
 
-## Automatically instrumented frameworks and libraries [#auto-instrumented]
+## Built-in instrumentation [#auto-instrumented]
 
 After you [install the Java agent](/docs/agents/java-agent/installation/install-java-agent), it automatically instruments many popular frameworks and libraries. With automatic instrumentation, the agent collects rich data out of the box, and data will show up in your New Relic dashboards within minutes of installation. Even if your library is not automatically instrumented, you can still collect data with [custom instrumentation](/docs/agents/java-agent/custom-instrumentation/java-custom-instrumentation) and the [Java agent API](/docs/agents/java-agent/api-guides/guide-using-java-agent-api).
 


### PR DESCRIPTION
While looking at issue #2420, I noticed that the heading "Automatically instrumented frameworks and libraries" includes the same phrase as the child collapser "Frameworks and libraries." I discussed with engineers, and they are OK with this change of the heading:

OLD: Automatically instrumented frameworks and libraries 
NEW:  Built-in instrumentation 