### PR TITLE
Add broken links and certificate monitors to table

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/getting-started/types-synthetic-monitors.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/getting-started/types-synthetic-monitors.mdx
@@ -40,7 +40,7 @@ You can also use the [host not reporting](/docs/infrastructure/new-relic-infrast
 
 ## Types of monitors [#types-monitors]
 
-These are the four types of synthetic monitors:
+These are the seven types of synthetic monitors:
 
 <table>
   <thead>
@@ -56,6 +56,27 @@ These are the four types of synthetic monitors:
   </thead>
 
   <tbody>
+
+    <tr>
+      <td>
+        Broken links monitor
+      </td>
+
+      <td>
+        Provide a url and this monitor will test all the links on the page for success. If a failure is detected you can view the individual non-successful links that caused the failure.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Certificate check monitor
+      </td>
+
+      <td>
+        Proactively ping your domain certificates based on a configurable threshold. Pair with an alert to ensure you are notified when your certificates need renewed.
+      </td>
+    </tr>
+
     <tr>
       <td>
         Ping monitor


### PR DESCRIPTION
This was requested by the Synthetics PMM. It adds the two new monitors to the list of monitors in our docs.