### PR TITLE
chore: Updated .NET NLog config instructions

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/logs-context-net/net-configure-nlog.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/logs-context-net/net-configure-nlog.mdx
@@ -65,7 +65,7 @@ Confirm that you have [log management](/docs/introduction-new-relic-logs) enable
 To configure logs in context with the NLog extension, complete the following steps:
 
 1. Using the Visual Studio [NuGet Package Manager](https://docs.microsoft.com/en-us/nuget/consume-packages/install-use-packages-visual-studio), locate and install the [`NewRelic.LogEnrichers.NLog`](https://www.nuget.org/packages/NewRelic.LogEnrichers.NLog/) package.
-2. In your application code, update your logging configuration to add the `NewRelicJsonLayout` and decide if you want to collect MappedDiagnosticsContext (MDC) or the MappedDiagnosticsLogicalContext (MDLC) data.
+2. In your application code, update your logging configuration to add the `NewRelicJsonLayout` and decide if you want to collect MappedDiagnosticsContext (**MDC**) or the MappedDiagnosticsLogicalContext (**MDLC**) data.
 
    **Don't collect MDC or the MDLC data (default)**  
    The following code example enriches log events with New Relic linking metadata, but not with MDC or the MDLC data. In addition to the existing log files, it outputs new log files in a specific JSON format at `C:\logs\NLogExample.log.json` for consumption by the Log Forwarder:
@@ -102,7 +102,7 @@ To configure logs in context with the NLog extension, complete the following ste
    ```
 
    <Callout variant="caution">
-     The above configuration examples result in new JSON files that are written to disk. Some of these [configuration options](https://github.com/nlog/NLog/wiki/File-target) may be useful in managing the amount of disk space used and/or the performance of the target.
+     The configuration examples above result in new JSON files that are written to disk. Some of these [configuration options](https://github.com/nlog/NLog/wiki/File-target) may be useful in managing the amount of disk space used and/or the performance of the target.
 
      * `archiveAboveSize`
      * `maxArchiveFiles`

--- a/src/content/docs/logs/enable-log-management-new-relic/logs-context-net/net-configure-nlog.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/logs-context-net/net-configure-nlog.mdx
@@ -65,24 +65,44 @@ Confirm that you have [log management](/docs/introduction-new-relic-logs) enable
 To configure logs in context with the NLog extension, complete the following steps:
 
 1. Using the Visual Studio [NuGet Package Manager](https://docs.microsoft.com/en-us/nuget/consume-packages/install-use-packages-visual-studio), locate and install the [`NewRelic.LogEnrichers.NLog`](https://www.nuget.org/packages/NewRelic.LogEnrichers.NLog/) package.
-2. In your application code, update your logging configuration to add the `NewRelicJsonLayout`.
+2. In your application code, update your logging configuration to add the `NewRelicJsonLayout` and decide if you want to collect MappedDiagnosticsContext (MDC) or the MappedDiagnosticsLogicalContext (MDLC) data.
 
-   The following code example enriches log events with New Relic linking metadata. In addition to the existing log files, it outputs new log files in a specific JSON format at `C:\logs\NLogExample.log.json` for consumption by the Log Forwarder:
+   **Don't collect MDC or the MDLC data (default)**  
+   The following code example enriches log events with New Relic linking metadata, but not with MDC or the MDLC data. In addition to the existing log files, it outputs new log files in a specific JSON format at `C:\logs\NLogExample.log.json` for consumption by the Log Forwarder:
 
    ```
    var loggerConfig = new LoggingConfiguration();
-     
-     var newRelicFileTarget = new FileTarget("NewRelicFileTarget");
-     newRelicFileTarget.Layout = new NewRelicJsonLayout();
-     newRelicFileTarget.FileName = "C:\logs\NLogExample.json";
-     loggerConfig.AddTarget(newRelicFileTarget);
-     loggerConfig.AddRuleForAllLevels("NewRelicFileTarget");
-     LogManager.Configuration = loggerConfig;
-     var logger = LogManager.GetLogger("Example");
+   var newRelicFileTarget = new FileTarget("NewRelicFileTarget");
+   newRelicFileTarget.Layout = new NewRelicJsonLayout();
+   newRelicFileTarget.FileName = "C:\logs\NLogExample.json";
+   loggerConfig.AddTarget(newRelicFileTarget);
+   loggerConfig.AddRuleForAllLevels("NewRelicFileTarget");
+   LogManager.Configuration = loggerConfig;
+   var logger = LogManager.GetLogger("Example");
+   ```
+
+   **Collect MDC or the MDLC data**  
+   If your application makes use of the MDC or the MDLC, you can configure the `NewRelicJsonLayout` to include items in those collections.  The following code example adds the additional configuration to enable collecting MDC and MDLC data.  As in the previous example, it outputs new log files in a specific JSON format at `C:\logs\NLogExample.log.json` for consumption by the Log Forwarder:
+
+   ```
+   var loggerConfig = new LoggingConfiguration();
+   var newRelicFileTarget = new FileTarget("NewRelicFileTarget");
+   var newRelicLayout = new NewRelicJsonLayout
+   {
+       IncludeMdc = true,
+       IncludeMdlc = true
+   };
+
+   newRelicFileTarget.Layout = newRelicLayout;
+   newRelicFileTarget.FileName = "C:\logs\NLogExample.json";
+   loggerConfig.AddTarget(newRelicFileTarget);
+   loggerConfig.AddRuleForAllLevels("NewRelicFileTarget");
+   LogManager.Configuration = loggerConfig;
+   var logger = LogManager.GetLogger("Example");
    ```
 
    <Callout variant="caution">
-     The above configuration results in new JSON files that are written to disk. Some of these [configuration options](https://github.com/nlog/NLog/wiki/File-target) may be useful in managing the amount of disk space used and/or the performance of the target.
+     The above configuration examples result in new JSON files that are written to disk. Some of these [configuration options](https://github.com/nlog/NLog/wiki/File-target) may be useful in managing the amount of disk space used and/or the performance of the target.
 
      * `archiveAboveSize`
      * `maxArchiveFiles`


### PR DESCRIPTION
### Give us some context

To coincide with our release of NewRelic.LogEnrichers.NLog 1.2.0 that adds support for pulling in data from different contexts, I updated the configuration section of the .NET NLog page to show how to enable the new contexts.  I also updated some of the wording in the examples.

### Are you making a change to site code?
No.

Resolves: newrelic/newrelic-logenricher-dotnet#106