### PR TITLE
chore: Deprecate CAT on ruby-agent docs

### DIFF
--- a/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -1375,6 +1375,21 @@ If `true` , disables [Sinatra instrumentation](/docs/agents/ruby-agent/framework
     </table>
 
   If `true`, disables agent middleware for Sinatra. This middleware is responsible for advanced feature support such as [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing), [page load timing](/docs/browser/new-relic-browser/getting-started/new-relic-browser), and [error collection](/docs/apm/applications-menu/events/view-apm-error-analytics).
+
+    <Callout variant="important">
+      Cross application tracing is deprecated in favor of [distributed tracing](https://docs.newrelic.com/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). Distributed tracing is on by default for Ruby agent versions 8.0.0 and above. Middlewares are not required to support distributed tracing.
+
+      To continue using cross application tracing, update the following options in your `newrelic.yml` configuration file:
+
+      ```
+      # newrelic.yml
+
+        cross_application_tracer:
+          enabled: true
+        distributed_tracing:
+          enabled: false
+      ```
+    </Callout>
   </Collapser>
   
   <Collapser id="disable_view_instrumentation" title="disable_view_instrumentation">

--- a/src/content/docs/agents/ruby-agent/features/cross-application-tracing-ruby.mdx
+++ b/src/content/docs/agents/ruby-agent/features/cross-application-tracing-ruby.mdx
@@ -4,16 +4,21 @@ tags:
   - Agents
   - Ruby agent
   - Features
-metaDescription: 'To set up cross application tracing for New Relic''s Ruby agent, start here.'
+metaDescription: To set up cross application tracing for New Relic's Ruby agent, start here.
 redirects:
   - /docs/ruby/cross-app-tracing-in-ruby
 ---
 
+<Callout variant="caution">
+  **Cross application tracing is deprecated in favor of [distributed tracing](https://docs.newrelic.com/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing).**
+
+  As of version 8.0.0 of the Ruby agent, [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) is on by default. Distributed tracing improves on cross application tracing and is recommended for large, distributed systems.
+
+  To continue using cross application tracing, visit [configuration](#configuration).
+</Callout>
+
 If you use a non-standard middleware framework, follow these procedures to install and configure New Relic's [cross application tracing feature](/docs/traces/cross-application-traces). If you have problems, follow the [troubleshooting procedures for cross application tracing](/docs/apm/transactions/cross-application-traces/troubleshooting-cross-application-tracing).
 
-<Callout variant="important">
-  New Relic also supports [distributed tracing](https://docs.newrelic.com/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). Distributed tracing improves on cross application tracing and is recommended for large, distributed systems.
-</Callout>
 
 ## Requirements
 
@@ -30,16 +35,23 @@ Cross application tracing works with Rack, and therefore requires Rails 2.3 or g
 * If you use Rails, the Ruby agent will install the middleware automatically.
 * If you use a different Rack-based framework, manually add the `NewRelic::Rack::AgentHooks` middleware to your stack.
 
-## Configuration
+## Configuration [#configuration]
 
-Cross application tracing can be controlled by a configuration flag.
+Cross application tracing can be controlled by a configuration flag. As of version 8.0.0 of the Ruby agent, the default for `cross_application_tracer.enabled` is `false`, even when unspecified. To enable cross application tracing, you must set this flag to `true` amd set `distributed_tracing.enabled` to `false`.
 
 ```
-cross_application_tracer
-	  enabled: true
+cross_application_tracer:
+	enabled: true
+distributed_tracing:
+  enabled: false
 ```
 
-The default for `cross_application_tracer.enabled` is `true`, even when unspecified. To disable cross application tracing, you must set this flag to `false`.
+For versions below 8.0.0, cross application can be configured using the following setting.
+
+```
+cross_application_tracer:
+	enabled: true
+```
 
 ## Cross application trace measurements [#cat-measurements]
 
@@ -79,4 +91,4 @@ Some of these components are easier to control than others. For example, to capt
 
 ## Get distributed tracing [#distributed-tracing]
 
-New Relic also offers [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). Distributed tracing is an improvement on cross application tracing and is recommended for large, distributed systems.
+As of version 8.0.0 of the Ruby agent, [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) is on by default. Distributed tracing is an improvement on cross application tracing and is recommended for large, distributed systems.

--- a/src/content/docs/agents/ruby-agent/features/http-client-tracing-ruby.mdx
+++ b/src/content/docs/agents/ruby-agent/features/http-client-tracing-ruby.mdx
@@ -129,8 +129,7 @@ The Ruby agent supports Excon version **0.19.0 or higher.** Excon instrumentatio
 
 The Ruby agent supports Typhoeus version **0.5.3 or higher**.
 
-## TODO: VERIFY - WILL THEY NOT GET DISTRIBUTED TRACING SUPPORT?
-Parallel requests made via the `Hydra` mechanism in Typhoeus currently only have partial tracing support. For such requests, the Ruby agent will record a single transaction trace node representing the entire batch, but you will not be able to see the details about each individual request in the batch. Requests made via the `Hydra` mechanism will also not get cross application tracing support.
+Parallel requests made via the `Hydra` mechanism in Typhoeus only have partial distributed tracing support. For such requests, the Ruby agent will record a single transaction trace node representing the entire batch, but you will not be able to see the details about each individual request in the batch. Cross application tracing does not support requests made via the `Hydra` mechanism.
 
 Testing has shown significant issues with segfaults when running Typhoeus on MRI 1.8.7.
 **Recommendation:** Use Ruby Enterprise Edition or MRI 1.9.3 or higher to avoid these problems.
@@ -139,5 +138,4 @@ Testing has shown significant issues with segfaults when running Typhoeus on MRI
 
 The Ruby agent supports Curb version **0.8.1 or higher.** Curb instrumentation on JRuby is **not** supported.
 
-# TODO: VERIFY
-Requests made via the `Curl::Multi` API currently only have partial tracing support (equivalent to what is offered for requests made via the Typhoeus `Hydra` API). For such requests, the Ruby agent will record a single transaction trace node representing the entire batch, but you will not be able to see the details about each individual request in the batch. Requests made via the `Curl::Multi` mechanism will also not get distributed tracing support.
+Requests made via the `Curl::Multi` API currently only have partial distributed tracing support (equivalent to what is offered for requests made via the Typhoeus `Hydra` API). For such requests, the Ruby agent will record a single transaction trace node representing the entire batch, but you will not be able to see the details about each individual request in the batch. Requests made via the `Curl::Multi` mechanism do not have cross application tracing support.

--- a/src/content/docs/agents/ruby-agent/features/http-client-tracing-ruby.mdx
+++ b/src/content/docs/agents/ruby-agent/features/http-client-tracing-ruby.mdx
@@ -13,7 +13,7 @@ The Ruby agent can trace outgoing HTTP requests made by your application or scri
 
 * Record metrics about how long your HTTP requests are taking and which hosts they're hitting.
 * Annotate transaction traces with nodes for each HTTP request.
-* Provide [cross application tracing](/docs/agents/ruby-agent/features/cross-application-tracing-ruby) for requests between applications instrumented with New Relic.
+* Provide [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing/) for requests between applications instrumented with New Relic.
 
 ## Supported HTTP client libraries [#supported_libraries]
 
@@ -129,6 +129,7 @@ The Ruby agent supports Excon version **0.19.0 or higher.** Excon instrumentatio
 
 The Ruby agent supports Typhoeus version **0.5.3 or higher**.
 
+## TODO: VERIFY - WILL THEY NOT GET DISTRIBUTED TRACING SUPPORT?
 Parallel requests made via the `Hydra` mechanism in Typhoeus currently only have partial tracing support. For such requests, the Ruby agent will record a single transaction trace node representing the entire batch, but you will not be able to see the details about each individual request in the batch. Requests made via the `Hydra` mechanism will also not get cross application tracing support.
 
 Testing has shown significant issues with segfaults when running Typhoeus on MRI 1.8.7.
@@ -138,4 +139,5 @@ Testing has shown significant issues with segfaults when running Typhoeus on MRI
 
 The Ruby agent supports Curb version **0.8.1 or higher.** Curb instrumentation on JRuby is **not** supported.
 
-Requests made via the `Curl::Multi` API currently only have partial tracing support (equivalent to what is offered for requests made via the Typhoeus `Hydra` API). For such requests, the Ruby agent will record a single transaction trace node representing the entire batch, but you will not be able to see the details about each individual request in the batch. Requests made via the `Curl::Multi` mechanism will also not get cross application tracing support.
+# TODO: VERIFY
+Requests made via the `Curl::Multi` API currently only have partial tracing support (equivalent to what is offered for requests made via the Typhoeus `Hydra` API). For such requests, the Ruby agent will record a single transaction trace node representing the entire batch, but you will not be able to see the details about each individual request in the batch. Requests made via the `Curl::Multi` mechanism will also not get distributed tracing support.

--- a/src/content/docs/agents/ruby-agent/features/http-client-tracing-ruby.mdx
+++ b/src/content/docs/agents/ruby-agent/features/http-client-tracing-ruby.mdx
@@ -123,7 +123,7 @@ The following HTTP client libraries are currently supported by the Ruby agent:
 
 ## Excon notes [#excon]
 
-The Ruby agent supports Excon version **0.10.1 or higher.** Excon instrumentation for Excon versions 0.19.0 and up relies on the ability to add an Excon middleware to the `:middlewares` key of `Excon.defaults`, so if your application modifies `Excon.defaults` you should ensure that you preserve the value of the `:middlewares` key.
+The Ruby agent supports Excon version **0.19.0 or higher.** Excon instrumentation relies on the ability to add an Excon middleware to the `:middlewares` key of `Excon.defaults`, so if your application modifies `Excon.defaults` you should ensure that you preserve the value of the `:middlewares` key.
 
 ## Typhoeus notes [#typhoeus]
 
@@ -131,7 +131,7 @@ The Ruby agent supports Typhoeus version **0.5.3 or higher**.
 
 Parallel requests made via the `Hydra` mechanism in Typhoeus currently only have partial tracing support. For such requests, the Ruby agent will record a single transaction trace node representing the entire batch, but you will not be able to see the details about each individual request in the batch. Requests made via the `Hydra` mechanism will also not get cross application tracing support.
 
-Testing has shown significant issues with segfaults when running Typhoeus on MRI 1.8.7.  
+Testing has shown significant issues with segfaults when running Typhoeus on MRI 1.8.7.
 **Recommendation:** Use Ruby Enterprise Edition or MRI 1.9.3 or higher to avoid these problems.
 
 ## Curb notes [#curb]

--- a/src/content/docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby.mdx
+++ b/src/content/docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby.mdx
@@ -28,7 +28,7 @@ The Ruby agent supports many of the most common [Ruby frameworks and platforms](
 * Monitor your app's [Apdex (user satisfaction)](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction).
 * Get a [high-level summary of your app](/docs/apm/applications-menu/monitoring/apm-overview-page).
 * Create [architectural maps](/docs/data-analysis/user-interface-functions/view-your-data/service-maps-visualize-monitor-apps-entire-architecture) of your app.
-* Enable [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) to understand activity in an environment that relies on many services.
+* Enable [distributed tracing](docs/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing/) to understand activity in an environment that relies on many services.
 * Install [New Relic Infrastructure](/docs/infrastructure) and view detailed host data for your app.
 
 **Find errors and problems quickly**
@@ -40,7 +40,7 @@ The Ruby agent supports many of the most common [Ruby frameworks and platforms](
 
 **Drill down into performance details**
 
-* Examine code-level [transaction traces](/docs/apm/transactions/transaction-traces/transaction-traces) and [cross application traces](/docs/agents/ruby-agent/features/cross-application-tracing-ruby).
+* Examine code-level [transaction traces](/docs/apm/transactions/transaction-traces/transaction-traces) 
 * Examine [database query traces](/docs/apm/transactions/transaction-traces/sql-statements).
 * Examine [error traces](/docs/apm/applications-menu/events/viewing-apm-errors-error-traces).
 * Monitor [Ruby background processes and daemons](/docs/agents/ruby-agent/background-jobs/monitoring-ruby-background-processes-daemons).

--- a/src/content/docs/agents/ruby-agent/instrumented-gems/rack-middlewares.mdx
+++ b/src/content/docs/agents/ruby-agent/instrumented-gems/rack-middlewares.mdx
@@ -90,8 +90,7 @@ If you do not want to instrument Rack middlewares, you may disable Rack middlewa
 
 ## Installing Ruby agent middlewares manually [#manual]
 
-
-The Ruby agent's implementation of New Relic's [Cross Application Tracing](/docs/apm/traces/cross-application-traces/cross-application-tracing) feature uses Rack middleware instrumentation to read and write HTTP headers that are necessary to pass information between monitored applications. If you have disabled middleware instrumentation as described above and want to use cross application tracing, you must manually add the `NewRelic::Rack::AgentHooks` middleware to your middleware stack. For more information, see [Cross application tracing in Ruby](/docs/agents/ruby-agent/features/cross-application-tracing-ruby).
+The Ruby agent's implementation of New Relic's [cross application tracing](/docs/apm/traces/cross-application-traces/cross-application-tracing) feature uses Rack middleware instrumentation to read and write HTTP headers that are necessary to pass information between monitored applications. If you are using Sinatra, have disabled middleware instrumentation as described above, and want to use cross application tracing, you must manually add the `NewRelic::Rack::AgentHooks` middleware to your middleware stack.
 
 <Callout variant="important">
   As of version 8.0.0, cross application tracing is deprecated in favor of [distributed tracing](/docs/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing/). When enabled, distributed tracing is automatically configured for all rack-based apps without the need for an additional middleware.

--- a/src/content/docs/agents/ruby-agent/instrumented-gems/rack-middlewares.mdx
+++ b/src/content/docs/agents/ruby-agent/instrumented-gems/rack-middlewares.mdx
@@ -12,7 +12,7 @@ redirects:
 
 The Ruby agent automatically instruments [Rack](http://rack.github.io/) middlewares. If you are unfamiliar with the basics of Rack middlewares, review the [resources linked by the Rails on Rack guide](http://guides.rubyonrails.org/rails_on_rack.html#resources). Additionally, the Ruby agent provides some features via Rack middlewares:
 
-* [Cross application traces](/docs/agents/ruby-agent/features/cross-application-tracing-ruby)
+* [Distributed traces](/docs/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing/)
 * Auto-instrumentation for [browser monitoring](/docs/agents/ruby-agent/features/page-load-timing-ruby)
 
 New Relic automatically installs these middlewares for Rails and Sinatra.
@@ -90,7 +90,14 @@ If you do not want to instrument Rack middlewares, you may disable Rack middlewa
 
 ## Installing Ruby agent middlewares manually [#manual]
 
+
 The Ruby agent's implementation of New Relic's [Cross Application Tracing](/docs/apm/traces/cross-application-traces/cross-application-tracing) feature uses Rack middleware instrumentation to read and write HTTP headers that are necessary to pass information between monitored applications. If you have disabled middleware instrumentation as described above and want to use cross application tracing, you must manually add the `NewRelic::Rack::AgentHooks` middleware to your middleware stack. For more information, see [Cross application tracing in Ruby](/docs/agents/ruby-agent/features/cross-application-tracing-ruby).
+
+<Callout variant="important">
+  As of version 8.0.0, cross application tracing is deprecated in favor of [distributed tracing](/docs/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing/). When enabled, distributed tracing is automatically configured for all rack-based apps without the need for an additional middleware.
+
+  If you would like to continue using cross application tracing, you will need to [update your configuration](/docs/agents/ruby-agent/features/cross-application-tracing-ruby#configuration).
+</Callout>
 
 ## Manual Rack instrumentation [#manual_instrumentation]
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?

**This should not be deployed to the site until 8.0 is released (expected during week of 13 September 2021).**

Updates Ruby-Agent documentation ahead of the 8.0 gem release to deprecate cross application tracing in favor of distributed tracing, which will be on by default.

This also updates the supported versions of the Excon gem, another change part of the 8.0 release.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  
The changes to "HTTP Client Tracing" and "Rack Middlewares" documents were tested using sample applications with the WIP of the 8.0 release. 

* If your issue relates to an existing GitHub issue, please link to it.

https://github.com/newrelic/newrelic-ruby-agent/issues/551 

### Are you making a change to site code?

No.

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.