### PR TITLE
Removed references to the deprecated Insights key

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -13,7 +13,7 @@ Set up your network devices so they send network data to New Relic One.
 ## Prerequisites [#prerequisites]
 
 - A **New Relic account ID**. Read how to [find your account ID](/docs/accounts/accounts-billing/account-setup/account-id/).
-- An **Insights Insert Key**. Read how to [generate an Insights insert key](/docs/apis/intro-apis/new-relic-api-keys/#insights-insert-key).
+- A **License key**. Read how to [generate a new License key](/docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).
 - [Docker](https://docs.docker.com/engine/install/) installed in a Linux host.
 - SSH access to the Docker host, with the ability to launch new containers.
 - We recommend using read-only community strings for SNMPv1 and SNMPv2c.
@@ -172,13 +172,13 @@ Set up your network devices so they send network data to New Relic One.
   5. Run `ktranslate` to poll target devices. Use the following example:
 
     <Callout variant="important">
-    Add your New Relic Insights insert key and your account ID in the `$NR_INSIGHTS_INSERT_KEY` and `$NR_ACCOUNT_ID` variables respectively.
+    Add your New Relic [License key](/docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key) and your account ID in the `$NR_LICENSE_KEY` and `$NR_ACCOUNT_ID` variables respectively.
     </Callout>
 
     ```shell
     docker run -d --name ktranslate-snmp --restart unless-stopped --net=host \
     -v `pwd`/snmp-base.yaml:/snmp-base.yaml \
-    -e NEW_RELIC_API_KEY=$NR_INSIGHTS_INSERT_KEY  \
+    -e NEW_RELIC_API_KEY=$NR_LICENSE_KEY  \
     kentik/ktranslate:v2 \
       -snmp /snmp-base.yaml \
       -nr_account_id=$NR_ACCOUNT_ID \


### PR DESCRIPTION
Removed references to the Insights key in both the requirements and the manual installation section. Updated with references to the License key as per /docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.