### PR TITLE
Support searching by attribute name in data dictionary

### DIFF
--- a/src/components/DataDictionaryFilter.js
+++ b/src/components/DataDictionaryFilter.js
@@ -5,6 +5,7 @@ import { graphql } from 'gatsby';
 import {
   PageTools,
   Button,
+  SearchInput,
   Link,
   useQueryParams,
 } from '@newrelic/gatsby-theme-newrelic';
@@ -62,6 +63,20 @@ const DataDictionaryFilter = ({ location, events }) => {
   return (
     <PageTools.Section>
       <PageTools.Title>Apply filter</PageTools.Title>
+      <FormControl>
+        <Label htmlFor="attributeSearch">Search for attribute</Label>
+        <SearchInput
+          onChange={(e) => {
+            const { value } = e.target;
+            const filteredAttributes = events.map((event) => {
+              return event.childrenDataDictionaryAttribute.filter(({ name }) =>
+                name.includes(value)
+              );
+            });
+            console.log(filteredAttributes);
+          }}
+        />
+      </FormControl>
       <FormControl>
         <Label htmlFor="dataSourceFilter">Data source</Label>
         <Select
@@ -129,6 +144,7 @@ const DataDictionaryFilter = ({ location, events }) => {
           ))}
         </Select>
       </FormControl>
+
       <FormControl>
         <Button
           variant={Button.VARIANT.PRIMARY}

--- a/src/components/DataDictionaryFilter.js
+++ b/src/components/DataDictionaryFilter.js
@@ -62,10 +62,6 @@ const DataDictionaryFilter = ({ location, events }) => {
     [events, formState.dataSource]
   );
 
-  const selectedEvent = formState.event
-    ? events.find((event) => event.name === formState.event)
-    : null;
-
   const navigateToParams = (params) => {
     Object.entries(params).forEach(([key, value]) => {
       value ? queryParams.set(key, value) : queryParams.delete(key);

--- a/src/components/DataDictionaryFilter.js
+++ b/src/components/DataDictionaryFilter.js
@@ -40,6 +40,18 @@ const DataDictionaryFilter = ({ location, events }) => {
     });
   }, [queryParams]);
 
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.keyCode === 13) {
+        navigateToParams(formState);
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => {
+      document.removeEventListener('keydown', handler);
+    };
+  });
+
   const filteredEvents = useMemo(
     () =>
       formState.dataSource

--- a/src/components/DataDictionaryFilter.js
+++ b/src/components/DataDictionaryFilter.js
@@ -142,30 +142,6 @@ const DataDictionaryFilter = ({ location, events }) => {
           ))}
         </Select>
       </FormControl>
-      <FormControl>
-        <Label htmlFor="attributeFilter">Attribute</Label>
-        <Select
-          id="attributeFilter"
-          value={formState.attribute || ''}
-          disabled={!selectedEvent}
-          onChange={(e) => {
-            const { value } = e.target;
-
-            setFormState((state) => ({
-              ...state,
-              attribute: value,
-              attributeSearch: null,
-            }));
-          }}
-        >
-          <option value="">All</option>
-          {selectedEvent?.childrenDataDictionaryAttribute.map((attribute) => (
-            <option key={attribute.name} value={attribute.name}>
-              {attribute.name}
-            </option>
-          ))}
-        </Select>
-      </FormControl>
 
       <FormControl>
         <Button

--- a/src/components/DataDictionaryFilter.js
+++ b/src/components/DataDictionaryFilter.js
@@ -74,7 +74,7 @@ const DataDictionaryFilter = ({ location, events }) => {
     <PageTools.Section>
       <PageTools.Title>Search and filter</PageTools.Title>
       <FormControl>
-        <Label htmlFor="attributeSearch">Search for attribute</Label>
+        <Label htmlFor="attributeSearch">Attribute name</Label>
         <SearchInput
           value={formState.attributeSearch || ''}
           onClear={() =>
@@ -89,6 +89,7 @@ const DataDictionaryFilter = ({ location, events }) => {
               attributeSearch: value,
             }));
           }}
