### PR TITLE
Trying to fix 404 from link on integrations auto-generated page.

### DIFF
--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -2353,5 +2353,11 @@
     "paths": [
       "/docs/serverless-function-monitoring/azure-functions-monitoring/get-started"
     ]
+  },
+  {
+    "url": "/docs/integrations/kubernetes-integration/logs",
+    "paths": [
+      "/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/"
+    ]
   }
 ]

--- a/src/data/taxonomy-redirects.json
+++ b/src/data/taxonomy-redirects.json
@@ -2353,11 +2353,5 @@
     "paths": [
       "/docs/serverless-function-monitoring/azure-functions-monitoring/get-started"
     ]
-  },
-  {
-    "url": "/docs/integrations/kubernetes-integration/logs",
-    "paths": [
-      "/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/"
-    ]
   }
 ]

--- a/src/nav/integrations.yml
+++ b/src/nav/integrations.yml
@@ -171,7 +171,6 @@ pages:
           - title: Kubernetes events integration
             path: /docs/integrations/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration
       - title: Kubernetes plugin for Logs
-        path: /docs/integrations/kubernetes-integration/logs
         pages:
           - title: Get Kubernetes log data
             path: /docs/integrations/kubernetes-integration/logs/get-kubernetes-log-data


### PR DESCRIPTION
Steps to reproduce:

1. Go to `https://docs.newrelic.com/docs/integrations/`
2. Scroll down and click on **Kubernetes plugin for Logs** and note the 404

Discussion:

The fix I chose for this, based on feedback from a colleague, was to simply remove the "path" line from `integrations.yml` for `Kubernetes plugin for Logs`. Now, if you go to  `https://docs.newrelic.com/docs/integrations/`, you should see the following if you scroll down the page, but `Kubernetes plugin for Logs` is no longer a link (just the child `Get Kubernetes log data`.

  Kubernetes plugin for Logs
    Get Kubernetes log data

