### PR TITLE
Added callout for timestamp logic

### DIFF
--- a/src/content/docs/logs/log-management/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-management/log-api/introduction-log-api.mdx
@@ -328,6 +328,10 @@ Some specific attributes have additional restrictions:
 * `eventType`: Can be a combination of alphanumeric characters, `_` underscores, and `:` colons.
 * `timestamp`: Must be a Unix epoch timestamp. You can define timestamps either in seconds or in milliseconds.
 
+<Callout variant="important">
+  Payloads with timestamps older than 48 hours may be dropped.
+</Callout>
+
 Rate limits on logs sent to the Log API:
 
 * Maximum rate for HTTP requests sent to the Log API: 300,000 requests per minute


### PR DESCRIPTION
Heard from CSM today that our logs weren't showing up because our timestamps were older than 48 hours. Not sure this would have helped, but felt it should be called out.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.