### PR TITLE
Add handler to convert Video component to html that's included in json output

### DIFF
--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -228,15 +228,13 @@ module.exports = {
       youtube: (id) => `//www.youtube.com/embed/${id}?modestbranding=1`,
       wistia: (id) => `//fast.wistia.net/embed/iframe/${id}`,
     };
-    return h(node, 'div', [
-      h('iframe', {
-        src: videoPlatforms[type](id),
-        allow:
-          'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture',
-        allowFullScreen: true,
-        width: '100%',
-      }),
-    ]);
+    return h(node, 'iframe', {
+      src: videoPlatforms[type](id),
+      allow:
+        'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture',
+      allowFullScreen: true,
+      width: '100%',
+    });
   },
   mark: (h, node) => h(node, 'mark', {}, [u('text', toString(node))]),
   figcaption: (h, node) =>

--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -221,6 +221,21 @@ module.exports = {
   th: (h, node) => h(node, 'th', {}, all(h, node)),
   td: (h, node) => h(node, 'td', {}, all(h, node)),
   var: (h, node) => h(node, 'var', {}, [u('text', toString(node))]),
+  Video: (h, node) => {
+    const id = findAttribute('id', node);
+    const type = findAttribute('type', node);
+    const videoPlatforms = {
+      youtube: (id) => `//www.youtube.com/embed/${id}?modestbranding=1`,
+      wistia: (id) => `//fast.wistia.net/embed/iframe/${id}`,
+    };
+    return h(node, 'iframe', {
+      src: videoPlatforms[type](id),
+      allow:
+        'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture',
+      allowFullScreen: true,
+      width: '100%',
+    });
+  },
   mark: (h, node) => h(node, 'mark', {}, [u('text', toString(node))]),
   figcaption: (h, node) =>
     h(node, 'div', { className: ['meta'] }, all(h, node)),

--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -228,13 +228,23 @@ module.exports = {
       youtube: (id) => `//www.youtube.com/embed/${id}?modestbranding=1`,
       wistia: (id) => `//fast.wistia.net/embed/iframe/${id}`,
     };
-    return h(node, 'iframe', {
-      src: videoPlatforms[type](id),
-      allow:
-        'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture',
-      allowFullScreen: true,
-      width: '100%',
-    });
+
+    return h(
+      node,
+      'div',
+      { style: 'position: relative; padding-top: 56.25%; height: 0;' },
+      [
+        h(node, 'iframe', {
+          src: videoPlatforms[type](id),
+          allow:
+            'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture',
+          allowFullScreen: true,
+          frameborder: '0',
+          style:
+            'width: 100%; height: 100%; position: absolute; top: 0; left: 0',
+        }),
+      ]
+    );
   },
   mark: (h, node) => h(node, 'mark', {}, [u('text', toString(node))]),
   figcaption: (h, node) =>

--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -228,13 +228,15 @@ module.exports = {
       youtube: (id) => `//www.youtube.com/embed/${id}?modestbranding=1`,
       wistia: (id) => `//fast.wistia.net/embed/iframe/${id}`,
     };
-    return h(node, 'iframe', {
-      src: videoPlatforms[type](id),
-      allow:
-        'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture',
-      allowFullScreen: true,
-      width: '100%',
-    });
+    return h(node, 'div', [
+      h('iframe', {
+        src: videoPlatforms[type](id),
+        allow:
+          'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture',
+        allowFullScreen: true,
+        width: '100%',
+      }),
+    ]);
   },
   mark: (h, node) => h(node, 'mark', {}, [u('text', toString(node))]),
   figcaption: (h, node) =>


### PR DESCRIPTION
## Description

Adds handler to local plugin that outputs JSON for each .mdx file in `src/content/docs` that includes html in the `body` field. The handler converts Video component to html `<iframe>`.

## Example JSON
https://docswebsitedevelop-clangfixvideoembeddocjson.gtsb.io/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts.json

## Related issues / PRs
Closes https://github.com/newrelic/docs-website/issues/3376

## Screenshots

![2021-08-03_16-10-10](https://user-images.githubusercontent.com/2952843/128097676-69a2895e-7cda-42cb-87e1-c4016ac977c1.png)
