### PR TITLE
Update nerdgraph-cloud-integrations-api-tutorial.mdx

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial.mdx
@@ -349,7 +349,7 @@ Mutations are requests that are intended to have side effects, such as creating 
   </Collapser>
 
   <Collapser
-    id="link-aws"
+    id="link-aws-cloudwatch"
     title="Link an Amazon AWS account using CloudWatch Metric Streams"
   >
     This mutation links an Amazon AWS account sending data through CloudWatch Metric Streams to your New Relic account.


### PR DESCRIPTION
Updated anchor link for "Link an Amazon AWS account using CloudWatch Metric Streams" section to be distinct from the anchor link for "Link an Amazon AWS account". Previously, both anchors were the same, making it impossible to link to the CloudWatch section.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.