### PR TITLE
Inserted more meaningful OpenTelemetry image title as a test of the private repo.

### DIFF
--- a/src/content/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-architecture-recipes.mdx
+++ b/src/content/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-architecture-recipes.mdx
@@ -38,7 +38,7 @@ Two common collector deployments are the standalone service and sidecar. We cove
 
 When you set up the collector as a standalone service, OpenTelemetry calls this a gateway:
 
-![Diagram showing how to set up the collector as a standalone service.](./images/collector_standalone_overview.png "collector_standalone_overview.png")
+![Diagram showing how to set up the collector as a standalone service](./images/collector_standalone_overview.png "Diagram showing how to set up the collector as a standalone service.")
 
 ### Sidecar/Daemon/Agent [#sidecar]
 


### PR DESCRIPTION
This is another test of transferring branches from the private repo to the public repo. This image title fix is minor, but still a valid change that we should review and publish.