### PR TITLE
infra-agent: new memory metrics for linux hosts

### DIFF
--- a/src/data-dictionary/events/SystemSample/memoryCachedBytes.md
+++ b/src/data-dictionary/events/SystemSample/memoryCachedBytes.md
@@ -1,0 +1,11 @@
+---
+name: memoryCachedBytes
+type: attribute
+units: bytes (B)
+events:
+  - SystemSample
+---
+
+The total amount of cached memory, in bytes, available to this server.
+
+This metric is only available for the Linux Infrastructure agent, version 1.18.1 or higher.

--- a/src/data-dictionary/events/SystemSample/memorySharedBytes.md
+++ b/src/data-dictionary/events/SystemSample/memorySharedBytes.md
@@ -1,0 +1,11 @@
+---
+name: memorySharedBytes
+type: attribute
+units: bytes (B)
+events:
+  - SystemSample
+---
+
+The total amount of shared memory, in bytes, available to this server.
+
+This metric is only available for the Linux Infrastructure agent, version 1.18.1 or higher.

--- a/src/data-dictionary/events/SystemSample/memorySlabBytes.md
+++ b/src/data-dictionary/events/SystemSample/memorySlabBytes.md
@@ -1,0 +1,11 @@
+---
+name: memorySlabBytes
+type: attribute
+units: bytes (B)
+events:
+  - SystemSample
+---
+
+The total amount of slab memory, in bytes, available to this server.
+
+This metric is only available for the Linux Infrastructure agent, version 1.18.1 or higher.


### PR DESCRIPTION
Adding infra-agent new memory metrics released in last 1.18.1 version https://github.com/newrelic/infrastructure-agent/releases/tag/1.18.1