### PR TITLE
Clarify limits of ignoring through configuration

### DIFF
--- a/src/content/docs/agents/ruby-agent/api-guides/ignoring-specific-transactions.mdx
+++ b/src/content/docs/agents/ruby-agent/api-guides/ignoring-specific-transactions.mdx
@@ -89,7 +89,7 @@ rules:
   ignore_url_regexes: ["secret", "^/admin"]
 ```
 
-This configuration will only prevent [Transaction events](https://docs.newrelic.com/docs/telemetry-data-platform/understand-data/event-data/events-reported-apm/) that match the set pattern from reporting. Use any of the `newrelic_ignore*` family of methods if you would like to prevent all data, such as trace data, from reporting from a transaction. 
+This configuration will only prevent [Transaction events](/docs/telemetry-data-platform/understand-data/event-data/events-reported-apm/) that match the set pattern from reporting. Use any of the `newrelic_ignore*` family of methods if you would like to prevent all data, such as trace data, from reporting from a transaction. 
 
 Note that regexes do not include any type of anchoring by default. The /secret/ regex will match 'newrelic.com/secret/login' and it will also match 'newrelic.com/users/secretpanda'. The anchored admin regex will match 'newrelic.com/admin/praetorians' but it will not match 'newrelic.com/users/totally-real-admin'.
 

--- a/src/content/docs/agents/ruby-agent/api-guides/ignoring-specific-transactions.mdx
+++ b/src/content/docs/agents/ruby-agent/api-guides/ignoring-specific-transactions.mdx
@@ -89,6 +89,8 @@ rules:
   ignore_url_regexes: ["secret", "^/admin"]
 ```
 
+This configuration will only prevent [Transaction events](https://docs.newrelic.com/docs/telemetry-data-platform/understand-data/event-data/events-reported-apm/) that match the set pattern from reporting. Use any of the `newrelic_ignore*` family of methods if you would like to prevent all data, such as trace data, from reporting from a transaction. 
+
 Note that regexes do not include any type of anchoring by default. The /secret/ regex will match 'newrelic.com/secret/login' and it will also match 'newrelic.com/users/secretpanda'. The anchored admin regex will match 'newrelic.com/admin/praetorians' but it will not match 'newrelic.com/users/totally-real-admin'.
 
 If necessary you may also provide a list of regexes in a comma-separated string, allowing you to set ignore regexes with an environment variable:


### PR DESCRIPTION
The configuration method `ignore_url_regexes` only prevents Transaction events reporting and not spans/traces. Related to:

* https://newrelic.atlassian.net/browse/GTSE-10084

Note: there is no engineering response in the above Jira as we discussed this in GTS pairing and determined this is how the configuration method is expected to work. Feel free to ping #ruby-agent or #gts-ruby for any questions!

Since new releases of the Ruby agent will overwrite any edits to the docs site [configuration page](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#rules-ignore_url_regexes), I submitted a Github issue to the Ruby team to specify this in the configuration doc:

https://github.com/newrelic/newrelic-ruby-agent/issues/729

### Give us some context

* What problems does this PR solve?

Prevent confusion around Ruby agent 'ignore' functionality. This may become more common as uses look to control data ingest

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

https://newrelic.atlassian.net/browse/GTSE-10084

* If your issue relates to an existing GitHub issue, please link to it.
* 
https://github.com/newrelic/newrelic-ruby-agent/issues/729

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.