### PR TITLE
Remove facet Limit part of NRQL query rules and limits

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/outlier-detection-nrql-alert.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/outlier-detection-nrql-alert.mdx
@@ -130,7 +130,7 @@ Here are the rules and logic behind how outlier detection works:
     id="nrql-query-rules"
     title="NRQL query rules and limits"
   >
-    The NRQL query must be a [faceted query](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions#sel-facet), and can only facet on one attribute. Queries that facet on more than one attribute won't work.
+    The NRQL query must be a [faceted query](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions#sel-facet).
 
     The number of unique values returned must be 500 or less. If the query returns more than this number of values, the condition won't be created. If the query later returns more than this number after being created, the alert will fail.
   </Collapser>


### PR DESCRIPTION
Removing the facet limit ", and can only facet on one attribute. Queries that facet on more than one attribute won't work." Multiple facets are supported

### Give us some context
* Existing Doc is out of date
* Got a note from Product Manager that multiple facets are supported for outlier conditions

### Are you making a change to site code?
No.