### PR TITLE
Fix usernames in auto-assign reviewer action

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -3,7 +3,7 @@ addReviewers: true
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:
-  - bradleyrcamacho
+  - bradleycamacho
   - barbnewrelic
   - paperclypse
   - zuluecho9


### PR DESCRIPTION
I misspelled my own username in the action. This fixes it!