### PR TITLE
Remove watermarks from release notes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-130.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-130.mdx
@@ -3,7 +3,6 @@ subject: Java agent
 releaseDate: '2011-03-17'
 version: 1.3.0
 metaDescription: Release notes for Java Agent 1.3.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-140.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-140.mdx
@@ -3,7 +3,6 @@ subject: Java agent
 releaseDate: '2011-04-11'
 version: 1.4.0
 metaDescription: Release notes for Java Agent 1.4.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-200.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-200.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2011-05-09'
 version: 2.0.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-201.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-201.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2011-05-23'
 version: 2.0.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-202.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-202.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2011-06-16'
 version: 2.0.2
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-203.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-203.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2011-08-04'
 version: 2.0.3
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-204.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-204.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2011-08-30'
 version: 2.0.4
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-210.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-210.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2011-10-07'
 version: 2.1.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2100.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2012-10-31'
 version: 2.10.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2101.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2101.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2012-11-13'
 version: 2.10.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2110.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2110.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2012-11-28'
 version: 2.11.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-212.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-212.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2011-11-07'
 version: 2.1.2
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2120.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2120.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2012-12-06'
 version: 2.12.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2130.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2130.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-01-16'
 version: 2.13.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2140.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2140.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-02-08'
 version: 2.14.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2141.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2141.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-02-15'
 version: 2.14.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2150.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2150.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-02-28'
 version: 2.15.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2151.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2151.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-03-13'
 version: 2.15.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2160.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2160.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-03-25'
 version: 2.16.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2170.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2170.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-04-11'
 version: 2.17.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2171.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2171.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-04-12'
 version: 2.17.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2172.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2172.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-04-17'
 version: 2.17.2
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2180.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2180.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-05-07'
 version: 2.18.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2190.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2190.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-05-29'
 version: 2.19.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2191.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2191.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-06-14'
 version: 2.19.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-220.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-220.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2011-12-06'
 version: 2.2.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2200.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2200.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-07-01'
 version: 2.20.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-221.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-221.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2011-12-29'
 version: 2.2.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2210.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2210.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-08-07'
 version: 2.21.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2211.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2211.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-08-09'
 version: 2.21.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2212.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2212.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-08-10'
 version: 2.21.2
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2213.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2213.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-08-13'
 version: 2.21.3
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2214.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2214.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-09-10'
 version: 2.21.4
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2215.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2215.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2014-03-05'
 version: 2.21.5
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2216.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2216.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2014-04-24'
 version: 2.21.6
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-230.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-230.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2012-02-01'
 version: 2.3.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-231.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-231.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2012-02-13'
 version: 2.3.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-240.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-240.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2012-03-27'
 version: 2.4.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-241.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-241.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2012-04-02'
 version: 2.4.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-242.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-242.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2012-04-18'
 version: 2.4.2
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-250.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-250.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2012-05-01'
 version: 2.5.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-260.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-260.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2012-06-06'
 version: 2.6.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-270.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-270.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2012-07-31'
 version: 2.7.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-280.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-280.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2012-09-11'
 version: 2.8.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-290.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-290.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2012-10-09'
 version: 2.9.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-300.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-300.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-10-01'
 version: 3.0.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-301.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-301.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-10-03'
 version: 3.0.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-310.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-310.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-10-21'
 version: 3.1.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-311.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-311.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-11-05'
 version: 3.1.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-320.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-320.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-12-03'
 version: 3.2.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-321.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-321.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-12-06'
 version: 3.2.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-322.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-322.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-12-12'
 version: 3.2.2
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-323.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-323.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2013-12-16'
 version: 3.2.3
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-331.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-331.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2014-01-07'
 version: 3.3.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-332.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-332.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2014-01-10'
 version: 3.3.2
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-340.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-340.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2014-01-16'
 version: 3.4.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-341.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-341.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2014-01-21'
 version: 3.4.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-342.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-342.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2014-01-23'
 version: 3.4.2
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-350.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-350.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2014-03-05'
 version: 3.5.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-351.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-351.mdx
