### PR TITLE
fix: removed versions and stating we do not support connect routing

### DIFF
--- a/src/content/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -9,7 +9,7 @@ translate:
 metaDescription: 'The New Relic Node.js agent supports these frameworks, architectures, and operating systems.'
 ---
 
-Our Node.js agent is publicly available on the [Node Package Manager (npm) repository](https://npmjs.org/package/newrelic) as well as on [GitHub](https://github.com/newrelic/node-newrelic). Before you install the Node.js agent, make sure your application meets the following system requirements. 
+Our Node.js agent is publicly available on the [Node Package Manager (npm) repository](https://npmjs.org/package/newrelic) as well as on [GitHub](https://github.com/newrelic/node-newrelic). Before you install the Node.js agent, make sure your application meets the following system requirements.
 
 If you haven't already, [create a New Relic account](https://newrelic.com/signup). It's free, forever.
 
@@ -138,7 +138,7 @@ Errors resulting in unhandled rejections are not scoped to the transaction that 
 
 * [Express](https://www.npmjs.com/package/express) 4.6.0 or higher
 * [Restify](https://www.npmjs.com/package/restify)
-* [Connect](https://www.npmjs.com/package/connect) v1 and v2 (router not supported)
+* [Connect](https://www.npmjs.com/package/connect)
 * [Hapi](https://www.npmjs.com/package/hapi)
 * [Koa](https://www.npmjs.com/package/koa) 2.0.0 or higher ([external module](https://github.com/newrelic/node-newrelic-koa) loaded with the agent)
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

One of our solutions consultants called out that it stated we only support v1 and v2 of connect.  We also started supporting the connect router in this PR: https://github.com/newrelic/node-newrelic/pull/847. Which will go out shortly(possibly as 8.2.0) of the Node.js agent.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.