### PR TITLE
AWS metric streams: New EU endpoint and clarification on output format

### DIFF
--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -90,7 +90,8 @@ Next, set up the metric stream using the [CloudFormation template](https://conso
   * Ensure the following settings are defined:
     * Third-party service provider: New Relic - Metrics
     * New Relic configuration
-      * HTTP endpoint URL (US Datacenter): `https://aws-api.newrelic.com/cloudwatch-metrics/v1`
+      * HTTP endpoint URL - US Datacenter: `https://aws-api.newrelic.com/cloudwatch-metrics/v1`
+      * HTTP endpoint URL - EU Datacenter: `https://aws-api.eu01.nr-data.net/cloudwatch-metrics/v1`
       * API key: Enter your [license key](/docs/accounts/accounts-billing/account-setup/new-relic-license-key/)
       * Content encoding: `GZIP`
       * Retry duration: `60`
@@ -109,16 +110,13 @@ Next, set up the metric stream using the [CloudFormation template](https://conso
     * Use inclusion and exclusion filters to select which services should push metrics to New Relic.
     * Select your Kinesis Data Firehose.
     * Define a meaningful name for the stream (for example, newrelic-metric-stream).
+  * Change default output format to `Open Telemetry 0.7` (JSON is not supported)
   * Confirm the creation of the metric stream. 
 
   Alternatively, you can find instructions on the AWS documentation in order to create the CloudWatch metric stream using a CloudFormation template, API, or the CLI.
 
 3. ** Add the new AWS account** in the **Metric streams** mode in the New Relic UI. 
   Go to **[one.newrelic.com](https://one.newrelic.com/) > Infrastructure > AWS**, click on **Add an AWS account**, then on **Use metric streams**, and follow the steps.
-
-<Callout variant="caution">
-The AWS Metric Streams integration is temporarily disabled for accounts hosted in the New Relic EU datacenter. 
-</Callout>
 
 ## Validate your data is received correctly [#validate-data]
 


### PR DESCRIPTION


<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context
* Removed limitation on EU datacenter (now fully available for customers)
* Add required mandatory output format to be Open Telemetry 0.7

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.