### PR TITLE
Fix Typo In SCIM Documentation

### DIFF
--- a/src/content/docs/accounts/accounts/automated-user-management/tutorial-manage-users-groups-scim.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/tutorial-manage-users-groups-scim.mdx
@@ -183,7 +183,7 @@ EOF
 ```
 
 <Callout variant="important">
-Take note of the returned user `id`. To update a group or its members in the future you will need to supply the same ID with the request.
+Take note of the returned group `id`. To update a group or its members in the future you will need to supply the same ID with the request.
 </Callout>
 
 ### Example responses


### PR DESCRIPTION
### Give us some context

In the SCIM documentation for the section describing how to create SCIM Groups, the callout incorrectly referred to the "user ID" where it should be "group ID".