### PR TITLE
Integration disabled given Azure has retired the service

### DIFF
--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-service-fabric-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-service-fabric-monitoring-integration.mdx
@@ -11,7 +11,7 @@ redirects:
 Our [infrastructure monitoring](/docs/infrastructure/) provides an integration for Microsoft Azure Service Fabric that reports data from your Service Fabric nodes to New Relic.
 
 <Callout variant="important">
-Microsoft Azure has communicated the [retirement of the Service Fabric Mesh service]((https://azure.microsoft.com/en-us/updates/azure-service-fabric-mesh-preview-retirement/)). Hence, this integration is not longer active. Data may still be accessed based on the [data retention policies in New Relic](/docs/telemetry-data-platform/manage-data/manage-data-retention/#adjust-retention). 
+Microsoft Azure has communicated the [retirement of the Service Fabric Mesh service]((https://azure.microsoft.com/en-us/updates/azure-service-fabric-mesh-preview-retirement/)). Hence, this integration is no longer active. Data may still be accessed based on the [data retention policies in New Relic](/docs/telemetry-data-platform/manage-data/manage-data-retention/#adjust-retention). 
 </Callout>
 
 ### Features [#features]

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-service-fabric-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-service-fabric-monitoring-integration.mdx
@@ -11,7 +11,7 @@ redirects:
 Our [infrastructure monitoring](/docs/infrastructure/) provides an integration for Microsoft Azure Service Fabric that reports data from your Service Fabric nodes to New Relic.
 
 <Callout variant="important">
-Microsoft Azure has communicated the [retirement of the Service Fabric Mesh service]((https://azure.microsoft.com/en-us/updates/azure-service-fabric-mesh-preview-retirement/)). Hence, this integration is not longer active, data might still be accessed based on the data retention policies in New Relic. 
+Microsoft Azure has communicated the [retirement of the Service Fabric Mesh service]((https://azure.microsoft.com/en-us/updates/azure-service-fabric-mesh-preview-retirement/)). Hence, this integration is not longer active. Data may still be accessed based on the [data retention policies in New Relic](/docs/telemetry-data-platform/manage-data/manage-data-retention/#adjust-retention). 
 </Callout>
 
 ### Features [#features]

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-service-fabric-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-service-fabric-monitoring-integration.mdx
@@ -1,5 +1,5 @@
 ---
-title: Azure Service Fabric monitoring integration
+title: Azure Service Fabric Mesh monitoring integration
 tags:
   - Integrations
   - Microsoft Azure integrations
@@ -10,9 +10,13 @@ redirects:
 ---
 Our [infrastructure monitoring](/docs/infrastructure/) provides an integration for Microsoft Azure Service Fabric that reports data from your Service Fabric nodes to New Relic.
 
+<Callout variant="important">
+Microsoft Azure has communicated the [retirement of the Service Fabric Mesh service]((https://azure.microsoft.com/en-us/updates/azure-service-fabric-mesh-preview-retirement/)). Hence, this integration is not longer active, data might still be accessed based on the data retention policies in New Relic. 
+</Callout
+
 ### Features [#features]
 
-Our Azure Service Fabric integration reports metrics about your node such as CPU usage, memory consumption, or network usage. It also collects metrics for [containers](/attribute-dictionary/?event=ContainerSample) and [processes](/attribute-dictionary/?event=ProcessSample) running on each node.
+Our Azure Service Fabric Mesh integration reports metrics about your node such as CPU usage, memory consumption, or network usage. It also collects metrics for [containers](/attribute-dictionary/?event=ContainerSample) and [processes](/attribute-dictionary/?event=ProcessSample) running on each node.
 
 You can monitor and alert on your Azure Service Fabric node data with our infrastructure monitoring, and you can [create custom queries and chart dashboards](/docs/telemetry-data-platform/ingest-manage-data/understand-data/introduction-querying-new-relic-data/).
 

--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-service-fabric-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-service-fabric-monitoring-integration.mdx
@@ -12,7 +12,7 @@ Our [infrastructure monitoring](/docs/infrastructure/) provides an integration f
 
 <Callout variant="important">
 Microsoft Azure has communicated the [retirement of the Service Fabric Mesh service]((https://azure.microsoft.com/en-us/updates/azure-service-fabric-mesh-preview-retirement/)). Hence, this integration is not longer active, data might still be accessed based on the data retention policies in New Relic. 
-</Callout
+</Callout>
 
 ### Features [#features]
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* Azure communicated the [service is no longer available](https://azure.microsoft.com/en-us/updates/azure-service-fabric-mesh-preview-retirement/).
* We had disabled the integration and we'll proceed to remove this documentation by end of the quarter.  

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.