### PR TITLE
Remove very old compatibility callout

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
@@ -17,10 +17,6 @@ Read on to install the Kafka integration, and to see what data it collects. To m
 
 Our integration is compatible with Kafka versions 0.8 or higher.
 
-<Callout variant="info">
-  Topic data collection is supported for Kafka versions 0.11.0.0 or higher.
-</Callout>
-
 Before installing the integration, make sure that you meet the following requirements:
 
 * If Kafka is **not** running on Kubernetes or Amazon ECS, you must [install the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) on a host that's running Kafka. Otherwise:


### PR DESCRIPTION
Remove a tip callout referencing a 2017+ version of Kafka