### PR TITLE
Stack level too deep update

### DIFF
--- a/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -126,17 +126,6 @@ These settings are available for agent configuration. Some settings depend on yo
   Specify the [application name](/docs/apm/new-relic-apm/installation-configuration/name-your-application) used to aggregate data in the New Relic UI. To report data to [multiple apps at the same time](/docs/apm/new-relic-apm/installation-configuration/using-multiple-names-app), specify a list of names separated by a semicolon `;`. For example, `MyApp` or `MyStagingApp;Instance1`.
   </Collapser>
   
-  <Collapser id="entity_guid" title="entity_guid">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`nil`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_ENTITY_GUID`</td></tr>
-      </tbody>
-    </table>
-
-  The [Entity GUID](/attribute-dictionary/span/entityguid) for the entity running this agent.
-  </Collapser>
   
   <Collapser id="monitor_mode" title="monitor_mode">
     <table>

--- a/src/content/docs/agents/ruby-agent/getting-started/migration-7x-guide.mdx
+++ b/src/content/docs/agents/ruby-agent/getting-started/migration-7x-guide.mdx
@@ -22,6 +22,70 @@ See [Milestone for 7.0 Target Release](https://github.com/newrelic/newrelic-ruby
 
 Ruby 2.0 and 2.1 reached [EOL in February 2016](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/) and New Relic is following suit with dropping support for these versions in the 7.0 release. There are no known changes that would inherently prevent these versions from continuing to work, but we are no longer guaranteeing the Ruby agent continues to function without issues going forward. If you need Ruby 2.0 or 2.1, then continue to use 6.15.0, which is the last release published to support these Ruby versions.
 
+## Prepend instrumentation configuration [#prepend-instrumentation]
+
+Relevant Pull Request: [Prepend instrumentation #565](https://github.com/newrelic/newrelic-ruby-agent/pull/565).
+
+**Potential Issue:** The agent fails to initialize and start reporting data. A Stack level too deep error message is reported in the logs.
+
+**Solution:** Our configuration and dependency detection mechanism can now be controlled through configuration. By default all auto-instrumented gems/libraries are activated with the prepend strategy. The default configuration setting for these libraries in the absence of any settings appearing in the configuration file is `auto`, which will pick the best strategy. In the case of a known conflict with prepend strategies, `auto` instructs the agent to fall back to method-chaining when such conflicts are detected. Below is a complete explanation of our changes to the configuration section for auto-instrumentation using sidekiq as an example.
+
+```
+instrumentation:
+
+    sidekiq: chain
+```
+
+<Callout variant="tip">
+    The use case for this is when an unknown gem is found to be conflicting. The user is able to revert to method-chaining to deal with the conflict until the agent can be updated to auto-detect and handle the conflict.
+</Callout>
+
+To disable instrumentation altogether:
+
+```
+instrumentation:
+
+    sidekiq: disable
+```
+
+In some cases, we may know specific gems conflict with prepend. To facilitate, we offer an auto config option (which is the default), which will automatically degrade to chain in such cases.
+
+The default setting in most cases is thus:
+
+```
+instrumentation:
+
+    sidekiq: auto
+```
+
+It's possible to force using prepend strategy by specifying it in the config like so:
+
+```
+instrumentation:
+
+    sidekiq: prepend
+```
+
+<Callout variant="tip">
+   The use case for this is when a newer version of the conflicting gem is released and it's known to no longer conflict with prepend strategy.
+</Callout>
+
+If you encounter stack level too deep errors, see our [troubleshooting guide](https://docs.newrelic.com/docs/agents/ruby-agent/troubleshooting/systemstackerror-stack-level-too-deep/) on how to resolve these issues. After working through this troubleshooting guide, you can let us know about the prepend conflict you find by commenting on this [GitHub issue](https://github.com/newrelic/newrelic-ruby-agent/issues/731). We appreciate your feedback so we may detect and automatically fall back to method-chaining in such scenarios. 
+
+## Modernized auto-instrumentation strategy [#modernized-auto-instrumentation]
+
+Ruby introduced prepend as a way to insert method definitions earlier into the method resolution stack in Ruby 2.0 (released in 2013) with the intent that prepend eliminates the need to do method-chaining as a means of patching original gem libraries' implementations with trace/observability logic.
+
+Mixing prepend with method-chaining (a.k.a. method\_alias monkey patching) can lead to a known stack level too deep scenario as described in [our blog post](https://blog.newrelic.com/engineering/ruby-agent-module-prepend-alias-method-chains/) on the topic.
+
+New Relic has previously updated many auto-instrumented libraries over the years to use prepend strategy. The 7.0 release makes prepend the default strategy of choice to auto-instrument over method-chaining, except when known scenarios exist that would lead to triggering stack level too deep errors. A best effort to identify conflicting external gems that would lead to this scenario was made, but there are bound to be others out in the wild that we have not identified.
+
+
+In the past, we had only one way to auto-instrument for most gems and that was method-chaining. With 7.0 release, we can instrument most gems using either method-chaining or prepend and our configuration of all auto-instrumented gems has been updated to reflect this.
+
+With the modernization of our auto-instrumentation, we have also introduced new functionality in our dependency detection mechanism to identify conflicting external gems and automatically switch from prepend strategy to method-chaining. This means our users no longer have to depend on the maintainers of other gems to make changes to their gem libraries in order to facilitate using the Ruby agent in conjunction with those gems. However, we are not aware of such conflicts until our users report them to us, so only a few of our auto-instrumented libraries can auto-detect these conflicts and auto-switch to method-chaining strategies. We need your help to hear about these scenarios and to add auto-detection to future Ruby agent releases.
+
+
 ## The SSL Certificate bundle is removed [#ssl-cert-removed]
 
 In the early days of Ruby (1.8, 1.9, etc.), integration with OpenSSL and making HTTPS connections was not well-handled. To ensure customers would be able to consistently make HTTPS connections to New Relic's Collector servers, a selection of SSL CA Certificates were bundled and distributed with the Ruby Agent. Over time, the Ruby ecosystem has stabilized and now supports system installed CA Certificates in a standard manner that largely obsoletes the need to bundle and distribute the certificate bundle. The vast majority of certificates bundled have expired or are nearing expiration, so we have decided to remove this dependency from the agent. If you're deploying a Ruby application and agent to a container or server that does not have CA certificates installed, you will need to ensure they're now installed for 7.0+ releases of the agent to make successful HTTPS connections to New Relic servers.
@@ -89,68 +153,4 @@ Relevant Pull Requests are:
 
 **Solution:** Instead, please see [insert\_distributed\_trace\_headers](https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent/DistributedTracing#insert_distributed_trace_headers-instance_method) and [accept\_distributed\_trace\_headers](https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent/DistributedTracing#accept_distributed_trace_headers-instance_method), respectively.
 
-## Prepend instrumentation configuration [#prepend-instrumentation]
-
-Relevant Pull Request: [Prepend instrumentation #565](https://github.com/newrelic/newrelic-ruby-agent/pull/565).
-
-**Potential Issue:** The agent fails to initialize and start reporting data. A Stack level too deep error message is reported in the logs.
-
-**Solution:** Our configuration and dependency detection mechanism can now be controlled through configuration. By default all auto-instrumented gems/libraries are activated with the prepend strategy. The default configuration setting for these libraries in the absence of any settings appearing in the configuration file is `auto`, which will pick the best strategy. In the case of a known conflict with prepend strategies, `auto` instructs the agent to fall back to method-chaining when such conflicts are detected. Below is a complete explanation of our changes to the configuration section for auto-instrumentation using sidekiq as an example.
-
-```
-instrumentation:
-
-    sidekiq: chain
-```
-
-<Callout variant="tip">
-    The use case for this is when an unknown gem is found to be conflicting. The user is able to revert to method-chaining to deal with the conflict until the agent can be updated to auto-detect and handle the conflict.
-</Callout>
-
-To disable instrumentation altogether:
-
-```
-instrumentation:
-
-    sidekiq: disable
-```
-
-In some cases, we may know specific gems conflict with prepend. To facilitate, we offer an auto config option (which is the default), which will automatically degrade to chain in such cases.
-
-The default setting in most cases is thus:
-
-```
-instrumentation:
-
-    sidekiq: auto
-```
-
-It's possible to force using prepend strategy by specifying it in the config like so:
-
-```
-instrumentation:
-
-    sidekiq: prepend
-```
-
-<Callout variant="tip">
-   The use case for this is when a newer version of the conflicting gem is released and it's known to no longer conflict with prepend strategy.
-</Callout>
-
-
-If you [find a conflict](https://github.com/newrelic/newrelic-ruby-agent/issues/510) between prepend and another gem in your application's Gemfile, we would highly appreciate opening an Issue or commenting on this gem so that we are aware and potentially work with gem authors to eliminate conflicts.
-
-## Modernized auto-instrumentation strategy [#modernized-auto-instrumentation]
-
-Ruby introduced prepend as a way to insert method definitions earlier into the method resolution stack in Ruby 2.0 (released in 2013) with the intent that prepend eliminates the need to do method-chaining as a means of patching original gem libraries' implementations with trace/observability logic.
-
-Mixing prepend with method-chaining (a.k.a. method\_alias monkey patching) can lead to a known stack level too deep scenario as described in [our blog post](https://blog.newrelic.com/engineering/ruby-agent-module-prepend-alias-method-chains/) on the topic.
-
-New Relic has previously updated many auto-instrumented libraries over the years to use prepend strategy. The 7.0 release makes prepend the default strategy of choice to auto-instrument over method-chaining, except when known scenarios exist that would lead to triggering stack level too deep errors. A best effort to identify conflicting external gems that would lead to this scenario was made, but there are bound to be others out in the wild that we have not identified.
-
-If you encounter stack level too deep errors, please help us identify the offending gems by filing an [issue on GitHub](https://github.com/newrelic/newrelic-ruby-agent/issues/new?assignees=&amp;labels=&amp;template=bug_report.md&amp;title=Stack+Level+Too+Deep+%5BCONFLICTING+GEM%5D) so we may detect and automatically fall back to method-chaining in such scenarios as well as encourage gem authors to update their method-chaining monkey patches to favor prepending over method-chaining. Many have already made the move or carry extra baggage in their gem libraries to allow their gems to co-exist peacefully with New Relic's former use of method-chaining. 7.0 makes prepend the default strategy of choice to auto-instrument.
-
-In the past, we had only one way to auto-instrument for most gems and that was method-chaining. With 7.0 release, we can instrument most gems using either method-chaining or prepend and our configuration of all auto-instrumented gems has been updated to reflect this.
-
-With the modernization of our auto-instrumentation, we have also introduced new functionality in our dependency detection mechanism to identify conflicting external gems and automatically switch from prepend strategy to method-chaining. This means our users no longer have to depend on the maintainers of other gems to make changes to their gem libraries in order to facilitate using the Ruby agent in conjunction with those gems. However, we are not aware of such conflicts until our users report them to us, so only a few of our auto-instrumented libraries can auto-detect these conflicts and auto-switch to method-chaining strategies. We need your help to hear about these scenarios and to add auto-detection to future Ruby agent releases.
 

--- a/src/content/docs/agents/ruby-agent/troubleshooting/systemstackerror-stack-level-too-deep.mdx
+++ b/src/content/docs/agents/ruby-agent/troubleshooting/systemstackerror-stack-level-too-deep.mdx
@@ -12,43 +12,103 @@ redirects:
 
 ## Problem
 
-You receive the error message `SystemStackError: stack level too deep` on the Error details page in your APM UI.
-
-In addition, because of a bug in Ruby versions 2.1 and lower, you might receive only a one-line stack trace that points to the Ruby agent as the issue.
+You are seeing a `stack level too deep (SystemStackError)` error after adding the `newrelic_rpm` gem to your application, or after upgrading to version 7.0.0 or higher.
 
 ## Solution
 
-In most cases, the Ruby agent is not the underlying issue. The issue is that `alias_method` and `Module#prepend` work together only in particular situations and can cause non-terminating recursions when not used together properly.
+In most cases, the Ruby agent is not the underlying issue. The issue is that method chaining (alias_method) and Module#prepend work together only in particular situations. When not used together properly, they can cause non-terminating recursions. The Ruby agent offers both Module#prepend and method chaining gem instrumentation to allow flexibility for customers. For more information about method chaining and Module#prepend incompatibility, read: [Resolving `Module#prepend` and `alias_method` Conflicts Involving the New Relic Ruby Agent](https://newrelic.com/blog/best-practices/ruby-agent-module-prepend-alias-method-chains)
 
