### PR TITLE
Update ruby agent configuration

### DIFF
--- a/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -99,7 +99,7 @@ These settings are available for agent configuration. Some settings depend on yo
       </tbody>
     </table>
 
-  Your New Relic <a href="https://docs.newrelic.com/docs/accounts-partnerships/accounts/account-setup/license-key">license key</a>.
+  Your New Relic [license key](/docs/accounts-partnerships/accounts/account-setup/license-key).
   </Collapser>
   
   <Collapser id="agent_enabled" title="agent_enabled">
@@ -123,7 +123,7 @@ These settings are available for agent configuration. Some settings depend on yo
       </tbody>
     </table>
 
-  Specify the <a href="https://docs.newrelic.com/docs/apm/new-relic-apm/installation-configuration/name-your-application">application name</a> used to aggregate data in the New Relic UI. To report data to <a href="https://docs.newrelic.com/docs/apm/new-relic-apm/installation-configuration/using-multiple-names-app">multiple apps at the same time</a>, specify a list of names separated by a semicolon (`;`). For example, `MyApp` or `MyStagingApp;Instance1`.
+  Specify the [application name](/docs/apm/new-relic-apm/installation-configuration/name-your-application) used to aggregate data in the New Relic UI. To report data to [multiple apps at the same time](/docs/apm/new-relic-apm/installation-configuration/using-multiple-names-app), specify a list of names separated by a semicolon `;`. For example, `MyApp` or `MyStagingApp;Instance1`.
   </Collapser>
   
   <Collapser id="entity_guid" title="entity_guid">
@@ -135,7 +135,7 @@ These settings are available for agent configuration. Some settings depend on yo
       </tbody>
     </table>
 
-  The <a href="https://docs.newrelic.com/attribute-dictionary/?event=Span&attribute=entity.guid">Entity GUID</a> for the entity running this agent.
+  The [Entity GUID](/attribute-dictionary/span/entityguid) for the entity running this agent.
   </Collapser>
   
   <Collapser id="monitor_mode" title="monitor_mode">
@@ -147,7 +147,7 @@ These settings are available for agent configuration. Some settings depend on yo
       </tbody>
     </table>
 
-  When `true`, the agent transmits data about your app to the New Relic <a href="/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector">collector</a>.
+  When `true`, the agent transmits data about your app to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector).
   </Collapser>
   
   <Collapser id="log_level" title="log_level">
@@ -171,7 +171,7 @@ These settings are available for agent configuration. Some settings depend on yo
       </tbody>
     </table>
 
-  If `true`, enables <a href="https://docs.newrelic.com/docs/accounts-partnerships/accounts/security/high-security">high security mode</a>. Ensure you understand the implications of high security mode before enabling this setting.
+  If `true`, enables [high security mode](/docs/accounts-partnerships/accounts/security/high-security). Ensure you understand the implications of high security mode before enabling this setting.
   </Collapser>
   
   <Collapser id="security_policies_token" title="security_policies_token">
@@ -195,7 +195,7 @@ These settings are available for agent configuration. Some settings depend on yo
       </tbody>
     </table>
 
-  Defines a host for communicating with the New Relic <a href="/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector">collector</a> via a proxy server.
+  Defines a host for communicating with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) via a proxy server.
   </Collapser>
   
   <Collapser id="proxy_port" title="proxy_port">
@@ -207,7 +207,7 @@ These settings are available for agent configuration. Some settings depend on yo
       </tbody>
     </table>
 
-  Defines a port for communicating with the New Relic <a href="/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector">collector</a> via a proxy server.
+  Defines a port for communicating with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) via a proxy server.
   </Collapser>
   
   <Collapser id="proxy_user" title="proxy_user">
@@ -219,7 +219,7 @@ These settings are available for agent configuration. Some settings depend on yo
       </tbody>
     </table>
 
-  Defines a user for communicating with the New Relic <a href="/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector">collector</a> via a proxy server.
+  Defines a user for communicating with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) via a proxy server.
   </Collapser>
   
   <Collapser id="proxy_pass" title="proxy_pass">
@@ -231,7 +231,7 @@ These settings are available for agent configuration. Some settings depend on yo
       </tbody>
     </table>
 
-  Defines a password for communicating with the New Relic <a href="/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector">collector</a> via a proxy server.
+  Defines a password for communicating with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) via a proxy server.
   </Collapser>
   
   <Collapser id="capture_params" title="capture_params">
