### PR TITLE
fix: MINION_VSE_PASSPHRASE

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/verified-script-execution-private-locations.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/verified-script-execution-private-locations.mdx
@@ -27,13 +27,13 @@ To enable verified script execution for containerized private minions, do the fo
 1. Go to **[one.newrelic.com](https://one.newrelic.com/) > Synthetics > Private locations > (select a private location)**. Select the private location's ellipses icon, and click **Edit**. Enable verified script execution, then save.
 2. Set the passphrase in your Docker or Kubernetes environment:
 
-   * **Docker:** Add the `MINION_VSE_PASSWORD` environment variable to the Docker `run` command used to start your private minion:
+   * **Docker:** Add the `MINION_VSE_PASSPHRASE` environment variable to the Docker `run` command used to start your private minion:
 
      ```
      docker run \
        --name <var>YOUR_CONTAINER_NAME</var> \
        -e "MINION_PRIVATE_LOCATION_KEY=<var>YOUR_PRIVATE_LOCATION_KEY</var>" \
-       -e "MINION_VSE_PASSWORD=<var>YOUR_PASSPHRASE</var>"
+       -e "MINION_VSE_PASSPHRASE=<var>YOUR_PASSPHRASE</var>"
        -v /tmp:/tmp:rw \
        -v /var/run/docker.sock:/var/run/docker.sock:rw \
        -d \
@@ -58,13 +58,13 @@ To change your passphrase, do the following. Be sure to record your passphrase i
 
 1. Update the passphrase in your Docker or Kubernetes environment:
 
-   * **Docker:** Stop your current minion. Then use the Docker `run` command to start a new minion with your updated `MINION_VSE_PASSWORD` environment variable:
+   * **Docker:** Stop your current minion. Then use the Docker `run` command to start a new minion with your updated `MINION_VSE_PASSPHRASE` environment variable:
 
      ```
      docker run \
        --name <var>YOUR_CONTAINER_NAME</var> \
        -e "MINION_PRIVATE_LOCATION_KEY=<var>YOUR_PRIVATE_LOCATION_KEY</var>" \
-       -e "MINION_VSE_PASSWORD=<var>YOUR_PASSPHRASE</var>"
+       -e "MINION_VSE_PASSPHRASE=<var>YOUR_PASSPHRASE</var>"
        -v /tmp:/tmp:rw \
        -v /var/run/docker.sock:/var/run/docker.sock:rw \
        -d \
@@ -89,7 +89,7 @@ To disable verified script execution for containerized private minions:
 
 1. Remove the passphrase in your Docker or Kubernetes environment:
 
-   * **Docker:** Stop your current minion container. Then use the Docker `run` command to start a new minion without the `MINION_VSE_PASSWORD` environment variable:
+   * **Docker:** Stop your current minion container. Then use the Docker `run` command to start a new minion without the `MINION_VSE_PASSPHRASE` environment variable:
 
      ```
      docker run \


### PR DESCRIPTION
- `MINION_VSE_PASSWORD` does not exist
- Corrected to `MINION_VSE_PASSPHRASE`

### Give us some context

* What problems does this PR solve? Wrong env var was listed in docs.

https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration/#docker-env-config
