### PR TITLE
Infrastructure agent - Update docker discovery snippet

### DIFF
--- a/src/content/docs/integrations/host-integrations/installation/container-auto-discovery-host-integrations.mdx
+++ b/src/content/docs/integrations/host-integrations/installation/container-auto-discovery-host-integrations.mdx
@@ -45,6 +45,7 @@ These examples (for Docker-only environments and for Kubernetes) show how to con
       - name: nginx-server-metrics
         command: metrics
         env:
+# use discovery.private.ip if container doesn't have attached public ip address
           STATUS_URL: http://${discovery.ip}:${discovery.port}/status
           STATUS_MODULE: discover
           REMOTE_MONITORING: true


### PR DESCRIPTION
Usually we will have ${discovery.private.ip} and only if public ip attached to container we could use ${discovery.ip}.

### Give us some context

* What problems does this PR solve?
* Update documentation
