### PR TITLE
Update docs for otel span errors and exceptions

### DIFF
--- a/src/content/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui.mdx
+++ b/src/content/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui.mdx
@@ -491,13 +491,14 @@ Here are some additional distributed tracing UI details, rules, and limits:
           </td>
 
           <td>
-            * `otel.status = error` will display the span as having an error.
-            * `otel.status_code` will display the status code in the error details box.
-            * `otel.status_description` will display the error description in the error details box.
+            Exceptions containing the following are displayed in the **Error Details** box of the right pane: 
+            * `otel.status = error` displays the span as having an error.
+            * `otel.status_code` displays the status code.
+            * `otel.status_description` displays the error description.
             
-            Note: OpenTelemetry _exceptions_ are displayed independently of span _error_ status.
-            
-            OpenTelemetry Span event exceptions are accessible via Span details by clicking the "view span events" link, but are not necessarily associated with a Span error status.
+            <Callout variant="tip">
+            OpenTelemetry exceptions handled by the app/service are displayed independently of span error status and are not necessarily associated with a span error status. You can view OpenTelemetry span event exceptions by clicking **View span events** in the right pane.
+            </Callout>
           </td>
         </tr>
       </tbody>

--- a/src/content/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui.mdx
+++ b/src/content/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui.mdx
@@ -491,13 +491,10 @@ Here are some additional distributed tracing UI details, rules, and limits:
           </td>
 
           <td>
-            Exceptions containing the following are displayed in the **Error Details** box of the right pane: 
-            * `otel.status = ERROR` displays the span as having an error.
-            * `otel.status_code` displays the status code.
-            * `otel.status_description` displays the error description.
+          The **Error Details** box of the right pane is populated by spans containing `otel.status_code = ERROR` and displays the content of `otel.status_description`.
             
             <Callout variant="tip">
-            OpenTelemetry exceptions handled by the app/service are displayed independently of span error status and are not necessarily associated with a span error status. You can view OpenTelemetry span event exceptions by clicking **View span events** in the right pane.
+            OpenTelemetry span events handled by the app/service are displayed independently of span error status and are not necessarily associated with a span error status. You can view span event exceptions and non-exceptions by clicking **View span events** in the right pane.
             </Callout>
           </td>
         </tr>

--- a/src/content/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui.mdx
+++ b/src/content/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui.mdx
@@ -433,7 +433,7 @@ Here are some additional distributed tracing UI details, rules, and limits:
     * All spans that exit with errors are counted in the span error count.
     * When multiple errors occur on the same span, only one is written to the span in this order of precedence:
       * A `noticeError`
-      * The most recent span exception
+      * The most recent span error within the scope of that span
 
     This table describes how different span errors are handled:
 

--- a/src/content/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui.mdx
+++ b/src/content/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui.mdx
@@ -425,7 +425,7 @@ Here are some additional distributed tracing UI details, rules, and limits:
     id="error-tips"
     title="How to understand span errors"
   >
-    Span-level errors show you where errors originated in a process, how they bubbled up, and where they were handled. Every span that ends with an exception is shown with an error in the UI and contributes to the total error count for that trace.
+    Span-level errors show you where errors originated in a process, how they bubbled up, and where they were handled. Every span that ends with an error is shown with an error in the UI and contributes to the total error count for that trace.
 
     Here are some general tips about understanding span errors:
 
@@ -453,11 +453,11 @@ Here are some additional distributed tracing UI details, rules, and limits:
       <tbody>
         <tr>
           <td>
-            Spans ending in exceptions
+            Spans ending in errors
           </td>
 
           <td>
-            An exception that leaves the boundary of a span results in an error on that span and on any ancestor spans that also exit with an error, until the exception is caught or exits the transaction. You can see if an exception is caught in an ancestor span.
+            An error that leaves the boundary of a span results in an error on that span and on any ancestor spans that also exit with an error, until the error is caught or exits the transaction. You can see if an error is caught in an ancestor span.
           </td>
         </tr>
 

--- a/src/content/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui.mdx
+++ b/src/content/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui.mdx
@@ -485,6 +485,21 @@ Here are some additional distributed tracing UI details, rules, and limits:
             The response code for these spans is captured as an attribute `httpResponseCode` and attached to that span.
           </td>
         </tr>
+        <tr>
+          <td>
+            OpenTelemetry Errors
+          </td>
+
+          <td>
+            * `otel.status = error` will display the span as having an error.
+            * `otel.status_code` will display the status code in the error details box.
+            * `otel.status_description` will display the error description in the error details box.
+            
+            Note: OpenTelemetry _exceptions_ are displayed independently of span _error_ status.
+            
+            OpenTelemetry Span event exceptions are accessible via Span details by clicking the "view span events" link, but are not necessarily associated with a Span error status.
+          </td>
+        </tr>
       </tbody>
     </table>
   </Collapser>

--- a/src/content/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui.mdx
+++ b/src/content/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui.mdx
@@ -492,7 +492,7 @@ Here are some additional distributed tracing UI details, rules, and limits:
 
           <td>
             Exceptions containing the following are displayed in the **Error Details** box of the right pane: 
-            * `otel.status = error` displays the span as having an error.
+            * `otel.status = ERROR` displays the span as having an error.
             * `otel.status_code` displays the status code.
             * `otel.status_description` displays the error description.
             


### PR DESCRIPTION
Hello, Justin Schrader from the DT team here. We've released a new feature allowing uses to see OTEL span events & errors.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
  - docs update for DT span details
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc. 
  ![image](https://user-images.githubusercontent.com/1458959/130510996-5338a239-830a-4fa5-8d90-7085fd2a672c.png)
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.