### PR TITLE
Fixed broken image in NRQL syntax, clauses, and functions

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -1351,12 +1351,12 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
       >
         Use the `name` attribute to return a score for a specific transaction, or return an overall Apdex by omitting `name`. This query returns an Apdex score for the **Controller/notes/index** transaction over the last hour:
 
-        ```
-        SELECT apdex(duration, t: 0.5) from Transaction
-          WHERE name='Controller/notes/index' SINCE 1 hour ago
-        ```
+      ```
+      SELECT apdex(duration, t: 0.5) from Transaction
+      WHERE name='Controller/notes/index' SINCE 1 hour ago
+      ```
 
-        ![crop-apdex-function](./images/screen-apdex-function.png "crop-apdex-function")
+      ![crop-apdex-function](./images/screen-apdex-function.png "crop-apdex-function")
 
         <figcaption>
           The `apdex` function returns an [Apdex score](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction) that measures user satisfaction with your site. Arguments are a response time attribute and an Apdex T threshold in seconds.

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -1351,16 +1351,16 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
       >
         Use the `name` attribute to return a score for a specific transaction, or return an overall Apdex by omitting `name`. This query returns an Apdex score for the **Controller/notes/index** transaction over the last hour:
 
-      ```
-      SELECT apdex(duration, t: 0.5) from Transaction
-      WHERE name='Controller/notes/index' SINCE 1 hour ago
-      ```
-
-      ![crop-apdex-function](./images/screen-apdex-function.png "crop-apdex-function")
+        ![crop-apdex-function](./images/screen-apdex-function.png "crop-apdex-function")
 
         <figcaption>
           The `apdex` function returns an [Apdex score](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction) that measures user satisfaction with your site. Arguments are a response time attribute and an Apdex T threshold in seconds.
         </figcaption>
+
+      ```
+      SELECT apdex(duration, t: 0.5) from Transaction
+      WHERE name='Controller/notes/index' SINCE 1 hour ago
+      ```
       </Collapser>
 
       <Collapser title="Get overall Apdex for your app">


### PR DESCRIPTION
Moved the image before the code block so the image is visible.