### PR TITLE
Add entity synthesis section and restricted attributes

### DIFF
--- a/src/content/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits.mdx
+++ b/src/content/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits.mdx
@@ -194,6 +194,63 @@ The attributes in the table below are restricted in the `newrelic`-format JSON (
   </tbody>
 </table>
 
+
+The attributes in the table below are used internally to identify entities. Any values submitted with these keys in the attributes section of a metric data point may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities. For more information please refer to [Entity synthesis](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#entity-synthesis):
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "180px" }}>
+        Restricted attribute
+      </th>
+
+      <th>
+        description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `entity.guid`
+
+        _string_
+      </td>
+
+      <td>
+        Unique identifier for the entity associated with this span.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `entity.name`
+
+        _string_
+      </td>
+
+      <td>
+        Human-readable name of an entity, often used to identify an entity in the UI.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `entity.type`
+
+        _string_
+      </td>
+
+      <td>
+        Used to differentiate between different types of entities, like hosts, applications, etc.
+      </td>
+    </tr>
+
+  </tbody>
+</table>
+
+
 ## Request metadata (headers and query parameters) [#headers-query-parameters]
 
 The following table shows the required request metadata for all trace data formats. This metadata can be sent as HTTP headers on an ingest request or, in some cases, provided as query parameters, which may be required for tracing frameworks that don't allow header modification.