@@ -2,7 +2,6 @@
 subject: Java agent
 releaseDate: '2014-03-27'
 version: 3.5.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-20103.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-20103.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2012-07-19'
 version: 2.0.10.3
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-20111.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-20111.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2012-08-22'
 version: 2.0.11.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-20124.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-20124.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2012-09-20'
 version: 2.0.12.4
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-205.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-205.mdx
@@ -3,7 +3,6 @@ subject: .NET agent
 releaseDate: '2011-12-07'
 version: 2.0.5
 metaDescription: .Net Agent release notes for version 2.0.5.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-206.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-206.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2012-01-26'
 version: 2.0.6
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-207.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-207.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2012-02-20'
 version: 2.0.7
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2084.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2084.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2012-04-27'
 version: 2.0.8.4
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-20915.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-20915.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2012-06-07'
 version: 2.0.9.15
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-210400.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-210400.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-08-20'
 version: 2.10.40.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2105.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2105.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2012-10-11'
 version: 2.1.0.5
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-21113.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-21113.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2012-11-16'
 version: 2.1.1.13
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2121460.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2121460.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-09-13'
 version: 2.12.146.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-212472.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-212472.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2012-11-28'
 version: 2.1.2.472
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-213380.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-213380.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-10-02'
 version: 2.13.38.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-213494.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-213494.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2012-12-04'
 version: 2.1.3.494
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-214530.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-214530.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-10-11'
 version: 2.14.53.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2151800.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2151800.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-10-21'
 version: 2.15.180.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2151861.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2151861.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-10-22'
 version: 2.15.186.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2161640.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2161640.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-11-19'
 version: 2.16.164.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2172660.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2172660.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-12-19'
 version: 2.17.266.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2172680.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2172680.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-12-20'
 version: 2.17.268.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-218350.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-218350.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-12-27'
 version: 2.18.35.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-21930.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-21930.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-01-01'
 version: 2.19.3.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-220240.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-220240.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-01-09'
 version: 2.20.24.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-220250.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-220250.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-01-18'
 version: 2.20.25.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-221840.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-221840.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-01-23'
 version: 2.21.84.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-222790.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-222790.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-02-04'
 version: 2.22.79.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-22320.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-22320.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-02-05'
 version: 2.23.2.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2242180.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2242180.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-03-05'
 version: 2.24.218.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2252080.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2252080.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-04-23'
 version: 2.25.208.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-22830.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-22830.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-01-16'
 version: 2.2.83.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-231260.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-231260.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-02-08'
 version: 2.3.126.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-24570.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-24570.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-02-28'
 version: 2.4.57.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-251120.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-251120.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-03-15'
 version: 2.5.112.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-26540.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-26540.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-05-10'
 version: 2.6.54.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-27600.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-27600.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-05-16'
 version: 2.7.60.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2810.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-2810.mdx
@@ -10,7 +10,6 @@ redirects:
     /docs/release-notes/agent-release-notes/net-release-notes/net-agent-281341-established-release
   - >-
     /docs/release-notes/agent-release-notes/net-release-notes/net-agent-2810-established-release
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-281340.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-281340.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-06-21'
 version: 2.8.134.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-291350.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-291350.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2013-07-24'
 version: 2.9.135.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-30790.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-30790.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-05-29'
 version: 3.0.79.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-310430.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-310430.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-11-20'
 version: 3.10.43.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-3112960.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-3112960.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2015-01-26'
 version: 3.11.296.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-3121400.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-3121400.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2015-02-19'
 version: 3.12.140.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-31650.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-31650.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-06-20'
 version: 3.1.65.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-321130.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-321130.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-06-30'
 version: 3.2.113.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-33380.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-33380.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-07-11'
 version: 3.3.38.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-34240.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-34240.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-07-24'
 version: 3.4.24.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-351070.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-351070.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-08-19'
 version: 3.5.107.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-361770.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-361770.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-08-27'
 version: 3.6.177.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-371350.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-371350.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-09-25'
 version: 3.7.135.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-3810.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-3810.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-10-01'
 version: 3.8.1.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-391460.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-391460.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2014-10-29'
 version: 3.9.146.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-401460.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-401460.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2015-03-12'
 version: 4.0.146.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-411340.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-411340.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2015-03-17'
 version: 4.1.134.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-411360.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-411360.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2015-03-18'
 version: 4.1.136.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-421850.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-421850.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2015-03-31'
 version: 4.2.185.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-431230.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-431230.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2015-04-16'
 version: 4.3.123.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-44600.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-44600.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2015-04-29'
 version: 4.4.60.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-45900.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-45900.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2015-05-14'
 version: 4.5.90.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-46290.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-46290.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2015-05-20'
 version: 4.6.29.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-501360.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-501360.mdx
