### PR TITLE
Support for the w3c trace context headers

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing.mdx
@@ -63,16 +63,16 @@ To enable distributed tracing for Browser monitoring:
    * [Full-Stack Observability](https://newrelic.com/products/application-monitoring/pricing)
    * [Browser Pro with SPA enabled](/docs/browser/single-page-app-monitoring/get-started/install-single-page-app-monitoring-new-relic-browser#enable-spa)
 2. Go to **[one.newrelic.com](http://one.newrelic.com), and click Browser > (select an app) > Settings > Application settings**.
-3. Turn on the **Distributed tracing** toggle. By default, for agent version 1173 and above, the `newrelic`, `traceparent` & `tracestate` headers will be added to all same-origin AJAX requests.
-4. Optional: If all of your services are configured to use the w3c trace context headers, you can choose to exclude the `newrelic` header from requests.
+3. Turn on the **Distributed tracing** toggle. By default, for agent version 1173 and above, the `newrelic`, `traceparent`, and `tracestate` headers will be added to all same-origin AJAX requests.
+4. Optional: If all of your services are configured to use the w3c trace context headers, you can choose to exclude the `newrelic`, `traceparent`, and `tracestate` headers from requests.
 5. Optional: [Enable cross-origin resource sharing](#cors).
 6. [Redeploy the Browser agent](/docs/browser/new-relic-browser/installation/upgrade-browser-agent) (either restarting the associated APM agent or updating the copy/paste Browser installation).
 
 ## Enable cross-origin resource sharing (CORS) [#cors]
 
-If you have AJAX requests that need resources from different origins, you can enable cross-origin resource sharing (CORS). By default, distributed tracing for cross-origin requests is not enabled because of browser CORS security restrictions: Distributed tracing is implemented by adding a custom HTTP header (`newrelic`) to outgoing AJAX requests, and browsers typically do not allow custom headers on cross-origin requests.
+If you have AJAX requests that need resources from different origins, you can enable cross-origin resource sharing (CORS). By default, distributed tracing for cross-origin requests is not enabled because of browser CORS security restrictions: Distributed tracing is implemented by adding a custom HTTP headers (`newrelic`, `traceparent`, and `tracestate`) to outgoing AJAX requests, and browsers typically do not allow custom headers on cross-origin requests.
 
-With the release of agent version 1173, we now support the w3c trace context headers (trace
+With the release of agent version 1173, we now support the w3c trace context headers (`traceparent` and `tracestate`) so these should also be allowed in your configuration.
 
 There are two separate configurations required to enable cross-origin distributed tracing:
 
@@ -101,11 +101,11 @@ Our [step-by-step instructions](#cors-configure) provide key concepts and steps 
 
 The best way to minimize your risk is to ensure you fully understand the process and to try it first in a test environment. Before reading the [step-by-step instructions](#cors-configure), it may help to first read this overview of the process:
 
-To use distributed tracing with cross-origin resources, you populate a list of approved cross-origin resources in New Relic, and then we automatically send the following custom header to those resources: `newrelic`. For this process to work, you must first ensure that someone has configured the services on the other origins to accept this custom header.
+To use distributed tracing with cross-origin resources, you populate a list of approved cross-origin resources in New Relic, and then we automatically send the following custom headers to those resources: `newrelic`, `traceparent`, and `tracestate`. For this process to work, you must first ensure that someone has configured the services on the other origins to accept this custom header.
 
-Cross-origin resource sharing uses a variety of HTTP headers (both in the request and response). The header that specifically applies to New Relic is the `Access-Control-Allow-Headers` response header, which needs to include `newrelic` in its value. You must configure your server to return this CORS header in its response. Example:
+Cross-origin resource sharing uses a variety of HTTP headers (both in the request and response). The header that specifically applies to New Relic is the `Access-Control-Allow-Headers` response header, which needs to include `newrelic`, `traceparent`, and `tracestate` in its value. You must configure your server to return this CORS header in its response. Example:
 
-`Access-Control-Allow-Headers: newrelic`
+`Access-Control-Allow-Headers: newrelic, traceparent, tracestate`
 
 <Callout variant="important">
   New Relic cannot perform any validation to ensure the services on the other origins were configured correctly. If you're unsure about how to allow these headers, do **not** add cross-origin resources to the approved list in the New Relic UI.
@@ -119,7 +119,7 @@ Cross-origin resource sharing uses a variety of HTTP headers (both in the reques
 
 To enable cross-origin resource sharing:
 
-1. Confirm that the services on the other origins are configured to accept the `newrelic` header using: `Access-Control-Allow-Headers: newrelic` (for details, see [Risks and mitigations](#mitigation)).
+1. Confirm that the services on the other origins are configured to accept the `newrelic` header using: `Access-Control-Allow-Headers: newrelic, traceparent, tracestate` (for details, see [Risks and mitigations](#mitigation)).
 2. Confirm that you meet the [Browser monitoring requirements](#requirements).
 3. Make sure you are in **[one.newrelic.com](http://one.newrelic.com), and click Browser > (select an app) > Application settings**.
 4. Turn on the **Distributed tracing** toggle if it's not already enabled.

--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing.mdx
@@ -103,7 +103,7 @@ The best way to minimize your risk is to ensure you fully understand the process
 
 To use distributed tracing with cross-origin resources, you populate a list of approved cross-origin resources in New Relic, and then we automatically send the following custom headers to those resources: `newrelic`, `traceparent`, and `tracestate`. For this process to work, you must first ensure that someone has configured the services on the other origins to accept this custom header.
 
-Cross-origin resource sharing uses a variety of HTTP headers (both in the request and response). The header that specifically applies to New Relic is the `Access-Control-Allow-Headers` response header, which needs to include `newrelic`, `traceparent`, and `tracestate` in its value. You must configure your server to return this CORS header in its response. Example:
+Cross-origin resource sharing uses a variety of HTTP headers (both in the request and response). The header that specifically applies to New Relic is the `Access-Control-Allow-Headers` response header, which can include `newrelic`, `traceparent, tracestate`, or `newrelic, traceparent, tracestate` in its value depending on what tracing strategies you enabled in your APM-monitored application. You must configure your server to return this CORS header in its response. Example:
 
 `Access-Control-Allow-Headers: newrelic, traceparent, tracestate`
 


### PR DESCRIPTION
Adding mention to the `traceparent` and `tracestate` headers introduced by agent version 1173.