### PR TITLE
chore: Updating Java's Kafka documentation

### DIFF
--- a/src/content/docs/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues.mdx
+++ b/src/content/docs/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues.mdx
@@ -130,17 +130,36 @@ To collect distributed traces from Kafka:
     id="instrument-kafka-consumer"
     title="3. Instrument the Kafka consumer"
   >
-    To instrument your Kafka consumer, you'll need to start a transaction when the message is being processed. The agent stores the distributed tracing payload header under the `newrelic` key. Retrieve the header, then call the New Relic transaction API to accept the payload.
+    To instrument your Kafka consumer, you'll need to start a transaction when the message is being processed. The agent stores the distributed tracing payload header under the `newrelic` key or under the W3C's `traceparent` and `tracestate` keys. Retrieve the header, then call the New Relic transaction API to accept the payload.
 
     For example:
-
     ```
     @Trace(dispatcher = true)
-    private static void <var>processMessage</var>(ConsumerRecord<String, String> rec){
-        Iterable<Header> headers = rec.headers().headers("newrelic");
-        for(Header header: headers) {
-            NewRelic.getAgent().getTransaction().acceptDistributedTracePayload(new String(header.value(), StandardCharsets.UTF_8));
+    private static void <var>processMessage</var>(ConsumerRecord<String, String> rec) {
+      // create a distributed trace headers map
+      Headers dtHeaders = ConcurrentHashMapHeaders.build(HeaderType.MESSAGE);
+
+      // Iterate through each record header and insert the trace headers into the dtHeaders map
+      for (Header header : rec.headers()) {
+        String headerValue = new String(header.value(), StandardCharsets.UTF_8);
+
+        // using the newrelic key
+        if (header.key().equals("newrelic")) {
+          dtHeaders.addHeader("newrelic", headerValue);
         }
+
+        // or using the W3C keys
+        if (header.key().equals("traceparent")) {
+          dtHeaders.addHeader("traceparent", headerValue);
+        }
+
+        if (header.key().equals("tracestate")) {
+          dtHeaders.addHeader("tracestate", headerValue);
+        }
+      }
+
+      // Accept distributed tracing headers to link this request to the originating request
+      NewRelic.getAgent().getTransaction().acceptDistributedTraceHeaders(TransportType.Kafka, dtHeaders);
     }
     ```
   </Collapser>


### PR DESCRIPTION
### Give us some context
Updates the Java Kafka documentation to update an example code that used deprecated methods.
Also adds new parameters that can be used for the instrumentation.

### Are you making a change to site code?
No