### PR TITLE
Change referrer policy to expose referrer for external link clicks

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -520,6 +520,11 @@ module.exports = {
       },
     },
     'gatsby-plugin-meta-redirect',
-    'gatsby-plugin-gatsby-cloud',
+    {
+      resolve: 'gatsby-plugin-gatsby-cloud',
+      options: {
+        allPageHeaders: ['Referrer-Policy: strict-origin'],
+      },
+    },
   ],
 };


### PR DESCRIPTION
## Description

Adds config option for gatsby cloud plugin to change referrer-policy from `same-origin` to `strict-origin`.

## Related issues / PRs
Partially addresses https://github.com/newrelic/gatsby-theme-newrelic/issues/437

