### PR TITLE
Add browserMonitoring.captureAttributes to disabled config list

### DIFF
--- a/src/content/docs/agents/net-agent/getting-started/8x-to-9x-agent-migration-guide.mdx
+++ b/src/content/docs/agents/net-agent/getting-started/8x-to-9x-agent-migration-guide.mdx
@@ -357,10 +357,12 @@ Most of the configuration options being removed relate to capture or exclusion o
 
     <tr>
       <td>
-        `transactionTrace.captureAttributes`
+        `transactionTracer.captureAttributes`
       </td>
       <td>
-        `attributes.enabled`
+        `transactionTracer.attributes.enabled`
+
+        `transactionTracer.attributes.include`/`exclude` gives finer control over which custom attributes to include with transaction traces.
       </td>    
     </tr>
 
@@ -372,6 +374,17 @@ Most of the configuration options being removed relate to capture or exclusion o
         `errorCollector.attributes.enabled`
 
         `errorCollector.attributes.include`/`exclude` gives finer control over which custom attributes to include with error events.
+      </td>      
+    </tr>
+
+    <tr>
+      <td>
+        `browserMonitoring.captureAttributes`
+      </td>
+      <td>
+        `browserMonitoring.attributes.enabled`
+
+        `browserMonitoring.attributes.include`/`exclude` gives finer control over which custom attributes to include with browser monitoring data.
       </td>      
     </tr>
 


### PR DESCRIPTION
### Give us some context

This PR corrects some mistakes in the .NET agent's migration guide for users upgrading from agent versions 8.x to agent version 9.0.

1. We missed one deprecated configuration option being removed: `browserMonitoring.captureAttributes`.  I added it to the list.
2. We incorrectly specified the replacement configuration option for `transactionTracer.captureAttributes`.
3. `transactionTracer` was incorrectly shown as `transactionTrace`