### PR TITLE
Correct memory units from GB to GiB

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
@@ -116,7 +116,7 @@ To host CPMs, your system must meet the minimum requirements for the chosen syst
           </td>
 
           <td>
-            2.5 GB of RAM per CPU core (dedicated)
+            2.5 GiB of RAM per CPU core (dedicated)
           </td>
         </tr>
 


### PR DESCRIPTION
Memory should be specified in units of GiB since memory modules contain multiples of 1024 bytes (powers of base 2).

- https://en.wikipedia.org/wiki/Gigabyte#:~:text=the%20capacity%20of%20modern%20computer%20random%20access%20memory%20devices%2C%20such%20as%20dimm%20modules%2C%20is%20always%20a%20multiple%20of%20a%20power%20of%201024
- https://en.wikipedia.org/wiki/Gigabyte#Base_2_(binary)

This aligns our Docker requirements with our Kubernetes requirements section which already correctly specifies memory in base 2 units using Kubernete's Mi or Gi.

### Give us some context

Correct units on memory to match industry standards.
https://en.wikipedia.org/wiki/Byte#History_of_the_conflicting_definitions