### PR TITLE
Update dotnet agent installation instructions for Linux based Azure Web Apps

### DIFF
--- a/src/content/docs/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
+++ b/src/content/docs/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
@@ -21,7 +21,7 @@ This document explains how to install New Relic's .NET agent for application per
 
 Use any of the following methods to add the New Relic .NET agent to your Azure-deployed web app. The best option depends on your role, environment, deployments, etc. For example:
 
-For operations teams that need to monitor the app, the easiest and most reliable option best practice may be to use the publicly maintained Azure site extension.
+For operations teams that need to monitor the app, the easiest and most reliable option is to use the publicly maintained Azure site extension.
 
 **Note:** Azure Site Extensions are only currently available for Windows App Service Resources.
 

--- a/src/content/docs/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
+++ b/src/content/docs/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
@@ -21,11 +21,13 @@ This document explains how to install New Relic's .NET agent for application per
 
 Use any of the following methods to add the New Relic .NET agent to your Azure-deployed web app. The best option depends on your role, environment, deployments, etc. For example:
 
-For operations teams that need to monitor the app, best practice may be to:
+For operations teams that need to monitor the app, the easiest and most reliable option best practice may be to use the publicly maintained Azure site extension.
+
+**Note:** Azure Site Extensions are only currently available for Windows App Service Resources.
 
 * [Install using the Azure Site Extension](#site-extention-install)
 
-For developer teams, best practice may be to use NuGet:
+For developer teams, or anyone needing to deploy the agent on a Linux App Service Resource, installing via nuget is the best option:
 
 * [Install using NuGet (.NET Framework)](#nuget-install-net-framework)
 * [Install using NuGet (.NET Core)](#nuget-install-net-core)
@@ -41,7 +43,7 @@ In addition, WebJobs may need [custom instrumentation](/docs/agents/net-agent/cu
 
 Both New Relic's .NET agent and Microsoft Application Insights rely on the CLR Profiler, but only one may be active at a time. You **must** disable Application Insights in order for the .NET agent to function properly. For more information, see our [Application Insights troubleshooting procedures](/docs/agents/net-agent/azure-troubleshooting/net-profiler-conflict-microsoft-application-insights).
 
-## Install using the New Relic Azure Site Extension [#site-extention-install]
+## Install using the New Relic Azure Site Extension (**Windows Only**)[#site-extention-install]
 
 To install the .NET agent for an Azure Web App using the New Relic Azure Site Extension:
 
@@ -53,6 +55,8 @@ To install the .NET agent for an Azure Web App using the New Relic Azure Site Ex
 5. Restart your web app to use the new version of the agent.
 
 ## Install using NuGet (.NET Framework) [#nuget-install-net-framework]
+
+The NuGet installation method packages the New Relic Agent with your application so that it is availabe to the Azure Web App Host.
 
 The NuGet packages in this procedure support only the old `packages.config`. They do not support the current `PackageReference` format. For more information, see [Microsoft's package reference documentation](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files).
 
@@ -135,7 +139,7 @@ New Relic .NET Core agent supports Linux and Windows applications on Azure App S
 To install the .NET agent on an Azure Web App using NuGet:
 
 1. Install the `NewRelic.Agent` NuGet package.
-2. Modify the **log** node by adding a directory attribute to your `newrelic.config` file:
+2. Modify the **log** node by adding a directory attribute to your `newrelic.config` file (**Note:** If Visual Studio prevents you from editing the `newrelic.config` file that was added to your project by NuGet then you will need to make a local copy of this in your application):
 
    <CollapserGroup>
      <Collapser
@@ -143,7 +147,7 @@ To install the .NET agent on an Azure Web App using NuGet:
        title="Log file configuration for Windows"
      >
        ```
-       log directory="D:\Home\LogFiles\NewRelic" level="info"/log
+       #lt;log directory="D:\Home\LogFiles\NewRelic" level="info"#gt;#lt;/log#gt;
        ```
      </Collapser>
 
@@ -152,7 +156,7 @@ To install the .NET agent on an Azure Web App using NuGet:
        title="Log file configuration for Linux"
      >
        ```
-       log directory="/home/LogFiles/NewRelic" level="info"/log
+       #lt;log directory="/home/LogFiles/NewRelic" level="info"#gt;#lt;/log#gt;
        ```
      </Collapser>
    </CollapserGroup>
@@ -287,6 +291,16 @@ To install the .NET agent on an Azure Web App using NuGet:
 
              <td>
                `/home/site/wwwroot/newrelic`
+             </td>
+           </tr>
+           
+           <tr>
+             <td>
+               `NEWRELIC_PROFILER_LOG_DIRECTORY`
+             </td>
+
+             <td>
+               `/home/LogFiles/NewRelic`
              </td>
            </tr>
          </tbody>

--- a/src/content/docs/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
+++ b/src/content/docs/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
@@ -147,7 +147,7 @@ To install the .NET agent on an Azure Web App using NuGet:
        title="Log file configuration for Windows"
      >
        ```
-       #lt;log directory="D:\Home\LogFiles\NewRelic" level="info"#gt;#lt;/log#gt;
+       &lt;log directory="D:\Home\LogFiles\NewRelic" level="info"&gt;&lt;/log&gt;
        ```
      </Collapser>
 
@@ -156,7 +156,7 @@ To install the .NET agent on an Azure Web App using NuGet:
        title="Log file configuration for Linux"
      >
        ```
-       #lt;log directory="/home/LogFiles/NewRelic" level="info"#gt;#lt;/log#gt;
+       &lt;log directory="/home/LogFiles/NewRelic" level="info"&gt;&lt;/log&gt;
        ```
      </Collapser>
    </CollapserGroup>

--- a/src/content/docs/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
+++ b/src/content/docs/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
@@ -56,7 +56,7 @@ To install the .NET agent for an Azure Web App using the New Relic Azure Site Ex
 
 ## Install using NuGet (.NET Framework) [#nuget-install-net-framework]
 
-The NuGet installation method packages the New Relic Agent with your application so that it is availabe to the Azure Web App Host.
+The NuGet installation method packages the New Relic Agent with your application so that it is available to the Azure Web App Host.
 
 The NuGet packages in this procedure support only the old `packages.config`. They do not support the current `PackageReference` format. For more information, see [Microsoft's package reference documentation](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files).
 
@@ -133,6 +133,8 @@ To install the .NET agent on an Azure Web App using NuGet:
 7. Restart your web app.
 
 ## Install using NuGet (.NET Core) [#nuget-install-net-core]
+
+The NuGet installation method packages the New Relic Agent with your application so that it is available to the Azure Web App Host.
 
 New Relic .NET Core agent supports Linux and Windows applications on Azure App Services. The installation process for Azure App Services differs from the .NET Core agent installation procedures for [Linux](/docs/agents/net-agent/installation/install-net-core-agent-linux) and [Windows](/docs/agents/net-agent/installation/install-net-agent-windows#installing_core).
 


### PR DESCRIPTION

I'm not sure how the formatting will all look on the main docs site... I tried to add less than/greater than symbol to an xml blob but it's not easy to see if it's working properly with the github preview tool.

### Give us some context

* I ran through the Dotnet agent Linux install instructions for Azure Web Apps and I'm not sure if Azure changed, or Visual Studio changed... but the steps required to get this going weren't clear from the existing documentation.
* I tried to add some missing less than/greater than symbols in sample XML fragments, but it's not clear if this will render properly on the main site.
* I added a new env var that I had to set to get things going
* I added a note about needing to manually copy the newrelic.config file out of the nuget package contents in to my application as visual studio was preventing me from editing the nuget checkout.