### PR TITLE
Added clarity about creating baseline conditions

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-baseline-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-baseline-alert-conditions.mdx
@@ -44,7 +44,7 @@ When your data escapes the predicted "normal" behavior and meets the criteria yo
   **[one.newrelic.com](https://one.newrelic.com) > AI & Alerts > Policies > (create or select policy) > Create alert condition:** Baseline alert conditions give you the ability to set intelligent, self-adjusting thresholds that only generate violations when abnormal behavior is detected.
 </figcaption>
 
-To create a baseline condition: When you start to create a [condition](/docs/alerts/new-relic-alerts/defining-conditions/define-alert-conditions#create-condition), choose one of the following [data sources](#availability):
+To create a baseline condition, go to **[one.newrelic.com](https://one.newrelic.com) > AI & Alerts > Policies > (create or select policy) > Create alert condition**: When you start to create a [condition](/docs/alerts/new-relic-alerts/defining-conditions/define-alert-conditions#create-condition), choose one of the following [data sources](#availability):
 
 * NRQL: Create a NRQL condition and then choose baseline
 * APM: Application metric baseline


### PR DESCRIPTION
Not so much how, as where you go.

I pulled the UI path from out of the image caption. I think this redundancy is ok.