@@ -2,7 +2,6 @@
 subject: .NET agent
 releaseDate: '2015-06-24'
 version: 5.0.136.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-100.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2013-10-24'
 version: 1.0.0
 metaDescription: Release notes for Node.js Agent 1.0.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-101.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-101.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2013-10-30'
 version: 1.0.1
 metaDescription: Release notes for Node.js Agent 1.0.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-110.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-110.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2013-11-06'
 version: 1.1.0
 metaDescription: Release notes for Node.js Agent 1.1.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1100.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2014-08-15'
 version: 1.10.0
 metaDescription: Release notes for Node Agent 1.10.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1101.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1101.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2014-08-22'
 version: 1.10.1
 metaDescription: Release notes for Node Agent 1.10.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1102.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1102.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2014-08-25'
 version: 1.10.2
 metaDescription: Release notes for Node Agent 1.10.2
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1103.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1103.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2014-08-28'
 version: 1.10.3
 metaDescription: Release notes for Node Agent 1.10.3
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-111.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-111.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2013-11-09'
 version: 1.1.1
 metaDescription: Release notes for Node.js Agent 1.1.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1110.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1110.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-09-05'
 version: 1.11.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1111.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1111.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-09-11'
 version: 1.11.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1112.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1112.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2014-09-19'
 version: 1.11.2
 metaDescription: Release notes for Node Agent 1.11.2
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1113.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1113.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2014-09-26'
 version: 1.11.3
 metaDescription: Release notes for Node Agent 1.11.3
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1114.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1114.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2014-10-03'
 version: 1.11.4
 metaDescription: Release notes for Node Agent 1.11.4
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1115.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1115.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2014-10-06'
 version: 1.11.5
 metaDescription: Release notes for Node Agent 1.11.5
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1120.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1120.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2014-10-10'
 version: 1.12.0
 metaDescription: Release notes for Node Agent 1.12.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1121.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1121.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2014-10-16'
 version: 1.12.1
 metaDescription: Release notes for Node Agent 1.12.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1122.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1122.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-10-23'
 version: 1.12.2
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1130.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1130.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2014-10-31'
 version: 1.13.0
 metaDescription: Release notes for Node Agent 1.13.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1131.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1131.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2014-11-06'
 version: 1.13.1
 metaDescription: Release notes for Node Agent 1.13.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1132.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1132.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2014-11-06'
 version: 1.13.2
 metaDescription: Release notes for Node Agent 1.13.2
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1133.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1133.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2014-11-13'
 version: 1.13.3
 metaDescription: Release notes for Node agent 1.13.3.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1134.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1134.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-11-20'
 version: 1.13.4
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1140.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1140.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-11-25'
 version: 1.14.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-120.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-120.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2013-12-07'
 version: 1.2.0
 metaDescription: Release notes for Node.js Agent 1.2.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-130.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-130.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-01-18'
 version: 1.3.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-131.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-131.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-02-01'
 version: 1.3.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-132.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-132.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-02-14'
 version: 1.3.2
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-140.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-140.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-03-14'
 version: 1.4.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-150.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-150.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-04-11'
 version: 1.5.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-151.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-151.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-04-18'
 version: 1.5.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-152.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-152.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-04-24'
 version: 1.5.2
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-153.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-153.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-05-01'
 version: 1.5.3
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-154.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-154.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-05-08'
 version: 1.5.4
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-155.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-155.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-05-15'
 version: 1.5.5
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-160.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-160.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-05-22'
 version: 1.6.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-170.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-170.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-05-29'
 version: 1.7.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-171.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-171.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-06-05'
 version: 1.7.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-172.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-172.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-06-13'
 version: 1.7.2
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-173.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-173.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-06-20'
 version: 1.7.3
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-174.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-174.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-06-26'
 version: 1.7.4
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-175.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-175.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-07-02'
 version: 1.7.5
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-180.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-180.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-07-11'
 version: 1.8.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-181.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-181.mdx
@@ -2,7 +2,6 @@
 subject: Node.js agent
 releaseDate: '2014-07-18'
 version: 1.8.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-190.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-190.mdx
@@ -6,7 +6,6 @@ metaDescription: "* We now support Cassandra via the `node-cassandra-cql` driver
 redirects:
   - /docs/release-notes/agent-release-notes/nodejs-release-notes/what-goes-here
   - /docs/release-notes/agent-release-notes/nodejs-release-notes/1.9.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-191.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-191.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2014-07-30'
 version: 1.9.1
 metaDescription: Release notes for Node.js Agent version 1.9.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-192.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-192.mdx
