### PR TITLE
Add Python agent release notes v6.8.1.164

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-6081164.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-6081164.mdx
@@ -5,31 +5,26 @@ version: 6.8.1.164
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 ---
 
-
 ## Notes
 
-This release of the Python agent updates the log file location in the default newrelic.ini file and includes multiple bug fixes.
+This release of the Python agent updates the log file location in the default `newrelic.ini` file, and includes multiple bug fixes.
 
-The agent can be installed using easy_install/pip/distribute via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or can be downloaded directly from the New Relic [download site](http://download.newrelic.com/python_agent/release).
-
-
+The agent can be installed using easy_install/pip/distribute via the [Python Package Index](https://pypi.python.org/pypi/newrelic), or it can be downloaded directly from the New Relic [download site](http://download.newrelic.com/python_agent/release).
 
 ## Improved Features
 
-* **Updated log_file location in default newrelic.ini**
+* **Updated log_file location in default `newrelic.ini`**
 
-  The newrelic.ini generated using newrelic-admin generate-config has been updated to set the default log_file location to stdout for improved initial visibility. This setting can still be customized to log to stderr or a user-specified file as well.
-
-
+  The `newrelic.ini` generated using `newrelic-admin generate-config` has been updated to set the default `log_file` location to `stdout` for improved initial visibility. This setting can still be customized to log to `stderr` or a user-specified file as well.
 
 ## Bug Fixes
 
-* **Handling of CherryPy HTTPRedirects**
+* **Handling of `cherryPy.HTTPRedirects`**
 
-  cherrypy.HttpRedirects were incorrectly being reported as errors. This has now been corrected thanks to contribution from [@bdeeney](https://github.com/bdeeney)!
+  `cherrypy.HttpRedirects` were incorrectly being reported as errors. This has now been corrected thanks to a contribution from [@bdeeney](https://github.com/bdeeney)!
 
-* **Invalid escape sequence DeprecationWarning**
+* **`DeprecationWarning` invalid escape sequence**
 
-  A deprecation warning concerning unrecognized escape sequences in Python 3.6+ has been fixed. Thank you [@urianchang](https://github.com/urianchang) for your contribution!
+  A deprecation warning concerning unrecognized escape sequences in Python 3.6 (and higher) has been fixed. Thank you [@urianchang](https://github.com/urianchang) for your contribution!
 
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-6081164.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-6081164.mdx
@@ -18,7 +18,7 @@ The agent can be installed using easy_install/pip/distribute via the [Python Pac
 
 * **Updated log_file location in default newrelic.ini**
 
-  The newrelic.ini generated using newrelic-admin generate-config has been updated to set the default log_file location to stdout for improved initial visibility. This setting can still be customized to log to a user-specified fie or stderr as well.
+  The newrelic.ini generated using newrelic-admin generate-config has been updated to set the default log_file location to stdout for improved initial visibility. This setting can still be customized to log to stderr or a user-specified file as well.
 
 
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-6081164.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-6081164.mdx
@@ -1,0 +1,35 @@
+---
+subject: Python agent
+releaseDate: '2021-08-24'
+version: 6.8.1.164
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+---
+
+
+## Notes
+
+This release of the Python agent updates the log file location in the default newrelic.ini file and includes multiple bug fixes.
+
+The agent can be installed using easy_install/pip/distribute via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or can be downloaded directly from the New Relic [download site](http://download.newrelic.com/python_agent/release).
+
+
+
+## Improved Features
+
+* **Updated log_file location in default newrelic.ini**
+
+  The newrelic.ini generated using newrelic-admin generate-config has been updated to set the default log_file location to stdout for improved initial visibility. This setting can still be customized to log to a user-specified fie or stderr as well.
+
+
+
+## Bug Fixes
+
+* **Handling of CherryPy HTTPRedirects**
+
+  cherrypy.HttpRedirects were incorrectly being reported as errors. This has now been corrected thanks to contribution from [@bdeeney](https://github.com/bdeeney)!
+
+* **Invalid escape sequence DeprecationWarning**
+
+  A deprecation warning concerning unrecognized escape sequences in Python 3.6+ has been fixed. Thank you [@urianchang](https://github.com/urianchang) for your contribution!
+
+


### PR DESCRIPTION
### Give us some context

* What problems does this PR solve?
This PR adds release notes for Python Agent v6.8.1.164.