### PR TITLE
Assorted taxonomy/nav file fixes

### DIFF
--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -51,13 +51,13 @@ pages:
           - title: Cloud services integrations
             path: /docs/full-stack-observability/instrument-everything/instrument-core-services-applications/cloud-services-integrations
           - title: Amazon ECS integration
-            path: /docs/full-stack-observability/instrument-everything/instrument-core-services-applications/amazon-ecs-integration
+            path: /docs/integrations/elastic-container-service-integration/get-started/introduction-amazon-ecs-integration
           - title: Open source telemetry integrations
-            path: /docs/full-stack-observability/instrument-everything/instrument-core-services-applications/open-source-telemetry-integrations
+            path: /docs/integrations/open-source-telemetry-integrations/get-started/introduction-new-relics-open-source-telemetry-integrations
           - title: Prometheus integrations
-            path: /docs/full-stack-observability/instrument-everything/instrument-core-services-applications/prometheus-integrations
+            path: /docs/integrations/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic
           - title: Grafana integrations
-            path: /docs/full-stack-observability/instrument-everything/instrument-core-services-applications/grafana-integrations
+            path: /docs/integrations/grafana-integrations
       - title: Develop your own integrations
         path: /docs/full-stack-observability/instrument-everything/develop-own-integrations
         pages:

--- a/src/nav/new-relic-one.yml
+++ b/src/nav/new-relic-one.yml
@@ -13,33 +13,33 @@ pages:
       - title: Core concepts
         path: /docs/new-relic-one/use-new-relic-one/core-concepts
         pages:
-          - title: What is an entity in New Relic?
+          - title: What's an entity?
             path: /docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic
-          - title: Use Tags to help organize and find your data
+          - title: Tags
             path: /docs/new-relic-one/use-new-relic-one/core-concepts/use-tags-help-organize-find-your-data
-          - title: 'New Relic Explorer: View performance across apps, services, and hosts'
+          - title: New Relic Explorer
             path: /docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts
-          - title: 'New Relic Lookout: Monitor your estate at a glance'
+          - title: New Relic Lookout
             path: /docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-lookout-monitor-your-estate-glance
           - title: Transition to New Relic One from Insights
             path: /docs/new-relic-one/use-new-relic-one/core-concepts/transition-new-relic-one-insights
-          - title: 'Dashboards API migration: from Insights API to Nerdgraph'
+          - title: Dashboards API migration
             path: /docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph
-      - title: UI data
+      - title: UI and data
         path: /docs/new-relic-one/use-new-relic-one/ui-data
         pages:
           - title: Basic UI features
             path: /docs/new-relic-one/use-new-relic-one/ui-data/basic-ui-features
-          - title: Explore downstream dependencies with New Relic One
+          - title: Downstream dependencies
             path: /docs/new-relic-one/use-new-relic-one/ui-data/explore-downstream-dependencies-new-relic-one
           - title: Metric normalization rules
             path: /docs/new-relic-one/use-new-relic-one/ui-data/metric-normalization-rules
-          - title: New Relic feature end of life announcements July 2020
+          - title: Feature EOL announcements July 2020
             path: /docs/new-relic-one/use-new-relic-one/ui-data/new-relic-feature-end-life-announcements-july-2020
       - title: Workloads
         path: /docs/new-relic-one/use-new-relic-one/workloads
         pages:
-          - title: 'Workloads: Isolate and resolve incidents faster'
+          - title: Intro to workloads
             path: /docs/new-relic-one/use-new-relic-one/workloads/workloads-isolate-resolve-incidents-faster
           - title: Use workloads
             path: /docs/new-relic-one/use-new-relic-one/workloads/use-workloads
@@ -50,5 +50,5 @@ pages:
       - title: Build on New Relic One
         path: /docs/new-relic-one/use-new-relic-one/build-new-relic-one
         pages:
-          - title: Build a custom New Relic One integration
+          - title: Build a New Relic One app
             path: /docs/new-relic-one/use-new-relic-one/build-new-relic-one/build-custom-new-relic-one-application


### PR DESCRIPTION
Just a few fixes, including: 

Putting correct URLs in for some docs in 'Instrument everything' category
Changing some long nav file docs titles from long to short titles in New Relic One nav file