### PR TITLE
Update spm-installation.mdx

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/spm-installation.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/spm-installation.mdx
@@ -44,8 +44,14 @@ Continue with the steps to configure New Relic for mobile monitoring.
 
 5. Add a build script to your target's **Build Phases**. Ensure the new build script is the very last build script. Then paste the following, replacing `APP_TOKEN` with your [application token](/docs/mobile-apps/viewing-your-application-token):
 
-   ```
+   ```   
    SCRIPT=`/usr/bin/find "${SRCROOT}" -name newrelic_postbuild.sh | head -n 1`
+
+   if [ -z "${SCRIPT}"]; then
+   ARTIFACT_DIR="${BUILD_DIR%Build/*}SourcePackages/artifacts"
+    SCRIPT=`/usr/bin/find "${ARTIFACT_DIR}" -name newrelic_postbuild.sh | head -n 1`
+   fi
+
    /bin/sh "${SCRIPT}" "<var>APP_TOKEN</var>"
    ```
 6. Clean and build your app, then run it in the simulator or other device.


### PR DESCRIPTION
Updated post-build script to support Swift Package Manager release. When using SPM, frameworks are located in a different place than they were when using Cocoapods or manual installation. The script snippet now looks in that original place first. If it does not find the Python script it is looking for, it then checks the location where SPM would have the framework, before declaring an error. 