### PR TITLE
nri-oracle: document usage of `tablespaces` argument

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
@@ -157,15 +157,13 @@ The `all_data` command accepts the following arguments:
 * `is_sys_dba`: boolean value that indicates whether the authenticating user has SysDBA permissions. Default: `false`.
 * `oracle_home`: path to where `ORACLE_HOME` is. This field is required.
 * `is_sys_oper`: boolean value that indicates whether the authenticating user has SysOper permissions. Default: `false`.
-* `tablespaces`: A JSON array of tablespaces to collect. If omitted, collects all tablespaces. Default: none (all tablespaces). [^1]
+* `tablespaces`: A JSON array of tablespaces to collect. If omitted, collects all tablespaces. Default: none (all tablespaces). Due to performance reasons, the integration will refuse to collect tablespace data for more than 200 tablespaces. If your database has more than 200 of tablespaces, you must restrict collection to a smaller number by using the `tablespaces` parameter.
 * `hostname`: hostname of the instance to monitor. Default: `127.0.0.1`.
 * `port`: port number on which Oracle Database is running. Default: `1521`.
 * `connection_string`: a full connection string such as those found in `tnsnames.ora`. If this is specified, it takes priority over `host`, `port`, and `service_name`.
 * `extended_metrics`: boolean value that indicates whether to collect extended metrics. Default: `false`.
 * `custom_metrics_query`: a custom SQL query to run against the configured instance. Each row of the query is added as a new metric set on OracleCustomSample. Each non-null column in the row is added as an attribute on that metric set.
 * `custom_metrics_config`: a path to a YAML file that contains a list of queries, along with custom sample names and metric type overrides. See example below for details.
-
-[^1]: Due to performance reasons, the integration will refuse to collect tablespace data for more than 200 tablespaces. If your database has more than this number of tablespaces, you must restrict collection to a smaller number by using the `tablespaces` parameter.
 
 ### Labels
 

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
@@ -157,12 +157,15 @@ The `all_data` command accepts the following arguments:
 * `is_sys_dba`: boolean value that indicates whether the authenticating user has SysDBA permissions. Default: `false`.
 * `oracle_home`: path to where `ORACLE_HOME` is. This field is required.
 * `is_sys_oper`: boolean value that indicates whether the authenticating user has SysOper permissions. Default: `false`.
+* `tablespaces`: A JSON array of tablespaces to collect. If omitted, collects all tablespaces. Default: none (all tablespaces). [^1]
 * `hostname`: hostname of the instance to monitor. Default: `127.0.0.1`.
 * `port`: port number on which Oracle Database is running. Default: `1521`.
 * `connection_string`: a full connection string such as those found in `tnsnames.ora`. If this is specified, it takes priority over `host`, `port`, and `service_name`.
 * `extended_metrics`: boolean value that indicates whether to collect extended metrics. Default: `false`.
 * `custom_metrics_query`: a custom SQL query to run against the configured instance. Each row of the query is added as a new metric set on OracleCustomSample. Each non-null column in the row is added as an attribute on that metric set.
 * `custom_metrics_config`: a path to a YAML file that contains a list of queries, along with custom sample names and metric type overrides. See example below for details.
+
+[^1]: Due to performance reasons, the integration will refuse to collect tablespace data for more than 200 tablespaces. If your database has more than this number of tablespaces, you must restrict collection to a smaller number by using the `tablespaces` parameter.
 
 ### Labels
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

The OracleDB integration will fail to collect more than 200 tablespaces. When the user's environment has more than this amount, it is required to restrict collection using the (previously undocumented) `tablespaces` argument.

This PR documents this parameter and its usage.

### Are you making a change to site code?

No