+          placeholder="Name contains..."
         />
       </FormControl>
       <FormControl>

--- a/src/components/DataDictionaryFilter.js
+++ b/src/components/DataDictionaryFilter.js
@@ -20,6 +20,7 @@ const DataDictionaryFilter = ({ location, events }) => {
     dataSource: queryParams.get('dataSource'),
     event: queryParams.get('event'),
     attribute: queryParams.get('attribute'),
+    attributeSearch: queryParams.get('attributeSearch'),
   }));
 
   const dataSources = useMemo(
@@ -35,6 +36,7 @@ const DataDictionaryFilter = ({ location, events }) => {
       dataSource: queryParams.get('dataSource'),
       event: queryParams.get('event'),
       attribute: queryParams.get('attribute'),
+      attributeSearch: queryParams.get('attributeSearch'),
     });
   }, [queryParams]);
 

--- a/src/components/DataDictionaryFilter.js
+++ b/src/components/DataDictionaryFilter.js
@@ -64,7 +64,7 @@ const DataDictionaryFilter = ({ location, events }) => {
 
   return (
     <PageTools.Section>
-      <PageTools.Title>Apply filter</PageTools.Title>
+      <PageTools.Title>Search and filter</PageTools.Title>
       <FormControl>
         <Label htmlFor="attributeSearch">Search for attribute</Label>
         <SearchInput
@@ -162,7 +162,7 @@ const DataDictionaryFilter = ({ location, events }) => {
             navigateToParams(formState);
           }}
         >
-          Apply
+          Search
         </Button>
         <Button
           as={Link}

--- a/src/components/DataDictionaryFilter.js
+++ b/src/components/DataDictionaryFilter.js
@@ -68,14 +68,17 @@ const DataDictionaryFilter = ({ location, events }) => {
       <FormControl>
         <Label htmlFor="attributeSearch">Search for attribute</Label>
         <SearchInput
+          value={formState.attributeSearch || ''}
           onChange={(e) => {
             const { value } = e.target;
-            const filteredAttributes = events.map((event) => {
-              return event.childrenDataDictionaryAttribute.filter(({ name }) =>
-                name.includes(value)
-              );
-            });
-            console.log(filteredAttributes);
+
+            setFormState((state) => ({
+              ...state,
+              dataSource: null,
+              event: null,
+              attribute: null,
+              attributeSearch: value,
+            }));
           }}
         />
       </FormControl>
@@ -92,6 +95,7 @@ const DataDictionaryFilter = ({ location, events }) => {
               event: null,
               attribute: null,
               dataSource: value,
+              attributeSearch: null,
             }));
           }}
         >
@@ -115,6 +119,7 @@ const DataDictionaryFilter = ({ location, events }) => {
               ...state,
               event: value,
               attribute: null,
+              attributeSearch: null,
             }));
           }}
         >
@@ -135,7 +140,11 @@ const DataDictionaryFilter = ({ location, events }) => {
           onChange={(e) => {
             const { value } = e.target;
 
-            setFormState((state) => ({ ...state, attribute: value }));
+            setFormState((state) => ({
+              ...state,
+              attribute: value,
+              attributeSearch: null,
+            }));
           }}
         >
           <option value="">All</option>
@@ -165,6 +174,7 @@ const DataDictionaryFilter = ({ location, events }) => {
               event: null,
               dataSource: null,
               attribute: null,
+              attributeSearch: null,
             };
 
             setFormState(formState);

--- a/src/components/DataDictionaryFilter.js
+++ b/src/components/DataDictionaryFilter.js
@@ -74,8 +74,6 @@ const DataDictionaryFilter = ({ location, events }) => {
 
             setFormState((state) => ({
               ...state,
-              dataSource: null,
-              event: null,
               attribute: null,
               attributeSearch: value,
             }));
@@ -95,7 +93,6 @@ const DataDictionaryFilter = ({ location, events }) => {
               event: null,
               attribute: null,
               dataSource: value,
-              attributeSearch: null,
             }));
           }}
         >
