### PR TITLE
Update use-tcp-endpoint-forward-logs-new-relic.mdx

### DIFF
--- a/src/content/docs/logs/log-management/log-api/use-tcp-endpoint-forward-logs-new-relic.mdx
+++ b/src/content/docs/logs/log-management/log-api/use-tcp-endpoint-forward-logs-new-relic.mdx
@@ -54,8 +54,6 @@ To forward logs to New Relic with `rsyslog`:
 
    ## Template expected by the New Relic Syslog endpoint
 
-   input(type="imfile" ruleset="infiles" Tag= <YOUR_FILE_TAG>
-    "File="<PATH_TO_FILE>" StateFile=<UNIQUE_STATEFILE_NAME>")
    template(name="newrelic-rfc5424"
             type="string"
             string="<YOUR_INSERT_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %hostname% %app-name% %procid% %msgid% %structured-data% %msg%\n"


### PR DESCRIPTION
There were extra lines before template definition which were corrupted copy of input definition.
Cleaned up to make configuration valid.
