### PR TITLE
Clarifying Metric API timestamp units accepted

### DIFF
--- a/src/content/docs/telemetry-data-platform/ingest-apis/report-metrics-metric-api.mdx
+++ b/src/content/docs/telemetry-data-platform/ingest-apis/report-metrics-metric-api.mdx
@@ -38,7 +38,7 @@ Follow this example to send your first metric data points to New Relic:
               "name":"memory.heap", 
               "type":"gauge", 
               "value":2.3, 
-              "timestamp":<var>CURRENT_TIME_IN_MILLISECONDS_HERE</var>, 
+              "timestamp":<var>CURRENT_TIME</var>, 
               "attributes":{"host.name":"dev.server.com"} 
               }] 
        }]'
@@ -187,7 +187,7 @@ The JSON payload uses this structure:
             "name": "service.errors.all",
             "type": "count",
             "value": 15,
-            "timestamp": <var>CURRENT_TIME_IN_MILLISECONDS_HERE</var>,
+            "timestamp": [<var>CURRENT_TIME</var>](#optional-map-attributes),
             "interval.ms": 10000,
             "attributes": {
               "service.response.statuscode": "400",
@@ -199,7 +199,7 @@ The JSON payload uses this structure:
             "name": "service.memory",
             "type": "gauge",
             "value": 2.7,
-            "timestamp": <var>CURRENT_TIME_IN_MILLISECONDS_HERE</var>,
+            "timestamp": <var>CURRENT_TIME</var>,
             "attributes": {
               "host.name": "dev.server.com",
               "app.name": "foo"
@@ -317,7 +317,7 @@ Each metric data point map in the `metrics` array uses the following key-value s
             "name": "cache.misses",
             "type": "count",
             "value": 15,
-            "timestamp": <var>CURRENT_TIME_IN_MILLISECONDS_HERE</var>,
+            "timestamp": [<var>CURRENT_TIME</var>](#optional-map-attributes),
             "interval.ms": 10000,
             "attributes": {
               "cache.name": "myCache",
@@ -328,7 +328,7 @@ Each metric data point map in the `metrics` array uses the following key-value s
             "name": "temperature", 
             "type": "gauge", 
             "value": 15, 
-            "timestamp": <var>CURRENT_TIME_IN_MILLISECONDS_HERE</var>, 
+            "timestamp": <var>CURRENT_TIME</var>, 
             "attributes": { 
               "city": "Portland", 
               "state": "Oregon" 
@@ -344,7 +344,7 @@ Each metric data point map in the `metrics` array uses the following key-value s
               "max": 0.001708826
             },
             "interval.ms": 10000, 
-            "timestamp": <var>CURRENT_TIME_IN_MILLISECONDS_HERE</var>,
+            "timestamp": <var>CURRENT_TIME</var>,
             "attributes": {
               "host.name": "dev.server.com",
               "app.name": "foo"


### PR DESCRIPTION
Small change, removing that timestamp must be in miliseconds and linking to that section for more info. 