### PR TITLE
Link fix

### DIFF
--- a/src/content/docs/new-relic-one/use-new-relic-one/workloads/workloads-isolate-resolve-incidents-faster.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/workloads/workloads-isolate-resolve-incidents-faster.mdx
@@ -63,7 +63,7 @@ Requirements for creating and managing workloads:
 
 ## Impact of accounts on the workload permissions and content [#accounts]
 
-Workloads can group and display entities from multiple accounts to provide complete observability of complex systems. When [creating a workload](#create), you must set:
+Workloads can group and display entities from multiple accounts to provide complete observability of complex systems. When [creating a workload](/docs/new-relic-one/use-new-relic-one/workloads/use-workloads/#create), you must set:
 
 * The [workload account](#workload-account)
 * [Scope accounts](#scope-accounts)


### PR DESCRIPTION
Fixing the link to the section that explains how to create a workload, which lives in a different page.
