### PR TITLE
Ubuntu 20 is supported for log-fwd in infra-agent

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
@@ -124,7 +124,7 @@ The log forwarding feature is compatible with the following operating systems:
       </td>
 
       <td>
-        Versions 16.04.x and 18.04.x (LTS versions)
+        Versions 16.04.x, 18.04.x and 20.04.x (LTS versions)
       </td>
     </tr>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* Ubuntu 20 is supported for log-fwd in infra-agent since late 2020.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.