### PR TITLE
Updated Infra related time limits

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-violations/how-alert-condition-violations-are-closed.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-violations/how-alert-condition-violations-are-closed.mdx
@@ -25,7 +25,7 @@ When a violation closes automatically:
 1. The closing timestamp is backdated to the start of the recovery period.
 2. The evaluation resets and restarts from when the previous violation ended.
 
-Some types of conditions have a [violation time limit](#time-limit) setting that will automatically force-close a long-lasting violation.
+All conditions have a [violation time limit](#time-limit) setting that will automatically force-close a long-lasting violation.
 
 ## Manually close a violation [#close-violation]
 
@@ -47,13 +47,13 @@ To close all violations associated with a condition:
 
 ## Set a time limit for long-lasting violations [#time-limit]
 
-Some types of conditions have a violation time limit setting. This limit will automatically force-close a long-lasting violation after the number of hours you select. This is most useful for ephemeral entities that, when they disappear, cause a continual violation that won't automatically close.
+The violation time limit setting will automatically force-close a long-lasting violation after the number of days/hours you select. This is most useful for ephemeral entities that, when they disappear, cause a continual violation that won't automatically close.
 
 **Limits and Defaults**
 
 * All alert violations will have a violation time limit applied to them. Most alert conditions will allow you to edit this field.
-* The default value, if one is not supplied during configuration, is 30 days.
-* Violation time limit can be set as low as 5 minutes, and as high as 30 days. If, for some reason, the signal is still violating in 30 days, the violation will close, and a new violation will open.
+* The default value, if one is not supplied during configuration, is 30 days (24 hours for Infrastructure conditions).
+* The violation time limit for non-Infrastructure conditions can be set as low as 5 minutes, and as high as 30 days. If, for some reason, the signal is still violating in 30 days, the violation will close, and a new violation will open. Infrastructure conditions can be set to the following hours: 1, 2, 4, 8, 12, 24, 48, or 72.
 
 **Examples:**
 


### PR DESCRIPTION

<!-- Thanks for contributing to our docs! -->

### Give us some context

* What problems does this PR solve?
All conditions now have TTL's applied to them. It is no longer allowed to have a condition without a TTL. The default value for infrastructure conditions is 24 hours. 0 (disabled) is no longer allowed. If a user sends 0, we will replace it with 24.
The Infra UI is being updated this week. The enable/disable checkbox is being removed and the default value will be 24. The user must use the default or change it to a pre-defined value.
