### PR TITLE
Change from test.com to example.com

### DIFF
--- a/src/content/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management.mdx
@@ -24,7 +24,8 @@ New Relic’s SCIM service provider follows the [SCIM 2.0 API](http://www.simple
 
 ## Authentication
 
-Authentication is done using a bearer token. This bearer token is specific to your [New Relic authentication domain](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more).
+Authentication is done using a bearer token. This bearer token is specific to your [New Relic authentication domain](https://docs.newrelic
+/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more).
 
 ## Supported resources
 
@@ -446,13 +447,13 @@ Supported actions are:
         "urn:ietf:params:scim:schemas:core:2.0:User"
       ],
       "externalId": "external-id-1",
-      "userName": "example-user-1@test.com",
+      "userName": "example-user-1@example.com",
       "name": {
         "familyName": "User 1",
         "givenName": "Example"
       },
       "emails": [{
-        "value": "example-user-1@test.com",
+        "value": "example-user-1@example.com",
         "primary": true
       }],
       "timezone": "America/Los_Angeles",
@@ -472,13 +473,13 @@ Supported actions are:
       ],
       "id": "f0cbc276-16c9-4d1a-abc0-1856b0c74224",
       "externalId": "external-id-1",
-      "userName": "example-user-1@test.com",
+      "userName": "example-user-1@example.com",
       "name": {
         "familyName": "User 1",
         "givenName": "Example"
       },
       "emails": [{
-        "value": "example-user-1@test.com",
+        "value": "example-user-1@example.com",
         "primary": true
       }],
       "timezone": "America/Los_Angeles",
@@ -514,13 +515,13 @@ Supported actions are:
       ],
       "id": "f0cbc276-16c9-4d1a-abc0-1856b0c74224",
       "externalId": "external-id-1",
-      "userName": "example-user-1@test.com",
+      "userName": "example-user-1@example.com",
       "name": {
         "familyName": "User 1",
         "givenName": "Example"
       },
       "emails": [{
-        "value": "example-user-1@test.com",
+        "value": "example-user-1@example.com",
         "primary": true
       }],
       "timezone": "America/Los_Angeles",
@@ -561,13 +562,13 @@ Supported actions are:
         ],
         "id": "f0cbc276-16c9-4d1a-abc0-1856b0c74224",
         "externalId": "external-id-1",
-        "userName": "example-user-1@test.com",
+        "userName": "example-user-1@example.com",
         "name": {
           "familyName": "User 1",
           "givenName": "Example"
         },
         "emails": [{
-          "value": "example-user-1@test.com",
+          "value": "example-user-1@example.com",
           "primary": true
         }],
         "timezone": "America/Los_Angeles",
@@ -614,13 +615,13 @@ Supported actions are:
       ],
       "id": "f0cbc276-16c9-4d1a-abc0-1856b0c74224",
       "externalId": "external-id-1",
-      "userName": "example-user-1@test.com",
+      "userName": "example-user-1@example.com",
       "name": {
         "familyName": "User 1A",
         "givenName": "Example"
       },
       "emails": [{
-        "value": "example-user-1@test.com",
+        "value": "example-user-1@example.com",
         "primary": true
       }],
       "timezone": "America/Los_Angeles",


### PR DESCRIPTION
Using a domain for examples is tremendously dangerous. `example.com` was created specifically for this purpose and is routable across the internet, so we should use it.