### PR TITLE
Added note about health status updated by NRQL queries

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/view-entity-health-status-find-entities-without-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/view-entity-health-status-find-entities-without-alert-conditions.mdx
@@ -25,10 +25,10 @@ With alerts you can easily tell whether an entity (the target for the notificati
 
 The health status indicator doesn't apply for:
 
-* [NRQL alert conditions](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions)
 * Infrastructure entities
 * [Dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards)
 * Entities targeted by labels
+* [NRQL alert conditions](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions), except for queries including the [FACET clause](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#sel-facet) applied to the [entity's GUID](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#find). 
 
 ## Color-coded health status [#colors]
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/view-entity-health-status-find-entities-without-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/view-entity-health-status-find-entities-without-alert-conditions.mdx
@@ -28,7 +28,7 @@ The health status indicator doesn't apply for:
 * Infrastructure entities
 * [Dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards)
 * Entities targeted by labels
-* [NRQL alert conditions](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions), except for queries including the [FACET clause](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#sel-facet) applied to the [entity's GUID](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#find). 
+* [NRQL alert conditions](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions), except for queries including the [FACET clause](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#sel-facet) applied to the [entity's GUID](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#find) 
 
 ## Color-coded health status [#colors]
 


### PR DESCRIPTION
As reported in DOC-7179, health status can be updated by NRQL queries that include the FACET clause applied to entity GUIDs. I'm adding a little, temporary note to mention this much. Nothing too big since this behavior is to be changed this quarter. 