### PR TITLE
Add Infinite Tracing gem requirement for Sinatra

### DIFF
--- a/src/content/docs/agents/ruby-agent/installation/install-new-relic-ruby-agent.mdx
+++ b/src/content/docs/agents/ruby-agent/installation/install-new-relic-ruby-agent.mdx
@@ -65,7 +65,9 @@ Our Ruby agent auto-instruments your code so you can start monitoring applicatio
 
          <td>
            * **Rails**: If you're using Rails 3 or higher, or Rails 2.3 in the [recommended configuration](http://bundler.io/v1.12/rails3.html), Rails will automatically call `Bundler.require` and cause `newrelic_rpm` to be required during startup of your application.
-           * **Sinatra**: If you're using Sinatra or another framework, you must either manually call `require 'newrelic_rpm'` and for Infinite Tracing, `require 'newrelic/infinite_tracing'`, or call `Bundler.require`.
+           * **Sinatra**: If you're using Sinatra or another framework, you must manually call `require 'newrelic_rpm'`. Additionally, if you're using Infinite Tracing, manually call `require 'newrelic/infinite_tracing'`. 
+           
+           Alternately, manually call `Bundler.require`, which also enables Infinite Tracing. 
          </td>
        </tr>
 

--- a/src/content/docs/agents/ruby-agent/installation/install-new-relic-ruby-agent.mdx
+++ b/src/content/docs/agents/ruby-agent/installation/install-new-relic-ruby-agent.mdx
@@ -65,7 +65,7 @@ Our Ruby agent auto-instruments your code so you can start monitoring applicatio
 
          <td>
            * **Rails**: If you're using Rails 3 or higher, or Rails 2.3 in the [recommended configuration](http://bundler.io/v1.12/rails3.html), Rails will automatically call `Bundler.require` and cause `newrelic_rpm` to be required during startup of your application.
-           * **Sinatra**: If you're using Sinatra or another framework, you must either manually call `require 'newrelic_rpm'`, or call `Bundler.require`.
+           * **Sinatra**: If you're using Sinatra or another framework, you must either manually call `require 'newrelic_rpm'` and for Infinite Tracing, `require 'newrelic/infinite_tracing'`, or call `Bundler.require`.
          </td>
        </tr>
 


### PR DESCRIPTION
### Give us some context

In order to use Infinite Tracing with Sinatra apps (that are not also using Rails) the customer would need to manually call the New Relic gem AND the Infinite Tracing gem, or use `Bundler.require`.
The wording in my edit may be a little clunky now and may need rephrasing. The basics are, for customers with Sinatra apps:
* For Infinite Tracing, they  _must_ either call `Bundler.require` OR `require 'newrelic_rpm'` and `require 'newrelic/infinite_tracing'`
* If Infinite Tracing is not configured and the agent is greater than/equal to v6.11 (released June 2020), then including `require 'newrelic/infinite_tracing'` will do nothing so it won't hurt to include it even if the customer has no intention to use ∞T
* If the customer attempts to add `require 'newrelic/infinite_tracing'` with an agent version less than v6.11, it will cause an error when it looks for a gem that doesn't exist

Since this is an install doc, I assume we can exclude any mention of version and just assume the customer is installing a version of the agent less than a year old

Confirmed this edit with the Ruby engineering team in https://newrelic.atlassian.net/browse/GTSE-10264

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.