### PR TITLE
Updating 'entity' doc with TTL & general improvements - DOC-7191

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial.mdx
@@ -14,7 +14,7 @@ redirects:
 
 One way to understand how your [entities](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic) relate to each other is using our [NerdGraph](/docs/introduction-new-relic-graphql) API. You can use the `relatedEntities` field to see how pairs of entities interact and how they're related. This can help troubleshoot upstream and downstream services and understand how minor issues may have larger repercussions, similar to how [service maps](/docs/service-maps-dependencies-new-relic-one) can be used.
 
-To learn more about what entities are and how to use them, see [Entities](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic).
+To learn general information about entities, their relationships, and how to use them, see [Entities](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic).
 
 ## Relationship types
 

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial.mdx
@@ -12,7 +12,9 @@ redirects:
   - /docs/understand-dependencies/understand-system-dependencies/relationship-api/relationship-api
 ---
 
-One way to understand how your monitored entities relate to each other is using our [NerdGraph](/docs/introduction-new-relic-graphql) API. You can use the `relatedEntities` field to see how pairs of entities interact and how they're related. This can help troubleshoot upstream and downstream services and understand how minor issues may have larger repercussions, similar to how [service maps](/docs/service-maps-dependencies-new-relic-one) can be used.
+One way to understand how your [entities](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic) relate to each other is using our [NerdGraph](/docs/introduction-new-relic-graphql) API. You can use the `relatedEntities` field to see how pairs of entities interact and how they're related. This can help troubleshoot upstream and downstream services and understand how minor issues may have larger repercussions, similar to how [service maps](/docs/service-maps-dependencies-new-relic-one) can be used.
+
+To learn more about what entities are and how to use them, see [Entities](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic).
 
 ## Relationship types
 

--- a/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
@@ -29,7 +29,7 @@ Our focus on entities and their relationships is important because our goal is t
 
 Some tips for finding and understanding entity data:
 
