### PR TITLE
Update java-agent-configuration-config-file.mdx

### DIFF
--- a/src/content/docs/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -2848,6 +2848,44 @@ These options are set in the `error_collector` stanza and unless noted otherwise
     Attribute keys found in this list will not be sent to New Relic in traced errors. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
   </Collapser>
 
+   <Collapser
+    id="ec-ignoreErrorPriority"
+    title="ignoreErrorPriority"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When multiple errors are noticed in a transaction, only the last error will be reported by default. Setting this property to `false` will report the first error that is noticed.  For more information, see the [noticeError API](/docs/agents/java-agent/configuration/java-agent-error-configuration/).
+    For example:
+
+    ```
+    error_collector:
+          ignoreErrorPriority: false
+    ```
+  </Collapser> 
+  
+  
   <Collapser
     id="ec-ignore_errors"
     title="ignore_errors (DEPRECATED)"

--- a/src/content/docs/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -2876,7 +2876,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
       </tbody>
     </table>
 
-    When multiple errors are noticed in a transaction, only the last error will be reported by default. Setting this property to `false` will report the first error that is noticed.  For more information, see the [noticeError API](/docs/agents/java-agent/configuration/java-agent-error-configuration/).
+    When multiple errors are noticed in a transaction, only the last error will be reported by default. Setting this property to `false` will instead report only the first error that is noticed.  For more information, see the [noticeError API](/docs/agents/java-agent/configuration/java-agent-error-configuration/).
     For example:
 
     ```


### PR DESCRIPTION
This change defines a configuration property related to the noticeError API that is used both internally and via public API.
A recent PR corrects some documentation on the behavior of the property.
https://github.com/newrelic/newrelic-java-agent/pull/313/files

Issue report for the agent is here:
https://github.com/newrelic/newrelic-java-agent/issues/305


