### PR TITLE
Add caution about removing users from the Heroku add-on

### DIFF
--- a/src/content/docs/accounts/install-new-relic/partner-based-installation/heroku-install-new-relic-add.mdx
+++ b/src/content/docs/accounts/install-new-relic/partner-based-installation/heroku-install-new-relic-add.mdx
@@ -179,3 +179,8 @@ In accordance with the terms of New Relic's partnership with Heroku, customers w
 The Heroku add-on automatically sends deployment notifications to New Relic for **one application** per account. If you add multiple applications to your add-on account, you must use the New Relic REST API to manually send deployment notifications for your additional applications.
 
 You cannot use a post-deploy hook, because the New Relic REST API call requires a header, and Heroku's post-deploy hook does not allow headers. However, you can write a script that generates this API call whenever you deploy on Heroku. For instructions on recording deployments via the REST API, see [Recording deployments](/docs/apm/new-relic-apm/maintenance/recording-deployments#api).
+
+
+## Caution about removing a user from the New Relic add-on
+
+When a user is added to the Heroku add-on, it creates a user record at New Relic for the user. However, if you remove the user from the Heroku add-on, the user record is not automatically removed at New Relic. Additional action is necessary to complete the process. It is recommended to manually remove the New Relic user record after removing the user from the Heroku add-on. This can be done by going to the user management page at the New Relic website.

--- a/src/content/docs/accounts/install-new-relic/partner-based-installation/heroku-install-new-relic-add.mdx
+++ b/src/content/docs/accounts/install-new-relic/partner-based-installation/heroku-install-new-relic-add.mdx
@@ -180,7 +180,7 @@ The Heroku add-on automatically sends deployment notifications to New Relic for 
 
 You cannot use a post-deploy hook, because the New Relic REST API call requires a header, and Heroku's post-deploy hook does not allow headers. However, you can write a script that generates this API call whenever you deploy on Heroku. For instructions on recording deployments via the REST API, see [Recording deployments](/docs/apm/new-relic-apm/maintenance/recording-deployments#api).
 
+<Callout variant="important">
+When you add a user to the Heroku add-on, this creates a user record for the user at New Relic. However, if you remove the user from the Heroku add-on, the user record is not automatically removed from New Relic. Instead, you must also manually remove the New Relic user record after removing the user from the Heroku add-on. You can do this by going to the **User Management** page.
+</Callout>
 
-## Caution about removing a user from the New Relic add-on
-
-When a user is added to the Heroku add-on, it creates a user record at New Relic for the user. However, if you remove the user from the Heroku add-on, the user record is not automatically removed at New Relic. Additional action is necessary to complete the process. It is recommended to manually remove the New Relic user record after removing the user from the Heroku add-on. This can be done by going to the user management page at the New Relic website.


### PR DESCRIPTION
### Give us some context

Adding users to the Heroku add-on causes New Relic users to automatically be created. Removing users from the Heroku app does not automatically remove the New Relic users. This can cause undesirable behavior.

Update the documentation to advise Heroku admins to manually remove the New Relic user after removing the user from the Heroku add-on.

### Are you making a change to site code?

No