@@ -270,7 +270,7 @@ When using the `capture_params` setting, the Ruby agent will not attempt to filt
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Deprecated. For agent versions 3.5.0 or higher, <a href="https://docs.newrelic.com/docs/apm/new-relic-apm/apdex/changing-your-apdex-settings">set your Apdex T via the New Relic UI</a>.
+  <b>DEPRECATED</b> Deprecated. For agent versions 3.5.0 or higher, [set your Apdex T via the New Relic UI](/docs/apm/new-relic-apm/apdex/changing-your-apdex-settings).
   </Collapser>
   
   <Collapser id="sync_startup" title="sync_startup">
@@ -282,7 +282,7 @@ When using the `capture_params` setting, the Ruby agent will not attempt to filt
       </tbody>
     </table>
 
-  When set to `true`, forces a synchronous connection to the New Relic <a href="/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector">collector</a> during application startup. For very short-lived processes, this helps ensure the New Relic agent has time to report.
+  When set to `true`, forces a synchronous connection to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) during application startup. For very short-lived processes, this helps ensure the New Relic agent has time to report.
   </Collapser>
   
   <Collapser id="send_data_on_exit" title="send_data_on_exit">
@@ -294,7 +294,7 @@ When using the `capture_params` setting, the Ruby agent will not attempt to filt
       </tbody>
     </table>
 
-  If `true`, enables the exit handler that sends data to the New Relic <a href="/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector">collector</a> before shutting down.
+  If `true`, enables the exit handler that sends data to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) before shutting down.
   </Collapser>
   
   <Collapser id="timeout" title="timeout">
@@ -354,7 +354,7 @@ When using the `capture_params` setting, the Ruby agent will not attempt to filt
       </tbody>
     </table>
 
-  If `true`, uses `Module.prepend` rather than `alias_method` for ActiveRecord instrumentation.
+  If `true`, uses `Module#prepend` rather than `alias_method` for ActiveRecord instrumentation.
   </Collapser>
   
   <Collapser id="capture_memcache_keys" title="capture_memcache_keys">
@@ -390,7 +390,7 @@ When using the `capture_params` setting, the Ruby agent will not attempt to filt
       </tbody>
     </table>
 
