### PR TITLE
Update Ruby ∞T requirements

### DIFF
--- a/src/content/docs/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing.mdx
+++ b/src/content/docs/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing.mdx
@@ -890,9 +890,8 @@ Find your language agents below to confirm if you can use your existing agents w
     id="ruby-version"
     title="Ruby"
   >
-    [Install](/docs/agents/ruby-agent/installation/install-new-relic-ruby-agent) or [update](/docs/agents/ruby-agent/installation/update-ruby-agent) to the required Ruby agent version. For best results, update to the [latest Ruby agent version](/docs/release-notes/agent-release-notes/ruby-release-notes).
+    [Install](/docs/agents/ruby-agent/installation/install-new-relic-ruby-agent) or [update](/docs/agents/ruby-agent/installation/update-ruby-agent) to the required Ruby agent and Infinite Tracing gem versions. For best results, update to the [latest Ruby agent version](/docs/release-notes/agent-release-notes/ruby-release-notes) and [Infinite Tracing gem version](https://github.com/newrelic/newrelic-ruby-agent/blob/main/infinite_tracing/CHANGELOG.md).
 
-    Also install the additional Ruby agent gem for Infinite Tracing.
 
     <table>
       <thead>
@@ -926,9 +925,9 @@ Find your language agents below to confirm if you can use your existing agents w
           </td>
 
           <td>
-            [newrelic_rpm](https://rubygems.org/gems/newrelic_rpm) 6.11.0.365 or higher (includes W3C Trace Context)
+            [newrelic_rpm](https://rubygems.org/gems/newrelic_rpm) 7.0.0 or higher (includes W3C Trace Context)
 
-            [newrelic-infinite_tracing](https://rubygems.org/gems/newrelic-infinite_tracing) 6.11.0.375 or higher
+            [newrelic-infinite_tracing](https://rubygems.org/gems/newrelic-infinite_tracing) 7.0.0 or higher
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
Current phrasing caused confusion on whether or not the Ruby agent also requires the separate Infinite Tracing gem to be installed. I attempted to clarify that it is required by tacking on the Infinite Tracing gem in the 'Install or update' step but I may have just created a run-on sentence so re-phrase as needed!

I also bumped the min. required version to v7 so new customers do not encounter this bug:
https://github.com/newrelic/newrelic-ruby-agent/pull/629