### PR TITLE
Added links to other alerts NerdGraph docs

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-examples.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-examples.mdx
@@ -19,7 +19,9 @@ Here's what you can do in NerdGraph:
 
 * [Manage policies](/docs/alerts/alerts-nerdgraph/nerdgraph-examples/nerdgraph-api-alerts-policies)
 * [Use NRQL conditions](/docs/alerts/alerts-nerdgraph/nerdgraph-examples/nerdgraph-api-alerts-nrql-conditions)
-* [Muting rules: suppress notifications](/docs/alerts/new-relic-alerts/managing-notification-channels/muting-rules-suppress-notifications)
+* [Add muting rules to suppress notifications](/docs/alerts/new-relic-alerts/managing-notification-channels/muting-rules-suppress-notifications)
+* [Manage notification channels](/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-notification-channels/)
+* [Customize loss of signal and gap filling](/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling/)
 
 The easiest way to discover alerts queries and mutations is through the NerdGraph API explorer.
 


### PR DESCRIPTION
closes #3211

We already have a doc on using NerdGraph with notification channels, so all we need to do is link to it.