### PR TITLE
Preparing users for the possibly jarring nomenclature change

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-violations/violation-event-attributes.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-violations/violation-event-attributes.mdx
@@ -23,11 +23,9 @@ The violation of a [condition](/docs/alerts/new-relic-alerts/getting-started/new
 
 ## Violation event attributes [#attributes]
 
-This table shows violation event attributes. The violation event data type is collected in [NrAiIncident](/attribute-dictionary/?event=NrAiIncident)
+This table shows violation event attributes. The violation event data type is collected in [NrAiIncident](/attribute-dictionary/?event=NrAiIncident).
 
-<Callout variant="important">
-  You may be wondering why we call the violation event `NrAiIncident`. Although we currently refer to these events as "violations," we are moving toward a new naming scheme where they will be called "incidents," and named this event in preparation for that change.
-</Callout>
+You may be wondering why we're using `NrAiIncident` as the name for the violation event data type. Although we currently refer to these events as "violations," they'll be called "incidents" in our new, upcoming naming scheme. This name prepares for and reflects our future intentions.
 
 All attributes are available for use in a [description](/docs/alerts/new-relic-alerts/defining-conditions/alert-condition-descriptions). Read about attributes available for [muting rules](/docs/alerts/new-relic-alerts/managing-notification-channels/muting-rules-suppress-notifications).
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-violations/violation-event-attributes.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-violations/violation-event-attributes.mdx
@@ -25,6 +25,10 @@ The violation of a [condition](/docs/alerts/new-relic-alerts/getting-started/new
 
 This table shows violation event attributes. The violation event data type is collected in [NrAiIncident](/attribute-dictionary/?event=NrAiIncident)
 
+<Callout variant="important">
+  You may be wondering why we call the violation event `NrAiIncident`. Although we currently refer to these events as "violations," we are moving toward a new naming scheme where they will be called "incidents," and named this event in preparation for that change.
+</Callout>
+
 All attributes are available for use in a [description](/docs/alerts/new-relic-alerts/defining-conditions/alert-condition-descriptions). Read about attributes available for [muting rules](/docs/alerts/new-relic-alerts/managing-notification-channels/muting-rules-suppress-notifications).
 
 <table>


### PR DESCRIPTION
We'll be changing the nomenclature, and this is already reflected in our event types' names. In order to proactively head off confusion and prepare users for the coming change, I inserted this little informational tidbit the first time we refer to the event by name.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.