### PR TITLE
fix: formatting of commands

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/verified-script-execution-private-locations.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/verified-script-execution-private-locations.mdx
@@ -35,7 +35,7 @@ Do the following to enable verified script execution for containerized private m
      docker run \
        --name <var>YOUR_CONTAINER_NAME</var> \
        -e MINION_PRIVATE_LOCATION_KEY="<var>YOUR_PRIVATE_LOCATION_KEY</var>" \
-       -e MINION_VSE_PASSPHRASE="<var>YOUR_PASSPHRASE</var>"
+       -e MINION_VSE_PASSPHRASE="<var>YOUR_PASSPHRASE</var>" \
        -v /tmp:/tmp:rw \
        -v /var/run/docker.sock:/var/run/docker.sock:rw \
        -d \
@@ -45,10 +45,7 @@ Do the following to enable verified script execution for containerized private m
    * **Kubernetes:** Set the `synthetics.minionVsePassphrase` value in the Helm `install` or `upgrade` command:
 
      ```
-     helm install <var>YOUR_CPM_NAME YOUR_REPO_NAME</var>/synthetics-minion \
-        -n <var>YOUR_NAMESPACE</var>
-        --set synthetics.privateLocationKey=<var>YOUR_PRIVATE_LOCATION_KEY</var> \
-        --set synthetics.minionVsePassphrase=<var>YOUR_PASSPHRASE</var>
+     helm install <var>YOUR_CPM_NAME YOUR_REPO_NAME</var>/synthetics-minion -n <var>YOUR_NAMESPACE</var> --set synthetics.privateLocationKey=<var>YOUR_PRIVATE_LOCATION_KEY</var> --set synthetics.minionVsePassphrase=<var>YOUR_PASSPHRASE</var>
      ```
 3. From the Synthetics UI, select a monitor assigned to that location. Then select **Settings > General**.
 4. From the list of private locations, select your location, type your passphrase, and save. Be sure to record your passphrase in a secure place.
@@ -66,7 +63,7 @@ To change your passphrase, do the following. Be sure to record your passphrase i
      docker run \
        --name <var>YOUR_CONTAINER_NAME</var> \
        -e MINION_PRIVATE_LOCATION_KEY="<var>YOUR_PRIVATE_LOCATION_KEY</var>" \
-       -e MINION_VSE_PASSPHRASE="<var>YOUR_PASSPHRASE</var>"
+       -e MINION_VSE_PASSPHRASE="<var>YOUR_PASSPHRASE</var>" \
        -v /tmp:/tmp:rw \
        -v /var/run/docker.sock:/var/run/docker.sock:rw \
        -d \
@@ -76,10 +73,7 @@ To change your passphrase, do the following. Be sure to record your passphrase i
    * **Kubernetes:** Use the Helm `upgrade` command to set your updated `synthetics.minionVsePassphrase` value:
 
      ```
-     helm upgrade <var>YOUR_CPM_NAME YOUR_REPO_NAME</var>/synthetics-minion \
-        -n <var>YOUR_NAMESPACE</var>
-        --set synthetics.privateLocationKey=<var>YOUR_PRIVATE_LOCATION_KEY</var> \
-        --set synthetics.minionVsePassphrase=<var>YOUR_PASSPHRASE</var>
+     helm upgrade <var>YOUR_CPM_NAME YOUR_REPO_NAME</var>/synthetics-minion -n <var>YOUR_NAMESPACE</var> --set synthetics.privateLocationKey=<var>YOUR_PRIVATE_LOCATION_KEY</var> --set synthetics.minionVsePassphrase=<var>YOUR_PASSPHRASE</var>
      ```
 2. Go to [**one.newrelic.com**](https://one.newrelic.com/) **> Synthetics > (assigned monitor) > Settings > General**.
 3. From the list of private locations, select your location, type your new passphrase, and save.
@@ -106,9 +100,7 @@ To disable verified script execution for containerized private minions:
    * **Kubernetes:** Use the Helm `upgrade` command without the `--set synthetics.minionVsePassphrase` value:
 
      ```
-     helm upgrade <var>YOUR_CPM_NAME YOUR_REPO_NAME</var>/synthetics-minion \
-        -n <var>YOUR_NAMESPACE</var>
-        --set synthetics.privateLocationKey=<var>YOUR_PRIVATE_LOCATION_KEY</var> \
+     helm upgrade <var>YOUR_CPM_NAME YOUR_REPO_NAME</var>/synthetics-minion -n <var>YOUR_NAMESPACE</var> --set synthetics.privateLocationKey=<var>YOUR_PRIVATE_LOCATION_KEY</var>
      ```
 2. Go to [**one.newrelic.com**](https://one.newrelic.com/) **> Synthetics > Private locations > (select a private location)**. Clear the **Enable verified script execution** checkbox, then save.
 


### PR DESCRIPTION
- line breaks for `docker run` commands needs `\`
- K8s commands don't typically use line breaks