### PR TITLE
Added link to AWS Lambda per customer comment.

### DIFF
--- a/src/content/docs/agents/python-agent/installation/standard-python-agent-install.mdx
+++ b/src/content/docs/agents/python-agent/installation/standard-python-agent-install.mdx
@@ -59,7 +59,14 @@ For more detailed installation procedures and helpful context, see [Python agent
 
 ## Other options [#other]
 
-If you cannot use the standard install, or if you want more details and context for the install procedures, see our [advanced installation](/docs/agents/python-agent/installation-configuration/python-agent-installation) documentation. You can also install the Python agent in a [Google App Engine flexible environment](/docs/agents/python-agent/hosting-services/install-new-relic-python-agent-gae-flexible-environment). For more information, see [Compatibility and requirements](/docs/agents/python-agent/getting-started/compatibility-requirements-python-agent).
+If you cannot use the standard install, or if you want more details and context for the install procedures, see our [advanced installation](/docs/agents/python-agent/installation-configuration/python-agent-installation) documentation. 
+
+You can also install the Python agent in the following:
+
+* [Google App Engine flexible environment](/docs/agents/python-agent/hosting-services/install-new-relic-python-agent-gae-flexible-environment). 
+* [AWS Lambda](https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-example/)
+
+For more information, see [Compatibility and requirements](/docs/agents/python-agent/getting-started/compatibility-requirements-python-agent).
 
 ## What's next? [#next-steps]
 


### PR DESCRIPTION
This was a request from a customer who said he was unable to find the Python Lambda doc from the standard Python installation doc. He ended up over in our blogs for a solution. So, I inserted a link to AWS Lambda in the standard installation doc.