### PR TITLE
Added link to the Pixie requirements doc

### DIFF
--- a/src/content/docs/auto-telemetry-pixie/get-started-auto-telemetry-pixie.mdx
+++ b/src/content/docs/auto-telemetry-pixie/get-started-auto-telemetry-pixie.mdx
@@ -44,6 +44,7 @@ If you want to install Auto-telemetry with Pixie on multiple clusters, re-run th
 
 * Review this [Pixie data security overview](/docs/auto-telemetry-pixie/pixie-data-security-overview) for actions to take to secure your data.
 * Make sure you have sufficient memory: Pixie requires 2Gb of memory per node in your cluster.
+* Review the other [Pixie technical requirements](https://docs.px.dev/installing-pixie/requirements/).
 * You must be a [full user](/docs/accounts/accounts-billing/new-relic-one-user-management/new-relic-one-user-model-understand-user-structure/#user-type). Other user-related requirements: 
   * For users on [original user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models): cannot be a [Restricted User](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model/#roles).
   * For users on [New Relic One user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model/#user-models): must be assigned to a [group](/docs/accounts/accounts-billing/new-relic-one-user-management/new-relic-one-user-model-understand-user-structure/#groups) that has a role with Pixie-related [capabilities](/docs/accounts/accounts-billing/new-relic-one-user-management/new-relic-one-user-model-understand-user-structure/#capabilities). 


### PR DESCRIPTION
Closes #3462

Rather than duplicating the content in this doc, I thought it best to link to the Pixie technical requirements doc.