### PR TITLE
fix: bump theme to version that handles blocked cookies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "^2.0.0-next.8",
     "@mdx-js/react": "^2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "2.4.0",
+    "@newrelic/gatsby-theme-newrelic": "^2.4.2",
     "@splitsoftware/splitio-react": "^1.2.4",
     "babel-jest": "^26.3.0",
     "common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2241,10 +2241,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-2.4.0.tgz#cd53bda7fd8230be0cc350a3f83067c7352f18ab"
-  integrity sha512-HXN+hkP6ixiOlN4ZOfjNefmH2dYfmDRBPJISM85+lvhZIJZ1EkHPEvmslIiAbixMOpolEgulYjT0PNMYMOdMaQ==
+"@newrelic/gatsby-theme-newrelic@^2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-2.4.2.tgz#e792fe218e7525e3e646cec636f71788b13aaedb"
+  integrity sha512-P4L0QogK8R/wzeRH90oG64E1TxeOB2Ylj++3xZ75pCuef7bHOkRYTBUiIBobo//la0Tt1N/LgDzgG4Cw+eI/fA==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"
@@ -2280,6 +2280,7 @@
     terser "^5.6.1"
     ua-parser-js "^0.7.28"
     use-dark-mode "^2.3.1"
+    use-local-storage-state "^9.0.2"
     use-media "^1.4.0"
     util "^0.12.3"
     warning "^4.0.3"
@@ -18535,6 +18536,11 @@ use-isomorphic-layout-effect@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz#7bb6589170cd2987a152042f9084f9effb75c225"
   integrity sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==
+
+use-local-storage-state@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/use-local-storage-state/-/use-local-storage-state-9.0.2.tgz#77ace2fd72c8d17d3da5be74cf6aa3e25b6e321c"
+  integrity sha512-loNVFqrzfsNoNVtM/3RJbjKVhSgTX15vPC5Tcuk7oflF0nonldRivMGAgFU3toi9v6hfTT/x8M+o6ifDN2n0OQ==
 
 use-media@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
# Summary
The latest release of the `gatsby-theme-newrelic` has been updated to handle cookies and localStorage being blocked. This gets us up to that version.

Closes #2293 