### PR TITLE
Updated PageAction limit to 120

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action.mdx
@@ -29,8 +29,8 @@ Agent version [nr-593](https://docs.newrelic.com/docs/release-notes/new-relic-br
 
 This API call sends a Browser [`PageAction` event](/docs/insights/explore-data/custom-events/insert-browser-custom-events-attributes-insights-javascript-api) with your user-defined name and optional attributes to [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards), along with [several default attributes](/docs/insights/explore-data/attributes/browser-default-attributes-insights). This is useful to track any event that is not already tracked automatically by the Browser agent, such as clicking a **Subscribe** button or accessing a tutorial.
 
-- PageAction events are sent to New Relic One every 30 seconds, with a maximum of 60 events per 30-second harvest cycle, per browser.
-- After the 60-event limit is reached, additional events are not captured for that harvest cycle.
+- PageAction events are sent to New Relic One every 30 seconds, with a maximum of 120 events per 30-second harvest cycle, per browser.
+- After the 120-event limit is reached, additional events are not captured for that harvest cycle.
 
 ## Parameters
 

--- a/src/content/docs/telemetry-data-platform/custom-data/custom-events/report-browser-monitoring-custom-events-attributes.mdx
+++ b/src/content/docs/telemetry-data-platform/custom-data/custom-events/report-browser-monitoring-custom-events-attributes.mdx
@@ -85,7 +85,7 @@ In order to report `PageAction` events, verify these prerequisites:
       </td>
 
       <td>
-        `PageAction` events are reported every 30 seconds, with a maximum of 60 events per 30-second harvest cycle, per browser. After the 60-event limit is reached, additional events are not captured for that cycle.
+        `PageAction` events are reported every 30 seconds, with a maximum of 120 events per 30-second harvest cycle, per browser. After the 120-event limit is reached, additional events are not captured for that cycle.
       </td>
     </tr>
 


### PR DESCRIPTION
Closes #2661.

With the recent release of the Browser agent, the PageAction event limit has been increased to 120.