### PR TITLE
Update outdated .net documentation

### DIFF
--- a/src/content/docs/agents/net-agent/installation/install-net-agent-linux.mdx
+++ b/src/content/docs/agents/net-agent/installation/install-net-agent-linux.mdx
@@ -21,10 +21,6 @@ The instructions in this document are for a standard .NET agent installation on 
 * [NuGet install](/docs/agents/net-agent/install-guides/install-net-agent-using-nuget)
 * [Docker container install](/docs/agents/net-agent/installation/install-docker-container)
 
-<Callout variant="important">
-  If you modify your `newrelic.config` file, make sure it retains the default **UTF-8** encoding. If your editor adds a BOM (Byte Order Mark) to the encoding, **the agent will be unable to read the file and will not start up in Linux.**
-</Callout>
-
 ## Step 1. Download and install the agent [#download-install]
 
 <Callout variant="caution">


### PR DESCRIPTION
Update .NET agent documentation to remove un-needed warning about BOM.

Resolves: https://github.com/newrelic/docs-website/issues/3472
