### PR TITLE
Fix sort order for Browser AMP doc

### DIFF
--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -1660,14 +1660,14 @@ pages:
             pages:
               - title: Install Browser
                 path: /docs/browser/browser-monitoring/installation/install-browser-monitoring-agent
+              - title: Install Browser for AMP
+                path: /docs/browser/new-relic-browser/installation/monitor-amp-pages-new-relic-browser
               - title: Update the Browser agent
                 path: /docs/browser/new-relic-browser/installation/update-browser-agent
               - title: Disable Browser monitoring
                 path: /docs/browser/new-relic-browser/installation/disable-browser-monitoring
               - title: Delete apps from Browser
                 path: /docs/browser/new-relic-browser/installation/delete-apps-new-relic-browser
-              - title: Install Browser for AMP
-                path: /docs/browser/new-relic-browser/installation/monitor-amp-pages-new-relic-browser
           - title: Configuration
             path: /docs/browser/new-relic-browser/configuration
             pages:


### PR DESCRIPTION
It's weird having an install doc at the bottom of the category, after delete/disable docs