### PR TITLE
Update video embeds to match width of other elements

### DIFF
--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -232,7 +232,10 @@ module.exports = {
     return h(
       node,
       'div',
-      { style: 'position: relative; padding-top: 56.25%; height: 0;' },
+      {
+        style:
+          'position: relative; padding-top: 29%; height: 0; max-width: 85ch',
+      },
       [
         h(node, 'iframe', {
           src: videoPlatforms[type](id),

--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -234,8 +234,6 @@ module.exports = {
       'div',
       {
         className: 'iframe-wrapper',
-        style:
-          'position: relative; padding-top: 29%; height: 0; max-width: 85ch',
       },
       [
         h(node, 'iframe', {
@@ -244,8 +242,6 @@ module.exports = {
             'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture',
           allowFullScreen: true,
           frameborder: '0',
-          style:
-            'width: 100%; height: 100%; position: absolute; top: 0; left: 0',
         }),
       ]
     );

--- a/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
+++ b/plugins/gatsby-plugin-generate-doc-json/utils/handlers.js
@@ -233,6 +233,7 @@ module.exports = {
       node,
       'div',
       {
+        className: 'iframe-wrapper',
         style:
           'position: relative; padding-top: 29%; height: 0; max-width: 85ch',
       },


### PR DESCRIPTION
## Description
Updates the inline style on the wrapper div for iframe to set same max-width as the NR1 Help XP nerdlet sets on many (but not all elements).

Will submit PR to add style rule in the nerdlet so we can eventually remove this inline style

## Related issues / PRs
- Related to https://github.com/newrelic/docs-website/pull/3378
- https://source.datanerd.us/nr1-dev-experience/nr1-help-xp/pull/123

## Screenshot(s)

### Current look
![2021-08-05_09-52-05](https://user-images.githubusercontent.com/2952843/128390417-a48e6654-dfe6-41c4-b01b-1fa81c2be9f6.png)

### After style update
![2021-08-05_10-18-34](https://user-images.githubusercontent.com/2952843/128393399-65179693-dd1e-4797-9f29-0f8482e32b4a.png)
