### PR TITLE
Update create-nrql-alert-conditions.mdx

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -504,10 +504,6 @@ Here are some tips for creating and using a NRQL condition:
 
       <td>
         You can use loss of signal detection to alert on when your data (a telemetry signal) should be considered lost. A signal loss can indicate that a service or entity is no longer online or that a periodic job failed to run. You can also use this to make sure that violations for sporadic data, such as error counts, are closed when no signal is coming in.
-
-        <Callout variant="tip">
-          To learn more about signal loss and how to request access to it, see [this announcement](https://discuss.newrelic.com/t/announcing-new-relic-one-streaming-alerts-for-nrql-conditions/115361).
-        </Callout>
       </td>
     </tr>
 


### PR DESCRIPTION
Loss of signal is now a standard part of the alerting platform and doesn't need to be requested, so removing the call-out.