### PR TITLE
Fixing some collapser issues

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
@@ -304,10 +304,7 @@ logs:
     id="syslog"
     title="syslog"
     >
-
-  </Collapser>
-</CollapserGroup>
-
+   
 Syslog data source.
 
 **Parameters:**
@@ -343,6 +340,9 @@ logs:
       uri: unix_udp:///var/unix-udp-socket-test
       parser: rfc5424
 ```
+    
+  </Collapser>
+</CollapserGroup>
 
 <CollapserGroup>
   <Collapser
@@ -618,12 +618,12 @@ The runtime file does not define a [`[SERVICE]` section](https://docs.fluentbit.
 
 `parsers_file:` path to an existing Fluent Bit parsers file. The following parser names are reserved: `rfc3164`, `rfc3164-local` and `rfc5424`.
 
+  </Collapser>
+</CollapserGroup>
+
 ### Sample configuration file [#running-modes]
 
 Here is an example of a `logging.d/` configuration file in YAML format. For more configuration examples, [see the infrastructure agent repository](https://github.com/newrelic/infrastructure-agent/tree/master/assets/examples/logging).
-
-  </Collapser>
-</CollapserGroup>
 
 <CollapserGroup>
 <Collapser


### PR DESCRIPTION
Looks like I missed syslog when i moved the content into a collapse group. Also moved the sample config to its own section since I accidentally put the header for it under fluentbit. Should be fixed now :)