### PR TITLE
Pixie beta users doc

### DIFF
--- a/src/content/docs/full-stack-observability/observe-everything/get-started/pixie-account-link.mdx
+++ b/src/content/docs/full-stack-observability/observe-everything/get-started/pixie-account-link.mdx
@@ -1,0 +1,40 @@
+---
+title: Update your Pixie account in New Relic
+watermark: BETA
+---
+
+If you used the beta version of Auto-telemetry with Pixie, you need to update your Pixie account in New Relic to work with the generally available version. Here's how:
+
+## Step 1: Unlink your Pixie account from your New Relic account [#1-unlink]
+
+* Open [this NerdGraph query](https://api.newrelic.com/graphiql?#query=mutation%20%7B%20%20pixieUnlinkPixieProject(accountId:%20YOUR_ACCOUNT_ID)%20%7B%20%20%20%20success%20%20%20%20errors%20%7B%20%20%20%20%20%20message%20%20%20%20%20%20type%20%20%20%20%7D%20%20%7D%7D) in New Relic's GraphiQL. 
+* Modify the query adding the account ID you're using for the Pixie Beta.
+* Execute the query by clicking the play button.
+
+## Step 2: Link your New Relic account to Pixie [#2-link]
+* Open [this NerdGrah query](https://api.newrelic.com/graphiql?#query=mutation%20%7B%20%20pixieLinkPixieProject(accountId:%20YOUR_ACCOUNT_ID)%20%7B%20%20%20%20success%20%20%20%20errors%20%7B%20%20%20%20%20%20message%20%20%20%20%20%20type%20%20%20%20%7D%20%20%20%20linkedPixieProject%20%7B%20%20%20%20%20%20apiKey%20%20%20%20%20%20deployKey%20%20%20%20%7D%20%20%7D%7D) in New Relic's GraphiQL. 
+* Add again the account ID you were using to run Pixie.
+* Execute the query by clicking the play button.
+
+## Step 3: Upgrade the Helm installation with the new configuration [#3-upgrade]
+
+Now you need to follow the steps in the guided install once more to accept the new General Availability Terms and Conditions, and also get the updated Pixie keys: 
+
+* Go to the [one.newrelic.com](htpps://one.newrelic.com) or to the Explorer and click on the **Add more data** button on the top right side of the screen. 
+* On the menu, click on **Guided Install**, select the account you're using to run Pixie, and click continue. 
+* Select Kubernetes and click continue. 
+* Go through the installation process. 
+
+<Callout variant="important">
+  You need to accept the new Terms and Conditions in order to be able to continue.
+</Callout>
+
+## Step 4: Verify everything's working! [#4-verify]
+
+* Confirm that the Pixie deployment is healthy. 
+* Confirm that you see Pixie data flowing into your New Relic account, like you used to.
+* Confirm that the Pixie iframe works well in the brand-new **Live debugging** tab in the Kubernetes Cluster Explorer.
+
+<Callout variant="important">
+  If something isn't working as expected please contact support@newrelic.com.
+</Callout>

--- a/src/content/docs/full-stack-observability/observe-everything/get-started/pixie-account-link.mdx
+++ b/src/content/docs/full-stack-observability/observe-everything/get-started/pixie-account-link.mdx
@@ -3,7 +3,7 @@ title: Update your Pixie account in New Relic
 watermark: BETA
 ---
 
-If you used the beta version of Auto-telemetry with Pixie, you need to update your Pixie account in New Relic to work with the generally available version. Here's how:
+If you have been using the beta version of Auto-telemetry with Pixie, you need to update your Pixie account in New Relic to work with the generally available version after the beta ends. Here's how:
 
 ## Step 1: Unlink your Pixie account from your New Relic account [#1-unlink]
 
@@ -21,8 +21,8 @@ If you used the beta version of Auto-telemetry with Pixie, you need to update yo
 Now you need to follow the steps in the guided install once more to accept the new General Availability Terms and Conditions, and also get the updated Pixie keys: 
 
 * Go to the [one.newrelic.com](htpps://one.newrelic.com) or to the Explorer and click on the **Add more data** button on the top right side of the screen. 
-* On the menu, click on **Guided Install**, select the account you're using to run Pixie, and click continue. 
-* Select Kubernetes and click continue. 
+* On the menu, click on **Guided Install**, select the account you're using to run Pixie, and click **continue**. 
+* Select Kubernetes and click **continue**. 
 * Go through the installation process. 
 
 <Callout variant="important">

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -24,7 +24,9 @@ pages:
           - title: Infrastructure monitoring
             path: /docs/full-stack-observability/monitor-everything/observability-solutions/infrastructure-monitoring
           - title: Auto-Telemetry with Pixie
-            path: /docs/full-stack-observability/observe-everything/get-started/get-started-auto-telemetry-pixie
+            path: /docs/full-stack-observability/observe-everything/get-started/get-started-auto-telemetry-pixie 
+          - title: Update your Pixie account in New Relic
+            path: /docs/full-stack-observability/observe-everything/get-started/pixie-account-link
           - title: Kubernetes monitoring
             path: /docs/integrations/kubernetes-integration/get-started/introduction-kubernetes-integration/
           - title: Logs in context


### PR DESCRIPTION
This adds a doc for Auto-telemetry with Pixie beta users to upgrade their accounts for use with the generally available version.