### PR TITLE
Unnecessary arch params on Debian & Ubuntu

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -250,23 +250,20 @@ To install the infrastructure monitoring agent in Linux, follow these instructio
        **Debian 8 ("Jessie")**
 
        ```
-       printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt jessie main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt jessie main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
        **Debian 9 ("Stretch")**
 
        ```
-       printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt stretch main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt stretch main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
        **Debian 10 ("Buster")**
 
        ```
-       printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt buster main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt buster main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
-       <Callout variant="tip">
-         Use [arch=arm64] to install on ARM architectures such us AWS Graviton.
-       </Callout>
      </Collapser>
 
      <Collapser
@@ -276,35 +273,32 @@ To install the infrastructure monitoring agent in Linux, follow these instructio
        **Ubuntu 12 ("Precise")**
 
        ```
-       printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt precise main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt precise main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
        **Ubuntu 14 ("Trusty")**
 
        ```
-       printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt trusty main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt trusty main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
        **Ubuntu 16 ("Xenial")**
 
        ```
-       printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt xenial main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt xenial main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
        **Ubuntu 18 ("Bionic")**
 
        ```
-       printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt bionic main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt bionic main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
        **Ubuntu 20 ("Focal")**
 
        ```
-       printf "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt focal main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt focal main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
-       <Callout variant="tip">
-         Use [arch=arm64] to install on ARM architectures such us AWS Graviton.
-       </Callout>
      </Collapser>
 
      <Collapser


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* We recently added support for ARM architecture. 
* We validated that it's actually not needed to determine the amd or arm64 architecture for Ubuntu and Debian since this will be automatically detected. 
* Removed unnecessary params to determine the right architecture in docs.


### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.