### PR TITLE
Remove references to Insights in Mobile HTTP errors

### DIFF
--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-errors-network-failure-analysis.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-errors-network-failure-analysis.mdx
@@ -182,15 +182,15 @@ This helps you take more of the guesswork out of resolving your mobile applicati
 
 To view details about an error or failure, select the **Request URL** link to be directed to the **Error summary** page. From the **Error summary** page, you can view the version information, request attributes, and **Response** body, as well as get a breakdown of error types for the request URL.
 
-## View and share error data in Insights [#insights]
+## View and share error data with query builder [#insights]
 
-To view any of the charts or lists on the **HTTP errors/requests** page in Insights:
+To explore the data behind any of the charts or lists on the **HTTP errors/requests** page:
 
 1. Select <Icon name="fe-more-horizontal"/>
    for any chart.
-2. Select **View query** and then **View in Insights**.
+2. Select **View query** and then **View in Insights**. This will open the query builder.
 
-From Insights, you can add the error data to a dashboard and [share it via a permalink](/docs/data-analysis/user-interface-functions/share-your-data/permalink).
+From the query builder, you can add the error data to a dashboard and [share it via a permalink](/docs/new-relic-one/use-new-relic-one/ui-data/basic-ui-features/#share).
 
 To dig deeper into the error data, [query your data](/docs/query-your-data/explore-query-data/explore-data/introduction-querying-new-relic-data) for the following events and attributes:
 
@@ -234,9 +234,9 @@ To view details about an error trace on the **Errors** page, select its request 
 
 The errors chart also appears on the selected mobile app's [Overview](/docs/mobile-apps/mobile-apps-dashboard) page. If the chart shows errors, you can select its **HTTP errors/network failures** title or select anywhere on the Overview page's chart to go directly to this **Errors** page.
 
-## View error data in Insights [#insights]
+## View error data in query builder [#insights]
 
-To dig deeper into your request data, use New Relic Insights to [query and chart](/docs/insights/nrql-new-relic-query-language/nrql-examples/insights-query-examples-mobile#mobilerequesterror-examples) the `MobileRequest` events and attributes.
+To dig deeper into your request data, use the query builder to [query and chart](/docs/insights/nrql-new-relic-query-language/nrql-examples/insights-query-examples-mobile#mobilerequesterror-examples) the `MobileRequest` events and attributes.
 
 ## Unknown errors or URL errors [#unknown_url]
 


### PR DESCRIPTION
The UI elements still say "View in Insights", but this changes the doc to not otherwise refer to that EOL'ed product, and instead point to dashboards and the query builder.