### PR TITLE
chore: update node agent compaitility and upgrade notes for Node agent v8 release.

### DIFF
--- a/src/content/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -42,6 +42,19 @@ The following are proposed time ranges. The actual release date may vary.
   </thead>
 
   <tbody>
+      <tr>
+      <td>
+        18
+      </td>
+
+      <td>
+        October 2022
+      </td>
+
+      <td>
+        April-October 2022
+      </td>
+    </tr>
     <tr>
       <td>
         16
@@ -52,7 +65,7 @@ The following are proposed time ranges. The actual release date may vary.
       </td>
 
       <td>
-        April-October 2021
+        July 26, 2021 with Node Agent v8.0.0
       </td>
     </tr>
 
@@ -107,7 +120,7 @@ The following are proposed time ranges. The actual release date may vary.
       </td>
 
       <td>
-        As of July 31, 2021, we're discontinuing support for Node.js 10. For more details, including how you can easily prepare for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-support-and-capabilities-across-browser-node-js-agent-query-builder-net-agent-apm-errors-distributed-tracing/153373).
+        As of July 26, 2021, we're discontinuing support for Node.js 10. For more details, including how you can easily prepare for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-support-and-capabilities-across-browser-node-js-agent-query-builder-net-agent-apm-errors-distributed-tracing/153373).
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -120,7 +120,7 @@ The following are proposed time ranges. The actual release date may vary.
       </td>
 
       <td>
-        As of July 26, 2021, we're discontinuing support for Node.js 10. For more details, including how you can easily prepare for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-support-and-capabilities-across-browser-node-js-agent-query-builder-net-agent-apm-errors-distributed-tracing/153373).
+        As of July 26, 2021, we have discontinued support for Node.js 10 with v8 of the Node.js agent. For more details, including how you can easily prepare for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-support-and-capabilities-across-browser-node-js-agent-query-builder-net-agent-apm-errors-distributed-tracing/153373).
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -65,7 +65,7 @@ The following are proposed time ranges. The actual release date may vary.
       </td>
 
       <td>
-        July 26, 2021 with Node Agent v8.0.0
+        July 26, 2021 with Node.js agent v8.0.0
       </td>
     </tr>
 

--- a/src/content/docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
+++ b/src/content/docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
@@ -18,6 +18,94 @@ To take full advantage of New Relic's latest features, enhancements, and importa
 
 **Recommendation:** Test your updated version before moving it into production. If you have problems, follow the Node.js agent [troubleshooting procedures](/docs/agents/nodejs-agent/troubleshooting/troubleshooting-your-nodejs-installation).
 
