### PR TITLE
Fixing typo

### DIFF
--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -259,7 +259,7 @@ FROM Metric SELECT bytecountestimate() where collector.name='cloudwatch-metric-s
 
 We recommend the following actions to control the data being ingested:
 * Make sure metric streams are enabled only on the AWS accounts and regions you want to monitor with New Relic.
-* Use the inclusion and exclusion filters in CloudWatch Metric Stream is order to select which services / namespaces are being collected.
+* Use the inclusion and exclusion filters in the CloudWatch Metric Stream in order to select which services / namespaces are being collected.
 * Consider using [drop data rules](https://docs.newrelic.com/docs/telemetry-data-platform/manage-data/drop-data-using-nerdgraph/) to discard metrics based on custom filters (for example, drop metrics by namespace and tag, tag value, or any other valid NRQL criteria).
 
 <Callout variant="important">


### PR DESCRIPTION
Fixing a typo

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

Fixing a typo in this:

> Use the inclusion and exclusion filters in CloudWatch Metric Stream is order to select which services / namespaces are being collected.

"is order" should be "in order".

Also changed "in CloudWatch Metric Stream" to "in the CloudWatch Metric Stream"

### Are you making a change to site code?

No

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.