### PR TITLE
Per-account trace rate limits

### DIFF
--- a/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
+++ b/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
@@ -81,6 +81,8 @@ Here are some details about how head-based sampling is implemented in our standa
     If the above sampling methods still result in too much trace data, we may limit incoming data by sampling traces after they're received. By making this decision at the trace level, it avoids fragmenting traces (accepting only part of a trace).
 
     This process works similarly to [adaptive sampling](#trace-origin-sampling). The total spans received in a minute are totaled. If too many spans are received, fewer spans may be accepted in the following minute, in order to achieve a floating-average throughput rate.
+
+    For other details about limits, see [New Relic data usage limits and policies](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/new-relic-data-usage-limits-policies/#all_products).
   </Collapser>
 
   <Collapser

--- a/src/content/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits.mdx
+++ b/src/content/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits.mdx
@@ -24,7 +24,7 @@ This document applies to the Trace API overall. For rules regarding specific dat
 
 ## Endpoints [#requirements]
 
-All trace data is sent via a POST to a Trace API endpoint. We have a few endpoints, depending on your setup:
+All trace data is sent via HTTPS POST to a Trace API endpoint. We have a few endpoints, depending on your setup:
 
 * Default Trace API endpoint: `https://trace-api.newrelic.com/trace/v1`
 * EU data centers: `https://trace-api.eu.newrelic.com/trace/v1` (see other [EU endpoints](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints)).
@@ -37,118 +37,6 @@ Currently, the Trace API accepts two types of data formats:
 
 * [`zipkin`](/docs/apm/distributed-tracing/trace-api/report-zipkin-format-traces-trace-api): For reporting Zipkin trace data. Zipkin data must be [Zipkin JSON v2](https://zipkin.io/zipkin-api/#/default/post_spans).
 * [`newrelic`](/docs/apm/distributed-tracing/trace-api/report-new-relic-format-traces-trace-api): For reporting all other trace data.
-
-## Data limits [#data-limits] 
-
-Data limits and rules:
-
-<table>
-  <thead>
-    <tr>
-      <th style={{ width: "280px" }}>
-        Condition
-      </th>
-
-      <th>
-        Limit
-      </th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td>
-        Max age of span `timestamp` values
-      </td>
-
-      <td>
-        20 minutes. `timestamp` must be within 20 minutes of current time at ingest, or within 20 minutes from the time the last span with the same `trace.id` was received by New Relic.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Max payload size
-      </td>
-
-      <td>
-        1MB (10^6 bytes) (gzip compression supported)
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Max requests per minute
-      </td>
-
-      <td>
-        100K
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Max spans per minute per account family
-      </td>
-
-      <td>
-        Dependent on agreement. Max limit: 2M.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Max spans per trace
-      </td>
-
-      <td>
-        50K
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Max attributes per span
-      </td>
-
-      <td>
-        200
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Max span attribute value length
-      </td>
-
-      <td>
-        4000 characters
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Allowed HTTP protocols
-      </td>
-
-      <td>
-        HTTPS only
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Cross-account visibility of span details
-      </td>
-
-      <td>
-        Potential [data obfuscation](/docs/apm/distributed-tracing/ui-data/understand-use-distributed-tracing-data#account-access)
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-To see an example of how span limits are enforced, see [Exceeding limits](#exceeding-limits).
 
 ## Restricted attributes [#restricted-attributes]
 
@@ -558,7 +446,9 @@ If you receive a `202` response and don't see an `NrIntegrationError` event, you
 traceId = <var>TRACE_ID_SENT</var>
 ```
 
-## Exceeding span limits [#exceeding-limits]
+## Data limits [#data-limits] 
+
+Distributed tracing rate limits are set per account and data type. For details about data limits, see [New Relic data usage limits and policies](/docs/licenses/license-information/general-usage-licenses/new-relic-data-usage-limits-policies/#all_products).
 
 When you exceed your span rate limit, an [`NrIntegrationError` event](/attribute-dictionary?attribute_name=&events_tids%5B%5D=9451) is generated. You can query rate limit messages with this NRQL:
 

--- a/src/content/docs/licenses/license-information/general-usage-licenses/new-relic-data-usage-limits-policies.mdx
+++ b/src/content/docs/licenses/license-information/general-usage-licenses/new-relic-data-usage-limits-policies.mdx
@@ -130,6 +130,46 @@ The following table includes general max limits that apply across all New Relic 
 
     <tr>
       <td>
+        Distributed tracing: Max age of span timestamp values
+      </td>
+
+      <td>
+        20 minutes. Timestamp must be within 20 minutes of current time at ingest or within 20 minutes from the time the last span with the same `trace.id` was received by New Relic.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Distributed tracing: Max spans per minute per account
+      </td>
+
+      <td>
+        Dependent on agreement. Max limit: 2M.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Distributed tracing: Max spans per trace
+      </td>
+
+      <td>
+        50K
+      </td>
+    </tr>
+
+        <tr>
+      <td>
+        Distributed tracing: Max attributes per span
+      </td>
+
+      <td>
+        200
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         Rate of [metric timeslice data](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types#timeslice-data) (used by APM, browser, mobile)
       </td>
 


### PR DESCRIPTION
I initially made these per-account rate limiting changes over a month ago on the private site. While I waited for signoff, the branch got stale. So, to speed up the migration, I just manually moved these over when I received SME confirmation that we can push these out.

Here's what to review:

DOC #1 (Trace API general requirements and limits)

* Migrated four of the limits entries from the table over to New Relic data usage limits and policies. As I understand it, the remaining rows were either already in the main limits doc or the rows were unrelated to limits.
* The table had two miscellaneous items unrelated to limits, so I moved the HTTPS requirement as just a a modifier in the first section about endpoints. I dropped the obfuscation comment because I couldn’t find a better spot, and this appears in the troubleshooting section. Let me know if you have other ideas.
* Created a new Data limits section by combining the old limits section (minus the table) with the old section about exceeding span limits. 

DOC #2 (New Relic data usage limits and policies)

* Migrated four of the Trace API limits table rows over to this doc.
* Prefixed each DT-related limit with “Distributed tracing:”

DOC #3 (How distributed tracing works)

I inserted a link in the collapser for Trace rate limiting that goes to the licenses page (above) that talks about limits.