### PR TITLE
Add missing redirect for alerts 

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
@@ -54,6 +54,7 @@ redirects:
   - /docs/apis/rest-api-v2/alert-examples-v2/alerting-rest-api
   - /docs/apis/rest-api-v2/alert-examples-v2/rest-api-calls-new-relic-alerts
   - /docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts/
+  - /docs/alerts-applied-intelligence/new-relic-alerts/rest-api-alerts/rest-api-calls-alerts/
 ---
 
 Our REST API (v2) allows you to configure settings for alerts. The [API Explorer](/docs/apm/apis/api-explorer-v2/getting-started-new-relics-api-explorer) also includes the curl request format, available parameters, potential response status codes, and JSON response structure for each of the available API calls. You can also [create alert conditions in the UI](/docs/alerts/new-relic-alerts/defining-conditions/define-alert-conditions).


### PR DESCRIPTION
This was a hero request to fix a broken 404. Looks like we had a missing redirect.