### PR TITLE
fix: catch errors in release notes failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,6 @@ jobs:
   create-release:
     name: Create Github release
     runs-on: ubuntu-latest
-    outputs:
-      tag: ${{ steps.get-tag.outputs.tag }}
-      last: ${{ steps.get-last-tag.outputs.last }}
       
     steps:
       - name: Checkout repository
@@ -26,12 +23,11 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         
-      - name: Get release tag
-        id: get-tag
+      - name: Get last release tag
+        id: get-last-tag
         run: |
-          MERGES=$(gh pr list -B main -s merged --search "closed:>2021-02-28" -L 9999 | wc -l | awk '{print $1}')
-          echo "::set-output name=tag::release-$MERGES"
-          echo COMPARE=$MERGES >> $GITHUB_ENV
+          echo LAST_RELEASE=$(git describe --tags --abbrev=0) >> $GITHUB_ENV
+          echo $LAST_RELEASE
           
       - name: Install Python Dependencies
         run: |
@@ -43,6 +39,12 @@ jobs:
         id: py-get-updates
         run: |
           python ./scripts/actions/release-notes.py
+          
+      - name: Create new release tag
+        id: create-new-tag
+        run: |
+          LAST_TAG_NUM=$(echo ${{ env.LAST_RELEASE }} | sed 's/release\-//')
+          echo NEW_TAG=$(echo "release-$((LAST_TAG_NUM + 1))") >> $GITHUB_ENV
 
       - name: Create release
-        run: gh release create ${{ steps.get-tag.outputs.tag }} -t ${{ steps.get-tag.outputs.tag }} -n "${{ env.RESULT }}" 
+        run: gh release create ${{ env.NEW_TAG }} -t ${{ env.NEW_TAG }} -n "${{ env.RESULT }}" 

--- a/scripts/actions/release-notes.py
+++ b/scripts/actions/release-notes.py
@@ -16,21 +16,21 @@ result = "## :rocket: What's new?\n\n\n"
 repo = github.get_repo("newrelic/docs-website")
 
 # Get latest merge number environment variable
-latestMerge = os.getenv('COMPARE', '...')
-
-# Minus 1 to get the previous release to compare updates since then
-compareRelease = int(latestMerge) - 1
+lastRelease = os.getenv('LAST_RELEASE', '...')
 
 # Compare diff between previous release and develop
-diff = repo.compare("release-{compare}".format(compare=compareRelease), "develop")
+diff = repo.compare(lastRelease, "develop")
 
 # Loop through commits and add details to result
 for commit in diff.commits:
-  result += "@{author} - {message} [->]({url})\n".format(
-    author=commit.author.login,
-    message=commit.commit.message.splitlines()[0],
-    url=commit.html_url
-  )
+  try:
+    result += "@{author} - {message} [->]({url})\n".format(
+      author=commit.author.login,
+      message=commit.commit.message.splitlines()[0],
+      url=commit.html_url
+    )
+  except AssertionError:
+    pass
 
 # Set result as an Env for use in Workflow
 run('echo "RESULT<<EOF" >> $GITHUB_ENV')


### PR DESCRIPTION
If there is an error getting any details from the commit object, the code will now catch these and continue with the loop instead of failing

I also refactored some of the `release.yml` workflow.
It will now grab the actual latest tag from a release rather than calculating it from the number of merges to `main`, so if a release fails, the next release won't look for a tag that failed to create,and will include all changes since the last release tag.

