### PR TITLE
Add order of precedence callout to ruby config

### DIFF
--- a/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -668,6 +668,10 @@ The agent collects and reports all uncaught exceptions by default. These configu
     </table>
 
   Specify a comma-delimited list of error classes that the agent should ignore.
+
+  <Callout variant="caution">
+  Server side configuration takes precedence for this setting over all environment configurations. This differs from all other configuration settings where environment variable take precedence over server side configuration.
+  </Callout>
   </Collapser>
   
   <Collapser id="error_collector-max_backtrace_frames" title="error_collector.max_backtrace_frames">


### PR DESCRIPTION
This PR add a callout to a specific config that is overwritten by server config instead of env variables. See #2546 for more context.