### PR TITLE
Small changes to doc

### DIFF
--- a/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/alert-infrastructure-processes.mdx
+++ b/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/alert-infrastructure-processes.mdx
@@ -14,7 +14,7 @@ redirects:
 Use New Relic infrastructure's **Process running** [alert condition](/docs/infrastructure/new-relic-infrastructure/configuration/infrastructure-alerts-add-edit-or-view-host-alert-information) to be notified when a set of processes on your [filtered hosts](/docs/infrastructure/new-relic-infrastructure/filter-group/filter-sets-organize-your-infrastructure-hosts) stop running for a configurable number of minutes. This is useful, for example, when:
 
 * Any of the processes on the hosts stop reporting
-* A process you expected to start on a host (such as a new program) is not actually running
+* A process is running too many instances on one host
 
 This feature's flexibility allows you to easily filter what hosts and processes to monitor and when to notify selected individuals or teams. In addition, the email notification includes links to help you quickly troubleshoot the situation.
 
@@ -65,15 +65,6 @@ By applying filters to the hosts and processes that are important to your busine
     **Problem:** You have a job that runs periodically, and you want to open a violation when it has been running longer than an expected number of minutes.
 
     **Solution:** Use the **At least one process is running** threshold.
-  </Collapser>
-
-  <Collapser
-    id="default-successful"
-    title="Validate that services started successfully"
-  >
-    **Problem:** When provisioning new hosts, you want to open a violation if a required service fails to successfully start up.
-
-    **Solution:** Use the **No processes are running** (default) threshold.
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
Process Running (PR) alert conditions are being migrated to use NRQL (Willamette pipeline). This move will mean that they can no longer tell if a process failed to start when a host is spun up. I have tried to remove all references to that sort of behavior, since PR conditions will change to being more "Process NO LONGER running."

I feel like these changes will not need to be applied until we move the PR condition types over to Willamette (happening soon, but has not happened yet). On the other hand, these don't feel like breaking changes to the document, so could be published immediately without any impact (I think).

Please do send me a DM in Slack (@shenry) if you have any questions about these changes.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.