### PR TITLE
Update jmx-monitoring-integration.mdx

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/jmx-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/jmx-monitoring-integration.mdx
@@ -101,7 +101,11 @@ To install the JMX integration, follow the instructions for your environment:
        ```
     6. Edit the `jmx-config.yml` file as described in the [configuration settings](#config).
     7. [Restart the infrastructure agent](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
-    8. Note: If the sample files are not present in your installation, you can download them directly from the root of the [GitHub repository](https://github.com/newrelic/nri-jmx).
+    
+    <Callout variant="important">
+      If the sample files are not present in your installation, you can download them directly from the [GitHub repository](https://github.com/newrelic/nri-jmx).
+    </Callout>
+    
   </Collapser>
 
   <Collapser

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/jmx-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/jmx-monitoring-integration.mdx
@@ -101,6 +101,7 @@ To install the JMX integration, follow the instructions for your environment:
        ```
     6. Edit the `jmx-config.yml` file as described in the [configuration settings](#config).
     7. [Restart the infrastructure agent](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
+    8. Note: If the sample files are not present in your installation, you can download them directly from the root of the [GitHub repository](https://github.com/newrelic/nri-jmx).
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
On at least Amazon Linux (and possibly other distros), it looks like the sample files aren't included in the nri-jmx package. This change points the user to an alternative source for the sample files.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.