### PR TITLE
Update auto-telemetry-pixie-data-model.mdx

### DIFF
--- a/src/content/docs/auto-telemetry-pixie/auto-telemetry-pixie-data-model.mdx
+++ b/src/content/docs/auto-telemetry-pixie/auto-telemetry-pixie-data-model.mdx
@@ -7,7 +7,7 @@ tags:
   - eBPF
 metaDescription:
 redirects:
-  - docs/integrations/kubernetes-integration/understand-use-data/auto-telemetry-pixie-data-model/
+  - /docs/integrations/kubernetes-integration/understand-use-data/auto-telemetry-pixie-data-model/
 ---
 
 [Auto-telemetry with Pixie](docs/auto-telemetry-pixie/get-started-auto-telemetry-pixie/) pulls data from the Pixie Cloud API and sends it to the New Relic OpenTelemetry endpoint. You can build your own charts and [query](/docs/using-new-relic/data/understand-data/query-new-relic-data) your Auto-telemetry with Pixie data using the query builder and the NerdGraph API.


### PR DESCRIPTION
The redirects should have a leading slash, this was breaking one of our workflows but I also added a check to our workflow to catch this in future
