### PR TITLE
Fix malformed links

### DIFF
--- a/src/content/docs/security/security-privacy/data-privacy/data-privacy-new-relic.mdx
+++ b/src/content/docs/security/security-privacy/data-privacy/data-privacy-new-relic.mdx
@@ -226,11 +226,11 @@ The following summarizes how individual New Relic products and components ensure
 
   <Collapser
     id="logs-security"
-    title={<Link to="/docs/serverless-function-monitoring">Logs management</Link>}
+    title="Logs management"
   >
-    [Due to the nature of our Logs management service, you have direct control over what data is reported to New Relic. To ensure data privacy and to limit the types of information New Relic receives, no customer data is captured except what you supply in your API calls or log forwarder configuration. All data for the Logs service is then reported to New Relic over HTTPS.](/docs/serverless-function-monitoring)
+    Due to the nature of our Logs management service, you have direct control over what data is reported to New Relic. To ensure data privacy and to limit the types of information New Relic receives, no customer data is captured except what you supply in your API calls or log forwarder configuration. All data for the Logs service is then reported to New Relic over HTTPS.
 
-    [The Logs service does mask number patterns that appear to be for items such as credit cards or Social Security numbers. For more information, see the](/docs/serverless-function-monitoring) [Logs security documentation](/docs/logs/new-relic-logs/get-started/new-relic-logs-security).
+    The Logs service does mask number patterns that appear to be for items such as credit cards or Social Security numbers. For more information, see the [Logs security documentation](/docs/logs/new-relic-logs/get-started/new-relic-logs-security).
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
This link extended over three ¶s. Probably an issue in the migration script.