### PR TITLE
Update auto-triage with new column name

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  COLUMN_NAME: Needs Triage # column where issues will be created
+  COLUMN_NAME: Hero to triage # column where issues will be created
 
 jobs:
   content_project:

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  COLUMN_NAME: Needs Triage # column where issues will be created
+  COLUMN_NAME: Hero to triage # column where issues will be created
 
 jobs:
   content_project:


### PR DESCRIPTION
We recently updated our docs board column names, which broke the auto-triaging. 

This PR updates the triage actions with the new column names.