-1. Upgrade to Ruby version 2.2 or higher to fix the one-line stack trace bug. Then, review the full stack trace to see if the Ruby agent is the issue.
+### 1. Get the full stack trace
+The first thing you’ll need to do is to get the full stacktrace for the error you’re seeing. The reason it needs to be the full stack trace is because you will need to find the section in the stacktrace that shows the recursion to find the two locations that are in conflict. Things like Rails logs and Passenger logs often truncate the stack trace since it’s so long, so you may need to reproduce the error in an environment where you will be able to grab the full, untruncated stack trace.  One way to do this is to call Exception#backtrace on the `stack level too deep` exception, which will return the full stack trace.
 
-   <Callout variant="tip">
-     If you can't upgrade, refer to the URL included in the `SystemStackError` message to troubleshoot the issue or [disable the Ruby agent](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#disabling) to see if the problem disappears.
-   </Callout>
-2. If the Ruby agent is not the cause of the error, look for evidence of non-terminating recursions including the following:
-   * You don't find `new_relic` near the top of the trace.
-   * You see repeating patterns in the trace.
-3. If you see evidence of a recursion, make sure that `alias_method` and `Module#prepend` are compatible with each other when used on the same method.
+### 2. Find the conflicting code in the stack trace
+Once you have the full stack trace, look for a section with repetition between one gem and the `newrelic_rpm` gem. This is likely the gem causing the conflict. Here is an example section of a stack trace that shows the locations in conflict with Module#prepend and method chaining.
 
