### PR TITLE
chore: improve tests

### DIFF
--- a/scripts/actions/__tests__/fetch-and-deserialize.test.js
+++ b/scripts/actions/__tests__/fetch-and-deserialize.test.js
@@ -35,6 +35,8 @@ describe('writeFilesSync', () => {
 
   it('should call copySync for each unique directory path', () => {
     expect(fse.copySync).toHaveBeenCalledTimes(2);
+    expect(fse.copySync).toHaveBeenNthCalledWith(1, 'src/content/docs/fake_path_1/images', 'src/i18n/content/jp/docs/fake_path_1/images', { overwrite: true });
+    expect(fse.copySync).toHaveBeenNthCalledWith(2, 'src/content/docs/fake_path_2/images', 'src/i18n/content/jp/docs/fake_path_2/images', { overwrite: true });
   });
 
   it('should not copy directories that dont have images', () => {

--- a/scripts/actions/fetch-and-deserialize.js
+++ b/scripts/actions/fetch-and-deserialize.js
@@ -36,12 +36,12 @@ const writeFilesSync = (vfiles) => {
     */
     if (
       !(imageDirectory in copiedDirectories) &&
-      fse.existsSync(`src/content/${imageDirectory}`)
+      fse.existsSync(path.join('src/content/', imageDirectory))
     ) {
       // sync 'src/content/docs/.../images' to 'src/i18n/content/.../docs/.../images'
       fse.copySync(
-        `src/content/${imageDirectory}`,
-        `${path.dirname(file.path)}/images`,
+        path.join('src/content/', imageDirectory),
+        path.join(path.dirname(file.path), '/images'),
         {
           overwrite: true,
         }


### PR DESCRIPTION
* realized that we should also check the arguments for the copy calls,
since those describe where images are, and where they need to go.
* as part of this, tests indicated the paths we were using had '//' in
them, so updated statements to use path.join().