@@ -119,7 +116,6 @@ const DataDictionaryFilter = ({ location, events }) => {
               ...state,
               event: value,
               attribute: null,
-              attributeSearch: null,
             }));
           }}
         >

--- a/src/components/DataDictionaryFilter.js
+++ b/src/components/DataDictionaryFilter.js
@@ -69,6 +69,9 @@ const DataDictionaryFilter = ({ location, events }) => {
         <Label htmlFor="attributeSearch">Search for attribute</Label>
         <SearchInput
           value={formState.attributeSearch || ''}
+          onClear={() =>
+            setFormState((state) => ({ ...state, attributeSearch: null }))
+          }
           onChange={(e) => {
             const { value } = e.target;
 

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -172,208 +172,220 @@ AttributeDictionary.propTypes = {
 
 const pluralize = (word, count) => (count === 1 ? word : `${word}s`);
 
-const EventDefinition = memo(({ location, event, searchedAttribute }) => {
-  const filteredAttributes = searchedAttribute
-    ? event.childrenDataDictionaryAttribute.filter(({ name }) =>
-        name.toLowerCase().includes(searchedAttribute.toLowerCase())
-      )
-    : event.childrenDataDictionaryAttribute;
+const EventDefinition = memo(
+  ({ location, event, searchedAttribute, filteredAttribute }) => {
+    let filteredAttributes = [];
 
-  return (
-    <div
-      key={`${event.name}-section`}
-      css={css`
-        &:not(:last-child) {
-          margin-bottom: 2rem;
-        }
-      `}
-    >
-      <h2
+    if (searchedAttribute) {
+      filteredAttributes = event.childrenDataDictionaryAttribute.filter(
+        ({ name }) =>
+          name.toLowerCase().includes(searchedAttribute.toLowerCase())
+      );
+    } else if (filteredAttribute) {
+      filteredAttributes = event.childrenDataDictionaryAttribute.filter(
+        ({ name }) => name === filteredAttribute
+      );
+    } else {
+      filteredAttributes = event.childrenDataDictionaryAttribute;
+    }
+
+    return (
+      <div
+        key={`${event.name}-section`}
         css={css`
-          position: sticky;
-          top: var(--global-header-height);
-          background: var(--primary-background-color);
-          padding: 1rem 0;
-
-          // cover up the right table border
-          margin-right: -1px;
-
-          &:hover svg {
-            opacity: 1;
-          }
-
-          @media (max-width: 1240px) {
-            position: relative;
+          &:not(:last-child) {
+            margin-bottom: 2rem;
           }
         `}
       >
-        <div
+        <h2
           css={css`
-            position: relative;
+            position: sticky;
+            top: var(--global-header-height);
+            background: var(--primary-background-color);
+            padding: 1rem 0;
+
+            // cover up the right table border
+            margin-right: -1px;
+
+            &:hover svg {
+              opacity: 1;
+            }
+
+            @media (max-width: 1240px) {
+              position: relative;
+            }
           `}
         >
-          <Link
-            to={`${location.pathname}?event=${event.name}`}
-            className="anchor before"
-          >
-            <Icon name="fe-link-2" focusable={false} size="1rem" />
-          </Link>
-          <code
+          <div
             css={css`
-              background: none !important;
-              padding: 0 !important;
+              position: relative;
             `}
           >
-            {event.name}
-          </code>
-        </div>
-      </h2>
-      <div
-        css={css`
-          margin-bottom: 1rem;
-        `}
-      >
-        <span
-          css={css`
-            font-size: 0.75rem;
-            margin-right: 0.5rem;
-          `}
-        >
-          Data {pluralize('source', event.dataSources.length)}:
-        </span>
-        <TagList>
-          {event.dataSources.map((dataSource) => (
-            <Tag
-              as={Link}
-              to={`${location.pathname}?dataSource=${dataSource}`}
-              key={dataSource}
+            <Link
+              to={`${location.pathname}?event=${event.name}`}
+              className="anchor before"
             >
-              {dataSource}
-            </Tag>
-          ))}
-        </TagList>
-      </div>
-      <div dangerouslySetInnerHTML={{ __html: event.definition?.html }} />
-      <Table>
-        <thead>
-          <tr>
-            <th
+              <Icon name="fe-link-2" focusable={false} size="1rem" />
+            </Link>
+            <code
               css={css`
-                white-space: nowrap;
+                background: none !important;
+                padding: 0 !important;
               `}
             >
-              Attribute name
-            </th>
-            <th>Definition</th>
-            <th>Events</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filteredAttributes.map((attribute) => {
-            const params = new URLSearchParams();
-            params.set('event', event.name);
-            params.set('attribute', attribute.name);
+              {event.name}
+            </code>
+          </div>
+        </h2>
+        <div
+          css={css`
+            margin-bottom: 1rem;
+          `}
+        >
+          <span
+            css={css`
+              font-size: 0.75rem;
+              margin-right: 0.5rem;
+            `}
+          >
+            Data {pluralize('source', event.dataSources.length)}:
+          </span>
+          <TagList>
+            {event.dataSources.map((dataSource) => (
+              <Tag
+                as={Link}
+                to={`${location.pathname}?dataSource=${dataSource}`}
+                key={dataSource}
+              >
+                {dataSource}
+              </Tag>
+            ))}
+          </TagList>
+        </div>
+        <div dangerouslySetInnerHTML={{ __html: event.definition?.html }} />
+        <Table>
+          <thead>
+            <tr>
+              <th
+                css={css`
+                  white-space: nowrap;
+                `}
+              >
+                Attribute name
+              </th>
+              <th>Definition</th>
+              <th>Events</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredAttributes.map((attribute) => {
+              const params = new URLSearchParams();
+              params.set('event', event.name);
+              params.set('attribute', attribute.name);
 
-            return (
-              <tr key={`${event.name}-${attribute.name}`}>
-                <td
-                  css={css`
-                    width: 40%;
-                    word-break: break-all;
-                  `}
-                >
-                  <Link
-                    to={`${location.pathname}?${params.toString()}`}
+              return (
+                <tr key={`${event.name}-${attribute.name}`}>
+                  <td
                     css={css`
-                      display: flex;
-                      align-items: center;
-                      color: var(--color-text-primary);
-                      text-decoration: none;
-
-                      &:hover svg {
-                        opacity: 1;
-                      }
+                      width: 40%;
+                      word-break: break-all;
                     `}
                   >
-                    <code
+                    <Link
+                      to={`${location.pathname}?${params.toString()}`}
                       css={css`
-                        display: inline-block;
-                        background: none !important;
-                        padding: 0 !important;
-                      `}
-                    >
-                      {attribute.name}
-                    </code>
-                    <Icon
-                      name="fe-link-2"
-                      size="1rem"
-                      focusable={false}
-                      css={css`
-                        margin-left: 0.5rem;
-                        opacity: 0;
-                        transition: opacity 0.2s ease-out;
-                      `}
-                    />
-                  </Link>
-                  {attribute.units && (
-                    <div
-                      css={css`
-                        font-size: 0.75rem;
+                        display: flex;
+                        align-items: center;
+                        color: var(--color-text-primary);
+                        text-decoration: none;
 
-                        .dark-mode & {
-                          color: var(--color-dark-600);
+                        &:hover svg {
+                          opacity: 1;
                         }
                       `}
                     >
-                      {attribute.units}
-                    </div>
-                  )}
-                </td>
-                <td
-                  key={`${event.name}-${attribute.name}-def}`}
-                  css={css`
-                    p:last-child {
-                      margin-bottom: 0;
-                    }
-                  `}
-                  dangerouslySetInnerHTML={{
-                    __html: attribute.definition.html,
-                  }}
-                />
-                <td
-                  css={css`
-                    width: 1px;
-                  `}
-                >
-                  <ul
+                      <code
+                        css={css`
+                          display: inline-block;
+                          background: none !important;
+                          padding: 0 !important;
+                        `}
+                      >
+                        {attribute.name}
+                      </code>
+                      <Icon
+                        name="fe-link-2"
+                        size="1rem"
+                        focusable={false}
+                        css={css`
+                          margin-left: 0.5rem;
+                          opacity: 0;
+                          transition: opacity 0.2s ease-out;
+                        `}
+                      />
+                    </Link>
+                    {attribute.units && (
+                      <div
+                        css={css`
+                          font-size: 0.75rem;
+
+                          .dark-mode & {
+                            color: var(--color-dark-600);
+                          }
+                        `}
+                      >
+                        {attribute.units}
+                      </div>
+                    )}
+                  </td>
+                  <td
+                    key={`${event.name}-${attribute.name}-def}`}
                     css={css`
-                      margin: 0;
-                      list-style: none;
-                      padding-left: 0;
-                      font-size: 0.875rem;
+                      p:last-child {
+                        margin-bottom: 0;
+                      }
+                    `}
+                    dangerouslySetInnerHTML={{
+                      __html: attribute.definition.html,
+                    }}
+                  />
+                  <td
+                    css={css`
+                      width: 1px;
                     `}
                   >
-                    {attribute.events.map((event) => (
-                      <li key={`${attribute.name}-${event.name}`}>
-                        <Link to={`${location.pathname}?event=${event.name}`}>
-                          {event.name}
-                        </Link>
-                      </li>
-                    ))}
-                  </ul>
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </Table>
-    </div>
-  );
-});
+                    <ul
+                      css={css`
+                        margin: 0;
+                        list-style: none;
+                        padding-left: 0;
+                        font-size: 0.875rem;
+                      `}
+                    >
+                      {attribute.events.map((event) => (
+                        <li key={`${attribute.name}-${event.name}`}>
+                          <Link to={`${location.pathname}?event=${event.name}`}>
+                            {event.name}
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </Table>
+      </div>
+    );
+  }
+);
 
 EventDefinition.propTypes = {
   event: PropTypes.object.isRequired,
   searchedAttribute: PropTypes.string,
+  filteredAttribute: PropTypes.string,
   location: PropTypes.shape({
     pathname: PropTypes.string.isRequired,
   }).isRequired,

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -54,12 +54,10 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
 
     if (queryParams.has('attributeSearch')) {
       filteredEvents = filteredEvents.filter((event) =>
-        Boolean(
-          event.childrenDataDictionaryAttribute.find(({ name }) =>
-            name
-              .toLowerCase()
-              .includes(queryParams.get('attributeSearch').toLowerCase())
-          )
+        event.childrenDataDictionaryAttribute.some(({ name }) =>
+          name
+            .toLowerCase()
+            .includes(queryParams.get('attributeSearch').toLowerCase())
         )
       );
     }

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -28,6 +28,7 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
 
   const [filteredEvents, setFilteredEvents] = useState([]);
   const [filteredAttribute, setFilteredAttribute] = useState(null);
+  const [searchedAttribute, setSearchedAttribute] = useState(null);
   const { queryParams } = useQueryParams();
 
   const isMobileScreen = useMedia('(max-width: 1240)');
@@ -52,7 +53,23 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
       );
     }
 
+    if (queryParams.has('attributeSearch')) {
+      filteredEvents = filteredEvents.reduce((events, currEvent) => {
+        currEvent.childrenDataDictionaryAttribute = currEvent.childrenDataDictionaryAttribute.filter(
+          ({ name }) =>
+            name.toLowerCase().includes(queryParams.get('attributeSearch'))
+        );
+        if (currEvent.childrenDataDictionaryAttribute.length) {
+          events.push(currEvent);
+        }
+        return events;
+      }, []);
+
+      console.log({ filteredEvents });
+    }
+
     setFilteredEvents(filteredEvents.map((event) => event.name));
+    setSearchedAttribute(queryParams.get('attributeSearch'));
     setFilteredAttribute(queryParams.get('attribute'));
   }, [queryParams, events]);
 
@@ -145,6 +162,7 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
                 location={location}
                 event={event}
                 filteredAttribute={filteredAttribute}
+                searchedAttribute={searchedAttribute}
               />
             </div>
           ))}
@@ -180,10 +198,10 @@ AttributeDictionary.propTypes = {
 
 const pluralize = (word, count) => (count === 1 ? word : `${word}s`);
 
-const EventDefinition = memo(({ location, event, filteredAttribute }) => {
-  const filteredAttributes = filteredAttribute
-    ? event.childrenDataDictionaryAttribute.filter(
-        (attribute) => attribute.name === filteredAttribute
+const EventDefinition = memo(({ location, event, searchedAttribute }) => {
+  const filteredAttributes = searchedAttribute
+    ? event.childrenDataDictionaryAttribute.filter(({ name }) =>
+        name.toLowerCase().includes(searchedAttribute)
       )
     : event.childrenDataDictionaryAttribute;
 

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { graphql } from 'gatsby';
 import {
-  Button,
   ContributingGuidelines,
   Layout,
   Link,
@@ -64,8 +63,6 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
         }
         return events;
       }, []);
-
-      console.log({ filteredEvents });
     }
 
     setFilteredEvents(filteredEvents.map((event) => event.name));
@@ -126,28 +123,6 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
           <hr />
         </div>
         <Layout.Content>
-          <div
-            css={css`
-              display: none;
-              position: sticky;
-              top: var(--global-header-height);
-              font-size: 0.875rem;
-              background: var(--primary-background-color);
-              padding: 2rem 0;
-            `}
-          >
-            Displaying {filteredEvents.length} of {events.length} results{' '}
-            {filteredEvents.length !== events.length && (
-              <Button
-                as={Link}
-                to={location.pathname}
-                variant={Button.VARIANT.LINK}
-              >
-                Clear
-              </Button>
-            )}
-          </div>
-
           {events.map((event) => (
             <div
               key={`${event.name}-div`}
@@ -399,7 +374,7 @@ const EventDefinition = memo(({ location, event, searchedAttribute }) => {
 
 EventDefinition.propTypes = {
   event: PropTypes.object.isRequired,
-  filteredAttribute: PropTypes.string,
+  searchedAttribute: PropTypes.string,
   location: PropTypes.shape({
     pathname: PropTypes.string.isRequired,
   }).isRequired,

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -53,16 +53,15 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
     }
 
     if (queryParams.has('attributeSearch')) {
-      filteredEvents = filteredEvents.reduce((events, currEvent) => {
-        currEvent.childrenDataDictionaryAttribute = currEvent.childrenDataDictionaryAttribute.filter(
-          ({ name }) =>
-            name.toLowerCase().includes(queryParams.get('attributeSearch'))
-        );
-        if (currEvent.childrenDataDictionaryAttribute.length) {
-          events.push(currEvent);
-        }
-        return events;
-      }, []);
+      filteredEvents = filteredEvents.filter((event) =>
+        Boolean(
+          event.childrenDataDictionaryAttribute.find(({ name }) =>
+            name
+              .toLowerCase()
+              .includes(queryParams.get('attributeSearch').toLowerCase())
+          )
+        )
+      );
     }
 
     setFilteredEvents(filteredEvents.map((event) => event.name));
@@ -176,7 +175,7 @@ const pluralize = (word, count) => (count === 1 ? word : `${word}s`);
 const EventDefinition = memo(({ location, event, searchedAttribute }) => {
   const filteredAttributes = searchedAttribute
     ? event.childrenDataDictionaryAttribute.filter(({ name }) =>
-        name.toLowerCase().includes(searchedAttribute)
+        name.toLowerCase().includes(searchedAttribute.toLowerCase())
       )
     : event.childrenDataDictionaryAttribute;
 


### PR DESCRIPTION
## Description

Replaces the filter for selecting a specific attribute with a text input to search for attributes by name. Just matches on any instance of the search string in the attribute name. It lower cases the search string and the attribute names when matching.

Adds ability to apply filters by typing `enter`.

## Related issues / PRs

Closes https://github.com/newrelic/docs-website/issues/626

## Screenshot(s)

https://user-images.githubusercontent.com/2952843/125660278-2a5aed92-3364-4001-802c-9507f4e3255a.mp4



