### PR TITLE
Document `renamed_commands` integration argument

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/redis-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/redis-monitoring-integration.mdx
@@ -185,6 +185,7 @@ Config commands include:
     * `keys_limit`: max number of the keys to retrieve their lengths. Default value: `30`. For more information, see [About this integration](#about) and [Keyspace metrics configuration](#keyspace-config).
     * `password`: password to use when connecting to the Redis server. Use only if your Redis server is password-protected. Default value: None.
     * `config_inventory`: set it to `false` to avoid invoking the `CONFIG GET` Redis command. This option is useful in managed environments without permissions to execute the `CONFIG` command (for example, AWS ElastiCache). Default value: `true`
+    * `renamed_commands`: tell the integration to use renamed redis-server commands over defaults. This option is useful in environments where certain redis server commands have been renamed. Example: `renamed_commands: '{"CONFIG": "XYZ"}'`. Default value: `None`
   </Collapser>
 
   <Collapser
@@ -192,6 +193,8 @@ Config commands include:
     title="inventory"
   >
     `inventory` captures all the Redis [configuration parameters](https://redis.io/commands/config-get), with the exception of `requirepass`. To disable collection of inventory data, delete the inventory command from the config file.
+    
+    Note: You may need to specify `renamed_commands` argument if your Redis Server installation has renamed the `CONFIG` command.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/redis-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/redis-monitoring-integration.mdx
@@ -26,7 +26,7 @@ Before installing the integration, make sure that you meet the following require
 
 * A New Relic account. Don't have one? [Sign up for free!](https://newrelic.com/signup) No credit card required.
 * If Redis is **not** running on Kubernetes or Amazon ECS, you must [install the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) on a Linux OS host that's running Redis. Otherwise:
-  * If running on Kubernetes, see [these requirements](https://docs.newrelic.com/docs/monitor-service-running-kubernetes#requirements).
+  * If running on Kubernetes, see [these requirements](/docs/monitor-service-running-kubernetes#requirements).
   * If running on ECS, see [these requirements](/docs/integrations/host-integrations/host-integrations-list/monitor-services-running-amazon-ecs).
 
 The integration obtains data by executing Redis commands:
@@ -154,7 +154,7 @@ Additional notes:
        copy redis-win-config.yml.sample redis-win-config.yml
        ```
     4. Edit the `redis-win-config.yml` file as described in the [configuration settings](#config).
-    5. [Restart the infrastructure agent](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
+    5. [Restart the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
   </Collapser>
 </CollapserGroup>
 
@@ -180,21 +180,21 @@ Config commands include:
     * `hostname`: Redis server hostname. Default value: `localhost`.
     * `port`: Port where Redis server is listening. Default value: `6379`.
     * `unix_socket_path`: Unix socket path on which Redis server is listening (if set). Default value: None.
-    * `use_unix_socket`: uses the `unix_socket_path` value to help you to uniquely identify the Redis instances when there are more than one on the same host using Unix sockets. Default value: `false`.
-    * `keys`: list of the keys for retrieving their lengths. Default value: None. See [keyspace config](#keyspace-config) for more information.
-    * `keys_limit`: max number of the keys to retrieve their lengths. Default value: `30`. For more information, see [About this integration](#about) and [Keyspace metrics configuration](#keyspace-config).
-    * `password`: password to use when connecting to the Redis server. Use only if your Redis server is password-protected. Default value: None.
-    * `config_inventory`: set it to `false` to avoid invoking the `CONFIG GET` Redis command. This option is useful in managed environments without permissions to execute the `CONFIG` command (for example, AWS ElastiCache). Default value: `true`
-    * `renamed_commands`: tell the integration to use renamed redis-server commands over defaults. This option is useful in environments where certain redis server commands have been renamed. Example: `renamed_commands: '{"CONFIG": "XYZ"}'`. Default value: `None`
+    * `use_unix_socket`: Uses the `unix_socket_path` value to help you to uniquely identify the Redis instances when there are more than one on the same host using Unix sockets. Default value: `false`.
+    * `keys`: List of the keys for retrieving their lengths. Default value: None. See [keyspace config](#keyspace-config) for more information.
+    * `keys_limit`: Max number of the keys to retrieve their lengths. Default value: `30`. For more information, see [About this integration](#about) and [Keyspace metrics configuration](#keyspace-config).
+    * `password`: Password to use when connecting to the Redis server. Use only if your Redis server is password-protected. Default value: None.
+    * `config_inventory`: Set it to `false` to avoid invoking the `CONFIG GET` Redis command. This option is useful in managed environments without permissions to execute the `CONFIG` command (for example, AWS ElastiCache). Default value: `true`.
+    * `renamed_commands`: Tell the integration to use renamed redis-server commands over defaults. This option is useful in environments where certain redis server commands have been renamed. Example: `renamed_commands: '{"CONFIG": "XYZ"}'`. Default value: None.
   </Collapser>
 
   <Collapser
     id="inventory-config"
     title="inventory"
   >
-    `inventory` captures all the Redis [configuration parameters](https://redis.io/commands/config-get), with the exception of `requirepass`. To disable collection of inventory data, delete the inventory command from the config file.
+    `inventory` captures all the Redis [configuration parameters](https://redis.io/commands/config-get), with the exception of `requirepass`. To disable the collection of inventory data, delete the inventory command from the config file.
     
-    Note: You may need to specify `renamed_commands` argument if your Redis Server installation has renamed the `CONFIG` command.
+    Note: If the `CONFIG` command in your Redis Server installation has been renamed you may need to specify `renamed_commands` argument.
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
The `renamed_commands` integration argument has been merged and was part of [v1.7.0](https://github.com/newrelic/nri-redis/releases/tag/v1.7.0).
The release is 10 days old (Aug 4th 2021), I'm unsure what the protocol is for feature addition (whether to put a `>=v1.7.0` annotation in the documentation.

Closes https://github.com/newrelic/nri-redis/issues/116

<!-- NOTE: New Relic is on a company-wide vacation the week of August 9 through
August 12. We'll take a look at your PR as soon as we're back on 
August 16. Or, if your issue is urgent, you can reach out to our support team 
at support.newrelic.com. -->

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.