-   <CollapserGroup>
-     <Collapser
-       id="activerecord5"
-       title="When used in ActiveRecord 5 code"
-     >
-       Upgrade to Ruby agent version 3.17.2 or higher.
-     </Collapser>
+```
+/Users/user/.rvm/gems/ruby-2.6.5/gems/airbrake-11.0.1/lib/airbrake/rails/net_http.rb:11:in `block in request'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/airbrake-11.0.1/lib/airbrake/rack.rb:25:in `capture_timing'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/airbrake-11.0.1/lib/airbrake/rails/net_http.rb:10:in `request'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/newrelic_rpm-7.0.0/lib/new_relic/agent/instrumentation/net_http/chain.rb:16:in `block in request_with_newrelic_trace'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/newrelic_rpm-7.0.0/lib/new_relic/agent/instrumentation/net_http/instrumentation.rb:26:in `block (2 levels) in request_with_tracing'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/newrelic_rpm-7.0.0/lib/new_relic/agent/tracer.rb:371:in `capture_segment_error'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/newrelic_rpm-7.0.0/lib/new_relic/agent/instrumentation/net_http/instrumentation.rb:25:in `block in request_with_tracing'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/newrelic_rpm-7.0.0/lib/new_relic/agent.rb:501:in `disable_all_tracing'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/newrelic_rpm-7.0.0/lib/new_relic/agent/instrumentation/net_http/instrumentation.rb:24:in `request_with_tracing'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/newrelic_rpm-7.0.0/lib/new_relic/agent/instrumentation/net_http/chain.rb:16:in `request_with_newrelic_trace'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/airbrake-11.0.1/lib/airbrake/rails/net_http.rb:11:in `block in request'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/airbrake-11.0.1/lib/airbrake/rack.rb:25:in `capture_timing'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/airbrake-11.0.1/lib/airbrake/rails/net_http.rb:10:in `request'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/newrelic_rpm-7.0.0/lib/new_relic/agent/instrumentation/net_http/chain.rb:16:in `block in request_with_newrelic_trace'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/newrelic_rpm-7.0.0/lib/new_relic/agent/instrumentation/net_http/instrumentation.rb:26:in `block (2 levels) in request_with_tracing'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/newrelic_rpm-7.0.0/lib/new_relic/agent/tracer.rb:371:in `capture_segment_error'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/newrelic_rpm-7.0.0/lib/new_relic/agent/instrumentation/net_http/instrumentation.rb:25:in `block in request_with_tracing'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/newrelic_rpm-7.0.0/lib/new_relic/agent.rb:501:in `disable_all_tracing'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/newrelic_rpm-7.0.0/lib/new_relic/agent/instrumentation/net_http/instrumentation.rb:24:in `request_with_tracing'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/newrelic_rpm-7.0.0/lib/new_relic/agent/instrumentation/net_http/chain.rb:16:in `request_with_newrelic_trace'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/airbrake-11.0.1/lib/airbrake/rails/net_http.rb:11:in `block in request'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/airbrake-11.0.1/lib/airbrake/rack.rb:25:in `capture_timing'
+/Users/user/.rvm/gems/ruby-2.6.5/gems/airbrake-11.0.1/lib/airbrake/rails/net_http.rb:10:in `request'
+```
 
