### PR TITLE
Update references to the entity-definitions repository

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial.mdx
@@ -7,7 +7,7 @@ tags:
 metaDescription: Use New Relic NerdGraph (our GraphQL API) to query or override golden metrics and tags.
 ---
 
-**Golden metrics** and **golden tags** are bits of information about an [entity](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic) that we consider to be the most important for that entity. We use this information to display a brief overview of an entity across all New Relic. You can see and contribute to the standard definitions of the golden metrics and tags in this [public repository](https://github.com/newrelic-experimental/entity-synthesis-definitions#golden-tags).
+**Golden metrics** and **golden tags** are bits of information about an [entity](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic) that we consider to be the most important for that entity. We use this information to display a brief overview of an entity across all New Relic. You can see and contribute to the standard definitions of the golden metrics and tags in this [public repository](https://github.com/newrelic/entity-definitions#golden-tags).
 
 This document explains how to query an entity's custom metrics using [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph).
 

--- a/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts.mdx
@@ -63,7 +63,7 @@ The New Relic Explorer brings together data reported by any [entity](/docs/new-r
 * **[Synthetic monitors](/docs/synthetics)**, for simulations.
 
 <Callout variant="tip">
-  You can create new entity types to monitor any data source. Learn more about [entity synthesis](https://github.com/newrelic-experimental/entity-synthesis-definitions#entity-synthesis-definitions).
+  You can create new entity types to monitor any data source. Learn more about [entity synthesis](https://github.com/newrelic/entity-definitions#entity-definitions).
 </Callout>
 
 To use the New Relic Explorer: Go to **[one.newrelic.com](http://one.newrelic.com)** and select **Explorer**.

--- a/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
@@ -34,7 +34,7 @@ This conceptual definition of "entity" is important because New Relic's goal is 
 You'll find your entities wherever you see your data reporting in New Relic.
 
 <Callout variant="tip">
-  You can create new entity types to monitor any data source. Learn more about [entity synthesis](https://github.com/newrelic-experimental/entity-synthesis-definitions#entity-synthesis-definitions).
+  You can create new entity types to monitor any data source. Learn more about [entity synthesis](https://github.com/newrelic/entity-definitions#entity-definitions).
 </Callout>
 
 Some tips for finding and understanding entity data:
@@ -50,7 +50,7 @@ Some tips for finding and understanding entity data:
 If you have telemetry from any source that's not supported by New Relic out of the box, you can propose a mapping for it. Once approved, any telemetry received by New Relic which matches your definition file will be synthesized into an entity.
 
 <Callout variant="tip">
-  For more information on how to modify existing entity types or create new ones please refer to our [Entity Synthesis documentation](https://github.com/newrelic-experimental/entity-synthesis-definitions#entity-synthesis-definitions).
+  For more information on how to modify existing entity types or create new ones please refer to our [Entity Synthesis documentation](https://github.com/newrelic/entity-definitions#entity-definitions).
 </Callout>
 
 
@@ -92,7 +92,7 @@ These attributes are meant to be synthesized from the telemetry we receive. **Do
       <td>
         This attribute shouldn't be put on ingested telemetry data unless you're trying to override the entity name that would have been selected by New Relic’s entity identification system. While New Relic won't change the value if it's already present on the data, New Relic may add the attribute to your data. Therefore invalid or unexpected values may cause undefined behavior such as missing entities in the UI, or telemetry not associating with the expected entities.
 
-        If this field is present on ingested telemetry, its value will be used to name the entity associated with the data point. This name will be used instead of the name selected by New Relic’s entity identification system (for example, [entity synthesis definitions](https://github.com/newrelic-experimental/entity-synthesis-definitions#entity-synthesis-definitions)). Note that many entities use the name as part of their identification, so changing this field may result in the generation of a new entity.
+        If this field is present on ingested telemetry, its value will be used to name the entity associated with the data point. This name will be used instead of the name selected by New Relic’s entity identification system (for example, [entity synthesis definitions](https://github.com/newrelic/entity-definitions#entity-definitions)). Note that many entities use the name as part of their identification, so changing this field may result in the generation of a new entity.
       </td>
     </tr>
 

--- a/src/content/whats-new/2021/03/kubernetes-whats-new.md
+++ b/src/content/whats-new/2021/03/kubernetes-whats-new.md
@@ -17,7 +17,7 @@ This change will be reflected within New Relic One as follows:
     *   Container Memory Usage - % Used vs Limit
     *   Container MBytes of Memory Used
     *   Node Resource Consumption
-*   [Golden metrics definition for containers](https://github.com/newrelic-experimental/entity-synthesis-definitions/blob/main/definitions/infra-container/golden_metrics.yml#L10) will now use `memoryWorkingSetBytes`
+*   [Golden metrics definition for containers](https://github.com/newrelic/entity-definitions/blob/main/definitions/infra-container/golden_metrics.yml#L10) will now use `memoryWorkingSetBytes`
 *   The Kubernetes cluster explorer now shows the container's memory consumption compared to the limit, using the `WorkingSetBytes` metric in the Pod preview
 *   New alerts can now be created based on:
     *   Memory Working Set Bytes

--- a/src/i18n/content/jp/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts.mdx
+++ b/src/i18n/content/jp/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts.mdx
@@ -49,7 +49,7 @@ New Relicエクスプローラーは、New Relicアカウント全体から[エ�
 * シミュレーション用の**[Syntheticモニター](/docs/synthetics)**。
 
 <Callout variant="tip">
-  新規エンティティタイプを作成し、データソースをモニターできます。[エンティティの統合](https://github.com/newrelic-experimental/entity-synthesis-definitions#entity-synthesis-definitions)の詳細をご覧ください。
+  新規エンティティタイプを作成し、データソースをモニターできます。[エンティティの統合](https://github.com/newrelic/entity-definitions#entity-definitions)の詳細をご覧ください。
 </Callout>
 
 New Relicエクスプローラーを使用するには：**[one.newrelic.com](http://one.newrelic.com)**から**エクスプローラー**を選択します。

--- a/src/i18n/content/jp/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
+++ b/src/i18n/content/jp/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
@@ -27,7 +27,7 @@ New Relic製品では、**エンティティ**を幅広いコンセプトとし�
 エンティティとは、New Relicにデータを報告するあらゆるものを指すため、New Relicでデータが報告されているのを見た場合は必ずエンティティを見つけることができます。
 
 <Callout variant="tip">
-  新規エンティティタイプを作成し、データソースをモニターできます。[エンティティの統合](https://github.com/newrelic-experimental/entity-synthesis-definitions#entity-synthesis-definitions)の詳細をご覧ください。
+  新規エンティティタイプを作成し、データソースをモニターできます。[エンティティの統合](https://github.com/newrelic/entity-definitions#entity-definitions)の詳細をご覧ください。
 </Callout>
 
 以下は、エンティティデータの発見と理解に役立ついくつかのポイントになります：


### PR DESCRIPTION
Update references to the entity-definitions repository after its graduation out of the newrelic-experimental org

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

This PR fixes outdated links to the newrelic-experimental organization for entity type definitions. You can see an example of outdated link on the [Find and explore entities section of the What is an entity in New Relic? page](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#find)
