### PR TITLE
Fixed broken link to MS announcement

### DIFF
--- a/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-service-fabric-monitoring-integration.mdx
+++ b/src/content/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-service-fabric-monitoring-integration.mdx
@@ -11,7 +11,7 @@ redirects:
 Our [infrastructure monitoring](/docs/infrastructure/) provides an integration for Microsoft Azure Service Fabric that reports data from your Service Fabric nodes to New Relic.
 
 <Callout variant="important">
-Microsoft Azure has communicated the [retirement of the Service Fabric Mesh service]((https://azure.microsoft.com/en-us/updates/azure-service-fabric-mesh-preview-retirement/)). Hence, this integration is no longer active. Data may still be accessed based on the [data retention policies in New Relic](/docs/telemetry-data-platform/manage-data/manage-data-retention/#adjust-retention). 
+Microsoft Azure has communicated the [retirement of the Service Fabric Mesh service](https://azure.microsoft.com/en-us/updates/azure-service-fabric-mesh-preview-retirement/). Hence, this integration is no longer active. Data may still be accessed based on the [data retention policies in New Relic](/docs/telemetry-data-platform/manage-data/manage-data-retention/#adjust-retention). 
 </Callout>
 
 ### Features [#features]


### PR DESCRIPTION
As reported in #documentation, there's a broken link in https://docs.newrelic.com/docs/integrations/microsoft-azure-integrations/azure-integrations-list/azure-service-fabric-monitoring-integration/. I'm fixing it in this PR.