### PR TITLE
OHIs now available for arm64 architecture

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -24,7 +24,7 @@ The infrastructure agent supports these processor architectures:
 
 * **Linux**: 64-bit for x86 processor architectures (also requires 64-bit package manager and dependencies)
 * **Windows**: both 32 and 64-bit for x86 processor architectures
-* **ARM**: arm64 architecture including [AWS Graviton 2 processor](https://aws.amazon.com/ec2/graviton/) is supported on compatible Linux operating sytems. Built-in log forwarding and on-host integrations are not yet available.
+* **ARM**: arm64 architecture including [AWS Graviton 2 processor](https://aws.amazon.com/ec2/graviton/) is supported on compatible Linux operating sytems. On-host integrations are also supported (with the exception of the Oracle integration). Built-in log forwarding is not yet available.
 
 ## Operating systems
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* All on-host integrations are now published and ready to be used on ARM64 architectures (e.g. Graviton 2 AWS hosts).

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.