### PR TITLE
Fixed link to list of Public IPs

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/administration/new-synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/new-synthetic-public-minion-ips.mdx
@@ -11,7 +11,7 @@ metaDescription: 'For New Relic synthetic minions: upcoming IP addresses to be i
 
 On July 15 2021, we'll be adding new IP addresses for several synthetics locations for both [US locations](#us_new_ip) and [EU locations](#eu_new_ip). To ensure your monitors are not affected by these changes, please add the appropriate IP addresses to your firewalls allow list.
 
-For the current list of IP addresses and more about this topic, see [Synthetic monitor public minion IPs](/docs/synthetics/synthetic-public-minion-ips).
+For the current list of IP addresses and more about this topic, see [Synthetic monitor public minion IPs](/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips/).
 
 ## US public minions: Upcoming IP addresses [#us_new_ip]
 

--- a/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
@@ -11,6 +11,7 @@ redirects:
   - /docs/synthetics/new-relic-synthetics/using-monitors/monitor-runners-ips
   - /docs/synthetics/new-relic-synthetics/using-monitors/synthetics-public-minion-ips
   - /docs/synthetics/new-relic-synthetics/administration/synthetics-public-minion-ips
+  - /docs/synthetics/synthetic-public-minion-ips
 ---
 
 New Relic uses a group of minions to execute your [synthetic monitors](/docs/synthetics/new-relic-synthetics/using-monitors/add-edit-monitors). These minions are deployed in different data centers around the globe, and they are in charge of actually running your monitors.


### PR DESCRIPTION
[Synthetic monitor public minion IPs] was updated to /docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips

Old link pointed to /docs/synthetics/synthetic-public-minion-ips

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.