### PR TITLE
Added note on webhooks for synthetics 

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/customize-your-webhook-payload.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/customize-your-webhook-payload.mdx
@@ -43,7 +43,7 @@ When defining static webhook variables in a form payload, use the format `name="
 current_state="acknowledged"
 ```
 
-Do not include any custom, self-signed SSL certificates in your webhook. Our agents [enable SSL by default](/docs/accounts-partnerships/accounts/security/data-security). Due to our security policy, custom SSL certificates will not be imported into our Trust store.
+Do not include any custom, self-signed SSL certificates in your webhook. Our agents [enable SSL by default](/docs/accounts-partnerships/accounts/security/data-security). Due to our security policy, custom SSL certificates will not be imported into our Trust store. Webhooks for Synthetics multi-location failure conditions are currently not supported.
 
 ## Webhook values [#variables]
 


### PR DESCRIPTION
As reported in #3469, there's some issues with webhooks for Synthetics multi-location failure conditions. This has been reported to the Alerts team, who have opened an issue to fix it. I've also agreed with them (in Slack) to add this little note in the meantime. 