### PR TITLE
Fix typo (`upate` s/be `update`) | Pixie security doc

### DIFF
--- a/src/content/docs/auto-telemetry-pixie/pixie-data-security-overview.mdx
+++ b/src/content/docs/auto-telemetry-pixie/pixie-data-security-overview.mdx
@@ -27,7 +27,7 @@ The data you view on the **Live debugging** tab comes via Pixie, and is therefor
 If you want to manage which members of your organization can view Pixie data, as well as install and delete Pixie links, you can [create a custom role](/docs/accounts/accounts-billing/new-relic-one-user-management/tutorial-add-new-user-groups-roles-new-relic-one-user-model/#roles). Note that this option is available only to Enterprise and Pro level customers.
 For more information, see [New Relic's user model](/docs/accounts/accounts-billing/new-relic-one-user-management/new-relic-one-user-model-understand-user-structure/).  
 
-## Manage auto-upate and two-way communication
+## Manage auto-update and two-way communication
 
 Pixie maintains an active two-way communication channel from your host system to Pixie at [withpixie.ai](https://work.withpixie.ai/). Pixie uses this communication channel to query data, push updates, and retrieve metadata and health checks about Pixie and your Kubernetes cluster.
 


### PR DESCRIPTION
Fix small heading typo in Pixie doc