### PR TITLE
minor fixes for translation

### DIFF
--- a/scripts/actions/__tests__/send-and-update-translation-queue.test.js
+++ b/scripts/actions/__tests__/send-and-update-translation-queue.test.js
@@ -233,7 +233,7 @@ describe('send-and-update-translation-queue tests', () => {
   });
 
   describe('uploadFiles', () => {
-    test('updates translation state to errored when upload fails', async () => {
+    test('when upload fails, status of translation is left as "PENDING"', async () => {
       uploadFile.mockReturnValueOnce(() => {
         return { code: 'NOT_ACCEPTED' };
       });
@@ -250,12 +250,7 @@ describe('send-and-update-translation-queue tests', () => {
 
       await uploadFiles(batches, translationsPerLocale, 'fake_access_token');
 
-      expect(updateTranslation.mock.calls.length).toBe(1);
-      expect(updateTranslation.mock.calls[0]).toEqual([
-        'fake_translation_id',
-        { status: 'ERRORED' },
-      ]);
-      expect(updateJob.mock.calls.length).toBe(0);
+      expect(updateTranslation.mock.calls.length).toBe(0);
     });
 
     test('adds TranslationsJobs record when upload succeeds', async () => {

--- a/scripts/actions/send-and-update-translation-queue.js
+++ b/scripts/actions/send-and-update-translation-queue.js
@@ -158,23 +158,22 @@ const uploadFiles = async (batches, translationsPerLocale, accessToken) => {
   for (const batch of batches) {
     let successCount = 0;
 
-    await Promise.all(
-      translationsPerLocale[batch.locale].map(async (translation) => {
-        const fileUploadResponse = await uploadFile(
-          batch.locale,
-          batch.batchUid,
-          accessToken
-        )(translation);
+    const translations = translationsPerLocale[batch.locale];
+    for (const translation of translations) {
+      const fileUploadResponse = await uploadFile(
+        batch.locale,
+        batch.batchUid,
+        accessToken
+      )(translation);
 
-        if (fileUploadResponse.code === 'ACCEPTED') {
-          await Database.updateTranslation(translation.id, {
-            status: 'IN_PROGRESS',
-          });
-          await Database.addTranslationsJobsRecord(translation.id, batch.jobId);
-          successCount += 1;
-        }
-      })
-    );
+      if (fileUploadResponse.code === 'ACCEPTED') {
+        await Database.updateTranslation(translation.id, {
+          status: 'IN_PROGRESS',
+        });
+        await Database.addTranslationsJobsRecord(translation.id, batch.jobId);
+        successCount += 1;
+      }
+    }
 
     if (successCount > 0) {
       // if at least one file was successfully uploaded, set job to in progress

--- a/scripts/actions/send-and-update-translation-queue.js
+++ b/scripts/actions/send-and-update-translation-queue.js
@@ -160,18 +160,27 @@ const uploadFiles = async (batches, translationsPerLocale, accessToken) => {
 
     const translations = translationsPerLocale[batch.locale];
     for (const translation of translations) {
-      const fileUploadResponse = await uploadFile(
-        batch.locale,
-        batch.batchUid,
-        accessToken
-      )(translation);
+      try {
+        const fileUploadResponse = await uploadFile(
+          batch.locale,
+          batch.batchUid,
+          accessToken
+        )(translation);
 
-      if (fileUploadResponse.code === 'ACCEPTED') {
-        await Database.updateTranslation(translation.id, {
-          status: 'IN_PROGRESS',
-        });
-        await Database.addTranslationsJobsRecord(translation.id, batch.jobId);
-        successCount += 1;
+        if (fileUploadResponse.code === 'ACCEPTED') {
+          await Database.updateTranslation(translation.id, {
+            status: 'IN_PROGRESS',
+          });
+          await Database.addTranslationsJobsRecord(translation.id, batch.jobId);
+          successCount += 1;
+        }
+      } catch (error) {
+        console.log(
+          `Error occured during upload process for: ${translation.slug}`
+        );
+        console.log(`Error: ${error}`);
+        console.log(error.stack);
+        process.exitCode = 1;
       }
     }
 

--- a/scripts/actions/send-and-update-translation-queue.js
+++ b/scripts/actions/send-and-update-translation-queue.js
@@ -172,10 +172,6 @@ const uploadFiles = async (batches, translationsPerLocale, accessToken) => {
           });
           await Database.addTranslationsJobsRecord(translation.id, batch.jobId);
           successCount += 1;
-        } else {
-          await Database.updateTranslation(translation.id, {
-            status: 'ERRORED',
-          });
         }
       })
     );


### PR DESCRIPTION
These changes are some minor adjustments which we identified after we executed the send workflow. 

In particular:
* remove usage of `ERRORED` status. for this first run, we saw many files encounter this status due to failed uploads that were retryable. its likely we will encounter this scenario again, so rather than manually resetting state to PENDING, we would rather it just stay that way. in the future, we can figure out how to better incorporate the ERRORED state.
* upload files serially. we are hitting an api limit doing concurrent file uploads. the easiest path forward for now is to just upload them serially. this does decrease performance, but that is something we have plenty to give, especially if it reduces manual toil.
* provide the translation.slug if a file fails to upload just for context. this is because we encountered a serialization error w/o knowing which file it failed on.

Relates to: #2655 