### PR TITLE
Add ruby agent 8 migration guide

### DIFF
--- a/src/content/docs/agents/ruby-agent/getting-started/migration-8x-guide.mdx
+++ b/src/content/docs/agents/ruby-agent/getting-started/migration-8x-guide.mdx
@@ -64,22 +64,18 @@ Note: The first metric name will be created as a scoped metric unless `push_scop
 The default configuration option for `distributed_tracing.enabled` is set to true for versions 8.0+. To disable distributed tracing, please set this configuration option to false in your newrelic.yml. 
 
 ```
-# newrelic.yml
-# ... 
 distributed_tracing:
   enabled: false
 ```
 
 ## Cross Application Tracing is deprecated  [#cross_application_tracing]
-Cross Application Tracing (https://docs.newrelic.com/docs/agents/ruby-agent/features/cross-application-tracing-ruby/) is deprecated in 8.0 and will be removed in a future release. 
+[Cross Application Tracing](https://docs.newrelic.com/docs/agents/ruby-agent/features/cross-application-tracing-ruby/) is deprecated in 8.0 and will be removed in a future release. 
 
 <Callout variant="tip">
 Distributed tracing and cross application tracing cannot be used simultaneously. If both configuration options are enabled, then only distributed tracing will be used. 
 To continue using cross application tracing, settings for both distributed tracing and cross application tracing will need to be updated in your newrelic.yml. 
 
 ```
-# newrelic.yml
-# … 
 cross_application_tracing:
   enabled: true
 
@@ -112,7 +108,7 @@ The following have been previously deprecated and are now removed.
         `disable_transaction_tracing` API method
       </td>
       <td>
-        [`disable_all_tracing`](https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent:disable_all_tracing) or [ignore_transaction](https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent:ignore_transaction) API methods
+        [`disable_all_tracing`](https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent:disable_all_tracing) or [`ignore_transaction`](https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent:ignore_transaction) API methods
       </td>
     </tr>
 

