### PR TITLE
Release notes for Go Agent v3.15.0

### DIFF
--- a/src/content/docs/agents/go-agent/get-started/go-agent-compatibility-requirements.mdx
+++ b/src/content/docs/agents/go-agent/get-started/go-agent-compatibility-requirements.mdx
@@ -277,7 +277,21 @@ The following integration packages must be imported along with the [newrelic](ht
       </td>
 
       <td>
-        Instrument database calls to Postgres
+        Instrument database calls to Postgres using the database/sql library and pq
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [jackc/pgx](https://github.com/jackc/pgx)
+      </td>
+
+      <td>
+        [v3/integrations/nrpgx](https://godoc.org/github.com/newrelic/go-agent/v3/integrations/nrpgx)
+      </td>
+
+      <td>
+        Instrument database calls to Postgres using the database/sql library and jackc/pgx
       </td>
     </tr>
 

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-15-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-15-0.mdx
@@ -1,0 +1,26 @@
+---
+subject: Go agent
+releaseDate: '2021-09-02'
+version: 3.15.0
+downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.15.0'
+---
+
+## 3.15.0
+
+### Fixed
+* Updated mongodb driver version to 1.5.1 to fix security issue in external dependency. Fixes [Issue #358](https://github.com/newrelic/go-agent/issues/358) and [Issue #370](https://github.com/newrelic/go-agent/pull/370).
+
+* Updated the `go.mod` file in the `nrgin` integration to require version 1.7.0 of the `github.com/gin-gonic/gin` package. This addresses [CVE-2020-28483](https://github.com/advisories/GHSA-h395-qcrw-5vmq) which documents a vulnerability in versions of `github.com/gin-gonic/gin` earlier than 1.7.0. 
+
+
+### Added
+* New integration `nrpgx` added to provide the same functionality for instrumenting Postgres database queries as the existing `nrpq` integration, but using the [pgx](https://github.com/jackc/pgx) driver instead. This only covers (at present) the use case of the `pgx` driver with the standard library `database/sql`. Fixes [Issue #142](https://github.com/newrelic/go-agent/issues/142) and [Issue #292](https://github.com/newrelic/go-agent/issues/292)
+
+### Changed
+* Enhanced debugging logs so that New Relic license keys are redacted from the log output. Fixes [Issue #353](https://github.com/newrelic/go-agent/issues/353).
+
+* Updated the advice in `GUIDE.md` to have correct `go get` commands with explicit reference to `v3`. 
+
+### Support Statement
+New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach end-of-life.
+


### PR DESCRIPTION
This is new release notes, and also an additional section in the list of integrations for the agent.