### PR TITLE
Adding Python. 3.9 support to requirements

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
@@ -12,7 +12,7 @@ Before [enabling serverless monitoring](/docs/serverless-function-monitoring/aws
 ## Recommended AWS Lambda language runtimes [#languages]
 
 * NodeJS: `nodejs10.x`, `nodejs12.x`, `nodejs14.x`
-* Python: `python3.7`, `python3.8`
+* Python: `python3.7`, `python3.8`, `python3.9`
 * Go: `provided`, `provided.al2`
 * Java: `java8.al2`, `java11`
 * .NET Core: `dotnetcore3.1`


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

AWS now supports a Python 3.9 runtime for Lambda. The New Relic Python agent also supports it, so we've added Python 3.9 Lambda layers, and added 3.9 support to our serverless-newrelic-lambda-layers plugin for the Serverless framework.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.