### PR TITLE
PHP 9.18.0 release notes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9180302.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9180302.mdx
@@ -8,20 +8,20 @@ downloadLink: 'https://download.newrelic.com/php_agent/archive/9.18.0.302'
 ## New Relic PHP Agent v9.18.0 ##
 
 ### New Features ###
-* [Added](https://github.com/newrelic/newrelic-php-agent/pull/162) a docker development environment. It is now possible for contributors to both develop and test (unit tests and integration tests) without setting up a specific environment on their own system. Please see our [documentation](https://github.com/newrelic/newrelic-php-agent/blob/main/docs/dev_environment.md) for more information.
-* [Route caching in `Laravel 7.x` is now supported!](https://github.com/newrelic/newrelic-php-agent/pull/174). Transaction naming now works with routes cached via `php artisan route:cache`. Thanks, @stockalexander for your contribution!
-* `Redis::mget` and `Redis::mset` [functions are now supported](https://github.com/newrelic/newrelic-php-agent/pull/156). Thanks, @b-viguier for your contribution!
+* [Added](https://github.com/newrelic/newrelic-php-agent/pull/162) a docker development environment. It's now possible for contributors to both develop and test (unit tests and integration tests) without setting up a specific environment on their own system. Please see our [documentation](https://github.com/newrelic/newrelic-php-agent/blob/main/docs/dev_environment.md) for more information.
+* [Route caching in `Laravel 7.x` is now supported!](https://github.com/newrelic/newrelic-php-agent/pull/174). Transaction naming now works with routes cached via `php artisan route:cache`. @stockalexander, thanks for your contribution!
+* `Redis::mget` and `Redis::mset` [functions are now supported](https://github.com/newrelic/newrelic-php-agent/pull/156). @b-viguier, thanks for your contribution!
 
 ### Bug Fixes ###
 * [Fixed](https://github.com/newrelic/newrelic-php-agent/pull/161) instances where a memory leak was occurring with our `curl multi` instrumentation.
 * [Fixed](https://github.com/newrelic/newrelic-php-agent/pull/176) an issue where a supportability metric used to track an edge case was causing a segfault.
 * [Fixed](https://github.com/newrelic/newrelic-php-agent/issues/87) an issue where PHP versions with an unknown API version were incorrectly handled during Debian package install.
-* [Fixed](https://github.com/newrelic/newrelic-php-agent/pull/164) instances where `parent.transportDuration` values are `0` for transactions between two PHP applications instrumented through distributed tracing. Thanks, @b-viguier for your contribution!
-* [Fixed](https://github.com/newrelic/newrelic-php-agent/pull/158) an issue where the `newrelic.ini` configuration file was incorrectly installed. Thanks, @b-viguier for your contribution!
+* [Fixed](https://github.com/newrelic/newrelic-php-agent/pull/164) instances where `parent.transportDuration` values are `0` for transactions between two PHP applications instrumented through distributed tracing. @b-viguier, thanks for your contribution!
+* [Fixed](https://github.com/newrelic/newrelic-php-agent/pull/158) an issue where the `newrelic.ini` configuration file was incorrectly installed. @b-viguier, thanks for your contribution!
 * [Fixed](https://github.com/newrelic/newrelic-php-agent/issues/172) an issue where PHP 8.0 builds were missing ZTS support.
   * Linux kernel version `4.19`
   * glibc `2.28-10`
   * libpcre `0.9.5`
 
 ### Support Statement ###
-* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [8.6.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-860238/).
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [8.6.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-860238/).

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9180302.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9180302.mdx
@@ -1,0 +1,30 @@
+---
+subject: PHP agent
+releaseDate: '2021-08-18'
+version: 9.18.0.302
+downloadLink: 'https://download.newrelic.com/php_agent/archive/9.18.0.302'
+---
+
+## New Relic PHP Agent v9.18.0 ##
+
+### New Features ###
+* [Added](https://github.com/newrelic/newrelic-php-agent/pull/162) a docker development environment. It is now possible for contributors to both develop and test (unit tests and integration tests) without setting up a specific environment on their own system. Please see our [documentation](https://github.com/newrelic/newrelic-php-agent/blob/main/docs/dev_environment.md) for more information.
+* [Route caching in `Laravel 7.x` is now supported!](https://github.com/newrelic/newrelic-php-agent/pull/174). Transaction naming now works with routes cached via `php artisan route:cache`. Thanks, @stockalexander for your contribution!
+* `Redis::mget` and `Redis::mset` [functions are now supported](https://github.com/newrelic/newrelic-php-agent/pull/156). Thanks, @b-viguier for your contribution!
+
+### Bug Fixes ###
+* [Fixed](https://github.com/newrelic/newrelic-php-agent/pull/161) instances where a memory leak was occurring with our `curl multi` instrumentation.
+* [Fixed](https://github.com/newrelic/newrelic-php-agent/pull/176) an issue where a supportability metric used to track an edge case was causing a segfault.
+* [Fixed](https://github.com/newrelic/newrelic-php-agent/issues/87) an issue where PHP versions with an unknown API version were incorrectly handled during Debian package install.
+* [Fixed](https://github.com/newrelic/newrelic-php-agent/pull/164) instances where `parent.transportDuration` values are `0` for transactions between two PHP applications instrumented through distributed tracing. Thanks, @b-viguier for your contribution!
+* [Fixed](https://github.com/newrelic/newrelic-php-agent/pull/158) an issue where the `newrelic.ini` configuration file was incorrectly installed. Thanks, @b-viguier for your contribution!
+* [Fixed](https://github.com/newrelic/newrelic-php-agent/issues/172) an issue where PHP 8.0 builds were missing ZTS support.
+  * Linux kernel version `4.19`
+  * glibc `2.28-10`
+  * libpcre `0.9.5`
+
+### Support Statement ###
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [8.6.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-860238/).
+
+### Support Statement ###
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [8.6.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-860238/).

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9180302.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9180302.mdx
@@ -25,6 +25,3 @@ downloadLink: 'https://download.newrelic.com/php_agent/archive/9.18.0.302'
 
 ### Support Statement ###
 * New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [8.6.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-860238/).
-
-### Support Statement ###
-* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [8.6.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-860238/).


### PR DESCRIPTION
This includes the release notes for PHP agent `9.18.0`. The release is targeted for `8/18/21`.