### PR TITLE
Add http request headers capture feature

### DIFF
--- a/src/content/docs/agents/net-agent/attributes/net-agent-attributes.mdx
+++ b/src/content/docs/agents/net-agent/attributes/net-agent-attributes.mdx
@@ -15,7 +15,7 @@ These attribute settings apply to version 3.6.177.0 or higher of the .NET agent.
 
 ## .NET agent attribute defaults [#attributes]
 
-The following attributes can be configured in the .NET agent. For more information, see [.NET agent configuration: Attributes element](/docs/agents/net-agent/installation-configuration/net-agent-configuration/#agent-attributes).
+The following attributes can be configured in the .NET agent. For more information, see [.NET agent configuration: Attributes element](/docs/agents/net-agent/configuration/net-agent-configuration/#agent-attributes).
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/agents/net-agent/attributes/net-agent-attributes.mdx
+++ b/src/content/docs/agents/net-agent/attributes/net-agent-attributes.mdx
@@ -15,7 +15,7 @@ These attribute settings apply to version 3.6.177.0 or higher of the .NET agent.
 
 ## .NET agent attribute defaults [#attributes]
 
-The following attributes can be configured in the .NET agent. For more information, see [.NET agent configuration: Attributes element](/docs/agents/net-agent/installation-configuration/net-agent-configuration#agent-attributes).
+The following attributes can be configured in the .NET agent. For more information, see [.NET agent configuration: Attributes element](/docs/agents/net-agent/installation-configuration/net-agent-configuration/#agent-attributes).
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1142,7 +1142,7 @@ The `application` element is a child of the `configuration` element. This requir
     <application>
       <name><var>MY APPLICATION PRIMARY</var></name>
       <name><var>SECOND APP NAME</var></name>
-      <name><var>THIRD APP NAME</var></name> 
+      <name><var>THIRD APP NAME</var></name>
     </application>
     ```
 
@@ -1499,7 +1499,7 @@ An attribute is a key/value pair that determines the properties of an event or t
 In this example, the agent excludes all attributes whose key begins with **myApiKey** (**myApiKey.bar**, **myApiKey.value**), but collects the custom attribute **myApiKey.foo**.
 
 ```
-<attributes enabled="true"> 
+<attributes enabled="true">
   <exclude><var>myApiKey.*</var></exclude>
   <include><var>myApiKey.foo</var></include>
 </attributes>
@@ -1621,6 +1621,81 @@ Use these options to enable, disable, and configure New Relic features. New Reli
 * [Datastore tracer](#datastore_tracer)
 * [Distributed tracing](#distributed_tracing)
 * [Span events](#span_events)
+* [Capture Http Request Headers](#capture_http_request_headers)
+
+### Capture Http Request Headers [#capture_http_request_headers]
+
+The `allowAllHeaders` element is a child of the `configuration` element. Set this to `true` to allow the .NET Agent to capture all Http request headers as `request.headers.{http-header-name}` attributes. Set to this to `false` to only allow the .NET agent to collects the following of Http request headers.
+
+```
+request.headers.referer
+request.headers.accept
+request.headers.content-length
+request.headers.host
+request.headers.user-agent
+```
+
+<CollapserGroup>
+  <Collapser
+    id="allow-all-headers-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable Http request headers capture. Example:
+
+    ```
+	  <allowAllHeaders enabled="true" />
+    <attributes enabled="true">
+       <include>request.headers.*</include>
+    </attributes>
+    ```
+  </Collapser>
+</CollapserGroup>
+
+<Callout variant="important">
+  The captured request header attributes from using the `allowAllHeaders` setting are still being controlled by the root level and destination level [Attributes](/docs/agents/net-agent/configuration/net-agent-configuration/#agent-attributes) settings. Without setting the `request.header.*` whitelist under the `attributes` element (see the following), the .NET Agent still filters out all header attributes. The default `newrelic.config` is set to include the `request.header.*`.
+
+  ```
+  <allowAllHeaders enabled="true" />
+  <attributes enabled="true">
+    <include>request.headers.*</include>
+  </attributes>
+  ```
+
+  The default `newrelic.config` is also set to explicitly exclude the following Http request headers to prevent the .NET Agent collecting unwanted data.
+
+  ```
+  <attributes enabled="true">
+    <exclude>request.headers.cookie</exclude>
+    <exclude>request.headers.authorization</exclude>
+    <exclude>request.headers.proxy-authorization</exclude>
+    <exclude>request.headers.x-*</exclude>
+  </attributes>
+  ```
+</Callout>
 
 ### App pools [#include_exclude_apps]
 
@@ -1981,7 +2056,7 @@ The `errorCollector` element supports the following elements and attributes:
 
 ### High security mode [#high_security_mode]
 
-The `highSecurity` element is a child of the `configuration` element. To enable [high security mode](/docs/subscriptions/high-security), set this property to `true` and enable high security property in the New Relic user interface. Enabling high security means SSL is turned on, request parameters and custom parameters are not collected, strip exception messages is enabled, and queries cannot be sent to New Relic in their raw form.
+The `highSecurity` element is a child of the `configuration` element. To enable [high security mode](/docs/subscriptions/high-security), set this property to `true` and enable high security property in the New Relic user interface. Enabling high security means SSL is turned on, request parameters, custom parameters and Http request headers are not collected, strip exception messages is enabled, and queries cannot be sent to New Relic in their raw form.
 
 <CollapserGroup>
   <Collapser
@@ -2693,7 +2768,7 @@ The `transactionTracer` element supports the following attributes:
 The `datastoreTracer` element is a child of the `configuration` element.
 
 ```
-<datastoreTracer> 
+<datastoreTracer>
   <instanceReporting enabled="true"  />
   <databaseNameReporting enabled="true" />
   <queryParameters enabled="false" />

--- a/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1623,80 +1623,6 @@ Use these options to enable, disable, and configure New Relic features. New Reli
 * [Span events](#span_events)
 * [Capture Http Request Headers](#capture_http_request_headers)
 
-### Capture Http Request Headers [#capture_http_request_headers]
-
-The `allowAllHeaders` element is a child of the `configuration` element. Set this to `true` to allow the .NET Agent to capture all Http request headers as `request.headers.{http-header-name}` attributes. Set to this to `false` to only allow the .NET agent to collects the following of Http request headers.
-
-```
-request.headers.referer
-request.headers.accept
-request.headers.content-length
-request.headers.host
-request.headers.user-agent
-```
-
-<CollapserGroup>
-  <Collapser
-    id="allow-all-headers-enabled"
-    title="enabled"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `false`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Enable or disable Http request headers capture. Example:
-
-    ```
-	  <allowAllHeaders enabled="true" />
-    <attributes enabled="true">
-       <include>request.headers.*</include>
-    </attributes>
-    ```
-  </Collapser>
-</CollapserGroup>
-
-<Callout variant="important">
-  The captured request header attributes from using the `allowAllHeaders` setting are still being controlled by the root level and destination level [Attributes](/docs/agents/net-agent/configuration/net-agent-configuration/#agent-attributes) settings. Without setting the `request.header.*` whitelist under the `attributes` element (see the following), the .NET Agent still filters out all header attributes. The default `newrelic.config` is set to include the `request.header.*`.
-
-  ```
-  <allowAllHeaders enabled="true" />
-  <attributes enabled="true">
-    <include>request.headers.*</include>
-  </attributes>
-  ```
-
-  The default `newrelic.config` is also set to explicitly exclude the following Http request headers to prevent the .NET Agent collecting unwanted data.
-
-  ```
-  <attributes enabled="true">
-    <exclude>request.headers.cookie</exclude>
-    <exclude>request.headers.authorization</exclude>
-    <exclude>request.headers.proxy-authorization</exclude>
-    <exclude>request.headers.x-*</exclude>
-  </attributes>
-  ```
-</Callout>
-
 ### App pools [#include_exclude_apps]
 
 <Callout variant="important">
@@ -3016,6 +2942,80 @@ The `spanEvents` element supports the following attributes:
     </Callout>
   </Collapser>
 </CollapserGroup>
+
+### Capture Http Request Headers [#capture_http_request_headers]
+
+The `allowAllHeaders` element is a child of the `configuration` element. Set this to `true` to allow the .NET Agent to capture all Http request headers as `request.headers.{http-header-name}` attributes. Set to this to `false` to only allow the .NET agent to collects the following of Http request headers.
+
+```
+request.headers.referer
+request.headers.accept
+request.headers.content-length
+request.headers.host
+request.headers.user-agent
+```
+
+<CollapserGroup>
+  <Collapser
+    id="allow-all-headers-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable Http request headers capture. Example:
+
+    ```
+	  <allowAllHeaders enabled="true" />
+    <attributes enabled="true">
+       <include>request.headers.*</include>
+    </attributes>
+    ```
+  </Collapser>
+</CollapserGroup>
+
+<Callout variant="important">
+  The `allowAllHeaders` setting is only available in the .NET Agent version 8.40.0+. The captured request header attributes from using the `allowAllHeaders` setting are still being controlled by the root level and destination level [Attributes](/docs/agents/net-agent/configuration/net-agent-configuration/#agent-attributes) settings. Without setting the `request.header.*` whitelist under the `attributes` element (see the following), the .NET Agent still filters out all header attributes. The default `newrelic.config` is set to include the `request.header.*`.
+
+  ```
+  <allowAllHeaders enabled="true" />
+  <attributes enabled="true">
+    <include>request.headers.*</include>
+  </attributes>
+  ```
+
+  The default `newrelic.config` is also set to explicitly exclude the following Http request headers to prevent the .NET Agent collecting unwanted data.
+
+  ```
+  <attributes enabled="true">
+    <exclude>request.headers.cookie</exclude>
+    <exclude>request.headers.authorization</exclude>
+    <exclude>request.headers.proxy-authorization</exclude>
+    <exclude>request.headers.x-*</exclude>
+  </attributes>
+  ```
+</Callout>
 
 ## Settings in app.config or web.config [#app-config-settings]
 

--- a/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -2996,12 +2996,13 @@ request.headers.user-agent
 </CollapserGroup>
 
 <Callout variant="important">
-  The `allowAllHeaders` setting is only available in the .NET Agent version 8.40.0+. The captured request header attributes from using the `allowAllHeaders` setting are still being controlled by the root level and destination level [Attributes](/docs/agents/net-agent/configuration/net-agent-configuration/#agent-attributes) settings. Without setting the `request.header.*` whitelist under the `attributes` element (see the following), the .NET Agent still filters out all header attributes. The default `newrelic.config` is set to include the `request.header.*`.
+  The `allowAllHeaders` setting is only available in the .NET Agent version 8.40.0+. The captured request header attributes from using the `allowAllHeaders` setting are still being controlled by the root level and destination level [Attributes](/docs/agents/net-agent/configuration/net-agent-configuration/#agent-attributes) settings. Without setting the `request.header.*` in the `include` list under the `attributes` element (see the following), the .NET Agent still filters out all header attributes. The default `newrelic.config` is set to include the `request.header.*`.
 
   ```
   <allowAllHeaders enabled="true" />
   <attributes enabled="true">
     <include>request.headers.*</include>
+    ...
   </attributes>
   ```
 

--- a/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1621,7 +1621,7 @@ Use these options to enable, disable, and configure New Relic features. New Reli
 * [Datastore tracer](#datastore_tracer)
 * [Distributed tracing](#distributed_tracing)
 * [Span events](#span_events)
-* [Capture Http Request Headers](#capture_http_request_headers)
+* [Capture HTTP Request Headers](#capture_http_request_headers)
 
 ### App pools [#include_exclude_apps]
 
@@ -1982,7 +1982,7 @@ The `errorCollector` element supports the following elements and attributes:
 
 ### High security mode [#high_security_mode]
 
-The `highSecurity` element is a child of the `configuration` element. To enable [high security mode](/docs/subscriptions/high-security), set this property to `true` and enable high security property in the New Relic user interface. Enabling high security means SSL is turned on, request parameters, custom parameters and Http request headers are not collected, strip exception messages is enabled, and queries cannot be sent to New Relic in their raw form.
+The `highSecurity` element is a child of the `configuration` element. To enable [high security mode](/docs/subscriptions/high-security), set this property to `true` and enable the high security property in the New Relic user interface. Enabling high security turns SSL on; request parameters, custom parameters and HTTP request headers are not collected; strip exception messages is enabled; and queries can't be sent to New Relic in their raw form.
 
 <CollapserGroup>
   <Collapser
@@ -2943,9 +2943,9 @@ The `spanEvents` element supports the following attributes:
   </Collapser>
 </CollapserGroup>
 
-### Capture Http Request Headers [#capture_http_request_headers]
+### Capture HTTP Request Headers [#capture_http_request_headers]
 
-The `allowAllHeaders` element is a child of the `configuration` element. Set this to `true` to allow the .NET Agent to capture all Http request headers as `request.headers.{http-header-name}` attributes. Set to this to `false` to only allow the .NET agent to collects the following of Http request headers.
+The `allowAllHeaders` element is a child of the `configuration` element. Set this to `true` to allow the .NET Agent to capture all HTTP request headers as `request.headers.{http-header-name}` attributes. Set this to `false` to only allow the .NET agent to collect the following HTTP request headers:
 
 ```
 request.headers.referer
@@ -2984,7 +2984,7 @@ request.headers.user-agent
       </tbody>
     </table>
 
-    Enable or disable Http request headers capture. Example:
+    Enable or disable HTTP request headers capture. Example:
 
     ```
 	  <allowAllHeaders enabled="true" />
@@ -2996,7 +2996,7 @@ request.headers.user-agent
 </CollapserGroup>
 
 <Callout variant="important">
-  The `allowAllHeaders` setting is only available in the .NET Agent version 8.40.0+. The captured request header attributes from using the `allowAllHeaders` setting are still being controlled by the root level and destination level [Attributes](/docs/agents/net-agent/configuration/net-agent-configuration/#agent-attributes) settings. Without setting the `request.header.*` in the `include` list under the `attributes` element (see the following), the .NET Agent still filters out all header attributes. The default `newrelic.config` is set to include the `request.header.*`.
+  The `allowAllHeaders` setting is only available in the .NET Agent version 8.40.0+. When using `allowAllHeaders` to capture attributes, the captured request header attributes are still being controlled by the root level and destination level [attributes](/docs/agents/net-agent/configuration/net-agent-configuration/#agent-attributes) settings. Without setting the `request.header.*` in the `include` list under the `attributes` element (see the following), the .NET Agent still filters out all header attributes. The default `newrelic.config` is set to include the `request.header.*`.
 
   ```
   <allowAllHeaders enabled="true" />
@@ -3006,7 +3006,7 @@ request.headers.user-agent
   </attributes>
   ```
 
-  The default `newrelic.config` is also set to explicitly exclude the following Http request headers to prevent the .NET Agent collecting unwanted data.
+  The default `newrelic.config` is also set to explicitly exclude the following HTTP request headers to prevent the .NET Agent collecting unwanted data.
 
   ```
   <attributes enabled="true">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-84000.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-84000.mdx
@@ -1,0 +1,151 @@
+---
+subject: .NET agent
+releaseDate: '2021-06-08'
+version: 8.40.0.0
+downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+---
+
+### New Features
+* Adds Agent support for capturing HTTP Request Headers.
+  * Support included for ASP.NET 4.x, ASP.NET Core, Owin, and WCF instrumentation. ([#558](https://github.com/newrelic/newrelic-dotnet-agent/issues/558), [#559](https://github.com/newrelic/newrelic-dotnet-agent/issues/559), [#560](https://github.com/newrelic/newrelic-dotnet-agent/issues/560), [#561](https://github.com/newrelic/newrelic-dotnet-agent/issues/561))
+  * To enable this feature, the new `allowAllHeaders` configuration setting must be set to `true`. For more information about this new configuration, visit the agent [configuration page](/docs/agents/net-agent/configuration/net-agent-configuration/#capture_http_request_headers).
+### Fixes
+* Fixes issue [#264](https://github.com/newrelic/newrelic-dotnet-agent/issues/264): Negative GC count metrics will now be clamped to 0, and a log message will be written to note the correction. This should resolve an issue where the GCSampler was encountering negative values and crashing. ([#550](https://github.com/newrelic/newrelic-dotnet-agent/pull/550))
+* Fixes issue [#584](https://github.com/newrelic/newrelic-dotnet-agent/issues/584): When the agent is configured to log to the console, the configured logging level from `newrelic.config` will be respected. ([#587](https://github.com/newrelic/newrelic-dotnet-agent/pull/587))
+
+### Checksums
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        File
+      </th>
+
+      <th>
+        SHA - 256 Hash
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        newrelic-agent-win-8.40.0.0-scriptable-installer.zip
+      </td>
+
+      <td>
+        1C752F5BAF8B1A13F0276BDE70522E08B92D34215A556C45AC8AF4AABBE0B87A
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        newrelic-agent-win-x64-8.40.0.0.msi
+      </td>
+
+      <td>
+        68A5C3C9CA6B8F35DD3F4FA4B97B7560CFADAE3D25790C33245CA69AF92F0BD0
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        newrelic-agent-win-x64-8.40.0.0.zip
+      </td>
+
+      <td>
+        93F1FE590F8D74483110250BBD94B7967BFADDB4C79241E9725B4FDEE8A85F6B
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        newrelic-agent-win-x86-8.40.0.0.msi
+      </td>
+
+      <td>
+        50E1C40F68CA7058D4491D994D3BCC31FF5EFB32C2EBB2F4E3EE9B391900CEEF
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        newrelic-agent-win-x86-8.40.0.0.zip
+      </td>
+
+      <td>
+        543C1473C7FE73B470B99A749A0E48B887116B82AAE784C0A195B5A88175AB1D
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        newrelic-netcore20-agent-8.40.0.0-1.x86_64.rpm
+      </td>
+
+      <td>
+        FCE857338C2ED7E740AEA6A57B506567AF8255C804CFDCD78BF4F6392B228893
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        newrelic-netcore20-agent-win-8.40.0.0-scriptable-installer.zip
+      </td>
+
+      <td>
+        3E12577B34CF8DE4E118D191B2C0EAA948AFC9AF15CEA4983A9C4AE5DBC74DA7
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        newrelic-netcore20-agent-win-x64-8.40.0.0.zip
+      </td>
+
+      <td>
+        34038A364C6B213F5CFD13D7785F925F244460DE995F02309CEA370F1A5E3BC4
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        newrelic-netcore20-agent-win-x86-8.40.0.0.zip
+      </td>
+
+      <td>
+        B52A6AAB8F24F2ECEAAD0589AE7A2B1CD71E28790627908B3DF9DE671C0D5E70
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        newrelic-netcore20-agent_8.40.0.0_amd64.deb
+      </td>
+
+      <td>
+        59188974CFECB5C7F8CB291D4669C48B7AA3FB936C3AF456EB1387D3CE99A4FA
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        newrelic-netcore20-agent_8.40.0.0_amd64.tar.gz
+      </td>
+
+      <td>
+        CF99691E1E6DF2B0ABDFB6C8740FBDC5FBA557BC248447E33D87214D167D217B
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### Support statement
+
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [.NET Agent 8.13.798.0](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8137980).
+
+### Upgrading
+
+* Follow standard procedures to [update the .NET agent](/docs/agents/net-agent/installation-configuration/update-net-agent).
+* If you are upgrading from a particularly old agent, review the list of major changes and procedures to [upgrade legacy .NET agents](/docs/agents/net-agent/troubleshooting/upgrade-legacy-net-agents).


### PR DESCRIPTION
### Give us some context

* What problems does this PR solve?
   1. The .NET agent team is completing the Http Request Header Capture work and expecting to release this feature next week. This PR updates the configuration doc with the new configuration `allowAllHeaders`. 
   2. Fix incorrect link.

### Are you making a change to site code?
No