### PR TITLE
chore: sort top level nav list before comparison

### DIFF
--- a/plugins/gatsby-source-nav/gatsby-node.js
+++ b/plugins/gatsby-source-nav/gatsby-node.js
@@ -277,7 +277,7 @@ const createNav = async ({ args, createNodeId, nodeModel, locales }) => {
 
   const allNavYamlNodes = nodeModel
     .getAllNodes({ type: 'NavYaml' })
-    .sort((a, b) => a.path.localeCompare(b.path));
+    .sort((a, b) => a.title.localeCompare(b.title));
 
   let nav =
     allNavYamlNodes.find((nav) => findPage(nav, slug)) ||
@@ -328,6 +328,3 @@ const findPage = (page, path) => {
   if (page.pages == null || page.pages.length === 0) {
     return null;
   }
-
-  return page.pages.find((child) => findPage(child, path));
-};

--- a/plugins/gatsby-source-nav/gatsby-node.js
+++ b/plugins/gatsby-source-nav/gatsby-node.js
@@ -275,13 +275,15 @@ const createNav = async ({ args, createNodeId, nodeModel, locales }) => {
     },
   });
 
-  const allNavYamlNodes = nodeModel.getAllNodes({ type: 'NavYaml' });
+  const allNavYamlNodes = nodeModel
+    .getAllNodes({ type: 'NavYaml' })
+    .sort((a, b) => a.path.localeCompare(b.path));
 
   let nav =
     allNavYamlNodes.find((nav) => findPage(nav, slug)) ||
     allNavYamlNodes.find((nav) => slug.includes(nav.path));
 
-  let trueNav = allNavYamlNodes.find((nav) => slug.includes(nav.path));
+  const trueNav = allNavYamlNodes.find((nav) => slug.includes(nav.path));
 
   if (!nav) {
     return null;

--- a/plugins/gatsby-source-nav/gatsby-node.js
+++ b/plugins/gatsby-source-nav/gatsby-node.js
@@ -328,3 +328,6 @@ const findPage = (page, path) => {
   if (page.pages == null || page.pages.length === 0) {
     return null;
   }
+
+  return page.pages.find((child) => findPage(child, path));
+};


### PR DESCRIPTION
# Summary
When deciding which nav to show for a given page, the path is compared against the top level navs of the site. This was previously done in whatever order the query returned. This PR explicitly sorts the list so that we can always be sure which nav is used.