### PR TITLE
Updating postgresql-monitoring-integration

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/postgresql-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/postgresql-monitoring-integration.mdx
@@ -342,6 +342,16 @@ These attributes are attached to the `PostgresqlDatabaseSample` event type:
         Number of backends currently connected to this database.
       </td>
     </tr>
+    
+    <tr>
+      <td>
+        `db.maxconnections`
+      </td>
+
+      <td>
+        The maximum number of concurrent connections to the database server.
+      </td>
+    </tr>
 
     <tr>
       <td>


### PR DESCRIPTION
Adding `db.maxconnections` metric.
This metric has been added and will be released in the next version of the integration, as soon as the this doc update is published

