### PR TITLE
Updating HNR to include the no_trigger_on toggle

### DIFF
--- a/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts.mdx
+++ b/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts.mdx
@@ -381,7 +381,7 @@ curl -v -X DELETE --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-sta
   >
     A [host not reporting condition](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/infrastructure-alerting-examples#reporting) alerts you when a host stops reporting. To [add (POST)](#post-conditions) or [update (PUT)](#put-condition) a host not reporting condition, use your [API key](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key), and refer to the [definitions](#definitions) to customize your values in the API call.
     
-    * The `no_trigger_on` field is optional. When set to `["shutdown"]` this enables the toggle for: *Don't trigger alerts for hosts that perform a clean shutdown*
+    * The `no_trigger_on` field is optional. When set to `["shutdown"]` this enables the **Don't trigger alerts for hosts that perform a clean shutdown** infrastructure condition option.
 
     <CollapserGroup>
       <Collapser

--- a/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts.mdx
+++ b/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts.mdx
@@ -380,6 +380,8 @@ curl -v -X DELETE --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-sta
     title="Host not reporting condition"
   >
     A [host not reporting condition](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/infrastructure-alerting-examples#reporting) alerts you when a host stops reporting. To [add (POST)](#post-conditions) or [update (PUT)](#put-condition) a host not reporting condition, use your [API key](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key), and refer to the [definitions](#definitions) to customize your values in the API call.
+    
+    * The `no_trigger_on` field is optional. When set to `["shutdown"]` this enables the toggle for: *Don't trigger alerts for hosts that perform a clean shutdown*
 
     <CollapserGroup>
       <Collapser
@@ -398,7 +400,8 @@ curl -v -X DELETE --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-sta
               "where_clause":"(hostname LIKE '\''<var>%cassandra%</var>'\'')",
               "policy_id":<var>policy_id</var>,
               "critical_threshold":{
-                 "duration_minutes":<var>12</var>
+                 "duration_minutes":<var>12</var>,
+                 "no_trigger_on": <var>["shutdown"]</var>
               }
            }
         }'


### PR DESCRIPTION
Howdy Docs team - updating the example here for the Host Not Reporting condition type to include the optional no_trigger_on toggle. This enables the setting 'Don't trigger alerts for hosts that perform a clean shutdown'

### Give us some context

* The current Rest API for Infra Conditions docs don't reflect an important setting that is available in the UI, and via API. The API part is (until now) undocumented.

