### PR TITLE
change the link to point to a different section

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -84,7 +84,7 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
       ...
     ```
 
-    Use the `FROM` clause to specify the [data type](/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql#what-you-can-query) you wish to query. You can start your query with `FROM` or with [`SELECT`](#state-select). You can merge values for the same attributes across multiple data types in a [comma separated list](#commas).
+    Use the `FROM` clause to specify the [data type](/docs/telemetry-data-platform/understand-data/new-relic-data-types) you wish to query. You can start your query with `FROM` or with [`SELECT`](#state-select). You can merge values for the same attributes across multiple data types in a [comma separated list](#commas).
 
     <CollapserGroup>
       <Collapser


### PR DESCRIPTION
The original links points to a section that doesn't really say much about what **data types** you can query

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->