### PR TITLE
Use word "dummy doc" in referring to multiple menus

### DIFF
--- a/src/content/docs/style-guide/processes-procedures/include-a-doc-in-multiple-menus.mdx
+++ b/src/content/docs/style-guide/processes-procedures/include-a-doc-in-multiple-menus.mdx
@@ -2,7 +2,7 @@
 title: 'Include a doc in multiple menus'
 ---
 
-If you have a document that should appear in multiple menus, you can include the same path in multiple taxonomy locations.
+If you have a document that should appear in multiple menus, you can include the same path in multiple taxonomy locations. (We sometimes refer to this casually as a "dummy doc.")
 
 For example, if you wanted to link to the APM landing page from another location of taxonomy (such as a differnt taxonomy level, a different category, etc.), you’d add a new entry in the navigation YAML file (for example, `/src/nav/agents.yml`).
 


### PR DESCRIPTION
Went looking for this doc today and realized it would help to mention this shorthand.