### PR TITLE
Call out .NET Agent versions that support expected errors configuration settings.

### DIFF
--- a/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1781,6 +1781,9 @@ The `errorCollector` element is a child of the `configuration` element. `errorCo
 <Callout variant="tip">
   For an overview of error configuration in APM, see [Manage errors in APM](/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-mark-expected).
 </Callout>
+<Callout variant="important">
+  `expectedClasses`, `expectedMessages` and `expectedStatusCodes` configuration settings require [.NET agent version 8.31.0.0 or higher](/docs/agents/net-agent/installation/update-net-agent).
+</Callout>
 
 The `errorCollector` element supports the following elements and attributes:
 

--- a/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1782,7 +1782,7 @@ The `errorCollector` element is a child of the `configuration` element. `errorCo
   For an overview of error configuration in APM, see [Manage errors in APM](/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-mark-expected).
 </Callout>
 <Callout variant="important">
-  `expectedClasses`, `expectedMessages` and `expectedStatusCodes` configuration settings require [.NET agent version 8.31.0.0 or higher](/docs/agents/net-agent/installation/update-net-agent).
+  `expectedClasses`, `expectedMessages`, and `expectedStatusCodes` configuration settings require [.NET agent version 8.31.0.0 or higher](/docs/agents/net-agent/installation/update-net-agent).
 </Callout>
 
 The `errorCollector` element supports the following elements and attributes:


### PR DESCRIPTION
Call out .NET Agent versions that support expected errors configuration settings.