### PR TITLE
Remove export single-paged dashboards

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api.mdx
@@ -15,24 +15,10 @@ Do you need to schedule reports that contain charts or dashboards? Do you want t
   You can also [export dashboards as PDF files using the UI](/docs/dashboards/manage-your-dashboard/manage-your-dashboard#dash-export).
 </Callout>
 
-## Export single-page dashboards [#dash-single]
-
-If your dashboard has [a single page](/docs/dashboards/manage-your-dashboard/manage-your-dashboard#add-pages):
+## Export dashboard pages [#dash-multiple]
 
 1. Obtain the dashboard's GUID: Click the <Icon name="fe-info"/>
    icon by the dashboard's name to access the **See metadata and manage tags** modal and see the dashboard's GUID.
-2. Run the **dashboardCreateSnapshotURL** mutation in the [NerdGraphQL explorer](https://api.newrelic.com/graphiql) with the GUID as a parameter.
-3. Get the link to retrieve your dashboard as a PDF. The link looks similar to:
-```
-https://gorgon.nr-assets.net/image/e0c22263-2d88-40bc-940a-b885dbc1d98d?format=PDF&width=2000&height=2000
-```
-4. [Configure](#configure) the exported file, if necessary.
-
-## Export multiple-page dashboards [#dash-multiple]
-
-For dashboards with multiple pages, first you need to obtain the GUID for each individual page:
-
-1. Obtain the parent GUID (that is, the GUID in the **See metadata and manage tags** modal).
 2. Get the individual pages' GUIDs using the query below:
 
    ```
@@ -54,7 +40,12 @@ For dashboards with multiple pages, first you need to obtain the GUID for each i
      }
    }
    ```
-3. Run the mutation for each page to get the PDF for all dashboards.
+3. Run the **dashboardCreateSnapshotURL** mutation in the [NerdGraphQL explorer](https://api.newrelic.com/graphiql) as many times as dashboard pages you want to export. You just need to provide the desired dashboard page GUID as a parameter.
+4. Get the link to retrieve your dashboard page as a PDF. The link looks similar to:
+```
+https://gorgon.nr-assets.net/image/e0c22263-2d88-40bc-940a-b885dbc1d98d?format=PDF&width=2000&height=2000
+```
+5. [Configure](#configure) the exported file, if necessary.
 
 ## Configure the file you retrieve [#configure]
 


### PR DESCRIPTION
### What

Removing the single-paged use case to export dashboards as PDF. This is not valid anymore, and users should follow the same process regardless the amount of pages.

### Why?

After the homogenization of dashboards, avoid user errors when exporting single-paged dashboards.