### PR TITLE
Fixed a broken URL

### DIFF
--- a/src/content/docs/new-relic-one/use-new-relic-one/workloads/use-workloads.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/workloads/use-workloads.mdx
@@ -16,7 +16,7 @@ The **Health** tab in a workload provides relevant status data that helps you op
 ![Workload_health_tab](./images/workloads20210526.png "Workload_health_tab")
 
 It comprises the following:
-  1. The navigator view shows the entities that make up the workload, and provides controls to group and sort them. If you’ve [used queries to dynamically select entities](/docs/new-relic-one/use-new-relic-one/workloads/use-workloads/#dynamic), the workload entities will change over time.
+  1. The navigator view shows the entities that make up the workload, and provides controls to group and sort them. If you’ve [used queries to dynamically select entities](/docs/new-relic-one/use-new-relic-one/workloads/use-workloads/#query-logic), the workload entities will change over time.
   2. The [workload status](/docs/new-relic-one/use-new-relic-one/workloads/workload-status-views-notifications/) informs about how your workload is performing, based on the individual alerting status of the entities in your workload. With health over time you’ll see whether and how the workload status has changed in the past three hours.  
   3. If one or more entities are alerting, you’ll get a count of criticals and warnings and a summary of the open conditions, which will make it easier to identify and troubleshoot the most important issues.
 


### PR DESCRIPTION
It was using the wrong ID for the section it was linking to. I updated the URL to use the correct ID for the collapser.

