### PR TITLE
Various tweaks and update examples for log sources

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
@@ -220,7 +220,7 @@ The infrastructure log forwarding `.yml` config supports the following parameter
 
 ### Name (required)
 
-To start, make sure to define a name for the logs you are wanting to forward:
+To start, make sure to define a name for the logs you want to forward:
 
 <CollapserGroup>
   <Collapser
@@ -253,7 +253,7 @@ logs:
     file: /var/log/example-two.log # Path to another single log file
 ```
 
-The `file` parameter can point to a specific log file or multiple ones by using wildcards applied to names and extensions; for example, `/logs/*.log`. Wildcards can also be used in place of directories in a file path, which can be used to tail files located in different directories.
+The `file` parameter can point to a specific log file or multiple files by using wildcards applied to names and extensions; for example, `/logs/*.log`. You can use wildcards in place of directories in a file path, which can be used to tail files located in different directories.
 
 **Example:**
 
@@ -287,7 +287,7 @@ If you add these changes, reboot the host to ensure your changes are applied.
     title="systemd"
     >
     
-The `systemd` paramater to forward log messages that are collected by the `journald` daemon in Linux environments. This input type requires the agent to run in [root mode](/docs/infrastructure/install-configure-infrastructure/linux-installation/linux-agent-running-modes).
+Use the `systemd` paramater to forward log messages that are collected by the `journald` daemon in Linux environments. This input type requires the agent to run in [root mode](/docs/infrastructure/install-configure-infrastructure/linux-installation/linux-agent-running-modes).
 
 **Example:**
 
@@ -453,7 +453,7 @@ The following are configuration paramaters that are not required but are still r
     title="attributes"
     >
 
-List of custom attributes as key-value pairs that can be used to send additional data with the logs which you can then query. Attributes can be added to any log source
+List of custom attributes as key-value pairs that can be used to send additional data with the logs which you can then query. Add attributes to any log source.
 
 **Example:**
 
@@ -803,7 +803,7 @@ To solve this problem, check your `newrelic-infra.yml` file, and ensure the `pro
 
 ### Send the agent's logs to New Relic [#agent-logs]
 
-The infrastructure agent can be configured to send its own logs to [New Relic](/docs/logs/new-relic-logs/get-started/introduction-new-relic-logs). This can be useful for troubleshooting issues with log forwarding, the agent, or when contacting [support](https://support.newrelic.com/).
+You can configure the infrastructure agent to send its own logs to [New Relic](/docs/logs/new-relic-logs/get-started/introduction-new-relic-logs). This is useful for troubleshooting issues with log forwarding, the agent, or when contacting [support](https://support.newrelic.com/).
 
 To forward the infrastructure agent logs to New Relic:
 
@@ -815,7 +815,7 @@ To forward the infrastructure agent logs to New Relic:
    </Callout>
 
 3. **(Recommended):** Enable agent logging in JSON format to `log_format: json`.
-4. [Restart the agent](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status) so that the new settings can be loaded.
+4. [Restart the agent](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status) to load the new settings.
 
 This configuration sets up the agent in troubleshooting mode, but the log forwarder (based on [Fluent Bit](https://fluentbit.io/)) will continue in a non-verbose mode. Sometimes you can have issues with the log forwarder itself. For example, there may be problems accessing a specific channel when shipping [Windows log events](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent#winlog) or when accessing a particular log file.
 

--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
@@ -39,9 +39,10 @@ To enable log forwarding through the infrastructure agent:
 
 1. Start by verifying the system requirements needed for configuring Logs.
 2. Ensure you have installed the [infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic), version 1.11.4 or higher.
-3. Configure your log sources and other parameters in the infrastructure agent's `logging.d` directory.
-4. Generate some traffic and wait a few minutes, then check your account for data.
-5. Explore your log data in the Logs UI and benefit from the log attributes automatically inserted by the infrastructure agent.
+3. Create a `logging.yml` file in the infrastructure agent's `logging.d` directory.
+4. Configure your log sources and other parameters.
+5. Generate some traffic and wait a few minutes, then check your account for data.
+6. Explore your log data in the Logs UI and benefit from the log attributes automatically inserted by the infrastructure agent.
 
 ## System Requirements [#requirements]
 
@@ -209,26 +210,30 @@ To add a new configuration file for the log forwarding feature:
    - Linux: `/etc/newrelic-infra/logging.d/`
    - Windows: `C:\Program Files\New Relic\newrelic-infra\logging.d\`
 
-2. Create a `.yml` configuration file with the parameters you need. Use our sample config file as reference.
+2. Create a `logging.yml` configuration file and add the parameters you need. The `logging.d` directory has various `.yml.example` files that can be used as a reference or starting point.
 
-<Callout variant="tip">
-The agent automatically processes new configuration files without having to restart the Infrastructure service.
-</Callout>
+3. The agent automatically processes new configuration files without having to restart the Infrastructure service. The only exception to this is when configuring a custom Fluent Bit configuration.
 
 ## Log forwarding parameters [#parameters]
 
 The infrastructure log forwarding `.yml` config supports the following parameters:
+
+### Name (required)
+
+To start, make sure to define a name for the logs you are wanting to forward:
 
 <CollapserGroup>
   <Collapser
     id="name"
     title="name"
     >
-    Name of the log or logs.
+    Name of the log or logs being forwarding to New Relic.
   </Collapser>
 </CollapserGroup>
 
-### Log source
+### Log source (required)
+
+What you use for the log source will depend on where you want to forward your logs from. The available options are listed below:
 
 <CollapserGroup>
   <Collapser
@@ -238,26 +243,24 @@ The infrastructure log forwarding `.yml` config supports the following parameter
     
 Path to the log file or files. The agent tracks changes on the log files in a way similar to `tail -f shell`.
 
-Your `file` can point to a specific log file or multiple ones by using wildcards applied to names and extensions; for example, `/logs/*.log`
-
 **Example:**
 
 ```
 logs:
-  - name: file-with-attributes
-    <mark>file: /var/log/test.log</mark> # Path to a single file or pattern
-    pattern: Error # Regular expression to filter log entries
+  - name: example-log
+    file: /var/log/example.log # Path to a single log file
+  - name: example-log-two
+    file: /var/log/example-two.log # Path to another single log file
 ```
 
-Wildcards can also be used in place of directories in a file path, which can be used to tail files located in different directories.
+The `file` parameter can point to a specific log file or multiple ones by using wildcards applied to names and extensions; for example, `/logs/*.log`. Wildcards can also be used in place of directories in a file path, which can be used to tail files located in different directories.
 
 **Example:**
 
 ```
 logs:
   - name: docker-logs
-    <mark>file: /var/lib/docker/containers/*/*.log</mark> # Path to multiple folders and files
-    pattern: redis # Regular expression to filter log entries
+    file: /var/lib/docker/containers/*/*.log # Path to multiple folders and files
 ```
 
 <Callout variant="important">
@@ -273,7 +276,7 @@ root hard nofile 65536
 *hard nofile 65536
 ```
 
-Once you add these changes, reboot the host to ensure your changes are applied.
+If you add these changes, reboot the host to ensure your changes are applied.
 
   </Collapser>
 </CollapserGroup>
@@ -284,16 +287,14 @@ Once you add these changes, reboot the host to ensure your changes are applied.
     title="systemd"
     >
     
-Service name. Once the `systemd` input is activated, log messages are collected from the `journald` daemon in Linux environments.
-
-This input type requires the agent to run in [root mode](/docs/infrastructure/install-configure-infrastructure/linux-installation/linux-agent-running-modes).
+The `systemd` paramater to forward log messages that are collected by the `journald` daemon in Linux environments. This input type requires the agent to run in [root mode](/docs/infrastructure/install-configure-infrastructure/linux-installation/linux-agent-running-modes).
 
 **Example:**
 
 ```
 logs:
   - name: systemd-example
-    <mark>systemd: cupsd</mark>
+    systemd: cupsd
 ```
 
   </Collapser>
@@ -444,27 +445,34 @@ logs:
 
 ### Optional Configuration
 
+The following are configuration paramaters that are not required but are still recommended.
+
 <CollapserGroup>
   <Collapser
     id="attributes"
     title="attributes"
     >
 
-List of custom attributes, as key-value pairs, that can be used to send additional data with the logs which you can then query. For example, you can enable built-in parsing rules by setting the `logtype` attribute.
+List of custom attributes as key-value pairs that can be used to send additional data with the logs which you can then query. Attributes can be added to any log source
 
 **Example:**
 
 ```
-...
- - name: tcp-simple-test
-    tcp:
-      uri: tcp://0.0.0.0:1234
-      format: none
-      separator: \t
-    attributes: # You can add custom attributes to any source of logs
-      <mark>tcpFormat: none</mark>
-      <mark><a href="/docs/logs/log-management/ui-data/new-relic-logs-parsing-built-rules-custom-parsing">logtype</a>: nginx # See https://docs.newrelic.com/docs/logs/log-management/ui-data/new-relic-logs-parsing-built-rules-custom-parsing</mark>
-      <mark>someOtherAttribute: associatedValue</mark>
+logs:
+ - name: example-file-attributes
+   file: /var/log/example.log
+   attributes:
+     logtype: nginx
+     region: example-us-02
+     team: A-team
+ - name: example-tcp-attributes
+   tcp:
+     uri: tcp://0.0.0.0:2345
+     format: json
+   attributes:
+     logtype: nginx
+     region: example-us-02
+     team: B-team      
 ```
 
 #### Log attributes automatically inserted by the infrastructure agent(#automatically-inserted-attributes)


### PR DESCRIPTION
Cleaned up some of the examples, adjusted the " Enable log forwarding using the infrastructure agent " section to be more accurate, added some additional clarifying lines to the configuration steps.