### PR TITLE
chore: copy over images for translated docs

### DIFF
--- a/.github/workflows/check-translations-and-deserialize.yml
+++ b/.github/workflows/check-translations-and-deserialize.yml
@@ -15,6 +15,7 @@ env:
   TRANSLATION_VENDOR_SECRET: ${{ secrets.TRANSLATION_VENDOR_SECRET }}
   BOT_NAME: nr-opensource-bot
   BOT_EMAIL: opensource+bot@newrelic.com
+  CI: true
 
 jobs:
   fetch-content:

--- a/scripts/actions/__tests__/fetch-and-deserialize.test.js
+++ b/scripts/actions/__tests__/fetch-and-deserialize.test.js
@@ -1,0 +1,48 @@
+import fetchAndDeserialize from '../fetch-and-deserialize';
+const fse = require('fs-extra');
+const vfile = require('vfile');
+const { writeSync } = require('to-vfile');
+
+jest.mock('fs-extra');
+jest.mock('to-vfile');
+
+describe('writeFilesSync', () => {
+  const testFiles = [
+    vfile({
+      contents: 'fake_content',
+      path: 'src/i18n/content/jp/docs/fake_path_1/fake_file_1.mdx',
+      extname: '.mdx',
+    }),
+    vfile({
+      contents: 'fake_content',
+      path: 'src/i18n/content/jp/docs/fake_path_1/fake_file_2.mdx',
+      extname: '.mdx',
+    }),
+    vfile({
+      contents: 'fake_content',
+      path: 'src/i18n/content/jp/docs/fake_path_2/fake_file_3.mdx',
+      extname: '.mdx',
+    }),
+  ];
+
+  fse.existsSync.mockClear();
+  fse.existsSync.mockReturnValue(true);
+  fetchAndDeserialize.writeFilesSync(testFiles);
+
+  it('should call writeSync for each file', () => {
+    expect(writeSync).toHaveBeenCalledTimes(testFiles.length);
+  });
+
+  it('should call copySync for each unique directory path', () => {
+    expect(fse.copySync).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not copy directories that dont have images', () => {
+    fse.existsSync.mockClear();
+    fse.existsSync.mockReturnValue(false);
+    fse.copySync.mockClear();
+    fetchAndDeserialize.writeFilesSync(testFiles);
+
+    expect(fse.copySync).toHaveBeenCalledTimes(0);
+  });
+});

--- a/scripts/actions/check-job-progress.js
+++ b/scripts/actions/check-job-progress.js
@@ -1,7 +1,7 @@
 const loadFromDB = require('./utils/load-from-db');
 
 const { getAccessToken, vendorRequest } = require('./utils/vendor-request');
-const fetchAndDeserialize = require('./fetch-and-deserialize');
+const { fetchAndDeserialize } = require('./fetch-and-deserialize');
 
 const PROJECT_ID = process.env.TRANSLATION_VENDOR_PROJECT;
 

--- a/scripts/actions/fetch-and-deserialize.js
+++ b/scripts/actions/fetch-and-deserialize.js
@@ -19,10 +19,10 @@ const projectId = process.env.TRANSLATION_VENDOR_PROJECT;
  * Method which writes translated content to the 'src/content/i18n' path, and copies images for translated files.
  * @param {vfile.VFile[]} vfiles
  */
-const writeFilesSync = vfiles => {
+const writeFilesSync = (vfiles) => {
   const copiedDirectories = {};
 
-  vfiles.forEach(file => {
+  vfiles.forEach((file) => {
     writeSync(file, 'utf-8');
 
     const imageDirectory = `${path.dirname(
@@ -69,7 +69,7 @@ const fetchTranslatedFilesZip = async (fileUris, locale, accessToken) => {
   );
 };
 
-const fetchAndDeserialize = accessToken => async ({ locale, fileUris }) => {
+const fetchAndDeserialize = (accessToken) => async ({ locale, fileUris }) => {
   const response = await fetchTranslatedFilesZip(fileUris, locale, accessToken);
 
   const buffer = await response.buffer();
@@ -77,7 +77,7 @@ const fetchAndDeserialize = accessToken => async ({ locale, fileUris }) => {
   const zip = new AdmZip(buffer);
   const zipEntries = zip.getEntries();
 
-  const translatedHtml = zipEntries.map(entry => {
+  const translatedHtml = zipEntries.map((entry) => {
     const filepath = entry.entryName.replace(`${locale}/src/content/docs`, '');
     const slug = filepath.replace(`.mdx`, '');
     return {

--- a/scripts/actions/fetch-and-deserialize.js
+++ b/scripts/actions/fetch-and-deserialize.js
@@ -16,7 +16,7 @@ const localesMap = {
 const projectId = process.env.TRANSLATION_VENDOR_PROJECT;
 
 /**
- * Brief description of the function here.
+ * Method which writes translated content to the 'src/content/i18n' path, and copies images for translated files.
  * @param {vfile.VFile[]} vfiles
  */
 const writeFilesSync = vfiles => {
@@ -25,10 +25,6 @@ const writeFilesSync = vfiles => {
   vfiles.forEach(file => {
     writeSync(file, 'utf-8');
 
-    // vfile.path will be like -> 'src/i18n/content/jp/docs/...'
-    // english path is: 'src/content/docs/...'
-
-    // get '/docs/...' from the string
     const imageDirectory = `${path.dirname(
       file.path.substring(file.path.indexOf('/docs/'))
     )}/images`;
@@ -116,4 +112,4 @@ const fetchAndDeserialize = accessToken => async ({ locale, fileUris }) => {
 
 fetchAndDeserialize();
 
-module.exports = fetchAndDeserialize;
+module.exports = { writeFilesSync, fetchAndDeserialize };

--- a/scripts/actions/fetch-and-deserialize.js
+++ b/scripts/actions/fetch-and-deserialize.js
@@ -110,6 +110,8 @@ const fetchAndDeserialize = (accessToken) => async ({ locale, fileUris }) => {
   writeFilesSync(files);
 };
 
-fetchAndDeserialize();
+if (process.env.CI) {
+  fetchAndDeserialize();
+}
 
 module.exports = { writeFilesSync, fetchAndDeserialize };


### PR DESCRIPTION
* added logic to copy over images for translated docs. also added in
paths for skipping over already copied images, & ignoring directories
with no images.

Resolves: #2288 