### PR TITLE
Removed link to Lambda@Edge

### DIFF
--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-lambda-monitoring-integration.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-lambda-monitoring-integration.mdx
@@ -11,7 +11,7 @@ redirects:
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-lambda-monitoring-integration
 ---
 
-[New Relic infrastructure integrations](https://docs.newrelic.com/docs/integrations/new-relic-integrations/getting-started/introduction-infrastructure-integrations) include an integration for reporting your AWS Lambda data to New Relic. This document explains how to activate this integration and describes the data that can be reported.
+[New Relic infrastructure integrations](/docs/integrations/new-relic-integrations/getting-started/introduction-infrastructure-integrations) include an integration for reporting your AWS Lambda data to New Relic. This document explains how to activate this integration and describes the data that can be reported.
 
 <Callout variant="important">
   New Relic also offers a more in-depth Lambda monitoring feature. For more information, see [New Relic Serverless monitoring for AWS Lambda](/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/introduction-new-relic-monitoring-aws-lambda).
@@ -31,7 +31,7 @@ New Relic's AWS Lambda integration reports data such as invocation counts, error
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](https://docs.newrelic.com/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 
@@ -46,9 +46,9 @@ Default [polling](/docs/infrastructure/amazon-integrations/aws-integrations-list
 
 To find your integration data, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure > AWS** and select one of the Lambda integration links.
 
-You can [query and explore your data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data) using the `ServerlessSample` [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type), with `provider` values of `LambdaRegion` , `LambdaFunction` and `LambdaFunctionAlias`.
+You can [query and explore your data](/docs/using-new-relic/data/understand-data/query-new-relic-data) using the `ServerlessSample` [event type](/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type), with `provider` values of `LambdaRegion` , `LambdaFunction` and `LambdaFunctionAlias`.
 
-For more on how to use your data, see [Understand and use integration data](https://docs.newrelic.com/docs/infrastructure/integrations/find-use-infrastructure-integration-data).
+For more on how to use your data, see [Understand and use integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data).
 
 ## Metric data [#metrics]
 
@@ -56,9 +56,9 @@ This integration collects the following metrics. For more on these metrics, see 
 
 ### Function and Alias
 
-Lambda function and Alias data is attached to the `ServerlessSample` [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type), with a `provider` value of `LambdaFunction` and `LambdaFunctionAlias`, respectively.
+Lambda function and Alias data is attached to the `ServerlessSample` [event type](/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type), with a `provider` value of `LambdaFunction` and `LambdaFunctionAlias`, respectively.
 
-Additionally, if you're using [AWS CloudFront](https://docs.newrelic.com/docs/integrations/amazon-integrations/aws-integrations-list/aws-cloudfront-monitoring-integration) to execute the functions in AWS locations closer to the clients, and have enabled the filter to collect [Lambda@Edge](mailto:Lambda@Edge) metrics, these data will be attached to the `ServerlessSample` event type, with a provider value of `LambdaEdgeFunction`.
+Additionally, if you're using [AWS CloudFront](/docs/integrations/amazon-integrations/aws-integrations-list/aws-cloudfront-monitoring-integration) to execute the functions in AWS locations closer to the clients, and have enabled the filter to collect Lambda@Edge metrics, these data will be attached to the `ServerlessSample` event type, with a provider value of `LambdaEdgeFunction`.
 
 <table>
   <thead>
@@ -171,7 +171,7 @@ Additionally, if you're using [AWS CloudFront](https://docs.newrelic.com/docs/in
 
 ### Region
 
-Lambda region data is attached to the `ServerlessSample` [event type](https://docs.newrelic.com/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type), with a `provider` value of `LambdaRegion`.
+Lambda region data is attached to the `ServerlessSample` [event type](/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type), with a `provider` value of `LambdaRegion`.
 
 <table>
   <thead>
@@ -211,7 +211,7 @@ Lambda region data is attached to the `ServerlessSample` [event type](https://do
 
 ## Inventory data [#inventory]
 
-This integration supports the following inventory data. For more about inventory data, see [Understand integration data](https://docs.newrelic.com/docs/infrastructure/integrations-getting-started/getting-started/understand-integration-data-data-types#inventory-data).
+This integration supports the following inventory data. For more about inventory data, see [Understand integration data](/docs/infrastructure/integrations-getting-started/getting-started/understand-integration-data-data-types#inventory-data).
 
 ### aws/lambda/function/
 


### PR DESCRIPTION
The Lambda team confirmed this link shouldn't be there and needs to be removed. Since I was at it, I fixed other links as well.

Originally reported in #3533. 