### PR TITLE
Add buffer tune-up section to fluentd docs

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/fluentd-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/fluentd-plugin-log-forwarding.mdx
@@ -77,7 +77,7 @@ To configure your Fluentd plugin:
        Configure with the New Relic [Insert API key](/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#register):
 
        ```
-       #Tail one or more log files 
+       #Tail one or more log files
        <source>
          @type tail
          <parse>
@@ -111,7 +111,7 @@ To configure your Fluentd plugin:
        Configure with the [New Relic license key](/docs/accounts/install-new-relic/account-setup/license-key):
 
        ```
-       #Tail one or more log files 
+       #Tail one or more log files
        <source>
          @type tail
          <parse>
@@ -150,9 +150,9 @@ By default the Fluentd plugin forwards logs to New Relic's US endpoint: `https:/
        title="Add EU Endpoint to API key configuration"
      >
       Configure EU endpoint with the New Relic [Insert API key](/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#register):
-       
+
       ```
-       #Tail one or more log files 
+       #Tail one or more log files
        <source>
          @type tail
          <parse>
@@ -185,11 +185,11 @@ By default the Fluentd plugin forwards logs to New Relic's US endpoint: `https:/
      <Collapser
        id="license-key-eu"
        title="Add EU Endpoint to License key configuration"
-     > 
+     >
       Configure EU Endpoint with the [New Relic license key](/docs/accounts/install-new-relic/account-setup/license-key):
 
        ```
-       #Tail one or more log files 
+       #Tail one or more log files
        <source>
          @type tail
          <parse>
@@ -240,6 +240,30 @@ If everything is configured correctly and your data is being collected, you shou
   ```
   SELECT * FROM Log
   ```
+
+## Tune-up log Fluentd buffer
+
+A default buffer configuration for log forwarding is hard to determinate since each case is totally different.
+
+By default the plugin will send logs to NR every 5s, if you want to tune this up and maybe send logs just
+each minute you could do it adding the `<buffer>` block to the configuration, for example:
+
+```
+[...]
+
+# Forward all events to New Relic EU Endpoint
+<match **>
+  @type newrelic
+  license_key <var>YOUR_LICENSE_KEY</var>
+
+  <buffer time>
+    timekey 60s
+  </buffer>
+</match>
+```
+
+If you want to read more about all the available configurations for buffers you should take a look
+to the fluentd [official documentation about Buffer configurations](https://docs.fluentd.org/configuration/buffer-section).
 
 ## What's next? [#what-next]
 

--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/fluentd-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/fluentd-plugin-log-forwarding.mdx
@@ -243,10 +243,7 @@ If everything is configured correctly and your data is being collected, you shou
 
 ## Tune-up log Fluentd buffer
 
-A default buffer configuration for log forwarding is hard to determinate since each case is totally different.
-
-By default the plugin will send logs to NR every 5s, if you want to tune this up and maybe send logs just
-each minute you could do it adding the `<buffer>` block to the configuration, for example:
+By default, the plugin sends logs to New Relic One every 5 seconds. If you want to change this timing, add a `<buffer>` block to the configuration by following this example:
 
 ```
 [...]
@@ -262,8 +259,7 @@ each minute you could do it adding the `<buffer>` block to the configuration, fo
 </match>
 ```
 
-If you want to read more about all the available configurations for buffers you should take a look
-to the fluentd [official documentation about Buffer configurations](https://docs.fluentd.org/configuration/buffer-section).
+To read more about all the available configurations for buffers, check out the [fluentd documentation about Buffer configurations](https://docs.fluentd.org/configuration/buffer-section).
 
 ## What's next? [#what-next]
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

This PR adds more information about how to configure fluentd when forwarding logs to NR and also show the customer what is the default buffer configuration when using the newrelic fluentd output plugin.

### Are you making a change to site code?

No