### PR TITLE
Start removing stray `''` from metaDescription

### DIFF
--- a/src/content/docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code.mdx
+++ b/src/content/docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code.mdx
@@ -6,7 +6,7 @@ tags:
   - Install and configure
 translate:
   - jp
-metaDescription: 'To monitor your app with New Relic, install (compile and link) the New Relic C SDK into your app''s code library.'
+metaDescription: "To monitor your app with New Relic, install (compile and link) the New Relic C SDK into your app's code library."
 redirects:
   - /docs/install-c-agent-compile-link-your-code
   - /docs/install-c-sdk-compile-link-your-code

--- a/src/content/docs/agents/c-sdk/troubleshooting/no-data-appears-c-sdk.mdx
+++ b/src/content/docs/agents/c-sdk/troubleshooting/no-data-appears-c-sdk.mdx
@@ -5,7 +5,7 @@ tags:
   - Agents
   - C SDK
   - Troubleshooting
-metaDescription: 'If your app is being monitored by the New Relic C SDK but isn''t reporting data, follow these troubleshooting tips.'
+metaDescription: "If your app is being monitored by the New Relic C SDK but isn't reporting data, follow these troubleshooting tips."
 redirects:
   - /docs/no-data-appears-c
   - /docs/agents/c-sdk/troubleshooting/no-data-appears-c

--- a/src/content/docs/agents/go-agent/features/add-browser-monitoring-your-go-apps.mdx
+++ b/src/content/docs/agents/go-agent/features/add-browser-monitoring-your-go-apps.mdx
@@ -4,7 +4,7 @@ tags:
   - Agents
   - Go agent
   - Features
-metaDescription: 'To enable browser monitoring for your Go app, use the copy and paste method, or use the Go agent''s Browser API.'
+metaDescription: "To enable browser monitoring for your Go app, use the copy and paste method, or use the Go agent's browser API."
 redirects:
   - /docs/agents/go-agent/features/install-new-relic-browser-go-apps
 ---

--- a/src/content/docs/agents/go-agent/get-started/introduction-new-relic-go.mdx
+++ b/src/content/docs/agents/go-agent/get-started/introduction-new-relic-go.mdx
@@ -6,7 +6,7 @@ tags:
   - Get started
 translate:
   - jp
-metaDescription: 'New Relic''s Go agent monitors your Golang apps and microservices, and helps you identify and solve performance issues.'
+metaDescription: "New Relic's Go agent monitors your Golang apps and microservices, and helps you identify and solve performance issues."
 redirects:
   - /docs/agents/new-relic-go
   - /agents/new-relic-go

--- a/src/content/docs/agents/go-agent/installation/update-go-agent.mdx
+++ b/src/content/docs/agents/go-agent/installation/update-go-agent.mdx
@@ -4,7 +4,7 @@ tags:
   - Agents
   - Go agent
   - Installation
-metaDescription: 'How to update New Relic APM''s Go agent so you can take advantage of the latest features, enhancements, and important security patches.'
+metaDescription: "How to update New Relic APM's Go agent so you can take advantage of the latest features, enhancements, and important security patches."
 ---
 
 To take full advantage of New Relic's latest features, enhancements, and important security patches, update your app's Go agent to the latest version. For additional information about specific agent updates, refer to the [Go agent release notes](/docs/release-notes/agent-release-notes/go-release-notes).

--- a/src/content/docs/agents/go-agent/instrumentation/instrument-go-segments.mdx
+++ b/src/content/docs/agents/go-agent/instrumentation/instrument-go-segments.mdx
@@ -4,7 +4,7 @@ tags:
   - Agents
   - Go agent
   - Instrumentation
-metaDescription: 'With New Relic APM''s Go agent, you can set up segments, which measure the timing of specific blocks of code in your Golang app.'
+metaDescription: "With New Relic APM's Go agent, you can set up segments, which measure the timing of specific blocks of code in your Golang app."
 redirects:
   - /docs/agents/go-agent/get-started/new-relic-go-monitor-segments
   - /docs/agents/go-agent/get-started/instrument-go-segments

