### PR TITLE
Add makara to Ruby Agent's Incompatible Gems

### DIFF
--- a/src/content/docs/agents/ruby-agent/troubleshooting/incompatible-gems.mdx
+++ b/src/content/docs/agents/ruby-agent/troubleshooting/incompatible-gems.mdx
@@ -5,7 +5,7 @@ tags:
   - Agents
   - Ruby agent
   - Troubleshooting
-metaDescription: A few incompatible gems and their workaround with the New Relic Ruby agent.
+metaDescription: A few incompatible gems and their workarounds with the New Relic Ruby agent.
 redirects:
   - /docs/ruby/incompatible-gems
   - /node/2971
@@ -24,13 +24,13 @@ While New Relic strives to be compatible with all gems, there are some that will
     id="db-charmer"
     title="db-charmer"
   >
-    **Problem**: The [db-charmer](http://rubygems.org/gems/db-charmer) gem has incompatibilities in how it patches Rails controllers.
+    **Problem**: The [db-charmer](http://rubygems.org/gems/db-charmer) gem has incompatibilities of how it patches Rails controllers.
 
     **Solution**: Force New Relic to load and start before `DbCharmer.enable_controller_magic!` is called. For example, add the following to your **config/application.rb**:
 
     ```
-    require 'newrelic_rpm' 
-    NewRelic::Agent.manual_start 
+    require 'newrelic_rpm'
+    NewRelic::Agent.manual_start
     DbCharmer.enable_controller_magic!
     ```
   </Collapser>
@@ -39,11 +39,11 @@ While New Relic strives to be compatible with all gems, there are some that will
     id="escape_utils"
     title="escape_utils"
   >
-    **Problem:** Use The [escape_utils](https://github.com/brianmario/escape_utils) gem is incompatible with automatic instrumentation for New Relic's page load timing feature (sometimes referred to as real user monitoring or RUM). Due to the way escape_utils monkey-patches Rack, your whole HTML response may be escaped.
+    **Problem:** The [escape_utils](https://github.com/brianmario/escape_utils) gem is incompatible with automatic instrumentation for New Relic's page load timing feature (sometimes referred to as real user monitoring or RUM). Due to the way `escape_utils` monkey-patches Rack, your whole HTML response may be escaped.
 
     **Solution:** If you see HTML source instead of the rendered page, use either of these options:
 
-    * Remove the escape_utils gems.
+    * Remove the `escape_utils` gem.
     * Use [manual instrumentation](/docs/agents/ruby-agent/features/page-load-timing-ruby#manual_instrumentation) for page load timing.
   </Collapser>
 
@@ -51,7 +51,7 @@ While New Relic strives to be compatible with all gems, there are some that will
     id="right_http_connection"
     title="right_http_connection"
   >
-    **Problem:** If the [right_http_connection](http://rubygems.org/gems/right_http_connection) gem is loaded after `newrelic_rpm`, it patches `Net::HTTP` class in a way that causes New Relic's Externals instrumentation to be missed.
+    **Problem:** If the [right_http_connection](http://rubygems.org/gems/right_http_connection) gem is loaded after `newrelic_rpm`, it patches the `Net::HTTP` class in a way that causes New Relic's Externals instrumentation to be missed.
 
     **Solution:** Ensure that `right_http_connection` is required before `newrelic_rpm`.
   </Collapser>
@@ -60,8 +60,17 @@ While New Relic strives to be compatible with all gems, there are some that will
     id="ar-octopus"
     title="ar-octopus"
   >
-    **Problem:** The [ar-octopus](https://github.com/tchandy/octopus) changes the way that ActiveRecord's connection management works, breaking the Ruby agent's ability to gather instance information, apply vendor-specific obfuscation to queries, and capture explain plans for long-running database queries.
+    **Problem:** The [ar-octopus](https://github.com/tchandy/octopus) gem changes the way ActiveRecord's connection management works, breaking the Ruby agent's ability to gather instance information, apply vendor-specific obfuscation to queries, and capture explain plans for long-running database queries.
 
-    **Solution:** No known workaround - either remove the ar-octopus gem, or continue to use it, in which case no explain plans will be captured.
+    **Solution:** No known workaround - either remove the `ar-octopus` gem, or continue to use it, in which case no explain plans will be captured.
+  </Collapser>
+
+  <Collapser
+    id="makara"
+    title="makara"
+  >
+    **Problem:** The [makara](https://github.com/instacart/makara) gem masks the Ruby agent's ability to detect the database adapter underlying ActiveRecord by modifying the name of the underlying connection. The original adapter name is needed to properly obfuscate queries. Some transaction traces display ActiveRecord content instead of MySQL content.
+
+    **Solution:** No known workaround - either remove the `makara` gem, or continue to use it. Over-obfuscation will be the expected behavior.
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/agents/ruby-agent/troubleshooting/incompatible-gems.mdx
+++ b/src/content/docs/agents/ruby-agent/troubleshooting/incompatible-gems.mdx
@@ -62,7 +62,7 @@ While New Relic strives to be compatible with all gems, there are some that will
   >
     **Problem:** The [ar-octopus](https://github.com/tchandy/octopus) gem changes the way ActiveRecord's connection management works, breaking the Ruby agent's ability to gather instance information, apply vendor-specific obfuscation to queries, and capture explain plans for long-running database queries.
 
-    **Solution:** No known workaround - either remove the `ar-octopus` gem, or continue to use it, in which case no explain plans will be captured.
+    **Solution:** No known workaround. Either remove the `ar-octopus` gem, or continue to use it, in which case no explain plans will be captured.
   </Collapser>
 
   <Collapser
@@ -71,6 +71,6 @@ While New Relic strives to be compatible with all gems, there are some that will
   >
     **Problem:** The [makara](https://github.com/instacart/makara) gem masks the Ruby agent's ability to detect the database adapter underlying ActiveRecord by modifying the name of the underlying connection. The original adapter name is needed to properly obfuscate queries. Some transaction traces display ActiveRecord content instead of MySQL content.
 
-    **Solution:** No known workaround - either remove the `makara` gem, or continue to use it. Over-obfuscation will be the expected behavior.
+    **Solution:** No known workaround. Either remove the `makara` gem, or continue to use it. Over-obfuscation will be the expected behavior.
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
### Give us some context

This PR resolves the Ruby Agent issue [Add makara to list of incompatible gems #507](https://github.com/newrelic/newrelic-ruby-agent/issues/507)

* Adds detail about the problem/solution based on the [Zendesk Ticket 325320](https://newrelic.zendesk.com/agent/tickets/325320)
* Updates some grammar and style inconsistencies on the page

### Are you making a change to site code?

No