### PR TITLE
Fix possible bullet nesting issue in network docs

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-flow-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-flow-monitoring.mdx
@@ -13,19 +13,19 @@ Set up your network devices so they send network data to New Relic One.
 ## Prerequisites [#prerequisites]
 
 - A **New Relic account ID**. Read how to [find your account ID](/docs/accounts/accounts-billing/account-setup/account-id/).
-    - An **Insights Insert Key**. Read how to [generate an Insights insert key](/docs/apis/intro-apis/new-relic-api-keys/#insights-insert-key).
-    - [Docker](https://docs.docker.com/engine/install/) installed in your local machine.
-    - SSH access to the Docker host, with the ability to launch new containers.
-    - Access to Layer 2/3 network devices that can generate and send network flow data, and also add and modify network flow targets on the device. Here's how to configure network flow data collection in some devices:
-      - NetFlow data
+- An **Insights Insert Key**. Read how to [generate an Insights insert key](/docs/apis/intro-apis/new-relic-api-keys/#insights-insert-key).
+- [Docker](https://docs.docker.com/engine/install/) installed in your local machine.
+- SSH access to the Docker host, with the ability to launch new containers.
+- Access to Layer 2/3 network devices that can generate and send network flow data, and also add and modify network flow targets on the device. Here's how to configure network flow data collection in some devices:
+    - NetFlow data
         - [Palo Alto - PAN-OS](https://docs.paloaltonetworks.com/pan-os/8-1/pan-os-admin/monitoring/netflow-monitoring/configure-netflow-exports)
         - [Fortinet Fortigate](https://kb.fortinet.com/kb/documentLink.do?externalID=FD36460)
         - [Cisco - NX-OS](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/7-x/system_management/configuration/guide/b_Cisco_Nexus_9000_Series_NX-OS_System_Management_Configuration_Guide_7x/b_Cisco_Nexus_9000_Series_NX-OS_System_Management_Configuration_Guide_7x_chapter_011100.html#task_52D8A0952B06404197D2536B6E33EE80)
-        - [Cisco - IOS](https://www.cisco.com/c/en/us/td/docs/ios/netflow/configuration/guide/12_2sr/nf_12_2sr_book/cfg_nflow_data_expt.html#wp1087069)
+    - [Cisco - IOS](https://www.cisco.com/c/en/us/td/docs/ios/netflow/configuration/guide/12_2sr/nf_12_2sr_book/cfg_nflow_data_expt.html#wp1087069)
         - [Cisco - Meraki](https://documentation.meraki.com/MX/Monitoring_and_Reporting/NetFlow_Overview)
       - sFlow data
         - [F5 - BIG-IP](https://techdocs.f5.com/en-us/bip-upd-16-0-0-u2/external-monitoring-of-big-ip-systems-implementations/monitoring-big-ip-system-traffic-with-sflow.html#GUID-294498AA-BBF7-4E5A-8AD8-1F778E294EE7)
-      - jFlow data
+    - jFlow data
         - [Juniper - Junos](https://www.juniper.net/documentation/us/en/software/junos/flow-monitoring/flow-monitoring.pdf)
 
 ### Network security prerequisites [#prerequisites-network]


### PR DESCRIPTION
Noticed what seems to be too-nested bullets in "Set up network flow data monitoring"

![image](https://user-images.githubusercontent.com/55203603/131037391-a3eef818-51ac-4624-8248-eda54a4f63bf.png)
