### PR TITLE
fix: infra agent config args

### DIFF
--- a/src/content/docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integrations-newer-configuration-format.mdx
+++ b/src/content/docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integrations-newer-configuration-format.mdx
@@ -86,7 +86,7 @@ This is a list of the general properties used to configure an integration. For m
       </td>
 
       <td>
-        Optional list of command line arguments when `name` is used to provide the integration executable.  
+        Optional list of command line arguments when `name` is used to provide the integration executable.
         _Available since agent version **1.13.0**._
       </td>
     </tr>
@@ -401,7 +401,7 @@ integrations:
           CONFIG_FILE: ${config.path}
         config:
           name: csvFileExample
-          apis: 
+          apis:
             - name: csvFile
               file: /Users/hello/test.csv
       - name: other-integration
@@ -417,7 +417,7 @@ integrations:
 
     ```
     name: csvFileExample
-    apis: 
+    apis:
       - name: csvFile
         file: /Users/hello/test.csv
     ```
@@ -444,7 +444,7 @@ integrations:
       - name: nri-example
         config:
           name: csvFileExample
-          apis: 
+          apis:
             - name: csvFile
               file: /Users/hello/test.csv
     ```
@@ -471,7 +471,7 @@ integrations:
       - name: foo-monitor
         exec: /opt/foo/bin/monitor --config=${config.path}
         config: |
-          foo.host=${discovery.ip} 
+          foo.host=${discovery.ip}
           foo.port=${discovery.port}
           foo.user=${my_credentials.user}
           foo.password=${my_credentials.password}
@@ -504,7 +504,7 @@ integrations:
     * First match (`/tmp/123_discovered`):
 
       ```
-      foo.host=10.0.0.3 
+      foo.host=10.0.0.3
       foo.port=8080
       foo.user=monitorer
       foo.password=5up3r53cr3t!
@@ -512,7 +512,7 @@ integrations:
     * Second match (`/tmp/456_discovered`):
 
       ```
-      foo.host=10.0.0.3 
+      foo.host=10.0.0.3
       foo.port=8081
       foo.user=monitorer
       foo.password=5up3r53cr3t!
@@ -520,7 +520,7 @@ integrations:
     * Third match (`/tmp/789_discovered`)
 
       ```
-      foo.host=10.0.0.3 
+      foo.host=10.0.0.3
       foo.port=8082
       foo.user=monitorer
       foo.password=5up3r53cr3t!
@@ -554,7 +554,7 @@ integrations:
     discovery:
         docker:
           match:
-            name: /^redis/ 
+            name: /^redis/
       integrations:
         - name: nri-flex
           env:
@@ -677,7 +677,7 @@ The properties of this section modify the way the Infrastructure agent executes 
     ```
     integrations:
       - name: nri-jmx
-        arguments:
+        cli_args:
           JMX_HOST: jmx-host.localnet
           JMX_PORT: 7096
           COLLECTION_FILES: "/etc/newrelic-infra/integrations.d/jvm-metrics.yml"
@@ -754,7 +754,7 @@ integrations:
   - name: apache-server-metrics
     integration_name: com.newrelic.apache
     command: metrics
-    arguments:
+    cli_args:
       status_url: http://127.0.0.1/server-status?auto
       remote_monitoring: true
     labels:
@@ -763,7 +763,7 @@ integrations:
   - name: apache-server-inventory
     integration_name: com.newrelic.apache
     command: inventory
-    arguments:
+    cli_args:
       remote_monitoring: true
     labels:
       env: production


### PR DESCRIPTION
Newer config format does not support `arguments` for CLI args.