### PR TITLE
A few SSO and AUM edits

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more.mdx
@@ -29,7 +29,7 @@ Requirements to configure these settings:
 * These features are for managing users on the [New Relic One user model](/docs/accounts/accounts-billing/new-relic-one-pricing-users/users-roles). For users on our original user model, see [Original account management](/docs/accounts/original-accounts-billing).
 * Configuring these settings requires [Pro or Enterprise edition](https://newrelic.com/pricing). 
 * To edit these settings, you must be in a group with the [**Authentication domain manager** role](/docs/accounts/accounts-billing/new-relic-one-pricing-users/users-roles#standard-roles).
-* [SCIM provisioning](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign), also known as automated user management, requires Enterprise edition.
+* [SCIM provisioning](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign), also known as automated user management (AUM), requires Enterprise edition.
 * SAML SSO requires Pro or Enterprise edition. SAML support includes:
   * [Active Directory Federation Services (ADFS)](http://technet.microsoft.com/en-us/library/hh831502.aspx "Link opens in a new window")
   * [Auth0](http://developers.auth0.com/newrelic)
@@ -77,6 +77,8 @@ From the [authentication domain UI](#ui), you can set one of two options for how
 * **Manual:** This means that your users are added manually to New Relic from the [**User management** UI](/docs/accounts/accounts-billing/new-relic-one-user-management/add-manage-users-groups-roles/#where). 
 * **SCIM:** Our automated user management (AUM) feature allows you to use SCIM provisioning to import and manage users from your identity provider. For instructions, see [Automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign). 
 
+Note that once you enable SCIM for an authentication domain, you can't later turn it off. Instead, you should create a new one. 
+
 ## Authentication [#authentication]
 
 The authentication method is the way in which New Relic users log in to New Relic. All users in an authentication domain have a single authentication method. There are two authentication options:
@@ -86,17 +88,17 @@ The authentication method is the way in which New Relic users log in to New Reli
 
 ### Set up SAML SSO authentication [#saml]
 
-Before enabling SAML SSO using the instructions below, here are some things to review and consider: 
+Before enabling SAML SSO using the instructions below, here are some things to understand and consider: 
 
 * For an introduction to our SAML SSO and SCIM offerings, please read [Get started with SSO and SCIM](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-saml-scim). 
 * We recommend reviewing the [SAML SSO requirements](#requirements). 
-* Note that enabling [SCIM provisioning](#source-users) requires enabling SAML SSO, but enabling SAML SSO doesn't require enabling SCIM. 
-* It may help you to consult your identity provider docs because they may have New Relic-specific instructions.
+* Note that your SSO-enabled users won't receive email verification notifications from New Relic because the login and password information is handled by your identity provider.  
+* Consult your identity provider docs because they may have New Relic-specific instructions.
 
 1. If you're setting up SCIM provisioning: 
     * If you use Azure, Okta, or OneLogin, follow these procedures first: [Azure](/docs/accounts/accounts/automated-user-management/azure-ad-scimsso-application-configuration/) \| [OneLogin](/docs/accounts/accounts/automated-user-management/onelogin-scimsso-application-configuration/) \| [Okta](/docs/accounts/accounts/automated-user-management/okta-scimsso-application-configuration/). 
     * If you use a different identity provider, follow the SAML procedures below and use our [SCIM API](/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management/) to enable SCIM. 
-2. If you **only** want to enable SAML SSO and not SCIM, and if you use Okta, Azure, or OneLogin, follow these instructions for configuring the relevant app: 
+2. If you **only** want to enable SAML SSO and not SCIM, and if you use Azure, Okta, or OneLogin, follow these instructions for configuring the relevant app: 
 
     <CollapserGroup>
       <Collapser

--- a/src/content/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign.mdx
@@ -24,7 +24,7 @@ Benefits of enabling automated user management include:
 * Increased productivity: By having a more automatic way to set up users and groups, they're enabled and ready to use New Relic more quickly.
 * Enhanced security: SCIM is an industry standard protocol for maintaining groups of users. 
 * Use of this feature requires SAML SSO, so once your users are added to New Relic, they can log in using your identity provider. 
-* Popular identity providers Okta, OneLogin, and Azure AD have dedicated New Relic apps, improving ease of enablement.  
+* Popular identity providers Azure AD, Okta, and OneLogin have dedicated New Relic apps, improving ease of enablement.  
 
 ## Requirements [#requirements]
 
@@ -35,7 +35,8 @@ Requirements and impacts:
   * This feature creates users on our [New Relic One user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model#user-models).
   * To implement AUM, you must be on our [New Relic One user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model#user-models) and have [user management roles assigned](/docs/accounts/accounts-billing/new-relic-one-user-management/add-manage-users-groups-roles#add-user-managers). If you're on our [original user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model#user-models) (or otherwise can't seem to implement this feature), talk to your New Relic account representative.
 * Supports SAML 2.0 standard for single sign on (SSO).
-* Supports SCIM 2.0 standard. Supported identity providers: Okta, Azure AD, OneLogin. For unsupported identity providers, we have a [SCIM API](/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management).
+* Supports SCIM 2.0 standard. 
+* There are three identity providers that have a dedicated New Relic app: Azure AD, Okta, and OneLogin. For other identity providers, you can use our [SCIM API](/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management).
 * Notes on initial enabling of AUM:
   * We don't currently support toggling SCIM on or off. If an authentication domain has already been set up with the source of users as **Manual**, you can't change it to SCIM.
   * When first enabled, the bearer token is generated and only shown once. If you need to view a bearer token later, the only way to do this is to generate a new one, and that will invalidate the old one and any integrations using the old token.
@@ -55,7 +56,7 @@ To use automated user management to import users from your identity provider:
   * [Configure SAML SSO](/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more/#saml).
   * If you're on [New Relic One pricing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing), you'll likely want to downgrade some of your billable [full users](/docs/accounts/accounts-billing/new-relic-one-user-management/new-relic-one-user-model-understand-user-structure#user-type) to free [basic users](/docs/accounts/accounts-billing/new-relic-one-user-management/new-relic-one-user-model-understand-user-structure#user-type). To do this, use the [**User management** UI](/docs/accounts/accounts-billing/new-relic-one-user-management/add-manage-users-groups-roles#add-users).
   * Once your users are provisioned in New Relic, you'll need to assign access grants to give them access to accounts. [Learn more about access grants.](/docs/accounts/accounts-billing/new-relic-one-user-management/add-manage-users-groups-roles/#understand-concepts) 
-6. Recommended: Set a time zone in your identity provider. If not specified, our UI shows date/times with the UTC time zone. Time zone is specified in IANA Time Zone database format, also known as the "Olson" time zone database format (e.g., "America/Los_Angeles").
+6. **Highly recommended**: Set a time zone in your identity provider. How you do this will vary by identity provider. If not set in your identity provider, our UI shows UTC time zone dates/times. Time zone is specified in IANA Time Zone database format, also known as the "Olson" time zone database format (e.g., "America/Los_Angeles").
 
 If you have issues, contact your account representative.
 

--- a/src/content/docs/accounts/accounts/automated-user-management/okta-scimsso-application-configuration.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/okta-scimsso-application-configuration.mdx
@@ -62,7 +62,8 @@ Assigning users is done using two different tabs in the app. We recommend having
 2. From the **Assignments** form, click on **Assign**.
 3. From the pop up menu, click on **Assign to groups**.
 4. From the **Assign ... to groups** form, click on **Assign** for the group you wish to assign to the application.
-5. Optional: in the **Time zone** field, enter the default time zone for members of the group. Members without a time zone configured, will use the group time zone. Time zone affects how date/times are shown in New Relic. Time zone is specified in IANA Time Zone database format, also known as the "Olson" time zone database format (e.g., "America/Los_Angeles").
+5. **Highly recommended**: We highly recommend setting your users' time zone in Okta. Time zone affects how date/times for that user are shown in New Relic. Users without a time zone configured will be shown in UTC time in New Relic. Time zone is specified in IANA Time Zone database format, also known as the "Olson" time zone database format (e.g., "America/Los_Angeles"). There are several ways in Okta to assign users' time zone, so consult the Okta docs for more information if needed. Here is one way to do this in the **Assignments** tab: 
+   * In the **Time zone** field, enter the default time zone for members of the group. 
 6. Click on **Save and go back**.
 7. Repeat the steps to add a group until all desired groups have been assigned to the application.
 8. Click **Done**.

--- a/src/content/docs/accounts/accounts/automated-user-management/okta-scimsso-application-configuration.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/okta-scimsso-application-configuration.mdx
@@ -62,7 +62,7 @@ Assigning users is done using two different tabs in the app. We recommend having
 2. From the **Assignments** form, click on **Assign**.
 3. From the pop up menu, click on **Assign to groups**.
 4. From the **Assign ... to groups** form, click on **Assign** for the group you wish to assign to the application.
-5. **Highly recommended**: We highly recommend setting your users' time zone in Okta. Time zone affects how date/times for that user are shown in New Relic. Users without a time zone configured will be shown in UTC time in New Relic. Time zone is specified in IANA Time Zone database format, also known as the "Olson" time zone database format (e.g., "America/Los_Angeles"). There are several ways in Okta to assign users' time zone, so consult the Okta docs for more information if needed. Here is one way to do this in the **Assignments** tab: 
+5. **Highly recommended**: Set your users' time zones in Okta. The time zone affects how date/times for that user are shown in New Relic. Users without a time zone configured will be shown in UTC time in New Relic. Time zone is specified in IANA Time Zone database format, also known as the "Olson" time zone database format (e.g., "America/Los_Angeles"). There are several ways in Okta to assign users' time zone, so consult the Okta docs for more information if needed. Here is one way to do this in the **Assignments** tab: 
    * In the **Time zone** field, enter the default time zone for members of the group. 
 6. Click on **Save and go back**.
 7. Repeat the steps to add a group until all desired groups have been assigned to the application.


### PR DESCRIPTION
Assorted build up of edits to these docs, per liaison work. Edits include: 

Clarifying that setting time zone in identity provider app is important for AUM. 
Clarifying that once they toggle AUM for an auth domain, they can't toggle it off. 
Clarifying that when they use SSO, their users don't get emails about password/login from NR; that's through their identity provider. 