### PR TITLE
chore: add infinite lineWidth to yaml deserializer

### DIFF
--- a/scripts/actions/deserialize-html.js
+++ b/scripts/actions/deserialize-html.js
@@ -74,7 +74,9 @@ const stripTranslateFrontmatter = () => {
       const frontmatterObj = yaml.load(tree.children[0].value);
       delete frontmatterObj.translate;
       delete frontmatterObj.redirects;
-      const frontmatterStr = yaml.dump(frontmatterObj).trim();
+      const frontmatterStr = yaml
+        .dump(frontmatterObj, { lineWidth: -1 })
+        .trim();
       tree.children[0].value = frontmatterStr;
       return tree;
     }


### PR DESCRIPTION
This is to stop it converting single line strings to use `>-` when over 80 characters long
