### PR TITLE
Corrected the link to validate injection of metadata.

### DIFF
--- a/src/content/docs/integrations/kubernetes-integration/link-your-applications/link-your-applications-kubernetes.mdx
+++ b/src/content/docs/integrations/kubernetes-integration/link-your-applications/link-your-applications-kubernetes.mdx
@@ -105,7 +105,7 @@ To link Openshift and Kubernetes you must enable mutating admission webhooks, wh
 
 ## Configure the injection of metadata [#configure-injection]
 
-By default, all the pods you create that include APM agents have the correct environment variables set and the metadata injection applies to the entire cluster. To check that the environment variables have been set, any container that is running must be stopped, and a new instance started (see [Validate the injection of metadata](/docs/integrations/kubernetes-integration/metadata-injection/kubernetes-apm-metadata-injection#validate-injection)).
+By default, all the pods you create that include APM agents have the correct environment variables set and the metadata injection applies to the entire cluster. To check that the environment variables have been set, any container that is running must be stopped, and a new instance started (see [Validate the injection of metadata](/docs/integrations/kubernetes-integration/link-your-applications/link-your-applications-kubernetes/#validate-injection)).
 
 This default configuration also uses the [Kubernetes certificates API](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/) to automatically manage the certificates required for the injection. If needed, you can limit the injection of metadata to specific namespaces in your cluster or self-manage your certificates.
 


### PR DESCRIPTION
This is a PR for GitHub issue @3245. The old link was redirecting to a different page and the anchor was ignored.

Closes #3245

It appears the #3246 is a duplicate and might be able to be closed.