### PR TITLE
Added verbose logs instructions for helm installs

### DIFF
--- a/src/content/docs/integrations/kubernetes-integration/troubleshooting/get-logs-version.mdx
+++ b/src/content/docs/integrations/kubernetes-integration/troubleshooting/get-logs-version.mdx
@@ -12,15 +12,15 @@ To generate verbose logs and get version and configuration information, follow t
 <CollapserGroup>
   <Collapser
     id="verbose"
-    title="Get verbose logs"
+    title="Get verbose logs for installations using a manifest file"
   >
     For the Kubernetes integration, the infrastructure agent adds a log entry only in the event of an error. Most common errors are displayed in the standard (non-verbose) logs. If you are doing a more in-depth investigation on your own or with New Relic Support, you can enable verbose mode.
 
     <Callout variant="caution">
-      Verbose mode significantly increases the amount of infor sent to log files. Temporarily enable this mode only for troubleshooting purposes, and reset the log level when finished.
+      Verbose mode significantly increases the amount of info sent to log files. Temporarily enable this mode only for troubleshooting purposes, and reset the log level when finished.
     </Callout>
 
-    To get verbose logging details:
+    To get verbose logging details for an integration using a manifest file:
 
     1. Enable `verbose` logging: In the deployment file, set the value of `NRIA_VERBOSE` to `1`.
     2. Apply the modified configuration by running:
@@ -48,7 +48,28 @@ To generate verbose logs and get version and configuration information, follow t
     8. [Get logs from the pod connecting to kube-state-metrics](#logs-pod-kubestatemetrics).
     9. [Retrieve kube-state-metrics service configuration](#kube-state-metrics-version).
   </Collapser>
+  <Collapser
+    className="freq-link"
+    id="verbose-helm"
+    title="Get verbose logs for installations using Helm"
+  >
+  For the Kubernetes integration, the infrastructure agent adds a log entry only in the event of an error. Most common errors are displayed in the standard (non-verbose) logs. If you are doing a more in-depth investigation on your own or with New Relic Support, you can enable verbose mode.
 
+    <Callout variant="caution">
+      Verbose mode significantly increases the amount of info sent to log files. Temporarily enable this mode only for troubleshooting purposes, and reset the log level when finished.
+    </Callout>
+  To get verbose logging details for an integration using Helm:
+
+    1. Enable verbose logging:
+    ```
+    helm upgrade -n <namespace> --reuse-values newrelic-bundle --set newrelic-infrastructure.verboseLog=true newrelic/nri-bundle
+    ```
+    2. Gather logs from the pod connecting to [Kubernetes state metrics](#logs-pod-kubestatemetrics) as described below.
+    3. When you have the information you need, make sure you disable verbose logging:
+        ```
+        helm upgrade --reuse-values newrelic-bundle --set newrelic-infrastructure.verboseLog=false newrelic/nri-bundle
+        ```
+  </Collapser>
   <Collapser
     id="infra-version"
     title="Get the infrastructure agent version"

--- a/src/content/docs/integrations/kubernetes-integration/troubleshooting/get-logs-version.mdx
+++ b/src/content/docs/integrations/kubernetes-integration/troubleshooting/get-logs-version.mdx
@@ -45,7 +45,7 @@ To generate verbose logs and get version and configuration information, follow t
        ```
        kubectl get pods --all-namespaces -o wide | egrep 'newrelic|kube-state-metrics'
        ```
-    8. [Get logs from the pod connecting to kube-state-metrics](#logs-pod-kubestatemetrics).
+    8. [Get logs from the pods connecting to kube-state-metrics](#logs-pod-kubestatemetrics).
     9. [Retrieve kube-state-metrics service configuration](#kube-state-metrics-version).
   </Collapser>
   <Collapser
@@ -64,7 +64,7 @@ To generate verbose logs and get version and configuration information, follow t
     ```
     helm upgrade -n <namespace> --reuse-values newrelic-bundle --set newrelic-infrastructure.verboseLog=true newrelic/nri-bundle
     ```
-    2. Gather logs from the pod connecting to [Kubernetes state metrics](#logs-pod-kubestatemetrics) as described below.
+    2. Gather logs from pods connecting to [Kubernetes state metrics](#logs-pod-kubestatemetrics) as described below.
     3. When you have the information you need, make sure you disable verbose logging:
         ```
         helm upgrade --reuse-values newrelic-bundle --set newrelic-infrastructure.verboseLog=false newrelic/nri-bundle
@@ -109,11 +109,11 @@ To generate verbose logs and get version and configuration information, follow t
 
   <Collapser
     id="logs-pod-kubestatemetrics"
-    title="Get logs from pod connecting to kube-state-metrics"
+    title="Get logs from pods connecting to kube-state-metrics"
   >
-    To get the logs from the pod connecting to kube-state-metrics:
+    To get the logs from pods connecting to kube-state-metrics:
 
-    1. Get the node that kube-state-metrics is running on:
+    1. Get the nodes that kube-state-metrics is running on:
 
        ```
        kubectl get pods --all-namespaces -o wide | grep kube-state-metrics
@@ -125,7 +125,7 @@ To generate verbose logs and get version and configuration information, follow t
        kube-system   kube-state-metrics-5c6f5cb9b5-pclhh     2/2       
        Running   4          4d        172.17.0.3   minikube
        ```
-    2. Get the New Relic pod that is running on the same node as kube-state-metrics:
+    2. Get the New Relic pods that are running on the same node as kube-state-metrics:
 
        ```
        kubectl describe node minikube | grep newrelic-infra
@@ -137,7 +137,7 @@ To generate verbose logs and get version and configuration information, follow t
        default                    newrelic-infra-5wcv6                     100m (5%)
        0 (0%)      100Mi (5%)       100Mi (5%)
        ```
-    3. Retrieve the logs for that node by running:
+    3. Retrieve the logs for the nodes by running:
 
        ```
        kubectl logs newrelic-infra-5wcv6
@@ -192,7 +192,7 @@ To generate verbose logs and get version and configuration information, follow t
        NAME                         STATUS  ROLES   AGE   VERSION
        ip-10-42-24-4.ec2.internal   Ready   master  42d   v1.14.8
        ```
-    2. Get the New Relic pod that is running on one of the nodes returned in the previous step:
+    2. Get the New Relic pods that are running on one of the nodes returned in the previous step:
 
        ```
        kubectl get pods --field-selector spec.nodeName=ip-10-42-24-4.ec2.internal -l name=newrelic-infra --all-namespaces
@@ -203,7 +203,7 @@ To generate verbose logs and get version and configuration information, follow t
        ```
        newrelic-infra-whvzt
        ```
-    3. Retrieve the logs for that node by running:
+    3. Retrieve the logs for the nodes by running:
 
        ```
        kubectl logs newrelic-infra-whvzt

--- a/src/content/docs/integrations/kubernetes-integration/troubleshooting/get-logs-version.mdx
+++ b/src/content/docs/integrations/kubernetes-integration/troubleshooting/get-logs-version.mdx
@@ -11,7 +11,7 @@ To generate verbose logs and get version and configuration information, follow t
 
 <CollapserGroup>
   <Collapser
-    id="verbose"
+    id="verbose-with-manifest"
     title="Get verbose logs for installations using a manifest file"
   >
     For the Kubernetes integration, the infrastructure agent adds a log entry only in the event of an error. Most common errors are displayed in the standard (non-verbose) logs. If you are doing a more in-depth investigation on your own or with New Relic Support, you can enable verbose mode.
@@ -53,7 +53,7 @@ To generate verbose logs and get version and configuration information, follow t
     id="verbose-helm"
     title="Get verbose logs for installations using Helm"
   >
-  For the Kubernetes integration, the infrastructure agent adds a log entry only in the event of an error. Most common errors are displayed in the standard (non-verbose) logs. If you are doing a more in-depth investigation on your own or with New Relic Support, you can enable verbose mode.
+  For the Kubernetes integration, the infrastructure agent adds a log entry only in the event of an error. Most common errors are displayed in the standard (non-verbose) logs. If you're doing a more in-depth investigation on your own or with New Relic Support, you can enable verbose mode.
 
     <Callout variant="caution">
       Verbose mode significantly increases the amount of info sent to log files. Temporarily enable this mode only for troubleshooting purposes, and reset the log level when finished.
@@ -64,11 +64,13 @@ To generate verbose logs and get version and configuration information, follow t
     ```
     helm upgrade -n <namespace> --reuse-values newrelic-bundle --set newrelic-infrastructure.verboseLog=true newrelic/nri-bundle
     ```
-    2. Gather logs from pods connecting to [Kubernetes state metrics](#logs-pod-kubestatemetrics) as described below.
-    3. When you have the information you need, make sure you disable verbose logging:
+    2. Leave on verbose mode for a few minutes, or until enough activity has occurred.
+    3. When you have the information you need, disable verbose logging:
         ```
         helm upgrade --reuse-values newrelic-bundle --set newrelic-infrastructure.verboseLog=false newrelic/nri-bundle
         ```
+    4. Follow the steps to restore your configuration from step 5 in the section, [Get verbose logs for installations using a manifest file](#verbose-with-manifest).
+
   </Collapser>
   <Collapser
     id="infra-version"


### PR DESCRIPTION
This PR addresses the request in Issue 3183

I added this section: http://localhost:8000/docs/integrations/kubernetes-integration/troubleshooting/get-logs-version/#verbose-helm

Question: Do we need steps like 5-9 from the previous section on verbose logs using a manifest file?

