### PR TITLE
Removed "beta" from heading in EKS Fargate doc

### DIFF
--- a/src/content/docs/integrations/kubernetes-integration/installation/install-fargate-integration.mdx
+++ b/src/content/docs/integrations/kubernetes-integration/installation/install-fargate-integration.mdx
@@ -1,7 +1,10 @@
 ---
-title: EKS Fargate (beta)
+title: EKS Fargate
 watermark: BETA
 ---
+<Callout variant="tip">
+This is currently a beta feature.
+</Callout>
 
 New Relic supports monitoring Kubernetes workloads on EKS Fargate by automatically injecting a sidecar containing the infrastructure agent and the `nri-kubernetes` integration in each pod that needs to be monitored.
 


### PR DESCRIPTION
### Give us some context

We received feedback that the "(beta)" designation in the title made it look like the doc was in beta-not the feature. 

To fix this, I removed that from the heading and inserted a more explicit callout.
