### PR TITLE
Pause workflow that sends content to be translated

### DIFF
--- a/.github/workflows/send-content-to-translate.yml
+++ b/.github/workflows/send-content-to-translate.yml
@@ -2,9 +2,9 @@ name: Send content to be translated
 
 on:
   workflow_dispatch:
-  schedule:
-    # At 1 am on the 1st and 15th day of a month
-    - cron: '0 1 1,15 * *'
+  # schedule:
+  # At 1 am on the 1st and 15th day of a month
+  # - cron: '0 1 1,15 * *'
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Description

Comments out the scheduled cron for workflow that sends content to be translated until all jobs in Smartling are completed and files are PR'ed back into the repo to ensure those files are fully translated.

## Related issues
https://github.com/newrelic/docs-website/issues/2597
https://github.com/newrelic/docs-website/issues/2655