### PR TITLE
Emphasis Log patterns note regarding EU region

### DIFF
--- a/src/content/docs/logs/log-management/ui-data/find-unusual-logs-log-patterns.mdx
+++ b/src/content/docs/logs/log-management/ui-data/find-unusual-logs-log-patterns.mdx
@@ -36,7 +36,11 @@ Log patterns use advanced clustering algorithms to group together similar log me
 
 ## Availability [#availability]
 
-Log patterns are not available in the [EU region](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers/#regions-availability). The ability to configure this feature is dependent on role-based permissions. If you see **Patterns are turned off** in your **Log management Patterns UI**, click the **Configure Patterns** button and enable it. If you don't see patterns within 30 minutes of enabling the feature, there may be a lack of data with a message attribute for the system to create a pattern from.
+<Callout variant="important">
+Log patterns are not available in the [EU region](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers/#regions-availability).
+</Callout>
+
+The ability to configure this feature is dependent on role-based permissions. If you see **Patterns are turned off** in your **Log management Patterns UI**, click the **Configure Patterns** button and enable it. If you don't see patterns within 30 minutes of enabling the feature, there may be a lack of data with a message attribute for the system to create a pattern from.
 
 <table>
   <thead>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

### Context

**TL;DR** : This PR tries to get attention regarding feature availability.


As a NewRelic consumer living in the EU region, many times I tried to use a feature that was not yet available in my region. It is not a big deal by itself, however I think this should be more obvious.

From my experience, users (including me) are not "reading" the doc. They are parsing it for keywords before focusing on a specific section. Using a `callout` can save some time and troubles.
