### PR TITLE
fix: some small typo

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/getting-started/security-synthetic-monitoring.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/getting-started/security-synthetic-monitoring.mdx
@@ -10,7 +10,7 @@ redirects:
   - /docs/synthetics/new-relic-synthetics/getting-started/data-privacy-security-new-relic-synthetics
 ---
 
-New Relic's synthetic monitoring uses [monitors](/docs/synthetics/new-relic-synthetics/getting-started/types-synthetics-monitors) distributed throughout [data centers around the world](/docs/synthetics/new-relic-synthetics/administration/synthetics-public-minion-ips). By design, it captures what is essentially performance data for simulated traffic. Tt does not capture or handle any personal data by default. All data handled by synthetic monitors is expected to be non-personal.
+New Relic's synthetic monitoring uses [monitors](/docs/synthetics/new-relic-synthetics/getting-started/types-synthetics-monitors) distributed throughout [data centers around the world](/docs/synthetics/new-relic-synthetics/administration/synthetics-public-minion-ips). By design, it captures what is essentially performance data for simulated traffic. It does not capture or handle any personal data by default. All data handled by synthetic monitors is expected to be non-personal.
 
 This document provides additional details about what we do to ensure data privacy and security with synthetic monitoring, plus additional options you can use. For more information about New Relic's security measures, see our [security and privacy documentation](https://docs.newrelic.com/docs/security/new-relic-security/data-privacy/data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 


### PR DESCRIPTION
This PR simply fix what seems to be a very small typo from _Tt does not ..._ to _It does not ..._ on the _Security for synthetic monitoring_ page.