### PR TITLE
Add instruction to restart APM services after making changes to tags

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial.mdx
@@ -56,6 +56,7 @@ To add new tags for an entity:
 1. Go to the NerdGraph GraphiQL explorer at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
 2. Use [`entitySearch()`](/docs/apis/graphql-api/tutorials/use-new-relic-graphql-api-query-entities#search-entity) to locate the GUID for the entity you want to tag.
 3. Use the `taggingAddTagsToEntity` mutation to add a tag with a value to the entity.
+4. For APM agents, a restart is required after adding a new tag.
 
 In this example, we have a browser application called `Cookie Checkout` owned by a UI team. We want to add a `team` tag with a `ui` value to this instance. Once the tag is added, we can filter by the tag `team:ui` and find the `Cookie Checkout` app in the New Relic One UI.
 
@@ -78,6 +79,7 @@ To delete a tag and all of its associated values from an entity:
 1. Go to the NerdGraph GraphiQL explorer at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
 2. Use [`entitySearch()`](/docs/apis/graphql-api/tutorials/use-new-relic-graphql-api-query-entities#search-entity) to locate the GUID for the entity with the tag you want to remove.
 3. Use the `taggingDeleteTagFromEntity` mutation.
+4. For APM agents, a restart is required after changing tags.
 
 The following example mutation removes the `team` tag from an entity:
 


### PR DESCRIPTION
Tested adding tags to APM agent through UI and NerdGraph, both did not take effect until I restarted my service and then only applied to new, incoming data.
I did check with Browser support team, this is not needed for Browser: https://newrelic.slack.com/archives/C7GUYJZ5E/p1629406376045100
Infra team did not get back to me so only including APM for now: https://newrelic.slack.com/archives/C7HGFBZMH/p1629406484141500