### PR TITLE
Java agent Release 7.0.1

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-700.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-700.mdx
@@ -38,4 +38,4 @@ the first error would be reported when in fact it's the last error that is repor
 
 * OkHttp
 
-This release contains a bugs that breaks OkHttp versions 3.X and below. All affected users should upgrade to 7.0.1.
+This release contains a bug that breaks OkHttp versions 3.X and below. All affected users should upgrade to 7.0.1.

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-700.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-700.mdx
@@ -33,3 +33,9 @@ the first error would be reported when in fact it's the last error that is repor
 * New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and
   performance benefits. Additionally, older releases will no longer be supported when they reach
   [end-of-life](/docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software/).
+
+### Known Issues
+
+* OkHttp
+
+This release contains a bugs that breaks OkHttp versions 3.X and below. All affected users should upgrade to 7.0.1.

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-701.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-701.mdx
@@ -1,0 +1,9 @@
+---
+subject: Java agent
+releaseDate: '2021-06-15'
+version: 7.0.1
+---
+
+### Fixes
+
+* Fixes an issue where the agent would break OkHttp versions 3.X and lower. ([#324](https://github.com/newrelic/newrelic-java-agent/issues/324))


### PR DESCRIPTION
### Give us some context

This commit adds the release notes for Java agent release 7.0.1 as well as a known issue on version 7.0.0.

### Are you making a change to site code?

No.