### PR TITLE
Update configure-proguard-or-dexguard-android-apps.mdx

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps.mdx
@@ -127,29 +127,6 @@ To add support for **DexGuard**:
    ```
 3. After the DexGuard plugin has been configured, check the following.
 
-   DexGuard 9.x: verify that R8 shrinking is disabled and your `dexguard` block configuration is similar to this:
-
-   ```
-   buildTypes {
-           release {
-              minifyEnabled false
-              shrinkResources false
-           } ...
-           ...
-        } 
-     
-        dexguard {
-           ...
-           configurations {
-              release {
-                 defaultConfiguration 'dexguard-release.pro'
-                 configuration 'proguard-rules.pro'
-                 configuration 'dexguard-project.txt
-              }
-           }
-        } ...
-   ```
-
    DexGuard 8.x: verify that your app's `buildTypes` configuration is similar to this:
 
    ```


### PR DESCRIPTION
The NR Android agent doesn't support Dexguard 9.x at present. These instructions were provided (if I recall) by a GuardSquare support contact, and will be applicable once we support 9.x.

<!-- NOTE: New Relic is on a company-wide vacation the week of August 9 through
August 12. We'll take a look at your PR as soon as we're back on 
August 16. Or, if your issue is urgent, you can reach out to our support team 
at support.newrelic.com. -->

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.