### PR TITLE
chore: Update Java compatibility of the JFR daemon

### DIFF
--- a/src/content/docs/agents/java-agent/features/real-time-profiling-java-using-jfr-metrics.mdx
+++ b/src/content/docs/agents/java-agent/features/real-time-profiling-java-using-jfr-metrics.mdx
@@ -34,8 +34,10 @@ There are three different usage scenarios for the JFR daemon:
 
 ## Supported Java versions [#supported-java-versions]
 
-While the JFR daemon supports any version of Java 11 and above as well as specific versions of Java 8 (specifically version `8u262`+), we don't recommend
-using any non-LTS version of Java in production environments. See [supported Java versions](https://github.com/newrelic/newrelic-jfr-core/blob/main/README.md#supported-java-versions) for full details.
+While the JFR daemon supports any version of Java 11 and above, we don't recommend
+using any non-LTS version of Java in production environments.
+
+Some vendors have backported JFR to their Java 8 binaries. For instance, OpenJDK backported JFR on version 8u262. The JFR daemon is compatible with those Java versions.
 
 ## Requirements and Usage Instructions [#requirements-and-usage-instructions]
 


### PR DESCRIPTION
### Give us some context
JFR daemon Java compatibility specified a Java version without specifying the vendor.
This caused confusion as costumers tried to use another vendor's Java at a version higher than the specified but it wouldn't work.
The link was removed as it led the user to the same information in a different page.

### Are you making a change to site code?
No
