### PR TITLE
Update profiler-conflicts.mdx

### DIFF
--- a/src/content/docs/agents/net-agent/troubleshooting/profiler-conflicts.mdx
+++ b/src/content/docs/agents/net-agent/troubleshooting/profiler-conflicts.mdx
@@ -40,7 +40,7 @@ To avoid a profiler conflict, fully remove the other profiler from the environme
   </Collapser>
 
   <Collapser
-    id="registry-keys"
+    id="compare-registry-keys"
     title="2. Compare registry keys to Process Explorer if necessary."
   >
     If the conflicting profiler has been disabled and there is still an issue, compare the registry keys to [**Process Explorer**](https://technet.microsoft.com/en-us/sysinternals/bb896653.aspx) to see which profiler is present. On the machine where you are experiencing this issue, check the **WAS** and **W3SVC REG** for IIS apps, or check your service keys or non-IIS app keys.
@@ -93,7 +93,7 @@ To avoid a profiler conflict, fully remove the other profiler from the environme
   </Collapser>
 
   <Collapser
-    id="registry-keys"
+    id="restore-registry-keys"
     title="3. Restore New Relic registry keys or environment variables."
   >
     Once the conflicting profiler has been disabled, you still may need to restore the New Relic registry keys or, if using Instrument All, the [system-wide environment variables](/docs/agents/net-agent/troubleshooting/profiler-conflicts#check-conflicts).
@@ -105,11 +105,11 @@ To avoid a profiler conflict, fully remove the other profiler from the environme
     $reg = [wmiclass]"\\.\root\default:StdRegprov"
     $key = "SYSTEM\CurrentControlSet\Services\W3SVC"
     $name = "Environment"
-    $value = "COR_ENABLE_PROFILING=1","COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}","NEWRELIC_INSTALL_PATH=C:\Program Files\New Relic\.NET Agent\"
+    $value = "COR_ENABLE_PROFILING=1","COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}","NEWRELIC_INSTALL_PATH=C:\Program Files\New Relic\.NET Agent\","CORECLR_ENABLE_PROFILING=1","CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}","CORECLR_NEWRELIC_HOME=C:\ProgramData\New Relic\.NET Agent\"
     $reg.SetMultiStringValue($HKLM, $key, $name, $value)
     $key = "SYSTEM\CurrentControlSet\Services\WAS"
     $name = "Environment"
-    $value = "COR_ENABLE_PROFILING=1","COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}","NEWRELIC_INSTALL_PATH=C:\Program Files\New Relic\.NET Agent\"
+    $value = "COR_ENABLE_PROFILING=1","COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}","NEWRELIC_INSTALL_PATH=C:\Program Files\New Relic\.NET Agent\","CORECLR_ENABLE_PROFILING=1","CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}","CORECLR_NEWRELIC_HOME=C:\ProgramData\New Relic\.NET Agent\"
     $reg.SetMultiStringValue($HKLM, $key, $name, $value)
     iisreset
     ```


### PR DESCRIPTION
Updated the powershell script so that it adds the .NET Core related values as well. Also updated the names of the collapse menus so that they are unique and can be linked to.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?

1. The current powershell script doesn't restore all of the registry values needed. 
2. The 2nd and 3rd collapse menus both have the same name `registry-keys` so we can't link to a specific one.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.