### PR TITLE
Fixing some table-of-contents views

### DIFF
--- a/src/content/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations.mdx
+++ b/src/content/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations.mdx
@@ -85,7 +85,7 @@ Cloud integrations collect data from cloud services and accounts. There's no ins
 
 ### On-host integrations
 
-On-host integrations are what we call integrations that you can run directly on your host or server. They typically connect to core services in your servers:
+On-host integrations are infrastructure monitoring integrations that can be run directly on your host or server: 
 
 <table>
   <thead>
@@ -117,7 +117,7 @@ On-host integrations are what we call integrations that you can run directly on 
       </td>
 
       <td>
-        Monitor and report data from many popular services, including Kubernetes, Redis, Apache, RabbitMQ, and many more.
+        Monitor and report data from many popular services, including NGINX, MySQL, Redis, Apache, RabbitMQ, and many more.
       </td>
     </tr>
 
@@ -140,7 +140,6 @@ To enable cloud integrations or install on-host integrations, see:
 * **Cloud integrations**: [AWS procedures](/docs/infrastructure/amazon-integrations/getting-started/connect-aws-services-infrastructure), [Azure procedures](/docs/infrastructure/microsoft-azure-integrations/getting-started/activate-azure-integrations), [Google Cloud Platform procedures](/docs/integrations/google-cloud-platform-integrations/getting-started/connect-google-cloud-platform-services-infrastructure)
 * **Kubernetes**: [Kubernetes procedures](https://docs.newrelic.com/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration)
 * **On-host integrations**: See an [integration's documentation](/docs/integrations/host-integrations) for install procedures
-* **SDK integrations**: [Procedures to create a custom integration](https://docs.newrelic.com/docs/integrations/integrations-sdk/getting-started/introduction-infrastructure-integrations-sdk#create)
 
 ## Features [#whats-next]
 

--- a/src/nav/accounts.yml
+++ b/src/nav/accounts.yml
@@ -21,7 +21,7 @@ pages:
           - title: Intro to account settings
             path: /docs/accounts/accounts-billing/general-account-settings/introduction-account-settings
           - title: Manage data
-            path: /docs/accounts/accounts-billing/general-account-settings/manage-data
+            path: /docs/telemetry-data-platform/manage-data/manage-your-data
           - title: Email settings
             path: /docs/accounts/accounts/account-maintenance/account-email-settings
           - title: Password requirements

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -17,21 +17,21 @@ pages:
         path: /docs/full-stack-observability/monitor-everything/observability-solutions
         pages:
           - title: Application monitoring (APM)
-            path: /docs/full-stack-observability/monitor-everything/observability-solutions/application-monitoring-apm
+            path: /docs/apm/table-of-contents
           - title: Browser monitoring
-            path: /docs/full-stack-observability/monitor-everything/observability-solutions/browser-monitoring
+            path: /docs/browser/table-of-contents
           - title: Distributed tracing
             path: /docs/full-stack-observability/monitor-everything/observability-solutions/distributed-tracing
           - title: Infrastructure monitoring
             path: /docs/full-stack-observability/monitor-everything/observability-solutions/infrastructure-monitoring
           - title: Kubernetes monitoring
-            path: /docs/integrations/kubernetes-integration/get-started/introduction-kubernetes-integration/
+            path: /docs/integrations/kubernetes-integration/get-started/introduction-kubernetes-integration 
           - title: Logs in context
             path: /docs/full-stack-observability/monitor-everything/observability-solutions/logs-context
           - title: Mobile monitoring
             path: /docs/full-stack-observability/monitor-everything/observability-solutions/mobile-monitoring
           - title: Serverless monitoring
-            path: /docs/full-stack-observability/monitor-everything/observability-solutions/serverless-monitoring
+            path: /docs/serverless-function-monitoring
           - title: Synthetic monitoring
             path: /docs/full-stack-observability/monitor-everything/observability-solutions/synthetic-monitoring
           - title: See all integrations
@@ -64,13 +64,13 @@ pages:
       - title: Instrument apps and infrastructure
         pages:
           - title: Language apps (APM)
-            path: /docs/agents
+            path: /docs/agents/table-of-contents
           - title: Hosts and infrastructure
-            path: /docs/full-stack-observability/instrument-everything/instrument-applications-infrastructure/infrastructure-agent
+            path: /docs/infrastructure/table-of-contents
           - title: Browser monitoring
-            path: /docs/browser
+            path: /docs/browser/table-of-contents 
           - title: Mobile apps
-            path: /docs/mobile
+            path: /docs/mobile/table-of-contents
           - title: See all integrations
             path: https://newrelic.com/integrations
       - title: Develop your own integrations

--- a/src/nav/integrations.yml
+++ b/src/nav/integrations.yml
@@ -598,6 +598,8 @@ pages:
             path: /docs/integrations/host-integrations/host-integrations-list/monitor-services-running-kubernetes
           - title: Monitor services on ECS
             path: /docs/integrations/host-integrations/host-integrations-list/monitor-services-running-amazon-ecs
+          - title: Build a custom integration
+            path: /docs/integrations/host-integrations/host-integrations-list/flex-integration-tool-build-your-own-integration
           - title: Apache integration
             path: /docs/integrations/host-integrations/host-integrations-list/apache-monitoring-integration
           - title: Cassandra integration


### PR DESCRIPTION
We had an issue where, if a category URL (like /docs/browser) associated with an index mdx file (landing page) was being used in multiple places in the same nav file (as this one was in FSO category), the 'See all docs' on the landing page would get confused and load the wrong category (e.g., use a different part of the nav file where that URL was located). 

I am going to file a deven request, after talking to @roadlittledawn, about being able to set/override the primary/main category of nav to use for one-off cases like this, but in mean time I did a fix that got rid of the duplicated URLs in the nav file and replaced them with table of contents URLs (e.g., /docs/browser/table-of-contents). 