@@ -3,7 +3,6 @@ subject: Node.js agent
 releaseDate: '2014-08-08'
 version: 1.9.2
 metaDescription: Release notes for Node Agent 1.9.2
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-20265.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-20265.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2011-05-25'
 version: 2.0.2.65
 metaDescription: Release notes for PHP Agent 2.0.2.65.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-20389.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-20389.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2011-06-06'
 version: 2.0.3.89
 metaDescription: Release notes for PHP Agent 2.0.3.89
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-20598.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-20598.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2011-06-11'
 version: 2.0.5.98
 metaDescription: Release notes for PHP Agent 2.0.5.98
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-211134.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-211134.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2011-07-13'
 version: 2.1.1.134
 metaDescription: Release notes for PHP Agent 2.1.1.134
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-213164.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-213164.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2011-07-26'
 version: 2.1.3.164
 metaDescription: Release notes for PHP Agent 2.1.3.164
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-221181.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-221181.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2011-08-03'
 version: 2.2.1.181
 metaDescription: Release notes for PHP Agent 2.2.1.181
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-221185.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-221185.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2011-08-06'
 version: 2.2.1.185
 metaDescription: Release notes for PHP Agent 2.2.1.185
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-222193.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-222193.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2011-08-16'
 version: 2.2.2.193
 metaDescription: Release notes for PHP Agent 2.2.2.193
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-223196.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-223196.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2011-08-18'
 version: 2.2.3.196
 metaDescription: Release notes for PHP Agent 2.2.3.196
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-23521.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-23521.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2011-09-22'
 version: 2.3.5.21
 metaDescription: Release notes for PHP Agent 2.3.5.21
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-24524.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-24524.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2011-10-04'
 version: 2.4.5.24
 metaDescription: Release notes for PHP Agent 2.4.5.24
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-24525.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-24525.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2011-10-07'
 version: 2.4.5.25
 metaDescription: Release notes for PHP Agent 2.4.5.25
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-24526.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-24526.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2011-11-01'
 version: 2.4.5.26
 metaDescription: Release notes for PHP Agent 2.4.5.26
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-25529.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-25529.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2011-11-10'
 version: 2.5.5.29
 metaDescription: Release notes for PHP Agent 2.5.5.29
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-26541.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-26541.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2011-12-13'
 version: 2.6.5.41
 metaDescription: Release notes for PHP Agent 2.6.5.41
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-26544.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-26544.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2011-12-16'
 version: 2.6.5.44
 metaDescription: Release notes for PHP Agent 2.6.5.44
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-26555.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-26555.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2012-01-09'
 version: 2.6.5.55
 metaDescription: Release notes for PHP Agent 2.6.5.55
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-26557.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-26557.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2012-01-16'
 version: 2.6.5.57
 metaDescription: Release notes for PHP Agent 2.6.5.57
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-27564.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-27564.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2012-02-21'
 version: 2.7.5.64
 metaDescription: Release notes for PHP Agent 2.7.5.64
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-27569.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-27569.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2012-03-15'
 version: 2.7.5.69
 metaDescription: Release notes for PHP Agent 2.7.5.69
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-28573.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-28573.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2012-04-24'
 version: 2.8.5.73
 metaDescription: Release notes for PHP Agent 2.8.5.73
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-29576.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-29576.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2012-05-24'
 version: 2.9.5.76
 metaDescription: Release notes for PHP Agent 2.9.5.76
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-29578.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-29578.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2012-06-07'
 version: 2.9.5.78
 metaDescription: Release notes for PHP Agent 2.9.5.78
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-315111.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-315111.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2012-11-20'
 version: 3.1.5.111
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-315120.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-315120.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2012-12-03'
 version: 3.1.5.120
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-315136.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-315136.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-01-08'
 version: 3.1.5.136
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-315137.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-315137.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-01-16'
 version: 3.1.5.137
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-315141.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-315141.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-01-25'
 version: 3.1.5.141
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-325143.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-325143.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-02-12'
 version: 3.2.5.143
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-325147.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-325147.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-02-27'
 version: 3.2.5.147
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-335154.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-335154.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-04-11'
 version: 3.3.5.154
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-335160.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-335160.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-04-23'
 version: 3.3.5.160
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-335161.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-335161.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-04-25'
 version: 3.3.5.161
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-345167.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-345167.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-05-01'
 version: 3.4.5.167
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-355170.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-355170.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-05-15'
 version: 3.5.5.170
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-355172.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-355172.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-05-22'
 version: 3.5.5.172
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-365178.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-365178.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-06-03'
 version: 3.6.5.178
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-3757.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-3757.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-06-11'
 version: 3.7.5.7
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-38511.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-38511.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-08-29'
 version: 3.8.5.11
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-39513.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-39513.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-09-12'
 version: 3.9.5.13
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-40518.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-40518.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-09-30'
 version: 4.0.5.18
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-410060.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-410060.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2014-06-30'
 version: 4.10.0.60
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-410162.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-410162.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2014-07-01'
 version: 4.10.1.62
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-4110.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-4110.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2014-07-31'
 version: 4.11.0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-4120.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-4120.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2014-08-28'
 version: 4.12.0
 metaDescription: Release notes for PHP Agent 2.9.5.78
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-4130.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-4130.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2014-09-10'
 version: 4.13.0
 metaDescription: Release notes for PHP Agent 4.13.0.70
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-4131.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-4131.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2014-09-11'
 version: 4.13.1
 metaDescription: Release notes for PHP Agent 4.13.1.71
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-4140.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-4140.mdx
@@ -3,7 +3,6 @@ subject: PHP agent
 releaseDate: '2014-09-24'
 version: 4.14.0
 metaDescription: Release notes for PHP Agent 4.14.0.72
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-415074.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-415074.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2014-10-28'
 version: 4.15.0.74
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-41524.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-41524.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-10-28'
 version: 4.1.5.24
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-417079.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-417079.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2014-12-19'
 version: 4.17.0.79
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-417083.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-417083.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2015-01-02'
 version: 4.17.0.83
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-418089.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-418089.mdx
@@ -5,7 +5,6 @@ version: 4.18.0.89
 redirects:
   - >-
     /docs/release-notes/agent-release-notes/php-release-notes/clone-php-agent-417083
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-419090.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-419090.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2015-03-04'
 version: 4.19.0.90
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-420092.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-420092.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2015-04-01'
 version: 4.20.0.92
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-420193.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-420193.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2015-04-02'
 version: 4.20.1.93
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-420295.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-420295.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2015-04-13'
 version: 4.20.2.95
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-421097.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-421097.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2015-04-30'
 version: 4.21.0.97
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-422099.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-422099.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2015-06-03'
 version: 4.22.0.99
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-423.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-423.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2015-07-08'
 version: 4.23.0.102
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-4231107.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-4231107.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2015-07-10'
 version: 4.23.1.107
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-4233111.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-4233111.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2015-07-20'
 version: 4.23.3.111
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-4234113.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-4234113.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2015-07-24'
 version: 4.23.4.113
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-42526.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-42526.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-11-13'
 version: 4.2.5.26
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-42527.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-42527.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-11-20'
 version: 4.2.5.27
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-43533.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-43533.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2013-12-11'
 version: 4.3.5.33
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-44535.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-44535.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2014-01-08'
 version: 4.4.5.35
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-45538.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-45538.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2014-02-13'
 version: 4.5.5.38
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-46540.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-46540.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2014-02-27'
 version: 4.6.5.40
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-47543.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-47543.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2014-04-01'
 version: 4.7.5.43
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-48047.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-48047.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2014-04-24'
 version: 4.8.0.47
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-49054.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-49054.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2014-05-20'
 version: 4.9.0.54
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent.mdx
@@ -2,7 +2,6 @@
 subject: PHP agent
 releaseDate: '2012-10-23'
 version: 3.0.5.95
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-102130.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-102130.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2011-11-14'
 version: 1.0.2.130
 metaDescription: Release notes for Python Agent 1.0.2.130.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-103138.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-103138.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2011-11-15'
 version: 1.0.3.138
 metaDescription: Release notes for Python Agent 1.0.3.138.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-105156.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-105156.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2011-11-30'
 version: 1.0.5.156
 metaDescription: Release notes for Python Agent 1.0.5.156.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-110028.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-110028.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2013-01-23'
 version: 1.10.0.28
 metaDescription: Release notes for Python Agent 1.10.0.28
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-110136.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-110136.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2013-02-22'
 version: 1.10.1.36
 metaDescription: Release notes for Python Agent 1.10.1.36
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-110192.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-110192.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2012-01-10'
 version: 1.1.0.192
 metaDescription: Release notes for Python Agent 1.1.0.192.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-110238.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-110238.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2013-02-23'
 version: 1.10.2.38
 metaDescription: Release notes for Python Agent 1.10.2.38
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-111055.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-111055.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2013-04-09'
 version: 1.11.0.55
 metaDescription: Release notes for Python Agent 1.11.0.55.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-112056.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-112056.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2013-05-28'
 version: 1.12.0.56
 metaDescription: Release notes for Python Agent 1.12.0.56.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-113030.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-113030.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2013-07-03'
 version: 1.13.0.30
 metaDescription: Release notes for Python Agent 1.13.0.30.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-113131.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-113131.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2013-07-05'
 version: 1.13.1.31
 metaDescription: Release notes for Python Agent 1.13.1.31.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-120246.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-120246.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2012-03-27'
 version: 1.2.0.246
 metaDescription: Release notes for Python Agent 1.2.0.246
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-121265.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-121265.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2012-04-25'
 version: 1.2.1.265
 metaDescription: Release notes for Python Agent 1.2.1.265.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-130289.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-130289.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2012-06-12'
 version: 1.3.0.289
 metaDescription: Release notes for Python Agent 1.3.0.289.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-140137.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-140137.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2012-08-01'
 version: 1.4.0.137
 metaDescription: Release notes for Python Agent 1.4.0.137
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-150103.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-150103.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2012-09-04'
 version: 1.5.0.103
 metaDescription: Release notes for Python Agent 1.5.0.103.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-16013.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-16013.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2012-10-16'
 version: 1.6.0.13
 metaDescription: Release notes for Python Agent 1.6.0.13.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-17031.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-17031.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2012-11-07'
 version: 1.7.0.31
 metaDescription: Release notes for Python Agent 1.7.0.31.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-18013.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-18013.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2012-11-14'
 version: 1.8.0.13
 metaDescription: Release notes for Python Agent 1.8.0.13.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-19021.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-19021.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2012-12-19'
 version: 1.9.0.21
 metaDescription: Release notes for Python Agent 1.9.0.21.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-2001.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-2001.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2013-09-04'
 version: 2.0.0.1
 metaDescription: Release notes for Python Agent 2.0.0.1.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-21008.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-21008.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2014-01-17'
 version: 2.10.0.8
 metaDescription: Release notes for Python Agent 2.10.0.8.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-21019.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-21019.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2014-01-24'
 version: 2.10.1.9
 metaDescription: Release notes for Python Agent 2.10.1.9.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-212010.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-212010.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2014-02-03'
 version: 2.12.0.10
 metaDescription: Release notes for Python Agent 2.12.0.10.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-214011.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-214011.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2014-02-17'
 version: 2.14.0.11
 metaDescription: Release notes for Python Agent 2.14.0.11.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-216012.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-216012.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2014-03-05'
 version: 2.16.0.12
 metaDescription: Release notes for Python Agent 2.16.0.12.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-218115.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-218115.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2014-03-28'
 version: 2.18.1.15
 metaDescription: Release notes for Python Agent 2.18.1.15.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-220017.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-220017.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2014-05-29'
 version: 2.20.0.17
 metaDescription: Release notes for Python Agent 2.20.0.17.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-220118.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-220118.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2014-06-13'
 version: 2.20.1.18
 metaDescription: Release notes for Python Agent 2.20.1.18.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-2202.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-2202.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2013-10-11'
 version: 2.2.0.2
 metaDescription: Release notes for Python Agent 2.2.0.2.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-2213.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-2213.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2013-10-11'
 version: 2.2.1.3
 metaDescription: Release notes for Python Agent 2.2.1.3.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-222019.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-222019.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2014-06-24'
 version: 2.22.0.19
 metaDescription: Release notes for Python Agent 2.22.0.19.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-222120.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-222120.mdx
