### PR TITLE
Add allow and deny list examples for remote write

### DIFF
--- a/src/content/docs/integrations/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
+++ b/src/content/docs/integrations/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
@@ -99,6 +99,31 @@ This rule matches any metric with the name `my_counter` and adds a `newrelic_met
 
 When a `newrelic_metric_type` label is present on a metric received and set to one of the valid values, New Relic will assign the indicated type to the metric (and strip the label) before downstream consumption in the data pipeline. If you have multiple metrics that don't follow the above naming conventions, you can add multiple rules with each rule matching different source labels.
 
+## Setting allow or deny lists for metrics sent [#allowlisting]
+
+If you only want to send a subset of metrics in order to control your data better, you can configure remote-write with the write_relabel_configs parameter with a subparameter action value of keep or deny.
+
+**Example:** This example sends all metrics that match the regex and drops the rest. You can also use action: drop to drop all metrics that match the regex
+
+```
+- url: https://metric-api.newrelic.com/prometheus/v1/write?X-License-Key=...
+  write_relabel_configs:
+  - source_labels: [__name__]
+    regex: "coredns_(.*)|etcd_(.*)"
+    action: keep
+```
+
+**Kubernetes and Helm Example:** This example uses this Helm chart's [`values.yaml`](https://github.com/helm/charts/blob/c40486ab2eba0391119b7cc1509d6958fd21c31d/stable/prometheus/values.yaml#L631) file. If you are using a different Helm chart, please check it's remote write documentation (e.g. some will use camel case writeRelabelConfigs instead)
+
+```
+  remoteWrite:
+    - url: https://metric-api.newrelic.com/prometheus/v1/write?X-License-Key=...
+      write_relabel_configs:
+      - source_labels: [__name__]
+        regex: "coredns_(.*)|etcd_(.*)"
+        action: keep
+```
+
 ## Customize remote write behavior [#customize]
 
 You can customize the following parameters if you are writing to more than one account in New Relic or are connecting more than one Prometheus data source to the same account in New Relic. For more information, see the [docs on remote write tuning](https://prometheus.io/docs/practices/remote_write/).

--- a/src/content/docs/integrations/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
+++ b/src/content/docs/integrations/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
@@ -62,7 +62,7 @@ Go to the [Prometheus remote write setup launcher in New Relic One](https://one.
 3. Restart your Prometheus server.
 4. View your data in the New Relic UI. For example, use the remote write [dashboard](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards) we automatically create when you set up your integration.
 
-## Mapping of Prometheus metric types [#mapping]
+## Map Prometheus and New Relic metric types [#mapping]
 
 The Prometheus remote write protocol does not include [metric type](/docs/telemetry-data-platform/ingest-manage-data/understand-data/metric-data-type#metric-types) information or other helpful metric metadata when sending metrics to New Relic. Because the remote write protocol doesn't include this information, New Relic infers the metric type based on Prometheus naming conventions. Metrics not following these naming conventions may not be mapped correctly.
 
@@ -99,11 +99,11 @@ This rule matches any metric with the name `my_counter` and adds a `newrelic_met
 
 When a `newrelic_metric_type` label is present on a metric received and set to one of the valid values, New Relic will assign the indicated type to the metric (and strip the label) before downstream consumption in the data pipeline. If you have multiple metrics that don't follow the above naming conventions, you can add multiple rules with each rule matching different source labels.
 
-## Setting allow or deny lists for metrics sent [#allowlisting]
+## Set allow or deny lists for sent metrics [#allow-deny]
 
-If you only want to send a subset of metrics in order to control your data better, you can configure remote-write with the write_relabel_configs parameter with a subparameter action value of keep or deny.
+If you need greater control over the data you send to New Relic, you can send a subset of your metrics. To do this, configure `remote-write` with the `write_relabel_configs` parameter with a subparameter `action` value of `keep` or `deny`.
 
-**Example:** This example sends all metrics that match the regex and drops the rest. You can also use action: drop to drop all metrics that match the regex
+In this example, you'll only send the metrics that match the regular expression. Unmatched metrics won't be sent. Alternatively, you can use `action: drop` to drop all of the metrics that match the regular expression.
 
 ```
 - url: https://metric-api.newrelic.com/prometheus/v1/write?X-License-Key=...
@@ -113,7 +113,7 @@ If you only want to send a subset of metrics in order to control your data bette
     action: keep
 ```
 
-**Kubernetes and Helm Example:** This example uses this Helm chart's [`values.yaml`](https://github.com/helm/charts/blob/c40486ab2eba0391119b7cc1509d6958fd21c31d/stable/prometheus/values.yaml#L631) file. If you are using a different Helm chart, please check it's remote write documentation (e.g. some will use camel case writeRelabelConfigs instead)
+This Kubernetes example uses this Helm chart's [`values.yaml`](https://github.com/helm/charts/blob/c40486ab2eba0391119b7cc1509d6958fd21c31d/stable/prometheus/values.yaml#L631) file. If you're using a different Helm chart, please check its `remoteWrite` documentation (for example, some Helm files use camelcase `writeRelabelConfigs` instead).
 
 ```
   remoteWrite:


### PR DESCRIPTION
Examples include Prometheus standalone and Prometheus on Kubernetes using a specific Helm chart. Also brings out a caveat of other helm charts

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.