### PR TITLE
DOC-7077 QB Basic Mode sweep

### DIFF
--- a/src/content/docs/agents/manage-apm-agents/agent-data/real-time-streaming.mdx
+++ b/src/content/docs/agents/manage-apm-agents/agent-data/real-time-streaming.mdx
@@ -47,7 +47,7 @@ Real time streaming is supported by all APM agents. Here are the minimum agent v
 * **Ruby:** [v6.7.0.359 or higher](/docs/release-notes/agent-release-notes/ruby-release-notes)
 
 <Callout variant="caution">
-  If Transaction event reporting is [disabled](https://docs.newrelic.com/docs/insights/use-insights-ui/manage-account-data/data-summary-page-manage-apps-reporting-insights#enable-disable), this can affect some UI elements throughout New Relic. You may see some empty charts on some UI pages that rely on this data.
+  If Transaction event reporting is [disabled](/docs/insights/use-insights-ui/manage-account-data/data-summary-page-manage-apps-reporting-insights#enable-disable), this can affect some UI elements throughout New Relic. You may see some empty charts on some UI pages that rely on this data.
 </Callout>
 
 ## Query real time streaming data [#nrql]
@@ -95,6 +95,6 @@ When building charts, include the following in your NRQL query:
 You can visualize the results of your NRQL query in New Relic One:
 
 1. Go to **[one.newrelic.com](https://one.newrelic.com)**, and at the top of the page, select **Query your data**.
-2. Use the [query builder](/docs/chart-builder/use-chart-builder/get-started/introduction-chart-builder) to start building a chart.
-3. Select the [advanced (NRQL) mode](/docs/chart-builder/use-chart-builder/get-started/introduction-chart-builder#advanced). (If you start with basic mode, switch to advanced mode to complete the next step.)
+2. Use the [data explorer](/docs/query-your-data/explore-query-data/browse-data/introduction-data-explorer/) to start building a chart.
+3. Select the [advanced (NRQL) mode](/docs/query-your-data/explore-query-data/query-builder/use-advanced-nrql-mode-query-data/) to refine your query.
 4. In your NRQL query, adjust the [`SINCE` and `TIMESERIES` clauses](#nrql) to take advantage of the 5 second refresh intervals.

--- a/src/content/docs/query-your-data/explore-query-data/use-charts/chart-types.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/use-charts/chart-types.mdx
@@ -93,10 +93,6 @@ This table contains all chart types. Whether a chart type is available for your 
 
     To enable a bar chart, add a [`FACET`](/docs/insights/nrql-new-relic-query-language/nrql-reference/nrql-syntax-components-functions#sel-facet) clause to the query.
 
-    <Callout variant="important">
-      You can add only one facet in basic mode.
-    </Callout>
-
     You can use `FACET` with up to 5 different attributes, separated by commas.
 
     <table>

--- a/src/content/docs/query-your-data/explore-query-data/use-charts/use-your-charts.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/use-charts/use-your-charts.mdx
@@ -17,7 +17,7 @@ Once you've created a chart, you can customize the appearance of it to best pres
 
 ## Change the appearance of your chart [#change-appearance]
 
-When you run your query in **advanced (NRQL) mode** or view your chart while using **basic mode** to specify data, the query builder analyzes your data and applies a [chart type](/docs/insights/use-insights-ui/manage-dashboards/insights-chart-types) that fits your data.
+When you run your query in **advanced (NRQL) mode** or view your chart while using the **data explorer** to specify data, the query builder analyzes your data and applies a [chart type](/docs/insights/use-insights-ui/manage-dashboards/insights-chart-types) that fits your data.
 
 For some queries, you'll have several options of chart types to choose from. To change chart type, use the **Chart type** menu to the right of the current chart. Each type in the list has a tooltip with information about using that type.
 

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language.mdx
@@ -115,9 +115,7 @@ NRQL is used behind the scenes to generate some New Relic charts:
 
 You can use NRQL in these places:
 
-* [New Relic One query builder](/docs/chart-builder/use-chart-builder/get-started/introduction-chart-builder):
-  * **Advanced mode** is a NRQL query interface
-  * **Basic mode** provides a simplified query experience that doesn't require knowledge of NRQL but that uses NRQL to generate results
+* [New Relic One query builder](/docs/chart-builder/use-chart-builder/get-started/introduction-chart-builder)
 * [NerdGraph](/docs/apis/graphql-api/tutorials/nerdgraph-graphiql-nrql-tutorial): our GraphQL-format API, which includes options for making NRQL queries
 
 ![nrql_example.png](./images/nrql_example.png "nrql_example.png")
@@ -173,12 +171,12 @@ NRQL is used behind the scenes to build some New Relic charts and dashboards. On
 </figcaption>
 
 <Callout variant="important">
-  To explore your data without having to use NRQL, use the [basic mode of New Relic One query builder](/docs/chart-builder/use-chart-builder/choose-data/use-basic-mode-specify-data).
+  To explore your data without having to use NRQL, use the [data explorer](/docs/query-your-data/explore-query-data/browse-data/introduction-data-explorer/). Learn more about [querying data in New Relic](/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data/).
 </Callout>
 
 ## NRQL query examples [#examples]
 
-Here's an example NRQL query of `Transaction` data, which is reported by [New Relic APM](/docs/apm).
+Here's an example NRQL query of `Transaction` data, which is reported by [APM](/docs/apm).
 
 ```
 FROM Transaction SELECT average(duration) 


### PR DESCRIPTION
First sweep to remove mentions to the QB basic mode, replacing it for links to intro to querying or data explorer.

See DOC-7077.