### PR TITLE
Update completed translation workflow to use new database calls

### DIFF
--- a/.github/workflows/check-translations-and-deserialize.yml
+++ b/.github/workflows/check-translations-and-deserialize.yml
@@ -92,4 +92,4 @@ jobs:
         if: steps.fetch-deserialize.outputs.batchesToDeserialize != 0
         id: remove-batches
         run: |
-          node ./scripts/actions/remove-completed-batch.js ${{steps.fetch-deserialize.outputs.batchUids}} ${{steps.fetch-deserialize.outputs.deserializedFileUris}}
+          node ./scripts/actions/remove-completed-batch.js ${{steps.fetch-deserialize.outputs.completedBatches}} ${{steps.fetch-deserialize.outputs.deserializedFileUris}}

--- a/scripts/actions/check-job-progress.js
+++ b/scripts/actions/check-job-progress.js
@@ -133,6 +133,11 @@ const main = async () => {
       }`
     );
 
+    console.log(
+      `::set-output name=completedBatches::${batchesToDeserialize.length ? batchesToDeserialize.join(',') : ','
+      }`
+    );
+
     // Output a list of new translated files for the next step in the workflow
     // (creating a new PR with the translated content)
     const deserializedFileUris = uniq(

--- a/scripts/actions/translation_workflow/models/typedefs.js
+++ b/scripts/actions/translation_workflow/models/typedefs.js
@@ -18,6 +18,7 @@
  * @typedef {Object} Status
  * @property {number} id auto-incrementing identifier
  * @property {string} status status of a job
+ * * possible status values are: {'PENDING', 'IN_PROGRESS', 'IN_REVIEW', 'COMPLETED'}
  */
 
 /**


### PR DESCRIPTION
- Closes #3078 
- Changes scripts called in .`check-translations-and-deserialize.yml` to replace calls to old database functions with new functions in `scripts/actions/translation_workflow/database.js`
- At the end of the workflow, updates job statuses to "IN_REVIEW"