### PR TITLE
Explanation of how to create custom docs callouts

### DIFF
--- a/src/content/docs/integrations/kubernetes-integration/installation/install-fargate-integration.mdx
+++ b/src/content/docs/integrations/kubernetes-integration/installation/install-fargate-integration.mdx
@@ -1,9 +1,8 @@
 ---
 title: EKS Fargate
-watermark: BETA
 ---
-<Callout variant="tip">
-This is currently a beta feature.
+<Callout title="Beta Feature">
+This feature is still in development, but we encourage you to try it out!
 </Callout>
 
 New Relic supports monitoring Kubernetes workloads on EKS Fargate by automatically injecting a sidecar containing the infrastructure agent and the `nri-kubernetes` integration in each pod that needs to be monitored.

--- a/src/content/docs/style-guide/processes-procedures/use-content-types-text-formats.mdx
+++ b/src/content/docs/style-guide/processes-procedures/use-content-types-text-formats.mdx
@@ -71,9 +71,8 @@ Thr top of every doc begins with a set of metadata. Read on for more information
 
     <tr>
       <td>watermark</td>
-      <td>We use watermarks for things like beta content or to show that something is an internal New Relic doc. Commonly used watermarks are: BETA, Legacy, Deprecated, NR ONLY, etc.
-      
-      Watermarks look like large, faded text behind the doc's content.</td>
+      <td>Watermarks are customizible text backgrounds that indicate something special about a page. They look like large, faded text behind the doc's content. We used to insert watermarks in beta docs, but now we insert a [custom callout](/docs/style-guide/quick-reference/callouts#tr-custom-callout). Here are some other examples of watermarks: Legacy, Deprecated, NR ONLY, etc.      
+      </td>
     </tr>
 
   </tbody>

--- a/src/content/docs/style-guide/processes-procedures/use-content-types-text-formats.mdx
+++ b/src/content/docs/style-guide/processes-procedures/use-content-types-text-formats.mdx
@@ -71,7 +71,7 @@ Thr top of every doc begins with a set of metadata. Read on for more information
 
     <tr>
       <td>watermark</td>
-      <td>Watermarks are customizible text backgrounds that indicate something special about a page. They look like large, faded text behind the doc's content. We used to insert watermarks in beta docs, but now we insert a [custom callout](/docs/style-guide/quick-reference/callouts#tr-custom-callout). Here are some other examples of watermarks: Legacy, Deprecated, NR ONLY, etc.      
+      <td>Watermarks are customizible text backgrounds that indicate something special about a page. They look like large, faded text behind the doc's content. We used to insert watermarks in beta docs, but now we insert a [custom callout](/docs/style-guide/quick-reference/callouts#tr-custom-callout). Here are some other examples of watermarks: Legacy, Deprecated, and NR ONLY).       
       </td>
     </tr>
 

--- a/src/content/docs/style-guide/quick-reference/callouts.mdx
+++ b/src/content/docs/style-guide/quick-reference/callouts.mdx
@@ -80,4 +80,27 @@ On our Docs site, we use these callout classes:
       Access to this feature depends on your [subscription level](http://newrelic.com/application-monitoring/pricing).
     </Callout>
   </Collapser>
+  <Collapser
+    id="tr-custom-callout"
+    title={<>Custom callouts</>}
+  >
+    Custom callouts are available for special cases, such as beta docs. Here's what you can control with custom callouts:
+    
+    * **Title text:** Change the callout label by inserting the `title` attribute like this: `title="YOUR CUSTOM TITLE"`. When you publish, this field is automatically converted to all capital letters.
+    * **Color:** The color is limited to the color of the variant you include, or if you don't include a variant, you get the default border color (blue-grey). 
+
+Here is what the code looks like:
+
+ ```
+<Callout variant="caution" title="YOUR CUSTOM TITLE">
+Your callout message goes here!
+</Callout>
+```
+
+For beta docs, no watermark is needed–just a custom callout. Also, we recommend that you don't include a variant so you display the default color:
+
+<Callout title="Beta feature">
+This feature is still in development, but we encourage you to try it out!
+</Callout>
+  </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
After a meeting about how to flag beta docs, we settled on having a custom callout. 

Reviewer, please look at the following:

* Changes in the style guide topic about callouts that now explains how to create a custom callout.
* Link from the data types doc in the style guide that explains we no longer use watermarks for beta docs.
* An update to the EKS Fargate beta callout so it now follows the new pattern.