### PR TITLE
Use space between list items in release note preview

### DIFF
--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -7,7 +7,6 @@ import Timeline from '../components/Timeline';
 import SEO from '../components/SEO';
 import { Icon, Layout, Link } from '@newrelic/gatsby-theme-newrelic';
 import filter from 'unist-util-filter';
-import toString from 'mdast-util-to-string';
 import { TYPES } from '../utils/constants';
 
 const EXCERPT_LENGTH = 200;
@@ -181,6 +180,31 @@ export const pageQuery = graphql`
     ...MainLayout_query
   }
 `;
+
+// copying in function from mdast-util-to-string so we can add a space
+function toString(node) {
+  return (
+    (node &&
+      (node.value ||
+        node.alt ||
+        node.title ||
+        ('children' in node && all(node.children)) ||
+        ('length' in node && all(node)))) ||
+    ''
+  );
+}
+
+function all(values) {
+  const result = [];
+  const length = values.length;
+  let index = -1;
+
+  while (++index < length) {
+    result[index] = toString(values[index]);
+  }
+
+  return result.join(' ');
+}
 
 const getBestGuessExcerpt = (mdxAST) => {
   const textTypes = [

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -181,20 +181,21 @@ export const pageQuery = graphql`
   }
 `;
 
-// copying in function from mdast-util-to-string so we can add a space
+// copying in function from mdast-util-to-string so we can render list items with periods and spaces between
 function toString(node) {
+  const isList = node.type === 'list';
   return (
     (node &&
       (node.value ||
         node.alt ||
         node.title ||
-        ('children' in node && all(node.children)) ||
-        ('length' in node && all(node)))) ||
+        ('children' in node && all(node.children, isList)) ||
+        ('length' in node && all(node, isList)))) ||
     ''
   );
 }
 
-function all(values) {
+function all(values, isList) {
   const result = [];
   const length = values.length;
   let index = -1;
@@ -202,8 +203,18 @@ function all(values) {
   while (++index < length) {
     result[index] = toString(values[index]);
   }
-
-  return result.join(' ');
+  if (isList) {
+    const strippedPeriodResults = result.map((listItem) => {
+      if (listItem[listItem.length - 1] === '.') {
+        return listItem.slice(0, -1);
+      } else {
+        return listItem;
+      }
+    });
+    return strippedPeriodResults.join('. ');
+  } else {
+    return result.join('');
+  }
 }
 
 const getBestGuessExcerpt = (mdxAST) => {


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

The release notes currently grab a portion of the markdown for a given note and render it as a string for a preview. The library we're using to stringify the elements concatenates list items with no space. This adds logic to render list items with periods and spaces 

Closes https://github.com/newrelic/docs-website/issues/2714

### Before
<img width="993" alt="Screen Shot 2021-07-12 at 4 54 27 PM" src="https://user-images.githubusercontent.com/39655074/125369841-f8ae3080-e331-11eb-845b-e5da4c059427.png">
<img width="1014" alt="Screen Shot 2021-07-12 at 4 54 34 PM" src="https://user-images.githubusercontent.com/39655074/125369842-fa77f400-e331-11eb-940b-258027c44579.png">

### After
<img width="1016" alt="Screen Shot 2021-07-12 at 4 54 51 PM" src="https://user-images.githubusercontent.com/39655074/125369849-ffd53e80-e331-11eb-91e6-aa23d664149d.png">
<img width="1041" alt="Screen Shot 2021-07-12 at 4 55 00 PM" src="https://user-images.githubusercontent.com/39655074/125369852-02d02f00-e332-11eb-8b86-c56e6ad01405.png">
