### PR TITLE
Fixed link to fedramp settings for Infrastructure (under Log API)

### DIFF
--- a/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
+++ b/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
@@ -513,7 +513,7 @@ Here are details on changing the endpoint for our [log forwarders](/docs/logs/en
 * AWS Firelens: Add the `endpoint` property to the `options` field of the `logConfiguration`, similar to to the EU account endpoint change shown in [these Firelens endpoint configuration instructions](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/aws-firelens-plugin-log-forwarding#find-data).
 * Fluentbit: Use [our Fluentbit endpoint configuration](https://github.com/newrelic/newrelic-fluent-bit-output#configuration-parameters).
 * Fluentd: Use [our Fluentd endpoint instructions](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/fluentd-plugin-log-forwarding#instrument-plugin).
-* Infrastructure agent: See [FedRAMP for infrastructure](/#infrastructure-endpoints).
+* Infrastructure agent: See [FedRAMP for infrastructure](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#fedramp).
 * Kubernetes: Our Kubernetes integration logs are based on fluentbit’s output plugin. Use [these endpoint instructions](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging#installation).
 * Logstash: Use [our Logstash endpoint configuration](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/logstash-plugin-log-forwarding#instrument-plugin).
 * Syslog: For configuring syslog clients, see [TCP endpoint configuration](/docs/logs/log-management/log-api/use-tcp-endpoint-forward-logs-new-relic/).


### PR DESCRIPTION
Adjusted link so the link for Infra will take you to the fedramp setting in Infra's config page.