### PR TITLE
Remove break elements to prevent serialization error

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/administration/new-synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/new-synthetic-public-minion-ips.mdx
@@ -47,15 +47,15 @@ The following table lists the IP addresses that will be added on July 15 2021 to
       "Tokyo, JP"
     </td>
     <td>
-      54.250.11.193<br/>
-      3.113.102.86<br/>
-      52.193.74.189<br/>
+      54.250.11.193
+      3.113.102.86
+      52.193.74.189
       18.177.40.17
     </td>
     <td>
-      ec2-54-250-11-193.ap-northeast-1.compute.amazonaws.com<br/>
-      ec2-3-113-102-86.ap-northeast-1.compute.amazonaws.com<br/>
-      ec2-52-193-74-189.ap-northeast-1.compute.amazonaws.com<br/>
+      ec2-54-250-11-193.ap-northeast-1.compute.amazonaws.com
+      ec2-3-113-102-86.ap-northeast-1.compute.amazonaws.com
+      ec2-52-193-74-189.ap-northeast-1.compute.amazonaws.com
       ec2-18-177-40-17.ap-northeast-1.compute.amazonaws.com
     </td>
   </tr>
@@ -68,11 +68,11 @@ The following table lists the IP addresses that will be added on July 15 2021 to
       "Seoul, KR"
     </td>
     <td>
-      3.34.173.249<br/>
+      3.34.173.249
       52.79.48.153
     </td>
     <td>
-      ec2-3-34-173-249.ap-northeast-2.compute.amazonaws.com<br/>
+      ec2-3-34-173-249.ap-northeast-2.compute.amazonaws.com
       ec2-52-79-48-153.ap-northeast-2.compute.amazonaws.com
     </td>
   </tr>
@@ -100,13 +100,13 @@ The following table lists the IP addresses that will be added on July 15 2021 to
       "Singapore, SG"
     </td>
     <td>
-      52.76.41.181<br/>
-      54.179.195.220<br/>
+      52.76.41.181
+      54.179.195.220
       18.138.16.42
     </td>
     <td>
-      ec2-52-76-41-181.ap-southeast-1.compute.amazonaws.com<br/>
-      ec2-54-179-195-220.ap-southeast-1.compute.amazonaws.com<br/>
+      ec2-52-76-41-181.ap-southeast-1.compute.amazonaws.com
+      ec2-54-179-195-220.ap-southeast-1.compute.amazonaws.com
       ec2-18-138-16-42.ap-southeast-1.compute.amazonaws.com
     </td>
   </tr>
@@ -119,11 +119,11 @@ The following table lists the IP addresses that will be added on July 15 2021 to
       "Montreal, Quebec, CA"
     </td>
     <td>
-      3.96.243.128<br/>
+      3.96.243.128
       3.97.226.155
     </td>
     <td>
-      ec2-3-96-243-128.ca-central-1.compute.amazonaws.com<br/>
+      ec2-3-96-243-128.ca-central-1.compute.amazonaws.com
       ec2-3-97-226-155.ca-central-1.compute.amazonaws.com
     </td>
   </tr>
@@ -136,11 +136,11 @@ The following table lists the IP addresses that will be added on July 15 2021 to
       "São Paulo, BR"
     </td>
     <td>
-      54.94.27.80<br/>
+      54.94.27.80
       18.229.241.206
     </td>
     <td>
-      ec2-54-94-27-80.sa-east-1.compute.amazonaws.com<br/>
+      ec2-54-94-27-80.sa-east-1.compute.amazonaws.com
       ec2-18-229-241-206.sa-east-1.compute.amazonaws.com
     </td>
   </tr>
@@ -153,11 +153,11 @@ The following table lists the IP addresses that will be added on July 15 2021 to
       "Portland, OR, USA"
     </td>
     <td>
-      44.236.111.66 <br/>
+      44.236.111.66 
       54.203.108.135
     </td>
     <td>
-      ec2-44-236-111-66.us-west-2.compute.amazonaws.com<br/>
+      ec2-44-236-111-66.us-west-2.compute.amazonaws.com
       ec2-54-203-108-135.us-west-2.compute.amazonaws.com
     </td>
   </tr>
@@ -200,11 +200,11 @@ The following table lists the upcoming IP addresses that will be added to public
       "Tokyo, JP"
     </td>
     <td>
-      35.72.129.240<br/>
+      35.72.129.240
       35.73.187.89
     </td>
     <td>
-      ec2-35-72-129-240.ap-northeast-1.compute.amazonaws.com<br/>
+      ec2-35-72-129-240.ap-northeast-1.compute.amazonaws.com
       ec2-35-73-187-89.ap-northeast-1.compute.amazonaws.com
     </td>
   </tr>
@@ -217,11 +217,11 @@ The following table lists the upcoming IP addresses that will be added to public
       "Seoul, KR"
     </td>
     <td>
-      13.125.155.211<br/>
+      13.125.155.211
       15.164.119.0
     </td>
     <td>
-      ec2-13-125-155-211.ap-northeast-2.compute.amazonaws.com<br/>
+      ec2-13-125-155-211.ap-northeast-2.compute.amazonaws.com
       ec2-15-164-119-0.ap-northeast-2.compute.amazonaws.com
     </td>
   </tr>


### PR DESCRIPTION
## Description

Removes `<br/>` elements from table in one file that was causing error when trying to serialize the HTML to upload to translation vendor. I believe we want to follow markdown syntax inside of `<td>` elements as much as possible.

I tested locally and serialization seemed to work with these changes.

## Related issues / PRs
Related to [this recent failure](https://github.com/newrelic/docs-website/runs/3479407196?check_suite_focus=true#step:6:66).

