### PR TITLE
Increase max layout column of a widget

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/dashboards/dashboards-api.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/dashboards-api.mdx
@@ -73,7 +73,7 @@ We have limited the values you can set to some of the dashboard properties. This
 | Maximum length of a widget title              | 255 |
 | Maximum number of entities linked to a widget | 1 |
 | Maximum number of queries in a widget         | 20 |
-| Maximum layout column of a widget             | 11|
+| Maximum layout column of a widget             | 12|
 | Minimum layout column of a widget             | 1|
 | Minimum layout row of a widget                | 1|
 | Maximum layout width of a widget              | 12|


### PR DESCRIPTION
### What

Small fix in the limits of a widget. In this case the maximum column a widget can have.