-  Specifies a marshaller for transmitting data to the <a href="/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector">collector</a>. Currently `json` is the only valid value for this setting.
+  Specifies a marshaller for transmitting data to the New Relic [collector](/docs/apm/new-relic-apm/getting-started/glossary#collector). Currently `json` is the only valid value for this setting.
   </Collapser>
   
   <Collapser id="backport_fast_active_record_connection_lookup" title="backport_fast_active_record_connection_lookup">
@@ -414,7 +414,7 @@ When using the `capture_params` setting, the Ruby agent will not attempt to filt
       </tbody>
     </table>
 
-  A dictionary of <a href="/docs/data-analysis/user-interface-functions/labels-categories-organize-your-apps-servers">label names</a> and values that will be applied to the data sent from this agent. May also be expressed as a semicolon-delimited `;` string of colon-separated `:` pairs. For example, `<var>Server</var>:<var>One</var>;<var>Data Center</var>:<var>Primary</var>`.
+  A dictionary of [label names](/docs/data-analysis/user-interface-functions/labels-categories-organize-your-apps-servers) and values that will be applied to the data sent from this agent. May also be expressed as a semicolon-delimited `;` string of colon-separated `:` pairs. For example, `<var>Server</var>:<var>One</var>;<var>Data Center</var>:<var>Primary</var>`.
   </Collapser>
   
   <Collapser id="ca_bundle_path" title="ca_bundle_path">
@@ -518,7 +518,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
       </tbody>
     </table>
 
-  If `true`, enables collection of <a href="https://docs.newrelic.com/docs/apm/traces/transaction-traces/transaction-traces">transaction traces</a>.
+  If `true`, enables collection of [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces).
   </Collapser>
   
   <Collapser id="transaction_tracer-transaction_threshold" title="transaction_tracer.transaction_threshold">
@@ -530,7 +530,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
       </tbody>
     </table>
 
-  Specify a threshold in seconds. Transactions with a duration longer than this threshold are eligible for transaction traces. Specify a float value or the string `<a href="https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/glossary#apdex_f">apdex_f</a>`.
+  Specify a threshold in seconds. Transactions with a duration longer than this threshold are eligible for transaction traces. Specify a float value or the string `apdex_f`.
   </Collapser>
   
   <Collapser id="transaction_tracer-record_sql" title="transaction_tracer.record_sql">
@@ -549,7 +549,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
   <ul>
     <li>If you do not want the agent to capture query information, set this to `none`.</li>
     <li>If you want the agent to capture all query information in its original form, set this to `raw`.</li>
-    <li>When you enable <a href="/docs/agents/manage-apm-agents/configuration/high-security-mode">high security mode</a>, this is automatically set to `obfuscated`.</li>
+    <li>When you enable [high security mode](/docs/agents/manage-apm-agents/configuration/high-security-mode), this is automatically set to `obfuscated`.</li>
   </ul>
   
   </Collapser>
@@ -575,7 +575,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Deprecated; use <a href="#transaction_tracer-attributes-enabled">`transaction_tracer.attributes.enabled`</a> instead.
+  <b>DEPRECATED</b> Deprecated; use [`transaction_tracer.attributes.enabled`](#transaction_tracer-attributes-enabled) instead.
   </Collapser>
   
   <Collapser id="transaction_tracer-explain_threshold" title="transaction_tracer.explain_threshold">
@@ -587,7 +587,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
       </tbody>
     </table>
 
-  Threshold (in seconds) above which the agent will collect explain plans. Relevant only when `<a href="#transaction_tracer.explain_enabled">explain_enabled</a>` is true.
+  Threshold (in seconds) above which the agent will collect explain plans. Relevant only when [`explain_enabled`](#transaction_tracer.explain_enabled) is true.
   </Collapser>
   
   <Collapser id="transaction_tracer-explain_enabled" title="transaction_tracer.explain_enabled">
@@ -599,7 +599,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
       </tbody>
     </table>
 
-  If `true`, enables the collection of explain plans in transaction traces. This setting will also apply to explain plans in slow SQL traces if <a href="#slow_sql-explain_enabled">`slow_sql.explain_enabled`</a> is not set separately.
+  If `true`, enables the collection of explain plans in transaction traces. This setting will also apply to explain plans in slow SQL traces if [`slow_sql.explain_enabled`](#slow_sql-explain_enabled) is not set separately.
   </Collapser>
   
   <Collapser id="transaction_tracer-stack_trace_threshold" title="transaction_tracer.stack_trace_threshold">
@@ -655,7 +655,7 @@ The agent collects and reports all uncaught exceptions by default. These configu
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Deprecated; use <a href="#error_collector-attributes-enabled">`error_collector.attributes.enabled`</a> instead.
+  <b>DEPRECATED</b> Deprecated; use [`error_collector.attributes.enabled`](#error_collector-attributes-enabled) instead.
   </Collapser>
   
   <Collapser id="error_collector-ignore_errors" title="error_collector.ignore_errors">
@@ -668,10 +668,6 @@ The agent collects and reports all uncaught exceptions by default. These configu
     </table>
 
   Specify a comma-delimited list of error classes that the agent should ignore.
-
-  <Callout variant="caution">
-  Server side configuration takes precedence for this setting over all environment configurations. This differs from all other configuration settings where environment variable take precedence over server side configuration.
-  </Callout>
   </Collapser>
   
   <Collapser id="error_collector-max_backtrace_frames" title="error_collector.max_backtrace_frames">
@@ -695,7 +691,7 @@ The agent collects and reports all uncaught exceptions by default. These configu
       </tbody>
     </table>
 
-  If `true`, the agent collects <a href="https://docs.newrelic.com/docs/insights/new-relic-insights/decorating-events/error-event-default-attributes-insights">TransactionError events</a>.
+  If `true`, the agent collects [TransactionError events](/docs/insights/new-relic-insights/decorating-events/error-event-default-attributes-insights).
   </Collapser>
   
   <Collapser id="error_collector-max_event_samples_stored" title="error_collector.max_event_samples_stored">
@@ -707,14 +703,14 @@ The agent collects and reports all uncaught exceptions by default. These configu
       </tbody>
     </table>
 
-  Defines the maximum number of <a href="https://docs.newrelic.com/docs/insights/new-relic-insights/decorating-events/error-event-default-attributes-insights">TransactionError events</a> sent to New Relic per harvest cycle.
+  Defines the maximum number of [TransactionError events](/docs/insights/new-relic-insights/decorating-events/error-event-default-attributes-insights) sent to Insights per harvest cycle.
   </Collapser>
   
 </CollapserGroup>
 
 ## Browser Monitoring
 
-The Browser monitorig [page load timing](/docs/browser/new-relic-browser/page-load-timing/page-load-timing-process) feature (sometimes referred to as real user monitoring or RUM) gives you insight into the performance real users are experiencing with your website. This is accomplished by measuring the time it takes for your users' browsers to download and render your web pages by injecting a small amount of JavaScript code into the header and footer of each page.
+The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-load-timing/page-load-timing-process) feature (sometimes referred to as real user monitoring or RUM) gives you insight into the performance real users are experiencing with your website. This is accomplished by measuring the time it takes for your users' browsers to download and render your web pages by injecting a small amount of JavaScript code into the header and footer of each page.
 
 <CollapserGroup>
   
@@ -727,7 +723,7 @@ The Browser monitorig [page load timing](/docs/browser/new-relic-browser/page-lo
       </tbody>
     </table>
 
-  If `true`, enables <a href="https://docs.newrelic.com/docs/browser/new-relic-browser/installation-configuration/adding-apps-new-relic-browser#select-apm-app">auto-injection</a> of the JavaScript header for page load timing (sometimes referred to as real user monitoring or RUM).
+  This is `true` by default, this enables [auto-injection](/docs/browser/new-relic-browser/installation-configuration/adding-apps-new-relic-browser#select-apm-app) of the JavaScript header for page load timing (sometimes referred to as real user monitoring or RUM).
   </Collapser>
   
   <Collapser id="browser_monitoring-capture_attributes" title="browser_monitoring.capture_attributes">
@@ -739,7 +735,7 @@ The Browser monitorig [page load timing](/docs/browser/new-relic-browser/page-lo
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Deprecated; use <a href="#browser_monitoring-attributes-enabled">`browser_monitoring.attributes.enabled`</a> instead.
+  <b>DEPRECATED</b> Deprecated; use [`browser_monitoring.attributes.enabled`](#browser_monitoring-attributes-enabled) instead.
   </Collapser>
   
 </CollapserGroup>
@@ -783,14 +779,14 @@ The Browser monitorig [page load timing](/docs/browser/new-relic-browser/page-lo
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Deprecated; use <a href="#transaction_events-attributes-enabled">`transaction_events.attributes.enabled`</a> instead.
+  <b>DEPRECATED</b> Deprecated; use [`transaction_events.attributes.enabled`](#transaction_events-attributes-enabled) instead.
   </Collapser>
   
 </CollapserGroup>
 
 ## Attributes
 
-[Attributes](/docs/features/agent-attributes) are key-value pairs containing information that determines the properties of an event or transaction. These key-value pairs can be viewed within transaction traces in APM, traced errors in APM, transaction events in dashboards, and page views in dashboards. You can customize exactly which attributes will be sent to each of these destinations.
+[Attributes](/docs/features/agent-attributes) are key-value pairs containing information that determines the properties of an event or transaction. These key-value pairs can be viewed within transaction traces in APM, traced errors in APM, transaction events in dashboards, and page views in dashboards. You can customize exactly which attributes will be sent to each of these destinations
 
 <CollapserGroup>
   
@@ -1063,7 +1059,7 @@ The Browser monitorig [page load timing](/docs/browser/new-relic-browser/page-lo
       </tbody>
     </table>
 
-  If `true`, enables an audit log which logs communications with the New Relic <a href="/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector">collector</a>.
+  If `true`, enables an audit log which logs communications with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector).
   </Collapser>
   
   <Collapser id="audit_log-path" title="audit_log.path">
@@ -1151,7 +1147,7 @@ The Browser monitorig [page load timing](/docs/browser/new-relic-browser/page-lo
       </tbody>
     </table>
 
-  If `true`, enables <a href="/docs/apm/transactions/cross-application-traces/cross-application-tracing">cross-application tracing</a>.
+  If `true`, enables [cross-application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing).
   </Collapser>
   
 </CollapserGroup>
@@ -1171,12 +1167,14 @@ The Browser monitorig [page load timing](/docs/browser/new-relic-browser/page-lo
       </tbody>
     </table>
 
-  If `false`, custom attributes will not be attached to events.
+  If `false`, custom attributes will not be sent on Insights events.
   </Collapser>
   
 </CollapserGroup>
 
-## Custom events
+## Custom Insights Events
+
+
 
 <CollapserGroup>
   
@@ -1189,7 +1187,7 @@ The Browser monitorig [page load timing](/docs/browser/new-relic-browser/page-lo
       </tbody>
     </table>
 
-  If `true`, the agent captures <a href="/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-new-relic-apm-agents">custom events</a>.
+  If `true`, the agent captures [New Relic Insights custom events](/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-new-relic-apm-agents).
   </Collapser>
   
   <Collapser id="custom_insights_events-max_samples_stored" title="custom_insights_events.max_samples_stored">
@@ -1201,7 +1199,7 @@ The Browser monitorig [page load timing](/docs/browser/new-relic-browser/page-lo
       </tbody>
     </table>
 
-  Specify a maximum number of custom events to buffer in memory at a time.
+  Specify a maximum number of custom Insights events to buffer in memory at a time.
   </Collapser>
   
 </CollapserGroup>
@@ -1221,7 +1219,7 @@ Use these settings to toggle instrumentation types during agent startup.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.rake](#instrumentation-rake). 
+  <b>DEPRECATED</b> Please see: [instrumentation.rake](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-rake). 
 
 If `true`, disables Rake instrumentation.
   </Collapser>
@@ -1247,9 +1245,9 @@ If `true`, disables Rake instrumentation.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.resque](#instrumentation-resque). 
+  <b>DEPRECATED</b> Please see: [instrumentation.resque](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-resque). 
 
-If `true`, disables <a href="/docs/agents/ruby-agent/background-jobs/resque-instrumentation">Resque instrumentation</a>.
+If `true`, disables [Resque instrumentation](/docs/agents/ruby-agent/background-jobs/resque-instrumentation).
   </Collapser>
   
   <Collapser id="disable_sidekiq" title="disable_sidekiq">
@@ -1261,7 +1259,7 @@ If `true`, disables <a href="/docs/agents/ruby-agent/background-jobs/resque-inst
       </tbody>
     </table>
 
-  If `true`, disables <a href="https://docs.newrelic.com/docs/agents/ruby-agent/background-jobs/sidekiq-instrumentation">Sidekiq instrumentation</a>.
+  If `true`, disables [Sidekiq instrumentation](/docs/agents/ruby-agent/background-jobs/sidekiq-instrumentation).
   </Collapser>
   
   <Collapser id="disable_dj" title="disable_dj">
@@ -1273,9 +1271,9 @@ If `true`, disables <a href="/docs/agents/ruby-agent/background-jobs/resque-inst
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.delayed_job](#instrumentation-delayed_job). 
+  <b>DEPRECATED</b> Please see: [instrumentation.delayed_job](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-delayed_job). 
 
-If `true`, disables <a href="https://docs.newrelic.com/docs/agents/ruby-agent/background-jobs/delayedjob">Delayed::Job instrumentation</a>.
+If `true`, disables [Delayed::Job instrumentation](/docs/agents/ruby-agent/background-jobs/delayedjob).
   </Collapser>
   
   <Collapser id="disable_sinatra" title="disable_sinatra">
@@ -1287,9 +1285,9 @@ If `true`, disables <a href="https://docs.newrelic.com/docs/agents/ruby-agent/ba
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.sinatra](#instrumentation-sinatra). 
+  <b>DEPRECATED</b> Please see: [instrumentation.sinatra](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-sinatra). 
 
-If `true` , disables <a href="/docs/agents/ruby-agent/frameworks/sinatra-support">Sinatra instrumentation</a>.
+If `true` , disables [Sinatra instrumentation](/docs/agents/ruby-agent/frameworks/sinatra-support).
   </Collapser>
   
   <Collapser id="disable_sinatra_auto_middleware" title="disable_sinatra_auto_middleware">
@@ -1301,7 +1299,7 @@ If `true` , disables <a href="/docs/agents/ruby-agent/frameworks/sinatra-support
       </tbody>
     </table>
 
-  If `true`, disables agent middleware for Sinatra. This middleware is responsible for advanced feature support such as <a href="/docs/apm/transactions/cross-application-traces/cross-application-tracing">cross application tracing</a>, <a href="/docs/browser/new-relic-browser/getting-started/new-relic-browser">page load timing</a>, and <a href="/docs/apm/applications-menu/events/view-apm-error-analytics">error collection</a>.
+  If `true`, disables agent middleware for Sinatra. This middleware is responsible for advanced feature support such as [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing), [page load timing](/docs/browser/new-relic-browser/getting-started/new-relic-browser), and [error collection](/docs/apm/applications-menu/events/view-apm-error-analytics).
   </Collapser>
   
   <Collapser id="disable_view_instrumentation" title="disable_view_instrumentation">
@@ -1385,7 +1383,7 @@ If `true` , disables <a href="/docs/agents/ruby-agent/frameworks/sinatra-support
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.memcached](#instrumentation-memcached). 
+  <b>DEPRECATED</b> Please see: [instrumentation.memcached](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcached). 
 
 If `true`, disables instrumentation for the memcached gem.
   </Collapser>
@@ -1399,7 +1397,7 @@ If `true`, disables instrumentation for the memcached gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.memcache-client](/docs/apm/transactions/cross-application-traces/cross-application-tracing). 
+  <b>DEPRECATED</b> Please see: [instrumentation.memcache-client](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache-client). 
 
 If `true`, disables instrumentation for the memcache-client gem.
   </Collapser>
@@ -1413,7 +1411,7 @@ If `true`, disables instrumentation for the memcache-client gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.memcache](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcached). 
+  <b>DEPRECATED</b> Please see: [instrumentation.memcache](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache). 
 
 If `true`, disables instrumentation for the dalli gem.
   </Collapser>
@@ -1427,7 +1425,7 @@ If `true`, disables instrumentation for the dalli gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.memcache](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcached). 
+  <b>DEPRECATED</b> Please see: [instrumentation.memcache](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache). 
 
 If `true`, disables instrumentation for the dalli gem's additional CAS client support.
   </Collapser>
@@ -1441,7 +1439,7 @@ If `true`, disables instrumentation for the dalli gem's additional CAS client su
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.memcache](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcached). 
+  <b>DEPRECATED</b> Please see: [instrumentation.memcache](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache). 
 
 If `true`, disables memcache instrumentation.
   </Collapser>
@@ -1467,7 +1465,7 @@ If `true`, disables memcache instrumentation.
       </tbody>
     </table>
 
-  If `true`, disables <a href="/docs/agents/ruby-agent/frameworks/sequel-instrumentation">Sequel instrumentation</a>.
+  If `true`, disables [Sequel instrumentation](/docs/agents/ruby-agent/frameworks/sequel-instrumentation).
   </Collapser>
   
   <Collapser id="disable_database_instrumentation" title="disable_database_instrumentation">
@@ -1479,7 +1477,7 @@ If `true`, disables memcache instrumentation.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Deprecated; use <a href="#disable_sequel_instrumentation">`disable_sequel_instrumentation`</a> instead.
+  <b>DEPRECATED</b> Deprecated; use [`disable_sequel_instrumentation`](#disable_sequel_instrumentation) instead.
   </Collapser>
   
   <Collapser id="disable_mongo" title="disable_mongo">
@@ -1491,9 +1489,9 @@ If `true`, disables memcache instrumentation.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.mongo](#instrumentation-mongo). 
+  <b>DEPRECATED</b> Please see: [instrumentation.mongo](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-mongo). 
 
-If `true`, the agent won't install <a href="/docs/agents/ruby-agent/frameworks/mongo-instrumentation">instrumentation for the Mongo gem</a>.
+If `true`, the agent won't install [instrumentation for the Mongo gem](/docs/agents/ruby-agent/frameworks/mongo-instrumentation).
   </Collapser>
   
   <Collapser id="disable_redis" title="disable_redis">
@@ -1505,9 +1503,9 @@ If `true`, the agent won't install <a href="/docs/agents/ruby-agent/frameworks/m
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.redis](#instrumentation-redis). 
+  <b>DEPRECATED</b> Please see: [instrumentation.redis](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-redis). 
 
-If `true`, the agent won't install <a href="/docs/agents/ruby-agent/frameworks/redis-instrumentation">instrumentation for Redis</a>.
+If `true`, the agent won't install [instrumentation for Redis](/docs/agents/ruby-agent/frameworks/redis-instrumentation).
   </Collapser>
   
   <Collapser id="disable_vm_sampler" title="disable_vm_sampler">
@@ -1519,7 +1517,7 @@ If `true`, the agent won't install <a href="/docs/agents/ruby-agent/frameworks/r
       </tbody>
     </table>
 
-  If `true`, the agent won't <a href="https://docs.newrelic.com/docs/agents/ruby-agent/features/ruby-vm-measurements">sample performance measurements from the Ruby VM</a>.
+  If `true`, the agent won't [sample performance measurements from the Ruby VM](/docs/agents/ruby-agent/features/ruby-vm-measurements).
   </Collapser>
   
   <Collapser id="disable_memory_sampler" title="disable_memory_sampler">
@@ -1579,7 +1577,7 @@ If `true`, the agent won't install <a href="/docs/agents/ruby-agent/frameworks/r
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.bunny](#instrumentation-bunny). 
+  <b>DEPRECATED</b> Please see: [instrumentation.bunny](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-bunny). 
 
 If `true`, disables instrumentation for the bunny gem.
   </Collapser>
@@ -1593,7 +1591,7 @@ If `true`, disables instrumentation for the bunny gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.curb](#instrumentation-curb). 
+  <b>DEPRECATED</b> Please see: [instrumentation.curb](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-curb). 
 
 If `true`, disables instrumentation for the curb gem.
   </Collapser>
@@ -1607,7 +1605,7 @@ If `true`, disables instrumentation for the curb gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.excon](#instrumentation-excon). 
+  <b>DEPRECATED</b> Please see: [instrumentation.excon](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-excon). 
 
 If `true`, disables instrumentation for the excon gem.
   </Collapser>
@@ -1621,7 +1619,7 @@ If `true`, disables instrumentation for the excon gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.httpclient](#instrumentation-httpclient). 
+  <b>DEPRECATED</b> Please see: [instrumentation.httpclient](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-httpclient). 
 
 If `true`, disables instrumentation for the httpclient gem.
   </Collapser>
@@ -1635,7 +1633,7 @@ If `true`, disables instrumentation for the httpclient gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.net_http](#instrumentation-net_http). 
+  <b>DEPRECATED</b> Please see: [instrumentation.net_http](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-net_http). 
 
 If `true`, disables instrumentation for Net::HTTP.
   </Collapser>
@@ -1649,7 +1647,7 @@ If `true`, disables instrumentation for Net::HTTP.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.rack](#instrumentation-rack). 
+  <b>DEPRECATED</b> Please see: [instrumentation.rack](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-rack). 
 
 If `true`, prevents the agent from hooking into the `to_app` method in Rack::Builder to find gems to instrument during application startup.
   </Collapser>
@@ -1663,7 +1661,7 @@ If `true`, prevents the agent from hooking into the `to_app` method in Rack::Bui
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.rack_urlmap](#instrumentation-rack_urlmap). 
+  <b>DEPRECATED</b> Please see: [instrumentation.rack_urlmap](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-rack_urlmap). 
 
 If `true`, prevents the agent from hooking into Rack::URLMap to install middleware tracing.
   </Collapser>
@@ -1677,7 +1675,7 @@ If `true`, prevents the agent from hooking into Rack::URLMap to install middlewa
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.puma_rack](#instrumentation-puma_rack). 
+  <b>DEPRECATED</b> Please see: [instrumentation.puma_rack](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-puma_rack). 
 
 If `true`, prevents the agent from hooking into the `to_app` method in Puma::Rack::Builder to find gems to instrument during application startup.
   </Collapser>
@@ -1691,7 +1689,7 @@ If `true`, prevents the agent from hooking into the `to_app` method in Puma::Rac
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.puma_rack_urlmap](#instrumentation-puma_rack_urlmap). 
+  <b>DEPRECATED</b> Please see: [instrumentation.puma_rack_urlmap](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-puma_rack_urlmap). 
 
 If `true`, prevents the agent from hooking into Puma::Rack::URLMap to install middleware tracing.
   </Collapser>
@@ -1705,7 +1703,7 @@ If `true`, prevents the agent from hooking into Puma::Rack::URLMap to install mi
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.typhoeus](#instrumentation-typhoeus). 
+  <b>DEPRECATED</b> Please see: [instrumentation.typhoeus](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-typhoeus). 
 
 If `true`, the agent won't install instrumentation for the typhoeus gem.
   </Collapser>
@@ -1719,7 +1717,7 @@ If `true`, the agent won't install instrumentation for the typhoeus gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.httprb](#instrumentation-httprb). 
+  <b>DEPRECATED</b> Please see: [instrumentation.httprb](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-httprb). 
 
 If `true`, the agent won't install instrumentation for the http.rb gem.
   </Collapser>
@@ -1745,7 +1743,7 @@ If `true`, the agent won't install instrumentation for the http.rb gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.grape](#instrumentation-grape). 
+  <b>DEPRECATED</b> Please see: [instrumentation.grape](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-grape). 
 
 If `true`, the agent won't install Grape instrumentation.
   </Collapser>
@@ -1767,7 +1765,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Distributed tracing lets you see the path that a request takes through your distributed system. Enabling distributed tracing changes the behavior of some New Relic features, so carefully consult the <a href="https://docs.newrelic.com/docs/transition-guide-distributed-tracing">transition guide</a> before you enable this feature.
+  Distributed tracing lets you see the path that a request takes through your distributed system. Enabling distributed tracing changes the behavior of some New Relic features, so carefully consult the [transition guide](/docs/transition-guide-distributed-tracing) before you enable this feature.
   </Collapser>
   
 </CollapserGroup>
@@ -2111,7 +2109,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Specify a custom host name for <a href="https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/add-rename-remove-hosts#display_name">display in the New Relic UI</a>.
+  Specify a custom host name for [display in the New Relic UI](/docs/apm/new-relic-apm/maintenance/add-rename-remove-hosts#display_name).
   </Collapser>
   
 </CollapserGroup>
@@ -2223,7 +2221,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  If `true`, the agent collects <a href="https://docs.newrelic.com/docs/apm/applications-menu/monitoring/viewing-slow-query-details">slow SQL queries</a>.
+  If `true`, the agent collects [slow SQL queries](/docs/apm/applications-menu/monitoring/viewing-slow-query-details).
   </Collapser>
   
   <Collapser id="slow_sql-explain_threshold" title="slow_sql.explain_threshold">
@@ -2235,7 +2233,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Specify a threshold in seconds. The agent collects <a href="https://docs.newrelic.com/docs/apm/applications-menu/monitoring/viewing-slow-query-details">slow SQL queries</a> and explain plans that exceed this threshold.
+  Specify a threshold in seconds. The agent collects [slow SQL queries](/docs/apm/applications-menu/monitoring/viewing-slow-query-details) and explain plans that exceed this threshold.
   </Collapser>
   
   <Collapser id="slow_sql-explain_enabled" title="slow_sql.explain_enabled">
@@ -2247,7 +2245,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  If `true`, the agent collects explain plans in slow SQL queries. If this setting is omitted, the <a href="#transaction_tracer-explain_enabled">`transaction_tracer.explain_enabled`</a> setting will be applied as the default setting for explain plans in slow SQL as well.
+  If `true`, the agent collects explain plans in slow SQL queries. If this setting is omitted, the [`transaction_tracer.explain_enabled`](#transaction_tracer-explain_enabled) setting will be applied as the default setting for explain plans in slow SQL as well.
   </Collapser>
   
   <Collapser id="slow_sql-record_sql" title="slow_sql.record_sql">
@@ -2335,7 +2333,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  If true, the agent strips messages from all exceptions except those in the <a href="#strip_exception_messages-allowlist">allowlist</a>. Enabled automatically in <a href="https://docs.newrelic.com/docs/accounts-partnerships/accounts/security/high-security">high security mode</a>.
+  If true, the agent strips messages from all exceptions except those in the [allowlist](#strip_exception_messages-allowlist). Enabled automatically in [high security mode](/docs/accounts-partnerships/accounts/security/high-security).
   </Collapser>
   
   <Collapser id="strip_exception_messages-allowed_classes" title="strip_exception_messages.allowed_classes">
@@ -2347,7 +2345,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Specify a list of exceptions you do not want the agent to strip when <a href="#strip_exception_messages-enabled">strip_exception_messages</a> is `true`. Separate exceptions with a comma. For example, `"ImportantException,PreserveMessageException"`.
+  Specify a list of exceptions you do not want the agent to strip when [strip_exception_messages](#strip_exception_messages-enabled) is `true`. Separate exceptions with a comma. For example, `"ImportantException,PreserveMessageException"`.
   </Collapser>
   
 </CollapserGroup>
@@ -2367,7 +2365,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  If `true`, enables use of the <a href="https://docs.newrelic.com/docs/apm/applications-menu/events/thread-profiler-tool">thread profiler</a>.
+  If `true`, enables use of the [thread profiler](/docs/apm/applications-menu/events/thread-profiler-tool).
   </Collapser>
   
 </CollapserGroup>

--- a/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -84,6 +84,8 @@ To update `newrelic.yml` file after a new release, use the template in the base 
   Updating the gem does not automatically update `config/newrelic.yml`.
 </Callout>
 
+<!--- BEGIN AUTO-GENERATED CONFIG DOCS -->
+
 ## General
 
 These settings are available for agent configuration. Some settings depend on your New Relic subscription level.
@@ -2453,6 +2455,8 @@ If `true`, the agent won't install Grape instrumentation.
   </Collapser>
   
 </CollapserGroup>
+
+<!--- END OF AUTO-GENERATED CONFIG DOCS -->
 
 ## For more help [#more_help]
 

--- a/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -668,6 +668,10 @@ The agent collects and reports all uncaught exceptions by default. These configu
     </table>
 
   Specify a comma-delimited list of error classes that the agent should ignore.
+  
+  <Callout variant="caution">
+  Server side configuration takes precedence for this setting over all environment configurations. This differs from all other configuration settings where environment variable take precedence over server side configuration.
+  </Callout>
   </Collapser>
   
   <Collapser id="error_collector-max_backtrace_frames" title="error_collector.max_backtrace_frames">

--- a/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -84,8 +84,6 @@ To update `newrelic.yml` file after a new release, use the template in the base 
   Updating the gem does not automatically update `config/newrelic.yml`.
 </Callout>
 
-<!--- BEGIN AUTO-GENERATED CONFIG DOCS -->
-
 ## General
 
 These settings are available for agent configuration. Some settings depend on your New Relic subscription level.
@@ -2378,8 +2376,6 @@ If `true`, the agent won't install Grape instrumentation.
 
 ## Utilization
 
-
-
 <CollapserGroup>
   
   <Collapser id="utilization-detect_aws" title="utilization.detect_aws">
@@ -2455,8 +2451,6 @@ If `true`, the agent won't install Grape instrumentation.
   </Collapser>
   
 </CollapserGroup>
-
-<!--- END OF AUTO-GENERATED CONFIG DOCS -->
 
 ## For more help [#more_help]
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context
This PR updates our autogenerated config documentation. This updates the wording on `browser_monitoring.auto_instrument` config option to clarify the default value, also we updated links to use markdown instead of html.
 I also added html comments to mark what sections are auto generated from the agent so it's easier to tell. (There used to be comments that showed the section was generated, but it seems like it went missing since the move to git for the docs site)

### Are you making a change to site code?
no