### PR TITLE
chore: now compares last release to latest develop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           MERGES=$(gh pr list -B main -s merged --search "closed:>2021-02-28" -L 9999 | wc -l | awk '{print $1}')
           echo "::set-output name=tag::release-$MERGES"
+          echo COMPARE=$MERGES >> $GITHUB_ENV
           
       - name: Install Python Dependencies
         run: |
@@ -44,4 +45,4 @@ jobs:
           python ./scripts/actions/release-notes.py
 
       - name: Create release
-        run: gh release create ${{ steps.get-tag.outputs.tag }} -t ${{ steps.get-tag.outputs.tag }} -n "${{ env.RESULT }}"
+        run: gh release create ${{ steps.get-tag.outputs.tag }} -t ${{ steps.get-tag.outputs.tag }} -n "${{ env.RESULT }}" 

--- a/scripts/actions/release-notes.py
+++ b/scripts/actions/release-notes.py
@@ -15,8 +15,14 @@ result = "## :rocket: What's new?\n\n\n"
 # Get the Docs repo
 repo = github.get_repo("newrelic/docs-website")
 
-# Compare diff between main and develop
-diff = repo.compare("main", "develop")
+# Get latest merge number environment variable
+latestMerge = os.getenv('COMPARE', '...')
+
+# Minus 1 to get the previous release to compare updates since then
+compareRelease = int(latestMerge) - 1
+
+# Compare diff between previous release and develop
+diff = repo.compare("release-{compare}".format(compare=compareRelease), "develop")
 
 # Loop through commits and add details to result
 for commit in diff.commits:


### PR DESCRIPTION
Previously it was just comparing latest main to latest develop which shows no results because this is run after the merge. I changed it to compare the tag of the previous release with latest develop to get commits since then.