### PR TITLE
Avoid apparent workflow failure when no changes to commit

### DIFF
--- a/.github/workflows/check-translations-and-deserialize.yml
+++ b/.github/workflows/check-translations-and-deserialize.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Commit changes
         id: commit-changes
+        if: steps.fetch-deserialize.outputs.batchesToDeserialize != 0
         run: |
           git config --local user.email "${{ env.BOT_EMAIL }}"
           git config --local user.name "${{ env.BOT_NAME }}"
@@ -57,6 +58,7 @@ jobs:
           echo "::set-output name=commit::true"
 
       - name: Create Pull Request
+        if: steps.fetch-deserialize.outputs.batchesToDeserialize != 0
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
@@ -69,6 +71,7 @@ jobs:
           delete-branch: true
 
       - name: Checkout repository
+        if: steps.fetch-deserialize.outputs.batchesToDeserialize != 0
         uses: actions/checkout@v2
 
       - name: Setup Node.js
@@ -85,6 +88,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Remove Completed Batches From Queue
+        if: steps.fetch-deserialize.outputs.batchesToDeserialize != 0
         id: remove-batches
         run: |
           node ./scripts/actions/remove-completed-batch.js ${{steps.fetch-deserialize.outputs.batchUids}} ${{steps.fetch-deserialize.outputs.deserializedFileUris}}

--- a/scripts/actions/check-job-progress.js
+++ b/scripts/actions/check-job-progress.js
@@ -65,6 +65,11 @@ const main = async () => {
     console.log(
       `[*] ${batchesToDeserialize.length} batches ready to be deserialized`
     );
+
+    console.log(
+      `::set-output name=batchesToDeserialize::${batchesToDeserialize.length}`
+    );
+
     await Promise.all(
       batchesToDeserialize.map(fetchAndDeserialize(accessToken))
     );


### PR DESCRIPTION
## Description

This adds output to the `fetch-deserialize` step which runs the `check-job-progress.js` script. If we have no batches of files to pull down and commit, we don't want to run most of the subsequent steps (git committing/PR-ing, removing batches from the queue).

## Related issues / PRs
Closes https://github.com/newrelic/docs-website/issues/2419