### PR TITLE
Clarify violation close for LoS violations

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -663,7 +663,7 @@ To create a NRQL alert configured with loss of signal detection in the UI:
 2. Write a [NRQL query](/docs/alerts/new-relic-alerts/defining-conditions/create-alert-conditions-nrql-queries#syntax) that returns the values you want to alert on.
 3. For **Threshold type**, select **Static** or **Baseline**.
 4. Click **+ Add lost signal threshold**, then set the signal expiration duration time in minutes or seconds in the **Signal is lost after** field.
-5. Choose what you want to happen when the signal is lost. You can check one or both of **Close all current open violations** and **Open new "lost signal" violation** . These control how loss of signal violations will be handled for the condition.
+5. Choose what you want to happen when the signal is lost. You can check one or both of **Close all current open violations** and **Open new "lost signal" violation** . These control how loss of signal violations will be handled for the condition. Newly opened lost signal violations will close immediately when new data is detected. 
 6. Make sure you name your condition before you save it.
 
 <Callout variant="tip">

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -663,7 +663,7 @@ To create a NRQL alert configured with loss of signal detection in the UI:
 2. Write a [NRQL query](/docs/alerts/new-relic-alerts/defining-conditions/create-alert-conditions-nrql-queries#syntax) that returns the values you want to alert on.
 3. For **Threshold type**, select **Static** or **Baseline**.
 4. Click **+ Add lost signal threshold**, then set the signal expiration duration time in minutes or seconds in the **Signal is lost after** field.
-5. Choose what you want to happen when the signal is lost. You can check one or both of **Close all current open violations** and **Open new "lost signal" violation** . These control how loss of signal violations will be handled for the condition. Newly opened lost signal violations will close immediately when new data is detected. 
+5. Choose what you want to happen when the signal is lost. You can check one or both of **Close all current open violations** and **Open new "lost signal" violation** . These control how loss of signal violations will be handled for the condition. Newly opened lost signal violations will close immediately when new data is evaluated. 
 6. Make sure you name your condition before you save it.
 
 <Callout variant="tip">


### PR DESCRIPTION


<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

As an engineer working in the platform, I was unsure what conditions needed to be met for a loss of signal violation to automatically close. Does the signal need to resume and maintain across the chosen expiration window? Does it immediately resume once it's detected?  I tested this with a synthetics monitor and the violation closed immediately once a new data point was detected. Hopefully this can help  our customers who have similar questions.

### Are you making a change to site code?
No! 😅 