### PR TITLE
Some 'custom data' related edits

### DIFF
--- a/src/content/docs/telemetry-data-platform/custom-data/custom-events/report-custom-event-data.mdx
+++ b/src/content/docs/telemetry-data-platform/custom-data/custom-events/report-custom-event-data.mdx
@@ -8,7 +8,7 @@ redirects:
   - /docs/insights/event-data-sources/custom-events/report-custom-event-data
 ---
 
-One of the ways to report custom data to New Relic is with custom events and attributes. 
+One of the ways to [report custom data](/docs/telemetry-data-platform/custom-data/intro-custom-data) to New Relic is with custom events and attributes. 
 
 Have questions about why you'd use custom data? See [Introduction to custom data](https://docs.newrelic.com/docs/telemetry-data-platform/custom-data/intro-custom-data).
 

--- a/src/content/docs/telemetry-data-platform/get-started/introduction-new-relic-data-ingest-apis-sdks.mdx
+++ b/src/content/docs/telemetry-data-platform/get-started/introduction-new-relic-data-ingest-apis-sdks.mdx
@@ -24,4 +24,4 @@ Some options for getting started:
 
 ## Report custom data [#custom-data]
 
-If you need to report data that our [agents and integrations](#integrations) don't provide, we give you the tools you need to bring in any type of data you need. To learn more, see [Intro to custom data](/docs/telemetry-data-platform/custom-data/intro-custom-data). 
+If you need to report data that our [agents and integrations](#integrations) don't provide, we have tools that will allow you to bring in any type of data you need. To learn more, see [Intro to custom data](/docs/telemetry-data-platform/custom-data/intro-custom-data). 

--- a/src/content/docs/telemetry-data-platform/get-started/introduction-new-relic-data-ingest-apis-sdks.mdx
+++ b/src/content/docs/telemetry-data-platform/get-started/introduction-new-relic-data-ingest-apis-sdks.mdx
@@ -17,32 +17,11 @@ There are many ways to get data into your New Relic account. Any New Relic user 
 
 When you enable New Relic solutions like [APM](/docs/apm), [browser monitoring](/docs/browser), [mobile monitoring](/docs/mobile-monitoring), [infrastructure monitoring](/docs/infrastructure), or any of our wide array of [integrations](https://newrelic.com/integrations), by default you'll receive data from your monitored applications, hosts, services, or other entities.
 
-To browse all New Relic-built tools and solutions, see [New Relic integrations](https://newrelic.com/integrations).
+Some options for getting started: 
 
-## Agent APIs
+* Log into [one.newrelic.com](https://one.newrelic.com) and click **Add more data** to get some guidance on setting up New Relic solutions.
+* To browse our solutions, see [New Relic integrations](https://newrelic.com/integrations).
 
-Some of our monitoring solutions come with APIs and/or SDKs that allow you to customize the data reported and how it reports. For more information, see the relevant product:
+## Report custom data [#custom-data]
 
-* [APM agent APIs](/docs/apis/get-started/intro-apis/introduction-new-relic-apis#apm-api)
-* [Browser API](/docs/apis/get-started/intro-apis/introduction-new-relic-apis#browser-api)
-* [Mobile API](/docs/apis/get-started/intro-apis/introduction-new-relic-apis#mobile-api)
-* Infrastructure monitoring: the [Flex integration tool](/docs/integrations/host-integrations/host-integrations-list/flex-integration-tool-build-your-own-integration)
-
-## Telemetry SDKs [#telemetry-sdk]
-
-If our [more curated solutions](#integrations) don't work for you, our open source [Telemetry SDKs](/docs/data-ingest-apis/get-data-new-relic/new-relic-sdks/telemetry-sdks-send-custom-telemetry-data-new-relic) let you build your own solution. These SDKs are language wrappers for our data-ingest APIs (below) that let you send telemetry data to New Relic without requiring install of an agent.
-
-## APIs for sending metrics, traces, logs, and events [#data-ingest-apis]
-
-If our more curated solutions don't work for you, we also have data-ingest APIs:
-
-* [Trace API](/docs/telemetry-data-platform/get-data/apis/introduction-trace-api/)
-* [Event API](/docs/insights/insights-data-sources/custom-data/introduction-event-api)
-* [Metric API](/docs/telemetry-data-platform/ingest-manage-data/ingest-apis/introduction-metric-api/)
-* [Log API](/docs/logs/new-relic-logs/log-api/introduction-log-api)
-
-To learn about the differences between these data types, see [Data types](/docs/using-new-relic/data/understand-data/new-relic-data-types).
-
-## New Relic One applications [#new-relic-one-apps]
-
-You can build entirely custom applications that reside in New Relic One and make use of any data you want. You can use existing open source New Relic One apps, or share your own with the open source community. For details, see [New Relic One applications](/docs/new-relic-one/use-new-relic-one/build-new-relic-one/new-relic-one-build-your-own-custom-new-relic-one-application).
+If you need to report data that our [agents and integrations](#integrations) don't provide, we give you the tools you need to bring in any type of data you need. To learn more, see [Intro to custom data](/docs/telemetry-data-platform/custom-data/intro-custom-data). 

--- a/src/content/docs/using-new-relic/data/customize-data/collect-custom-attributes.mdx
+++ b/src/content/docs/using-new-relic/data/customize-data/collect-custom-attributes.mdx
@@ -20,7 +20,18 @@ redirects:
   - /docs/agents/manage-apm-agents/agent-data/collect-custom-attributes
 ---
 
-New Relic allows you to collect custom [attributes](/docs/agents/manage-apm-agents/agent-data/agent-attributes). For example, you can create a custom attribute to track the user name associated with a slow or failing request. This document contains links to docs on how to do this for APM, infrastructure monitoring, browser monitoring, and mobile monitoring.
+For some New Relic solutions, one way to [report custom data to New Relic](/docs/telemetry-data-platform/custom-data/intro-custom-data) is to use custom [attributes](/docs/agents/manage-apm-agents/agent-data/agent-attributes). For example, for New Relic browser monitoring, you might create a custom attribute to track the user name associated with a slow or failing request. 
+
+## Requirements [#requirements]
+
+Custom attributes are available for these New Relic solutions: 
+
+* APM
+* Browser monitoring
+* Mobile monitoring 
+* Infrastructure monitoring
+
+For other custom data solutions, see [Intro to custom data](/docs/telemetry-data-platform/custom-data/intro-custom-data). 
 
 ## APM: Record custom attributes [#enabling-custom]
 


### PR DESCRIPTION
Some quick work: 

Giving a couple more links to the 'Intro to custom data' doc. 
Reducing some redundant content that was in two places and pointing to 'custom data' doc. 
Giving more context for how one recommended path was going into the UI to get started with New Relic. 