### PR TITLE
These collapser IDs were all the same

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
@@ -1281,7 +1281,7 @@ These API functions include links to the API Explorer, where you can view inform
   </Collapser>
 
   <Collapser
-    id="incidents"
+    id="list-incidents"
     title="List Incidents"
   >
     To view [incidents](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#alert-incident) for any [entity](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#alert-entity) monitored for your account, include these values in the API call:
@@ -1300,7 +1300,7 @@ These API functions include links to the API Explorer, where you can view inform
   </Collapser>
 
   <Collapser
-    id="incidents"
+    id="show-incidents"
     title="Show Incident"
   >
     To show a single [incident](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#alert-incident) associated with your account, include these values in the API call:
@@ -1317,7 +1317,7 @@ These API functions include links to the API Explorer, where you can view inform
   </Collapser>
 
   <Collapser
-    id="incidents"
+    id="acknowledge-incidents"
     title="Acknowledge Incident"
   >
     To acknowledge an [incident](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#alert-incident) associated with your account, include these values in the API call:
@@ -1335,7 +1335,7 @@ These API functions include links to the API Explorer, where you can view inform
   </Collapser>
 
   <Collapser
-    id="incidents"
+    id="close-incidents"
     title="Close Incident"
   >
     To close an [incident](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#alert-incident) associated with your account, include these values in the API call:


### PR DESCRIPTION
That means it wasn't possible to link to any one of them directly.

(courtesy of @HenryTech)