### PR TITLE
chore: adds release notes for Node.js agent release v8.0.0.

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-0-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-0-0.mdx
@@ -13,8 +13,8 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
   see: https://docs.newrelic.com/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.
   * Upgraded `@newrelic/superagent` `@newrelic/aws-sdk` `@newrelic/koa` `@newrelic/native-metrics` and `@newrelic/test-utilities` to the latest major versions.
   * Refactored creation of span event aggregator to prevent crash of gRPC when running on invalid Node.js version.
-  * Added check for minimum `node` version >= 12.
-  * Set package.json engines `node` field >= 12 and `npm` field to >=6.
+  * Added check for minimum `node` version \>= 12.
+  * Set package.json engines `node` field \>= 12 and `npm` field to \>=6.
   * Removed Node v10 from ci workflow and smoke-test version matrix.
   * Removed comments around replacing `temporarilyOverrideTapUncaughtBehavior` test helper function.
   * Removed non-applicable semver checks for versions the agents no longer supports.
@@ -39,4 +39,4 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
 * Added `no-const-assign` to eslint ruleset.
 
-* Pinned mongodb versioned tests to <4.0.0.
+* Pinned mongodb versioned tests to \<4.0.0.

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-0-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-0-0.mdx
@@ -39,4 +39,4 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
 * Added `no-const-assign` to eslint ruleset.
 
-* Pinned mongodb versioned tests to
+* Pinned mongodb versioned tests to <4.0.0.

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-0-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-0-0.mdx
@@ -39,4 +39,4 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
 * Added `no-const-assign` to eslint ruleset.
 
-* Pinned mongodb versioned tests to <4.0.0.
+* Pinned mongodb versioned tests to \<4.0.0.

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-0-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-0-0.mdx
@@ -13,13 +13,13 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
   see: https://docs.newrelic.com/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.
   * Upgraded `@newrelic/superagent` `@newrelic/aws-sdk` `@newrelic/koa` `@newrelic/native-metrics` and `@newrelic/test-utilities` to the latest major versions.
   * Refactored creation of span event aggregator to prevent crash of gRPC when running on invalid Node.js version.
-  * Added check for minimum `node` version \>= 12.
-  * Set package.json engines `node` field \>= 12 and `npm` field to \>=6.
+  * Added check for minimum `node` version &gt;= 12.
+  * Set package.json engines `node` field &gt;= 12 and `npm` field to &gt;=6.
   * Removed Node v10 from ci workflow and smoke-test version matrix.
   * Removed comments around replacing `temporarilyOverrideTapUncaughtBehavior` test helper function.
   * Removed non-applicable semver checks for versions the agents no longer supports.
 
-* **BREAKING**: The agent no-longer includes the New Relic certificate bundle automatically when using the 'certificates' configuration (commonly with proxies). If you find this breaking your current environment, you may leverage a feature-flag to temporarily restore this functionality. Example configuration: feature_flag: { certificate_bundle: true }. In this case, we recommend getting a certificate bundle for your environment such as the one from Mozilla. The New Relic bundle and feature flag will be fully removed in next major release.
+* **BREAKING**: The agent no-longer includes the New Relic certificate bundle automatically when using the 'certificates' configuration (commonly with proxies). If you find this breaking your current environment, you may leverage a feature-flag to temporarily restore this functionality. Example configuration: `feature_flag: { certificate_bundle: true }`. In this case, we recommend getting a certificate bundle for your environment such as the one from Mozilla. The New Relic bundle and feature flag will be fully removed in next major release.
    * Defaulted config.feature_flags.certificate_bundle to false.
 
 * **BREAKING**: Removed `serverless_mode` as a feature flag.
@@ -39,4 +39,4 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
 * Added `no-const-assign` to eslint ruleset.
 
-* Pinned mongodb versioned tests to <4.0.0.
+* Pinned mongodb versioned tests to &lt;4.0.0.

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-0-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-0-0.mdx
@@ -39,4 +39,4 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
 * Added `no-const-assign` to eslint ruleset.
 
-* Pinned mongodb versioned tests to \<4.0.0.
+* Pinned mongodb versioned tests to

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-0-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-0-0.mdx
@@ -1,0 +1,42 @@
+---
+subject: Node.js agent
+releaseDate: '2021-07-26'
+version: 8.0.0
+downloadLink: 'https://www.npmjs.com/package/newrelic'
+---
+
+## Notes
+
+* Added official parity support for Node 16.
+
+* **BREAKING**: Dropped Node v10.x support. For further information on our support policy,
+  see: https://docs.newrelic.com/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.
+  * Upgraded `@newrelic/superagent` `@newrelic/aws-sdk` `@newrelic/koa` `@newrelic/native-metrics` and `@newrelic/test-utilities` to the latest major versions.
+  * Refactored creation of span event aggregator to prevent crash of gRPC when running on invalid Node.js version.
+  * Added check for minimum `node` version >= 12.
+  * Set package.json engines `node` field >= 12 and `npm` field to >=6.
+  * Removed Node v10 from ci workflow and smoke-test version matrix.
+  * Removed comments around replacing `temporarilyOverrideTapUncaughtBehavior` test helper function.
+  * Removed non-applicable semver checks for versions the agents no longer supports.
+
+* **BREAKING**: The agent no-longer includes the New Relic certificate bundle automatically when using the 'certificates' configuration (commonly with proxies). If you find this breaking your current environment, you may leverage a feature-flag to temporarily restore this functionality. Example configuration: feature_flag: { certificate_bundle: true }. In this case, we recommend getting a certificate bundle for your environment such as the one from Mozilla. The New Relic bundle and feature flag will be fully removed in next major release.
+   * Defaulted config.feature_flags.certificate_bundle to false.
+
+* **BREAKING**: Removed `serverless_mode` as a feature flag.
+
+  The standard `serverless_mode` configuration still exists.
+
+* Added hapi 19 and 20 to versioned tests for Node.js `>=12` and `<16`
+ * Added hapi `^20.1.2` to versioned tests for for Node.js `>=16`
+
+* Upgraded tap to v15.
+
+* Upgraded https-proxy-agent to v5.0.0.
+
+* Updated linting to always use latest LTS Node version.
+
+* Updated CI and Smoke Test scripts to use setup-node@v2.
+
+* Added `no-const-assign` to eslint ruleset.
+
+* Pinned mongodb versioned tests to <4.0.0.


### PR DESCRIPTION
adds release notes for Node.js agent release v8.0.0.