### PR TITLE
Remove "Relic Recharge" from PR/issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/content-issue.md
+++ b/.github/ISSUE_TEMPLATE/content-issue.md
@@ -6,10 +6,6 @@ labels: content
 assignees: ''
 ---
 
-<!-- NOTE: New Relic is honoring employees with a Relic Recharge Week. This means many of us are out of the office from August 9th through August 13th. We'll take a look at your issue as soon as we're back on August 16. 
-Or, if your issue is urgent, you can reach out to our support team 
-at support.newrelic.com. -->
-
 <!-- Thanks for filing an issue on our docs! -->
 
 <!-- This repo is public. Anything you share here is visible to the world. -->

--- a/.github/ISSUE_TEMPLATE/site-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/site-bug-report.md
@@ -6,16 +6,9 @@ labels: bug, eng
 assignees: ''
 ---
 
-<!-- NOTE: New Relic is honoring employees with a Relic Recharge Week. This means many of us are out of the office from August 9th through August 13th. We'll take a look at your issue as soon as we're back on August 16. 
-Or, if your issue is urgent, you can reach out to our support team 
-at support.newrelic.com. -->
-
 <!-- Please fill out each section below. This info allows our engineers to 
 diagnose your issue as quickly as possible. This repo is public. Anything you 
 share here is visible to the world. -->
-
-<!-- ** Check for existing issues**: Before opening a new issue, please search 
-existing issues: https://github.com/newrelic/docs-website/issues -->
 
 ### Description
 

--- a/.github/ISSUE_TEMPLATE/site-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/site-enhancement.md
@@ -6,10 +6,6 @@ labels: enhancement, eng
 assignees: ''
 ---
 
-<!-- NOTE: New Relic is honoring employees with a Relic Recharge Week. This means many of us are out of the office from August 9th through August 13th. We'll take a look at your issue as soon as we're back on August 16. 
-Or, if your issue is urgent, you can reach out to our support team 
-at support.newrelic.com. -->
-
 <!-- Please fill out each section below. This info allows our engineers to 
 diagnose your issue as quickly as possible. This repo is public. Anything you 
 share here is visible to the world. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,3 @@
-<!-- NOTE: New Relic is on a company-wide vacation the week of August 9 through
-August 12. We'll take a look at your PR as soon as we're back on 
-August 16. Or, if your issue is urgent, you can reach out to our support team 
-at support.newrelic.com. -->
-
 <!-- Thanks for contributing to our docs! -->
 
 <!-- For Japanese readers: 


### PR DESCRIPTION
Remove mentions of Relic Recharge week from templates.