### PR TITLE
Add sentence case policy for diagrams

### DIFF
--- a/src/content/docs/style-guide/quick-reference/capitalization.mdx
+++ b/src/content/docs/style-guide/quick-reference/capitalization.mdx
@@ -7,7 +7,7 @@ redirects:
   - /docs/new-relic-only/basic-style-guide/writing-guidelines/capitalization
 ---
 
-In general, we only capitalize things when we need to. Excess capitalization is distracting to our readers and restricts accessibility to our documents. Read on for some guidelines on how to decide what to capitalize in a document's title, headings, products, features, and other elements of the page.
+In general, we only capitalize things when we need to. Over use of capitalization is distracting and limits accessibility for our readers with vision impairment. Read on for some guidelines on how to decide what to capitalize in a document's title, headings, products, features, and other elements of the page.
 
 ## Use sentence case in headings [#heading_caps]
 
@@ -23,7 +23,7 @@ Use sentence case for headings. This includes category headings and document tit
 * If the heading includes a colon, follow the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/punctuation/colons#in-titles-and-headings) for titles and headings, and capitalize the first word that appears after the colon; for example: [APM Error profiles: Troubleshoot trends](/docs/apm/applications-menu/error-analytics/apm-error-profiles-troubleshoot-trends).
 
 <Callout variant="important">
-  Use sentence case for graphical illustrations such as diagrams and figures. Explore our [Screenshots and images](https://docs.newrelic.com/docs/style-guide/writing-guidelines/screenshots-images/#graphics) document for more information on our image guidelines.
+  Use sentence case for graphical illustrations such as diagrams and figures. Explore our [Screenshots and images](/docs/style-guide/writing-guidelines/screenshots-images/#graphics) document for more information on our image guidelines.
 </Callout>
 
 ## Products and features [#features]

--- a/src/content/docs/style-guide/quick-reference/capitalization.mdx
+++ b/src/content/docs/style-guide/quick-reference/capitalization.mdx
@@ -7,7 +7,7 @@ redirects:
   - /docs/new-relic-only/basic-style-guide/writing-guidelines/capitalization
 ---
 
-In general, we only capitalize things when we need to. Read on for some guidelines on how to decide what to capitalize in a document's title, headings, products, features, and other elements of the page.
+In general, we only capitalize things when we need to. Excess capitalization is distracting to our readers and restricts accessibility to our documents. Read on for some guidelines on how to decide what to capitalize in a document's title, headings, products, features, and other elements of the page.
 
 ## Use sentence case in headings [#heading_caps]
 
@@ -21,6 +21,10 @@ Use sentence case for headings. This includes category headings and document tit
 
 * If the heading is a code term, such as a variable or function, then capitalize it exactly as it's used in the code; for example: [`noticeError`](/docs/browser/new-relic-browser/browser-agent-spa-api/notice-error).
 * If the heading includes a colon, follow the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/punctuation/colons#in-titles-and-headings) for titles and headings, and capitalize the first word that appears after the colon; for example: [APM Error profiles: Troubleshoot trends](/docs/apm/applications-menu/error-analytics/apm-error-profiles-troubleshoot-trends).
+
+<Callout variant="important">
+  Use sentence case for graphical illustrations such as diagrams and figures. Explore our [Screenshots and images](https://docs.newrelic.com/docs/style-guide/writing-guidelines/screenshots-images/#graphics) document for more information on our image guidelines.
+</Callout>
 
 ## Products and features [#features]
 

--- a/src/content/docs/style-guide/writing-guidelines/screenshots-images.mdx
+++ b/src/content/docs/style-guide/writing-guidelines/screenshots-images.mdx
@@ -113,6 +113,16 @@ Review the [Tech Docs team's five questions](/docs/style-guide/writing-guideline
             Make sure your caption summarizes what the overall flow chart or diagram intends to communicate (see our caption tips below).
           </td>
         </tr>
+
+        <tr>
+          <td>
+            Use sentence case.
+          </td>
+
+          <td>
+            Make sure all labels are written in sentence case. Only capitalize the first letter of a first word, proper noun, acronym, or abbreviation.
+          </td>
+        </tr>
       </tbody>
     </table>
   </Collapser>


### PR DESCRIPTION
Added our sentence case policy for diagrams in both the "Capitalization" and "Screenshots and images" docs.