### PR TITLE
Added changes based on new JFR "on-by-default."

### DIFF
--- a/src/content/docs/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -1494,7 +1494,7 @@ Real-time profiling can be configured in the `jfr` stanza in the agent yaml, wit
     Set to `false` to disable [Real-time profiling with JFR](/docs/agents/java-agent/features/real-time-profiling-java-using-jfr-metrics/).
     
     <Callout variant="important">
-      This applies to Java agent [version 7.1.0 or higher](/docs/release-notes/agent-release-notes/java-release-notes).
+      Real-time profiling with JFR is on my default starting in Java agent [version 7.1.0 or higher](/docs/release-notes/agent-release-notes/java-release-notes). If you are on agent version 7.0.0, you can turn on JFR by changing the value to `true`.
     </Callout>
   </Collapser>
 

--- a/src/content/docs/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -1485,16 +1485,16 @@ Real-time profiling can be configured in the `jfr` stanza in the agent yaml, wit
           </th>
 
           <td>
-            `false`
+            `true`
           </td>
         </tr>
       </tbody>
     </table>
 
-    Set to `true` to enable [Real-time profiling with JFR](/docs/agents/java-agent/features/real-time-profiling-java-using-jfr-metrics/).
+    Set to `false` to disable [Real-time profiling with JFR](/docs/agents/java-agent/features/real-time-profiling-java-using-jfr-metrics/).
     
     <Callout variant="important">
-      This applies to Java agent [version 7.0.0 or higher](/docs/release-notes/agent-release-notes/java-release-notes).
+      This applies to Java agent [version 7.1.0 or higher](/docs/release-notes/agent-release-notes/java-release-notes).
     </Callout>
   </Collapser>
 


### PR DESCRIPTION
This is a clarification of the Java configuration document. This change should go out when we announce Java Flight Recorder real time profiling that is on-by-default on July 8, 2021.