--- a/src/content/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits.mdx
+++ b/src/content/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits.mdx
@@ -31,14 +31,14 @@ All trace data is sent via a POST to a Trace API endpoint. We have a few endpoin
 * [Infinite Tracing](/docs/understand-dependencies/distributed-tracing/infinite-tracing/introduction-infinite-tracing): when you complete the [Trace observer setup](/docs/understand-dependencies/distributed-tracing/infinite-tracing/set-trace-observer), you get a custom <var>YOUR_TRACE_OBSERVER_URL</var> value to use as an endpoint. If you're using an integration that uses the Trace API (for example, [these integrations](/docs/understand-dependencies/distributed-tracing/enable-configure/integrations-enable-distributed-tracing)), you must configure that integration with that endpoint. You will also want to adjust the [sampling of your tracing service](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works#tail-based) to send us 100% of spans.
 * For FedRAMP, see [FedRAMP endpoints](/docs/security/security-privacy/compliance/fedramp-compliant-endpoints/#trace-api).
 
-## Data formats
+## Data formats [#data-formats]
 
 Currently, the Trace API accepts two types of data formats:
 
 * [`zipkin`](/docs/apm/distributed-tracing/trace-api/report-zipkin-format-traces-trace-api): For reporting Zipkin trace data. Zipkin data must be [Zipkin JSON v2](https://zipkin.io/zipkin-api/#/default/post_spans).
 * [`newrelic`](/docs/apm/distributed-tracing/trace-api/report-new-relic-format-traces-trace-api): For reporting all other trace data.
 
-## Data limits
+## Data limits [#data-limits] 
 
 Data limits and rules:
 
@@ -150,7 +150,7 @@ Data limits and rules:
 
 To see an example of how span limits are enforced, see [Exceeding limits](#exceeding-limits).
 
-## Restricted attributes
+## Restricted attributes [#restricted-attributes]
 
 The attributes in the table below are restricted in the `newrelic`-format JSON (in the `attributes` block) and in the [`zipkin`](/docs/apm/distributed-tracing/trace-api/report-zipkin-format-traces-trace-api)-format JSON (in the `tags` block). **Any values with these keys will be omitted**:
 
@@ -162,7 +162,7 @@ The attributes in the table below are restricted in the `newrelic`-format JSON (
       </th>
 
       <th>
-        description
+        Description
       </th>
     </tr>
   </thead>

--- a/src/content/docs/logs/log-management/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-management/log-api/introduction-log-api.mdx
@@ -323,6 +323,7 @@ Restrictions on logs sent to the Log API:
 Some specific attributes have additional restrictions:
 
 * `accountId`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
+* `entity.guid`, `entity.name`, and `entity.type`: These attributes are used internally to identify entities. Any values submitted with these keys in the attributes section of a metric data point may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities. For more information please refer to [Entity synthesis](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#entity-synthesis).
 * [`appId`](/docs/apis/rest-api-v2/requirements/find-product-id#apm): Value must be an integer. If it is not an integer, the attribute name and value will be dropped during ingest.
 * `eventType`: Can be a combination of alphanumeric characters, `_` underscores, and `:` colons.
 * `timestamp`: Must be a Unix epoch timestamp. You can define timestamps either in seconds or in milliseconds.

--- a/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
@@ -47,16 +47,16 @@ Some tips for finding and understanding entity data:
 
 ## Entity synthesis [#entity-synthesis]
 
-If you have telemetry from any source that is not supported by NewRelic out of the box, you can propose a mapping for it and once approved, any telemetry received by NewRelic and that matches your definition's file will be synthesized into an entity.
+If you have telemetry from any source that's not supported by New Relic out of the box, you can propose a mapping for it. Once approved, any telemetry received by New Relic which matches your definition file will be synthesized into an entity.
 
 <Callout variant="tip">
   For more information on how to modify existing entity types or create new ones please refer to our [Entity Synthesis documentation](https://github.com/newrelic-experimental/entity-synthesis-definitions#entity-synthesis-definitions).
 </Callout>
 
 
-### Reserved attributes for synthesized entities
+### Reserved attributes for synthesized entities [#reserved-attributes]
 
-These attributes are meant to be synthesized from the telemetry we receive and you **should not** set them unless you are aware of the implications and sure that it's needed:
+These attributes are meant to be synthesized from the telemetry we receive. **Do not** set them unless you are aware of the implications and consequences.
 
 <table>
   <thead>
@@ -78,9 +78,9 @@ These attributes are meant to be synthesized from the telemetry we receive and y
       </td>
 
       <td>
-        Generally, you should not set this attribute field on your telemetry data. New Relic may add this field to ingested data to store a unique identifier for the entity associated with the data point. If telemetry arrives with the `entity.guid` attribute already present, then New Relic will not change the value. However, it may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities.
+        Generally, you should not set this attribute field on your telemetry data. New Relic may add this field to ingested data to store a unique identifier for the entity associated with the data point. If telemetry arrives with the `entity.guid` attribute already present, then New Relic will not change the value. However, it may cause undefined behavior such as missing entities in the UI, or telemetry not associating with the expected entities.
 
-The one use case for passing in this attribute is to associate ingested telemetry with an already created New Relic entity. When the `entity.guid` attribute is sent, the value will override New Relic’s entity identification system such as entity synthesis definitions and instead use the value present as the data.
+        One use case for passing this attribute is to associate ingested telemetry with an entity already created by New Relic. When the `entity.guid` attribute is sent, the value will override New Relic’s entity identification system (such as entity synthesis definitions) and instead will use the attribute as the data.
       </td>
     </tr>
 
@@ -90,9 +90,9 @@ The one use case for passing in this attribute is to associate ingested telemetr
       </td>
 
       <td>
-        This attribute should not be put on ingested telemetry data unless you are trying to override the entity name that would have been selected by New Relic’s entity identification system. While New Relic will not change the value if already present on the data, New Relic may add the attribute to your data. Therefore invalid or unexpected values may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities.
+        This attribute shouldn't be put on ingested telemetry data unless you're trying to override the entity name that would have been selected by New Relic’s entity identification system. While New Relic won't change the value if it's already present on the data, New Relic may add the attribute to your data. Therefore invalid or unexpected values may cause undefined behavior such as missing entities in the UI, or telemetry not associating with the expected entities.
 
-If this field is present on ingested telemetry, its value will be used to name the entity associated with the data point. This name will be used instead of the name selected by New Relic’s entity identification system (for example, [entity synthesis definitions](https://github.com/newrelic-experimental/entity-synthesis-definitions#entity-synthesis-definitions)). Note that many entities use the name as part of their identification, so changing this field may result in generation of a new entity.
+        If this field is present on ingested telemetry, its value will be used to name the entity associated with the data point. This name will be used instead of the name selected by New Relic’s entity identification system (for example, [entity synthesis definitions](https://github.com/newrelic-experimental/entity-synthesis-definitions#entity-synthesis-definitions)). Note that many entities use the name as part of their identification, so changing this field may result in the generation of a new entity.
       </td>
     </tr>
 
@@ -102,11 +102,11 @@ If this field is present on ingested telemetry, its value will be used to name t
       </td>
 
       <td>
-        This attribute should not be put on ingested telemetry data except for certain legacy cases where it is required to distinguish entity types. Passing this field may interfere with entity detection, particularly if unrecognized values are sent in this field.
+        This attribute shouldn't be put on ingested telemetry data except for certain legacy cases where it's required to distinguish entity types. Passing this field may interfere with entity detection, particularly if unrecognized values are sent in this field.
 
-While New Relic will not change the value if already present on the data, the field is not guaranteed to provide unambiguous filtering of telemetry at query-time. Existing entity definitions already have overlapping values, and we recommend avoiding `entity.type` in favor of other fields for filtering telemetry queries.
+        While New Relic won't change the value if already present on the data, the field is not guaranteed to provide unambiguous filtering of telemetry at query-time. Existing entity definitions already have overlapping values, and we recommend avoiding `entity.type` in favor of other fields for filtering telemetry queries.
 
-This field is used by New Relic, meaning that invalid or unexpected values may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities.
+        This field is used by New Relic, meaning that invalid or unexpected values may cause undefined behavior such as missing entities in the UI, or telemetry not associating with the expected entities.
 
       </td>
     </tr>

--- a/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
@@ -17,6 +17,7 @@ New Relic monitoring is built around the concept of the **entity**. An entity is
 
 * What entities are
 * How to find entity data
+* How to modify existing entity types or create new ones
 * How entities are related to one another
 * How to organize them into groups for easier analysis
 
@@ -43,6 +44,75 @@ Some tips for finding and understanding entity data:
 * An entity's GUID is reported as the attribute [`entityGuid`](/attribute-dictionary/span/entityguid). You can query for an entity using this attribute in the [query builder](/docs/introduction-chart-builder).
 * Use the Related Entities view in the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/core-concepts/entity-explorer-view-performance-across-apps-services-hosts), [service maps](/docs/service-maps-dependencies-new-relic-one), [distributed tracing](/docs/distributed-tracing-new-relic-one), and our [relationships API in GraphQL](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial) to see connections between entities.
 * Explore entity data using our NerdGraph GraphiQL explorer ([api.newrelic.com/graphiql](https://api.newrelic.com/graphiql)).
+
+## Entity synthesis [#entity-synthesis]
+
+If you have telemetry from any source that is not supported by NewRelic out of the box, you can propose a mapping for it and once approved, any telemetry received by NewRelic and that matches your definition's file will be synthesized into an entity.
+
+<Callout variant="tip">
+  For more information on how to modify existing entity types or create new ones please refer to our [Entity Synthesis documentation](https://github.com/newrelic-experimental/entity-synthesis-definitions#entity-synthesis-definitions).
+</Callout>
+
+
+### Reserved attributes for synthesized entities
+
+These attributes are meant to be synthesized from the telemetry we receive and you **should not** set them unless you are aware of the implications and sure that it's needed:
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "200px" }}>
+        Attribute
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `entity.guid`
+      </td>
+
+      <td>
+        Generally, you should not set this attribute field on your telemetry data. New Relic may add this field to ingested data to store a unique identifier for the entity associated with the data point. If telemetry arrives with the `entity.guid` attribute already present, then New Relic will not change the value. However, it may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities.
+
+The one use case for passing in this attribute is to associate ingested telemetry with an already created New Relic entity. When the `entity.guid` attribute is sent, the value will override New Relic’s entity identification system such as entity synthesis definitions and instead use the value present as the data.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `entity.name`
+      </td>
+
+      <td>
+        This attribute should not be put on ingested telemetry data unless you are trying to override the entity name that would have been selected by New Relic’s entity identification system. While New Relic will not change the value if already present on the data, New Relic may add the attribute to your data. Therefore invalid or unexpected values may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities.
+
+If this field is present on ingested telemetry, its value will be used to name the entity associated with the data point. This name will be used instead of the name selected by New Relic’s entity identification system (for example, [entity synthesis definitions](https://github.com/newrelic-experimental/entity-synthesis-definitions#entity-synthesis-definitions)). Note that many entities use the name as part of their identification, so changing this field may result in generation of a new entity.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `entity.type`
+      </td>
+
+      <td>
+        This attribute should not be put on ingested telemetry data except for certain legacy cases where it is required to distinguish entity types. Passing this field may interfere with entity detection, particularly if unrecognized values are sent in this field.
+
+While New Relic will not change the value if already present on the data, the field is not guaranteed to provide unambiguous filtering of telemetry at query-time. Existing entity definitions already have overlapping values, and we recommend avoiding `entity.type` in favor of other fields for filtering telemetry queries.
+
+This field is used by New Relic, meaning that invalid or unexpected values may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities.
+
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 
 ## Entity relationships [#related-entities]
 

--- a/src/content/docs/telemetry-data-platform/ingest-apis/introduction-event-api.mdx
+++ b/src/content/docs/telemetry-data-platform/ingest-apis/introduction-event-api.mdx
@@ -33,7 +33,7 @@ redirects:
   - /docs/apis/insights-apis/getting-started/send-insights-events
   - /docs/telemetry-data-platform/ingest-manage-data/ingest-apis/introduction-event-api
   - /docs/insights/insights-api
-  - /docs/insights/insights-api/insert-data 
+  - /docs/insights/insights-api/insert-data
 ---
 
 The New Relic Event API is one way to report [custom events](/docs/insights/insights-data-sources/custom-data/report-custom-event-data) to New Relic. The Event API lets you send custom [event data](/docs/using-new-relic/data/understand-data/new-relic-data-types#event-data) to your New Relic account with a POST command. These events are then queryable and chartable using [NRQL](/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql).
@@ -53,7 +53,7 @@ Related content:
 
 For Event API limits and restricted attributes, see [Limits](#limits).
 
-Ensure outbound connectivity on TCP port 443 is allowed to the [CIDR range](/docs/using-new-relic/cross-product-functions/install-configure/networks/#infrastructure) that matches your [region](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers). 
+Ensure outbound connectivity on TCP port 443 is allowed to the [CIDR range](/docs/using-new-relic/cross-product-functions/install-configure/networks/#infrastructure) that matches your [region](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers).
 The preferred configuration method is to use the DNS name `insights-collector.nr-data.net` or `insights-collector.eu01.nr-data.net`.
 
 ## Basic workflow [#workflow]
@@ -233,6 +233,7 @@ The Event API accepts specific formats for attributes included in the payload. O
     Some specific attributes have additional restrictions:
 
     * `accountId`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
+    * `entity.guid`, `entity.name`, and `entity.type`: These attributes are used internally to identify entities. Any values submitted with these keys in the attributes section of a metric data point may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities. For more information please refer to [Entity synthesis](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#entity-synthesis).
     * [`appId`](/docs/apis/rest-api-v2/requirements/find-product-id#apm): Value must be an integer. If it is not an integer, the attribute name and value will be dropped during ingest.
     * `eventType`: Can be a combination of alphanumeric characters, `_` underscores, and `:` colons.
     * `timestamp`: Must be a Unix epoch timestamp. You can define timestamps either in seconds or in milliseconds.
@@ -249,8 +250,8 @@ Data submitted to the Event API uses a compressed JSON format in a simple HTTPS 
     title="Linux/bash example"
   >
     ```
-    gzip -c example_events.json | curl -X POST -H "Content-Type: application/json" 
-    -H "X-Insert-Key: <var>YOUR_KEY_HERE</var>" -H "Content-Encoding: gzip" 
+    gzip -c example_events.json | curl -X POST -H "Content-Type: application/json"
+    -H "X-Insert-Key: <var>YOUR_KEY_HERE</var>" -H "Content-Encoding: gzip"
     https://insights-collector.newrelic.com/v1/accounts/<var>YOUR_ACCOUNT_ID</var>/events --data-binary @-
     ```
   </Collapser>
@@ -265,8 +266,8 @@ Data submitted to the Event API uses a compressed JSON format in a simple HTTPS 
     # Replace with your custom event for the body
     $body = '[{"eventType": "powershell", "account": 4, "amount": 123, "fileLocation": "c:\\temp2", "zipped": "true" }]'
 
-    $headers = @{} 
-    $headers.Add("X-Insert-Key", "$insertkey") 
+    $headers = @{}
+    $headers.Add("X-Insert-Key", "$insertkey")
     $headers.Add("Content-Encoding", "gzip")
 
 

--- a/src/content/docs/telemetry-data-platform/ingest-apis/metric-api-limits-restricted-attributes.mdx
+++ b/src/content/docs/telemetry-data-platform/ingest-apis/metric-api-limits-restricted-attributes.mdx
@@ -235,7 +235,7 @@ The following default limits apply only to data collected via the Prometheus Rem
 
 Metric API limits apply at the individual account level. Trial and paid accounts receive a 1M DPM and 1M cardinality limit for trial purposes, but you can request up to 15M DPM and 15M cardinality for your account. To request changes to your metric rate limits, contact your New Relic account representative, or visit our [Support portal](http://support.newrelic.com/).
 
-## Rate limit violations
+## Rate limit violations [#rate-limit-violations]
 
 This section describes how the Metric API behaves when you exceed the rate limits, and how to respond if limits are exceeded.
 
@@ -359,7 +359,7 @@ These attributes are used internally to identify entities. Any values submitted 
         `entity.guid`
       </td>
       <td>
-         Unique identifier assigned by NewRelic to an entity
+         Unique identifier assigned to an entity by New Relic.
        </td>
     </tr>
 

--- a/src/content/docs/telemetry-data-platform/ingest-apis/metric-api-limits-restricted-attributes.mdx
+++ b/src/content/docs/telemetry-data-platform/ingest-apis/metric-api-limits-restricted-attributes.mdx
@@ -337,6 +337,52 @@ These attributes are restricted by the New Relic platform. Any values submitted 
   </tbody>
 </table>
 
+
+These attributes are used internally to identify entities. Any values submitted with these keys in the attributes section of a metric data point may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities. For more information please refer to [Entity synthesis](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#entity-synthesis):
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "200px" }}>
+        Attribute
+      </th>
+      <th>
+        Description
+       </th>
+
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `entity.guid`
+      </td>
+      <td>
+         Unique identifier assigned by NewRelic to an entity
+       </td>
+    </tr>
+
+    <tr>
+      <td>
+        `entity.name`
+      </td>
+      <td>
+         Human-readable name of an entity, often used to identify an entity in the UI.
+       </td>
+    </tr>
+
+    <tr>
+      <td>
+        `entity.type`
+      </td>
+      <td>
+         Used to differentiate between different types of entities, like hosts, applications, etc.
+       </td>
+    </tr>
+  </tbody>
+</table>
+
 Additional restrictions include:
 
 <table>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* Add a synthesis section to the Entities' documentation, explaining our reserved attributes.
* Add entity reserved attributes as restricted attributes on the relevant Ingestion APIs docs.

I checked how the changes look locally as instructed in the README. 

### Are you making a change to site code?

No, only documentation changes.