### PR TITLE
Add python agent release notes for v6.04.03.160.

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60403160.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60403160.mdx
@@ -1,0 +1,20 @@
+---
+subject: Python agent
+releaseDate: '2021-06-23'
+version: 6.4.3.160
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+---
+
+
+## Notes
+
+This release of the Python agent includes a bug fix related to middleware and background tasks in Starlette/ FastAPI.
+
+The agent can be installed using easy_install/pip/distribute via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or can be downloaded directly from the New Relic [download site](http://download.newrelic.com/python_agent/release).
+
+
+## Bug Fixes
+
+* **Fix Starlette/ FastAPI transaction naming and classification**
+
+  Starlette/ FastAPI routes that contained middleware and background tasks were being incorrectly classified as non-web transactions and named after the background task rather than the route. This has been corrected in this release.


### PR DESCRIPTION
### Give us some context
This PR adds release notes for Python Agent v6.4.3.160. 