### PR TITLE
Solutions - remove link and update nav name

### DIFF
--- a/src/nav/new-relic-solutions.yml
+++ b/src/nav/new-relic-solutions.yml
@@ -1,4 +1,4 @@
-title: Solutions
+title: Solutions and best practices
 path: /docs/new-relic-solutions
 pages:
   - title: New Relic solutions
@@ -120,5 +120,4 @@ pages:
             path: /docs/new-relic-solutions/observability-maturity/aqm-implementation-guide
           - title: Service level management
             path: /docs/new-relic-solutions/observability-maturity/slm-implementation-guide
-  - title: Solutions and best practices
-    path: /docs/new-relic-solutions
+


### PR DESCRIPTION
- Noticed an  extra link while working on DOC-7092.
- Also renaming the left nav to Solutions and best practices to match what's in there.

Tried locally, works ok.