+## Upgrade to Node.js agent version 8 [#node-agent-v8]
+
+Before upgrading to Node.js version 8, review this information for major changes.
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "250px" }}>
+        **Major changes with Node.js agent v8**
+      </th>
+
+      <th>
+        **Comments**
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+
+     <tr>
+      <td>
+        Added official parity support for Node 16.
+      </td>
+
+      <td>
+      </td>
+    </tr>
+
+     <tr>
+      <td>
+        **BREAKING**: Dropped Node v10.x support.
+      </td>
+
+      <td>
+        * For further information see our [support policy](/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        **BREAKING**: Removed `serverless_mode` as a feature flag.
+      </td>
+
+      <td>
+        * The standard `serverless_mode` configuration still exists.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        **BREAKING**: The agent no-longer includes the New Relic certificate bundle automatically when using the 'certificates' configuration (commonly with proxies).
+      </td>
+
+      <td>
+        * If you find this breaking your current environment, you may leverage a feature-flag to temporarily restore this functionality. Example configuration: `feature_flag: { certificate_bundle: true }`. In this case, we recommend getting a certificate bundle for your environment such as the one from Mozilla. The New Relic bundle and feature flag will be fully removed in next major release.
+        * Defaulted config.feature_flags.certificate_bundle to false.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Update New Relic Dependencies to versions with updated Node version support
+      </td>
+
+      <td>
+        * @newrelic/aws-sdk v4.0.1
+        * @newrelic/koa v6.0.1
+        * @newrelic/native-metrics v7.0.1
+        * @newrelic/superagent v5.0.1
+        * @newrelic/test-utilities v6.0.0
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Node version support [#node-support-v8]
+
+Node v12 is the earliest version supported by the New Relic Node.js v8 agent. Node 10 and 11 are not supported by v8. Customers running Node 11 and earlier have two options:
+
+* Upgrade to a supported version of Node and take advantage of the New Relic Node.js v8 agent's new features.
+* Remain on New Relic Node.js v6 agent without the ability to use new features only available with update agent versions.
+
+[Node 12 no longer receive updates](https://github.com/nodejs/Release/tree/7a62313a0cf40e3fd6c75c3643b2637289acc82d), but New Relic will continue to support these versions of Node for the time being.
+
+<Callout variant="tip">
+  Upgrade to a newer version of Node as soon as possible. The next major version of the New Relic Node.js agent will likely remove support for Node 12.
+</Callout>
+
 ## Upgrade to Node.js agent version 7 [#node-agent-v7]
 
 Before upgrading to Node.js version 7, review this information for major changes.
@@ -36,7 +124,7 @@ Before upgrading to Node.js version 7, review this information for major changes
   </thead>
 
   <tbody>
-    
+
      <tr>
       <td>
         **BREAKING** Removed deprecated `httpResponseCode`, `response.status` and `httpResponseMessage` http response attributes
@@ -47,7 +135,7 @@ Before upgrading to Node.js version 7, review this information for major changes
         * **v7:** When http response attribute reporting is enabled, `http.statusCode` and `http.statusText` will be reported.
       </td>
     </tr>
-    
+
     <tr>
       <td>
         **BREAKING** Removed deprecated `setIgnoreTransaction` API method
@@ -58,7 +146,7 @@ Before upgrading to Node.js version 7, review this information for major changes
         * **v7:** Applications must use the API method [`transactionHandle.ignore()`](/docs/agents/nodejs-agent/api-guides/nodejs-agent-api/#transaction-handle-ignore).
       </td>
     </tr>
-    
+
     <tr>
       <td>
         **BREAKING** Removed the `api.custom_parameters_enabled` configuration item and associated environment variable `NEW_RELIC_API_CUSTOM_PARAMETERS`.
@@ -80,7 +168,7 @@ Before upgrading to Node.js version 7, review this information for major changes
 `](/docs/agents/nodejs-agent/api-guides/nodejs-agent-api/#transaction-handle-acceptDistributedTraceHeaders). With these methods, the Node agent will now accept W3C's `traceparent` and `tracestate` headers when calling `transactionHandle.acceptDistributedTraceHeaders(headers)` and include the W3C headers along with the New Relic distributed tracing header when calling `transactionHandle.insertDistributedTraceHeaders(headers)`, unless the New Relic trace header format is disabled using [`distributed_tracing.exclude_newrelic_header:true`.](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#dt-exclude-newrelic-header)
       </td>
     </tr>
-    
+
     <tr>
       <td>
         Update New Relic Dependencies to versions with updated Node version support

--- a/src/content/docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
+++ b/src/content/docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
@@ -98,9 +98,7 @@ Before upgrading to Node.js version 8, review this information for major changes
 Node v12 is the earliest version supported by the New Relic Node.js v8 agent. Node 10 and 11 are not supported by v8. Customers running Node 11 and earlier have two options:
 
 * Upgrade to a supported version of Node and take advantage of the New Relic Node.js v8 agent's new features.
-* Remain on New Relic Node.js v6 agent without the ability to use new features only available with update agent versions.
-
-[Node 12 no longer receive updates](https://github.com/nodejs/Release/tree/7a62313a0cf40e3fd6c75c3643b2637289acc82d), but New Relic will continue to support these versions of Node for the time being.
+* Remain on New Relic Node.js v7 agent without the ability to use new features only available with update agent versions.
 
 <Callout variant="tip">
   Upgrade to a newer version of Node as soon as possible. The next major version of the New Relic Node.js agent will likely remove support for Node 12.


### PR DESCRIPTION
For Node agent version 8.0.0 release, this PR updates the Upgrade Node Agent and Node Agent compatibility docs.