### PR TITLE
LIC for C SDK

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/configure-logs-context/c-sdk-configure-logs-context.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/configure-logs-context/c-sdk-configure-logs-context.mdx
@@ -4,9 +4,9 @@ tags:
   - Logs
   - Enable log management in New Relic
   - Configure logs in context
-metaDescription: How to link log data for apps monitored by the C SDK with related data across the rest of the New Relic platform.
+metaDescription: For apps monitored by the C SDK, learn how to link log data with related data across the rest of the New Relic platform.
 ---
 
-Logs in context is not available for apps monitored by the C SDK. Instead, you can build your own logging extension library by using the [Log API](/docs/logs/log-management/log-api/introduction-log-api/). Make sure your app uses [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing/), so you can quickly understand what happens to requests as they travel through upstream and downstream services.
+Logs in context is not available for apps monitored by the C SDK. Instead, you can build your own logging extension library by using the [Log API](/docs/logs/log-management/log-api/introduction-log-api/). Make sure your app has distributed tracing enabled, so you can quickly understand what happens to requests as they travel through upstream and downstream services.
 
-To [enable distributed tracing](/docs/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing/#update-agents) for apps monitored by the C SDK, [install](/docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code/) or [update](/docs/agents/c-sdk/install-configure/update-your-c-sdk-library/) to the latest C SDK version. Use [C SDK version 1.1.0 or higher](/docs/release-notes/agent-release-notes/c-sdk-release-notes/) for distributed tracing.
+To enable distributed tracing for apps monitored by the C SDK, [install](/docs/distributed-tracing/enable-configure/quick-start/) or [update](/docs/agents/c-sdk/install-configure/update-your-c-sdk-library/) to the latest C SDK version. Distributed tracing requires [C SDK version 1.1.0 or higher](/docs/release-notes/agent-release-notes/c-sdk-release-notes/).

--- a/src/content/docs/logs/enable-log-management-new-relic/configure-logs-context/c-sdk-configure-logs-context.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/configure-logs-context/c-sdk-configure-logs-context.mdx
@@ -1,0 +1,12 @@
+---
+title: 'C SDK: Configure logs in context'
+tags:
+  - Logs
+  - Enable log management in New Relic
+  - Configure logs in context
+metaDescription: How to link log data for apps monitored by the C SDK with related data across the rest of the New Relic platform.
+---
+
+Logs in context is not available for apps monitored by the C SDK. Instead, you can build your own logging extension library by using the [Log API](/docs/logs/log-management/log-api/introduction-log-api/). Make sure your app uses [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing/), so you can quickly understand what happens to requests as they travel through upstream and downstream services.
+
+To [enable distributed tracing](/docs/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing/#update-agents) for apps monitored by the C SDK, [install](/docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code/) or [update](/docs/agents/c-sdk/install-configure/update-your-c-sdk-library/) to the latest C SDK version. Use [C SDK version 1.1.0 or higher](/docs/release-notes/agent-release-notes/c-sdk-release-notes/) for distributed tracing.

--- a/src/content/docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-apm-agents.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-apm-agents.mdx
@@ -41,8 +41,8 @@ Don't spend extra time trying to narrow down all your logs from different parts 
 
 The process to enable logs in context is basically the same, regardless of which APM agent you use to monitor your application:
 
-1. Update to a supported APM agent version for your app, and enable [distributed tracing](/docs/understand-dependencies/distributed-tracing/enable-configure/enable-distributed-tracing/).
-2. Configure a [supported log forwarder](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/enable-log-management-new-relic/) to collect your application logs and extend the metadata that is forwarded to New Relic.
+1. Make sure you have already [set up logging in New Relic](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/enable-log-management-new-relic/). This includes configuring a supported log forwarder that collects your application logs and extends the metadata that is forwarded to New Relic.
+2. Update to a supported APM agent version for your app, and enable [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing/).
 3. Configure logs in context for your APM agent or for your infrastructure monitoring agent.
 4. View your logs within the context of your apps or infrastructure in [New Relic One](/docs/logs/log-management/ui-data/use-logs-ui/#links).
 

--- a/src/content/docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-apm-agents.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-apm-agents.mdx
@@ -21,18 +21,11 @@ redirects:
   - /docs/logs/log-monitoring/enable-logs/configure-logs-context-apm-agents
 ---
 
-Logs in context makes it easy to link to your log data with related data across the rest of the New Relic platform. For example, you can easily correlate log messages to a related error trace or distributed trace in [APM](/docs/apm/applications-menu/monitoring/apm-overview-page-view-transaction-apdex-usage-data). This is accomplished by appending trace IDs to the corresponding application logs, automatically filtering to those logs from the [errors](/docs/apm/applications-menu/error-analytics/error-analytics-explore-events-behind-errors) or [distributed trace](/docs/apm/distributed-tracing/ui-data/understand-use-distributed-tracing-data) UIs.
+When you need to correlate log data with other telemetry data, enable logs in context in New Relic. Logs in context adds metadata that links your logs with related APM data, like [errors](/docs/apm/apm-ui-pages/error-analytics/errors-page-find-fix-verify-problems/) or [distributed traces](/docs/apm/distributed-tracing/ui-data/understand-use-distributed-tracing-data), or your platform performance data from infrastructure monitoring in New Relic One.
 
-## Why it matters
+## See the root cause of issues across your platform [#compatibility-requirements]
 
-Bringing all of this data together in a single tool allows you to quickly get to the root cause of an issue and find the log lines that you need to identify and resolve a problem.
-
-New Relic’s logs in context feature gives you the ability to see logs associated with various objects in the New Relic UI:
-
-* Applications
-* APM errors
-* APM traces and spans
-* Kubernetes containers
+By bringing all of your application and infrastructure data together in a single solution, you can get to the root cause of issues faster. Logs in context help you quickly see meaningful patterns and trends.
 
 The following diagram shows the lifecycle of a log message, from enrichment with agent metadata (contextual logging), to formatting and forwarding the log data to New Relic:
 
@@ -42,133 +35,45 @@ The following diagram shows the lifecycle of a log message, from enrichment with
   This diagram illustrates the flow of log messages through New Relic.
 </figcaption>
 
-## Compatibility and requirements [#compatibility-requirements]
+Don't spend extra time trying to narrow down all your logs from different parts of your platform. Instead, enable logs in context to see the exact log lines you need to identify and resolve a problem.
 
-To configure APM logs in context for New Relic, ensure your configuration meets the following requirements:
+## Basic process to enable logs in context [#enable-logs]
 
-* [New Relic logs management](/docs/introduction-new-relic-logs) enabled, with a compatible [log forwarding plugin](/docs/logs/enable-logs/enable-logs/enable-new-relic-logs#enable-logs) installed.
-* Ability to update to a supported version of the APM agent, and ability to [enable distributed tracing](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/enable-configure/enable-distributed-tracing) for your agent:
-  * C SDK: n/a
-  * [Go agent](/docs/agents/go-agent/get-started/go-agent-compatibility-requirements) version 2.12 or higher
-  * [Java agent](/docs/agents/java-agent/getting-started/introduction-new-relic-java) version 5.6 or higher
-  * [.NET agent](/docs/agents/net-agent/getting-started/introduction-new-relic-net) version 8.21 or higher
-  * [Node.js agent](/docs/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs) version 6.2.0 or higher
-  * [PHP agent](/docs/agents/php-agent/getting-started/introduction-new-relic-php) version 9.3.0 or higher
-  * [Python agent](/docs/agents/python-agent/getting-started/introduction-new-relic-python) version 5.4.0 or higher
-  * [Ruby agent](/docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby) version 6.7.0 or higher
+The process to enable logs in context is basically the same, regardless of which APM agent you use to monitor your application:
 
-## Configure APM logs in context for New Relic [#enable-logs]
+1. Update to a supported APM agent version for your app, and enable [distributed tracing](/docs/understand-dependencies/distributed-tracing/enable-configure/enable-distributed-tracing/).
+2. Configure a [supported log forwarder](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/enable-log-management-new-relic/) to collect your application logs and extend the metadata that is forwarded to New Relic.
+3. Configure logs in context for your APM agent or for your infrastructure monitoring agent.
+4. View your logs within the context of your apps or infrastructure in [New Relic One](/docs/logs/log-management/ui-data/use-logs-ui/#links).
 
-Choose your APM agent to see specific instructions on how to configure APM logs in context for your agent language:
+The main differences in this procedure are which log appenders you can use to extend and enrich your log data, and how to configure the log appender you select for your APM agent.
 
-<table>
-  <thead>
-    <tr>
-      <th style={{ width: "200px" }}>
-        Agent
-      </th>
+For detailed information, see the logs-in-context procedures for:
 
-      <th>
-        Supported logging framework
-      </th>
-    </tr>
-  </thead>
+* [C SDK](/docs/logs/enable-log-management-new-relic/configure-logs-context/c-sdk-configure-logs-context)
+* Go
+* Java
+* .NET
+* Node.js
+* PHP
+* Python
+* Ruby
+* [Infrastructure monitoring agent](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent/)
 
-  <tbody>
-    <tr>
-      <td>
-        C SDK
-      </td>
+## API and other options [#API]
 
-      <td>
-        * n/a
-      </td>
-    </tr>
+If our logging solutions don't meet your needs, you can use other options to send your log data to New Relic:
 
-    <tr>
-      <td>
-        [Go agent](/docs/enable-logs-context-go)
-      </td>
-
-      <td>
-        * logrus 1.4 or higher
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [Java agent](/docs/enable-logs-context-java)
-      </td>
-
-      <td>
-        * Dropwizard 1.3 or higher
-        * Log4j 1.x
-        * Log4j 2.x
-        * Logback
-        * java.util.logging
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [.NET agent](/docs/logs/new-relic-logs/enable-logs-context/enable-logs-context-net)
-      </td>
-
-      <td>
-        * log4net
-        * NLog
-        * Serilog
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [Node.js agent](/docs/logs/new-relic-logs/enable-logs-context/enable-logs-context-nodejs)
-      </td>
-
-      <td>
-        * Winston
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [PHP agent](/docs/logs/enable-logs/logs-context-php/configure-logs-context-php)
-      </td>
-
-      <td>
-        * Monolog
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [Python agent](/docs/logs/new-relic-logs/enable-logs-context/enable-logs-context-python)
-      </td>
-
-      <td>
-        * Python `logging`
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [Ruby agent](/docs/logs/new-relic-logs/enable-logs-context/enable-logs-context-ruby)
-      </td>
-
-      <td>
-        * Ruby `logger`
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-For information on creating your own logging extension, see [logs in context API calls](/docs/logs/new-relic-logs/apm-integration/apm-agent-apis-manual-logs-context-instrumentation).
+* Logging extensions via [agent API calls](/docs/logs/new-relic-logs/apm-integration/apm-agent-apis-manual-logs-context-instrumentation)
+* HTTP endpoint via our [Log API](/docs/logs/log-management/log-api/introduction-log-api/)
+* Syslog protocols via [TCP endpoint](/docs/logs/log-management/log-api/use-tcp-endpoint-forward-logs-new-relic/) (useful for CDNs, hardware devices, or managed services)
 
 ## What's next? [#what-next]
 
-Now that you've set up APM logs in context, here are some potential next steps:
+After you set up APM logs in context, make the most of your logging data:
 
-* Explore your data using the [Logs UI](/docs/explore-your-data-new-relic-logs-ui).
-* Troubleshoot errors with [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing), stack traces, application logs, and more.
-* [Query your data](/docs/using-new-relic/data/understand-data/query-new-relic-data) and [create custom dashboards](/docs/dashboards/new-relic-one-dashboards/get-started/introduction-new-relic-one-dashboards) or [alerts](/docs/alerts/new-relic-alerts/configuring-alert-policies/create-edit-or-find-alert-policy).
+* Explore the logging data across your platform with our [Logs UI](/docs/logs/log-management/ui-data/use-logs-ui/).
+* See your logs in context of your app's performance in the [APM UI](/docs/logs/log-management/ui-data/use-logs-ui/#links). Troubleshoot [errors](/docs/apm/apm-ui-pages/error-analytics/errors-page-find-fix-verify-problems/) with [distributed tracing](/docs/apm/distributed-tracing/ui-data/understand-use-distributed-tracing-data), stack traces, application logs, and more.
+* Get deeper visibility into both your application and your platform performance data by forwarding your logs with our [infrastructure monitoring agent](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent/). Review your [infrastructure logs](/docs/logs/log-management/ui-data/use-logs-ui/#links) in the UI.
+* Set up [alerts](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions/).
+* [Query your data](/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data/) and [create dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/).

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -2197,6 +2197,8 @@ pages:
             pages:
               - title: Configure logs in context
                 path: /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-apm-agents
+              - title: C SDK configure logs in context
+                path: /docs/logs/enable-log-management-new-relic/configure-logs-context/c-sdk-configure-logs-context
           - title: Logs in context for Java
             path: /docs/logs/enable-log-management-new-relic/logs-context-java
             pages:

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -2193,10 +2193,8 @@ pages:
               - title: Stream logs from Heroku
                 path: /docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/heroku-log-forwarding
           - title: Configure logs in context
-            path: /docs/logs/enable-log-management-new-relic/configure-logs-context
+            path: /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-apm-agents
             pages:
-              - title: Configure logs in context
-                path: /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-apm-agents
               - title: C SDK configure logs in context
                 path: /docs/logs/enable-log-management-new-relic/configure-logs-context/c-sdk-configure-logs-context
           - title: Logs in context for Java


### PR DESCRIPTION
C SDK was never documented for logs in context. This adds a new doc in the streamlined LiC taxonomy, which will also include the other APM agents.