### PR TITLE
Update android-610.mdx

### DIFF
--- a/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-610.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-610.mdx
@@ -3,11 +3,14 @@ subject: Android agent
 releaseDate: '2021-06-29'
 version: 6.1.0
 downloadLink: 'https://download.newrelic.com/android_agent/ant/NewRelic_Android_Agent_6.1.0.zip'
-Disclaimer: We have noticed that this version has issues running on devices with API levels below 24.
-This will be fixed in the upcoming release. In the meantime we suggest to revert to version 6.0.0 (or upgrade compileSDK to 24)
 ---
 
-###  New in the release
+<Callout variant="important"> We have noticed that this version has issues running on devices with API levels below 24.
+
+This will be fixed in the upcoming release. In the meantime we suggest you revert to version 6.0.0 (or upgrade compileSDK to 24).
+</Callout>
+
+##  New in this release
 In consideration of customers still dependent on Android 5.0, we've reverted the minimum supported SDK level (minSdkVersion) from 24 to 21.
 
 

--- a/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-610.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-610.mdx
@@ -3,7 +3,8 @@ subject: Android agent
 releaseDate: '2021-06-29'
 version: 6.1.0
 downloadLink: 'https://download.newrelic.com/android_agent/ant/NewRelic_Android_Agent_6.1.0.zip'
-Disclaimer: We have noticed that this version has issues running on devices with API levels below 24. 
+Disclaimer: We have noticed that this version has issues running on devices with API levels below 24.
+This will be fixed in the upcoming release. In the meantime we suggest to revert to version 6.0.0 (or upgrade compileSDK to 24)
 ---
 
 ###  New in the release

--- a/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-610.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-610.mdx
@@ -3,6 +3,7 @@ subject: Android agent
 releaseDate: '2021-06-29'
 version: 6.1.0
 downloadLink: 'https://download.newrelic.com/android_agent/ant/NewRelic_Android_Agent_6.1.0.zip'
+Disclaimer: We have noticed that this version has issues running on devices with API levels below 24. 
 ---
 
 ###  New in the release


### PR DESCRIPTION
Fixed the issue we are seeing with crashes using API levels below 24. So writing a disclaimer to let our clients know that this may cause issues. 
It seems as though the New Relic Android Agent is still using the putIfAbsent method on the Map class, which is only available on API 24 devices: https://developer.android.com/reference/java/util/Map#putIfAbsent(K,%20V)

