### PR TITLE
Adding to PageViewTiming event in data dictionary

### DIFF
--- a/src/data-dictionary/events/PageViewTiming/PageViewTiming.event-definition.md
+++ b/src/data-dictionary/events/PageViewTiming/PageViewTiming.event-definition.md
@@ -5,4 +5,4 @@ dataSources:
   - Browser agent
 ---
 
-This event represents individual timing events during a page view lifecycle (for example, time when the largest element is displayed, or the first user interaction with the page). See [the PageViewTiming docs](/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics) for a list of the events we report.
+This event represents individual timing events during a page view lifecycle (for example, time when the largest element is displayed, or the first user interaction with the page). See [the PageViewTiming docs](/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics) for a list of reported events.

--- a/src/data-dictionary/events/PageViewTiming/PageViewTiming.event-definition.md
+++ b/src/data-dictionary/events/PageViewTiming/PageViewTiming.event-definition.md
@@ -5,4 +5,4 @@ dataSources:
   - Browser agent
 ---
 
-Sends each data point as a separate event as soon as it is available. Useful for asynchronous or dynamic pages.
+This event represents individual timing events during a page view lifecycle (for example, time when the largest element is displayed, or the first user interaction with the page). See [the PageViewTiming docs](/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics) for a list of the events we report.

--- a/src/data-dictionary/events/PageViewTiming/pageHide.md
+++ b/src/data-dictionary/events/PageViewTiming/pageHide.md
@@ -1,0 +1,8 @@
+---
+name: pageHide
+type: attribute
+events:
+  - PageViewTiming
+---
+
+Sent when the browser hides the current page in the process of loading a different page from the session's history (for example, a browser back button click). 


### PR DESCRIPTION
Based on issue https://github.com/newrelic/docs-website/issues/3062, added pageHide attribute and improved PageViewTiming description. @urbiz-nr you were assigned via random assignment so just a heads up: I couldn't get the new attribute to show up in my local build but I know with data dictionary there are cache issues, but maybe the gatsby preview build will show it. 