### PR TITLE
Remove link to blog about Insights and alerts

### DIFF
--- a/src/content/docs/new-relic-solutions/new-relic-solutions/measure-devops-success/set-proactive-alerting-understand-respond-performance-issues.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-solutions/measure-devops-success/set-proactive-alerting-understand-respond-performance-issues.mdx
@@ -187,7 +187,7 @@ Be sure to check your alerts and confirm that they're firing regularly and are s
   **[insights.newrelic.com](https://insights.newrelic.com) > All dashboards > (selected dashboard)**
 </figcaption>
 
-Use [NRQL](/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) to create your dashboards. For detailed instructions, check out [Sending alerts data to Insights](https://blog.newrelic.com/2016/03/21/sending-alerts-data-to-insights/) (Insights is no longer our querying interface but the same concepts apply).
+Use [NRQL](/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) to create your dashboards. You'll create a query on `NrAiIncident`. To get some ideas about how this might look, go to New Relic and select **Alerts & AI > Overview**. For any of the charts, select **View query** to see an example query that you could modify for your dashboard.
 
 The dashboard above was created using the following NRQL queries. It's recommended you recreate them as needed for your alerting dashboards.
 

--- a/src/content/docs/new-relic-solutions/new-relic-solutions/measure-devops-success/set-proactive-alerting-understand-respond-performance-issues.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-solutions/measure-devops-success/set-proactive-alerting-understand-respond-performance-issues.mdx
@@ -187,9 +187,7 @@ Be sure to check your alerts and confirm that they're firing regularly and are s
   **[insights.newrelic.com](https://insights.newrelic.com) > All dashboards > (selected dashboard)**
 </figcaption>
 
-Use [NRQL](/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) to create your dashboards. You'll create a query on `NrAiIncident`. To get some ideas about how this might look, go to New Relic and select **Alerts & AI > Overview**. For any of the charts, select **View query** to see an example query that you could modify for your dashboard.
-
-The dashboard above was created using the following NRQL queries. It's recommended you recreate them as needed for your alerting dashboards.
+Use [NRQL](/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) to create your dashboards. For example, the dashboard above was created using the following NRQL queries:
 
 * **Incidents by condition**:
 


### PR DESCRIPTION
It turns out we had a doc that still references an Insights routine for setting up alerts. I removed this based on SME input, but we'll need to update the query examples as soon as the new table is available. I created DOC-7187 to track that effort.