### PR TITLE
Reduce link fatigue in Intro to APM doc

### DIFF
--- a/src/content/docs/apm/new-relic-apm/getting-started/introduction-apm.mdx
+++ b/src/content/docs/apm/new-relic-apm/getting-started/introduction-apm.mdx
@@ -28,10 +28,6 @@ Use our APM solutions to gather both current and historical information about me
 
 ## Monitor all aspects of your business [#monitor-business]
 
-<Callout variant="tip">
-  To get a high-level overview of all your applications and services, use our [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer).
-</Callout>
-
 Take advantage of these APM features, and more:
 
 <table>
@@ -149,13 +145,3 @@ Start benefiting from APM in 5 simple steps (and just a few minutes!).
 5. Log in to your account, and [start exploring New Relic](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one)!
 
 If data does not appear after waiting a few minutes, follow the [troubleshooting tips](/docs/agents/manage-apm-agents/troubleshooting/not-seeing-data) for your APM agent.
-
-## What's next? [#what-next]
-
-Learn some more!
-
-* For a library of videos and other resources about New Relic, visit [newrelic.com/resources](https://newrelic.com/resources).
-* [New Relic One](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one) is our [Full-Stack Observability](https://docs.newrelic.com/docs/full-stack-observability/monitor-everything/get-started-new-relic-monitoring-tools/get-started-full-stack-observability) platform which allows you to easily access, visualize, and troubleshoot your entire software stack in one unified experience. Use New Relic as the single source of truth for Infrastructure monitoring, Serverless monitoring, [APM agents](/docs/agents), Browser monitoring, and Logs.
-* Our [Telemetry Data Platform](https://docs.newrelic.com/docs/telemetry-data-platform/get-started/capabilities/get-know-telemetry-data-platform) collects, explores, and alerts on all your metrics, events, logs, and traces from any source with our unified telemetry database.
-
-Check out our [site](https://newrelic.com/pricing) for pricing details.


### PR DESCRIPTION
This doc includes a lot of CTAs and noise. Reducing some of the noise to help highlight the key flow for new users.