### PR TITLE
Fixing bad category URL

### DIFF
--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -15,7 +15,6 @@ pages:
           - title: New Relic guided install overview
             path: /docs/full-stack-observability/observe-everything/get-started/new-relic-guided-install-overview
       - title: Observability solutions
-        path: /docs/full-stack-observability/monitor-everything/observability-solutions
         pages:
           - title: Application monitoring (APM)
             path: /docs/apm/table-of-contents

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -70,7 +70,7 @@ pages:
           - title: Browser monitoring
             path: /docs/browser/table-of-contents 
           - title: Mobile apps
-            path: /docs/mobile/table-of-contents
+            path: /docs/mobile-monitoring/table-of-contents
           - title: See all integrations
             path: https://newrelic.com/integrations
       - title: Develop your own integrations


### PR DESCRIPTION
Someone changed something in folders so the category URL was no longer working. So this will remove path and make that category header not clickable and just an expander/collapser. Which is okay for now, better than the broken category link. We say now in style guide that it's acceptable to have a nonclickable category for categories that are just assemblies of docs that "live" in other locations. 

Also fixed a bad mobile-monitoring URL.