### PR TITLE
Some removals of 'Account settings UI page' references

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/new-relic-license-key.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/new-relic-license-key.mdx
@@ -24,10 +24,7 @@ Your New Relic license key is a 40-character hexadecimal string created when you
 
 ## View and manage your license key [#finding]
 
-You can view the license key for your New Relic account in the [API keys page](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher).
-
-1. From the [account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown), select **Account settings**.
-2. Select **API keys** from the options at the side of the page.
+To view the license key: from the [account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown), click **API keys**.
 
 You can also get to the **API keys** page by navigating directly to [one.newrelic.com/launcher/api-keys-ui.api-keys-launcher](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher).
 

--- a/src/content/docs/accounts/accounts-billing/account-setup/new-relic-license-key.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/new-relic-license-key.mdx
@@ -24,7 +24,7 @@ Your New Relic license key is a 40-character hexadecimal string created when you
 
 ## View and manage your license key [#finding]
 
-To view the license key: from the [account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown), click **API keys**.
+To view the license key: From the [account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown), click **API keys**.
 
 You can also get to the **API keys** page by navigating directly to [one.newrelic.com/launcher/api-keys-ui.api-keys-launcher](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher).
 

--- a/src/content/docs/accounts/accounts/saml-single-sign/delete-sso-configuration.mdx
+++ b/src/content/docs/accounts/accounts/saml-single-sign/delete-sso-configuration.mdx
@@ -4,11 +4,15 @@ tags:
   - Accounts
   - Original accounts and billing
   - SAML SSO (original users)
-metaDescription: 'If account Owners delete their SAML SSO integration with New Relic, they cannot restore it, but they can follow standard procedures to set it up again.'
+metaDescription: 'New Relic original user model: tips on deleting an SSO configuration.'
 redirects:
   - /docs/subscriptions/deleting-the-sso-configuration
   - /docs/accounts-partnerships/accounts/saml-single-sign/deleting-sso-configuration
   - /docs/accounts-partnerships/accounts/saml-single-sign/delete-sso-configuration
+watermark: |-
+  Original
+  user
+  model
 ---
 
 <Callout variant="important">

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -28,7 +28,7 @@ New Relic has several different [APIs](/docs/apis/getting-started/intro-apis/int
 
 ## Manage API keys in UI [#find]
 
-Here's [a direct link to the API keys UI page](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher). To find this from the New Relic UI: from the [account dropdown](/docs/using-new-relic/welcome-new-relic/get-started/glossary#account-dropdown), select **API keys**.
+Here's [a direct link to the API keys UI page](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher). To find this from the New Relic UI: From the [account dropdown](/docs/using-new-relic/welcome-new-relic/get-started/glossary#account-dropdown), select **API keys**.
 
 ## Overview of API keys [#types]
 

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -28,10 +28,7 @@ New Relic has several different [APIs](/docs/apis/getting-started/intro-apis/int
 
 ## Manage API keys in UI [#find]
 
-Here's [a direct link to the API keys UI page](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher). To find this from the New Relic UI:
-
-1. From the [account dropdown](/docs/using-new-relic/welcome-new-relic/get-started/glossary#account-dropdown), select **Account settings**.
-2. Select **API keys**.
+Here's [a direct link to the API keys UI page](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher). To find this from the New Relic UI: from the [account dropdown](/docs/using-new-relic/welcome-new-relic/get-started/glossary#account-dropdown), select **API keys**.
 
 ## Overview of API keys [#types]
 

--- a/src/content/docs/telemetry-data-platform/ingest-apis/introduction-event-api.mdx
+++ b/src/content/docs/telemetry-data-platform/ingest-apis/introduction-event-api.mdx
@@ -88,10 +88,8 @@ You submit multiple event types under a single Insert API key. However, to help 
 
 To register an Insert API key:
 
-1. From [one.newrelic.com](https://one.newrelic.com), click the [account dropdown](/docs/using-new-relic/welcome-new-relic/get-started/glossary#account-dropdown) and then click **Account settings**.
-2. Click **API keys** and click **Insights insert keys**.
-3. Next to the **Insert keys** heading, select the <Icon name="fe-plus"/>
-   symbol and follow the instructions.
+1. From [one.newrelic.com](https://one.newrelic.com), click the [account dropdown](/docs/using-new-relic/welcome-new-relic/get-started/glossary#account-dropdown), click **API keys**, and click **Insights insert keys**.
+2. Next to the **Insert keys** heading, select the <Icon name="fe-plus"/> symbol and follow the instructions.
 
 The **Insert key** page lists the [curl command](#submit-event) necessary to add event data for the key.
 


### PR DESCRIPTION
Noticed a couple bad mentions of 'Account settings' UI page, which isn't available for v2 users. So I fixed that. 

I'm out next week so if someone can merge this for me, apprciated. 