--- a/src/content/docs/agents/go-agent/troubleshooting/no-data-appears-go.mdx
+++ b/src/content/docs/agents/go-agent/troubleshooting/no-data-appears-go.mdx
@@ -5,7 +5,7 @@ tags:
   - Agents
   - Go agent
   - Troubleshooting
-metaDescription: 'If your New Relic Go application isn''t reporting data, follow these troubleshooting tips.'
+metaDescription: "If your New Relic Go application isn't reporting data, follow these troubleshooting tips."
 ---
 
 ## Problem

--- a/src/content/docs/agents/java-agent/additional-installation/wildfly-installation-java.mdx
+++ b/src/content/docs/agents/java-agent/additional-installation/wildfly-installation-java.mdx
@@ -4,7 +4,7 @@ tags:
   - Agents
   - Java agent
   - Additional installation
-metaDescription: 'If you use WildFly version 11, New Relic''s Java agent requires additional configuration after you install it.'
+metaDescription: "If you use WildFly version 11, New Relic's Java agent requires additional configuration after you install it."
 redirects:
   - /docs/agents/java-agent/additional-installation/wildfly-11-installation-java
   - /docs/agents/java-agent/additional-installation/wildfly-version-11-installation-java

--- a/src/content/docs/agents/java-agent/api-guides/guide-using-java-agent-api.mdx
+++ b/src/content/docs/agents/java-agent/api-guides/guide-using-java-agent-api.mdx
@@ -6,7 +6,7 @@ tags:
   - API guides
 translate:
   - jp
-metaDescription: 'A goal-focused guide to New Relic''s Java agent API, with links to relevant sections of the complete API documentation on GitHub.'
+metaDescription: "A goal-focused guide to New Relic's Java agent API, with links to relevant sections of the complete API documentation on GitHub."
 redirects:
   - /docs/java/java-agent-api
   - /docs/agents/java-agent/custom-instrumentation/instrumentation-tasks

--- a/src/content/docs/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -6,7 +6,7 @@ tags:
   - Configuration
 translate:
   - jp
-metaDescription: 'New Relic''s Java agent config settings for APM, including transaction tracer, errors, custom instrumentation, distributed tracing, system properties, etc.'
+metaDescription: "New Relic's Java agent config settings for APM, including transaction tracer, errors, custom instrumentation, distributed tracing, system properties, etc."
 redirects:
   - /docs/docs/java-agent-configuration
   - /docs/java/java-agent-configuration

--- a/src/content/docs/agents/java-agent/configuration/java-agent-error-configuration.mdx
+++ b/src/content/docs/agents/java-agent/configuration/java-agent-error-configuration.mdx
@@ -4,7 +4,7 @@ tags:
   - Agents
   - Java agent
   - Configuration
-metaDescription: 'Use New Relic''s Java agent to prevent expected errors from affecting error rate or Apdex score, also to ignore or report errors not reported automatically.'
+metaDescription: "Use New Relic's Java agent to prevent expected errors from affecting error rate or Apdex score, also to ignore or report errors not reported automatically."
 ---
 
 APM's Java agent reports detailed information about errors that occur within your application. This gives you insight into problematic areas that may be affecting your application’s performance or the end user’s experience.

--- a/src/content/docs/agents/java-agent/custom-instrumentation/custom-instrumentation-editor-instrument-ui.mdx
+++ b/src/content/docs/agents/java-agent/custom-instrumentation/custom-instrumentation-editor-instrument-ui.mdx
@@ -6,7 +6,7 @@ tags:
   - Custom instrumentation
 translate:
   - jp
-metaDescription: 'To instrument methods and frameworks in your Java app directly from the APM UI, use New Relic''s custom instrumentation editor.'
+metaDescription: "To instrument methods and frameworks in your Java app directly from the APM UI, use New Relic's custom instrumentation editor."
 redirects:
   - /docs/apm/applications-menu/features/custom-instrumentation-editor-quickly-customize-your-java-instrumentation
   - /docs/agents/java-agent/custom-instrumentation/custom-instrumentation-editor-quickly-customize-your-java-instrumentation

