### PR TITLE
Update .Net Lambda async doc example

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
@@ -192,15 +192,13 @@ id="net-handler-returns-task-example"
 title="Async handler function"
 >
 ```
-public override Task<int> FunctionHandlerAsync(ILambdaContext lambdaContext)
+public async Task<int> FunctionHandlerAsync(ILambdaContext lambdaContext)
 {
-  // This call will block by calling task.Result
-  Task<int> task = new TracingRequestHandler().LambdaWrapper(
+  return await new TracingRequestHandler().LambdaWrapper(
                         ActualFunctionHandlerAsync, lambdaContext);
-  return task;
 }
 
-public Task<APIGatewayProxyResponse> ActualFunctionHandlerAsync(ILambdaContext
+public async Task<APIGatewayProxyResponse> ActualFunctionHandlerAsync(ILambdaContext
                                                     lambdaContext)
 { // Function can make other async operations here
 ...


### PR DESCRIPTION
Updated the .Net Agent's provided AWS Lambda async example with better guidelines inline with new support.