### PR TITLE
Document min permissions for AWS metric streams

### DIFF
--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -117,6 +117,18 @@ Next, set up the metric stream using the [CloudFormation template](https://conso
 
 3. ** Add the new AWS account** in the **Metric streams** mode in the New Relic UI. 
   Go to **[one.newrelic.com](https://one.newrelic.com/) > Infrastructure > AWS**, click on **Add an AWS account**, then on **Use metric streams**, and follow the steps.
+  
+<Callout variant="tip">
+  The following are the minimal permissions that should be granted on the AWS role configured in New Relic so that CloudWatch metrics can be enriched with additional service metadata and custom tags when applicable:
+
+  ```
+  config:BatchGetResourceConfig
+  config:ListDiscoveredResources
+  tag:GetResources
+  ```
+  
+  The New Relic UI currently recommends the `ReadOnlyAccess` policy over these individual items so that New Relic has proper permissions to collect service data that's not available in AWS CloudWatch Metric Streams.
+</Callout>
 
 ## Validate your data is received correctly [#validate-data]
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* Documents the minimal permissions required on the AWS Account / Role in order to use the AWS Metric Stream integration. 
* Feedback from support / field, customers willing to understand what's the impact if they cannot enable the broad "ReadyOnlyAccess" permission on the AWS role. 

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.