### PR TITLE
Made fixes for broken links found by the Fargate team.

### DIFF
--- a/src/content/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations.mdx
+++ b/src/content/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations.mdx
@@ -117,7 +117,7 @@ On-host integrations are what we call integrations that you can run directly on 
 
     <tr id="on-host">
       <td>
-        [On-host integrations](/docs/infrastructure/host-integrations/host-integrations-list)
+        [On-host integrations](/docs/integrations/host-integrations/host-integrations-list/)
       </td>
 
       <td>

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -2355,7 +2355,7 @@
     ]
   },
   {
-    "url": "/docs/integrations/kubernetes-integration/logs/get-kubernetes-log-data",
+    "url": "/docs/integrations/kubernetes-integration/logs",
     "paths": [
       "/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/"
     ]

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -2355,9 +2355,9 @@
     ]
   },
   {
-    “url”: “/docs/integrations/kubernetes-integration/logs/get-kubernetes-log-data”,
-    “paths”: [
-      “/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/”
+    "url": "/docs/integrations/kubernetes-integration/logs/get-kubernetes-log-data",
+    "paths": [
+      "/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/"
     ]
   }
 ]

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -2353,5 +2353,11 @@
     "paths": [
       "/docs/serverless-function-monitoring/azure-functions-monitoring/get-started"
     ]
+  },
+  {
+    “url”: “/docs/integrations/kubernetes-integration/logs/get-kubernetes-log-data”,
+    “paths”: [
+      “/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/”
+    ]
   }
 ]

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -2353,11 +2353,5 @@
     "paths": [
       "/docs/serverless-function-monitoring/azure-functions-monitoring/get-started"
     ]
-  },
-  {
-    "url": "/docs/integrations/kubernetes-integration/logs",
-    "paths": [
-      "/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/"
-    ]
   }
 ]

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -26,7 +26,7 @@ pages:
           - title: Auto-Telemetry with Pixie
             path: /docs/full-stack-observability/observe-everything/get-started/get-started-auto-telemetry-pixie
           - title: Kubernetes monitoring
-            path: /docs/full-stack-observability/monitor-everything/observability-solutions/kubernetes-monitoring
+            path: /docs/integrations/kubernetes-integration/get-started/introduction-kubernetes-integration/
           - title: Logs in context
             path: /docs/full-stack-observability/monitor-everything/observability-solutions/logs-context
           - title: Mobile monitoring
@@ -47,9 +47,9 @@ pages:
         path: /docs/full-stack-observability/instrument-everything/instrument-core-services-applications
         pages:
           - title: On-host integrations
-            path: /docs/full-stack-observability/instrument-everything/instrument-core-services-applications/core-services-integrations
+            path: /docs/integrations/host-integrations/get-started/introduction-host-integrations
           - title: Kubernetes integration
-            path: /docs/full-stack-observability/instrument-everything/instrument-core-services-applications/kubernetes-integration
+            path: /docs/integrations/kubernetes-integration/get-started/introduction-kubernetes-integration/
           - title: Cloud services integrations
             path: /docs/full-stack-observability/instrument-everything/instrument-core-services-applications/cloud-services-integrations
           - title: Amazon ECS integration
@@ -1852,7 +1852,7 @@ pages:
           - title: Intro to infrastructure monitoring
             path: /docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring
           - title: Get integrations
-            path: /docs/infrastructure/new-relic-infrastructure/getting-started/infrastructure-integrations
+            path: /docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring
           - title: Infrastructure agent release notes
             path: /docs/infrastructure/new-relic-infrastructure/getting-started/infrastructure-agent-release-notes
           - title: Infrastructure monitoring best practices guide


### PR DESCRIPTION
The Fargate team noticed several broken links. Here are the fixes:

* In `full-stack-observability.yml`, under **Infrastructure monitoring > Get started**, the link for **Get Integrations** was failing: `/docs/infrastructure/new-relic-infrastructure/getting-started/infrastructure-integrations`. Now it is this to get around a redirect issue: `/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring`.
* `/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations.mdx` had this bad link in the table under **On-host integrations**: `https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/`. To get around this failing redirect, I changed it to this: `/docs/integrations/host-integrations/host-integrations-list/`.
* In `full-stack-observability.yml`, under **FSO > instrument everything > Instrument core services**, the on-host integrations path had a bad link: `https://docs.newrelic.com/docs/full-stack-observability/instrument-everything/instrument-core-services-applications/core-services-integrations/`. I changed it to this to avoid a redirect issue: `/docs/integrations/host-integrations/get-started/introduction-host-integrations`.
* In `full-stack-observability.yml`, under **Observe everything > Observability solutions > Kubernetes monitor**, the link was bad: `/docs/full-stack-observability/monitor-everything/observability-solutions/kubernetes-monitoring`. It is now this to get around the redirect problems: `/docs/integrations/kubernetes-integration/get-started/introduction-kubernetes-integration/`.
* In `full-stack-observability.yml`, under **Instrument everything > Instrument core services and applications**, the link for Kubernetes integration was bad: `/docs/full-stack-observability/instrument-everything/instrument-core-services-applications/kubernetes-integration`. It is now this to get around a redirect issue: `/docs/integrations/kubernetes-integration/get-started/introduction-kubernetes-integration/`.