### PR TITLE
Reintroduce docs for deprecated record_exception

### DIFF
--- a/src/content/docs/agents/python-agent/python-agent-api/recordexception-python-agent-api.mdx
+++ b/src/content/docs/agents/python-agent/python-agent-api/recordexception-python-agent-api.mdx
@@ -19,3 +19,151 @@ newrelic.agent.record_exception(exc=None, value=None, tb=None, params={}, ignore
 
 This API has been deprecated. Please use [`notice_error()`](/docs/agents/python-agent/python-agent-api/notice_error).
 
+---
+
+Records details of a Python exception as an error.
+
+## Description
+
+By default, the Python agent only reports unhandled exceptions. Use `record_exception` to record any Python exception as an error, which can then be found in New Relic One. If no parameters are provided, the details of the exception currently being handled will be used.
+
+You can record up to five distinct exceptions per [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction), and up to 20 total exceptions across all transactions per [harvest cycle](/docs/apm/new-relic-apm/getting-started/glossary#harvest-cycle).
+
+When `record_exception()` is called within the context of a monitored web request or background task, the details of the exception will be reported against the application that the request or task is being reported to.
+
+If called outside of the context of a monitored web request or background task, the call will be ignored unless the [`application`](/docs/agents/python-agent/python-agent-api/application) keyword argument is provided and an application object corresponding to the application against which the exception should be recorded is provided. A suitable application object can be obtained using the `newrelic.agent.application()` function.
+
+## Parameters
+
+<Callout variant="tip">
+  In almost all cases, `record_exception` will require no parameters.
+</Callout>
+
+<table>
+  <thead>
+    <tr>
+      <th width="25%">
+        Parameter
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `exc`
+
+        _class object_
+      </td>
+
+      <td>
+        Optional and rarely used. The exception type of the exception being handled (a class object). One of three values (`exc`, `value`, and `tb`) returned from [`sys.exc_info()`](https://docs.python.org/2/library/sys.html#sys.exc_info). If you want to pass any of these parameters, all three must be set and and cannot be set to `None`. If you only pass one of these values, the call will not work.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `value`
+
+        _int, string, other_
+      </td>
+
+      <td>
+        Optional and rarely used. The exception parameter. One of three values (`exc`, `value`, and `tb`) returned from [`sys.exc_info()`](https://docs.python.org/2/library/sys.html#sys.exc_info). If you want to pass any of these parameters, all three must be set and and cannot be set to `None`. If you only pass one of these values, the call will not work.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `tb`
+
+        _object_
+      </td>
+
+      <td>
+        Optional and rarely used. A traceback object that encapsulates the call stack at the point where the exception originally occurred. One of three values (`exc`, `value`, and `tb`) returned from [`sys.exc_info()`](https://docs.python.org/2/library/sys.html#sys.exc_info). If you want to pass any of these parameters, all three must be set and and cannot be set to `None`. If you only pass one of these values, the call will not work.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `params`
+
+        _dict_
+      </td>
+
+      <td>
+        Optional. Custom attributes to add to the error event (in addition to any custom attributes already added to the transaction). If [high security mode](/docs/agents/manage-apm-agents/configuration/high-security-mode) is enabled, this will not work.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `ignore_errors`
+
+        _string_
+      </td>
+
+      <td>
+        Optional. Errors to ignore can be passed in the form `module:class`. Useful when certain types of exceptions should always be ignored and never recorded.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `application`
+
+        _application object_
+      </td>
+
+      <td>
+        Optional. If called outside of the context of a monitored web request or background task, the call will be ignored unless the [`application` object](/docs/agents/python-agent/python-agent-api/application) is provided.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Return values
+
+None.
+
+## Examples
+
+### Simple example of reporting exceptions [#simple-example]
+
+In large majority of cases, you won't need to pass any paramters. You would just call the following where you want to report an exception:
+
+```
+newrelic.agent.record_exception()
+```
+
+### Call with sys.exc_info() tuple and additional parameters [#complex-example]
+
+An example of `record_exception` using `sys.exc_info()` data:
+
+```
+def complex_ignore_errors(exc, val, tb):
+   # do some logic here
+   return False
+
+newrelic.agent.record_exception(params={'my_special_exception': True}, ignore_errors=complex_ignore_errors)
+```
+
+### Example using callback [#callback-example]
+
+If you need to filter exceptions dynamically based on the attributes of a specific exception type, you can supply a callback function:
+
+```
+def _ignore_errors(exc, value, tb): 
+    if instance(value, HTTPError): 
+        if value.status == 404: 
+            return True
+
+newrelic.agent.record_exception(ignore_errors=_ignore_errors)
+```
+
+If the exception is to be ignored, set the return value for the callable to `True`. Return `False` if the exception should never be ignored regardless of any other checks, and `None` if subsequent checks and inbuilt rules should determine if the exception should be ignored. A callback would normally return either `True` or `None`.

--- a/src/content/docs/agents/python-agent/python-agent-api/recordexception-python-agent-api.mdx
+++ b/src/content/docs/agents/python-agent/python-agent-api/recordexception-python-agent-api.mdx
@@ -19,11 +19,9 @@ newrelic.agent.record_exception(exc=None, value=None, tb=None, params={}, ignore
 
 This API has been deprecated. Please use [`notice_error()`](/docs/agents/python-agent/python-agent-api/notice_error).
 
----
+## Description
 
 Records details of a Python exception as an error.
-
-## Description
 
 By default, the Python agent only reports unhandled exceptions. Use `record_exception` to record any Python exception as an error, which can then be found in New Relic One. If no parameters are provided, the details of the exception currently being handled will be used.
 


### PR DESCRIPTION
Just because a function is deprecated doesn't mean the documentation isn't still useful to those who
haven't updated their dependencies yet.

See #3467