--- a/src/content/docs/agents/java-agent/custom-instrumentation/custom-jmx-yaml-examples.mdx
+++ b/src/content/docs/agents/java-agent/custom-instrumentation/custom-jmx-yaml-examples.mdx
@@ -4,7 +4,7 @@ tags:
   - Agents
   - Java agent
   - Custom instrumentation
-metaDescription: 'Example of a custom JMX YAML file for New Relic''s Java agent: value and definition, MBean, attributes, type, and names for metrics, objects, and attributes.'
+metaDescription: "Example of a custom JMX YAML file for New Relic's Java agent: value and definition, MBean, attributes, type, and names for metrics, objects, and attributes."
 redirects:
   - /docs/java/java-agent-custom-instrument-jmx-yaml-example
   - /docs/java/custom-jmx-yaml-examples

--- a/src/content/docs/agents/java-agent/features/jvms-page-java-view-app-server-metrics-jmx.mdx
+++ b/src/content/docs/agents/java-agent/features/jvms-page-java-view-app-server-metrics-jmx.mdx
@@ -6,7 +6,7 @@ tags:
   - Features
 translate:
   - jp
-metaDescription: 'APM''s JVM page for Java: Thread pools, HTTP sessions, and transactions; WebSphere PMI and WebLogic JMX metrics.'
+metaDescription: "APM's JVM page for Java: Thread pools, HTTP sessions, and transactions; WebSphere PMI and WebLogic JMX metrics."
 redirects:
   - /docs/applications-dashboards/jvm-metrics
   - /docs/site/jvm-metrics

--- a/src/content/docs/agents/java-agent/getting-started/introduction-new-relic-java.mdx
+++ b/src/content/docs/agents/java-agent/getting-started/introduction-new-relic-java.mdx
@@ -6,7 +6,7 @@ tags:
   - Getting started
 translate:
   - jp
-metaDescription: 'For an overview of New Relic''s Java agent (compatibility, requirements, installation, configuration), start here.'
+metaDescription: "For an overview of New Relic's Java agent (compatibility, requirements, installation, configuration), start here."
 redirects:
   - /docs/java/new-relic-for-java
   - /docs/java/java-agent-installation

--- a/src/content/docs/agents/java-agent/installation/uninstall-java-agent.mdx
+++ b/src/content/docs/agents/java-agent/installation/uninstall-java-agent.mdx
@@ -4,7 +4,7 @@ tags:
   - Agents
   - Java agent
   - Installation
