### PR TITLE
enable translation workflow to handle 'sending' documents that dont exist

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,4 +4,5 @@ module.exports = {
   tabWidth: 2,
   semi: true,
   singleQuote: true,
+  arrowParens: 'always',
 };

--- a/scripts/actions/__tests__/send-and-update-translation-queue.test.js
+++ b/scripts/actions/__tests__/send-and-update-translation-queue.test.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+
+const { getContent } = require('../send-and-update-translation-queue');
+
+jest.mock('../serialize-mdx');
+jest.mock('fs');
+
+test('getContent skips over files that dont exist', async () => {
+  fs.existsSync
+    .mockReturnValueOnce(false)
+    .mockReturnValueOnce(false)
+    .mockReturnValueOnce(false)
+    .mockReturnValue(true);
+
+  const mockInput = {
+    jp: ['slug1', 'slug2', 'slug3', 'slug4', 'slug5'],
+  };
+
+  const fileContent = getContent(mockInput);
+  const pages = await fileContent['jp'];
+
+  expect(pages.length).toBe(2); // 5 submitted slugs - 3 false mock returns = 2 files not skipped
+});

--- a/scripts/actions/send-and-update-translation-queue.js
+++ b/scripts/actions/send-and-update-translation-queue.js
@@ -41,6 +41,7 @@ const getContent = (locales) => {
              * this step, it won't become a failed upload, and will then be
              * cleaned up from the queue.
              */
+            console.log(`Skipping over -- ${slug} -- since it no longer exists.`);
             return fs.existsSync(path.join(process.cwd(), slug));
           })
           .map(async (slug) => {

--- a/scripts/actions/send-and-update-translation-queue.js
+++ b/scripts/actions/send-and-update-translation-queue.js
@@ -29,7 +29,7 @@ const DOCS_SITE_URL = 'https://docs.newrelic.com';
  * @returns {Object<string, Promise<Page[]>>}
  */
 const getContent = (locales) => {
-  Object.entries(locales).reduce((acc, [locale, slugs]) => {
+  return Object.entries(locales).reduce((acc, [locale, slugs]) => {
     return {
       ...acc,
       [locale]: Promise.all(
@@ -283,4 +283,13 @@ const main = async () => {
   }
 };
 
-main();
+/**
+ * This allows us to check if the script was invoked directly from the command line, i.e 'node validate_packs.js', or if it was imported.
+ * This would be true if this was used in one of our GitHub workflows, but false when imported for use in a test.
+ * See here: https://nodejs.org/docs/latest/api/modules.html#modules_accessing_the_main_module
+ */
+if (require.main === module) {
+  main();
+}
+
+module.exports = { main, getContent };

--- a/scripts/actions/send-and-update-translation-queue.js
+++ b/scripts/actions/send-and-update-translation-queue.js
@@ -36,8 +36,8 @@ const getContent = (locales) => {
         slugs
           .filter((slug) => {
             /**
-             * if a doc doesn't exist, it must have been renamed or deleted. in
-             * that case, it is safe to ignore. if we skip including a doc in
+             * If a doc doesn't exist, it must have been renamed or deleted. In
+             * that case, it is safe to ignore. If we skip including a doc in
              * this step, it won't become a failed upload, and will then be
              * cleaned up from the queue.
              */


### PR DESCRIPTION
This PR is for allowing the send translation workflow to handle files that are queued for translation, but dont exist due to being renamed or deleted in a separate edit. 

The way this is done is to ignore getting the content for those documents. This prevents them from being sent for translation, which also removes them from the queue, since only failed uploads are left on the queue.

Resolves: #2931