### PR TITLE
Guided install updates.

### DIFF
--- a/src/content/docs/full-stack-observability/observe-everything/get-started/new-relic-guided-install-overview.mdx
+++ b/src/content/docs/full-stack-observability/observe-everything/get-started/new-relic-guided-install-overview.mdx
@@ -35,28 +35,6 @@ Ready to get started? Click the Guided install button. If your account reports d
 
  Our infrastructure agent discovers the applications and infrastructure and log sources running in your environment, and recommends which ones should be instrumented. The install automates the configuration and deployment of each system you choose to instrument.
 
-## Supported APM agents [#supported-agents]
-
-If you have a .NET Windows application on IIS, the guided install configures and enables an APM agent.
-
-<ButtonGroup>
-<ButtonLink
-  role="button"
-  to="https://one.newrelic.com/launcher/nr1-core.home?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5ob21lLXNjcmVlbiJ9&cards[0]=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsInBhdGgiOiJhcG0iLCJsYW5ndWFnZSI6ICJkb3RuZXQiLCAicmVjaXBlTmFtZSI6ICJkb3RuZXQtYWdlbnQtaW5zdGFsbGVyIiwgImluaXRpYWxBY3Rpb25JbmRleCI6MiwiYWNjb3VudElkIjpudWxsfQ=="
-  variant="primary"
->
-  Guided install for .NET
-</ButtonLink>
-
-<ButtonLink
-  role="button"
-  to="https://one.eu.newrelic.com/launcher/nr1-core.home?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5ob21lLXNjcmVlbiJ9&cards[0]=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsInBhdGgiOiJhcG0iLCJsYW5ndWFnZSI6ICJkb3RuZXQiLCAicmVjaXBlTmFtZSI6ICJkb3RuZXQtYWdlbnQtaW5zdGFsbGVyIiwgImluaXRpYWxBY3Rpb25JbmRleCI6MiwiYWNjb3VudElkIjpudWxsfQ=="
-  variant="primary"
->
-  EU Guided install for .NET
-</ButtonLink>
-</ButtonGroup>
-
 ## Why it matters [#why-it-matters]
 
 With our guided install, you can instrument your applications and infrastructure and start seeing your data in New Relic in minutes.

--- a/src/content/docs/full-stack-observability/observe-everything/get-started/new-relic-guided-install-overview.mdx
+++ b/src/content/docs/full-stack-observability/observe-everything/get-started/new-relic-guided-install-overview.mdx
@@ -128,10 +128,6 @@ Our open source integrations send performance metrics and inventory data from yo
 			<td>newrelic install -n hashicorp-consul-open-source-integration</td>
 		</tr>
 		<tr>
-			<td>JMX</td>
-			<td>newrelic install -n jmx-open-source-integration</td>
-		</tr>
-		<tr>
 			<td>Memcached</td>
 			<td>newrelic install -n memcached-open-source-integration</td>
 		</tr>

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/jmx-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/jmx-monitoring-integration.mdx
@@ -26,36 +26,6 @@ Before installing the integration, make sure that you meet the following require
   * If running on ECS, see [these requirements](/docs/integrations/host-integrations/host-integrations-list/monitor-services-running-amazon-ecs).
 * This integration does not support the IIOP protocol.
 
-## Quick start [#quick]
-
-Instrument your JMX-enabled application quickly and send your telemetry data with guided install. Our guided install creates a customized CLI command for your environment that downloads and installs the New Relic CLI and the infrastructure agent.
-
-![A screenshot of the guided install CLI.](./images/guided-install-cli.png "The guided install CLI.")
-
-Ready to get started? Click one of these button to try it out.
-
-<ButtonGroup>
-<ButtonLink
-  role="button"
-  to="https://one.newrelic.com/launcher/nr1-core.home?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5ob21lLXNjcmVlbiJ9&cards%5B0%5D=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsImFjdGlvbkluZGV4IjoxfQ=="
-  variant="primary"
->
-  Guided install
-</ButtonLink>
-
-<ButtonLink
-  role="button"
-  to="https://one.eu.newrelic.com/launcher/nr1-core.home?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5ob21lLXNjcmVlbiJ9&cards%5B0%5D=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsImFjdGlvbkluZGV4IjoxfQ=="
-  variant="primary"
->
-  EU Guided install
-</ButtonLink>
-</ButtonGroup>
-
-Our guided install uses the infrastructure agent to set up the JMX integration. Not only that, it discovers other applications and log sources running in your environment and then recommends which ones you should instrument.
-
-The guided install works with most setups. But if it doesn't suit your needs, you can find other methods below to get started monitoring your JMX-enabled application.
-
 ## Install and activate [#install]
 
 To install the JMX integration, follow the instructions for your environment:


### PR DESCRIPTION
Guided install no longer supports the JMX integration. I've removed mention of them.

closes #3487 and closes #3492 

I've also removed the Support APM agents section. Until we support more than one APM agent, this section doesn't really make sense.