### PR TITLE
OpsGenie schema needed to have a syntax update

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/incident-intelligence-destination-examples.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/incident-intelligence-destination-examples.mdx
@@ -36,7 +36,7 @@ The following template example destinations are formatted in [Jinja2](https://ji
     		"closed_on": {% if closed_on is defined %} {{ closed_on }} {% else %} None {% endif %},
     		"is_correlated": {{ is_correlated }}
     	},
-    	"description": 'Incidents [
+    	"description": """Incidents [
     		{% for incident in incidents %}
     		{
     			"id": {{ incident.id }},
@@ -51,7 +51,7 @@ The following template example destinations are formatted in [Jinja2](https://ji
     			"closed_on": {{ incident.closed_on }}
     		}
     		{% if not loop.last %},{% endif %}{% endfor %}
-    	]'
+    	]"""
     }
     ```
   </Collapser>


### PR DESCRIPTION
The only difference is the triple quotes ””” for parsing the 'description' field properly. This was a string escaping problem in the description field.

