### PR TITLE
Fixing that Get started link in the left nav (hero request)

### DIFF
--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -2570,7 +2570,7 @@ pages:
       - title: Azure functions monitoring
         pages:
           - title: Get started
-            path: /docs/serverless-function-monitoring/azure-functions-monitoring/get-started
+            path: /docs/serverless-function-monitoring/azure-functions-monitoring/get-started/azure-functions-monitoring-integration
             pages:
               - title: Azure Functions monitoring integration
                 path: /docs/serverless-function-monitoring/azure-functions-monitoring/get-started/azure-functions-monitoring-integration


### PR DESCRIPTION
It was full on broken. Because there's only one doc in that category, I just made Get started point to that one doc.

This is the broken link I updated: https://docs.newrelic.com/docs/serverless-function-monitoring/azure-functions-monitoring/get-started/