### PR TITLE
fix: add github token to job

### DIFF
--- a/.github/workflows/get-slugs-to-translate.yml
+++ b/.github/workflows/get-slugs-to-translate.yml
@@ -37,6 +37,8 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Get slugs and save
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files"
           yarn get-translated-files $URL


### PR DESCRIPTION
# Summary
A quick PR to add the GITHUB_TOKEN to the add-files-translation-queue job