### PR TITLE
Fixing Lambda category 

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking.mdx
@@ -1,14 +1,11 @@
 ---
-title: Link your AWS and New Relic accounts
-tags:
-  - Serverless function monitoring
-  - AWS Lambda monitoring
-  - Enable Lambda monitoring
-  - Account Linking
+title: "Enable Lambda monitoring step 1: Link your AWS and New Relic accounts"
 metaDescription: Linking your AWS account with New Relic for Lambda Monitoring
 redirects:
   - /docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-serverless-monitoring-using-lambda-layer
 ---
+
+This is one step of [enabling New Relic's AWS Lambda monitoring](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring). 
 
 When you link your AWS account to New Relic, you're granting permission to New Relic to create an inventory of your AWS account, and gather CloudWatch metrics for your Lambda functions. Resources in your AWS account then show up as entities in the [explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer-view-performance-across-apps-services-hosts), decorated with config information.
 

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Enable Lambda monitoring step 1: Link your AWS and New Relic accounts"
-metaDescription: Linking your AWS account with New Relic for Lambda Monitoring
+title: "Step 1: Link your AWS and New Relic accounts"
+metaDescription: Step 1 of enabling New Relic AWS Lambda Monitoring.
 redirects:
   - /docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-serverless-monitoring-using-lambda-layer
 ---
@@ -50,7 +50,7 @@ To enable serverless monitoring using our Lambda layer, you need the following:
 * [Python](https://www.python.org/downloads/) version 3.3 or higher installed.
 * [newrelic-lambda CLI](https://github.com/newrelic/newrelic-lambda-cli#installation),
   which you can install by running `pip3 install newrelic-lambda-cli`.
-* A New Relic account. You must be an admin, or have the **Infrastructure manager** [add-on role](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model#add-on).
+* A New Relic account. You must have an admin role or have the **Infrastructure manager** [add-on role](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model#add-on).
 * A [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#personal-api-key).
 * An AWS account with permissions for creating IAM resources, managed secrets, and Lambdas. You also need permissions for creating CloudFormation stacks and S3 buckets.
 
@@ -149,17 +149,16 @@ com/secrets-manager/) for greater security.
     the [linking process](docs/integrations/amazon-integrations/get-started/connect-aws-new-relic-infrastructure-monitoring)
     manually. Be sure to enable Lambda when selecting services to be monitored.
 
-    Don't forget to configure the License Key Secret manually, as described next.
+    Don't forget to configure the license key secret manually, as described next.
 
-    ### Manually Configuring the License Key Secret
+    ### Manually configure the license key secret
 
     In addition to linking your accounts, you'll need to configure the license key secret.
 
     1. Download this CloudFormation Template: [license-key-secret.yaml](https://github.com/newrelic/newrelic-lambda-cli/blob/master/newrelic_lambda_cli/templates/license-key-secret.yaml)
     2. Using the AWS CLI, or the AWS CloudFormation Console, install the template, supplying the `LicenseKey` parameter.
-    You can find your New Relic License Key [here](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher). It
-    will be labeled "INGEST - LICENSE". Be sure to use the license key for the account you configured with the
-    Infrastructure UI above.
+    You can find your New Relic license key [here](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher). It
+    will be labeled "INGEST - LICENSE". Be sure to use the license key for the account you configured with the Infrastructure UI above.
 
     AWS CLI example:
 
@@ -178,7 +177,7 @@ com/secrets-manager/) for greater security.
 
 ## Troubleshooting [#troubleshooting]
 
-### Cannot Use AWS secrets manager [#cannot-use-secrets]
+### Cannot use AWS secrets manager [#cannot-use-secrets]
 
 If your organization does not allow the use of AWS Secrets Manager, the New Relic Lambda Extension will accept a `NEW_RELIC_LICENSE_KEY` environment variable. Add the `--disable-license-key-secret` flag from the `newrelic-lambda integrations install` command. Then set this environment variable to your [New Relic license key](/docs/accounts/accounts-billing/account-setup/new-relic-license-key) in your Lambda function configuration.
 

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/configure-serverless-monitoring-aws-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/configure-serverless-monitoring-aws-lambda.mdx
@@ -1,17 +1,13 @@
 ---
-title: Configure serverless monitoring for AWS Lambda
-tags:
-  - Serverless function monitoring
-  - AWS Lambda monitoring
-  - Enable Lambda monitoring
-metaDescription: Read about how to set up alerts and custom events when using our Serverless monitoring for AWS Lambda.
+title: "Enable Lambda monitoring: Next steps"
+metaDescription: After enabling New Relic's AWS Lambda monitoring, you can set up alerts and custom events.
 redirects:
   - /docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/configure-new-relic-serverless-aws-lambda
   - /docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/configure-monitoring-aws-lambda-new-relic-serverless
   - /docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/configure-serverless-monitoring-aws-lambda
 ---
 
-After you set up serverless monitoring for AWS Lambda, you can add additional configuration to fine-tune your data.
+After you [enable serverless monitoring for AWS Lambda](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring), you can add additional configuration to fine-tune your data.
 
 ## Set up alerts [#alerts]
 

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/configure-serverless-monitoring-aws-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/configure-serverless-monitoring-aws-lambda.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Enable Lambda monitoring: Next steps"
+title: "Step 5: Additional configuration"
 metaDescription: After enabling New Relic's AWS Lambda monitoring, you can set up alerts and custom events.
 redirects:
   - /docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/configure-new-relic-serverless-aws-lambda

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring.mdx
@@ -1,10 +1,6 @@
 ---
 title: Enable monitoring for AWS Lambda
-tags:
-  - Serverless function monitoring
-  - AWS Lambda monitoring
-  - Enable Lambda monitoring
-metaDescription: Read about how to enable Serverless monitoring for AWS Lambda.
+metaDescription: Get started enabling New Relic's serverless monitoring for AWS Lambda.
 ---
 
 There are several steps to enabling Lambda monitoring:

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring.mdx
@@ -5,13 +5,8 @@ metaDescription: Get started enabling New Relic's serverless monitoring for AWS 
 
 There are several steps to enabling Lambda monitoring:
 
-1. [Link your AWS Account](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking)
-   1. Link your AWS Account with your New Relic account. This allows New Relic to gather metadata about
-      your Lambda functions (and, optionally, other AWS Resources), to link with your telemetry. This happens once.
-   2. Add your New Relic License Key to AWS Secrets Manager, so that your functions can send telemetry to New Relic.
-      Secrets Manager secrets are scoped to the local region, so this must be done once in every AWS account region
-      you monitor.
-2. [(Optional) Configure CloudWatch Log collection](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/aws-lambda-sending-cloudwatch-logs) (The `newrelic-lambda` CLI will automatically install the CloudWatch logs collector by default)
-3. [Instrument a function](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-example)
-4. [Instrument other functions](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own)
-5. [(Optional) Add distributed tracing instrumentation](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy)
+1. [Link your AWS account.](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking)
+2. [Optional: configure CloudWatch Log collection](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/aws-lambda-sending-cloudwatch-logs): if in Step 1, you used the `newrelic-lambda` CLI, that automatically installs the CloudWatch logs collector by default and you can skip this step. 
+3. [Instrument an example function.](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-example)
+4. [Instrument your functions.](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own)
+5. [Optional: Set up alerts and custom events.](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/configure-serverless-monitoring-aws-lambda)

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
@@ -1,12 +1,6 @@
 ---
 title: Legacy manual instrumentation
-tags:
-  - Serverless function monitoring
-  - AWS Lambda monitoring
-  - Enable Lambda monitoring
-translate:
-  - jp
-metaDescription: Read about how to install and enable New Relic monitoring for Amazon AWS Lambda.
+metaDescription: Legacy instructions for manually enabling New Relic monitoring for Amazon AWS Lambda.
 redirects:
   - /docs/install-enable-new-relics-monitoring-aws-lambda
   - /docs/net-core-new-relic-monitoring-aws-lambda

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
@@ -1,5 +1,5 @@
 ---
-title: Legacy manual instrumentation
+title: Legacy manual instrumentation for Lambda monitoring
 metaDescription: Legacy instructions for manually enabling New Relic monitoring for Amazon AWS Lambda.
 redirects:
   - /docs/install-enable-new-relics-monitoring-aws-lambda

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-example.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-example.mdx
@@ -1,10 +1,5 @@
 ---
-title: Instrument a Lambda function
-tags:
-  - Serverless function monitoring
-  - AWS Lambda monitoring
-  - Enable Lambda monitoring
-  - Instrumentation
+title: "Enable Lambda monitoring step 2: Instrument a Lambda function"
 metaDescription: Instrumenting your first Lambda function
 ---
 

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-example.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-example.mdx
@@ -1,13 +1,16 @@
 ---
-title: "Enable Lambda monitoring step 2: Instrument a Lambda function"
-metaDescription: Instrumenting your first Lambda function
+title: "Step 3: Instrument a Lambda function"
+metaDescription: Step 3 of enabling New Relic's AWS Lambda monitoring. 
 ---
+
+This is one step of [enabling New Relic's AWS Lambda monitoring](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring). 
 
 New Relic provides working minimal examples as a starting point for instrumenting your own serverless functions, so that you can become familiar with the necessary elements, test the account link, and use them as a reference for your own instrumentation.
 
 While there are many ways to manage and deploy Lambda functions, AWS CloudFormation is the mechanism we use for our examples. It requires minimal tooling, has first-party support, and underpins many of the third party deployment options as well.
 
 ## Example features [#features]
+
 Each of our basic examples is functionally identical, and illustrates the following New Relic features:
 
 - Sending invocation telemetry to New Relic, via the New Relic Lambda Extension
@@ -34,24 +37,14 @@ New Relic can instrument:
 - [.NET](https://github.com/newrelic/newrelic-lambda-extension/tree/main/examples/sam/dotnet)
 
 <Callout variant="tip">
-  As you test the examples, you may notice that telemetry isn't always sent right away. The AWS Lambda lifecycle places
-  certain constraints on the execution of our agent and Lambda Extension. In addition, valuable platform telemetry
-  is only available after an invocation has completed. The New Relic Extension balances overall performance against
-  the need for timely telemetry delivery by buffering telemetry for a period of time, and delivering it to New Relic in
-  batches, during a subsequent invocation (or during shutdown).
+  As you test the examples, you may notice that telemetry isn't always sent right away. The AWS Lambda lifecycle places certain constraints on the execution of our agent and Lambda Extension. In addition, valuable platform telemetry is only available after an invocation has completed. The New Relic Extension balances overall performance against the need for timely telemetry delivery by buffering telemetry for a period of time, and delivering it to New Relic in batches, during a subsequent invocation (or during shutdown).
 
-  In a production function, we find this works very well. When manually testing, it's often necessary to wait seven
-  seconds, and then invoke a function again to give it an opportunity to deliver previously buffered telemetry.
+  In a production function, we find this works very well. When manually testing, it's often necessary to wait seven seconds, and then invoke a function again to give it an opportunity to deliver previously buffered telemetry.
 </Callout>
 
-While we make an effort to keep the templates in our examples up to date, you can always find the latest New Relic
-Lambda layer for your region and runtime at our [layers site](https://layers.newrelic-external.com/). This site also
-offers an API, which you're welcome to use in your CI/CD pipeline to keep your own templates up to date.
+While we make an effort to keep the templates in our examples up to date, you can always find the latest New Relic Lambda layer for your region and runtime at our [layers site](https://layers.newrelic-external.com/). This site also offers an API, which you're welcome to use in your CI/CD pipeline to keep your own templates up to date.
 
 ## Distributed tracing [#dt]
 
-In addition to our basic examples, we offer an example of how to integrate Distributed Tracing into a non-trivial
-serverless application in our
-[Distributed Tracing example](https://github.com/newrelic/newrelic-lambda-extension/tree/main/examples/sam/distributedtracing).
-It illustrates manual trace propagation for SQS and SNS, two of the more popular services that might invoke Lambda
-functions, with Node, Python and Java functions.
+In addition to our basic examples, we offer an example of how to integrate distributed tracing into a non-trivial serverless application in our
+[distributed tracing example](https://github.com/newrelic/newrelic-lambda-extension/tree/main/examples/sam/distributedtracing). It illustrates manual trace propagation for SQS and SNS, two of the more popular services that might invoke Lambda functions, with Node, Python and Java functions.

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own.mdx
@@ -1,23 +1,17 @@
 ---
-title: Instrument your own functions
-tags:
-  - Serverless function monitoring
-  - AWS Lambda monitoring
-  - Enable Lambda monitoring
-  - Instrumentation
+title: "Enable Lambda monitoring step 3: Instrument your own functions"
 metaDescription: Instrumenting your own Lambda functions
 ---
 
+This is one step of [enabling New Relic's AWS Lambda monitoring](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring). 
+
 <Callout variant="important">
-  Because there are several steps to integration, it's important that you test your account link by deploying and
-  testing [an example](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-example/) function before instrumenting your own code.
+  Because there are several steps to integration, it's important that you test your account link by deploying and testing [an example](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-example/) function before instrumenting your own code.
 </Callout>
 
 ## Deployment strategies [#strats]
 
-There are many different deployment strategies for Lambda functions. New Relic offers direct support for several,
-but we cannot cover every option. At its core, New Relic Lambda instrumentation relies on the Lambda service itself,
-rather than any particular deployment strategy or tool, so we're confident that it can be made to work in your use case.
+There are many different deployment strategies for Lambda functions. New Relic offers direct support for several, but we cannot cover every option. At its core, New Relic Lambda instrumentation relies on the Lambda service itself, rather than any particular deployment strategy or tool, so we're confident that it can be made to work in your use case.
 
 ### `newrelic-lambda` CLI quickstart [#quickstarts]
 
@@ -26,16 +20,13 @@ New Relic.
 
 To install or upgrade the New Relic instrumentation layer, run:
 
-  ```
-  newrelic-lambda layers install --nr-account-id <var><a href="/docs/accounts/accounts-billing/account-setup/account-id">YOUR_NR_ACCOUNT_ID</a></var> --function my-function --upgrade
-  ```
+```
+newrelic-lambda layers install --nr-account-id <var><a href="/docs/accounts/accounts-billing/account-setup/account-id">YOUR_NR_ACCOUNT_ID</a></var> --function my-function --upgrade
+```
 
 This command automatically finds the newest available layer for your Lambda's region and runtime.
 
-This is a great way to quick-start instrumentation, and this tool can easily be integrated into your existing CI/CD
-processes. However, since it modifies existing Lambda function resources, when you deploy a code update to your
-function, you may inadvertently remove the New Relic instrumentation. Be sure to re-run the command above after every
-update, or (even better) integrate the layer and associated configuration with your existing deployment process.
+This is a great way to quick-start instrumentation, and this tool can easily be integrated into your existing CI/CD processes. However, since it modifies existing Lambda function resources, when you deploy a code update to your function, you may inadvertently remove the New Relic instrumentation. Be sure to re-run the command above after every update, or (even better) integrate the layer and associated configuration with your existing deployment process.
 
 Note that the CLI can operate on many functions in a batch: use `--function all`, `--function installed`, or
 `--function not-installed` to operate on all functions in a region, or only those with or without existing
@@ -43,9 +34,7 @@ New Relic instrumentation.
 
 ### Continuous deployment [#cont]
 
-In the long term, it's usually less work to integrate New Relic into your existing continuous deployment
-process. Instead of running the CLI after updating your function, you can integrate New Relic into your continuous
-deployment framework.
+In the long term, it's usually less work to integrate New Relic into your existing continuous deployment process. Instead of running the CLI after updating your function, you can integrate New Relic into your continuous deployment framework.
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Enable Lambda monitoring step 3: Instrument your own functions"
-metaDescription: Instrumenting your own Lambda functions
+title: "Step 4: Instrument your own Lambda functions"
+metaDescription: Step 4 of enabling New Relic AWS Lambda monitoring.
 ---
 
 This is one step of [enabling New Relic's AWS Lambda monitoring](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring). 

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/set-up-cloudwatch-logs.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/set-up-cloudwatch-logs.mdx
@@ -1,0 +1,6 @@
+---
+title: "Step 2 (optional): Set up AWS CloudWatch log collection"
+metaDescription: An optional step of setting up CloudWatch logs when enabling New Relic's AWS Lambda monitoring.
+---
+
+This is an optional step in [enabling New Relic's AWS Lambda monitoring](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring). In [Step 1](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking), if you used the `newrelic-lambda` CLI, that automatically installs an AWS CloudWatch logs collector by default. If you didn't use that in Step 1, you can [configure CloudWatch logs yourself](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/aws-lambda-sending-cloudwatch-logs).

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/update-serverless-monitoring-aws-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/update-serverless-monitoring-aws-lambda.mdx
@@ -1,9 +1,5 @@
 ---
 title: Update serverless monitoring for AWS Lambda
-tags:
-  - Serverless function monitoring
-  - AWS Lambda monitoring
-  - Enable Lambda monitoring
 metaDescription: How to update our Serverless monitoring for AWS Lambda.
 redirects:
   - /docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/update-lambda-monitoring

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/update-serverless-monitoring-aws-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/update-serverless-monitoring-aws-lambda.mdx
@@ -1,6 +1,6 @@
 ---
-title: Update serverless monitoring for AWS Lambda
-metaDescription: How to update our Serverless monitoring for AWS Lambda.
+title: Update Lambda monitoring
+metaDescription: How to update New Relic's AWS Lambda monitoring.
 redirects:
   - /docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/update-lambda-monitoring
   - /docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/update-serverless-monitoring-aws-lambda

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -2569,9 +2569,9 @@ pages:
     path: /docs/serverless-function-monitoring
     pages:
       - title: AWS Lambda monitoring
-        ath: /docs/serverless-function-monitoring/aws-lambda-monitoring
+        path: /docs/serverless-function-monitoring/aws-lambda-monitoring
         pages:
-          - title: Intro to Lambda monitoring
+          - title: Get started with Lambda
             path: /docs/serverless-function-monitoring/aws-lambda-monitoring/get-started
             pages:
               - title: Intro to Lambda monitoring
@@ -2583,13 +2583,15 @@ pages:
           - title: Enable Lambda monitoring
             path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring
             pages:
-              - title: 1. Account linking
+              - title: Intro to enabling Lambda monitoring
+                path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring
+              - title: Step 1. Account linking
                 path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking
-              - title: 2. Instrumentation examples
+              - title: Step 2. Instrumentation examples
                 path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-example
-              - title: 3. Instrument your functions
+              - title: Step 3. Instrument your functions
                 path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own
-              - title: 4. Next steps
+              - title: Step 4. Next steps
                 path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/configure-serverless-monitoring-aws-lambda
               - title: Legacy manual instrumentation
                 path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -2585,13 +2585,15 @@ pages:
             pages:
               - title: Intro to enabling Lambda monitoring
                 path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring
-              - title: Step 1. Account linking
+              - title: "Step 1: Link accounts"
                 path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking
-              - title: Step 2. Instrumentation examples
+              - title: "Step 2 (optional): Configure Cloudwatch"
+                path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/set-up-cloudwatch-logs
+              - title: "Step 3: Review example functions"
                 path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-example
-              - title: Step 3. Instrument your functions
+              - title: "Step 4: Instrument your functions"
                 path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own
-              - title: Step 4. Next steps
+              - title: "Step 5: Additional configuration"
                 path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/configure-serverless-monitoring-aws-lambda
               - title: Legacy manual instrumentation
                 path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy


### PR DESCRIPTION
Loosely related to DOC-7184, where I'm investigating our 'nav and sidebar' tech writer how-to content. I fixed the Lambda category; was pretty messy, with typo of 'path' in nav file, a landing page `index` file that should have been a doc, clarifying doc titles and improving intros, and a few more things. Should work okay now. 

For review, just click around that Lambda category and make sure it seems okay structurally. 