### PR TITLE
infra agent 1.19.0 release notes: recommends explanation

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1190.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1190.mdx
@@ -14,8 +14,8 @@ We recommend you to upgrade the agent every 3 months.
 
 ## Changed
 
-[#562](https://github.com/newrelic/infrastructure-agent/pull/562) Log forwarder as package "recommended" dependency in linux systems.
-  * Supported distros have enabled "recommends" declared dependencies out of the box. So unless this was disabled installation should be transparent.
-  * In case your distro have disabled "recommends" dependencies you'll need to explicitly enable it via `apt-get -o APT::Install-Suggests="true" install newrelic-infra`.
+[#562](https://github.com/newrelic/infrastructure-agent/pull/562) Log forwarder as "recommended" package dependency in linux systems.
+  * Supported distributions have enabled "recommends" declared dependencies out of the box. Unless this is disabled, installation should be transparent.
+  * In case your distribution has disabled "recommends" dependencies you'll need to explicitly enable it via `apt-get -o APT::Install-Suggests="true" install newrelic-infra`.
 
 [#552](https://github.com/newrelic/infrastructure-agent/pull/552) Goreleaser updated to version [0.169.0](https://github.com/goreleaser/goreleaser/releases/tag/v0.169.0)

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1190.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1190.mdx
@@ -13,5 +13,9 @@ We recommend you to upgrade the agent every 3 months.
 [#212](https://github.com/newrelic/infrastructure-agent/pull/212) A temporal hostType value for boxes running in the cloud is defined  until cloud identifier gets resolved.
 
 ## Changed
-[#562](https://github.com/newrelic/infrastructure-agent/pull/562) Log forwarder as package dependency in linux systems.
+
+[#562](https://github.com/newrelic/infrastructure-agent/pull/562) Log forwarder as package "recommended" dependency in linux systems.
+  * Supported distros have enabled "recommends" declared dependencies out of the box. So unless this was disabled installation should be transparent.
+  * In case your distro have disabled "recommends" dependencies you'll need to explicitly enable it via `apt-get -o APT::Install-Suggests="true" install newrelic-infra`.
+
 [#552](https://github.com/newrelic/infrastructure-agent/pull/552) Goreleaser updated to version [0.169.0](https://github.com/goreleaser/goreleaser/releases/tag/v0.169.0)


### PR DESCRIPTION
Infrastructure agent release notes update to add explanation on "recommends" dependencies.