### PR TITLE
fix: update frontmatter after translation

### DIFF
--- a/scripts/actions/utils/handlers.js
+++ b/scripts/actions/utils/handlers.js
@@ -42,11 +42,18 @@ module.exports = {
   frontmatter: {
     deserialize: (h, node) => {
       const data = deserializeJSValue(node.properties.dataValue);
+      const frontMatterAtt = node.children.reduce((acc, child) => {
+        const key = child.properties.dataKey;
+        const value = child.children[0].value;
+        return { ...acc, [key]: value };
+      }, {});
 
       return h(
         node,
         'yaml',
-        yaml.safeDump(data, { lineWidth: Infinity }).trim()
+        yaml
+          .safeDump({ ...data, ...frontMatterAtt }, { lineWidth: Infinity })
+          .trim()
       );
     },
     serialize: (h, node) => {


### PR DESCRIPTION
# Summary
Updates to the frontmatter during translation were not being pulled into the frontmatter for localized files, this fixes that.