### PR TITLE
Removing 'sub-account' language

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-users/usage-queries-alerts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-users/usage-queries-alerts.mdx
@@ -183,11 +183,11 @@ Here are some NRQL alert condition examples. For attribute definitions, see [Att
        WHERE productLine = 'DataPlatform'
     ```
 
-    If you have multiple [sub-accounts](/docs/accounts/install-new-relic/account-setup/manage-apps-or-users-sub-accounts), you may want to set threshold alerts for a specific subaccount:
+    If you have multiple [child accounts](/docs/accounts/install-new-relic/account-setup/manage-apps-or-users-sub-accounts), you may want to set threshold alerts for a specific subaccount:
 
     ```
     FROM NrConsumption SELECT sum(GigabytesIngested) 
-       WHERE productLine = 'DataPlatform' AND consumingAccountId = <var>YOUR_SUB-ACCOUNT_ID</var>
+       WHERE productLine = 'DataPlatform' AND consumingAccountId = <var>YOUR_CHILD-ACCOUNT_ID</var>
     ```
   </Collapser>
 

--- a/src/content/docs/accounts/new-relic-account-usage/getting-started-usage/apm-host-based-subscription-usage.mdx
+++ b/src/content/docs/accounts/new-relic-account-usage/getting-started-usage/apm-host-based-subscription-usage.mdx
@@ -166,7 +166,7 @@ Here are definitions of the column headers in the UI table and CSV files. The co
 
 ## General attributes [#attributes]
 
-The following are general (not APM-specific) account-related [attributes](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#attribute). These attributes can help you understand how your accounts and sub-accounts are using New Relic products.
+The following are general (not APM-specific) account-related [attributes](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#attribute). These attributes can help you understand how your accounts are using New Relic products.
 
 <table>
   <thead>

--- a/src/content/docs/accounts/new-relic-account-usage/getting-started-usage/insights-subscription-usage.mdx
+++ b/src/content/docs/accounts/new-relic-account-usage/getting-started-usage/insights-subscription-usage.mdx
@@ -446,7 +446,7 @@ Here are some NRQL query examples about usage.
 
   <Collapser
     id="example-subaccount"
-    title="Retention periods by sub-account and event namespace"
+    title="Retention periods by child account and event namespace"
   >
     This query will tell you the total, paid, and included retention periods for the different event categories associated with the various New Relic products (such as APM `Transaction` events), for each child account under the specified parent account ID. When creating your own NRQL queries, be sure to replace <var>YOUR_ACCOUNT_ID</var> with your specific [account ID](/docs/accounts/install-new-relic/account-setup/account-id).
 

--- a/src/content/docs/accounts/new-relic-account-usage/getting-started-usage/mobile-subscription-usage.mdx
+++ b/src/content/docs/accounts/new-relic-account-usage/getting-started-usage/mobile-subscription-usage.mdx
@@ -213,7 +213,7 @@ The following are general (not Mobile-specific) account-related [attributes](/do
       </td>
 
       <td>
-        [ID of the sub-account](/docs/accounts-partnerships/accounts/account-setup/account-id) that is responsible for the stored event. When this attribute is present, `subAccountId` is the [`consumingAccountId`](#consumingAccountId).
+        [ID of the child account](/docs/accounts-partnerships/accounts/account-setup/account-id) that is responsible for the stored event. When this attribute is present, `subAccountId` is the [`consumingAccountId`](#consumingAccountId).
 
         This attribute is only present if the consuming account is a [child account](/docs/accounts/install-new-relic/account-setup/manage-apps-or-users-sub-accounts#hierarchy) (not a parent account).
       </td>

--- a/src/content/docs/accounts/original-accounts-billing/original-product-based-pricing/switch-new-models.mdx
+++ b/src/content/docs/accounts/original-accounts-billing/original-product-based-pricing/switch-new-models.mdx
@@ -49,8 +49,8 @@ How you'll review and update your users will differ depending on what account/us
 To update your users, you must have admin permissions for managing users.
 
 Steps for reviewing and updating your users: 
-1. If your organization has multiple accounts, you'll want to make sure that you're aware of all sub-accounts and review all users on those accounts. It's possible for you to log into a sub-account and not see all your users. To see your associated accounts: from the [account dropdown](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#account-dropdown), click **Account settings**, and look for associated accounts. 
-2. To see a count of full users for an account: from the [account dropdown](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#account-dropdown), click **View your usage** and see the **Users** chart. This shows **all** full users and, for some organizations, that will include users on sub-accounts. You'll want to be sure to update users for all accounts because users by default start out as billable full users.
+1. If your organization has multiple accounts, you'll want to make sure that you're aware of all child accounts and review all users on those accounts. It's possible for you to log into a sub-account and not see all your users. To see your associated accounts: from the [account dropdown](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#account-dropdown), click **Account settings**, and look for associated accounts. 
+2. To see a count of full users for an account: from the [account dropdown](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#account-dropdown), click **View your usage** and see the **Users** chart. This shows **all** full users and, for some organizations, that will include users on child accounts. You'll want to be sure to update users for all accounts because users by default start out as billable full users.
 3. To update your users: from that page click **Manage users** and edit the user type field. 
 
   </Collapser>

--- a/src/content/docs/agents/manage-apm-agents/configuration/enable-configurable-security-policies.mdx
+++ b/src/content/docs/agents/manage-apm-agents/configuration/enable-configurable-security-policies.mdx
@@ -57,7 +57,7 @@ For the limited release, there is no UI component.
 
 If you are participating in the limited release, follow this procedure to set up your accounts:
 
-1. Choose the accounts or sub-accounts on which to enable configurable security policies.
+1. Choose the accounts on which to enable configurable security policies.
 2. Choose the [configurable security policies options](#options) that you want for those accounts.
 3. Inform your New Relic sales rep of the options that you have chosen.
 4. Ensure your [agent versions support this feature](#compatibility). Update agents if necessary.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts.mdx
@@ -70,7 +70,7 @@ These are the available notification channel types.
 
     If a user has [configured the New Relic mobile app](/docs/mobile-apps/new-relic-mobile-apps/authentication-alerts/alerting-new-relic-mobile-apps/), the user notification channel also sends [push notifications](#mobile-push) to any of the user's registered mobile devices. 
 
-    If your account has one or more [sub-accounts](/docs/accounts/install-new-relic/account-setup/manage-apps-or-users-sub-accounts), the notification channel includes only users for the [currently selected master or sub-account](/docs/accounts/install-new-relic/account-setup/use-multiple-accounts).
+    If your account has one or more [child accounts](/docs/accounts/install-new-relic/account-setup/manage-apps-or-users-sub-accounts), the notification channel includes only users for the [currently selected parent or child account](/docs/accounts/install-new-relic/account-setup/use-multiple-accounts).
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apis/intro-apis/introduction-new-relic-apis.mdx
+++ b/src/content/docs/apis/intro-apis/introduction-new-relic-apis.mdx
@@ -550,7 +550,7 @@ For more information about API capabilities, see the specific [New Relic API](#p
       </td>
 
       <td>
-        To retrieve information about your New Relic partner account, sub-accounts, and users, use the [Partner API](/docs/new-relic-partnerships/partnerships/partner-api).
+        To retrieve information about your New Relic partner account, child accounts, and users, use the [Partner API](/docs/new-relic-partnerships/partnerships/partner-api).
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -314,7 +314,7 @@ The instructions below are for managing keys in the UI. For managing keys via AP
 We highly recommend using a [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key) instead, because that key has fewer restrictions.
 </Callout>
 
-You can use a REST API key with our [REST API](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2) and the [API Explorer](/docs/apis/rest-api-v2/api-explorer-v2/introduction-new-relics-rest-api-explorer). For accounts that have sub-accounts, each [sub-account](/docs/accounts/accounts-billing/account-structure/mastersub-account-structure) must use its own REST API key.
+You can use a REST API key with our [REST API](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2) and the [API Explorer](/docs/apis/rest-api-v2/api-explorer-v2/introduction-new-relics-rest-api-explorer). For accounts that have child accounts, each [child account](/docs/accounts/accounts-billing/account-structure/mastersub-account-structure) must use its own REST API key.
 
 Requirements: 
 * Requires admin-level user permissions. If you don't have access to the REST API key or the REST API explorer, it might be due to lack of permissions. Talk to your New Relic account manager, or use a [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key) instead.  

--- a/src/content/docs/apm/transactions/cross-application-traces/troubleshoot-cross-application-tracing.mdx
+++ b/src/content/docs/apm/transactions/cross-application-traces/troubleshoot-cross-application-tracing.mdx
@@ -11,7 +11,7 @@ redirects:
   - /docs/apm/transactions/cross-application-traces/troubleshooting-cross-application-tracing
 ---
 
-Here are troubleshooting tips when using [cross application traces](/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces). This is not the same as using New Relic's [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) feature.
+Here are troubleshooting tips when using [cross application traces](/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces). Note that this feature is not the same as [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing), which is preferred over cross application tracing. 
 
 ## Agent versions and protocols [#agents]
 
@@ -178,6 +178,8 @@ If you expect to see a cross application trace link but it consistently does not
 
 If one or more of your Java applications uses an async or "reactive" programming model, a transaction's activity may span across multiple threads. New Relic supports the Play framework and Servlet Async but not all async frameworks. For unsupported frameworks, activity on other threads is not reported as part of the transaction. Calls to other applications will not be traced.
 
-## Sub-accounts [#accounts]
+## Multiple accounts [#accounts]
 
-Currently cross application traces do not cross New Relic accounts. If you have multiple New Relic accounts (including sub-accounts), you will only see traces for applications within one account.
+Currently cross application traces do not cross New Relic accounts. If you have multiple New Relic accounts (including child accounts), you will only see traces for applications within one account.
+
+Our [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing) feature does cross account boundaries. 

--- a/src/content/docs/integrations/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic.mdx
+++ b/src/content/docs/integrations/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic.mdx
@@ -88,7 +88,7 @@ We currently offer two integration options: [Prometheus remote write integration
         * Evaluate your observability needs to manage your data volumes better:
           * The [scrape interval](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) is the biggest factor influencing data volumes: select it based on your observability needs. For example, changing from 15s (default value) to 30s can reduce data volumes by 50%.
           * Set your filters and configure data to target (see [metrics or targets](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_action)).
-        * Balance remote write(s) between one or more New Relic accounts or sub-accounts to manage rate limits.
+        * Balance remote write(s) between one or more New Relic accounts to manage rate limits.
       </td>
 
       <td/>

--- a/src/content/docs/integrations/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
+++ b/src/content/docs/integrations/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
@@ -112,7 +112,7 @@ You can customize the following parameters if you are writing to more than one a
     id="x-license-key"
     title="X-License Key"
   >
-    Your account's [license key](/docs/accounts/install-new-relic/account-setup/license-key) is not an API key. The license key is used for authentication and to identify which account to write data into. If you are configuring Prometheus to write into different New Relic accounts or sub-accounts, use a different key on each remote write URL.
+    Your account's [license key](/docs/accounts/install-new-relic/account-setup/license-key) is not an API key. The license key is used for authentication and to identify which account to write data into. If you are configuring Prometheus to write into different New Relic accounts, use a different key on each remote write URL.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/licenses/license-information/general-usage-licenses/new-relic-data-usage-limits-policies.mdx
+++ b/src/content/docs/licenses/license-information/general-usage-licenses/new-relic-data-usage-limits-policies.mdx
@@ -15,7 +15,7 @@ This document lists some important account-level limits and links to other limit
 
 We strive to keep our resources operating efficiently so that our services are available to all our users. To prevent data usage spikes in one New Relic account from impacting other customers' accounts, we have various data volume and rate limits in place. We reserve the right to enforce these limits to protect our system and to avoid issues for you and other customers.
 
-If your New Relic account, whether by configuration or by error, exceeds one of these limits, it or its sub-accounts might experience one or both of the following:
+If your New Relic account, whether by configuration or by error, exceeds one of these limits, it or its child accounts might experience one or both of the following:
 
 * Sampling of data
 * Temporary pause or cessation of data collection

--- a/src/content/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api.mdx
+++ b/src/content/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api.mdx
@@ -62,7 +62,7 @@ The [account object](/docs/new-relic-partnerships/partnerships/partner-api/partn
 * Set primary admin ([some accounts](#requirements))
 * Set subscription ([some accounts](#requirements))
 
-There is also a [sub-account object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-sub-account-object) for creating sub-accounts. 
+There is also a [child account object](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-sub-account-object) for creating child accounts. 
 
 **Users:**
 

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
@@ -68,7 +68,7 @@ On this page, you will learn how to manually instrument your lambda function. It
 
       6. The following environment variables are not required for Lambda monitoring to function but they are required if you want your Lambda functions to be included in distributed traces. To enable [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing), set these [environment variables](https://docs.aws.amazon.com/amplify/latest/userguide/environment-variables.html) in the AWS console:
          * `NEW_RELIC_ACCOUNT_ID`. Your [account ID](/docs/accounts/install-new-relic/account-setup/account-id).
-         * `NEW_RELIC_TRUSTED_ACCOUNT_KEY.` This is also your [account ID](/docs/accounts/install-new-relic/account-setup/account-id). If your account is a sub-account, this is the account ID for the root/parent account.
+         * `NEW_RELIC_TRUSTED_ACCOUNT_KEY.` This is also your [account ID](/docs/accounts/install-new-relic/account-setup/account-id). If your account is a child account, this is the account ID for the root/parent account.
       7. Optional: To configure logging, see [Go agent logging](/docs/agents/go-agent/configuration/go-agent-logging).
       8. Invoke the Lambda at least once. This creates a CloudWatch log group, which must be present for the next step to work.
 
@@ -115,7 +115,7 @@ On this page, you will learn how to manually instrument your lambda function. It
     7. The following [AWS console environment variables](https://docs.aws.amazon.com/amplify/latest/userguide/environment-variables.html) are required if you want your Lambda function to be included in [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). This is recommended.
         * `NEW_RELIC_ACCOUNT_ID`. Your [account ID](/docs/accounts/install-new-relic/account-setup/account-id).
         * `NEW_RELIC_PRIMARY_APPLICATION_ID`. This is also your [account ID](/docs/accounts/install-new-relic/account-setup/account-id).
-        * `NEW_RELIC_TRUSTED_ACCOUNT_KEY`. This is also your [account ID](/docs/accounts/install-new-relic/account-setup/account-id). If your account is a sub-account, this must be the account ID for the root/parent account.
+        * `NEW_RELIC_TRUSTED_ACCOUNT_KEY`. This is also your [account ID](/docs/accounts/install-new-relic/account-setup/account-id). If your account is a child account, this must be the account ID for the root/parent account.
     8. Optional: In the Lambda console, enable debug logging by adding this environment variable: `NEW_RELIC_DEBUG` is `true`.
     9. Invoke the Lambda at least once. This creates a CloudWatch log group, which must be present for the next step to work.
 
@@ -326,7 +326,7 @@ Task<PublishResponse> ResponseTwo = SNSWrapper.WrapRequest(client.PublishAsync, 
 </CollapserGroup>
     5. The following environment variables are not required for Lambda monitoring to function but they are required if you want your Lambda functions to be included in distributed traces. To enable [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing), set these environment variables in the [AWS Lambda console](https://docs.aws.amazon.com/lambda/latest/dg/env_variables.html):
         * `NEW_RELIC_ACCOUNT_ID`: The [account ID](/docs/accounts/install-new-relic/account-setup/account-id) the Lambda is reporting to.
-        * `NEW_RELIC_TRUSTED_ACCOUNT_KEY`: This is also the [account ID](/docs/accounts/install-new-relic/account-setup/account-id). If your account is a sub-account, this needs to be the account ID for the root/parent account.
+        * `NEW_RELIC_TRUSTED_ACCOUNT_KEY`: This is also the [account ID](/docs/accounts/install-new-relic/account-setup/account-id). If your account is a child account, this needs to be the account ID for the root/parent account.
     6. Ensure that the wrapper function (`FunctionWrapper` in above example) is set up as the function handler.
     7. Invoke the Lambda at least once. This creates a CloudWatch log group, which must be present for the next step to work.
 
@@ -384,7 +384,7 @@ callback();
     * `NEW_RELIC_NO_CONFIG_FILE`. Set to `true` if not using a configuration file.
     * `NEW_RELIC_APP_NAME`: Your application name.
     * `NEW_RELIC_ACCOUNT_ID`. Your [account ID](/docs/accounts/install-new-relic/account-setup/account-id).
-    * `NEW_RELIC_TRUSTED_ACCOUNT_KEY`. This is also your [account ID](/docs/accounts/install-new-relic/account-setup/account-id). If your account is a sub-account, this needs to be the account ID for the root/parent account.
+    * `NEW_RELIC_TRUSTED_ACCOUNT_KEY`. This is also your [account ID](/docs/accounts/install-new-relic/account-setup/account-id). If your account is a child account, this needs to be the account ID for the root/parent account.
 8. Optional: To run the agent in serverless mode outside of AWS in a local environment, set the environment variable `NEW_RELIC_SERVERLESS_MODE_ENABLED` to `true`. (When executing this in an AWS Lambda environment, the agent will automatically run in serverless mode. **Do not use this variable if you're running in AWS**.)
 9. Optional: To enable logging in serverless mode, set these environment variables:
     * Set `NEW_RELIC_LOG_ENABLED` to `true`.
@@ -440,7 +440,7 @@ def handler(event, context):
   7. The following environment variables are not required for Lambda monitoring to function but they are required if you want your Lambda functions to be included in distributed traces. To enable [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing), set these [environment variables](https://docs.aws.amazon.com/amplify/latest/userguide/environment-variables.html) in the AWS console:
       * `NEW_RELIC_DISTRIBUTED_TRACING_ENABLED`. Set to true.
       * `NEW_RELIC_ACCOUNT_ID`. Your [account ID](/docs/accounts/install-new-relic/account-setup/account-id).
-      * `NEW_RELIC_TRUSTED_ACCOUNT_KEY.` This is also your [account ID](/docs/accounts/install-new-relic/account-setup/account-id). If your account is a sub-account, this needs to be the account ID for the root/parent account.
+      * `NEW_RELIC_TRUSTED_ACCOUNT_KEY.` This is also your [account ID](/docs/accounts/install-new-relic/account-setup/account-id). If your account is a child account, this needs to be the account ID for the root/parent account.
   8. Optional: To configure logging, use the [`NEW_RELIC_LOG` and `NEW_RELIC_LOG_LEVEL` environment variables](/docs/agents/python-agent/configuration/python-agent-configuration#environment-variables) in the AWS Console.
   9. Invoke the Lambda at least once. This creates a CloudWatch log group, which must be present for the next step to work.
 

--- a/src/content/docs/telemetry-data-platform/custom-data/custom-events/data-requirements-limits-custom-event-data.mdx
+++ b/src/content/docs/telemetry-data-platform/custom-data/custom-events/data-requirements-limits-custom-event-data.mdx
@@ -255,7 +255,7 @@ Avoid using the following reserved words as names for events and attributes. Oth
 
 ## Event type limits [#event-limits]
 
-The current limit for total number of `eventType` values is 250 per sub-account in a given 24-hour time period. If a user exceeds this limit, New Relic may filter or drop data. Event types include:
+The current limit for total number of `eventType` values is 250 per child account in a given 24-hour time period. If a user exceeds this limit, New Relic may filter or drop data. Event types include:
 
 * Default events from New Relic agents
 * Custom events from New Relic agents

--- a/src/content/docs/telemetry-data-platform/manage-data/view-system-limits.mdx
+++ b/src/content/docs/telemetry-data-platform/manage-data/view-system-limits.mdx
@@ -13,7 +13,7 @@ To ensure our systems are always up and ready to support you, and to keep you fr
 
 ## Responses to limit violations [#violations]
 
-Limits are enforced per sub-account, and across our APIs. You might reach a limit if you start monitoring a new high-traffic application, or have a sudden data spike. When you do reach a limit, New Relic responds according to the type of data and the limit that’s reached. For example:
+Limits are enforced per child account, and across our APIs. You might reach a limit if you start monitoring a new high-traffic application, or have a sudden data spike. When you do reach a limit, New Relic responds according to the type of data and the limit that’s reached. For example:
 
 * We place a limit on the number of ingested requests per minute (RPM) per data type. When this limit is reached, we stop accepting data and return a 429 status code for the duration of the minute.
 * For queries, we place limits on the number of queries per minute and the number of records inspected (see [query limits](/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries)). When the number of queries per minute limit is reached, New Relic will begin rejecting queries until the number of queries is below the limit.  When the records inspected limit is reached, New Relic will reject traffic from the source scanning the largest number of records and attempt to allow traffic from other sources.

--- a/src/content/docs/telemetry-data-platform/understand-data/event-data/query-account-audit-logs-nrauditevent.mdx
+++ b/src/content/docs/telemetry-data-platform/understand-data/event-data/query-account-audit-logs-nrauditevent.mdx
@@ -1,6 +1,6 @@
 ---
 title: Query account audit logs (NrAuditEvent)
-metaDescription: 'To view audit logs that show changes to your New Relic account for a selected time frame, query the NrAuditLog event.'
+metaDescription: 'To view audit logs that show changes in your New Relic account for a selected time frame, query the NrAuditLog event.'
 redirects:
   - /docs/insights/use-insights-ui/manage-account-data/querythe-account-audit-logs-auditevent
   - /docs/insights/use-insights-ui/manage-account-data/query-account-audit-logs-auditevent
@@ -8,7 +8,7 @@ redirects:
   - /docs/insights/event-data-sources/default-events/query-account-audit-logs-nrauditevent
 ---
 
-As an additional security measure for managing your New Relic account, you can use the `NrAuditEvent` event to view audit logs that show changes to your New Relic account. This includes:
+As an additional security measure for managing your New Relic account, you can use the `NrAuditEvent` event to view audit logs that show changes in your New Relic account. This includes:
 
 * Individuals added or deleted
 * Role changes
@@ -17,17 +17,17 @@ As an additional security measure for managing your New Relic account, you can u
 * Dashboard deletion
 * Workload configuration changes
 
-You can also use [alerts](/docs/alerts/new-relic-alerts/getting-started/alerting-new-relic) to be notified about changes to your New Relic account.
+You can also use [alerts](/docs/alerts/new-relic-alerts/getting-started/alerting-new-relic) to be notified about changes in your New Relic account.
 
 ## Account data security and retention [#retention]
 
-All New Relic accounts can query up to 13 months of account changes. To ensure account security, the audit logging [NRQL](/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) query only tracks changes to your currently selected account. It does not show audit log events for any associated child accounts. To query changes to another account or sub-account, select the account and run a NRQL query there.
+All New Relic accounts can query up to 13 months of account changes. To ensure account security, the audit logging [NRQL](/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) query only tracks changes in your currently selected account. It does not show audit log events for any associated child accounts. To query changes in another account or sub-account, select the account and run a NRQL query there.
 
 Audit logging is different than configuring [audit mode](/docs/agents/manage-apm-agents/configuration/log-audit-all-data-your-new-relic-agent-transmits) for your APM agent. APM audit mode records information about all data being transmitted from your app.
 
 ## Run NrAuditEvent query [#nrql]
 
-To track and view changes to your New Relic account:
+To track and view changes in your New Relic account:
 
 1. At any [NRQL interface](/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql#where), run the following query, adjusting the time frame as needed up to thirteen months:
 

--- a/src/content/docs/telemetry-data-platform/understand-data/event-data/query-account-audit-logs-nrauditevent.mdx
+++ b/src/content/docs/telemetry-data-platform/understand-data/event-data/query-account-audit-logs-nrauditevent.mdx
@@ -21,7 +21,7 @@ You can also use [alerts](/docs/alerts/new-relic-alerts/getting-started/alerting
 
 ## Account data security and retention [#retention]
 
-All New Relic accounts can query up to 13 months of account changes. To ensure account security, the audit logging [NRQL](/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) query only tracks changes to your currently selected account. It does not show audit log events for any associated sub-accounts. To query changes to another account or sub-account, select the account and run a NRQL query there.
+All New Relic accounts can query up to 13 months of account changes. To ensure account security, the audit logging [NRQL](/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) query only tracks changes to your currently selected account. It does not show audit log events for any associated child accounts. To query changes to another account or sub-account, select the account and run a NRQL query there.
 
 Audit logging is different than configuring [audit mode](/docs/agents/manage-apm-agents/configuration/log-audit-all-data-your-new-relic-agent-transmits) for your APM agent. APM audit mode records information about all data being transmitted from your app.
 
@@ -37,4 +37,4 @@ To track and view changes to your New Relic account:
 2. To customize your query, use any of the available [`NrAuditEvent` attributes](/attribute-dictionary/?attribute_name=&events_tids%5B%5D=8287&event=NrAuditEvent).
 3. To be notified about account changes, create [NRQL conditions with New Relic Alerts](/docs/alerts/new-relic-alerts/defining-conditions/create-alert-conditions-nrql-queries).
 
-To query changes to another account or sub-account, select the account and run a separate NRQL query for that account.
+To query changes in another account, select the account and run a separate NRQL query for that account.


### PR DESCRIPTION
Noticed there were a few remaining 'sub-account' refs, not sure how I missed em. Edited them away. 