### PR TITLE
Logging 5518 add api key query parameters log api

### DIFF
--- a/src/content/docs/logs/log-management/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-management/log-api/introduction-log-api.mdx
@@ -34,8 +34,9 @@ To send log data to your New Relic account:
 
 1. Get your [New Relic license key](/docs/accounts/install-new-relic/account-setup/license-key) **(recommended)** or register an [Insert API key](/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#register).
 2. Generate the JSON message using the required [headers](#json-headers) and [body](#json-body) fields.
-3. Submit the JSON message to the [HTTP endpoint](#endpoint) in a **POST** request.
-4. Generate some traffic and wait a few minutes, then [check your account](#find-data) for data.
+3. Ensure you're providing an Api-Key or License-Key by [headers](#json-headers) or [query parameters](#query-parameters)
+4. Submit the JSON message to the [HTTP endpoint](#endpoint) in a **POST** request.
+5. Generate some traffic and wait a few minutes, then [check your account](#find-data) for data.
 
 ## HTTP headers [#json-headers]
 
@@ -52,6 +53,7 @@ When creating your HTTP headers, use these guidelines:
         Supported values
       </th>
     </tr>
+
   </thead>
 
   <tbody>
@@ -72,25 +74,54 @@ When creating your HTTP headers, use these guidelines:
 
     <tr>
       <td>
-        Exactly one of:
-
         `Api-Key`
 
         or
 
         `X-License-Key`
-
-        Required
       </td>
 
       <td>
-        Use either your New Relic Insert API key (with Api-Key) or [license key](/docs/accounts/install-new-relic/account-setup/license-key) (with `X-License-Key`).
+        Use either your [insert API key](/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#register) (with `Api-Key`) or [license key](/docs/accounts/install-new-relic/account-setup/license-key) (with `X-License-Key`) or take a look bellow to see how to send it by query parameters.
       </td>
     </tr>
+
   </tbody>
 </table>
 
 Gzipped JSON formatting is accepted. If sending compressed JSON, please include the `Content-Type: application/json` and `Content-Encoding: gzip` headers.
+
+## HTTP query parameters [#query-parameters]
+
+The Insert API Key could be sent also by query parameters so sources that doesn't support add custom headers can send logs.
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "200px" }}>
+        Query parameter
+      </th>
+      <th>
+        Value
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `Api-Key`
+      </td>
+
+      <td>
+        Use your [Insert API key](/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#register) if your provider does not support add custom headers.
+
+        We recommend to send this on the headers whenever possible.
+      </td>
+    </tr>
+
+  </tbody>
+</table>
 
 ## JSON body [#json-content]
 
@@ -222,6 +253,7 @@ You can send your JSON message using either a simplified or detailed set of attr
         </tr>
       </tbody>
     </table>
+
   </Collapser>
 
   <Collapser
@@ -301,30 +333,33 @@ You can send your JSON message using either a simplified or detailed set of attr
         </tr>
       </tbody>
     </table>
+
   </Collapser>
 </CollapserGroup>
 
 ## Limits and restricted characters [#limits]
 
 <Callout variant="caution">
-  Avoid calling our API from within the code of a customer-facing application. This could cause performance issues or be blocking if response time is slow. If you must do this, try to do it asynchronously.
+  Avoid calling our API from within the code of a customer-facing application.
+  This could cause performance issues or be blocking if response time is slow.
+  If you must do this, try to do it asynchronously.
 </Callout>
 
 Restrictions on logs sent to the Log API:
 
-* Payload total size: **1MB(10^6 bytes) maximum per POST**. We highly recommend using compression.
-* The payload must be encoded as **UTF-8**.
-* Number of attributes per event: 255 maximum
-* Length of attribute name: 255 characters
-* Length of attribute value: 4096 maximum character length
+- Payload total size: **1MB(10^6 bytes) maximum per POST**. We highly recommend using compression.
+- The payload must be encoded as **UTF-8**.
+- Number of attributes per event: 255 maximum
+- Length of attribute name: 255 characters
+- Length of attribute value: 4096 maximum character length
 
 Some specific attributes have additional restrictions:
 
-* `accountId`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
-* `entity.guid`, `entity.name`, and `entity.type`: These attributes are used internally to identify entities. Any values submitted with these keys in the attributes section of a metric data point may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities. For more information please refer to [Entity synthesis](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#entity-synthesis).
-* [`appId`](/docs/apis/rest-api-v2/requirements/find-product-id#apm): Value must be an integer. If it is not an integer, the attribute name and value will be dropped during ingest.
-* `eventType`: Can be a combination of alphanumeric characters, `_` underscores, and `:` colons.
-* `timestamp`: Must be a Unix epoch timestamp. You can define timestamps either in seconds or in milliseconds.
+- `accountId`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
+- `entity.guid`, `entity.name`, and `entity.type`: These attributes are used internally to identify entities. Any values submitted with these keys in the attributes section of a metric data point may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities. For more information please refer to [Entity synthesis](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#entity-synthesis).
+- [`appId`](/docs/apis/rest-api-v2/requirements/find-product-id#apm): Value must be an integer. If it is not an integer, the attribute name and value will be dropped during ingest.
+- `eventType`: Can be a combination of alphanumeric characters, `_` underscores, and `:` colons.
+- `timestamp`: Must be a Unix epoch timestamp. You can define timestamps either in seconds or in milliseconds.
 
 <Callout variant="important">
   Payloads with timestamps older than 48 hours may be dropped.
@@ -332,8 +367,8 @@ Some specific attributes have additional restrictions:
 
 Rate limits on logs sent to the Log API:
 
-* Maximum rate for HTTP requests sent to the Log API: 300,000 requests per minute
-* Maximum rate of uncompressed Log JSON bytes sent to the Log API: 10 GB per minute
+- Maximum rate for HTTP requests sent to the Log API: 300,000 requests per minute
+- Maximum rate of uncompressed Log JSON bytes sent to the Log API: 10 GB per minute
 
 ### Rate limit violations
 
@@ -346,6 +381,7 @@ Exceeding rate limits affects how the Log API behaves. Follow these instructions
     To resolve this issue, either reduce the number of data points you are sending, or request a rate limit change. Subsequent subscription changes do not impact modified rate limits. If an account change impacts your rate limit, you must notify us to adjust your rate limit.
 
     To request rate limit changes, contact your New Relic account representative, or visit our [Support portal](http://support.newrelic.com).
+
   </Collapser>
 
   <Collapser title="JSON bytes per minute">
@@ -354,6 +390,7 @@ Exceeding rate limits affects how the Log API behaves. Follow these instructions
     To resolve this issue, try to reduce the amount of log data you are sending, or spread it out over a larger period of time.
 
     To request rate limit changes, contact your New Relic account representative, or visit our [Support portal](http://support.newrelic.com).
+
   </Collapser>
 </CollapserGroup>
 
@@ -445,6 +482,7 @@ We accept any valid JSON payload. The payload must encoded as **UTF-8**.
         </tr>
       </tbody>
     </table>
+
   </Collapser>
 
   <Collapser
@@ -612,6 +650,7 @@ We accept any valid JSON payload. The payload must encoded as **UTF-8**.
         </tr>
       </tbody>
     </table>
+
   </Collapser>
 </CollapserGroup>
 
@@ -675,6 +714,7 @@ will result in the following attributes being stored with the log event:
         Value
       </th>
     </tr>
+
   </thead>
 
   <tbody>
@@ -707,6 +747,7 @@ will result in the following attributes being stored with the log event:
         `"alice"`
       </td>
     </tr>
+
   </tbody>
 </table>
 
@@ -757,6 +798,7 @@ The above `POST` message would result in the following log messages being stored
         Value
       </th>
     </tr>
+
   </thead>
 
   <tbody>
@@ -789,6 +831,7 @@ The above `POST` message would result in the following log messages being stored
         `"login.example.com"`
       </td>
     </tr>
+
   </tbody>
 </table>
 
@@ -805,6 +848,7 @@ The above `POST` message would result in the following log messages being stored
         Value
       </th>
     </tr>
+
   </thead>
 
   <tbody>
@@ -837,6 +881,7 @@ The above `POST` message would result in the following log messages being stored
         `123`
       </td>
     </tr>
+
   </tbody>
 </table>
 
@@ -882,8 +927,8 @@ For where to find data sent via the Log API (including from integrations that us
 
 Now that you've enabled Log management, here are some potential next steps:
 
-* Explore your data using the [Logs UI](/docs/explore-your-data-new-relic-logs-ui).
-* [Configure your agent](/docs/logs/new-relic-logs/enable-logs-context/enable-logs-context-apm-agents) to see contextual log data, such as [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing), stack traces, application logs, and more.
-* [Query your data](/docs/logs/new-relic-logs/ui-data/query-syntax-logs) and [create custom dashboards](/docs/insights/use-insights-ui/manage-dashboards/create-edit-copy-insights-dashboards), [charts](/docs/insights/use-insights-ui/manage-dashboards/add-customize-nrql-charts), or [alerts](https://docs.newrelic.com/docs/alerts/new-relic-alerts/configuring-alert-policies/create-edit-or-find-alert-policy).
+- Explore your data using the [Logs UI](/docs/explore-your-data-new-relic-logs-ui).
+- [Configure your agent](/docs/logs/new-relic-logs/enable-logs-context/enable-logs-context-apm-agents) to see contextual log data, such as [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing), stack traces, application logs, and more.
+- [Query your data](/docs/logs/new-relic-logs/ui-data/query-syntax-logs) and [create custom dashboards](/docs/insights/use-insights-ui/manage-dashboards/create-edit-copy-insights-dashboards), [charts](/docs/insights/use-insights-ui/manage-dashboards/add-customize-nrql-charts), or [alerts](https://docs.newrelic.com/docs/alerts/new-relic-alerts/configuring-alert-policies/create-edit-or-find-alert-policy).
 
 If no data appears after you enable Log management, follow the [troubleshooting procedures](/docs/logs/new-relic-logs/troubleshooting/no-data-appears-logs).

--- a/src/content/docs/logs/log-management/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-management/log-api/introduction-log-api.mdx
@@ -34,7 +34,7 @@ To send log data to your New Relic account:
 
 1. Get your [New Relic license key](/docs/accounts/install-new-relic/account-setup/license-key) **(recommended)** or register an [Insert API key](/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#register).
 2. Generate the JSON message using the required [headers](#json-headers) and [body](#json-body) fields.
-3. Ensure you're providing an Api-Key or License-Key by [headers](#json-headers) or [query parameters](#query-parameters)
+3. Ensure you're providing an Api-Key or License-Key via [headers](#json-headers) or [query parameters](#query-parameters)
 4. Submit the JSON message to the [HTTP endpoint](#endpoint) in a **POST** request.
 5. Generate some traffic and wait a few minutes, then [check your account](#find-data) for data.
 
@@ -82,7 +82,7 @@ When creating your HTTP headers, use these guidelines:
       </td>
 
       <td>
-        Use either your [insert API key](/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#register) (with `Api-Key`) or [license key](/docs/accounts/install-new-relic/account-setup/license-key) (with `X-License-Key`) or take a look bellow to see how to send it by query parameters.
+        Use either your [insert API key](/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#register) (with `Api-Key`) or [license key](/docs/accounts/install-new-relic/account-setup/license-key) (with `X-License-Key`) or send it via [query parameters](#query-parameters).
       </td>
     </tr>
 
@@ -93,7 +93,7 @@ Gzipped JSON formatting is accepted. If sending compressed JSON, please include 
 
 ## HTTP query parameters [#query-parameters]
 
-The Insert API Key could be sent also by query parameters so sources that doesn't support add custom headers can send logs.
+Sources that don't support adding custom headers often can't send logs. You can get around this by sending the insert API key via query parameters. 
 
 <table>
   <thead>
@@ -114,9 +114,9 @@ The Insert API Key could be sent also by query parameters so sources that doesn'
       </td>
 
       <td>
-        Use your [Insert API key](/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#register) if your provider does not support add custom headers.
+        Use your [insert API key](/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#register) if your provider doesn't support adding custom headers.
 
-        We recommend to send this on the headers whenever possible.
+        Use this key whenever you send a header.
       </td>
     </tr>
 
@@ -341,25 +341,26 @@ You can send your JSON message using either a simplified or detailed set of attr
 
 <Callout variant="caution">
   Avoid calling our API from within the code of a customer-facing application.
-  This could cause performance issues or be blocking if response time is slow.
-  If you must do this, try to do it asynchronously.
+  This can cause performance issues or block your application if response time is slow.
+
+  If you need to do it this way, call our API asynchronously to avoid these performance issues.
 </Callout>
 
 Restrictions on logs sent to the Log API:
 
-- Payload total size: **1MB(10^6 bytes) maximum per POST**. We highly recommend using compression.
-- The payload must be encoded as **UTF-8**.
-- Number of attributes per event: 255 maximum
-- Length of attribute name: 255 characters
-- Length of attribute value: 4096 maximum character length
+* Payload total size: **1MB(10^6 bytes) maximum per POST**. We highly recommend using compression.
+* The payload must be encoded as **UTF-8**.
+* Number of attributes per event: 255 maximum
+* Length of attribute name: 255 characters
+* Length of attribute value: 4096 maximum character length
 
 Some specific attributes have additional restrictions:
 
-- `accountId`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
-- `entity.guid`, `entity.name`, and `entity.type`: These attributes are used internally to identify entities. Any values submitted with these keys in the attributes section of a metric data point may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities. For more information please refer to [Entity synthesis](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#entity-synthesis).
-- [`appId`](/docs/apis/rest-api-v2/requirements/find-product-id#apm): Value must be an integer. If it is not an integer, the attribute name and value will be dropped during ingest.
-- `eventType`: Can be a combination of alphanumeric characters, `_` underscores, and `:` colons.
-- `timestamp`: Must be a Unix epoch timestamp. You can define timestamps either in seconds or in milliseconds.
+* `accountId`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
+* `entity.guid`, `entity.name`, and `entity.type`: These attributes are used internally to identify entities. Any values submitted with these keys in the attributes section of a metric data point may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities. For more information please refer to [Entity synthesis](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#entity-synthesis).
+* [`appId`](/docs/apis/rest-api-v2/requirements/find-product-id#apm): Value must be an integer. If it is not an integer, the attribute name and value will be dropped during ingest.
+* `eventType`: Can be a combination of alphanumeric characters, `_` underscores, and `:` colons.
+* `timestamp`: Must be a Unix epoch timestamp. You can define timestamps either in seconds or in milliseconds.
 
 <Callout variant="important">
   Payloads with timestamps older than 48 hours may be dropped.
@@ -367,8 +368,8 @@ Some specific attributes have additional restrictions:
 
 Rate limits on logs sent to the Log API:
 
-- Maximum rate for HTTP requests sent to the Log API: 300,000 requests per minute
-- Maximum rate of uncompressed Log JSON bytes sent to the Log API: 10 GB per minute
+* Maximum rate for HTTP requests sent to the Log API: 300,000 requests per minute
+* Maximum rate of uncompressed Log JSON bytes sent to the Log API: 10 GB per minute
 
 ### Rate limit violations
 
@@ -927,8 +928,8 @@ For where to find data sent via the Log API (including from integrations that us
 
 Now that you've enabled Log management, here are some potential next steps:
 
-- Explore your data using the [Logs UI](/docs/explore-your-data-new-relic-logs-ui).
-- [Configure your agent](/docs/logs/new-relic-logs/enable-logs-context/enable-logs-context-apm-agents) to see contextual log data, such as [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing), stack traces, application logs, and more.
-- [Query your data](/docs/logs/new-relic-logs/ui-data/query-syntax-logs) and [create custom dashboards](/docs/insights/use-insights-ui/manage-dashboards/create-edit-copy-insights-dashboards), [charts](/docs/insights/use-insights-ui/manage-dashboards/add-customize-nrql-charts), or [alerts](https://docs.newrelic.com/docs/alerts/new-relic-alerts/configuring-alert-policies/create-edit-or-find-alert-policy).
+* Explore your data using the [Logs UI](/docs/explore-your-data-new-relic-logs-ui).
+* [Configure your agent](/docs/logs/new-relic-logs/enable-logs-context/enable-logs-context-apm-agents) to see contextual log data, such as [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing), stack traces, application logs, and more.
+* [Query your data](/docs/logs/new-relic-logs/ui-data/query-syntax-logs) and [create custom dashboards](/docs/insights/use-insights-ui/manage-dashboards/create-edit-copy-insights-dashboards), [charts](/docs/insights/use-insights-ui/manage-dashboards/add-customize-nrql-charts), or [alerts](https://docs.newrelic.com/docs/alerts/new-relic-alerts/configuring-alert-policies/create-edit-or-find-alert-policy).
 
 If no data appears after you enable Log management, follow the [troubleshooting procedures](/docs/logs/new-relic-logs/troubleshooting/no-data-appears-logs).


### PR DESCRIPTION
<!-- NOTE: New Relic is on a company-wide vacation the week of August 9 through
August 12. We'll take a look at your PR as soon as we're back on 
August 16. Or, if your issue is urgent, you can reach out to our support team 
at support.newrelic.com. -->

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

This PR just update the log api documentation to indicate a new query parameter that the customer could use to authentication (this means, send their Api-Key in a query parameter)

### Are you making a change to site code?

No