### PR TITLE
adding notes for setting HTTPS_PROXY env var during runtime

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/advanced-config.mdx
@@ -535,6 +535,14 @@ In this table you can find additional options you can use with the **ktranslate*
         Forwards logs from **ktranslate** into **New Relic One Logs**.
       </td>
     </tr>
+    <tr>
+      <td>
+        `HTTPS_PROXY`
+      </td>
+      <td>
+        Environment variable that can be used during Docker runtime to setup **ktranslate** to ship data to New Relic via proxy. Ex: `-e HTTPS_PROXY=https://user:password@hostname:port`
+      </td>
+    </tr>
     </tbody>
 </table>                                                                                                                           
 


### PR DESCRIPTION
### Give us some context

* What problems does this PR solve?

This PR adds details on new `HTTPS_PROXY` setting for the `ktranslate` docker container from Kentik

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

Added in [PR 108](https://github.com/kentik/ktranslate/pull/108) in the `ktranslate` repo


* If your issue relates to an existing GitHub issue, please link to it.

N/A

### Are you making a change to site code?
No