### PR TITLE
Handle paginated results from the Github API

### DIFF
--- a/scripts/actions/add-files-to-translation-queue.js
+++ b/scripts/actions/add-files-to-translation-queue.js
@@ -15,7 +15,7 @@ const { prop } = require('../utils/functional');
  */
 const getUpdatedQueue = async (url, queue) => {
   try {
-    const files = await fetchPaginatedGHResults(url);
+    const files = await fetchPaginatedGHResults(url, process.env.GITHUB_TOKEN);
 
     const mdxFiles = files
       ? files.filter((file) => path.extname(file.filename) === '.mdx')

--- a/scripts/actions/add-files-to-translation-queue.js
+++ b/scripts/actions/add-files-to-translation-queue.js
@@ -1,8 +1,8 @@
 const fs = require('fs');
 const path = require('path');
-const fetch = require('node-fetch');
 const frontmatter = require('@github-docs/frontmatter');
 
+const { fetchPaginatedGHResults } = require('./utils/github-api-helpers');
 const { saveToTranslationQueue } = require('./utils/save-to-db');
 const loadFromDB = require('./utils/load-from-db');
 const checkArgs = require('./utils/check-args');
@@ -15,8 +15,7 @@ const { prop } = require('../utils/functional');
  */
 const getUpdatedQueue = async (url, queue) => {
   try {
-    const resp = await fetch(url);
-    const files = await resp.json();
+    const files = await fetchPaginatedGHResults(url);
 
     const mdxFiles = files
       ? files.filter((file) => path.extname(file.filename) === '.mdx')

--- a/scripts/actions/utils/__tests__/github-api-helpers.test.js
+++ b/scripts/actions/utils/__tests__/github-api-helpers.test.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const {
+  getNextLink,
+  fetchPaginatedGHResults,
+} = require('../github-api-helpers');
+
+jest.mock('node-fetch');
+
+const fetch = require('node-fetch');
+
+describe('Github API Helpers', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('getNextLink', () => {
+    test('returns null for malformed header', async () => {
+      expect(getNextLink('askdflaksjdhf2421dfdfs')).toBe(null);
+    });
+
+    test('returns null when `next` is not present', async () => {
+      expect(
+        getNextLink('<https://fakesite.com/files?page=1>; rel="last"')
+      ).toBe(null);
+    });
+
+    test('returns url for next page', async () => {
+      expect(
+        getNextLink(
+          '<https://fakesite.com/files?page=36>; rel="last", <https://fakesite.com/files?page=2>; rel="next"'
+        )
+      ).toEqual('https://fakesite.com/files?page=2');
+    });
+  });
+
+  describe('fetchPaginatedGHResults', () => {
+    test('throws error when response is not ok', async () => {
+      fetch.mockResolvedValueOnce({ ok: false });
+      await expect(fetchPaginatedGHResults('test', 'test')).rejects.toThrow();
+    });
+
+    test('properly sets API URL and token', async () => {
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([]),
+        headers: {
+          get: () => null,
+        },
+      });
+
+      await fetchPaginatedGHResults('testurl', 'testtoken');
+      expect(fetch.mock.calls[0]).toEqual([
+        'testurl',
+        { headers: { authorization: 'token testtoken' } },
+      ]);
+    });
+
+    test('returns 1 page of results', async () => {
+      const files = [{ file: 1 }, { file: 2 }, { file: 3 }];
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(files),
+        headers: {
+          get: () => null,
+        },
+      });
+
+      const page = await fetchPaginatedGHResults('test', 'test');
+      expect(page).toEqual(files);
+    });
+
+    test('returns more than 1 page of results', async () => {
+      const files = [{ file: 1 }, { file: 2 }, { file: 3 }];
+      fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(files.slice(0, 1)),
+          headers: {
+            get: () => '<https://fakesite.com/files?page=2>; rel="next"',
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(files.slice(1, 2)),
+          headers: {
+            get: () => '<https://fakesite.com/files?page=3>; rel="next"',
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(files.slice(2)),
+          headers: {
+            get: () => '',
+          },
+        });
+
+      const pages = await fetchPaginatedGHResults('test', 'test');
+      expect(pages).toEqual(files);
+    });
+  });
+});

--- a/scripts/actions/utils/__tests__/github-api-helpers.test.js
+++ b/scripts/actions/utils/__tests__/github-api-helpers.test.js
@@ -15,17 +15,17 @@ describe('Github API Helpers', () => {
   });
 
   describe('getNextLink', () => {
-    test('returns null for malformed header', async () => {
+    test('returns null for malformed header', () => {
       expect(getNextLink('askdflaksjdhf2421dfdfs')).toBe(null);
     });
 
-    test('returns null when `next` is not present', async () => {
+    test('returns null when `next` is not present', () => {
       expect(
         getNextLink('<https://fakesite.com/files?page=1>; rel="last"')
       ).toBe(null);
     });
 
-    test('returns url for next page', async () => {
+    test('returns url for next page', () => {
       expect(
         getNextLink(
           '<https://fakesite.com/files?page=36>; rel="last", <https://fakesite.com/files?page=2>; rel="next"'

--- a/scripts/actions/utils/github-api-helpers.js
+++ b/scripts/actions/utils/github-api-helpers.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const fetch = require('node-fetch');
+const parseLinkHeader = require('parse-link-header');
+
+/**
+ * Fetches paginated results from the Github API
+ * @param {String} url the API to query
+ * @param {String} token a token for the API
+ * @returns {Promise<Object[]>} all pages of results
+ */
+const fetchPaginatedGHResults = async (url, token) => {
+  let files = [];
+  let nextPageLink = url;
+
+  while (nextPageLink) {
+    const resp = await fetch(nextPageLink, {
+      headers: { authorization: `token ${token}` },
+    });
+    if (!resp.ok) {
+      throw new Error(
+        `Github API returned status ${resp.code} - ${resp.message}`
+      );
+    }
+    const page = await resp.json();
+    nextPageLink = getNextLink(resp.headers.get('Link'));
+    files = [...files, ...page];
+  }
+
+  return files;
+};
+
+/**
+ * Pulls the next page off of a `Link` header
+ * @param {String} linkHeader the `Link` header value
+ * @returns {String|Null} the next page of results
+ */
+const getNextLink = (linkHeader) => {
+  const parsedLinkHeader = parseLinkHeader(linkHeader);
+  if (parsedLinkHeader && parsedLinkHeader.next) {
+    return parsedLinkHeader.next.url || null;
+  }
+  return null;
+};
+
+module.exports = { fetchPaginatedGHResults, getNextLink };


### PR DESCRIPTION
# Summary
Update `add-files-to-translation-queue.js` to handle paginated results from the Github API and abstract that logic.

### Closes https://github.com/newrelic/docs-website/issues/2727 