### PR TITLE
fix(style guide): Clarify how to refer to the docs site itself

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/alert-custom-violation-descriptions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/alert-custom-violation-descriptions.mdx
@@ -162,7 +162,7 @@ Attention <!channel>
 Recommendations for learning more:
 
 * To learn more about NerdGraph, see [Introduction to NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph).
-* See the Docs site's Alerts [landing page](/docs/alerts).
+* See the [alerts landing page](/docs/alerts).
 * Browse [New Relic's Explorers Hub](https://discuss.newrelic.com/c/telemetry-data-platform/alerts "Link opens in a new window.") for community discussions about Alerts.
 * [Find additional help or file a support ticket](/docs/accounts-partnerships/getting-started-new-relic/find-help-or-file-support-ticket).
 * Review the [Alerts licenses attributions](/docs/licenses/product-or-service-licenses/new-relic-alerts), [data usage limits](/docs/licenses/license-information/general-usage-licenses/new-relic-data-usage-limits-policies), and [other notices](/docs/licenses/license-information).

--- a/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/setcustomattribute-browser-agent-api.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/setcustomattribute-browser-agent-api.mdx
@@ -85,7 +85,7 @@ Errors for custom attributes will be included in events on the [JS Errors page](
 
 ### Get JavaScript/jQuery for HTML elements [#jquery-example]
 
-This example uses JavaScript/jQuery to get the values of the following HTML elements on the Drupal-generated pages for New Relic's Docs site:
+This example uses JavaScript/jQuery to get the values of the following HTML elements on a Drupal-generated page:
 
 * `<link rel="shortlink" href="/node/1111" />`
 * `<h1>Using NRQL</h1>`

--- a/src/content/docs/integrations/prometheus-integrations/install-configure-remote-write/prometheus-remote-write-integration.mdx
+++ b/src/content/docs/integrations/prometheus-integrations/install-configure-remote-write/prometheus-remote-write-integration.mdx
@@ -40,12 +40,3 @@ Ready to get started?
 * Set up the integration on New Relic
   * [US](http://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJ0dWNzb24ucGxnLWluc3RydW1lbnQtZXZlcnl0aGluZyJ9)
   * [EU](http://one.eu.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJ0dWNzb24ucGxnLWluc3RydW1lbnQtZXZlcnl0aGluZyJ9)
-
-## For more help
-
-Recommendations for learning more:
-
-* See the Docs site's [landing page](/docs/integrations) for Infrastructure integrations documentation.
-* Browse [New Relic's Explorers Hub](https://discuss.newrelic.com/c/full-stack-observability/infrastructure "Link opens in a new window.") for community discussions about our Infrastructure integrations.
-* [Find additional help or file a support ticket](/docs/accounts-partnerships/getting-started-new-relic/find-help-or-file-support-ticket).
-* Review New Relic's [licenses, attributions](/docs/licenses/), [data usage limits](/docs/licenses/license-information/general-usage-licenses/new-relic-data-usage-limits-policies), and [other notices](/docs/licenses/license-information).

--- a/src/content/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings.mdx
+++ b/src/content/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings.mdx
@@ -791,10 +791,3 @@ Support for Community Plus Projects from New Relic’s Global Technical Support 
 ## Support videos
 
 For a library of additional videos, webinars, and other information about using New Relic features, visit [New Relic University](https://learn.newrelic.com/) and [newrelic.com/resources](https://newrelic.com/resources).
-
-## For more help [#more_help]
-
-**Recommendations for learning more:**
-
-* See the Docs site's [landing page](/docs/licenses) for Licenses documentation.
-* Browse [New Relic's Explorers Hub](https://discuss.newrelic.com/) for community discussions about New Relic licenses.

--- a/src/content/docs/new-relic-partnerships/partner-integration-guide/getting-started/support-resources-new-relic-partners.mdx
+++ b/src/content/docs/new-relic-partnerships/partner-integration-guide/getting-started/support-resources-new-relic-partners.mdx
@@ -23,15 +23,15 @@ To obtain support for partner accounts, create a ticket at [support.newrelic.com
 
 ## Documentation [#docs]
 
-Documentation from [New Relic's Docs site](https://docs.newrelic.com) is an important resource for your support group when providing Level 1 support to your New Relic subscribers. Posting these links on your support pages is an effective way to encourage self help and reduce your support efforts.
+Documentation from [New Relic's docs site](https://docs.newrelic.com) is an important resource for your support group when providing Level 1 support to your New Relic subscribers. Posting these links on your support pages is an effective way to encourage self help and reduce your support efforts.
 
 Top level entry point for New Relic documentation: [docs.newrelic.com](https://docs.newrelic.com). From here you can select information about New Relic products and features by category.
 
 <Callout variant="tip">
-  The Docs site includes a [Partnerships](/docs/accounts-partnerships/partnerships) category with information for New Relic partners and some partnership customers.
+  The docs site includes a [Partnerships](/docs/accounts-partnerships/partnerships) category with information for New Relic partners and some partnership customers.
 </Callout>
 
-Here are the five most commonly consulted articles on the New Relic Docs site. Providing easily found and direct links to these articles can provide many users with self-serve answers to their questions.
+Here are the five most commonly consulted articles on the New Relic docs site. Providing easily found and direct links to these articles can provide many users with self-serve answers to their questions.
 
 * [Create your New Relic account](/docs/accounts-partnerships/accounts/account-setup/creating-your-new-relic-account)
 * [Name your application](/docs/apm/new-relic-apm/installation-configuration/naming-your-application)

--- a/src/content/docs/security/index.mdx
+++ b/src/content/docs/security/index.mdx
@@ -19,7 +19,7 @@ redirects:
   ![Docs site search](./images/docs-site-search.png "Docs site search")
 
   <figcaption>
-    **[docs.newrelic.com](https://docs.newrelic.com)**: You can find documentation about data privacy, security, compliance, and other topics on New Relic's Docs site.
+    **[docs.newrelic.com](https://docs.newrelic.com)**: You can find documentation about data privacy, security, compliance, and other topics on New Relic's docs site.
   </figcaption>
 </LandingPageHero>
 

--- a/src/content/docs/style-guide/article-templates/basic-doc-template.mdx
+++ b/src/content/docs/style-guide/article-templates/basic-doc-template.mdx
@@ -10,15 +10,15 @@ redirects:
   - /docs/style-guide/article-templates/html-template
 ---
 
-**This is a template.** Feel free to copy the formatting tips in this template to organize the docs you create on the Docs site. Then replace the template information with your own text, lists, and tables as needed.
+**This is a template.** Feel free to copy the formatting tips in this template to organize the docs you create on the docs site. Then replace the template information with your own text, lists, and tables as needed.
 
 Before you create sections, start your doc with a brief introduction, usually no more than a paragraph, that helps readers understand what your doc will cover. Your introduction (and the structure of your doc) should help readers understand within ten seconds whether [they are in the right place](/docs/style-guide/writing-guidelines/five-questions-help-write-docs).
 
 ## Section example [#h2_heading_example]
 
-Begin each section with a meaningful H2 title. The Docs site uses these to generate the contents, which appears automatically in the left navigation.
+Begin each section with a meaningful H2 title. The docs site uses these to generate the contents, which appears automatically in the left navigation.
 
-If you want to include a screenshot with the section, provide a permalink for the Docs team to create the image for you. Due to security requirements, the Docs team manages all images on the Docs site.
+If you want to include a screenshot with the section, provide a permalink for the Docs team to create the image for you. Due to security requirements, the Docs team manages all images on the docs site.
 
 ## Code example [#h2_code]
 

--- a/src/content/docs/style-guide/article-templates/create-release-notes.mdx
+++ b/src/content/docs/style-guide/article-templates/create-release-notes.mdx
@@ -13,7 +13,7 @@ This page is for release notes for downloadable software. For product announceme
 
 ## New release note [#new-note]
 
-To add a release note to the Docs site:
+To add a release note to the docs site:
 
 1. Find the most recent release note for your agent, and make a copy of it in the same folder.
 2. When you rename your copy, avoid potential version naming conflicts by using a `-` separator in your file name. For example, instead of `agent-123`, use `agent-1-2-3` for version 1.2.3 and `agent-12-3` for version 12.3.
@@ -23,7 +23,7 @@ To add a release note to the Docs site:
 
 A Tech Docs hero will review your release note content and approve your PR to get it published. You can also request others on your team to review your PR.
 
-We build and deploy the Docs site a few times a day, and sometimes builds can take a few hours to complete. If your release is time-sensitive, ensure you've planned for enough time to get your docs live.
+We build and deploy the docs site a few times a day, and sometimes builds can take a few hours to complete. If your release is time-sensitive, ensure you've planned for enough time to get your docs live.
 
 ## What makes a great release note? [#guidelines]
 
@@ -40,7 +40,7 @@ To write a great release note, be as specific as possible. For example:
 
 This information is primarily for the Tech Docs team's use.
 
-To add a new release notes category, update the following areas of the Docs site. (You do not need to update the `releaseNote.js` or `releaseNoteLandingPage.js` files in the `nav/templates` folder.) Before you submit your pull request to the GitHub docs site, check that the landing pages and placeholder release note build correctly in your localhost.
+To add a new release notes category, update the following areas of the docs site. (You do not need to update the `releaseNote.js` or `releaseNoteLandingPage.js` files in the `nav/templates` folder.) Before you submit your pull request to the GitHub docs site, check that the landing pages and placeholder release note build correctly in your localhost.
 
 ### Category landing page
 

--- a/src/content/docs/style-guide/article-templates/whats-new-style-guidelines.mdx
+++ b/src/content/docs/style-guide/article-templates/whats-new-style-guidelines.mdx
@@ -84,7 +84,7 @@ Learn more links are used to highlight blog posts or other marketing material th
 </Callout>
 
 <Callout variant="important">
-  Make sure to use full URLs. Relative URLs to the Docs site won't work from New Relic One.
+  Make sure to use full URLs. Relative URLs to the docs site won't work from New Relic One.
 </Callout>
 
 ### Body

--- a/src/content/docs/style-guide/processes-procedures/docs-site-edit-checklist.mdx
+++ b/src/content/docs/style-guide/processes-procedures/docs-site-edit-checklist.mdx
@@ -51,7 +51,7 @@ Do not monitor your own applications from the partnership owner account. Instead
 
 ## Structure
 
-The original tech writer or Docs site contributor is the best judge of whether the draft doc is complete. However, in your peer edit, make notes if you have unanswered questions that aren't addressed within the doc or its cross references.
+The original tech writer or docs site contributor is the best judge of whether the draft doc is complete. However, in your peer edit, make notes if you have unanswered questions that aren't addressed within the doc or its cross references.
 
 <table>
   <thead>
@@ -114,7 +114,7 @@ The original tech writer or Docs site contributor is the best judge of whether t
         * UI paths in captions always have hyperlinks.
         * Cropped images clearly show their relevance, with or without captions.
 
-        In addition, make sure that screenshots and images follow the Docs site's security guidelines, and that no private information related to customers or New Relic is displayed.
+        In addition, make sure that screenshots and images follow the docs site's security guidelines, and that no private information related to customers or New Relic is displayed.
       </td>
     </tr>
 

--- a/src/content/docs/style-guide/processes-procedures/embed-videos.mdx
+++ b/src/content/docs/style-guide/processes-procedures/embed-videos.mdx
@@ -15,7 +15,7 @@ Embed videos as an additional aid for readers when appropriate; for example, tip
 * New Relic University has its own site: [learn.newrelic.com](https://learn.newrelic.com/).
 * Marketing also stores a library of videos at [newrelic.com/resources/videos](https://newrelic.com/resources/videos) and [newrelic.com/resources/webinars](https://newrelic.com/resources/webinars).
 
-Videos are hosted externally and are embedded in the Docs site's page, linking to the external source. Official New Relic videos are hosted on [Wistia](//wistia.com). You can also embed YouTube videos, if necessary.
+Videos are hosted externally and are embedded in the docs site's page, linking to the external source. Official New Relic videos are hosted on [Wistia](//wistia.com). You can also embed YouTube videos, if necessary.
 
 ## Embed a video
 

--- a/src/content/docs/style-guide/processes-procedures/use-content-types-text-formats.mdx
+++ b/src/content/docs/style-guide/processes-procedures/use-content-types-text-formats.mdx
@@ -10,7 +10,7 @@ redirects:
   - /docs/new-relic-only/tech-writer-style-guide/processes-procedures/using-content-editors
 ---
 
-Our Docs site is made up of different content types and templates. Most of the time, the default page content type and the basic template will have everything you'll need.
+Our docs site is made up of different content types and templates. Most of the time, the default page content type and the basic template will have everything you'll need.
 
 Read on for more information about our page types.
 

--- a/src/content/docs/style-guide/quick-reference/callouts.mdx
+++ b/src/content/docs/style-guide/quick-reference/callouts.mdx
@@ -23,7 +23,7 @@ Here's an example of the `callout` format:
 </Callout>
 ```
 
-On our Docs site, we use these callout classes:
+On our docs site, we use these callout classes:
 
 <CollapserGroup>
   <Collapser
@@ -113,7 +113,7 @@ Keep these things in mind when you're working with callouts:
 
 * **If you add a callout, remove a callout.** Wherever possible, don't increase the number of callouts.
 * **Do not use stacked callouts.** Stacked callouts are two or more callouts that follow directly one after another. Not only do not use these, but if you see this in a doc, take a few minutes to break these callouts up.
-* **Remove outdated callouts.** As you're going through the Docs site, if you see a callout that's outdated, for whatever reason, take a few minutes to delete it from the doc.
+* **Remove outdated callouts.** As you're going through the docs site, if you see a callout that's outdated, for whatever reason, take a few minutes to delete it from the doc.
 * **Be stingy in your use of important and warning callouts.** If we use important and warning callouts too often, they lose their effectiveness.
 
 ### Stacked callouts example [#stacked]

--- a/src/content/docs/style-guide/quick-reference/tables.mdx
+++ b/src/content/docs/style-guide/quick-reference/tables.mdx
@@ -95,7 +95,7 @@ Additional options:
       </td>
 
       <td>
-        Set `style="width:###px;"` in the header row. In general, for two-column tables on the Docs site:
+        Set `style="width:###px;"` in the header row. In general, for two-column tables on the docs site:
 
         1. Set the first column as 200 pixels: `<th style="width:200px">`.
         2. To allow the table to adjust automatically to the remaining page width, do not set a width for the second column.

--- a/src/content/docs/style-guide/quick-reference/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/quick-reference/usage-dictionary.mdx
@@ -313,7 +313,7 @@ For a glossary of terminology specific to New Relic, [see the public glossary](/
 
     If there's not a good alternative, `doc` generally sounds more natural than `document` or `documentation`. If you're tempted to use a longer form, try reading it aloud to see which reads best.
 
-    If you must refer to the site as a whole, call it the `docs site` rather than `Docs site` or `documentation site`. Internally, you can also refer to the whole URL `docs.newrelic.com` to avoid ambiguity with other sources of docs like internal platform docs or API explorer docs.
+    If you must refer to the site as a whole, call it the `docs site` rather than `Docs site` or `documentation site`. Internally, you can also refer to the whole URL `docs.newrelic.com` to avoid ambiguity with other sources of docs like internal platform docs or API explorer docs. To refer to [our docs GitHub repo](https://github.com/newrelic/docs-website), use the repo name `docs-website` or the repo path `newrelic/docs-website`.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/style-guide/quick-reference/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/quick-reference/usage-dictionary.mdx
@@ -8,9 +8,9 @@ redirects:
   - /docs/new-relic-only/basic-style-guide/writing-guidelines/usage-dictionary
 ---
 
-We use this dictionary to ensure consistency across our Docs site. Other than the terms listed here, we generally follow the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/), but we'll use Chicago Manual of Style in a pinch. We also follow American English conventions, rather than British English ones.
+We use this dictionary to ensure consistency across our docs site. Other than the terms listed here, we generally follow the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/), but we'll use Chicago Manual of Style in a pinch. We also follow American English conventions, rather than British English ones.
 
-For a glossary of terminology specific to New Relic, [see the public glossary](/docs/using-new-relic/welcome-new-relic/getting-started/glossary) on the Docs site.
+For a glossary of terminology specific to New Relic, [see the public glossary](/docs/using-new-relic/welcome-new-relic/getting-started/glossary) on the docs site.
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/style-guide/quick-reference/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/quick-reference/usage-dictionary.mdx
@@ -8,7 +8,7 @@ redirects:
   - /docs/new-relic-only/basic-style-guide/writing-guidelines/usage-dictionary
 ---
 
-You can use this dictionary to guide your writing on [**docs.newrelic.com**](https://docs.newrelic.com). We use this to help ensure consistency across our Docs site. Other than the terms listed here, we generally follow the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/), but we'll use Chicago Manual of Style in a pinch. We also follow American English conventions, rather than British English ones.
+We use this dictionary to ensure consistency across our Docs site. Other than the terms listed here, we generally follow the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/), but we'll use Chicago Manual of Style in a pinch. We also follow American English conventions, rather than British English ones.
 
 For a glossary of terminology specific to New Relic, [see the public glossary](/docs/using-new-relic/welcome-new-relic/getting-started/glossary) on the Docs site.
 
@@ -307,11 +307,13 @@ For a glossary of terminology specific to New Relic, [see the public glossary](/
 
   <Collapser
     id="document"
-    title="doc, document, documentation"
+    title="doc, document, documentation, docs site"
   >
-    Avoid referring to the document itself (the docs site page) as much as possible. If there's not a good alternative, you can use `doc`, `document`, or `documentation` (whatever sounds most natural; try reading it aloud).
+    If you need to refer to the docs themselves—don't. Generally it's better to directly link to the doc you're referencing and use the doc title as your link text. For example, `See [Install the .NET agent](URL)` rather than `See our [.NET agent install docs](URL)`.
 
-    For example, `This document explains how to...` or `For related docs, see...`
+    If there's not a good alternative, `doc` generally sounds more natural than `document` or `documentation`. If you're tempted to use a longer form, try reading it aloud to see which reads best.
+
+    If you must refer to the site as a whole, call it the `docs site` rather than `Docs site` or `documentation site`. Internally, you can also refer to the whole URL `docs.newrelic.com` to avoid ambiguity with other sources of docs like internal platform docs or API explorer docs.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/style-guide/writing-guidelines/create-edit-content.mdx
+++ b/src/content/docs/style-guide/writing-guidelines/create-edit-content.mdx
@@ -84,7 +84,7 @@ If you are comfortable with deleting the page yourself, go for it. If not, ask u
 
 ## Add or update license documentation [#license-docs]
 
-To add or update New Relic license information, follow [standard procedures](#editing-workflow) to add or update documentation in the appropriate [**Licenses** category](/docs/licenses) on the [Docs site](https://docs.newrelic.com).
+To add or update New Relic license information, follow [standard procedures](#editing-workflow) to add or update documentation in the appropriate [**Licenses** category](/docs/licenses) on the [docs site](https://docs.newrelic.com).
 
 ## Private edits [#private-edits]
 

--- a/src/content/docs/style-guide/writing-guidelines/docs-translation.mdx
+++ b/src/content/docs/style-guide/writing-guidelines/docs-translation.mdx
@@ -17,7 +17,7 @@ New Relic documentation exists on these sites:
 * [**docs.newrelic.com**](https://docs.newrelic.com): English
 * [**docs.newrelic.co.jp**](https://docs.newrelic.co.jp): Japanese
 
-## Toggle between Docs sites [#translation-toggle]
+## Toggle between languages [#translation-toggle]
 
 The Japanese site contains the same docs as the English site—some translated into Japanese, others in English.
 

--- a/src/content/docs/style-guide/writing-guidelines/five-questions-help-write-docs.mdx
+++ b/src/content/docs/style-guide/writing-guidelines/five-questions-help-write-docs.mdx
@@ -11,7 +11,7 @@ redirects:
 
 Our five questions form the core of how our Tech Docs team thinks about writing excellent technical documentation. Informally, we call these our 5Qs.
 
-Anyone can contribute to our Docs site. We want you to feel confident and proud that your contributions provide valuable content and quality. We also want our readers to trust and easily use the information in our docs. To help you plan, write, and edit excellent docs, ask yourself the questions in this doc.
+Anyone can contribute to our docs site. We want you to feel confident and proud that your contributions provide valuable content and quality. We also want our readers to trust and easily use the information in our docs. To help you plan, write, and edit excellent docs, ask yourself the questions in this doc.
 
 ## There's really only 1Q [#one-q]
 
@@ -125,7 +125,7 @@ Each of the five questions includes sub-questions to help guide your thinking.
           <td>
             For example:
 
-            * Are we duplicating content from somewhere else in the Docs site?
+            * Are we duplicating content from somewhere else in the docs site?
             * Are we duplicating content already in the UI?
             * Could customers have a better experience if we modified the UI design or copy instead of creating a doc?
           </td>

--- a/src/content/docs/style-guide/writing-guidelines/hyperlinks.mdx
+++ b/src/content/docs/style-guide/writing-guidelines/hyperlinks.mdx
@@ -85,7 +85,7 @@ Get support at [support.newrelic.com](support.newrelic.com).
 
 ## Docs site ("internal") links [#Hyperlinks-internal]
 
-When creating links to other documents on the Docs site, include only the path from `/docs` forward. Do not include `https://docs.newrelic.com`, or the site will treat it as an external link.
+When creating links to other documents on the docs site, include only the path from `/docs` forward. Do not include `https://docs.newrelic.com`, or the site will treat it as an external link.
 
 Here is an example:
 
@@ -106,7 +106,7 @@ When creating or editing an HTML `id` for an anchor link, follow these guideline
 
 ## External links [#hyperlinks-external]
 
-When creating links to websites outside the `docs.newrelic.com` subdomain (including `newrelic.com`, `one.newrelic.com`, `discuss.newrelic.com`), the Docs site automatically includes code that opens the link in a new tab.
+When creating links to websites outside the `docs.newrelic.com` subdomain (including `newrelic.com`, `one.newrelic.com`, `discuss.newrelic.com`), the docs site automatically includes code that opens the link in a new tab.
 
 In addition to the link text guidelines in this doc, here are some other things to keep in mind when linking to external sites:
 

--- a/src/content/docs/style-guide/writing-guidelines/levels-headings.mdx
+++ b/src/content/docs/style-guide/writing-guidelines/levels-headings.mdx
@@ -25,7 +25,7 @@ For all headers, keep the title as short as possible. In particular, avoid heade
 
 ## Do not use h1 headings [#h1_headings]
 
-After you publish your doc, the Docs site will automatically use what you added to the **Title** field as the doc's level one heading (h1). To ensure that your doc is properly indexed for search, do not manually create additional h1 headings.
+After you publish your doc, the docs site will automatically use what you added to the **Title** field as the doc's level one heading (h1). To ensure that your doc is properly indexed for search, do not manually create additional h1 headings.
 
 If your doc's title is long and you would like a shorter title to appear in the sidebar menu, [create a GitHub issue](https://github.com/newrelic/docs-website/issues/new/choose) and we'll help you with that change. 
 

--- a/src/content/docs/style-guide/writing-guidelines/screenshots-images.mdx
+++ b/src/content/docs/style-guide/writing-guidelines/screenshots-images.mdx
@@ -9,10 +9,6 @@ topics:
 
 Images help to illustrate confusing UI paths, complex concepts like [config file overrides](/docs/agents/python-agent/installation-configuration/python-agent-configuration#options), or sometimes just to add visual interest. Whenever possible, send the Docs team a [permalink](/docs/accounts-partnerships/education/getting-started-new-relic/permalink) rather than an image.
 
-<Callout variant="important">
-  To ensure the consistency and security of any data presented in Docs site images, only the Docs team is authorized to add or update screenshots and other images on the Docs site.
-</Callout>
-
 The goal of this document it to give you some tips about creating images, but if you need help embedding them on our site, see [Embed images](/docs/style-guide/processes-procedures/embed-images).
 
 ## Guidelines for image types [#types]

--- a/src/content/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal.mdx
+++ b/src/content/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal.mdx
@@ -48,7 +48,7 @@ New Relic offers a variety of support options, including online help, a troubles
 
 ## Find answers in New Relic Docs and New Relic University [#find-answers]
 
-New Relic's [Docs site](https://docs.newrelic.com/) contains helpful installation, configuration, and troubleshooting tips. From the [main page](http://docs.newrelic.com), select from frequently-used categories and topics, like [release notes](/docs/release-notes). Or, [search from any page](http://docs.newrelic.com/search).
+New Relic's [docs site](https://docs.newrelic.com/) contains helpful installation, configuration, and troubleshooting tips. From the [main page](http://docs.newrelic.com), select from frequently-used categories and topics, like [release notes](/docs/release-notes). Or, [search from any page](http://docs.newrelic.com/search).
 
 For a library of additional videos, webinars, and other information about using New Relic features, visit [New Relic University](https://learn.newrelic.com/) and [newrelic.com/resources](https://newrelic.com/resources/videos).
 


### PR DESCRIPTION
* Improve intro paragraph by removing redundant sentences
* Clarify how to refer to the docs site itself, and what the best linking styles are