### PR TITLE
Update fedramp browser copy/paste instructions

### DIFF
--- a/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
+++ b/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
@@ -406,11 +406,12 @@ To edit environment variables, use these values:
 
 ### Browser agent [#browser-endpoints]
 
-To configure the browser agent to use a FedRAMP-compliant endpoint, you must use the [copy-paste method](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/#copy-paste-app) method (other browser agent install methods are not supported) and edit the browser code’s script element tag so that the domain is `gov-bam.nr-data.net` for both `beacon` and `error_beacon`, like this:
+To configure the browser agent to use a FedRAMP-compliant endpoint, you must use the [copy-paste method](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/#copy-paste-app) method (other browser agent install methods are not supported) and edit the browser code’s script element tag so that the domain is `gov-bam.nr-data.net` for both `beacon` and `errorBeacon`, like this:
 
 ```
 window.NREUM||(NREUM={});NREUM.info={"beacon":"gov-bam.nr-data.net","errorBeacon":"gov-bam.nr-data.net"...
 ```
+Note: You only need to modify the `beacon` and `errorBeacon` properties in the `NREUM.info` object.  These values will override the default values found in the NR loader script.
 
 ## Data-ingest APIs [#data-ingest-apis]
 


### PR DESCRIPTION
Add a note explaining that only the NREUM.info block needs update
Tweak error_beacon to errorBeacon to match property name

Provides a small note regarding which beacon props need updated for fedramp support.  Support has confirmed that the values in NREUM.info block override the default values in the nr loader script.