### PR TITLE
DOC-6871 - Nested queries limitation

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -422,6 +422,13 @@ If, in the aggregation window being evaluated, there's at least one instance of 
   >
     For more information on signal loss, see [NerdGraph API: Loss of signal and gap filling](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling).
   </Collapser>
+
+  <Collapser
+    id=""
+    title="Nested queries containing 'WITH METRIC FORMAT' can't be used to create NRQL alert conditions"
+  >
+    You can use nested queries to create NRQL alerts. However, you can't use a nested query containing the `WITH METRIC FORMAT` segment to create NRQL alert conditions.
+  </Collapser>
 </CollapserGroup>
 
 ## NRQL condition creation tips

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -425,9 +425,9 @@ If, in the aggregation window being evaluated, there's at least one instance of 
 
   <Collapser
     id=""
-    title="Nested queries containing 'WITH METRIC FORMAT' can't be used to create NRQL alert conditions"
+    title="Nested queries containing 'WITH METRIC_FORMAT' in the inner query are not currently supported"
   >
-    You can use nested queries to create NRQL alerts. However, you can't use a nested query containing the `WITH METRIC FORMAT` segment to create NRQL alert conditions.
+    You can't use a nested query containing the `WITH METRIC_FORMAT` in the inner query to create NRQL alert conditions.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -395,7 +395,7 @@ If, in the aggregation window being evaluated, there's at least one instance of 
 
 <CollapserGroup>
   <Collapser
-    id=""
+    id="non-faceted_innermost_query"
     title="Nested queries with a non-faceted innermost query are not currently supported"
   >
     Without a `FACET`, the inner query produces a single result, giving the outer query nothing to aggregate. If you're using a nested query, make sure your inner query is faceted.
@@ -406,7 +406,7 @@ If, in the aggregation window being evaluated, there's at least one instance of 
   </Collapser>
 
   <Collapser
-    id=""
+    id="aggregation_window_size"
     title="Queries at all levels must have the same aggregation window size"
   >
     With an alert aggregation window of 1 minute, the inner query would produce two smaller windows of 30 seconds. In theory, these two windows could be aggregated by the outer query. However, this is not currently supported.
@@ -417,14 +417,14 @@ If, in the aggregation window being evaluated, there's at least one instance of 
   </Collapser>
 
   <Collapser
-    id=""
+    id="signal_loss"
     title="Signal loss is not yet supported for nested queries"
   >
     For more information on signal loss, see [NerdGraph API: Loss of signal and gap filling](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling).
   </Collapser>
 
   <Collapser
-    id=""
+    id="with_metric_format"
     title="Nested queries containing 'WITH METRIC_FORMAT' in the inner query are not currently supported"
   >
     You can't use a nested query containing the `WITH METRIC_FORMAT` in the inner query to create NRQL alert conditions.


### PR DESCRIPTION
Nested queries with `WITH METRIC FORMAT` cannot be used to set a NRQL condition. For more details, see [Doc6871](https://newrelic.atlassian.net/browse/DOC-6871).