@@ -2,7 +2,6 @@
 subject: Python agent
 releaseDate: '2014-07-01'
 version: 2.22.1.20
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-224021.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-224021.mdx
@@ -6,7 +6,6 @@ metaDescription: Release notes for Python Agent 2.24.0.21.
 redirects:
   - >-
     /docs/release-notes/agent-release-notes/python-release-notes/python-agent-222019-0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-226022.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-226022.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2014-08-20'
 version: 2.26.0.22
 metaDescription: Release notes for Python Agent 2.26.0.22.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-226224.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-226224.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2014-08-25'
 version: 2.26.2.24
 metaDescription: Release notes for Python Agent 2.26.2.24.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-228026.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-228026.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2014-08-26'
 version: 2.28.0.26
 metaDescription: Release notes for Python Agent 2.28.0.26.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-230027.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-230027.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2014-09-16'
 version: 2.30.0.27
 metaDescription: Release notes for Python Agent 2.30.0.27.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-232028.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-232028.mdx
@@ -6,7 +6,6 @@ metaDescription: Release notes for Python Agent 2.32.0.28.
 redirects:
   - >-
     /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2320x
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-234029.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-234029.mdx
@@ -6,7 +6,6 @@ metaDescription: Release notes for Python Agent 2.34.0.29.
 redirects:
   - >-
     /docs/release-notes/agent-release-notes/python-release-notes/python-agent-2340xxx
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-236030.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-236030.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2014-10-29'
 version: 2.36.0.30
 metaDescription: Release notes for Python Agent 2.36.0.30.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-238031.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-238031.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2014-11-12'
 version: 2.38.0.31
 metaDescription: Release notes for Python Agent 2.38.0.31.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-238233.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-238233.mdx