-* To find an entity's `entityGuid` and `entityName` and other metadata: from any list of monitored entities in the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer-view-performance-across-apps-services-hosts), click an entity's <Icon name="fe-ellipsis-h"/> icon, and click **See metadata and tags**.
+* To find an entity's `entityGuid` and `entityName` and other metadata: from any list of monitored entities in the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer-view-performance-across-apps-services-hosts), click an entity's <Icon name="fe-more-horizontal"/> icon, and click **See metadata and tags**.
 * For most entities, its GUID is reported as the attribute [`entityGuid`](/?event=SyntheticCheck&attribute=entityGuid). For workloads, it's `workloadGuid`. You can run [NRQL queries](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language) to find entities by their GUID.
 * To see connections between entities, you have several options: 
   * When viewing a specific entity in the UI, use the [**Related entities** UI](#related-entities). 

--- a/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
@@ -13,37 +13,44 @@ redirects:
   - /docs/what-entity-new-relic
 ---
 
-New Relic monitoring is built around the concept of the **entity**. An entity is anything that reports data to New Relic. This document explains:
+New Relic monitoring is built around the concept of **entities**, which are basically the hosts and services and other systems that New Relic monitors. In this doc, you'll learn how we define entities, what you can do with them, and how you can create your own entities or groupings of entities. 
 
-* What entities are
-* How to find entity data
-* How to modify existing entity types or create new ones
-* How entities are related to one another
-* How to organize them into groups for easier analysis
+## What's an entity? [#what-is-entity]
 
-## What is an entity? [#what-is-entity]
+From a New Relic product perspective, **entity** is purposefully a broad concept. An entity is anything that has data you can monitor and that we've identified with a unique entity ID. For most entities, this is indicated by the [attribute](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#attribute) `entityGuid`. 
 
-From a New Relic product perspective, **entity** is a broad concept. An entity is anything we can identify that has data you can monitor.
+An entity can be any fundamental data-reporting component, like an application, a host, or a database service, but it can also refer to larger groupings of those components. For example, to monitor a data center, you could aggregate those hosts in New Relic to be a [workload](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one) (a custom grouping of entities). That workload is, itself, also an entity. 
 
-"Entity" can refer to fundamental data-reporting components like applications, hosts, and database services, but it can also refer to larger groupings of those components. For example, to monitor a data center, you could aggregate those hosts in New Relic to be a [workload](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one) (a custom grouping of entities). That workload is, itself, also an entity.
+Also very important is the [relationships between entities](/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial). Our behind-the-scenes relationship-mapping helps us understand how entities are connected, how they affect each other. And this allows us to give you the power to configure how any data you're bringing in is related to existing entities, or how it's related to other entities.   
 
-This conceptual definition of "entity" is important because New Relic's goal is to give you practical information about the status of your business-important entities (and not just give you an unhelpfully large stream of assorted metrics and data). Our focus on entities, and the relationships between them, helps us optimize monitoring and troubleshooting of complex, modern systems.
+Our focus on entities and their relationships is important because our goal is to give you **practical information about your business-important entities**, and **not** give you an unhelpfully huge stream of data from a huge list of monitored things. With more insight at the entity level, you can better monitor and troubleshoot complex, modern systems.
 
-## Find and explore entities [#find]
+## Find and explore entities and entity data [#find]
 
 You'll find your entities wherever you see your data reporting in New Relic.
 
 <Callout variant="tip">
-  You can create new entity types to monitor any data source. Learn more about [entity synthesis](https://github.com/newrelic/entity-definitions#entity-definitions).
+  You can create new entity types to monitor any data source. [Learn more about entity synthesis](https://github.com/newrelic/entity-definitions#entity-definitions).
 </Callout>
 
 Some tips for finding and understanding entity data:
 
-* To find an entity's unique global identifier (GUID): from any list of monitored entities in the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer-view-performance-across-apps-services-hosts), hover over a specific entity and click the <Icon name="fe-info"/>
-  icon to see the GUID and other metadata.
+* To find an entity's GUID: from any list of monitored entities in the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer-view-performance-across-apps-services-hosts), hover over a specific entity and click the <Icon name="fe-info"/> icon to see the GUID and other metadata.
 * An entity's GUID is reported as the attribute [`entityGuid`](/?event=SyntheticCheck&attribute=entityGuid). You can query for an entity using this attribute in the [query builder](/docs/introduction-chart-builder).
-* Use the Related Entities view in the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/core-concepts/entity-explorer-view-performance-across-apps-services-hosts), [service maps](/docs/service-maps-dependencies-new-relic-one), [distributed tracing](/docs/distributed-tracing-new-relic-one), and our [relationships API in GraphQL](/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial) to see connections between entities.
-* Explore entity data using our NerdGraph GraphiQL explorer ([api.newrelic.com/graphiql](https://api.newrelic.com/graphiql)).
+* To group entities together, see Workloads. 
+* To see connections between entities, use the **Related entities** view in the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/core-concepts/entity-explorer-view-performance-across-apps-services-hosts), [service maps](/docs/service-maps-dependencies-new-relic-one), [distributed tracing](/docs/distributed-tracing-new-relic-one). 
+* You can use [NerdGraph to view entity relationships](/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial).
+
+
+## Group and organize entities [#group]
+
+You can place entities into groups that reflect business-important relationships in your organization. For example, you might group all entities related to a specific team or department, or related to a specific service. Or you might group multiple hosts together to reflect their grouping in a data center.
+
+To group your entities, see:
+
+* [How to tag entities](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor)
+* [Create workloads](/docs/new-relic-one/use-new-relic-one/workloads/workloads-new-relic-one-isolate-resolve-incidents-faster) (groups of related entities)
+
 
 ## Entity synthesis [#entity-synthesis]
 
@@ -792,11 +799,3 @@ These are the relationships created between entities:
   
 </CollapserGroup>
 
-## Group and organize entities [#group]
-
-You can place entities into groups that reflect business-important relationships in your organization. For example, you might group all entities related to a specific team or department, or related to a specific service. Or you might group multiple hosts together to reflect their grouping in a data center.
-
-To group your entities, see:
-
-* [How to tag entities](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor)
-* [Create workloads](/docs/new-relic-one/use-new-relic-one/workloads/workloads-new-relic-one-isolate-resolve-incidents-faster) (groups of related entities)

--- a/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
@@ -27,24 +27,22 @@ Our focus on entities and their relationships is important because our goal is t
 
 ## Find and explore entities and entity data [#find]
 
-You'll find your entities wherever you see your data reporting in New Relic.
-
-<Callout variant="tip">
-  You can create new entity types to monitor any data source. [Learn more about entity synthesis](https://github.com/newrelic/entity-definitions#entity-definitions).
-</Callout>
-
 Some tips for finding and understanding entity data:
 
-* To find an entity's GUID and other metadata: from any list of monitored entities in the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer-view-performance-across-apps-services-hosts), click an entity's <Icon name="fe-ellipsis-h"/> icon, and click **See metadata and tags**.
-* An entity's GUID is reported as the attribute [`entityGuid`](/?event=SyntheticCheck&attribute=entityGuid). For workloads, it's `workloadGuid`. You can run [NRQL queries](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language) to look up entities by their GUID, or find entities' GUIDs. 
+* To find an entity's `entityGuid` and `entityName` and other metadata: from any list of monitored entities in the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer-view-performance-across-apps-services-hosts), click an entity's <Icon name="fe-ellipsis-h"/> icon, and click **See metadata and tags**.
+* For most entities, its GUID is reported as the attribute [`entityGuid`](/?event=SyntheticCheck&attribute=entityGuid). For workloads, it's `workloadGuid`. You can run [NRQL queries](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language) to find entities by their GUID.
 * To see connections between entities, you have several options: 
   * When viewing a specific entity in the UI, use the [**Related entities** UI](#related-entities). 
   * Use [service maps](/docs/service-maps-dependencies-new-relic-one). 
   * Use [distributed tracing](/docs/distributed-tracing-new-relic-one). 
   * Use [our NerdGraph API to view entity relationships](/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial).
 * To group entities together, see [Group entities](#group). 
-* [Customize how your data is mapped to entities.](#entity-synthesis) 
-
+* [Configure entity definitions and relationships.](#entity-synthesis)
+* To learn technical details about entity types, see our [GitHub repo](https://github.com/newrelic/entity-definitions/tree/main/definitions). In an entity type's `definition` file, you'll see information like: 
+  * The `domain`: for example, `APM`, or `Infra`.
+  * Its `type`: for example, `Application` or `AWSECSCONTAINERINSTANCE`. 
+  * Default [tags](/docs/new-relic-one/use-new-relic-one/core-concepts/use-tags-help-organize-find-your-data).
+  * The `entityExpirationTime`: how long data from that entity lasts in the UI, which is different from [database data retention](/docs/telemetry-data-platform/manage-data/manage-data-retention).  
 
 ## Group and organize entities [#group]
 
@@ -55,7 +53,7 @@ To group your entities, see:
 * [Tag entities](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor).
 * [Create workloads](/docs/new-relic-one/use-new-relic-one/workloads/workloads-new-relic-one-isolate-resolve-incidents-faster), which allow you to group business-important sets of entities. 
 
-## Entity synthesis [#entity-synthesis]
+## Configure your own entity data with entity synthesis [#entity-synthesis]
 
 If you have telemetry from any source that's not supported by New Relic out of the box, you can propose a mapping for it. Once approved, any telemetry received by New Relic that matches your definition file will be synthesized into an entity. 
 

--- a/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
@@ -13,11 +13,11 @@ redirects:
   - /docs/what-entity-new-relic
 ---
 
-New Relic monitoring is built around the concept of **entities**, which are basically the hosts and services and other systems that New Relic monitors. In this doc, you'll learn how we define entities, what you can do with them, and how you can create your own entities or groupings of entities. 
+New Relic monitoring is built around the concept of **entities**. In this doc, you'll learn how we define entities, what you can do with them, and how you can create your own entities or groupings of entities. 
 
 ## What's an entity? [#what-is-entity]
 
-From a New Relic product perspective, **entity** is purposefully a broad concept. An entity is anything that has data you can monitor and that we've identified with a unique entity ID. For most entities, this is indicated by the [attribute](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#attribute) `entityGuid`. 
+From a New Relic perspective, **entity** is purposefully a broad concept. An entity is anything that a) reports data to New Relic or that contains data that we have access to, and b) is something we've identified with a unique entity ID. For most entities, the ID is indicated by the [attribute](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#attribute) `entityGuid`. 
 
 An entity can be any fundamental data-reporting component, like an application, a host, or a database service, but it can also refer to larger groupings of those components. For example, to monitor a data center, you could aggregate those hosts in New Relic to be a [workload](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one) (a custom grouping of entities). That workload is, itself, also an entity. 
 
@@ -27,18 +27,22 @@ Our focus on entities and their relationships is important because our goal is t
 
 ## Find and explore entities and entity data [#find]
 
+<Callout variant="tip">
+You can create new entity types for monitoring any data source. [Learn more about entity synthesis.](#entity-synthesis)
+</Callout>
+
 Some tips for finding and understanding entity data:
 
 * To find an entity's `entityGuid` and `entityName` and other metadata: from any list of monitored entities in the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer-view-performance-across-apps-services-hosts), click an entity's <Icon name="fe-more-horizontal"/> icon, and click **See metadata and tags**.
 * For most entities, its GUID is reported as the attribute [`entityGuid`](/?event=SyntheticCheck&attribute=entityGuid). For workloads, it's `workloadGuid`. You can run [NRQL queries](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language) to find entities by their GUID.
 * To see connections between entities, you have several options: 
-  * When viewing a specific entity in the UI, use the [**Related entities** UI](#related-entities). 
-  * Use [service maps](/docs/service-maps-dependencies-new-relic-one). 
-  * Use [distributed tracing](/docs/distributed-tracing-new-relic-one). 
-  * Use [our NerdGraph API to view entity relationships](/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial).
+  * When viewing an entity in the UI, use the [**Related entities** UI](#related-entities). 
+  * [Service maps](/docs/service-maps-dependencies-new-relic-one). 
+  * [Distributed tracing](/docs/distributed-tracing-new-relic-one). 
+  * [Our NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial).
 * To group entities together, see [Group entities](#group). 
-* [Configure entity definitions and relationships.](#entity-synthesis)
-* To learn technical details about entity types, see our [GitHub repo](https://github.com/newrelic/entity-definitions/tree/main/definitions). In an entity type's `definition` file, you'll see information like: 
+* [Customize entity definitions and relationships.](#entity-synthesis)
+* To learn technical details about entity types, see our [GitHub repo](https://github.com/newrelic/entity-definitions/tree/main/definitions). In an entity type's `definition` file, you'll see information like:
   * The `domain`: for example, `APM`, or `Infra`.
   * Its `type`: for example, `Application` or `AWSECSCONTAINERINSTANCE`. 
   * Default [tags](/docs/new-relic-one/use-new-relic-one/core-concepts/use-tags-help-organize-find-your-data).
@@ -52,14 +56,15 @@ To group your entities, see:
 
 * [Tag entities](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor).
 * [Create workloads](/docs/new-relic-one/use-new-relic-one/workloads/workloads-new-relic-one-isolate-resolve-incidents-faster), which allow you to group business-important sets of entities. 
+* [Create entities and customize entity data](#entity-synthesis)
 
-## Configure your own entity data with entity synthesis [#entity-synthesis]
+## Customize entity data with entity synthesis [#entity-synthesis]
 
 If you have telemetry from any source that's not supported by New Relic out of the box, you can propose a mapping for it. Once approved, any telemetry received by New Relic that matches your definition file will be synthesized into an entity. 
 
 To learn more: 
-* To learn about reserved attributes and how entity relationships are defined, keep reading this doc. 
-* To learn how to do the work of modifying existing entity types or creating new ones, see [our GitHub repo on entity synthesis](https://github.com/newrelic/entity-definitions#entity-definitions). 
+* For reserved attributes and how entity relationships are defined, keep reading this doc. 
+* For how to do the work of modifying existing entity types or creating new ones, see [our GitHub repo on entity synthesis](https://github.com/newrelic/entity-definitions#entity-definitions). 
 
 ### Reserved attributes for synthesized entities [#reserved-attributes]
 

--- a/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic.mdx
@@ -35,11 +35,15 @@ You'll find your entities wherever you see your data reporting in New Relic.
 
 Some tips for finding and understanding entity data:
 
-* To find an entity's GUID: from any list of monitored entities in the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer-view-performance-across-apps-services-hosts), hover over a specific entity and click the <Icon name="fe-info"/> icon to see the GUID and other metadata.
-* An entity's GUID is reported as the attribute [`entityGuid`](/?event=SyntheticCheck&attribute=entityGuid). You can query for an entity using this attribute in the [query builder](/docs/introduction-chart-builder).
-* To group entities together, see Workloads. 
-* To see connections between entities, use the **Related entities** view in the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/core-concepts/entity-explorer-view-performance-across-apps-services-hosts), [service maps](/docs/service-maps-dependencies-new-relic-one), [distributed tracing](/docs/distributed-tracing-new-relic-one). 
-* You can use [NerdGraph to view entity relationships](/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial).
+* To find an entity's GUID and other metadata: from any list of monitored entities in the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer-view-performance-across-apps-services-hosts), click an entity's <Icon name="fe-ellipsis-h"/> icon, and click **See metadata and tags**.
+* An entity's GUID is reported as the attribute [`entityGuid`](/?event=SyntheticCheck&attribute=entityGuid). For workloads, it's `workloadGuid`. You can run [NRQL queries](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language) to look up entities by their GUID, or find entities' GUIDs. 
+* To see connections between entities, you have several options: 
+  * When viewing a specific entity in the UI, use the [**Related entities** UI](#related-entities). 
+  * Use [service maps](/docs/service-maps-dependencies-new-relic-one). 
+  * Use [distributed tracing](/docs/distributed-tracing-new-relic-one). 
+  * Use [our NerdGraph API to view entity relationships](/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial).
+* To group entities together, see [Group entities](#group). 
+* [Customize how your data is mapped to entities.](#entity-synthesis) 
 
 
 ## Group and organize entities [#group]
@@ -48,22 +52,20 @@ You can place entities into groups that reflect business-important relationships
 
 To group your entities, see:
 
-* [How to tag entities](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor)
-* [Create workloads](/docs/new-relic-one/use-new-relic-one/workloads/workloads-new-relic-one-isolate-resolve-incidents-faster) (groups of related entities)
-
+* [Tag entities](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor).
+* [Create workloads](/docs/new-relic-one/use-new-relic-one/workloads/workloads-new-relic-one-isolate-resolve-incidents-faster), which allow you to group business-important sets of entities. 
 
 ## Entity synthesis [#entity-synthesis]
 
-If you have telemetry from any source that's not supported by New Relic out of the box, you can propose a mapping for it. Once approved, any telemetry received by New Relic which matches your definition file will be synthesized into an entity.
+If you have telemetry from any source that's not supported by New Relic out of the box, you can propose a mapping for it. Once approved, any telemetry received by New Relic that matches your definition file will be synthesized into an entity. 
 
-<Callout variant="tip">
-  For more information on how to modify existing entity types or create new ones please refer to our [Entity Synthesis documentation](https://github.com/newrelic/entity-definitions#entity-definitions).
-</Callout>
-
+To learn more: 
+* To learn about reserved attributes and how entity relationships are defined, keep reading this doc. 
+* To learn how to do the work of modifying existing entity types or creating new ones, see [our GitHub repo on entity synthesis](https://github.com/newrelic/entity-definitions#entity-definitions). 
 
 ### Reserved attributes for synthesized entities [#reserved-attributes]
 
-These attributes are meant to be synthesized from the telemetry we receive. **Do not** set them unless you are aware of the implications and consequences.
+These attributes are meant to be synthesized from the telemetry we receive. **Do not** set them unless you're aware of the implications and consequences.
 
 <table>
   <thead>
@@ -120,18 +122,19 @@ These attributes are meant to be synthesized from the telemetry we receive. **Do
   </tbody>
 </table>
 
+To learn how to do the work of modifying existing entity types or creating new ones, see [our GitHub repo on entity synthesis](https://github.com/newrelic/entity-definitions#entity-definitions). 
 
 ## Entity relationships [#related-entities]
 
 Connections between entities are automatically created by New Relic based on what we can infer from your telemetry. For example, when two services that communicate using HTTP are instrumented with New Relic, we infer a "calls/called-by" relationship between them.
 
-When viewing a single entity in either the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/core-concepts/entity-explorer-view-performance-across-apps-services-hosts), Navigator, or Lookout, you can see its **Related Entities** in the entity's mini overview. Related Entities is a visualization of the various entities connected directly to the current entity in focus. You can quickly view important metrics for these related entities and navigate from one entity to another, through all the connected parts of your stack.
+When viewing a specific entity in either the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/core-concepts/entity-explorer-view-performance-across-apps-services-hosts), Navigator, or Lookout, you can see its **Related entities** in the entity's mini overview. This gives a visualization of the various entities connected directly to the current entity. You can quickly view important metrics for these related entities and navigate from one entity to another, through all the connected parts of your stack.
 
 <Callout variant="tip">
-  You can learn more about how entities are related [using our NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial).
+  Learn more about how entities are related [with our NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-relationships-api-tutorial).
 </Callout>
 
-When relationships are not automatically detected, you can manually create them using the "Add/edit related entities" link in **Related Entities**.
+When relationships are not automatically detected, you can manually create them using the "Add/edit related entities" link in **Related entities**.
 
 <Callout variant="important">
   Currently, you can only manually create calls/called-by relationships between service entities.


### PR DESCRIPTION
See DOC-7191 for details. Synopsis of changes: 

* Added links to the github repo where our entity definitions live and explained what info is there.
* Made some general improvements, to help with flow of doc (links to different section and such), and to improve description of what an entity is to reflect current functionality. 