### PR TITLE
LOGGING-5959: Fix permissions for drop filter rules

### DIFF
--- a/src/content/docs/logs/log-management/ui-data/drop-data-drop-filter-rules.mdx
+++ b/src/content/docs/logs/log-management/ui-data/drop-data-drop-filter-rules.mdx
@@ -49,7 +49,7 @@ Creating rules about sensitive data can leak information about what kinds of dat
 
 ## Create drop filter rules [#create]
 
-To create and edit drop filters, you must have [admin permissions](/docs/accounts/accounts-billing/new-relic-one-pricing-users/users-roles#user-group) in New Relic, or you must be a member of a role with create and edit permissions for **Logging Parsing Rules**.
+To create and edit drop filters, you must have [admin permissions](/docs/accounts/accounts-billing/new-relic-one-pricing-users/users-roles#user-group) in New Relic, or you must be a member of a role with create and edit permissions for **Insights &gt; NRQL Drop Rules**.
 
 Once a drop filter rule is active, it's applied to all log events ingested from that point onwards. Rules are not applied retroactively. Logs collected before creating a rule are not filtered by that rule.
 


### PR DESCRIPTION
https://newrelic.atlassian.net/browse/LOGGING-5959

<!-- NOTE: New Relic is on a company-wide vacation the week of August 9 through
August 12. We'll take a look at your PR as soon as we're back on 
August 16. Or, if your issue is urgent, you can reach out to our support team 
at support.newrelic.com. -->

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

Some smart person discovered that we had a copy/paste error in our docs for drop filters, and had the incorrect permission listed.