@@ -6,7 +6,6 @@ metaDescription: Release notes for Python Agent 2.38.2.33.
 redirects:
   - >-
     /docs/release-notes/agent-release-notes/python-release-notes/python-agent-238233-0
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-240034.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-240034.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2014-12-03'
 version: 2.40.0.34
 metaDescription: Release notes for Python Agent 2.40.0.34.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-2404.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-2404.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2013-10-16'
 version: 2.4.0.4
 metaDescription: Release notes for Python Agent 2.4.0.4.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-2605.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-2605.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2013-11-02'
 version: 2.6.0.5
 metaDescription: Release notes for Python Agent 2.6.0.5.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-2807.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-2807.mdx
@@ -3,7 +3,6 @@ subject: Python agent
 releaseDate: '2013-12-13'
 version: 2.8.0.7
 metaDescription: Release notes for Python Agent 2.8.0.7.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-300.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-300.mdx
@@ -4,7 +4,6 @@ releaseDate: '2011-05-11'
 version: 3.0.0
 downloadLink: 'https://rubygems.org/gems/newrelic_rpm/versions/3.0.0'
 metaDescription: Ruby agent release notes for version 3.0.0.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-301.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-301.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2011-05-20'
 version: 3.0.1
 metaDescription: Ruby agent release notes for version 3.0.1.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-310.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-310.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2011-06-15'
 version: 3.1.0
 metaDescription: Ruby agent release notes for version 3.1.0.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-311.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-311.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2011-07-28'
 version: 3.1.1
 metaDescription: Ruby agent release notes for version 3.1.1.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-320.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-320.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2011-10-13'
 version: 3.2.0
 metaDescription: Ruby agent release notes for version 3.2.0.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-330.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-330.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2011-11-07'
 version: 3.3.0
 metaDescription: Ruby agent release notes for version 3.3.0.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-331.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-331.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2011-12-15'
 version: 3.3.1
 metaDescription: Ruby agent release notes for version 3.3.1.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-332.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-332.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-02-16'
 version: 3.3.2
 metaDescription: Ruby agent release notes for version 3.3.2.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3321.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3321.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-03-15'
 version: 3.3.2.1
 metaDescription: Release notes for Ruby agent 3.3.2.1.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-333.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-333.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-03-29'
 version: 3.3.3
 metaDescription: Release notes for Ruby Agent 3.3.3
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-334.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-334.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-04-19'
 version: 3.3.4
 metaDescription: Release notes for Ruby Agent 3.3.4.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3341.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3341.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-04-26'
 version: 3.3.4.1
 metaDescription: Release notes for Ruby Agent 3.3.4.1.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-335.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-335.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-05-31'
 version: 3.3.5
 metaDescription: Release notes for Ruby Agent 3.3.5.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-340.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-340.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-06-04'
 version: 3.4.0
 metaDescription: Release notes for Ruby Agent 3.4.0.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3401.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3401.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-06-27'
 version: 3.4.0.1
 metaDescription: Release notes for Ruby Agent 3.4.0.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-341.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-341.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-07-26'
 version: 3.4.1
 metaDescription: Release notes for Ruby Agent 3.4.1
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-342.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-342.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-09-06'
 version: 3.4.2
 metaDescription: Release notes for Ruby Agent 3.4.2.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3421.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3421.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-09-13'
 version: 3.4.2.1
 metaDescription: Release notes for Ruby Agent 3.4.2.1.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-350.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-350.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-10-09'
 version: 3.5.0
 metaDescription: Release notes for Ruby Agent 3.5.0.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3501.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3501.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-10-23'
 version: 3.5.0.1
 metaDescription: Release notes for Ruby Agent 3.5.0.1.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35114.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35114.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-11-13'
 version: 3.5.1.14
 metaDescription: Release notes for Ruby Agent 3.5.1.14.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35217.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35217.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-11-15'
 version: 3.5.2.17
 metaDescription: Release notes for Ruby Agent 3.5.2.17.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35325.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35325.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-12-05'
 version: 3.5.3.25
 metaDescription: Release notes for Ruby Agent 3.5.3.25.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35433.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35433.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-12-18'
 version: 3.5.4.33
 metaDescription: Release notes for Ruby Agent 3.5.4.33.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35434.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35434.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2012-12-26'
 version: 3.5.4.34
 metaDescription: Release notes for Ruby Agent 3.5.4.34.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35538.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35538.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2013-01-09'
 version: 3.5.5.38
 metaDescription: Release notes for Ruby Agent 3.5.5.38
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35655.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35655.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2013-02-14'
 version: 3.5.6.55
 metaDescription: Release notes for Ruby Agent 3.5.6.55
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35759.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35759.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2013-02-20'
 version: 3.5.7.59
 metaDescription: Release notes for Ruby Agent 3.5.7.59
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35872.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-35872.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2013-02-28'
 version: 3.5.8.72
 metaDescription: Release notes for Ruby Agent 3.5.8.72
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-36083.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-36083.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2013-03-20'
 version: 3.6.0.83
 metaDescription: Release notes for Ruby Agent 3.6.0.83
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-36188.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-36188.mdx
@@ -5,7 +5,6 @@ version: 3.6.1.88
 metaDescription: Release notes for Ruby Agent 3.6.1.88
 redirects:
   - /docs/release-notes/agent-release-notes/ruby-release-notes/agent-36188
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-36296.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-36296.mdx
@@ -6,7 +6,6 @@ metaDescription: Release notes for Ruby Agent 3.6.2.96
 redirects:
   - /docs/release-notes/agent-release-notes/ruby-release-notes/clone-agent-36296
   - /docs/release-notes/agent-release-notes/ruby-release-notes/agent-36296
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-363111.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-363111.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2013-05-30'
 version: 3.6.3.111
 metaDescription: Release notes for Ruby Agent 3.6.3.111
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-364122.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-364122.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2013-06-18'
 version: 3.6.4.122
 metaDescription: Release notes for New Relic Ruby agent 3.6.4.122
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-365130.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-365130.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2013-06-27'
 version: 3.6.5.130
 metaDescription: Release notes for Ruby Agent 3.6.5.130
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-366147.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-366147.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2013-07-25'
 version: 3.6.6.147
 metaDescription: Release notes for Ruby Agent 3.6.6.147
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-367152.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-367152.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2013-09-09'
 version: 3.6.7.152
 metaDescription: Release notes for Ruby Agent 3.6.7.152
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-367159.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-367159.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2013-09-23'
 version: 3.6.7.159
 metaDescription: Release notes for Ruby Agent 3.6.7.159
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-368164.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-368164.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2013-10-09'
 version: 3.6.8.164
 metaDescription: Release notes for Ruby Agent 3.6.8.164.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-368168.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-368168.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2013-10-19'
 version: 3.6.8.168
 metaDescription: Release notes for Ruby Agent 3.6.8.168.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-369171.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-369171.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2013-11-07'
 version: 3.6.9.171
 metaDescription: Release notes for Ruby Agent 3.6.9.171.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-370177.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-370177.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2013-12-05'
 version: 3.7.0.177
 metaDescription: Release notes for Ruby Agent 3.7.0.177.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-371180.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-371180.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2013-12-20'
 version: 3.7.1.180
 metaDescription: Release notes for Ruby Agent 3.7.1.180.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-371182.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-371182.mdx
