### PR TITLE
Clarified when Apdex settings are visible

### DIFF
--- a/src/content/docs/apm/new-relic-apm/apdex/change-your-apdex-settings.mdx
+++ b/src/content/docs/apm/new-relic-apm/apdex/change-your-apdex-settings.mdx
@@ -14,8 +14,8 @@ redirects:
 
 You can define Apdex T values for each application, with separate values for app server and end-user browser performance. You can also define individual Apdex T thresholds for [key transactions](/docs/apm/transactions/key-transactions/introduction-key-transactions).
 
-<Callout variant="tip">
-  To get a high-level overview of all your applications and services, use the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer).
+<Callout variant="important">
+You can only change Apdex thresholds for apps that are actively reporting data. For example, if one of your apps is not reporting, you won't see its Apdex setting options.
 </Callout>
 
 ## App server Apdex settings [#change-app-server]


### PR DESCRIPTION
This is a PR to clarify that Apdex threshold settings are only visible when an app is actively reporting data.

Closes issue #3458.