### PR TITLE
Add download link to Java agent 7.0.1 release notes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-701.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-701.mdx
@@ -2,6 +2,7 @@
 subject: Java agent
 releaseDate: '2021-06-15'
 version: 7.0.1
+downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/7.0.1/'
 ---
 
 ### Fixes


### PR DESCRIPTION
### Give us some context
Release notes  page for Java agent 7.0.1 was missing the download link.

### Are you making a change to site code?
No
