### PR TITLE
Updated infrastructure-agent Amazon Linux 2 repository location

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-aws-elastic-beanstalk.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-aws-elastic-beanstalk.mdx
@@ -74,7 +74,7 @@ To install the infrastructure agent on instances launched with AWS Elastic Beans
        commands:
        # Create the agent’s yum repository
          "01-agent-repository":
-           command: sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/7/x86_64/newrelic-infra.repo
+           command: sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2/x86_64/newrelic-infra.repo
        #
        # Update your yum cache
          "02-update-yum-cache":

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -308,13 +308,13 @@ To install the infrastructure monitoring agent in Linux, follow these instructio
        **Amazon Linux 2 (x86)**
 
        ```
-       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/7/x86_64/newrelic-infra.repo
+       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2/x86_64/newrelic-infra.repo
        ```
 
        **Amazon Linux 2 (arm64)**
 
        ```
-       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/7/aarch64/newrelic-infra.repo
+       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2/aarch64/newrelic-infra.repo
        ```
      </Collapser>
 

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/monitor-services-running-amazon-ecs.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/monitor-services-running-amazon-ecs.mdx
@@ -116,7 +116,7 @@ Here are instructions for changing EC2 launch configuration (taken from [Amazon 
 
      <Collapser
        id="os-2"
-       title="CentOS 7, RHEL 7, Amazon Linux 2"
+       title="CentOS 7, RHEL 7"
      >
        Replace the highlighted fields with relevant values:
 
@@ -133,6 +133,64 @@ Here are instructions for changing EC2 launch configuration (taken from [Amazon 
        yum_repos:
            newrelic-infra:
                baseurl: https://download.newrelic.com/infrastructure_agent/linux/yum/el/7/x86_64
+               gpgkey: https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
+               gpgcheck: 1
+               repo_gpgcheck: 1
+               enabled: true
+               name: New Relic Infrastructure
+       write_files:
+       -   content: |
+               ---
+               # New Relic config file
+               license_key: <a href="/docs/accounts/install-new-relic/account-setup/license-key"><var>YOUR_LICENSE_KEY</var></a>
+           path: /etc/newrelic-infra.yml
+       packages:
+         - newrelic-infra
+         - nri-*
+       runcmd:
+         - [ yum, install, newrelic-infra, -y ]
+         - [ systemctl, daemon-reload ]
+         - [ systemctl, enable, newrelic-infra.service ]
+         - [ systemctl, start, --no-block, newrelic-infra.service ]
+
+       --MIMEBOUNDARY
+       Content-Transfer-Encoding: 7bit
+       Content-Type: text/x-shellscript
+       Mime-Version: 1.0
+
+       #!/bin/bash
+
+       # ECS config
+       {
+         echo "ECS_CLUSTER=<var>YOUR_ECS_CLUSTER_NAME</var>"
+       } >> /etc/ecs/ecs.config
+
+       start ecs
+
+       echo "Done"
+       --MIMEBOUNDARY--
+       ```
+     </Collapser>
+
+     <Collapser
+       id="os-2"
+       title="Amazon Linux 2"
+     >
+       Replace the highlighted fields with relevant values:
+
+       ```
+       Content-Type: multipart/mixed; boundary="MIMEBOUNDARY"
+       MIME-Version: 1.0
+
+       --MIMEBOUNDARY
+       Content-Disposition: attachment; filename="init.cfg"
+       Content-Transfer-Encoding: 7bit
+       Content-Type: text/cloud-config
+       Mime-Version: 1.0
+
+       yum_repos:
+           newrelic-infra:
+               baseurl: https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2/x86_64
                gpgkey: https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
                gpgcheck: 1
                repo_gpgcheck: 1

--- a/src/i18n/content/jp/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/i18n/content/jp/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -263,7 +263,7 @@ InfrastructureモニタリングエージェントをLinuxでインストール�
        **Amazon Linux 2**
 
        ```
-       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/7/x86_64/newrelic-infra.repo
+       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2/x86_64/newrelic-infra.repo
        ```
      </Collapser>
 


### PR DESCRIPTION
As part of the epic to install fluent-bit package as an infrastructure-agent dependency, the Amazon Linux 2 repository location is being changed.