### PR TITLE
Changed image title from filename to meaningful title.

### DIFF
--- a/src/content/docs/distributed-tracing/concepts/introduction-distributed-tracing.mdx
+++ b/src/content/docs/distributed-tracing/concepts/introduction-distributed-tracing.mdx
@@ -31,7 +31,7 @@ Distributed tracing tracks and observes service requests as they flow through di
 
 Distributed tracing systems collect data as the requests go from one service to another, recording each segment of the journey as a span. These spans contain important details about each segment of the request and are combined into one trace. The completed trace gives you a picture of the entire request.
 
-  ![Diagram showing how spans are generated in a distributed trace](./images/span-diagram.png "span-diagram.png")
+  ![Diagram showing how spans are generated in a distributed trace](./images/span-diagram.png "Diagram showing how spans are generated in a distributed trace")
 
   <figcaption>
     Here is an example of three spans captured from an HTTP request. These spans are sent to New Relic where they are combined into one distributed trace.


### PR DESCRIPTION
As part of testing the migration of changes from the private docs site, I am fixing a poor image title.

Reviewer: please hover over the image to confirm that the title is no longer the filename.