@@ -6,7 +6,6 @@ metaDescription: Release notes for Ruby Agent 3.7.1.182.
 redirects:
   - >-
     /docs/release-notes/agent-release-notes/ruby-release-notes/clone-ruby-agent-371182
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-371188.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-371188.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2014-01-20'
 version: 3.7.1.188
 metaDescription: Release notes for Ruby Agent 3.7.1.188.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-372192.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-372192.mdx
@@ -6,7 +6,6 @@ metaDescription: Release notes for Ruby Agent 3.7.2.192.
 redirects:
   - >-
     /docs/release-notes/agent-release-notes/ruby-release-notes/clone-ruby-agent-372192
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-372195.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-372195.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2014-02-18'
 version: 3.7.2.195
 metaDescription: Release notes for Ruby Agent 3.7.2.195.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-373199.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-373199.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2014-03-05'
 version: 3.7.3.199
 metaDescription: Release notes for Ruby Agent 3.7.3.199.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-373204.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-373204.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2014-03-11'
 version: 3.7.3.204
 metaDescription: Release notes for Ruby Agent 3.7.3.204.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-380218.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-380218.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2014-04-22'
 version: 3.8.0.218
 metaDescription: Release notes for Ruby Agent 3.8.0.218.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-381221.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-381221.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2014-05-16'
 version: 3.8.1.221
 metaDescription: Release notes for Ruby Agent 3.8.1.221.
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-390229.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-390229.mdx
@@ -2,7 +2,6 @@
 subject: Ruby agent
 releaseDate: '2014-06-25'
 version: 3.9.0.229
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-391236.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-391236.mdx
@@ -2,7 +2,6 @@
 subject: Ruby agent
 releaseDate: '2014-07-31'
 version: 3.9.1.236
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-392239.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-392239.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2014-08-21'
 version: 3.9.2.239
 metaDescription: Release notes for Ruby Agent 3.9.2.239
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-393241.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-393241.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2014-08-25'
 version: 3.9.3.241
 metaDescription: Release notes for Ruby Agent 3.9.3.241
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-394245.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-394245.mdx
@@ -3,7 +3,6 @@ subject: Ruby agent
 releaseDate: '2014-09-08'
 version: 3.9.4.245
 metaDescription: Release notes for Ruby Agent 3.9.4.245
-watermark: End of Life
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-395251.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-395251.mdx
@@ -2,7 +2,6 @@
 subject: Ruby agent
 releaseDate: '2014-09-29'
 version: 3.9.5.251
-watermark: End of Life
 ---
 
 <Callout variant="important">


### PR DESCRIPTION
As the team has talked through watermarks, we're trying to move away from watermarks across the site. The release notes all include (pretty redundant) watermarks that indicate EoL status. Since this status is also indicated clearly in a callout, the watermark here is redundant.

Reviewer notes:

- I did this via find and replace
- I've tested this locally on a dozen or so pages and they all worked fine, but I'd like to poke at it more in the cloud preview where it's more responsive
- To test, just click around in some of the oldest agent release notes