### PR TITLE
Fixed issue #2561  

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -620,9 +620,9 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
 
     The **default** value is **NOW**. Only use `UNTIL` to specify an end point other than the default.
 
-    Use the `UNTIL` clause to define the end of a time range across which to return data. Once a time range has been specified, the data will be preserved and can be reviewed after the time range has ended. You can specify a [UTC timestamp](/docs/insights/new-relic-insights/managing-dashboards-data/set-time-range-insights-dashboards-widgets#utc-range) or [relative time range](/docs/insights/new-relic-insights/managing-dashboards-data/set-time-range-insights-dashboards-widgets#relative-range). You can specify a time zone for the query but not for the results. The returned results are based on your system time.
+    Use the `UNTIL` clause to define the end of a time range across which to return data. Once a time range has been specified, the data will be preserved and can be reviewed after the time range has ended.
 
-    See [Set time range on dashboards and charts](/docs/insights/new-relic-insights/managing-dashboards-data/set-time-range-insights-dashboards-widgets) for detailed information and examples.
+    See [Use the time picker to adjust time settings](/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/#dash-time-picker) for detailed information and examples.
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
The content for the `UNTIL` clause in [NRQL syntax, clauses, and functions](https://docs.newrelic.com/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#sel-until) needed an update.