-     <Collapser
-       id="not-activerecord5"
-       title="When used outside of ActiveRecord 5 code"
-     >
-       * Verify that your app always calls `alias_method` before `Module#prepend` when used on the same method.
-       * Also, check to see if your app calls `Module#prepend` before the **Ruby agent** calls `alias_method` on the same method. If so, follow the recommendations in the New Relic blog post about [resolving `Module#prepend` and `alias_method` conflicts](https://blog.newrelic.com/2016/12/15/ruby-agent-module-prepend-alias-method-chains/).
-     </Collapser>
-   </CollapserGroup>
+You can see which files are causing the conflict, including line numbers. This will allow you to know which gem instrumentation is part of this error.
+Using the example above, the two locations causing the recursion are:
+```
+/Users/user/.rvm/gems/ruby-2.6.5/gems/newrelic_rpm-7.0.0/lib/new_relic/agent/instrumentation/net_http/chain.rb:16:in `request_with_newrelic_trace'
+```
+```
+/Users/user/.rvm/gems/ruby-2.6.5/gems/airbrake-11.0.1/lib/airbrake/rails/net_http.rb:11:in `block in request'
+```
+
+If you were to pull up the code in those two places, you’d see one uses prepend, and the other uses method chaining. In this specific example, the agent uses method chaining, and Airbrake is uses Module#prepend. Since the agent offers both method chaining and Module#prepend, you can configure the agent to use the strategy compatible with the conflicting gem. 
+
+
+### 3. Update config file
+Taking a closer look at the line from the agent in the stack trace, you can see in the path name what gem instrumentation needs to be configured. 
+
+```
+new_relic/agent/instrumentation/net_http/chain.rb:16
+```
+The gem name follows `new_relic/agent/instrumentation/` in the file path. For this example, you can see that this is our Net::HTTP instrumentation, so you’ll want to use `net_http` in your config file to control this instrumentation. When looking at the file name, you can also see that this is using method chaining instrumentation. The file name for method chaining is `/chain.rb`, and for Module#prepend it would be `/prepend.rb`.
+
+Add the config option to your `newrelic.yml`, using whatever gem instrumentation you found was part of the conflict. In this example, the error was raised due to a conflict with the method chaining instrumentation. To resolve it, we’ll set our Net::HTTP instrumentation to use Module#prepend:
+
+```
+instrumentation:
+  net_http: prepend
+```
+If instead we saw the `prepend.rb` file was referenced in the stack trace, we would instead set this config option to `chain`.
+
+For details about the agent’s available configuration options, please refer to the instrumentation section of our [configuration documentation](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#instrumentation ).  
+
+### 4. Still seeing an error?
+If after following the above instructions you are still seeing a stack level too deep error, check and see if this is the same conflict and stack trace, or if this is a different conflict  than the one you just fixed. 
+
+If this is a different conflict with a different stack trace, repeat the above steps with the new stack trace. That should resolve the newly surfaced conflict.
+
+If the stack trace is the same as the first one, check to make sure the agent can load your configuration file. If the agent is having trouble locating or loading the configuration file, resolving that issue should allow the agent to use the gem instrumentation you need. Please see our [configuration documentation](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/) for more information.
+
 
 ## Cause
 
-When your app uses `Module#prepend` on a method that the Ruby agent later uses an `alias_method` on, it creates a non-terminating recursion and throws the `SystemStackError: stack level too deep` error.
+When one location in your application (or a gem used in your application) uses Module#prepend on a method that another location (or gem) later uses an alias_method on, it creates a non-terminating recursion and throws the `SystemStackError: stack level too deep error`.
 
-If you upgraded to Rails 5, which deprecated `alias_method_chain`, you might have replaced `alias_method` with `Module#prepend`, and that could be the source of your issue.
+With the 7.0 release of the Ruby agent, Module#prepend instrumentation has been added for all gem instrumentation that previously only used method chaining. Module#prepend will also be used by default in most cases. The agent still allows method chaining to be used for gem instrumentation, this behavior is controlled by the [agent configuration](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#instrumentation). 
+ 
+When the agent uses the default value for gem instrumentation configuration, it will check the environment for common known conflicts with Module#prepend. If a gem that causes this conflict is detected, the agent instead installs the method chaining instrumentation.
+
+However, we don’t know all of the possible conflicts.  Any gem or application can add method chaining to any method. This is why we offer the option to configure which type of instrumentation is used. 
+
+Here are just a few examples of known conflicts the agent checks for and installs the compatible gem instrumentation.
+
+**Net::HTTP Instrumentation**
+
+Uses method chaining on Net::HTTP methods when Airbrake &lt; 10.0.2 is being used. Airbrake 10.0.2+ updated to use Module#prepend on Net::HTTP, so the agent will install the prepend instrumentation when that version or higher is detected. 
+
+**Resque Instrumentation**
+
+Uses method chaining on Reque methods when Airbrake &lt; 11.0.3 is being used. Airbrake 11.0.3+ updated to use Module#prepend on Resque, so the agent will install the prepend instrumentation when that version or higher is detected. 
+
+**Redis Instrumentation**
+
+Uses method chaining when PrometheusExporter is detected, as that gem uses method chaining on redis methods.
+


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

This PR updates the stack level too deep troubleshooting page for the ruby agent. What was there before was pretty outdated, and referenced ruby versions we no longer support. I've updated the page with instructions on how to troubleshoot the stack level too deep errors in the agent for 7.0+. I've also updated our migration guide for ruby agent version 7.0 to link to the troubleshooting guide, and updated instructions on reporting conflicts on github.

Also, this pr closes https://github.com/newrelic/newrelic-ruby-agent/issues/723 by removing the entity_guid config option from documentation.


### Are you making a change to site code?
No
If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.