### PR TITLE
Update resolve-net-scom-conflicts.mdx

### DIFF
--- a/src/content/docs/agents/net-agent/troubleshooting/resolve-net-scom-conflicts.mdx
+++ b/src/content/docs/agents/net-agent/troubleshooting/resolve-net-scom-conflicts.mdx
@@ -33,11 +33,11 @@ To resolve SCOM profiler conflicts:
    $reg = [wmiclass]"\\.\root\default:StdRegprov"
    $key = "SYSTEM\CurrentControlSet\Services\W3SVC"
    $name = "Environment"
-   $value = "COR_ENABLE_PROFILING=1","COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}","NEWRELIC_INSTALL_PATH=C:\Program Files\New Relic\.NET Agent\"
+   $value = "COR_ENABLE_PROFILING=1","COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}","NEWRELIC_INSTALL_PATH=C:\Program Files\New Relic\.NET Agent\","CORECLR_ENABLE_PROFILING=1","CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}","CORECLR_NEWRELIC_HOME=C:\ProgramData\New Relic\.NET Agent\"
    $reg.SetMultiStringValue($HKLM, $key, $name, $value)
    $key = "SYSTEM\CurrentControlSet\Services\WAS"
    $name = "Environment"
-   $value = "COR_ENABLE_PROFILING=1","COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}","NEWRELIC_INSTALL_PATH=C:\Program Files\New Relic\.NET Agent\"
+   $value = "COR_ENABLE_PROFILING=1","COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}","NEWRELIC_INSTALL_PATH=C:\Program Files\New Relic\.NET Agent\","CORECLR_ENABLE_PROFILING=1","CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}","CORECLR_NEWRELIC_HOME=C:\ProgramData\New Relic\.NET Agent\"
    $reg.SetMultiStringValue($HKLM, $key, $name, $value)
    iisreset
    ```


### PR DESCRIPTION
Fixed the powershell script to restore all of the registry values needed

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?

The current powershell script doesn't restore the registry values needed for .NET Core.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.