### PR TITLE
AWSHealth now publishes NR1 events

### DIFF
--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration.mdx
@@ -12,7 +12,7 @@ redirects:
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your AWS Health data to New Relic. This document explains how to activate this integration and describes the data that can be reported.
 
-## Features
+## Features [#features]
 
 This integration collects information from [AWS Health](https://docs.aws.amazon.com/health/latest/ug/what-is-aws-health.html) about events that can affect the AWS resources and services globally or in a specific account. This data can help you anticipate potential application outages.
 
@@ -22,13 +22,13 @@ AWS Health reports three types of events:
 * **Scheduled changes**: Informs you in advance of scheduled activities that might have an impact on AWS services and resources.
 * **Notifications**: Provides additional information.
 
-## Requirements
+## Requirements [#requirements]
 
 This integration is available only for AWS customers who have a Business or Enterprise support plan, because this is a requirement for using the AWS Health API.
 
-## Activate integration [#requirements]
+## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](https://docs.newrelic.com/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 
@@ -42,16 +42,16 @@ You can change the polling frequency and filter data using [configuration option
 
 To use this integration's data:
 
-1. Go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure > AWS**.
+1. Go to [**one.newrelic.com**](https://one.newrelic.com) **> Infrastructure > AWS**.
 2. Select any of the available AWS Health integration links.
 3. To view a complete list of open issues, select the [**Inventory** page](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-inventory-page-search-your-entire-infrastructure).
 4. To view a timeline when an AWS Health inventory event is created, modified, or deleted, use the [**Events** page](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-events-page-live-feed-every-config-change).
 
-## Events monitoring and alerts
+## Events monitoring and alerts [#event-monitoring]
 
-AWS Health events are ingested in New Relic One as **AwsHealthNotification** events. You can query, create widgets and define NRQL alert policies based on these events.
+AWS Health events are ingested in New Relic One as **AwsHealthNotification** events. You can query, create widgets, and define NRQL alert policies based on these events.
 
-The following table shows main attributes available for **AwsHealthNotification** events:
+The following table shows the main attributes available for **AwsHealthNotification** events:
 <table>
   <thead>
     <tr>
@@ -132,7 +132,7 @@ The following table shows main attributes available for **AwsHealthNotification*
       </td>
       
       <td>
-        A list of unique identifiers for event types. For example, "AWS_EC2_SYSTEM_MAINTENANCE_EVENT","AWS_RDS_MAINTENANCE_SCHEDULED".
+        A list of unique identifiers for event types. For example,`AWS_EC2_SYSTEM_MAINTENANCE_EVENT` or `AWS_RDS_MAINTENANCE_SCHEDULED`.
       </td>
     </tr>
     
@@ -142,7 +142,7 @@ The following table shows main attributes available for **AwsHealthNotification*
       </td>
       
       <td>
-        The AWS services associated with the event. For example, EC2 , RDS.
+        The AWS services associated with the event. For example, EC2, RDS.
       </td>
     </tr>
     
@@ -152,7 +152,7 @@ The following table shows main attributes available for **AwsHealthNotification*
       </td>
       
       <td>
-        The AWS health event status: open, closed, upcoming.
+        The AWS health event status: `Open`, `Closed`, `Upcoming`.
       </td>
     </tr>
     
@@ -169,7 +169,8 @@ The following table shows main attributes available for **AwsHealthNotification*
 </table>
 
 NRQL alert conditions can be defined to receive notifications when health events are reported by AWS.
-In example, the following query would monitor any open issues on EC2 by resource:
+
+For example, the following query monitors any open issues on EC2 by resource:
 ```
 SELECT uniqueCount(affectedEntityArn) FROM AwsHealthNotification where statusCode = 'open' and eventTypeCategory = 'Issue' and service = 'EC2'
 ```

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration.mdx
@@ -165,7 +165,7 @@ The following table shows the main attributes available for **AwsHealthNotificat
         Date and time the event began.
       </td>
     </tr>
-</tbody>
+  </tbody>
 </table>
 
 NRQL alert conditions can be defined to receive notifications when health events are reported by AWS.
@@ -241,7 +241,6 @@ SELECT uniqueCount(affectedEntityArn) FROM AwsHealthNotification where statusCod
       <td>
         `awsRegion`
       </td>
-
       <td>
         The Personal Health Dashboard region.
       </td>

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration.mdx
@@ -51,7 +51,7 @@ To use this integration's data:
 
 AWS Health events are ingested in New Relic One as **AwsHealthNotification** events. You can query, create widgets and define NRQL alert policies based on these events.
 
-The following table shows main attributes avaialble for **AwsHealthNotification** events:
+The following table shows main attributes available for **AwsHealthNotification** events:
 <table>
   <thead>
     <tr>
@@ -70,78 +70,97 @@ The following table shows main attributes avaialble for **AwsHealthNotification*
       <td>
         `affectedEntityArn`
       </td>
+      
       <td>
         The AWS resource ARN.
       </td>
     </tr>
+    
     <tr>
       <td>
         `arn`
       </td>
+      
       <td>
         The ARN of the AWS Health event itself.
       </td>
     </tr>
+    
     <tr>
       <td>
         `affectedRegion`
       </td>
+      
       <td>
         The AWS affected region.
       </td>
     </tr>
+    
     <tr>
       <td>
         `affectedResources`
       </td>
+      
       <td>
         Number of affected resources. Auto-generated metric that can be used to define New Relic alert conditions. 
       </td>
     </tr>
+    
     <tr>
       <td>
         `description`
       </td>
+      
       <td>
         Detailed description of the event.
       </td>
     </tr>
+    
     <tr>
       <td>
         `eventTypeCategory`
       </td>
+      
       <td>
         AWS Health category: Issue, ScheduledChange, AccountNotification, Investigation.
       </td>
     </tr>
+    
     <tr>
       <td>
         `eventTypeCode`
       </td>
+      
       <td>
         A list of unique identifiers for event types. For example, "AWS_EC2_SYSTEM_MAINTENANCE_EVENT","AWS_RDS_MAINTENANCE_SCHEDULED".
       </td>
     </tr>
+    
     <tr>
       <td>
         `service`
       </td>
+      
       <td>
         The AWS services associated with the event. For example, EC2 , RDS.
       </td>
     </tr>
+    
     <tr>
       <td>
         `statusCode`
       </td>
+      
       <td>
         The AWS health event status: open, closed, upcoming.
       </td>
     </tr>
+    
     <tr>
       <td>
         `startTime`
       </td>
+      
       <td>
         Date and time the event began.
       </td>

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration.mdx
@@ -40,12 +40,120 @@ You can change the polling frequency and filter data using [configuration option
 
 ## Explore integration data [#find-use]
 
-This integration does not fetch metrics, only [inventory information](#metrics). To use this integration's data:
+To use this integration's data:
 
 1. Go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure > AWS**.
 2. Select any of the available AWS Health integration links.
 3. To view a complete list of open issues, select the [**Inventory** page](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-inventory-page-search-your-entire-infrastructure).
 4. To view a timeline when an AWS Health inventory event is created, modified, or deleted, use the [**Events** page](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-events-page-live-feed-every-config-change).
+
+## Events monitoring and alerts
+
+AWS Health events are ingested in New Relic One as **AwsHealthNotification** events. You can query, create widgets and define NRQL alert policies based on these events.
+
+The following table shows main attributes avaialble for **AwsHealthNotification** events:
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "300px" }}>
+        Event Attribute
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `affectedEntityArn`
+      </td>
+      <td>
+        The AWS resource ARN.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `arn`
+      </td>
+      <td>
+        The ARN of the AWS Health event itself.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `affectedRegion`
+      </td>
+      <td>
+        The AWS affected region.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `affectedResources`
+      </td>
+      <td>
+        Number of affected resources. Auto-generated metric that can be used to define New Relic alert conditions. 
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `description`
+      </td>
+      <td>
+        Detailed description of the event.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `eventTypeCategory`
+      </td>
+      <td>
+        AWS Health category: Issue, ScheduledChange, AccountNotification, Investigation.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `eventTypeCode`
+      </td>
+      <td>
+        A list of unique identifiers for event types. For example, "AWS_EC2_SYSTEM_MAINTENANCE_EVENT","AWS_RDS_MAINTENANCE_SCHEDULED".
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `service`
+      </td>
+      <td>
+        The AWS services associated with the event. For example, EC2 , RDS.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `statusCode`
+      </td>
+      <td>
+        The AWS health event status: open, closed, upcoming.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `startTime`
+      </td>
+      <td>
+        Date and time the event began.
+      </td>
+    </tr>
+</tbody>
+</table>
+
+NRQL alert conditions can be defined to receive notifications when health events are reported by AWS.
+In example, the following query would monitor any open issues on EC2 by resource:
+```
+SELECT uniqueCount(affectedEntityArn) FROM AwsHealthNotification where statusCode = 'open' and eventTypeCategory = 'Issue' and service = 'EC2'
+```
 
 ## Inventory data [#metrics]
 

--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration.mdx
@@ -52,6 +52,7 @@ To use this integration's data:
 AWS Health events are ingested in New Relic One as **AwsHealthNotification** events. You can query, create widgets, and define NRQL alert policies based on these events.
 
 The following table shows the main attributes available for **AwsHealthNotification** events:
+
 <table>
   <thead>
     <tr>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* AWS Health events received are now published as NR1 events so that customers can create widget and alert conditions based on them. Previously, events were only available as inventory data (which cannot be queried). 

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.