### PR TITLE
fix for stalled workflows

### DIFF
--- a/.github/workflows/update-whats-new-ids.yml
+++ b/.github/workflows/update-whats-new-ids.yml
@@ -2,6 +2,8 @@ name: whats-new
 
 on:
   pull_request:
+    types:
+      - opened
     branches:
       - main
 
@@ -18,6 +20,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: develop
+          persist-credentials: false
 
       - name: Setup node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
* this action currently does not trigger workflow push event. adding
`persist-credentials: false` should let it trigger the event, and
limiting the type to `opened` is to prevent the action from triggering
the workflow endlessly when a change is pushed.

Resolves: #2932 