### PR TITLE
fix: destination path reference for K8s CPM custom modules

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
@@ -127,7 +127,7 @@ To set up the modules:
        2. Make sure that your custom modules directory is available on the Minion Pod. You can use `kubectl cp` as one method to copy the directory from your host to the Minion. For example:
 
           ```
-          kubectl cp /example-custom-modules-dir <namespace>/<pod_name>:/var/lib/newrelic/synthetics/
+          kubectl cp /example-custom-modules-dir <namespace>/<pod_name>:/var/lib/newrelic/synthetics/modules
           ```
      </Collapser>
    </CollapserGroup>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

This update fixes the destination path for customer modules on the Synthetics - Kubernetes Containerized Private Minion (CPM) installation docs. Refer to https://discuss.newrelic.com/t/deploy-cpm-on-kubernetes-pod-fails-to-start-with-custom-modules/145992/2 for the issue that was raised.

### Are you making a change to site code?

No