### PR TITLE
Added a link to the Pixie docs from the main install page.

### DIFF
--- a/src/content/docs/integrations/kubernetes-integration/installation/kubernetes-integration-install-configure.mdx
+++ b/src/content/docs/integrations/kubernetes-integration/installation/kubernetes-integration-install-configure.mdx
@@ -31,6 +31,8 @@ import eks from './images/eks.png'
 
 The easiest way to install the Kubernetes integration is to use our automated installer to generate a manifest. It bundles not just the integration DaemonSets, but also other New Relic Kubernetes configurations, like [Kubernetes events](/docs/integrations/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration), [Prometheus OpenMetrics](/docs/integrations/prometheus-integrations/get-started/new-relic-prometheus-openmetrics-integration-kubernetes), and [New Relic log monitoring](/docs/logs).
 
+Looking to install our New Relic One integration with Pixie for fine-grained telemetry data? See our [Auto-telemetry with Pixie install instructions](/docs/auto-telemetry-pixie/get-started-auto-telemetry-pixie/#install-auto-telemetry-with-pixie), to get deeper insight into your Kubernetes clusters and workloads with just one install command. No language agents required.
+
 Want to try out our Kubernetes integration? [Create a New Relic account](https://newrelic.com/signup) for free! No credit card required.
 
 ## Use automated installer [#installer]

--- a/src/content/docs/integrations/kubernetes-integration/installation/kubernetes-integration-install-configure.mdx
+++ b/src/content/docs/integrations/kubernetes-integration/installation/kubernetes-integration-install-configure.mdx
@@ -31,7 +31,7 @@ import eks from './images/eks.png'
 
 The easiest way to install the Kubernetes integration is to use our automated installer to generate a manifest. It bundles not just the integration DaemonSets, but also other New Relic Kubernetes configurations, like [Kubernetes events](/docs/integrations/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration), [Prometheus OpenMetrics](/docs/integrations/prometheus-integrations/get-started/new-relic-prometheus-openmetrics-integration-kubernetes), and [New Relic log monitoring](/docs/logs).
 
-Looking to install our New Relic One integration with Pixie for fine-grained telemetry data? See our [Auto-telemetry with Pixie install instructions](/docs/auto-telemetry-pixie/get-started-auto-telemetry-pixie/#install-auto-telemetry-with-pixie), to get deeper insight into your Kubernetes clusters and workloads with just one install command. No language agents required.
+Looking to install our New Relic One integration with Pixie for fine-grained telemetry data? See our [Auto-telemetry with Pixie install instructions](/docs/auto-telemetry-pixie/get-started-auto-telemetry-pixie/#install-auto-telemetry-with-pixie) to get deeper insight into your Kubernetes clusters and workloads with just one install command. No language agents required.
 
 Want to try out our Kubernetes integration? [Create a New Relic account](https://newrelic.com/signup) for free! No credit card required.
 


### PR DESCRIPTION
We noted that there's not really a Pixie mention in the Kubernetes integration install doc. This adds a little info and link.