### PR TITLE
Explaining AWS metric stream is supported

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/query-infrastructure-dimensional-metrics-nrql.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/query-infrastructure-dimensional-metrics-nrql.mdx
@@ -63,7 +63,7 @@ For example, the query to get the maximum duration of your Lambda functions is s
 
 No agent or integration updates are required to use these metrics.
 
-[NRQL alerting](/docs/alerts/new-relic-alerts/defining-conditions/create-alert-conditions-nrql-queries) based on dimensional metrics is also supported, except for data coming from [cloud integrations](/docs/integrations/infrastructure-integrations/cloud-integrations) (that is metrics from [AWS](/docs/integrations/amazon-integrations/aws-integrations-list), [GCP](/docs/integrations/google-cloud-platform-integrations), and [Azure](/docs/integrations/microsoft-azure-integrations/azure-integrations-list)).
+[NRQL alerting](/docs/alerts/new-relic-alerts/defining-conditions/create-alert-conditions-nrql-queries) based on dimensional metrics is also supported, except for data coming from [cloud integrations](/docs/integrations/infrastructure-integrations/cloud-integrations) (that is metrics from [AWS polling integrations](/docs/integrations/amazon-integrations/aws-integrations-list), [GCP](/docs/integrations/google-cloud-platform-integrations), and [Azure](/docs/integrations/microsoft-azure-integrations/azure-integrations-list)). AWS CloudWatch Metric Streams metrics are ingested as dimensional metrics and NRQL alerts are recommended. 
 
 ## Where and how to query dimensional metrics [#where]
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* Feedback from customers: updating the note about AWS not being supported. There are two AWS integrations: polling (not supported) and metric streams (supported). 

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.