### PR TITLE
adds GUID for JetBrains' dotCover profiler

### DIFF
--- a/src/content/docs/agents/net-agent/troubleshooting/profiler-conflicts.mdx
+++ b/src/content/docs/agents/net-agent/troubleshooting/profiler-conflicts.mdx
@@ -203,5 +203,15 @@ Here are some commonly reported profiler conflicts. This is not an exhaustive li
         AD5651A8-B5C8-46ca-A11B-E82AEC2B8E78
       </td>
     </tr>
+    
+     <tr>
+      <td>
+        JetBrains dotCover
+      </td>
+       
+      <td>
+        9AA5D52F-37E2-487D-AAEC-727478B8BDB5      
+      </td>
+     </tr>     
   </tbody>
 </table>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

Adds to documentation an issue I ran into trying to setup a New Relic agent on Windows. There was already an environment variable set from an old installation of JetBrains dotCover and it was preventing the New Relic agent from working -- this is its GUID.