### PR TITLE
Added metadata exception in dashboards permissions.

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards.mdx
@@ -183,7 +183,7 @@ Dashboards have three types of permissions:
 
 * **Public - Read and write**: All users have full rights to the dashboard.
 * **Public - Read only**: All users are able to see the dashboard, but only you have full rights to work with the dashboard. Other users can access the dashboard but are not able to edit or delete it, although they can duplicate it.
-* **Private**: Only you can see the dashboard.
+* **Private**: Only you can see the dashboard. Everything but the metadata is hidden.
 
 When you [create a dashboard](/docs/dashboards/explore-dashboards-index/explore-dashboards-index#create-dashboard) using the **Create a dashboard** button or by duplicating another dashboard, it will have **Public - Read and write** rights by default. Access the new dashboard to change this setting.
 


### PR DESCRIPTION
In private dashboards, everything s hidden for the rest of users, except the metadata. I've added a little point clarifying that. 

See UIWRITE-1261 for more details.