### PR TITLE
Update relationship API tutorial section with the new API 

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial.mdx
@@ -12,9 +12,7 @@ redirects:
   - /docs/understand-dependencies/understand-system-dependencies/relationship-api/relationship-api
 ---
 
-One way to understand how your monitored entities relate to each other is through our [NerdGraph](/docs/introduction-new-relic-graphql) API.
-
-The NerdGraph relatedEntities API captures how pairs of entities interact and how they're related. By using the API, you can troubleshoot upstream and downstream services and understand how minor issues may have larger repercussions, similar to [service maps](/docs/service-maps-dependencies-new-relic-one).
+One way to understand how your monitored entities relate to each other is using our [NerdGraph](/docs/introduction-new-relic-graphql) API. You can use the `relatedEntities` field to see how pairs of entities interact and how they're related. This can help troubleshoot upstream and downstream services and understand how minor issues may have larger repercussions, similar to how [service maps](/docs/service-maps-dependencies-new-relic-one) can be used.
 
 ## Relationship types
 
@@ -87,7 +85,7 @@ Relationship types provide additional information about how two entities are rel
 
 ## Read relationships of an entity [#read-relationships]
 
-You can use the NerdGraph relatedEntities API to read the existing relationship of your monitored entities. The following example shows how to query an entity by its specific GUID, using the [NerdGraph GraphiQL explorer](https://api.newrelic.com/graphiql). For more information, see [Use NerdGraph to query entities](/docs/apis/graphql-api/tutorials/use-new-relic-graphql-api-query-entities).
+You can use NerdGraph to return the relationships between your monitored entities. The following example shows how to query an entity by its specific GUID, using the [NerdGraph GraphiQL explorer](https://api.newrelic.com/graphiql). For more information, see [Use NerdGraph to query entities](/docs/apis/graphql-api/tutorials/use-new-relic-graphql-api-query-entities).
 
 ```
 query{

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial.mdx
@@ -14,7 +14,7 @@ redirects:
 
 One way to understand how your monitored entities relate to each other is through our [NerdGraph](/docs/introduction-new-relic-graphql) API.
 
-The NerdGraph relationship API captures how pairs of entities interact and how they're related. By using the API, you can troubleshoot upstream and downstream services and understand how minor issues may have larger repercussions, similar to [service maps](/docs/service-maps-dependencies-new-relic-one).
+The NerdGraph relatedEntities API captures how pairs of entities interact and how they're related. By using the API, you can troubleshoot upstream and downstream services and understand how minor issues may have larger repercussions, similar to [service maps](/docs/service-maps-dependencies-new-relic-one).
 
 ## Relationship types
 
@@ -87,27 +87,29 @@ Relationship types provide additional information about how two entities are rel
 
 ## Read relationships of an entity [#read-relationships]
 
-You can use the NerdGraph relationship API to read the existing relationship of your monitored entities. The following example shows how to query an entity by its specific GUID, using the [NerdGraph GraphiQL explorer](https://api.newrelic.com/graphiql). For more information, see [Use NerdGraph to query entities](/docs/apis/graphql-api/tutorials/use-new-relic-graphql-api-query-entities).
+You can use the NerdGraph relatedEntities API to read the existing relationship of your monitored entities. The following example shows how to query an entity by its specific GUID, using the [NerdGraph GraphiQL explorer](https://api.newrelic.com/graphiql). For more information, see [Use NerdGraph to query entities](/docs/apis/graphql-api/tutorials/use-new-relic-graphql-api-query-entities).
 
 ```
 query{
   actor{
     entity(guid: <var>YOUR_ENTITY_GUID</var>){
       name
-      relationships{
-        source {
-          entity{
-            guid,
-            name
+      relatedEntities {
+        results {
+          source {
+            entity {
+              guid
+              name
+            }
           }
+          target {
+            entity {
+              guid
+              name
+            }
+          }
+          type
         }
-        target {
-          entity{
-            guid,
-            name
-          }
-        },
-        type
       }
     }
   }


### PR DESCRIPTION
We're in the process of deprecating the `relationships` API in favour of the new `relatedEntities` one. For this reason, I've updated the docs to remove the reference to the soon-to-be-deprecated `relationships` API. 


<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.