### PR TITLE
Adding dummy doc to fix sidebar issue

### DIFF
--- a/src/content/docs/accounts/accounts-billing/general-account-settings/manage-data.mdx
+++ b/src/content/docs/accounts/accounts-billing/general-account-settings/manage-data.mdx
@@ -1,0 +1,5 @@
+---
+title: Manage your data
+---
+
+dummy doc in accounts docs redirecting to 'Manage data' doc

--- a/src/content/docs/telemetry-data-platform/manage-data/manage-your-data.mdx
+++ b/src/content/docs/telemetry-data-platform/manage-data/manage-your-data.mdx
@@ -10,6 +10,7 @@ redirects:
   - /telemetry-data-platform/get-started/manage-data/manage-your-data
   - /docs/telemetry-data-platform/get-data-new-relic/manage-data/manage-your-data
   - /docs/telemetry-data-platform/ingest-manage-data/manage-data/manage-your-data  
+  - /docs/accounts/accounts-billing/general-account-settings/manage-data
 ---
 
 At New Relic, we're super proud of [NRDB](/docs/telemetry-data-platform/ingest-manage-data/get-started/nrdb-horsepower-under-hood), the New Relic database where we store your data. It gathers all your telemetry data in one place, gives you a connected view of all your data, and scales as your business grows.

--- a/src/nav/accounts.yml
+++ b/src/nav/accounts.yml
@@ -25,7 +25,7 @@ pages:
           - title: Intro to account settings
             path: /docs/accounts/accounts-billing/general-account-settings/introduction-account-settings
           - title: Manage data
-            path: /docs/telemetry-data-platform/manage-data/manage-your-data
+            path: /docs/accounts/accounts-billing/general-account-settings/manage-data
           - title: Email settings
             path: /docs/accounts/accounts/account-maintenance/account-email-settings
           - title: Password requirements


### PR DESCRIPTION
We were having a problem with the 'Manage data' doc ref addition in the accounts doc section; it was essentially stealing the location from the real location, so that when you clicked it, instead of going to the place it actually was located (in 'Manage your data' docs section) it was remaining in the accounts docs section, and that wasn't good at all. This is due to some known issues in how the sidebar/nav files work and we may fix that but in meantime I fixed this with a more old-fashioned dummy doc fix. 

Please merge this if it looks fine. 