### PR TITLE
fixed typo in message json parsing example

### DIFF
--- a/src/content/docs/logs/log-management/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-management/log-api/introduction-log-api.mdx
@@ -632,7 +632,7 @@ Will be treated as:
 {
   "timestamp": 1562767499238,
   "message": "{\"service-name\": \"my-service\", \"user\": {\"id\": 123, \"name\": \"alice\"}}",
-  "service-name": "login-service",
+  "service-name": "my-service",
   "user": {
     "id": 123,
     "name": "alice"


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

in message field json parsing example, key-value data between message and parsed json did not match: login-service --> my-service.

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.