### PR TITLE
Add missing path to create index page for "Observe Everything"

### DIFF
--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -5,6 +5,7 @@ pages:
   - title: Overview
     path: /docs/full-stack-observability
   - title: Observe everything
+    path: /docs/full-stack-observability/observe-everything
     pages:
       - title: Get started
         path: /docs/full-stack-observability/observe-everything/get-started


### PR DESCRIPTION
## Description
Does what it says on the tin.

Of note, we previously had documentation for this stuff but it was [recently removed](https://github.com/newrelic/docs-website/pull/3670).

## Screenshot(s)
![Screen Shot 2021-08-30 at 10 46 16](https://user-images.githubusercontent.com/1946433/131382461-8f1ce801-67cb-40ac-a225-bf706765434e.png)
