### PR TITLE
Adding note about optional dependency on Linux

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
@@ -196,6 +196,13 @@ icon={<img src={windows} alt="amazonlinux.png"/>}
 
 If you don't have a New Relic account yet, or prefer to follow the procedure manually, see our [tutorial to install the package manager](/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-agent-linux-using-package-manager).
 
+<Callout variant="tip">
+  The "td-agent-bit" package is required to forward logs. It's currently packaged as a "recommended" dependency for the Infrastructure Agent in Linux systems. Linux distributions have this feature enabled by default. In case your distribution has disabled "recommended" dependencies you'll need to explicitly enable them using:
+  ```
+  apt-get -o APT::Install-Suggests="true" install newrelic-infra
+  ```
+</Callout>
+
 ## Configure the infrastructure agent [#configure]
 
 Configuration files describe which log sources are forwarded. The Infrastructure agent uses `.yml` files for configuring logging. You can add as many config files as you want.

--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
@@ -197,7 +197,7 @@ icon={<img src={windows} alt="amazonlinux.png"/>}
 If you don't have a New Relic account yet, or prefer to follow the procedure manually, see our [tutorial to install the package manager](/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-agent-linux-using-package-manager).
 
 <Callout variant="tip">
-  The "td-agent-bit" package is required to forward logs. It's currently packaged as a "recommended" dependency for the Infrastructure Agent in Linux systems. Linux distributions have this feature enabled by default. In case your distribution has disabled "recommended" dependencies you'll need to explicitly enable them using:
+  The "td-agent-bit" package is required to forward logs. Starting with Infrastructure Agent 1.19.0, the package is installed as a "recommended" dependency in Linux systems. Linux distributions have this feature enabled by default. In case your distribution has disabled "recommended" dependencies you'll need to explicitly enable at installation time them using:
   ```
   apt-get -o APT::Install-Suggests="true" install newrelic-infra
   ```


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* Starting with agent 1.19.0, the td-agent-bit dependency might not be installed by default on customer environments. Adding explanation and workaround until we determine if this will be changed. 

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.