### PR TITLE
Release Updates for Android Agent 6.2.0 release

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
@@ -73,7 +73,7 @@ Make sure your Android app meets these requirements:
       </td>
 
       <td>
-        Java 1.7 through Java 9
+        Java 1.7 through Java 9. JDK 11 is supported in version 6.2.0 and higher.
       </td>
     </tr>
 

--- a/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-620.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-620.mdx
@@ -1,0 +1,18 @@
+---
+subject: Android agent
+releaseDate: '2021-08-01'
+version: 6.2.0
+downloadLink: 'https://download.newrelic.com/android_agent/ant/NewRelic_Android_Agent_6.2.0.zip'
+---
+
+##  New in this release
+* Add suppport for Android Gradle plugin (AGP) version 7.0
+* Update instrumentation support level to JDK 11
+
+## Fixed in this release
+* Replace `Map.putIfAsent()` method reference that caused runtime crashes when using compileSDK `< 24`
+* Remove any remaining location listener when app goes to background 
+* Fix OkHttp interceptor failure when updating the URL of Retrofit POST requests
+
+## Support statement:
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.23.0](https://docs.newrelic.com/docs/release-notes/mobile-release-notes/android-release-notes/android-5230).


### PR DESCRIPTION
This PR reverts #3353, which reverted an accidental early publish. 

Tl;DR: This publishes the 6.2.0 android agent release. 

Reverts newrelic/docs-website#3353