### PR TITLE
Update verified-script-execution-private-locations.mdx

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/verified-script-execution-private-locations.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/verified-script-execution-private-locations.mdx
@@ -27,7 +27,7 @@ To enable verified script execution for containerized private minions, do the fo
 1. Go to **[one.newrelic.com](https://one.newrelic.com/) > Synthetics > Private locations > (select a private location)**. Select the private location's ellipses icon, and click **Edit**. Enable verified script execution, then save.
 2. Set the passphrase in your Docker or Kubernetes environment:
 
-   * **Docker:** Add the `MINION_VSE_PASSWORD` environment variable to the Docker `run` command used to start your private minion:
+   * **Docker:** Add the `MINION_VSE_PASSWPHRASE` environment variable to the Docker `run` command used to start your private minion:
 
      ```
      docker run \
@@ -58,7 +58,7 @@ To change your passphrase, do the following. Be sure to record your passphrase i
 
 1. Update the passphrase in your Docker or Kubernetes environment:
 
-   * **Docker:** Stop your current minion. Then use the Docker `run` command to start a new minion with your updated `MINION_VSE_PASSWORD` environment variable:
+   * **Docker:** Stop your current minion. Then use the Docker `run` command to start a new minion with your updated `MINION_VSE_PASSPHRASE` environment variable:
 
      ```
      docker run \
@@ -89,7 +89,7 @@ To disable verified script execution for containerized private minions:
 
 1. Remove the passphrase in your Docker or Kubernetes environment:
 
-   * **Docker:** Stop your current minion container. Then use the Docker `run` command to start a new minion without the `MINION_VSE_PASSWORD` environment variable:
+   * **Docker:** Stop your current minion container. Then use the Docker `run` command to start a new minion without the `MINION_VSE_PASSPHRASE` environment variable:
 
      ```
      docker run \

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/verified-script-execution-private-locations.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/verified-script-execution-private-locations.mdx
@@ -32,8 +32,8 @@ To enable verified script execution for containerized private minions, do the fo
      ```
      docker run \
        --name <var>YOUR_CONTAINER_NAME</var> \
-       -e "MINION_PRIVATE_LOCATION_KEY=<var>YOUR_PRIVATE_LOCATION_KEY</var>" \
-       -e "MINION_VSE_PASSWORD=<var>YOUR_PASSPHRASE</var>"
+       -e MINION_PRIVATE_LOCATION_KEY="<var>YOUR_PRIVATE_LOCATION_KEY</var>" \
+       -e MINION_VSE_PASSPHRASE="<var>YOUR_PASSPHRASE</var>"
        -v /tmp:/tmp:rw \
        -v /var/run/docker.sock:/var/run/docker.sock:rw \
        -d \

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/verified-script-execution-private-locations.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/verified-script-execution-private-locations.mdx
@@ -64,7 +64,7 @@ To change your passphrase, do the following. Be sure to record your passphrase i
      docker run \
        --name <var>YOUR_CONTAINER_NAME</var> \
        -e MINION_PRIVATE_LOCATION_KEY="<var>YOUR_PRIVATE_LOCATION_KEY</var>" \
-       -e MINION_VSE_PASSWORD="<var>YOUR_PASSPHRASE</var>"
+       -e MINION_VSE_PASSPHRASE="<var>YOUR_PASSPHRASE</var>"
        -v /tmp:/tmp:rw \
        -v /var/run/docker.sock:/var/run/docker.sock:rw \
        -d \

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/verified-script-execution-private-locations.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/verified-script-execution-private-locations.mdx
@@ -63,8 +63,8 @@ To change your passphrase, do the following. Be sure to record your passphrase i
      ```
      docker run \
        --name <var>YOUR_CONTAINER_NAME</var> \
-       -e "MINION_PRIVATE_LOCATION_KEY=<var>YOUR_PRIVATE_LOCATION_KEY</var>" \
-       -e "MINION_VSE_PASSWORD=<var>YOUR_PASSPHRASE</var>"
+       -e MINION_PRIVATE_LOCATION_KEY="<var>YOUR_PRIVATE_LOCATION_KEY</var>" \
+       -e MINION_VSE_PASSWORD="<var>YOUR_PASSPHRASE</var>"
        -v /tmp:/tmp:rw \
        -v /var/run/docker.sock:/var/run/docker.sock:rw \
        -d \

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/verified-script-execution-private-locations.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/verified-script-execution-private-locations.mdx
@@ -18,16 +18,18 @@ icon indicates that verified script execution has been set up for that location.
 
 Be sure to safeguard your private minion's passphrase. No other users on your account can view it, and it is never stored in New Relic's collector.
 
+<Callout variant="important">
 This restriction includes New Relic support personnel. Because our collector never stores your passphrase, our support team cannot recover or reset your passphrase for you. If you forget your passphrase, you will need to change it in the [minion **Overview** page](/docs/synthetics/new-relic-synthetics/private-locations/install-configure-private-minions#configure), and then update each monitor assigned to that private location.
+</Callout>
 
 ## Enable verified script execution [#cpm]
 
-To enable verified script execution for containerized private minions, do the following. Be sure to record your passphrase in a secure place.
+Do the following to enable verified script execution for containerized private minions. Be sure to record your passphrase in a secure place.
 
-1. Go to **[one.newrelic.com](https://one.newrelic.com/) > Synthetics > Private locations > (select a private location)**. Select the private location's ellipses icon, and click **Edit**. Enable verified script execution, then save.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/) > Synthetics > Private locations > (select a private location)**. Select the private location's ellipses icon, and click **Edit**. Enable verified script execution, and then save.
 2. Set the passphrase in your Docker or Kubernetes environment:
 
-   * **Docker:** Add the `MINION_VSE_PASSWPHRASE` environment variable to the Docker `run` command used to start your private minion:
+   * **Docker:** Add the `MINION_VSE_PASSPHRASE` environment variable to the Docker `run` command used to start your private minion:
 
      ```
      docker run \


### PR DESCRIPTION
Was trying to follow along the docs and realized that they were slightly incorrect. Using the previously given command creates a minion who does not have VSE enabled, because the minion code doesn't recognize MINION_VSE_PASSWORD

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
This solves any issues users might be having with following our VSE documentation, namely that the command we provide doesn't work
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.