### PR TITLE
Ruby Agent 7.2.0 release

### DIFF
--- a/src/content/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
+++ b/src/content/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
@@ -80,10 +80,10 @@ For the Ruby and Java agents, you can mark errors as expected. These errors will
 To configure errors as expected, see the agent-specific documentation:
 
 * [Java](/docs/agents/java-agent/configuration/java-agent-error-configuration)
-* [Ruby](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#error-collector)
-* [Node.js](https://docs.newrelic.com/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration)
-* [.NET](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration#error_collector)
-* [Python](https://docs.newrelic.com/docs/agents/python-agent/configuration/python-agent-configuration/#error-collector-settings)
+* [Ruby](/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#error-collector)
+* [Node.js](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration)
+* [.NET](/docs/agents/net-agent/configuration/net-agent-configuration#error_collector)
+* [Python](/docs/agents/python-agent/configuration/python-agent-configuration/#error-collector-settings)
 
 If expected errors are enabled, APM's [**Error analytics**](/docs/apm/applications-menu/error-analytics/error-analytics-explore-events-behind-errors) page will, by default, have a filter applied with the `error.expected` attribute set to `false`, meaning expected errors will not be displayed. To view expected errors, turn off the `error.expected` filter.
 

--- a/src/content/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
+++ b/src/content/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
@@ -80,7 +80,7 @@ For the Ruby and Java agents, you can mark errors as expected. These errors will
 To configure errors as expected, see the agent-specific documentation:
 
 * [Java](/docs/agents/java-agent/configuration/java-agent-error-configuration)
-* [Ruby](/docs/agents/ruby-agent/api-guides/sending-new-relic-handled-errors)
+* [Ruby](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#error-collector)
 * [Node.js](https://docs.newrelic.com/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration)
 * [.NET](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration#error_collector)
 * [Python](https://docs.newrelic.com/docs/agents/python-agent/configuration/python-agent-configuration/#error-collector-settings)

--- a/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -270,7 +270,7 @@ When using the `capture_params` setting, the Ruby agent will not attempt to filt
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Deprecated. For agent versions 3.5.0 or higher, [set your Apdex T via the New Relic UI](/docs/apm/new-relic-apm/apdex/changing-your-apdex-settings).
+  <b>DEPRECATED</b> For agent versions 3.5.0 or higher, [set your Apdex T via the New Relic UI](/docs/apm/new-relic-apm/apdex/changing-your-apdex-settings).
   </Collapser>
   
   <Collapser id="sync_startup" title="sync_startup">
@@ -575,7 +575,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Deprecated; use [`transaction_tracer.attributes.enabled`](#transaction_tracer-attributes-enabled) instead.
+  <b>DEPRECATED</b> Use [`transaction_tracer.attributes.enabled`](#transaction_tracer-attributes-enabled) instead.
   </Collapser>
   
   <Collapser id="transaction_tracer-explain_threshold" title="transaction_tracer.explain_threshold">
@@ -632,6 +632,8 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
 
 The agent collects and reports all uncaught exceptions by default. These configuration options allow you to customize the error collection.
 
+For information on ignored and expected errors, [see this page on Error Analytics in APM](https://docs.newrelic.com/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected/). To set expected errors via the `NewRelic::Agent.notice_error` Ruby method, [consult the Ruby Agent API](https://docs.newrelic.com/docs/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/).
+
 <CollapserGroup>
   
   <Collapser id="error_collector-enabled" title="error_collector.enabled">
@@ -655,7 +657,7 @@ The agent collects and reports all uncaught exceptions by default. These configu
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Deprecated; use [`error_collector.attributes.enabled`](#error_collector-attributes-enabled) instead.
+  <b>DEPRECATED</b> Use [`error_collector.attributes.enabled`](#error_collector-attributes-enabled) instead.
   </Collapser>
   
   <Collapser id="error_collector-ignore_errors" title="error_collector.ignore_errors">
@@ -667,11 +669,91 @@ The agent collects and reports all uncaught exceptions by default. These configu
       </tbody>
     </table>
 
-  Specify a comma-delimited list of error classes that the agent should ignore.
-  
+  <b>DEPRECATED</b> Use [`error_collector.ignore_classes`](#error_collector-ignore_classes) instead.
+
   <Callout variant="caution">
   Server side configuration takes precedence for this setting over all environment configurations. This differs from all other configuration settings where environment variable take precedence over server side configuration.
   </Callout>
+  </Collapser>
+  
+  <Collapser id="error_collector-ignore_classes" title="error_collector.ignore_classes">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>None</td></tr>
+      </tbody>
+    </table>
+
+  A list of error classes that the agent should ignore.
+
+  <Callout variant="caution">This option cannot be set via environment variable.</Callout>
+  </Collapser>
+  
+  <Collapser id="error_collector-ignore_messages" title="error_collector.ignore_messages">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Hash</td></tr>
+        <tr><th>Default</th><td>`{}`</td></tr>
+        <tr><th>Environ variable</th><td>None</td></tr>
+      </tbody>
+    </table>
+
+  A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored. *Note: this setting cannot be set via environment variable.*
+
+  <Callout variant="caution">This option cannot be set via environment variable.</Callout>
+  </Collapser>
+  
+  <Collapser id="error_collector-ignore_status_codes" title="error_collector.ignore_status_codes">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`""`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_IGNORE_STATUS_CODES`</td></tr>
+      </tbody>
+    </table>
+
+  A comma separated list of status codes, possibly including ranges. Errors associated with these status codes, where applicable, will be ignored.
+  </Collapser>
+  
+  <Collapser id="error_collector-expected_classes" title="error_collector.expected_classes">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>None</td></tr>
+      </tbody>
+    </table>
+
+  A list of error classes that the agent should treat as expected. *Note: this setting cannot be set via environment variable.*
+
+  <Callout variant="caution">This option cannot be set via environment variable.</Callout>
+  </Collapser>
+  
+  <Collapser id="error_collector-expected_messages" title="error_collector.expected_messages">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Hash</td></tr>
+        <tr><th>Default</th><td>`{}`</td></tr>
+        <tr><th>Environ variable</th><td>None</td></tr>
+      </tbody>
+    </table>
+
+  A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected. *Note: this setting cannot be set via environment variable.*
+
+  <Callout variant="caution">This option cannot be set via environment variable.</Callout>
+  </Collapser>
+  
+  <Collapser id="error_collector-expected_status_codes" title="error_collector.expected_status_codes">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`""`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_EXPECTED_STATUS_CODES`</td></tr>
+      </tbody>
+    </table>
+
+  A comma separated list of status codes, possibly including ranges. Errors associated with these status codes, where applicable, will be treated as expected.
   </Collapser>
   
   <Collapser id="error_collector-max_backtrace_frames" title="error_collector.max_backtrace_frames">
@@ -727,7 +809,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
       </tbody>
     </table>
 
-  This is `true` by default, this enables [auto-injection](/docs/browser/new-relic-browser/installation-configuration/adding-apps-new-relic-browser#select-apm-app) of the JavaScript header for page load timing (sometimes referred to as real user monitoring or RUM).
+  If `true`, enables [auto-injection](/docs/browser/new-relic-browser/installation-configuration/adding-apps-new-relic-browser#select-apm-app) of the JavaScript header for page load timing (sometimes referred to as real user monitoring or RUM).
   </Collapser>
   
   <Collapser id="browser_monitoring-capture_attributes" title="browser_monitoring.capture_attributes">
@@ -739,7 +821,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Deprecated; use [`browser_monitoring.attributes.enabled`](#browser_monitoring-attributes-enabled) instead.
+  <b>DEPRECATED</b> Use [`browser_monitoring.attributes.enabled`](#browser_monitoring-attributes-enabled) instead.
   </Collapser>
   
 </CollapserGroup>
@@ -783,7 +865,7 @@ The Browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Deprecated; use [`transaction_events.attributes.enabled`](#transaction_events-attributes-enabled) instead.
+  <b>DEPRECATED</b> Use [`transaction_events.attributes.enabled`](#transaction_events-attributes-enabled) instead.
   </Collapser>
   
 </CollapserGroup>
@@ -1481,7 +1563,7 @@ If `true`, disables memcache instrumentation.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Deprecated; use [`disable_sequel_instrumentation`](#disable_sequel_instrumentation) instead.
+  <b>DEPRECATED</b> Use [`disable_sequel_instrumentation`](#disable_sequel_instrumentation) instead.
   </Collapser>
   
   <Collapser id="disable_mongo" title="disable_mongo">
@@ -2375,6 +2457,8 @@ If `true`, the agent won't install Grape instrumentation.
 </CollapserGroup>
 
 ## Utilization
+
+
 
 <CollapserGroup>
   

--- a/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -699,9 +699,9 @@ For information on ignored and expected errors, [see this page on Error Analytic
       </tbody>
     </table>
 
-  A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored. *Note: this setting cannot be set via environment variable.*
+  A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored.
 
-  <Callout variant="caution">This option cannot be set via environment variable.</Callout>
+  <Callout variant="caution">This option can't be set via environment variable.</Callout>
   </Collapser>
   
   <Collapser id="error_collector-ignore_status_codes" title="error_collector.ignore_status_codes">
@@ -725,9 +725,9 @@ For information on ignored and expected errors, [see this page on Error Analytic
       </tbody>
     </table>
 
-  A list of error classes that the agent should treat as expected. *Note: this setting cannot be set via environment variable.*
+  A list of error classes that the agent should treat as expected.
 
-  <Callout variant="caution">This option cannot be set via environment variable.</Callout>
+  <Callout variant="caution">This option can't be set via environment variable.</Callout>
   </Collapser>
   
   <Collapser id="error_collector-expected_messages" title="error_collector.expected_messages">
@@ -739,9 +739,9 @@ For information on ignored and expected errors, [see this page on Error Analytic
       </tbody>
     </table>
 
-  A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected. *Note: this setting cannot be set via environment variable.*
+  A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected.
 
-  <Callout variant="caution">This option cannot be set via environment variable.</Callout>
+  <Callout variant="caution">This option can't be set via environment variable.</Callout>
   </Collapser>
   
   <Collapser id="error_collector-expected_status_codes" title="error_collector.expected_status_codes">

--- a/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -632,7 +632,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
 
 The agent collects and reports all uncaught exceptions by default. These configuration options allow you to customize the error collection.
 
-For information on ignored and expected errors, [see this page on Error Analytics in APM](https://docs.newrelic.com/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected/). To set expected errors via the `NewRelic::Agent.notice_error` Ruby method, [consult the Ruby Agent API](https://docs.newrelic.com/docs/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/).
+For information on ignored and expected errors, [see this page on Error Analytics in APM](/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected/). To set expected errors via the `NewRelic::Agent.notice_error` Ruby method, [consult the Ruby Agent API](/docs/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/).
 
 <CollapserGroup>
   
@@ -687,7 +687,7 @@ For information on ignored and expected errors, [see this page on Error Analytic
 
   A list of error classes that the agent should ignore.
 
-  <Callout variant="caution">This option cannot be set via environment variable.</Callout>
+  <Callout variant="caution">This option can't be set via environment variable.</Callout>
   </Collapser>
   
   <Collapser id="error_collector-ignore_messages" title="error_collector.ignore_messages">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-720.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-720.mdx
@@ -8,7 +8,7 @@ downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-7.2.0.gem'
 ## v7.2.0
 
   * **Expected Errors and Ignore Errors**
-    This release adds support for configuration for expected/ignored errors by class name, status code, and message. The following configuration options are now available:
+    This release adds support for configuration of expected/ignored errors by class name, status code, and message. The following configuration options are now available:
     - `error_collector.ignore_classes`
     - `error_collector.ignore_messages`
     - `error_collector.ignore_status_codes`

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-720.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-720.mdx
@@ -1,0 +1,35 @@
+---
+subject: Ruby agent
+releaseDate: '2021-05-28'
+version: 7.1.0
+downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-7.2.0.gem'
+---
+
+## v7.2.0
+
+  * **Expected Errors and Ignore Errors**
+    This release adds support for configuration for expected/ignored errors by class name, status code, and message. The following configuration options are now available:
+    - `error_collector.ignore_classes`
+    - `error_collector.ignore_messages`
+    - `error_collector.ignore_status_codes`
+    - `error_collector.expected_classes`
+    - `error_collector.expected_messages`
+    - `error_collector.expected_status_codes`
+    For more details about expected and ignored errors, please see our [configuration documentation](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/)
+
+  * **Bugfix: resolves "can't add a new key into hash during iteration" Errors**
+
+    Thanks to @wyhaines for this fix that prevents "can't add a new key into hash during iteration" errors from occuring when iterating over environment data.
+
+  * **Bugfix: kwarg support fixed for Rack middleware instrumentation**
+   
+    Thanks to @walro for submitting this fix. This fixes the rack instrumentation when using kwargs. 
+
+  * **Update known conflicts with use of Module#Prepend**
+
+    With our release of v7.0.0, we updated our instrumentation to use Module#Prepend by default, instead of method chaining. We have received reports of conflicts and added a check for these known conflicts. If a known conflict with prepend is detected while using the default value of 'auto' for gem instrumentation, the agent will instead install method chaining instrumentation in order to avoid this conflict. This check can be bypassed by setting the instrumentation method for the gem to 'prepend'.
+
+
+## Support statement
+
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.2.0.345](https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-520345).

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-720.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-720.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ruby agent
-releaseDate: '2021-05-28'
-version: 7.1.0
+releaseDate: '2021-07-02'
+version: 7.2.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-7.2.0.gem'
 ---
 


### PR DESCRIPTION
* Added configuration options for expected errors
* updated existing links from Ruby API to error collector config section

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

Update docs for Ruby Agent 7.2.0 release.

Adds configuration options for expected errors which are introduced in this release. Updates links to general information on expected errors - previously the Ruby link pointed to the API docs for expected errors.

Also did some clean up on deprecated options - removed duplicate "deprecate"s adjacent to each other.

### Are you making a change to site code?

No.

**NOTE:** Please do not merge until Ruby Agent 7.2.0 is released (which should be soon this week).