### PR TITLE
mysql and postgres doc update

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/mysql-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Our integration is compatible with MySQL version 5.6 or higher.
 
 Before installing the integration, make sure that you meet the following requirements:
 
-* If MySQL is **not** running on Kubernetes or Amazon ECS, you must [install the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) on a Linux OS host that's running MySQL. Otherwise:
+* If MySQL is **not** running on Kubernetes or Amazon ECS, you can [install the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) on a Linux or Windows OS host. Otherwise:
   * If running on Kubernetes, see [these requirements](https://docs.newrelic.com/docs/monitor-service-running-kubernetes#requirements).
   * If running on ECS, see [these requirements](/docs/integrations/host-integrations/host-integrations-list/monitor-services-running-amazon-ecs).
 
@@ -122,6 +122,27 @@ Gives select privileges to `newrelic@localhost` with a maximum of 5 connections.
        ```
     5. [Edit the configuration file](#config) `mysql-config.yml` as explained in the next section.
     6. [Restart](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status) the infrastructure agent.
+  </Collapser>
+
+  <Collapser
+    id="windows-install"
+    title="Windows"
+  >
+    1. Download the `nri-mysql` .MSI installer image from:
+
+       [https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-mysql/nri-mysql-amd64.msi](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-mysql/nri-mysql-amd64.msi)
+    2. To install from the Windows command prompt, run:
+
+       ```
+       msiexec.exe /qn /i <var>PATH\TO\</var>nri-mysql-amd64.msi
+       ```
+    3. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration file by running:
+
+       ```
+       cp mysql-config.yml.sample mysql-config.yml
+       ```
+    4. Edit the `mysql-config.yml` file as described in the [configuration settings](#config).
+    5. [Restart the infrastructure agent](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/postgresql-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/postgresql-monitoring-integration.mdx
@@ -99,7 +99,7 @@ To install the PostgreSQL integration, follow the instructions for your environm
   >
     1. Download the `nri-postgresql` .MSI installer image from:
 
-       [http://download.newrelic.com/infrastructure_agent/windows/integrations/nri-postgresql/nri-postgresql-amd64.msi](http://download.newrelic.com/infrastructure_agent/windows/integrations/nri-postgresql/nri-postgresql-amd64.msi)
+       [https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-postgresql/nri-postgresql-amd64.msi](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-postgresql/nri-postgresql-amd64.msi)
     2. To install from the Windows command prompt, run:
 
        ```


### PR DESCRIPTION
Added an entry for mysql installation on Windows. NR hosts the windows .msi file on our download site but we don't have directions for it in our docs. The docs explicity required a linux host which isn't true so I cleaned up that verbiage as well. For both files i just updated our links to the download site to default to https since we don't redirect there from http links.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.