### PR TITLE
Corrects 'cross-account' to 'cross-application'

### DIFF
--- a/src/content/docs/agents/ruby-agent/api-guides/guide-using-ruby-agent-api.mdx
+++ b/src/content/docs/agents/ruby-agent/api-guides/guide-using-ruby-agent-api.mdx
@@ -388,7 +388,7 @@ Use these methods to collect data for external requests:
 
     <tr>
       <td>
-        Add cross-account tracing (CAT) headers to an outbound HTTP request
+        Add cross-application tracing (CAT) headers to an outbound HTTP request
       </td>
 
       <td>


### PR DESCRIPTION
### Give us some context

* What problems does this PR solve?

Corrects 'cross-account' to 'cross-application'

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

API method `add_request_headers()` add 'cross-application' headers to external requests - here is the documentation for this method:

https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent/Transaction/ExternalRequestSegment#add_request_headers-instance_method