### PR TITLE
Fixed typo & remove unsupported NodeJS version

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
@@ -63,7 +63,7 @@ To install the infrastructure monitoring agent, follow the step-by-step instruct
     4. Then, open the terminal and run the following command:    
     
     ```
-      brew install newrelic-infra -q
+      brew install newrelic-infra-agent -q
     ```
 
     5. Start the infrastructure agent service:

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
@@ -11,7 +11,7 @@ Before [enabling serverless monitoring](/docs/serverless-function-monitoring/aws
 
 ## Recommended AWS Lambda language runtimes [#languages]
 
-* NodeJS: `nodejs10.x`, `nodejs12.x`, `nodejs14.x`
+* NodeJS: `nodejs12.x`, `nodejs14.x`
 * Python: `python3.7`, `python3.8`, `python3.9`
 * Go: `provided`, `provided.al2`
 * Java: `java8.al2`, `java11`


### PR DESCRIPTION
- Fixed typo for installing the `newrelic-infra-agent` in macOS
- Removed nodejs v10 support for AWS Lambda