### PR TITLE
Change attribute dictionary link text to data dictionary

### DIFF
--- a/src/nav/attribute-dictionary.yml
+++ b/src/nav/attribute-dictionary.yml
@@ -1,4 +1,4 @@
-title: Attribute dictionary
+title: Data dictionary
 path: /attribute-dictionary
 filterable: false
 pages:


### PR DESCRIPTION
@zuluecho9's request.

In general, we refer to the "attribute dictionary" as the "data dictionary". I've updated the link text to reflect that. Please note: I have not updated the URL.

