### PR TITLE
Add more API rate limiting details

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries.mdx
@@ -68,7 +68,7 @@ Once the limit has been reached for a given time period, limiting will be impose
 
 ## NRQL query rate limits [#query-limits]
 
-The limit on NRQL queries is 3000 queries per account per minute.  When this limit is exceeded, queries may be rejected until the number of queries sent per minute no longer exceed the limit.  See [Query system limits](https://docs.newrelic.com/docs/telemetry-data-platform/manage-data/query-limits/) for information on how to view your limits.
+The limit on NRQL queries is 3,000 queries per account per minute.  When this limit is exceeded, queries may be rejected until the number of queries sent per minute no longer exceed the limit.  To learn more about how to view your limits, see our [query system limits](https://docs.newrelic.com/docs/telemetry-data-platform/manage-data/query-limits/).
 
 ## Limits on count of data types [#event-limits]
 

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries.mdx
@@ -68,7 +68,7 @@ Once the limit has been reached for a given time period, limiting will be impose
 
 ## NRQL query rate limits [#query-limits]
 
-The limit on NRQL queries is 3000 queries per account per minute.  When this limit is exceeded, queries may be rejected until the number of queries sent per minute no longer exceed the limit.
+The limit on NRQL queries is 3000 queries per account per minute.  When this limit is exceeded, queries may be rejected until the number of queries sent per minute no longer exceed the limit.  See [Query system limits](https://docs.newrelic.com/docs/telemetry-data-platform/manage-data/query-limits/) for information on how to view your limits.
 
 ## Limits on count of data types [#event-limits]
 

--- a/src/content/docs/telemetry-data-platform/manage-data/query-limits.mdx
+++ b/src/content/docs/telemetry-data-platform/manage-data/query-limits.mdx
@@ -15,7 +15,7 @@ New Relic has resource limits in place to protect your experience, our systems, 
 This page describes the limit metrics and `NrIntegrationError` events that enable you to view  your limits, your current data usage and overall resource consumption as compared to those limits, and the impact of experiencing a limit event. We also provide a handful of queries that, when compiled into a dashboard, can give you consistent insight into your limits status.
 
 <Callout variant="important">
-While `NrIntegrationError` events cover many limits, resource metrics currently only cover request rate ingestion limits.
+While `NrIntegrationError` events cover many limits, resource metrics currently only cover request rate ingestion limits and API query rate limits.
 </Callout>
 
 ## What happens when you reach a limit 

--- a/src/content/docs/telemetry-data-platform/manage-data/query-limits.mdx
+++ b/src/content/docs/telemetry-data-platform/manage-data/query-limits.mdx
@@ -12,10 +12,10 @@ redirects:
 
 New Relic has resource limits in place to protect your experience, our systems, and our other customers. These limits range from the maximum number of characters you can have in a query, to API request rates, to how many events your queries inspect, and more.
 
-This page describes the limit metrics and `NrIntegrationError` events that enable you to view  your limits, your current data usage and overall resource consumption as compared to those limits, and the impact of experiencing a limit event. We also provide a handful of queries that, when compiled into a dashboard, can give you consistent insight into your limits status.
+This page describes the limit metrics and `NrIntegrationError` events that enable you to view your limits, your current data usage and overall resource consumption as compared to those limits, and the impact of experiencing a limit event. We also provide a handful of queries that, when compiled into a dashboard, can give you consistent insight into your limits status.
 
 <Callout variant="important">
-While `NrIntegrationError` events cover many limits, resource metrics currently only cover request rate ingestion limits and API query rate limits.
+While `NrIntegrationError` events provide data on many limits types, resource limit metrics currently only cover request rate ingestion and API query rate limits.
 </Callout>
 
 ## What happens when you reach a limit 


### PR DESCRIPTION
Links to information on how to view your limits from the NRQL rate limits page.
Updates the callout in the Query system limits page to reflect that resource metrics now also include API query rate limits.