-metaDescription: 'To uninstall New Relic''s Java agent, delete the newrelic folder from root and the Java options variable from your startup script, then restart your app.'
+metaDescription: "To uninstall New Relic's Java agent, delete the newrelic folder from root and the Java options variable from your startup script, then restart your app."
 ---
 
 This document explains how to uninstall the New Relic Java agent. For instructions on how to temporarily disable the agent, see [Disable the agent](/docs/agents/manage-apm-agents/installation/disable-apm-agent#java).

--- a/src/content/docs/agents/java-agent/instrumentation/use-rabbitmq-or-jms-message-queues.mdx
+++ b/src/content/docs/agents/java-agent/instrumentation/use-rabbitmq-or-jms-message-queues.mdx
@@ -4,7 +4,7 @@ tags:
   - Agents
   - Java agent
   - Instrumentation
-metaDescription: 'To troubleshoot queue operations'' performance problems, use RabbitMQ with New Relic''s Java agent 3.9.0 or higher or JMS with Java agent 3.1.1 or higher.'
+metaDescription: "To troubleshoot queue operations' performance problems, use RabbitMQ with New Relic's Java agent 3.9.0 or higher or JMS with Java agent 3.1.1 or higher."
 redirects:
   - /docs/agents/java-agent/instrumentation/use-rabbitmq-message-queues
   - /docs/agents/java-agent/instrumentation/use-rabbitmq-jms-message-queues

--- a/src/content/docs/agents/java-agent/troubleshooting/firewall-or-traffic-connectivity-failures.mdx
+++ b/src/content/docs/agents/java-agent/troubleshooting/firewall-or-traffic-connectivity-failures.mdx
@@ -5,7 +5,7 @@ tags:
   - Agents
   - Java agent
   - Troubleshooting
-metaDescription: 'If your Java app''s logs show INFO messages about connectivity failures with New Relic, follow these troubleshooting steps based on frequency of the message.'
+metaDescription: "If your Java app's logs show INFO messages about connectivity failures with New Relic, follow these troubleshooting steps based on frequency of the message."
 redirects:
   - /docs/java/java-kb-103
   - /node/2401

--- a/src/content/docs/agents/java-agent/troubleshooting/java-solr-data-does-not-appear.mdx
+++ b/src/content/docs/agents/java-agent/troubleshooting/java-solr-data-does-not-appear.mdx
@@ -5,7 +5,7 @@ tags:
   - Agents
   - Java agent
   - Troubleshooting
-metaDescription: 'If your Java app''s Solr data is missing or not reporting to New Relic, follow these troubleshooting steps to ensure Solr is configured correctly.'
+metaDescription: "If your Java app's Solr data is missing or not reporting to New Relic, follow these troubleshooting steps to ensure Solr is configured correctly."
 redirects:
   - /docs/agents/java-agent/troubleshooting/solr-metrics-not-appearing-solr-tab
   - /docs/agents/java-agent/troubleshooting/solr-metrics-not-appearing-apm-solr-tab

--- a/src/content/docs/agents/java-agent/troubleshooting/nullpointerexception-issues-java.mdx
+++ b/src/content/docs/agents/java-agent/troubleshooting/nullpointerexception-issues-java.mdx
@@ -5,7 +5,7 @@ tags:
   - Agents
   - Java agent
   - Troubleshooting
-metaDescription: 'What to do if you see NullPointerException issues with SEVERE: or ERROR: in your New Relic Java agent''s log files.'
+metaDescription: "What to do if you see NullPointerException issues with SEVERE: or ERROR: in your New Relic Java agent's log files."
 redirects:
   - /docs/java/java-kb-104
   - /docs/agents/java-agent/troubleshooting/nullpointerexception-issues

--- a/src/content/docs/agents/manage-apm-agents/configuration/view-config-values-your-app.mdx
+++ b/src/content/docs/agents/manage-apm-agents/configuration/view-config-values-your-app.mdx
@@ -5,7 +5,7 @@ tags:
   - Agents
   - Manage APM agents
   - Configuration
-metaDescription: 'To view the agent configuration settings for your app without having to open the config file itself, use New Relic APM''s Agent initialization page.'
+metaDescription: "To view the agent configuration settings for your app without having to open the config file itself, use New Relic APM's agent initialization page."
 redirects:
   - /docs/agents/manage-apm-agents/troubleshooting/view-config-values-your-app
 ---

--- a/src/content/docs/agents/manage-apm-agents/troubleshooting/get-environment-data-about-your-apm-app.mdx
+++ b/src/content/docs/agents/manage-apm-agents/troubleshooting/get-environment-data-about-your-apm-app.mdx
@@ -5,7 +5,7 @@ tags:
   - Agents
   - Manage APM agents
   - Troubleshooting
-metaDescription: 'To get information about your application''s services, agent versions, and other settings, use New Relic APM''s Environment snapshot page.'
+metaDescription: "To get information about your application's services, agent versions, and other settings, use New Relic APM's Environment snapshot page."
 redirects:
   - /docs/agents/manage-apm-agents/agent-data/get-environment-data-about-your-apm-app
 ---

--- a/src/content/docs/agents/net-agent/api-guides/guide-using-net-agent-api.mdx
+++ b/src/content/docs/agents/net-agent/api-guides/guide-using-net-agent-api.mdx
@@ -6,7 +6,7 @@ tags:
   - API guides
 translate:
   - jp
-metaDescription: 'A goal-focused guide to New Relic''s .NET agent API, with links to relevant sections of the complete API documentation.'
+metaDescription: "A goal-focused guide to New Relic's .NET agent API, with links to relevant sections of the complete API documentation."
 redirects:
   - /docs/agents/net-agent/net-agent-api/net-agent-api-guide
   - /docs/agents/net-agent/net-agent-api/guide-using-net-agent-api

--- a/src/content/docs/agents/net-agent/attributes/custom-attributes-net.mdx
+++ b/src/content/docs/agents/net-agent/attributes/custom-attributes-net.mdx
@@ -4,7 +4,7 @@ tags:
   - Agents
   - NET agent
   - Attributes
-metaDescription: 'APM''s .NET agent: how custom attribute values are processed and how they will appear in APM.'
+metaDescription: "APM's .NET agent: how custom attribute values are processed and how they will appear in APM."
 redirects:
   - /docs/agents/net-agent/attributes/custom-attributes
 ---

--- a/src/content/docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation.mdx
+++ b/src/content/docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation.mdx
@@ -6,7 +6,7 @@ tags:
   - Custom instrumentation
 translate:
   - jp
-metaDescription: 'How to instrument (or time) code that New Relic''s .NET agent does not instrument by default, and how to choose between the two methods.'
+metaDescription: "How to instrument (or time) code that New Relic's .NET agent does not instrument by default, and how to choose between the two methods."
 redirects:
   - /docs/dotnet/CustomInstrumentation
   - /docs/dotnet/dotnet-agent-custom-metrics

--- a/src/content/docs/agents/net-agent/getting-started/introduction-new-relic-net.mdx
+++ b/src/content/docs/agents/net-agent/getting-started/introduction-new-relic-net.mdx
@@ -6,7 +6,7 @@ tags:
   - Getting started
 translate:
   - jp
-metaDescription: 'An overview of New Relic''s .NET APM agent, including features, resources for installation, configuration, and troubleshooting.'
+metaDescription: "An overview of New Relic's .NET APM agent, including features, resources for installation, configuration, and troubleshooting."
 redirects:
   - /docs/docs/net-support
   - /docs/dotnet/AgentDocumentation

--- a/src/content/docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -6,7 +6,7 @@ tags:
   - Getting started
 translate:
   - jp
-metaDescription: 'APM .NET agent: Software and hardware requirements for the agent''s support of .NET Core, and an explanation of automatically instrumented features.'
+metaDescription: "APM .NET agent: Software and hardware requirements for the agent's support of .NET Core, and an explanation of automatically instrumented features."
 redirects:
   - /docs/agents/net-agent/getting-started/compatibility-requirements-net-core-agent
   - /docs/agents/net-agent/getting-started/compatibility-requirements-net-core-20-agent

--- a/src/content/docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -6,7 +6,7 @@ tags:
   - Getting started
 translate:
   - jp
-metaDescription: 'New Relic APM''s .NET agent for .NET Framework applications: compatibility and requirement, and what frameworks are automatically instrumented.'
+metaDescription: "New Relic APM's .NET agent for .NET Framework applications: compatibility and requirement, and what frameworks are automatically instrumented."
 redirects:
   - /docs/agents/net-agent/getting-started/compatibility-requirements-net-agent
   - /docs/agents/net-agent/getting-started/compatibility-requirements-net-framework-agent

--- a/src/content/docs/agents/net-agent/net-agent-api/start-agent.mdx
+++ b/src/content/docs/agents/net-agent/net-agent-api/start-agent.mdx
@@ -6,7 +6,7 @@ tags:
   - Agents
   - NET agent
   - NET agent API
-metaDescription: 'New Relic .NET agent API call to force the .NET agent to start, if it hasn''t been started already. Usually unnecessary, since the agent starts automatically.'
+metaDescription: "New Relic .NET agent API call to force the .NET agent to start, if it hasn't been started already. Usually unnecessary, since the agent starts automatically."
 redirects:
   - /docs/agents/net-agent/net-agent-api/startagent-net-agent
 ---

--- a/src/content/docs/agents/net-agent/other-features/async-support-net.mdx
+++ b/src/content/docs/agents/net-agent/other-features/async-support-net.mdx
@@ -4,7 +4,7 @@ tags:
   - Agents
   - NET agent
   - Other features
-metaDescription: 'How to activate asynchronous mode with New Relic''s .NET agent, plus a summary of new, disabled, or unavailable features when async mode is active.'
+metaDescription: "How to activate asynchronous mode with New Relic's .NET agent, plus a summary of new, disabled, or unavailable features when async mode is active."
 redirects:
   - /docs/agents/net-agent/features/enable-async-net-agent
   - /docs/agents/net-agent/features/try-out-net-agents-async-mode

--- a/src/content/docs/agents/net-agent/troubleshooting/no-browser-data-appears-net.mdx
+++ b/src/content/docs/agents/net-agent/troubleshooting/no-browser-data-appears-net.mdx
@@ -5,7 +5,7 @@ tags:
   - Agents
   - NET agent
   - Troubleshooting
-metaDescription: 'If your New Relic .NET application isn''t reporting browser data, follow these troubleshooting procedures.'
+metaDescription: "If your New Relic .NET application isn't reporting browser data, follow these troubleshooting procedures."
 redirects:
   - /docs/agents/net-agent/troubleshooting/no-page-load-timing-data-appears-net
   - /node/8351

--- a/src/content/docs/agents/net-agent/troubleshooting/resolve-net-scom-conflicts.mdx
+++ b/src/content/docs/agents/net-agent/troubleshooting/resolve-net-scom-conflicts.mdx
@@ -5,7 +5,7 @@ tags:
   - Agents
   - NET agent
   - Troubleshooting
-metaDescription: 'If you are running SCOM and New Relic''s .NET agent, enable SCOM APM and repair the installation to resolve conflicts.'
+metaDescription: "If you are running SCOM and New Relic's .NET agent, enable SCOM APM and repair the installation to resolve conflicts."
 redirects:
   - /docs/dotnet/dotnet-kb-104
   - /docs/agents/net-agent/troubleshooting/resolving-net-and-scom-conflicts

--- a/src/content/docs/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -732,7 +732,7 @@ New Relic's Node.js agent includes additional API calls.
     newrelic.getBrowserTimingHeader()
     ```
 
-    Returns the HTML snippet to be inserted into the header of HTML pages to enable [New Relic Browser](/docs/agents/nodejs-agent/supported-features/page-load-timing-nodejs). The HTML will instruct the browser to fetch a small JavaScript file and start the page timer.
+    Returns the HTML snippet to be inserted into the header of HTML pages to enable [browser monitoring](/docs/agents/nodejs-agent/supported-features/page-load-timing-nodejs). The HTML will instruct the browser to fetch a small JavaScript file and start the page timer.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs.mdx
+++ b/src/content/docs/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs.mdx
@@ -4,7 +4,7 @@ tags:
   - Agents
   - Nodejs agent
   - Troubleshooting
-metaDescription: 'To reduce disk space consumption, be sure to lower the ''trace'' log level after generating a troubleshooting log for your New Relic Node.js agent.'
+metaDescription: "To reduce disk space consumption, be sure to lower the 'trace' log level after generating a troubleshooting log for your New Relic Node.js agent."
 redirects:
   - /docs/agents/nodejs-agent/troubleshooting/generate-logs-troubleshooting-nodejs
 ---

--- a/src/content/docs/prometheus-remote-write-integration.mdx
+++ b/src/content/docs/prometheus-remote-write-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Prometheus remote write integration
-metaDescription: 'New Relic''s Prometheus remote write integration: get started info.'
+metaDescription: "New Relic's Prometheus remote write integration: get started info."
 watermark: |-
   EARLY
   ACCESS


### PR DESCRIPTION
While working on #2926, I ran across a number of docs with malformed metadescriptions. This PR sweeps the site for these using this VS code regex search:

![image](https://user-images.githubusercontent.com/55203603/124223533-bfb3c780-dab8-11eb-8792-cf9689ea7997.png)