--- a/src/content/docs/agents/ruby-agent/getting-started/migration-8x-guide.mdx
+++ b/src/content/docs/agents/ruby-agent/getting-started/migration-8x-guide.mdx
@@ -1,0 +1,157 @@
+---
+title: Ruby Agent 7.x to 8.x migration guide
+tags: 
+  - Agents
+  - Ruby agent
+  - Getting started
+---
+## Summary [#summary]
+
+This guide covers the major changes between the 7.x and 8.x series of the Ruby Agent, issues that may be encountered while upgrading, and how to successfully migrate to version 8.x.
+
+The main changes include:
+
+- [Changes to the add_method_tracer API method](#add_method_tracer)
+- [Distributed Tracing is enabled by default](#distributed_tracing)
+- [Cross Application Tracing is deprecated](#cross_application_tracing)
+- [Removed deprecated API methods and legacy instrumentation](#removed_deprecated)
+
+See [Milestone for 8.0](https://github.com/newrelic/newrelic-ruby-agent/milestone/10) for more information.
+
+
+## Changes to the `add_method_tracer` API method  [#add_method_tracer]
+### Metric name parameter accepts Procs; strings no longer interpolated
+
+The second argument to `add_method_tracer` is the name of the metric used to record calls to the traced method. Previously, this string could include Ruby-style interpolation to allow for the metric name to include variables from the method receiver. For example,
+```
+# old (<= 7.2)
+add_method_tracer :foo, ‘metric_#{args[0]}’
+```
+As of 8.0, this string will no longer be interpolated. To preserve the above behavior, pass a Proc instead:
+```
+# new (8.0+)
+add_method_tracer :foo, -> (*args) { “metric_#{args[0]}” }   # note the double-quotes
+```
+NOTE: the arity of the Proc passed to `add_method_tracer` should match the arity of the original traced method (or use a compatible splat).
+
+### `:code_header` and `:code_footer` parameters accept only Procs
+
+Similar to metric names, the `:code_header` and `:code_footer` options to `add_method_tracer` were previously given as strings that would be interpolated in the context of the method receiver.
+
+In Ruby Agent 8.0, `:code_header` and `:code_footer` will only be invoked if given as Procs, as in the example above.
+
+### Call `add_method_tracer` once per method
+Calling `add_method_tracer` multiple times on the same method will overwrite any previously defined method tracers for that method. There should be only one `add_method_tracer` line for each traced method.
+
+Previously, the agent allowed adding multiple metrics to the same method by invoking `add_method_tracer` once for each such metric. This can still be done, but the metric names need to be  passed as the second argument of `add_method_tracer`  as an array of strings or procs.
+
+```
+# old
+add_method_tracer :foo, ‘metric1’
+add_method_tracer :foo, ‘metric2’, push_scope: false
+add_method_tracer :foo, ‘metric3’, push_scope: false
+```
+
+```
+# new
+add_method_tracer :foo, [‘metric1’, ‘metric2’, ‘metric3’]
+```
+
+Note: The first metric name will be created as a scoped metric unless `push_scope: false` is specified. The following named metrics will be unscoped. Each traced method may only have one scoped metric.
+
+
+## Distributed Tracing is enabled by default  [#distributed_tracing]
+The default configuration option for `distributed_tracing.enabled` is set to true for versions 8.0+. To disable distributed tracing, please set this configuration option to false in your newrelic.yml. 
+
+```
+# newrelic.yml
+# ... 
+distributed_tracing:
+  enabled: false
+```
+
+## Cross Application Tracing is deprecated  [#cross_application_tracing]
+Cross Application Tracing (https://docs.newrelic.com/docs/agents/ruby-agent/features/cross-application-tracing-ruby/) is deprecated in 8.0 and will be removed in a future release. 
+
+<Callout variant="tip">
+Distributed tracing and cross application tracing cannot be used simultaneously. If both configuration options are enabled, then only distributed tracing will be used. 
+To continue using cross application tracing, settings for both distributed tracing and cross application tracing will need to be updated in your newrelic.yml. 
+
+```
+# newrelic.yml
+# … 
+cross_application_tracing:
+  enabled: true
+
+distributed_tracing:
+  enabled: false
+```
+</Callout>
+
+
+## Removed deprecated API methods and legacy instrumentation  [#removed_deprecated]
+
+The following have been previously deprecated and are now removed. 
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        Removed
+      </th>
+      <th>
+        Replacement
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+
+    <tr>
+      <td>
+        `disable_transaction_tracing` API method
+      </td>
+      <td>
+        [`disable_all_tracing`](https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent:disable_all_tracing) or [ignore_transaction](https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent:ignore_transaction) API methods
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `External.start_segment` API method
+      </td>
+      <td>
+        [`Tracer#start_external_request_segment`](https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent/Tracer.start_external_request_segment) API method
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `Transaction.wrap` API method
+      </td>
+      <td>
+        [`Tracer#in_transaction`](https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent/Tracer.in_transaction) API method
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Mongo &lt; 2.1 instrumentation
+      </td>
+      <td>
+        Upgrade to Mongo 2.1+
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Excon &lt; 0.19.0 instrumentation
+      </td>
+      <td>
+        Upgrade to Excon 0.19.0+
+      </td>
+    </tr>
+
+  </tbody>
+</table>
+

--- a/src/content/docs/agents/ruby-agent/getting-started/migration-8x-guide.mdx
+++ b/src/content/docs/agents/ruby-agent/getting-started/migration-8x-guide.mdx
@@ -11,28 +11,34 @@ This guide covers the major changes between the 7.x and 8.x series of the Ruby A
 
 The main changes include:
 
-- [Changes to the add_method_tracer API method](#add_method_tracer)
+- [Changes to the `add_method_tracer` API method](#add_method_tracer)
 - [Distributed Tracing is enabled by default](#distributed_tracing)
 - [Cross Application Tracing is deprecated](#cross_application_tracing)
 - [Removed deprecated API methods and legacy instrumentation](#removed_deprecated)
 
 See [Milestone for 8.0](https://github.com/newrelic/newrelic-ruby-agent/milestone/10) for more information.
 
-
 ## Changes to the `add_method_tracer` API method  [#add_method_tracer]
+
 ### Metric name parameter accepts Procs; strings no longer interpolated
 
-The second argument to `add_method_tracer` is the name of the metric used to record calls to the traced method. Previously, this string could include Ruby-style interpolation to allow for the metric name to include variables from the method receiver. For example,
+The second argument to `add_method_tracer` is the name of the metric used to record calls to the traced method. 
+
+Previously, this string could include Ruby-style interpolation to allow for the metric name to include variables from the method receiver. For example:
+
 ```
 # old (<= 7.2)
 add_method_tracer :foo, ‘metric_#{args[0]}’
 ```
-As of 8.0, this string will no longer be interpolated. To preserve the above behavior, pass a Proc instead:
+
+As of 8.0, this string will no longer be interpolated. To preserve the behavior described above, pass a Proc instead:
+
 ```
 # new (8.0+)
 add_method_tracer :foo, -> (*args) { “metric_#{args[0]}” }   # note the double-quotes
 ```
-NOTE: the arity of the Proc passed to `add_method_tracer` should match the arity of the original traced method (or use a compatible splat).
+
+Note that the arity of the Proc passed to `add_method_tracer` should match the arity of the original traced method (or use a compatible splat).
 
 ### `:code_header` and `:code_footer` parameters accept only Procs
 
@@ -41,9 +47,10 @@ Similar to metric names, the `:code_header` and `:code_footer` options to `add_m
 In Ruby Agent 8.0, `:code_header` and `:code_footer` will only be invoked if given as Procs, as in the example above.
 
 ### Call `add_method_tracer` once per method
+
 Calling `add_method_tracer` multiple times on the same method will overwrite any previously defined method tracers for that method. There should be only one `add_method_tracer` line for each traced method.
 
-Previously, the agent allowed adding multiple metrics to the same method by invoking `add_method_tracer` once for each such metric. This can still be done, but the metric names need to be  passed as the second argument of `add_method_tracer`  as an array of strings or procs.
+Previously, the agent allowed adding multiple metrics to the same method by invoking `add_method_tracer` once for each such metric. This can still be done, but the metric names need to be passed as the second argument of `add_method_tracer`  as an array of strings or procs.
 
 ```
 # old
@@ -57,11 +64,11 @@ add_method_tracer :foo, ‘metric3’, push_scope: false
 add_method_tracer :foo, [‘metric1’, ‘metric2’, ‘metric3’]
 ```
 
-Note: The first metric name will be created as a scoped metric unless `push_scope: false` is specified. The following named metrics will be unscoped. Each traced method may only have one scoped metric.
-
+Note that the first metric name will be created as a scoped metric unless `push_scope: false` is specified. The following named metrics will be unscoped. Each traced method may only have one scoped metric.
 
 ## Distributed Tracing is enabled by default  [#distributed_tracing]
-The default configuration option for `distributed_tracing.enabled` is set to true for versions 8.0+. To disable distributed tracing, please set this configuration option to false in your newrelic.yml. 
+
+The default configuration option for `distributed_tracing.enabled` is set to true for versions 8.0 or higher. To disable distributed tracing, set this configuration option to false in your newrelic.yml. 
 
 ```
 distributed_tracing:
@@ -69,11 +76,13 @@ distributed_tracing:
 ```
 
 ## Cross Application Tracing is deprecated  [#cross_application_tracing]
-[Cross Application Tracing](https://docs.newrelic.com/docs/agents/ruby-agent/features/cross-application-tracing-ruby/) is deprecated in 8.0 and will be removed in a future release. 
+
+[Cross Application Tracing](/docs/agents/ruby-agent/features/cross-application-tracing-ruby/) is deprecated in 8.0 and will be removed in a future release. 
 
 <Callout variant="tip">
-Distributed tracing and cross application tracing cannot be used simultaneously. If both configuration options are enabled, then only distributed tracing will be used. 
-To continue using cross application tracing, settings for both distributed tracing and cross application tracing will need to be updated in your newrelic.yml. 
+Distributed tracing and cross application tracing cannot be used simultaneously. If both configuration options are enabled, then only distributed tracing is used. 
+
+To continue using cross application tracing, settings for both distributed tracing and cross application tracing need to be updated in your newrelic.yml. 
 
 ```
 cross_application_tracing:
@@ -84,10 +93,9 @@ distributed_tracing:
 ```
 </Callout>
 
-
 ## Removed deprecated API methods and legacy instrumentation  [#removed_deprecated]
 
-The following have been previously deprecated and are now removed. 
+The following methods had been previously deprecated and are now removed. 
 
 <table>
   <thead>
@@ -135,7 +143,7 @@ The following have been previously deprecated and are now removed.
         Mongo &lt; 2.1 instrumentation
       </td>
       <td>
-        Upgrade to Mongo 2.1+
+        Upgrade to Mongo 2.1 or higher
       </td>
     </tr>
 
@@ -144,7 +152,7 @@ The following have been previously deprecated and are now removed.
         Excon &lt; 0.19.0 instrumentation
       </td>
       <td>
-        Upgrade to Excon 0.19.0+
+        Upgrade to Excon 0.19.0 or higher
       </td>
     </tr>
 

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -1351,6 +1351,8 @@ pages:
                     path: /docs/agents/ruby-agent/getting-started/ruby-release-notes
                   - title: Ruby agent 7x migration guide
                     path: /docs/agents/ruby-agent/getting-started/migration-7x-guide
+                  - title: Ruby agent 8x migration guide
+                    path: /docs/agents/ruby-agent/getting-started/migration-8x-guide  
               - title: Installation
                 path: /docs/agents/ruby-agent/installation
                 pages:


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

This PR adds a migration guide for the ruby agent next major release detailing the changes present in 8.0. 

### Are you making a change to site code?
no
