### PR TITLE
Kafka v4 config samples and improvements

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
@@ -60,13 +60,15 @@ The integration will use Zookeeper only for discovering brokers and will not ret
 
 ### Topic listing [#topic-listing]
 
-To correctly list the topics processed by the brokers, the integration needs to to contact brokers over the Kafka protocol. Depending on how the brokers are configured, this might require setting up SSL and/or SASL to match the broker configuration.
+To correctly list the topics processed by the brokers, the integration needs to to contact brokers over the Kafka protocol. Depending on how the brokers are configured, this might require setting up SSL and/or SASL to match the broker configuration. The topics must have DESCRIBE access.
 
 ### Broker monitoring (JMX) [#broker-monitoring]
 
 The Kafka integration queries JMX, a standard Java extension for exchanging metrics in Java applications. JMX is not enabled by default in Kafka brokers, and you need to enable it for metrics collection to work properly. JMX requires RMI to be enabled, and the RMI port needs to be set to the same port as JMX.
 
 You can configure JMX to use username/password authentication, as well as SSL. If such features have been enabled in the broker's JMX settings, you need to configure the integration accordingly.
+
+If autodiscovery is set to bootstrap, the JMX settings defined for the bootstrap broker will be applied for all other discovered brokers, so the Port and other settings should be the same on all the brokers.
 
 <Callout variant="important">
 
@@ -88,7 +90,7 @@ As a summary, the integration needs to be configured and allowed to connect to:
 * All brokers in the cluster over the Kafka protocol and port, using the Kafka brokers' authentication/transport mechanisms.
 * All brokers in the cluster over the JMX protocol and port, using the authentication/transport mechanisms specified in the JMX configuration of the brokers.
 * All producers/consumers specified in producers and consumers over the JMX protocol and port, if you want producer/consumer monitoring. JMX settings for the consumer must be the same as for the brokers.
-    
+
 <Callout variant="important">
 
 **For the cloud:** By default, Security Groups (and their equivalents in other cloud providers) in AWS do not have the required ports open by default. JMX requires two ports in order to work: the JMX port and the RMI port. These can be set to the same value when configuring the JVM to enable JMX and **must** be open for the integration to be able to connect to and collect metrics from brokers.
@@ -1288,7 +1290,7 @@ Troubleshooting tips:
     To check whether JMX is correctly configured, run the following command for each broker from the machine running the Kafka integration. Replace the highlighted <var>PORT</var>, <var>USERNAME</var>, and <var>PASSWORD</var> tokens with the corresponding JMX settings for the brokers:
 
     ```
-    $ echo "*:*" | nrjmx -hostname <var>HOSTNAME</var> -port <var>PORT</var> -v -username <var>USERNAME</var> -password <var>PASSWORD</var>    
+    $ echo "*:*" | nrjmx -hostname <var>HOSTNAME</var> -port <var>PORT</var> -v -username <var>USERNAME</var> -password <var>PASSWORD</var>
     ```
     The command should generate the output showing a long series of metrics without any errors.
   </Collapser>

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
@@ -40,11 +40,11 @@ Given the distributed nature of Kafka, the actual number and list of brokers is 
 
 #### Bootstrap [#bootstrap]
 
-With the bootstrap mechanism, the integration uses a bootstrap broker to perform the autodiscovery. This is a broker whose address is well known and that will be asked for any other brokers it is aware of. The integration needs to be able to contact this broker in the address provided in the bootstrap_broker_host parameter for bootstrap discovery to work.
+With the [bootstrap mechanism](#bootstrap-discovery), the integration uses a bootstrap broker to perform the autodiscovery. This is a broker whose address is well known and that will be asked for any other brokers it is aware of. The integration needs to be able to contact this broker in the address provided in the bootstrap_broker_host parameter for bootstrap discovery to work.
 
 #### Zookeeper [#zookeeper]
 
-Alternatively, the Kafta integration can also talk to a Zookeeper server in order to obtain the list of brokers. To do this, the integration needs to be provided with the following:
+Alternatively, the Kafta integration can also talk to a [Zookeeper server](#zookeeper-discovery) in order to obtain the list of brokers. To do this, the integration needs to be provided with the following:
 
 * The list of Zookeeper hosts to contact (zookeeper_hosts).
 * The proper authentication secrets to connect with the hosts.
@@ -60,7 +60,7 @@ The integration will use Zookeeper only for discovering brokers and will not ret
 
 ### Topic listing [#topic-listing]
 
-To correctly list the topics processed by the brokers, the integration needs to to contact brokers over the Kafka protocol. Depending on how the brokers are configured, this might require setting up SSL and/or SASL to match the broker configuration. The topics must have DESCRIBE access.
+To correctly list the topics processed by the brokers, the integration needs to contact brokers over the Kafka protocol. Depending on how the brokers are configured, this might require setting up SSL and/or SASL to match the broker configuration. The topics must have DESCRIBE access.
 
 ### Broker monitoring (JMX) [#broker-monitoring]
 
@@ -75,9 +75,13 @@ If autodiscovery is set to bootstrap, the JMX settings defined for the bootstrap
 We do not recommend enabling anonymous and/or unencrypted JMX/RMI access on public or untrusted network segments because this poses a big security risk.
 </Callout>
 
+### Consumer offset [#consumer-offset]
+
+The offset of the consumer and consumer groups of the topics as well as the lag, can be retrieved as a [KafkaOffsetSample](#KafkaOffsetSample-collection) with the `CONSUMER_OFFSET=true` flag but should be in a separate instance because when this flag is activated the instance will not collect other Samples.
+
 ### Producer/consumer monitoring (JMX) [#producer]
 
-Producers and consumers written in Java can also be monitored through the same mechanism (JMX). JMX needs to be enabled and configured on those applications where it is not enabled by default.
+Producers and consumers written in Java can also be monitored to get more specific metadata through the same mechanism (JMX). This will generate [KafkaConsumerSamples and KafkaProducerSamples](#KafkaConsumerSample-collection). JMX needs to be enabled and configured on those applications where it is not enabled by default.
 
 Non-Java producers and consumers do not support JMX and are therefore not supported by the Kafka integration.
 
@@ -181,8 +185,8 @@ Specific settings related to Kafka are defined using the `env` section of the co
 
 <Callout variant="important">
   The integration has two modes of operation, which are mutually exclusive: “Core” collection and "Consumer offset collection" controlled by the CONSUMER_OFFSET parameter:
-  - `CONSUMER_OFFSET = true` is consumer offset collection mode, and will produce KafkaOffsetSample.
-  - `CONSUMER_OFFSET = false` is core collection mode, which can collect the rest of the samples (KafkaBrokerSample, KafkaProducerSample, KafkaConsumerSample, KafkaTopicSample).
+  - `CONSUMER_OFFSET = true` is consumer offset collection mode, and will produce [KafkaOffsetSample](#KafkaOffsetSample-collection).
+  - `CONSUMER_OFFSET = false` is core collection mode, which can collect the rest of the samples ([KafkaBrokerSample, KafkaTopicSample](#broker-collection), [KafkaProducerSample, KafkaConsumerSample](#KafkaConsumerSample-collection)).
 
 These modes are separated because consumer offset collection takes a long time to run and has high performance requirements.
 </Callout>
@@ -207,7 +211,7 @@ Our default sample config file includes examples of labels but, as they are not 
 
 For more about the general structure of on-host integration configuration, see [Configuration](/docs/integrations/integrations-sdk/file-specifications/host-integration-configuration-overview).
 
-## Configure KafkaBrokerSample and KafkaTopicSample collection
+## Configure KafkaBrokerSample and KafkaTopicSample collection [#broker-collection]
 
 The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<strong>I</strong>) information. Check the **Applies To** column below to find which settings can be used for each specific collection:
 
@@ -309,7 +313,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
   </tbody>
 </table>
 
-#### **Zookeeper autodiscovery arguments** (only relevant when `autodiscover_strategy` is `zookeeper`):
+#### **Zookeeper autodiscovery arguments** (only relevant when `autodiscover_strategy` is `zookeeper`): [#zookeeper-discovery]
 
 <table>
   <thead>
@@ -409,7 +413,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
   </tbody>
 </table>
 
-#### **Bootstrap broker discovery arguments** (only relevant when `autodiscover_strategy` is `bootstrap`):
+#### **Bootstrap broker discovery arguments** (only relevant when `autodiscover_strategy` is `bootstrap`): [#bootstrap-discovery]
 
 <table>
   <thead>
@@ -1035,7 +1039,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
   </tbody>
 </table>
 
-## Configure KafkaConsumerSample and KafkaProducerSample collection
+## Configure KafkaConsumerSample and KafkaProducerSample collection [#KafkaConsumerSample-collection]
 
 The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<strong>I</strong>) information. Check the **Applies To** column below to find which settings can be used for each specific collection:
 
@@ -1297,7 +1301,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
   </tbody>
 </table>
 
-## Configure KafkaOffsetSample collection
+## Configure KafkaOffsetSample collection [#KafkaOffsetSample-collection]
 
 The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<strong>I</strong>) information. Check the **Applies To** column below to find which settings can be used for each specific collection:
 
@@ -2250,7 +2254,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
   </Collapser>
   <Collapser
     id="example7"
-    title="CONSUMER PRODUCER"
+    title="JAVA CONSUMER & PRODUCER"
   >
     This gives an example for collecting JMX metrics from Java consumers and producers:
 

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
@@ -163,280 +163,2151 @@ Additional notes:
 
 ## Configure the integration [#config]
 
-An integration's YAML-format configuration is where you can place required login credentials and configure how data is collected. Which options you change depend on your setup and preference. The entire environment can be monitored remotely or on any node in that environment.
-
 There are several ways to configure the integration, depending on how it was installed:
 
 * If enabled via Kubernetes: see [Monitor services running on Kubernetes](/docs/monitor-service-running-kubernetes).
 * If enabled via Amazon ECS: see [Monitor services running on ECS](/docs/integrations/host-integrations/host-integrations-list/monitor-services-running-amazon-ecs).
 * If installed on-host: edit the config in the integration's YAML config file, `kafka-config.yml`.
 
-For examples of typical configurations, see the [example configurations](#example-config).
+An integration's YAML-format configuration is where you can place required login credentials and configure how data is collected. Which options you change depend on your setup and preference. The entire environment can be monitored remotely or on any node in that environment.
+
+The configuration file has common settings applicable to all integrations like `interval`, `timeout`, `inventory_source`. To read all about these common settings refer to our [Configuration Format](/docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integrations-newer-configuration-format/#configuration-basics) document.
 
 <Callout variant="important">
-  With secrets management, you can configure on-host integrations with New Relic infrastructure's agent to use sensitive data (such as passwords) without having to write them as plain text into the integration's configuration file. For more information, see [Secrets management](/docs/integrations/host-integrations/installation/secrets-management).
+  If you are still using our Legacy configuration/definition files please refer to this [document](/docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integrations-standard-configuration-format/) for help.
 </Callout>
 
-### Commands
+Specific settings related to Kafka are defined using the `env` section of the configuration file. These settings control the connection to your Brokers, Zookeeper and JMX as well as other security settings and features. The list of valid settings is described in the next section of this document.
 
-The configuration accepts the following commands:
+<Callout variant="important">
+  The integration has two modes of operation, which are mutually exclusive: “Core” collection and "Consumer offset collection" controlled by the CONSUMER_OFFSET parameter:
+  - `CONSUMER_OFFSET = true` is consumer offset collection mode, and will produce KafkaOffsetSample.
+  - `CONSUMER_OFFSET = false` is core collection mode, which can collect the rest of the samples (KafkaBrokerSample, KafkaProducerSample, KafkaConsumerSample, KafkaTopicSample).
 
-* `inventory`: collects configuration status
-* `metrics`: collects performance metrics
-* `consumer_offset`: collects consumer group offset data
-
-### Arguments
-
-The configuration accepts the following arguments:
-
-**General arguments:**
-
-* `cluster_name`: user-defined name to uniquely identify the cluster being monitored. Required.
-* `kafka_version`: the version of the Kafka broker you're connecting to, used for setting optimum API versions. Defaults to `1.0.0`. Versions older than 1.0.0 may be missing some features.
-* `autodiscover_strategy`: the method of discovering brokers. Options are `zookeeper` or `bootstrap`. Defaults to `zookeeper`
-
-**Zookeeper autodiscovery arguments** (only relevant when `autodiscover_strategy` is `zookeeper`):
-
-* `zookeeper_hosts`: the list of Apache ZooKeeper hosts (in JSON format) that need to be connected.
-* `zookeeper_auth_scheme`: the ZooKeeper authentication scheme that is used to connect. Currently, the only supported value is `digest`. If omitted, no authentication is used.
-* `zookeeper_auth_secret`: the ZooKeeper authentication secret that is used to connect. Should be of the form `username:password`. Only required if `zookeeper_auth_scheme` is specified.
-* `zookeeper_path`: the Zookeeper node under which the Kafka configuration resides. Defaults to `/`.
-* `preferred_listener`: use a specific listener to connect to a broker. If unset, the first listener that passes a successful test connection is used. Supported values are `PLAINTEXT`, `SASL_PLAINTEXT`, `SSL`, and `SASL_SSL`. Note: The `SASL_*` protocols only support Kerberos (GSSAPI) authentication.
-
-**Bootstrap broker discovery arguments** (only relevant when `autodiscover_strategy` is `bootstrap`):
-
-* `bootstrap_broker_host`: the host for the bootstrap broker.
-* `bootstrap_broker_kafka_port`: the Kafka port for the bootstrap broker.
-* `bootstrap_broker_kafka_protocol`: the protocol to use to connect to the bootstrap broker. Supported values are `PLAINTEXT`, `SASL_PLAINTEXT`, `SSL`, and `SASL_SSL`. Note: The `SASL_*` protocols only support Kerberos (GSSAPI) authentication. Default: `PLAINTEXT`.
-* `bootstrap_broker_jmx_port`: the JMX port to use for collection.
-* `bootstrap_broker_jmx_user`: the JMX user to use for collection.
-* `bootstrap_broker_jmx_password`: the JMX password to use for collection.
-
-**Producer and consumer collection:**
-
-* `producers`: producers to collect. For each provider a `name`, `hostname`, `port`, `username`, and `password` can be provided in JSON form. `name` is the producer’s name as it appears in Kafka. `hostname`, `port`, `username`, and `password` are optional and use the default if unspecified.
-* `consumers`: consumers to collect. For each consumer a `name`, `hostname`, `port`, `username`, and `password` can be specified in JSON form. `name` is the consumer’s name as it appears in Kafka. `hostname`, `port`, `username`, and `password` are optional and use the default if unspecified.
-
-**JMX connection options:**
-
-* `default_jmx_host`: the default host to collect JMX metrics. If the host field is omitted from a producer or consumer configuration, this value will be used.
-* `default_jmx_port`: the default port to collect JMX metrics. If the port field is omitted from a producer or consumer configuration, this value will be used.
-* `default_jmx_user`: the default user that is connecting to the JMX host to collect metrics. This field should only be used if all brokers have a non-default username. If the username field is omitted from a producer or consumer configuration, this value will be used.
-* `default_jmx_password`: the default password to connect to the JMX host. This field should only be used if all brokers have a non-default password. If the password field is omitted from a producer or consumer configuration, this value will be used.
-* `key_store`: the filepath of the keystore containing the JMX client's SSL certificate.
-* `key_store_password`: the password for the JMX SSL key store.
-* `trust_store`: the filepath of the trust keystore containing the JMX server's SSL certificate.
-* `trust_store_password`: the password for the JMX trust store.
-* `timeout`: the timeout for individual JMX queries in milliseconds. Default: `10000`.
-
-**Broker connection options:**
-
-* `tls_ca_file`: the certificate authority file for SSL and SASL_SSL listeners, in PEM format.
-* `tls_cert_file`: the client certificate file for SSL and SASL_SSL listeners, in PEM format.
-* `tls_key_file`: the client key file for SSL and SASL_SSL listeners, in PEM format.
-* `tls_insecure_skip_verify`: skip verifying the server's certificate chain and host name
-* `sasl_mechanism`: the type of SASL authentication to use. Supported options are `SCRAM-SHA-512`, `SCRAM-SHA-256`, `PLAIN`, and `GSSAPI`.
-* `sasl_gssapi_realm`: kerberos realm. Required for `SASL_SSL` or `SASL_PLAINTEXT`
-* `sasl_gssapi_service_name`: kerberos service name. Required for `SASL_SSL` or `SASL_PLAINTEXT`
-* `sasl_gssapi_username`: kerberos username. Required for `SASL_SSL` or `SASL_PLAINTEXT`
-* `sasl_gssapi_key_tab_path`: path to the kerberos keytab. Required for `SASL_SSL` or `SASL_PLAINTEXT`
-* `sasl_gssapi_kerberos_config_path`: path to the kerberos config file. Default: `/etc/krb5.conf`
-
-**Collection filtering:**
-
-* `collect_broker_topic_data`: signals if broker and topic metrics are collected. Options are `true` or `false`, defaults to `true`. Should only be set to `false` when monitoring only producers and consumers, and `topic_mode` is set to `all`.
-* `local_only_collection`: collect only the metrics related to the configured bootstrap broker. Only used if `autodiscover_strategy` is `bootstrap`. Default: `false`
-* `consumer_group_regex`: regex pattern that matches the consumer groups to collect offset statistics for. This is limited to collecting statistics for 300 consumer groups. Note: `consumer_groups` has been deprecated, use this argument instead.
-* `topic_mode`: determines how many topics we collect. Options are `all`, `none`, `list`, or `regex`.
-* `collect_topic_size`: collect the metric Topic size. Options are `true` or `false`, defaults to `false`. `topic_size` is a resource-intensive metric to collect.
-* `topic_list`: array of topic names to monitor. Only in effect if `topic_mode` is set to `list`.
-* `topic_regex`: regex pattern that matches the topic names to monitor. Only in effect if `topic_mode` is set to `regex`.
-* `topic_bucket`: used to split topic collection across multiple instances. Should be of the form `<bucket number>/<number of buckets>`. Default: `1/1`.
-
-### Labels
-
-Labels are optional tags which help to identify collection data. Some examples are included below.
-
-* `env`: label to identify the environment. For example: `production`.
-* `role`: label to identify which role is accessing the data.
-
-### Example configuration [#example-config]
-
-<Callout variant="tip">
-  For more details on configuration parameters, see the [kafka-config.yml.sample config file](https://github.com/newrelic/nri-kafka/blob/master/kafka-config.yml.sample) on GitHub.
+These modes are separated because consumer offset collection takes a long time to run and has high performance requirements.
 </Callout>
 
-<CollapserGroup id="config-examples">
-  <Collapser
-    id="single-agent"
-    title="Example: Single agent deployment"
-  >
-    Let's consider an environment with the following structure. For this environment, assume the infrastructure agent is installed on the ZooKeeper node.
+The values for these settings can be defined in several ways:
+* Adding the value directly in the config file. This is the most common way.
+* Replacing the values from environment variables using the `{{}}` notation. This requires infrastructure agent v1.14.0+. Read more [here](/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/#passthrough).
+* Using Secrets management. Use this to protect sensible information such as passwords to be exposed in plain text on the configuration file. For more information, see [Secrets management](https://docs.newrelic.com/docs/integrations/host-integrations/installation/secrets-management).
 
-    * Brokers
-    * Single ZooKeeper node
-    * Single producer:
+### Labels/Custom Attributes [#labels]
 
-      * Name: `my-producer`
-      * Host: `my-producer.my.localnet`
-      * JMX Port: `9989`
-    * Single consumer:
+Environment variables can be used to control config settings, such as your license key, and are then passed through to the Infrastructure agent. For instructions on how to use this feature, see [Configure the Infrastructure agent](/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#passthrough).
 
-      * Name: `my-consumer`
-      * Host: `my-consumer.my.localnet`
-      * JMX Port: `9987`
-
-    Example `kafka-config.yml` config file for this environment:
+You can further decorate your metrics using labels. Labels allow you to add key/value pairs attributes to your metrics which you can then use to query, filter or group your metrics on.<br/>
+Our default sample config file includes examples of labels but, as they are not mandatory, you can remove, modify or add new ones of your choice.
 
 ```
-integration_name: com.newrelic.kafka
-
-instances:
-  - name: kafka-metrics
-    command: metrics
-    arguments:
-      zookeeper_hosts: '[{"host": "localhost", "port": 2181}]'
-      producers: '[{"name": "my-producer", "host": "my-producer.my.localnet", "port": 9989}]'
-      consumers: '[{"name": "my-consumer", "host": "my-consumer.my.localnet", "port": 9987}]'
-      topic_mode: List
-      collect_topic_size: false
-      topic_list: '["topic_1", "topic_2"]'
-    labels:
-      env: production
-      role: kafka
-
-  - name: kafka-inventory
-    command: inventory
-    arguments:
-      zookeeper_hosts: '[{"host": "localhost", "port": 2181}]'
-      topic_mode: Regex
-      topic_regex: 'topic_[0-9]+'
-    labels:
-      env: production
-      role: kafka
-```
-  </Collapser>
-
-  <Collapser
-    id="multiple-agents"
-    title="Example: Multiple agent deployment"
-  >
-    Let's consider an environment with the following structure. For this environment, assume the infrastructure agent is installed on the ZooKeeper node, the producer node, and the consumer node.
-
-    * Brokers
-    * Single ZooKeeper node
-    * Single producer:
-
-      * Name: `my-producer`
-      * Host: `my-producer.my.localnet`
-      * JMX Port: `9989`
-    * Single consumer:
-
-      * Name: `my-consumer`
-      * Host: `my-consumer.my.localnet`
-      * JMX Port: `9987`
-
-    Example `kafka-config.yml` config file for this environment:
-
-    **ZooKeeper node configuration:**
-
-```
-integration_name: com.newrelic.kafka
-
-instances:
-  - name: kafka-metrics
-    command: metrics
-    arguments:
-      zookeeper_hosts: '[{"host": "localhost", "port": 2181}]'
-      topic_mode: List
-      collect_topic_size: false
-      topic_list: '["topic_1", "topic_2"]'
-    labels:
-      env: production
-      role: kafka
-
-  - name: kafka-inventory
-    command: inventory
-    arguments:
-      zookeeper_hosts: '[{"host": "localhost", "port": 2181}]'
-      topic_mode: List
-      topic_list: '["topic_1", "topic_2"]'
-    labels:
-      env: production
-      role: kafka
-```
-
-    **Producer node configuration:**
-
-```
-integration_name: com.newrelic.kafka
-
-instances:
-  - name: kafka-metrics
-    command: metrics
-    arguments:
-      producers: '[{"name": "my-producer", "host": "my-producer.my.localnet", "port": 9989}]'
-      topic_mode: List
-      topic_list: '["topic_1", "topic_2"]'
-    labels:
-      env: production
-      role: kafka
-```
-
-    **Consumer node configuration:**
-
-```
-integration_name: com.newrelic.kafka
-
-instances:
-  - name: kafka-metrics
-    command: metrics
-    arguments:
-      consumers: '[{"name": "my-consumer", "host": "my-consumer.my.localnet", "port": 9987}]'
-      topic_mode: List
-      topic_list: '["topic_1", "topic_2"]'
-    labels:
-      env: production
-      role: kafka
-```
-  </Collapser>
-
-  <Collapser
-    id="offset-collection"
-    title="Example: Offset collection"
-  >
-    Let's consider an environment with the following structure. For this environment, assume the infrastructure agent is installed on the ZooKeeper node.
-
-    <Callout variant="important">
-      Due to the load that collecting offset data can put on the Kafka environment, collecting offsets is done independently of normal metric and inventory data collection. We recommend installing the offset collection only on one node.
-    </Callout>
-
-    * Brokers
-    * Single ZooKeeper node
-    * Consumers
-    * Consumer Groups
-      * consumer_group_a1
-      * consumer_group_a2
-      * consumer_group_b1
-
-    For this example environment, if you want to monitor offsets for only `consumer_group_a1` and `consumer_group_a2`, a sample config might look like this:
-
-```
-integration_name: com.newrelic.kafka
-
-- name: kafka-consumer-offsets
-  command: consumer_offset
-  arguments:
-    zookeeper_hosts: '[{"host": "localhost", "port": 2181}]'
-    consumer_group_regex: 'consumer_group_a.'
   labels:
     env: production
     role: kafka
 ```
+
+For more about the general structure of on-host integration configuration, see [Configuration](/docs/integrations/integrations-sdk/file-specifications/host-integration-configuration-overview).
+
+## Configure KafkaBrokerSample and KafkaTopicSample collection
+
+The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<strong>I</strong>) information. Check the **Applies To** column below to find which settings can be used for each specific collection:
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>
+      **CLUSTER_NAME**
+    </td>
+    <td>
+      user-defined name to uniquely identify the cluster being monitored. **Required**.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **KAFKA_VERSION**
+    </td>
+    <td>
+      The version of the Kafka broker you're connecting to, used for setting optimum API versions. It must match -or be lower than- the version from the broker.
+
+      Versions older than 1.0.0 may be missing some features.
+
+      **Note that if the broker binary name is kafka_2.12-2.7.0 the Kafka api version to be used is 2.7.0, the preceding 2.12 is the Scala language version**.
+    </td>
+    <td>
+      1.0.0
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **AUTODISCOVER_STRATEGY**
+    </td>
+    <td>
+      the method of discovering brokers. Options are `zookeeper` or `bootstrap`.
+    </td>
+    <td>
+      zookeeper
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **METRICS**
+    </td>
+    <td>
+      Set to `true` to enable Metrics only collection.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **INVENTORY**
+    </td>
+    <td>
+      Set to `true` to enable Inventory only collection.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+#### **Zookeeper autodiscovery arguments** (only relevant when `autodiscover_strategy` is `zookeeper`):
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>
+      **ZOOKEEPER_HOSTS**
+    </td>
+    <td>
+      The list of Apache ZooKeeper hosts (in JSON format) that need to be connected.
+
+      ** If `CONSUMER_OFFSET` is set to `false` `KafkaBrokerSamples` and `KafkaTopicSamples` will be collected.**
+    </td>
+    <td>
+      []
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **ZOOKEEPER_AUTH_SCHEME**
+    </td>
+    <td>
+      The ZooKeeper authentication scheme that is used to connect. Currently, the only supported value is `digest`. If omitted, no authentication is used.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **ZOOKEEPER_AUTH_SECRET**
+    </td>
+    <td>
+      The ZooKeeper authentication secret that is used to connect. Should be of the form `username:password`. Only required if `zookeeper_auth_scheme` is specified.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **ZOOKEEPER_PATH**
+    </td>
+    <td>
+      The Zookeeper node under which the Kafka configuration resides. Defaults to `/`.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **PREFERRED_LISTENER**
+    </td>
+    <td>
+      Use a specific listener to connect to a broker. If unset, the first listener that passes a successful test connection is used. Supported values are `PLAINTEXT`, `SASL_PLAINTEXT`, `SSL`, and `SASL_SSL`. Note: The `SASL_*` protocols only support Kerberos (GSSAPI) authentication.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+#### **Bootstrap broker discovery arguments** (only relevant when `autodiscover_strategy` is `bootstrap`):
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>
+      **BOOTSTRAP_BROKER_HOST**
+    </td>
+    <td>
+      The host for the bootstrap broker.
+
+      ** If `CONSUMER_OFFSET` is set to `false` `KafkaBrokerSamples` and `KafkaTopicSamples` will be collected.**
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **BOOTSTRAP_BROKER_KAFKA_PORT**
+    </td>
+    <td>
+      The Kafka port for the bootstrap broker.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **BOOTSTRAP_BROKER_KAFKA_PROTOCOL**
+    </td>
+    <td>
+      The protocol to use to connect to the bootstrap broker. Supported values are `PLAINTEXT`, `SASL_PLAINTEXT`, `SSL`, and `SASL_SSL`.
+
+      **Note the `SASL_*` protocols only support Kerberos (GSSAPI) authentication.**
+    </td>
+    <td>
+      PLAINTEXT
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **BOOTSTRAP_BROKER_JMX_PORT**
+    </td>
+    <td>
+      The JMX port to use for collection on each broker in the cluster.
+
+      **Note that all discovered brokers should have JMX active on this port**
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **BOOTSTRAP_BROKER_JMX_USER**
+    </td>
+    <td>
+      The JMX user to use for collection on each broker in the cluster.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **BOOTSTRAP_BROKER_JMX_PASSWORD**
+    </td>
+    <td>
+      The JMX password to use for collection on each broker in the cluster.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+#### **JMX options (Applies to all JMX connections on the instance):**
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>
+      **KEY_STORE**
+    </td>
+    <td>
+      The filepath of the keystore containing the JMX client's SSL certificate.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **KEY_STORE_PASSWORD**
+    </td>
+    <td>
+      The password for the JMX SSL key store.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TRUST_STORE**
+    </td>
+    <td>
+      The filepath of the trust keystore containing the JMX server's SSL certificate.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TRUST_STORE_PASSWORD**
+    </td>
+    <td>
+      The password for the JMX trust store.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **DEFAULT_JMX_USER**
+    </td>
+    <td>
+      The default user that is connecting to the JMX host to collect metrics. If the username field is omitted for a JMX host, this value will be used.
+    </td>
+    <td>
+      admin
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **DEFAULT_JMX_PASSWORD**
+    </td>
+    <td>
+      The default password to connect to the JMX host. If the password field is omitted for a JMX host, this value will be used.
+    </td>
+    <td>
+      admin
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TIMEOUT**
+    </td>
+    <td>
+      The timeout for individual JMX queries in milliseconds.
+    </td>
+    <td>
+      10000
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+#### **Broker TLS connection options (Needed if the broker protocol is SSL or SASL_SSL):**
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>
+      **TLS_CA_FILE**
+    </td>
+    <td>
+      The certificate authority file for SSL and SASL_SSL listeners, in PEM format.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TLS_CERT_FILE**
+    </td>
+    <td>
+      The client certificate file for SSL and SASL_SSL listeners, in PEM format.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TLS_KEY_FILE**
+    </td>
+    <td>
+      The client key file for SSL and SASL_SSL listeners, in PEM format.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TLS_INSECURE_SKIP_VERIFY**
+    </td>
+    <td>
+      Skip verifying the server's certificate chain and host name.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+#### **Broker SASL and Kerberos connection options (Needed if the broker protocol is SASL_PLAINTEXT or SASL_SSL):**
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>
+      **SASL_MECHANISM**
+    </td>
+    <td>
+      The type of SASL authentication to use. Supported options are `SCRAM-SHA-512`, `SCRAM-SHA-256`, `PLAIN`, and `GSSAPI`.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **SASL_USERNAME**
+    </td>
+    <td>
+      SASL username required with the PLAIN and SCRAM mechanisms.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **SASL_PASSWORD**
+    </td>
+    <td>
+      SASL password required with the PLAIN and SCRAM mechanisms.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **SASL_GSSAPI_REALM**
+    </td>
+    <td>
+      Kerberos realm required with the GSSAPI mechanism.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **SASL_GSSAPI_SERVICE_NAME**
+    </td>
+    <td>
+      Kerberos service name required with the GSSAPI mechanism.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **SASL_GSSAPI_USERNAME**
+    </td>
+    <td>
+      Kerberos username required with the GSSAPI mechanism.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **SASL_GSSAPI_KEY_TAB_PATH**
+    </td>
+    <td>
+      Kerberos key tab path required with the GSSAPI mechanism.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **SASL_GSSAPI_KERBEROS_CONFIG_PATH**
+    </td>
+    <td>
+      Kerberos config path required with the GSSAPI mechanism.
+    </td>
+    <td>
+      /etc/krb5.conf
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **SASL_GSSAPI_DISABLE_FAST_NEGOTIATION**
+    </td>
+    <td>
+      Disable FAST negotiation.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+#### **Broker Collection filtering:**
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+
+  <tr>
+    <td>
+      **LOCAL_ONLY_COLLECTION**
+    </td>
+    <td>
+      Collect only the metrics related to the configured bootstrap broker. Only used if `autodiscover_strategy` is `bootstrap`.
+
+      **Environments that use discovery (e.g. Kubernetes) must be set to true because othwerwise brokers will be discovered twice: By the integration, and by the discovery mechanism, leading to duplicate data.**
+
+      **Note that activating this flag will skip KafkaTopicSample collection**
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TOPIC_MODE**
+    </td>
+    <td>
+      Determines how many topics we collect. Options are `all`, `none`, `list`, or `regex`.
+    </td>
+    <td>
+      none
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TOPIC_LIST**
+    </td>
+    <td>
+      JSON array of topic names to monitor. Only in effect if `topic_mode` is set to `list`.
+    </td>
+    <td>
+      []
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TOPIC_REGEX**
+    </td>
+    <td>
+      Regex pattern that matches the topic names to monitor. Only in effect if `topic_mode` is set to `regex`.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TOPIC_BUCKET**
+    </td>
+    <td>
+      Used to split topic collection across multiple instances. Should be of the form `<bucket number>/<number of buckets>`.
+    </td>
+    <td>
+      1/1
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+
+  <tr>
+    <td>
+      **COLLECT_TOPIC_SIZE**
+    </td>
+    <td>
+      Collect the metric Topic size. Options are `true` or `false`, defaults to `false`.
+
+      **This is a resource-intensive metric to collect, especially against many topics.**
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **COLLECT_TOPIC_OFFSET**
+    </td>
+    <td>
+      Collect the metric Topic offset. Options are `true` or `false`, defaults to `false`.
+
+      **This is a resource-intensive metric to collect, especially against many topics.**
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+### Example configurations [#examples-broker]
+
+<CollapserGroup>
+  <Collapser
+    id="example1"
+    title="ZOOKEEPER DISCOVERY"
+  >
+    This configuration collects Metrics and Inventory including all topics discovering the brokers from two different JMX hosts :
+
+    ```
+    integrations:
+      - name: nri-kafka
+        env:
+          CLUSTER_NAME: testcluster1
+          KAFKA_VERSION: "1.0.0"
+          AUTODISCOVER_STRATEGY: zookeeper
+          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}, {"host": "localhost2", "port": 2181}]'
+          ZOOKEEPER_AUTH_SECRET: "username:password"
+          ZOOKEEPER_PATH: "/kafka-root"
+          DEFAULT_JMX_USER: username
+          DEFAULT_JMX_PASSWORD: password
+          TOPIC_MODE: all
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+    ```
+  </Collapser>
+
+  <Collapser
+    id="example2"
+    title="ZOOKEEPER SSL DISCOVERY"
+  >
+    This configuration collects Metrics and Inventory discovering the brokers from a JMX host with SSL :
+
+    ```
+    integrations:
+      - name: nri-kafka
+        env:
+          CLUSTER_NAME: testcluster1
+          KAFKA_VERSION: "1.0.0"
+          AUTODISCOVER_STRATEGY: zookeeper
+          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}]'
+          ZOOKEEPER_AUTH_SECRET: "username:password"
+          ZOOKEEPER_PATH: "/kafka-root"
+          DEFAULT_JMX_USER: username
+          DEFAULT_JMX_PASSWORD: password
+
+          KEY_STORE: "/path/to/your/keystore"
+          KEY_STORE_PASSWORD: keystore_password
+          TRUST_STORE: "/path/to/your/truststore"
+          TRUST_STORE_PASSWORD: truststore_password
+
+          TIMEOUT: 10000  #The timeout for individual JMX queries in milliseconds.
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+    ```
+  </Collapser>
+  <Collapser
+    id="example3"
+    title="BOOOTSTRAP DISCOVERY"
+  >
+    This configuration collects Metrics and Inventory including all topics discovering the brokers from one bootstrap broker :
+
+    ```
+    integrations:
+      - name: nri-kafka
+        env:
+          CLUSTER_NAME: testcluster1
+          AUTODISCOVER_STRATEGY: bootstrap
+          BOOTSTRAP_BROKER_HOST: localhost
+          BOOTSTRAP_BROKER_KAFKA_PORT: 9092
+          BOOTSTRAP_BROKER_KAFKA_PROTOCOL: PLAINTEXT
+          BOOTSTRAP_BROKER_JMX_PORT: 9999  # This same port will be used to connect to all discover broker JMX
+          BOOTSTRAP_BROKER_JMX_USER: admin
+          BOOTSTRAP_BROKER_JMX_PASSWORD: password
+
+          LOCAL_ONLY_COLLECTION: false
+
+          COLLECT_BROKER_TOPIC_DATA: true
+          TOPIC_MODE: "all"
+          COLLECT_TOPIC_SIZE: false
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+    ```
+  </Collapser>
+  <Collapser
+    id="example4"
+    title="BOOOTSTRAP DISCOVERY TLS"
+  >
+    This configuration collects only Metrics discovering the brokers from one bootstrap broker listening with TLS protocol :
+
+    ```
+    integrations:
+      - name: nri-kafka
+        env:
+          METRICS: true
+          CLUSTER_NAME: testcluster1
+          AUTODISCOVER_STRATEGY: bootstrap
+          BOOTSTRAP_BROKER_HOST: localhost
+          BOOTSTRAP_BROKER_KAFKA_PORT: 9092
+          BOOTSTRAP_BROKER_KAFKA_PROTOCOL: SSL
+          BOOTSTRAP_BROKER_JMX_PORT: 9999
+          BOOTSTRAP_BROKER_JMX_USER: admin
+          BOOTSTRAP_BROKER_JMX_PASSWORD: password
+
+          # Kerberos authentication arguments
+          TLS_CA_FILE: "/path/to/CA.pem"
+          TLS_CERT_FILE: "/path/to/cert.pem"
+          TLS_KEY_FILE: "/path/to/key.pem"
+          TLS_INSECURE_SKIP_VERIFY: false
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+    ```
+  </Collapser>
+  <Collapser
+    id="example5"
+    title="BOOOTSTRAP DISCOVERY KERBEROS AUTH"
+  >
+    This configuration collects only Metrics discovering the brokers from one bootstrap broker in a Kerberos Auth Cluster :
+
+    ```
+    integrations:
+      - name: nri-kafka
+        env:
+          METRICS: true
+          CLUSTER_NAME: testcluster1
+          AUTODISCOVER_STRATEGY: bootstrap
+          BOOTSTRAP_BROKER_HOST: localhost
+          BOOTSTRAP_BROKER_KAFKA_PORT: 9092
+          BOOTSTRAP_BROKER_KAFKA_PROTOCOL: PLAINTEXT # Currently support PLAINTEXT and SSL
+          BOOTSTRAP_BROKER_JMX_PORT: 9999
+          BOOTSTRAP_BROKER_JMX_USER: admin
+          BOOTSTRAP_BROKER_JMX_PASSWORD: password
+
+          # Kerberos authentication arguments
+          SASL_MECHANISM: GSSAPI
+          SASL_GSSAPI_REALM: SOMECORP.COM
+          SASL_GSSAPI_SERVICE_NAME: Kafka
+          SASL_GSSAPI_USERNAME: kafka
+          SASL_GSSAPI_KEY_TAB_PATH: /etc/newrelic-infra/kafka.keytab
+          SASL_GSSAPI_KERBEROS_CONFIG_PATH: /etc/krb5.conf
+          SASL_GSSAPI_DISABLE_FAST_NEGOTIATION: false
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+    ```
+  </Collapser>
+
+  <Collapser
+    id="example6"
+    title="ZOOKEEPER DISCOVERY TOPIC BUCKET"
+  >
+    This configuration collects Metrics splitting topic collection between 3 different instances:
+
+    ```
+    integrations:
+      - name: nri-kafka
+        env:
+          METRICS: true
+          CLUSTER_NAME: testcluster1
+          KAFKA_VERSION: "1.0.0"
+          AUTODISCOVER_STRATEGY: zookeeper
+          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}]'
+          ZOOKEEPER_AUTH_SECRET: "username:password"
+          ZOOKEEPER_PATH: "/kafka-root"
+          DEFAULT_JMX_USER: username
+          DEFAULT_JMX_PASSWORD: password
+          TOPIC_MODE: regex
+          TOPIC_REGEX: 'topic\d+'
+          TOPIC_BUCKET: '1/3'
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+      - name: nri-kafka
+        env:
+          METRICS: true
+          CLUSTER_NAME: testcluster1
+          KAFKA_VERSION: "1.0.0"
+          AUTODISCOVER_STRATEGY: zookeeper
+          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}]'
+          ZOOKEEPER_AUTH_SECRET: "username:password"
+          ZOOKEEPER_PATH: "/kafka-root"
+          DEFAULT_JMX_USER: username
+          DEFAULT_JMX_PASSWORD: password
+          TOPIC_MODE: regex
+          TOPIC_REGEX: 'topic\d+'
+          TOPIC_BUCKET: '2/3'
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+      - name: nri-kafka
+        env:
+          METRICS: true
+          CLUSTER_NAME: testcluster1
+          KAFKA_VERSION: "1.0.0"
+          AUTODISCOVER_STRATEGY: zookeeper
+          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}]'
+          ZOOKEEPER_AUTH_SECRET: "username:password"
+          ZOOKEEPER_PATH: "/kafka-root"
+          DEFAULT_JMX_USER: username
+          DEFAULT_JMX_PASSWORD: password
+          TOPIC_MODE: regex
+          TOPIC_REGEX: 'topic\d+'
+          TOPIC_BUCKET: '3/3'
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+    ```
   </Collapser>
 </CollapserGroup>
 
-For more about the general structure of on-host integration configuration, see [Configuration](/docs/integrations/integrations-sdk/file-specifications/host-integration-configuration-overview).
+## Configure KafkaConsumerSample and KafkaProducerSample collection
+
+The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<strong>I</strong>) information. Check the **Applies To** column below to find which settings can be used for each specific collection:
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>
+      **CLUSTER_NAME**
+    </td>
+    <td>
+      user-defined name to uniquely identify the cluster being monitored. **Required**.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **PRODUCERS**
+    </td>
+    <td>
+      Producers to collect. For each provider a `name`, `hostname`, `port`, `username`, and `password` can be provided in JSON form. `name` is the producer’s name as it appears in Kafka. `hostname`, `port`, `username`, and `password` are the optional JMX settings and use the default if unspecified.
+      Required to produce KafkaProducerSample.
+
+      **Example: ```[{"name": "myProducer", "host": "localhost", "port": 24, "username": "me", "password": "secret"}]``` **
+    </td>
+    <td>
+      []
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **CONSUMERS**
+    </td>
+    <td>
+      Consumers to collect. For each consumer a `name`, `hostname`, `port`, `username`, and `password` can be specified in JSON form. `name` is the consumer’s name as it appears in Kafka. `hostname`, `port`, `username`, and `password` are the optional JMX settings and use the default if unspecified.
+      Required to produce KafkaConsumerSample.
+
+      **Example: ```[{"name": "myConsumer", "host": "localhost", "port": 24, "username": "me", "password": "secret"}]``` **
+    </td>
+    <td>
+      []
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **DEFAULT_JMX_HOST**
+    </td>
+    <td>
+      The default host to collect JMX metrics. If the host field is omitted from a producer or consumer configuration, this value will be used.
+    </td>
+    <td>
+      localhost
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **DEFAULT_JMX_PORT**
+    </td>
+    <td>
+      The default port to collect JMX metrics. If the port field is omitted from a producer or consumer configuration, this value will be used.
+    </td>
+    <td>
+      9999
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **DEFAULT_JMX_USER**
+    </td>
+    <td>
+      The default user that is connecting to the JMX host to collect metrics. If the username field is omitted from a producer or consumer configuration, this value will be used.
+    </td>
+    <td>
+      admin
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **DEFAULT_JMX_PASSWORD**
+    </td>
+    <td>
+      The default password to connect to the JMX host. If the password field is omitted from a producer or consumer configuration, this value will be used.
+    </td>
+    <td>
+      admin
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **METRICS**
+    </td>
+    <td>
+      Set to `true` to enable Metrics only collection.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **INVENTORY**
+    </td>
+    <td>
+      Set to `true` to enable Inventory only collection.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+#### **JMX SSL and timeout options (Applies to all JMX connections on the instance):**
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>
+      **KEY_STORE**
+    </td>
+    <td>
+      The filepath of the keystore containing the JMX client's SSL certificate.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **KEY_STORE_PASSWORD**
+    </td>
+    <td>
+      The password for the JMX SSL key store.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TRUST_STORE**
+    </td>
+    <td>
+      The filepath of the trust keystore containing the JMX server's SSL certificate.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TRUST_STORE_PASSWORD**
+    </td>
+    <td>
+      The password for the JMX trust store.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TIMEOUT**
+    </td>
+    <td>
+      The timeout for individual JMX queries in milliseconds.
+    </td>
+    <td>
+      10000
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+### Example configurations [#examples-consumer-producer]
+
+<CollapserGroup>
+  <Collapser
+    id="example7"
+    title="CONSUMER PRODUCER"
+  >
+    This gives an example for collecting JMX metrics from Java consumers and producers:
+
+    ```
+    integrations:
+      - name: nri-kafka
+        env:
+          METRICS: "true"
+          CLUSTER_NAME: "testcluster3"
+          PRODUCERS: '[{"name": "myProducer", "host": "localhost", "port": 24, "username": "me", "password": "secret"}]'
+          CONSUMERS: '[{"name": "myConsumer", "host": "localhost", "port": 24, "username": "me", "password": "secret"}]'
+          DEFAULT_JMX_HOST: "localhost"
+          DEFAULT_JMX_PORT: "9999"
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+    ```
+  </Collapser>
+</CollapserGroup>
+
+## Configure KafkaOffsetSample collection
+
+The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<strong>I</strong>) information. Check the **Applies To** column below to find which settings can be used for each specific collection:
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>
+      **CLUSTER_NAME**
+    </td>
+    <td>
+      user-defined name to uniquely identify the cluster being monitored. **Required**.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **KAFKA_VERSION**
+    </td>
+    <td>
+      The version of the Kafka broker you're connecting to, used for setting optimum API versions. It must match -or be lower than- the version from the broker.
+
+      Versions older than 1.0.0 may be missing some features.
+
+      **Note that if the broker binary name is kafka_2.12-2.7.0 the Kafka api version to be used is 2.7.0, the preceding 2.12 is the Scala language version**.
+    </td>
+    <td>
+      1.0.0
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **AUTODISCOVER_STRATEGY**
+    </td>
+    <td>
+      the method of discovering brokers. Options are `zookeeper` or `bootstrap`.
+    </td>
+    <td>
+      zookeeper
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **CONSUMER_OFFSET**
+    </td>
+    <td>
+      Populate consumer offset data in KafkaOffsetSample if set to true.
+
+      **Note that this option will skip Broker/Consumer/Producer collection and only collect KafkaOffsetSample**
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **CONSUMER_GROUP_REGEX**
+    </td>
+    <td>
+      regex pattern that matches the consumer groups to collect offset statistics for. This is limited to collecting statistics for 300 consumer groups.
+
+      Note: `consumer_groups` has been deprecated, use this argument instead. This option must be set when CONSUMER_OFFSET is true.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **METRICS**
+    </td>
+    <td>
+      Set to `true` to enable Metrics only collection.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **INVENTORY**
+    </td>
+    <td>
+      Set to `true` to enable Inventory only collection.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+#### **Zookeeper autodiscovery arguments** (only relevant when `autodiscover_strategy` is `zookeeper`):
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>
+      **ZOOKEEPER_HOSTS**
+    </td>
+    <td>
+      The list of Apache ZooKeeper hosts (in JSON format) that need to be connected.
+
+      ** If `CONSUMER_OFFSET` is set to `false` `KafkaBrokerSamples` and `KafkaTopicSamples` will be collected.**
+    </td>
+    <td>
+      []
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **ZOOKEEPER_AUTH_SCHEME**
+    </td>
+    <td>
+      The ZooKeeper authentication scheme that is used to connect. Currently, the only supported value is `digest`. If omitted, no authentication is used.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **ZOOKEEPER_AUTH_SECRET**
+    </td>
+    <td>
+      The ZooKeeper authentication secret that is used to connect. Should be of the form `username:password`. Only required if `zookeeper_auth_scheme` is specified.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **ZOOKEEPER_PATH**
+    </td>
+    <td>
+      The Zookeeper node under which the Kafka configuration resides. Defaults to `/`.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **PREFERRED_LISTENER**
+    </td>
+    <td>
+      Use a specific listener to connect to a broker. If unset, the first listener that passes a successful test connection is used. Supported values are `PLAINTEXT`, `SASL_PLAINTEXT`, `SSL`, and `SASL_SSL`. Note: The `SASL_*` protocols only support Kerberos (GSSAPI) authentication.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+#### **Bootstrap broker discovery arguments** (only relevant when `autodiscover_strategy` is `bootstrap`):
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>
+      **BOOTSTRAP_BROKER_HOST**
+    </td>
+    <td>
+      The host for the bootstrap broker.
+
+      ** If `CONSUMER_OFFSET` is set to `false` `KafkaBrokerSamples` and `KafkaTopicSamples` will be collected.**
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **BOOTSTRAP_BROKER_KAFKA_PORT**
+    </td>
+    <td>
+      The Kafka port for the bootstrap broker.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **BOOTSTRAP_BROKER_KAFKA_PROTOCOL**
+    </td>
+    <td>
+      The protocol to use to connect to the bootstrap broker. Supported values are `PLAINTEXT`, `SASL_PLAINTEXT`, `SSL`, and `SASL_SSL`.
+
+      **Note the `SASL_*` protocols only support Kerberos (GSSAPI) authentication.**
+    </td>
+    <td>
+      PLAINTEXT
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **BOOTSTRAP_BROKER_JMX_PORT**
+    </td>
+    <td>
+      The JMX port to use for collection on each broker in the cluster.
+
+      **Note that all discovered brokers should have JMX active on this port**
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **BOOTSTRAP_BROKER_JMX_USER**
+    </td>
+    <td>
+      The JMX user to use for collection on each broker in the cluster.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **BOOTSTRAP_BROKER_JMX_PASSWORD**
+    </td>
+    <td>
+      The JMX password to use for collection on each broker in the cluster.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+#### **JMX SSL and timeout options (Applies to all JMX connections on an instance):**
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>
+      **KEY_STORE**
+    </td>
+    <td>
+      The filepath of the keystore containing the JMX client's SSL certificate.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **KEY_STORE_PASSWORD**
+    </td>
+    <td>
+      The password for the JMX SSL key store.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TRUST_STORE**
+    </td>
+    <td>
+      The filepath of the trust keystore containing the JMX server's SSL certificate.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TRUST_STORE_PASSWORD**
+    </td>
+    <td>
+      The password for the JMX trust store.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **DEFAULT_JMX_USER**
+    </td>
+    <td>
+      The default user that is connecting to the JMX host to collect metrics. If the username field is omitted for a JMX host, this value will be used.
+    </td>
+    <td>
+      admin
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **DEFAULT_JMX_PASSWORD**
+    </td>
+    <td>
+      The default password to connect to the JMX host. If the password field is omitted for a JMX host, this value will be used.
+    </td>
+    <td>
+      admin
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TIMEOUT**
+    </td>
+    <td>
+      The timeout for individual JMX queries in milliseconds.
+    </td>
+    <td>
+      10000
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+#### **Broker TLS connection options (Needed if the broker protocol is SSL or SASL_SSL):**
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>
+      **TLS_CA_FILE**
+    </td>
+    <td>
+      The certificate authority file for SSL and SASL_SSL listeners, in PEM format.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TLS_CERT_FILE**
+    </td>
+    <td>
+      The client certificate file for SSL and SASL_SSL listeners, in PEM format.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TLS_KEY_FILE**
+    </td>
+    <td>
+      The client key file for SSL and SASL_SSL listeners, in PEM format.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TLS_INSECURE_SKIP_VERIFY**
+    </td>
+    <td>
+      Skip verifying the server's certificate chain and host name.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+#### **Broker SASL and Kerberos connection options (Needed if the broker protocol is SASL_PLAINTEXT or SASL_SSL):**
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>
+      **SASL_MECHANISM**
+    </td>
+    <td>
+      The type of SASL authentication to use. Supported options are `SCRAM-SHA-512`, `SCRAM-SHA-256`, `PLAIN`, and `GSSAPI`.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **SASL_USERNAME**
+    </td>
+    <td>
+      SASL username required with the PLAIN and SCRAM mechanisms.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **SASL_PASSWORD**
+    </td>
+    <td>
+      SASL password required with the PLAIN and SCRAM mechanisms.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **SASL_GSSAPI_REALM**
+    </td>
+    <td>
+      Kerberos realm required with the GSSAPI mechanism.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **SASL_GSSAPI_SERVICE_NAME**
+    </td>
+    <td>
+      Kerberos service name required with the GSSAPI mechanism.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **SASL_GSSAPI_USERNAME**
+    </td>
+    <td>
+      Kerberos username required with the GSSAPI mechanism.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **SASL_GSSAPI_KEY_TAB_PATH**
+    </td>
+    <td>
+      Kerberos key tab path required with the GSSAPI mechanism.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **SASL_GSSAPI_KERBEROS_CONFIG_PATH**
+    </td>
+    <td>
+      Kerberos config path required with the GSSAPI mechanism.
+    </td>
+    <td>
+      /etc/krb5.conf
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **SASL_GSSAPI_DISABLE_FAST_NEGOTIATION**
+    </td>
+    <td>
+      Disable FAST negotiation.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+### Example configurations [#examples-offset]
+
+<CollapserGroup>
+  <Collapser
+    id="example8"
+    title="ZOOKEEPER DISCOVERY"
+  >
+    This configuration collects consumer offset Metrics and Inventory for the cluster:
+
+    ```
+    integrations:
+      - name: nri-kafka
+        env:
+          CONSUMER_OFFSET: true
+          CLUSTER_NAME: testcluster3
+          AUTODISCOVER_STRATEGY: bootstrap
+          BOOTSTRAP_BROKER_HOST: localhost
+          BOOTSTRAP_BROKER_KAFKA_PORT: 9092
+          BOOTSTRAP_BROKER_KAFKA_PROTOCOL: PLAINTEXT
+          # A regex pattern that matches the consumer groups to collect metrics from
+          CONSUMER_GROUP_REGEX: '.*'
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+    ```
+  </Collapser>
+</CollapserGroup>
 
 ## Find and use data [#find-and-use]
 
@@ -721,6 +2592,26 @@ The Kafka integration collects the following metric data attributes. Each metric
 
       <td>
         Time for produce requests for 99th percentile.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `topic.diskSize`
+      </td>
+
+      <td>
+        In disk Topic size. Only present if COLLECT_TOPIC_SIZE is enabled.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `topic.offset`
+      </td>
+
+      <td>
+        Topic offset. Only present if COLLECT_TOPIC_OFFSET is enabled.
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
@@ -1035,236 +1035,6 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
   </tbody>
 </table>
 
-### Example configurations [#examples-broker]
-
-<CollapserGroup>
-  <Collapser
-    id="example1"
-    title="ZOOKEEPER DISCOVERY"
-  >
-    This configuration collects Metrics and Inventory including all topics discovering the brokers from two different JMX hosts :
-
-    ```
-    integrations:
-      - name: nri-kafka
-        env:
-          CLUSTER_NAME: testcluster1
-          KAFKA_VERSION: "1.0.0"
-          AUTODISCOVER_STRATEGY: zookeeper
-          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}, {"host": "localhost2", "port": 2181}]'
-          ZOOKEEPER_AUTH_SECRET: "username:password"
-          ZOOKEEPER_PATH: "/kafka-root"
-          DEFAULT_JMX_USER: username
-          DEFAULT_JMX_PASSWORD: password
-          TOPIC_MODE: all
-        interval: 15s
-        labels:
-          env: production
-          role: kafka
-        inventory_source: config/kafka
-    ```
-  </Collapser>
-
-  <Collapser
-    id="example2"
-    title="ZOOKEEPER SSL DISCOVERY"
-  >
-    This configuration collects Metrics and Inventory discovering the brokers from a JMX host with SSL :
-
-    ```
-    integrations:
-      - name: nri-kafka
-        env:
-          CLUSTER_NAME: testcluster1
-          KAFKA_VERSION: "1.0.0"
-          AUTODISCOVER_STRATEGY: zookeeper
-          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}]'
-          ZOOKEEPER_AUTH_SECRET: "username:password"
-          ZOOKEEPER_PATH: "/kafka-root"
-          DEFAULT_JMX_USER: username
-          DEFAULT_JMX_PASSWORD: password
-
-          KEY_STORE: "/path/to/your/keystore"
-          KEY_STORE_PASSWORD: keystore_password
-          TRUST_STORE: "/path/to/your/truststore"
-          TRUST_STORE_PASSWORD: truststore_password
-
-          TIMEOUT: 10000  #The timeout for individual JMX queries in milliseconds.
-        interval: 15s
-        labels:
-          env: production
-          role: kafka
-        inventory_source: config/kafka
-    ```
-  </Collapser>
-  <Collapser
-    id="example3"
-    title="BOOOTSTRAP DISCOVERY"
-  >
-    This configuration collects Metrics and Inventory including all topics discovering the brokers from one bootstrap broker :
-
-    ```
-    integrations:
-      - name: nri-kafka
-        env:
-          CLUSTER_NAME: testcluster1
-          AUTODISCOVER_STRATEGY: bootstrap
-          BOOTSTRAP_BROKER_HOST: localhost
-          BOOTSTRAP_BROKER_KAFKA_PORT: 9092
-          BOOTSTRAP_BROKER_KAFKA_PROTOCOL: PLAINTEXT
-          BOOTSTRAP_BROKER_JMX_PORT: 9999  # This same port will be used to connect to all discover broker JMX
-          BOOTSTRAP_BROKER_JMX_USER: admin
-          BOOTSTRAP_BROKER_JMX_PASSWORD: password
-
-          LOCAL_ONLY_COLLECTION: false
-
-          COLLECT_BROKER_TOPIC_DATA: true
-          TOPIC_MODE: "all"
-          COLLECT_TOPIC_SIZE: false
-        interval: 15s
-        labels:
-          env: production
-          role: kafka
-        inventory_source: config/kafka
-    ```
-  </Collapser>
-  <Collapser
-    id="example4"
-    title="BOOOTSTRAP DISCOVERY TLS"
-  >
-    This configuration collects only Metrics discovering the brokers from one bootstrap broker listening with TLS protocol :
-
-    ```
-    integrations:
-      - name: nri-kafka
-        env:
-          METRICS: true
-          CLUSTER_NAME: testcluster1
-          AUTODISCOVER_STRATEGY: bootstrap
-          BOOTSTRAP_BROKER_HOST: localhost
-          BOOTSTRAP_BROKER_KAFKA_PORT: 9092
-          BOOTSTRAP_BROKER_KAFKA_PROTOCOL: SSL
-          BOOTSTRAP_BROKER_JMX_PORT: 9999
-          BOOTSTRAP_BROKER_JMX_USER: admin
-          BOOTSTRAP_BROKER_JMX_PASSWORD: password
-
-          # Kerberos authentication arguments
-          TLS_CA_FILE: "/path/to/CA.pem"
-          TLS_CERT_FILE: "/path/to/cert.pem"
-          TLS_KEY_FILE: "/path/to/key.pem"
-          TLS_INSECURE_SKIP_VERIFY: false
-        interval: 15s
-        labels:
-          env: production
-          role: kafka
-        inventory_source: config/kafka
-    ```
-  </Collapser>
-  <Collapser
-    id="example5"
-    title="BOOOTSTRAP DISCOVERY KERBEROS AUTH"
-  >
-    This configuration collects only Metrics discovering the brokers from one bootstrap broker in a Kerberos Auth Cluster :
-
-    ```
-    integrations:
-      - name: nri-kafka
-        env:
-          METRICS: true
-          CLUSTER_NAME: testcluster1
-          AUTODISCOVER_STRATEGY: bootstrap
-          BOOTSTRAP_BROKER_HOST: localhost
-          BOOTSTRAP_BROKER_KAFKA_PORT: 9092
-          BOOTSTRAP_BROKER_KAFKA_PROTOCOL: PLAINTEXT # Currently support PLAINTEXT and SSL
-          BOOTSTRAP_BROKER_JMX_PORT: 9999
-          BOOTSTRAP_BROKER_JMX_USER: admin
-          BOOTSTRAP_BROKER_JMX_PASSWORD: password
-
-          # Kerberos authentication arguments
-          SASL_MECHANISM: GSSAPI
-          SASL_GSSAPI_REALM: SOMECORP.COM
-          SASL_GSSAPI_SERVICE_NAME: Kafka
-          SASL_GSSAPI_USERNAME: kafka
-          SASL_GSSAPI_KEY_TAB_PATH: /etc/newrelic-infra/kafka.keytab
-          SASL_GSSAPI_KERBEROS_CONFIG_PATH: /etc/krb5.conf
-          SASL_GSSAPI_DISABLE_FAST_NEGOTIATION: false
-        interval: 15s
-        labels:
-          env: production
-          role: kafka
-        inventory_source: config/kafka
-    ```
-  </Collapser>
-
-  <Collapser
-    id="example6"
-    title="ZOOKEEPER DISCOVERY TOPIC BUCKET"
-  >
-    This configuration collects Metrics splitting topic collection between 3 different instances:
-
-    ```
-    integrations:
-      - name: nri-kafka
-        env:
-          METRICS: true
-          CLUSTER_NAME: testcluster1
-          KAFKA_VERSION: "1.0.0"
-          AUTODISCOVER_STRATEGY: zookeeper
-          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}]'
-          ZOOKEEPER_AUTH_SECRET: "username:password"
-          ZOOKEEPER_PATH: "/kafka-root"
-          DEFAULT_JMX_USER: username
-          DEFAULT_JMX_PASSWORD: password
-          TOPIC_MODE: regex
-          TOPIC_REGEX: 'topic\d+'
-          TOPIC_BUCKET: '1/3'
-        interval: 15s
-        labels:
-          env: production
-          role: kafka
-        inventory_source: config/kafka
-      - name: nri-kafka
-        env:
-          METRICS: true
-          CLUSTER_NAME: testcluster1
-          KAFKA_VERSION: "1.0.0"
-          AUTODISCOVER_STRATEGY: zookeeper
-          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}]'
-          ZOOKEEPER_AUTH_SECRET: "username:password"
-          ZOOKEEPER_PATH: "/kafka-root"
-          DEFAULT_JMX_USER: username
-          DEFAULT_JMX_PASSWORD: password
-          TOPIC_MODE: regex
-          TOPIC_REGEX: 'topic\d+'
-          TOPIC_BUCKET: '2/3'
-        interval: 15s
-        labels:
-          env: production
-          role: kafka
-        inventory_source: config/kafka
-      - name: nri-kafka
-        env:
-          METRICS: true
-          CLUSTER_NAME: testcluster1
-          KAFKA_VERSION: "1.0.0"
-          AUTODISCOVER_STRATEGY: zookeeper
-          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}]'
-          ZOOKEEPER_AUTH_SECRET: "username:password"
-          ZOOKEEPER_PATH: "/kafka-root"
-          DEFAULT_JMX_USER: username
-          DEFAULT_JMX_PASSWORD: password
-          TOPIC_MODE: regex
-          TOPIC_REGEX: 'topic\d+'
-          TOPIC_BUCKET: '3/3'
-        interval: 15s
-        labels:
-          env: production
-          role: kafka
-        inventory_source: config/kafka
-    ```
-  </Collapser>
-</CollapserGroup>
-
 ## Configure KafkaConsumerSample and KafkaProducerSample collection
 
 The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<strong>I</strong>) information. Check the **Applies To** column below to find which settings can be used for each specific collection:
@@ -1526,34 +1296,6 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
 
   </tbody>
 </table>
-
-### Example configurations [#examples-consumer-producer]
-
-<CollapserGroup>
-  <Collapser
-    id="example7"
-    title="CONSUMER PRODUCER"
-  >
-    This gives an example for collecting JMX metrics from Java consumers and producers:
-
-    ```
-    integrations:
-      - name: nri-kafka
-        env:
-          METRICS: "true"
-          CLUSTER_NAME: "testcluster3"
-          PRODUCERS: '[{"name": "myProducer", "host": "localhost", "port": 24, "username": "me", "password": "secret"}]'
-          CONSUMERS: '[{"name": "myConsumer", "host": "localhost", "port": 24, "username": "me", "password": "secret"}]'
-          DEFAULT_JMX_HOST: "localhost"
-          DEFAULT_JMX_PORT: "9999"
-        interval: 15s
-        labels:
-          env: production
-          role: kafka
-        inventory_source: config/kafka
-    ```
-  </Collapser>
-</CollapserGroup>
 
 ## Configure KafkaOffsetSample collection
 
@@ -2279,12 +2021,259 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
   </tbody>
 </table>
 
-### Example configurations [#examples-offset]
-
+## Example configurations [#examples]
 <CollapserGroup>
   <Collapser
-    id="example8"
+    id="example1"
     title="ZOOKEEPER DISCOVERY"
+  >
+    This configuration collects Metrics and Inventory including all topics discovering the brokers from two different JMX hosts :
+
+    ```
+    integrations:
+      - name: nri-kafka
+        env:
+          CLUSTER_NAME: testcluster1
+          KAFKA_VERSION: "1.0.0"
+          AUTODISCOVER_STRATEGY: zookeeper
+          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}, {"host": "localhost2", "port": 2181}]'
+          ZOOKEEPER_AUTH_SECRET: "username:password"
+          ZOOKEEPER_PATH: "/kafka-root"
+          DEFAULT_JMX_USER: username
+          DEFAULT_JMX_PASSWORD: password
+          TOPIC_MODE: all
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+    ```
+  </Collapser>
+
+  <Collapser
+    id="example2"
+    title="ZOOKEEPER SSL DISCOVERY"
+  >
+    This configuration collects Metrics and Inventory discovering the brokers from a JMX host with SSL :
+
+    ```
+    integrations:
+      - name: nri-kafka
+        env:
+          CLUSTER_NAME: testcluster1
+          KAFKA_VERSION: "1.0.0"
+          AUTODISCOVER_STRATEGY: zookeeper
+          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}]'
+          ZOOKEEPER_AUTH_SECRET: "username:password"
+          ZOOKEEPER_PATH: "/kafka-root"
+          DEFAULT_JMX_USER: username
+          DEFAULT_JMX_PASSWORD: password
+
+          KEY_STORE: "/path/to/your/keystore"
+          KEY_STORE_PASSWORD: keystore_password
+          TRUST_STORE: "/path/to/your/truststore"
+          TRUST_STORE_PASSWORD: truststore_password
+
+          TIMEOUT: 10000  #The timeout for individual JMX queries in milliseconds.
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+    ```
+  </Collapser>
+  <Collapser
+    id="example3"
+    title="BOOOTSTRAP DISCOVERY"
+  >
+    This configuration collects Metrics and Inventory including all topics discovering the brokers from one bootstrap broker :
+
+    ```
+    integrations:
+      - name: nri-kafka
+        env:
+          CLUSTER_NAME: testcluster1
+          AUTODISCOVER_STRATEGY: bootstrap
+          BOOTSTRAP_BROKER_HOST: localhost
+          BOOTSTRAP_BROKER_KAFKA_PORT: 9092
+          BOOTSTRAP_BROKER_KAFKA_PROTOCOL: PLAINTEXT
+          BOOTSTRAP_BROKER_JMX_PORT: 9999  # This same port will be used to connect to all discover broker JMX
+          BOOTSTRAP_BROKER_JMX_USER: admin
+          BOOTSTRAP_BROKER_JMX_PASSWORD: password
+
+          LOCAL_ONLY_COLLECTION: false
+
+          COLLECT_BROKER_TOPIC_DATA: true
+          TOPIC_MODE: "all"
+          COLLECT_TOPIC_SIZE: false
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+    ```
+  </Collapser>
+  <Collapser
+    id="example4"
+    title="BOOOTSTRAP DISCOVERY TLS"
+  >
+    This configuration collects only Metrics discovering the brokers from one bootstrap broker listening with TLS protocol :
+
+    ```
+    integrations:
+      - name: nri-kafka
+        env:
+          METRICS: true
+          CLUSTER_NAME: testcluster1
+          AUTODISCOVER_STRATEGY: bootstrap
+          BOOTSTRAP_BROKER_HOST: localhost
+          BOOTSTRAP_BROKER_KAFKA_PORT: 9092
+          BOOTSTRAP_BROKER_KAFKA_PROTOCOL: SSL
+          BOOTSTRAP_BROKER_JMX_PORT: 9999
+          BOOTSTRAP_BROKER_JMX_USER: admin
+          BOOTSTRAP_BROKER_JMX_PASSWORD: password
+
+          # Kerberos authentication arguments
+          TLS_CA_FILE: "/path/to/CA.pem"
+          TLS_CERT_FILE: "/path/to/cert.pem"
+          TLS_KEY_FILE: "/path/to/key.pem"
+          TLS_INSECURE_SKIP_VERIFY: false
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+    ```
+  </Collapser>
+  <Collapser
+    id="example5"
+    title="BOOOTSTRAP DISCOVERY KERBEROS AUTH"
+  >
+    This configuration collects only Metrics discovering the brokers from one bootstrap broker in a Kerberos Auth Cluster :
+
+    ```
+    integrations:
+      - name: nri-kafka
+        env:
+          METRICS: true
+          CLUSTER_NAME: testcluster1
+          AUTODISCOVER_STRATEGY: bootstrap
+          BOOTSTRAP_BROKER_HOST: localhost
+          BOOTSTRAP_BROKER_KAFKA_PORT: 9092
+          BOOTSTRAP_BROKER_KAFKA_PROTOCOL: PLAINTEXT # Currently support PLAINTEXT and SSL
+          BOOTSTRAP_BROKER_JMX_PORT: 9999
+          BOOTSTRAP_BROKER_JMX_USER: admin
+          BOOTSTRAP_BROKER_JMX_PASSWORD: password
+
+          # Kerberos authentication arguments
+          SASL_MECHANISM: GSSAPI
+          SASL_GSSAPI_REALM: SOMECORP.COM
+          SASL_GSSAPI_SERVICE_NAME: Kafka
+          SASL_GSSAPI_USERNAME: kafka
+          SASL_GSSAPI_KEY_TAB_PATH: /etc/newrelic-infra/kafka.keytab
+          SASL_GSSAPI_KERBEROS_CONFIG_PATH: /etc/krb5.conf
+          SASL_GSSAPI_DISABLE_FAST_NEGOTIATION: false
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+    ```
+  </Collapser>
+
+  <Collapser
+    id="example6"
+    title="ZOOKEEPER DISCOVERY TOPIC BUCKET"
+  >
+    This configuration collects Metrics splitting topic collection between 3 different instances:
+
+    ```
+    integrations:
+      - name: nri-kafka
+        env:
+          METRICS: true
+          CLUSTER_NAME: testcluster1
+          KAFKA_VERSION: "1.0.0"
+          AUTODISCOVER_STRATEGY: zookeeper
+          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}]'
+          ZOOKEEPER_AUTH_SECRET: "username:password"
+          ZOOKEEPER_PATH: "/kafka-root"
+          DEFAULT_JMX_USER: username
+          DEFAULT_JMX_PASSWORD: password
+          TOPIC_MODE: regex
+          TOPIC_REGEX: 'topic\d+'
+          TOPIC_BUCKET: '1/3'
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+      - name: nri-kafka
+        env:
+          METRICS: true
+          CLUSTER_NAME: testcluster1
+          KAFKA_VERSION: "1.0.0"
+          AUTODISCOVER_STRATEGY: zookeeper
+          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}]'
+          ZOOKEEPER_AUTH_SECRET: "username:password"
+          ZOOKEEPER_PATH: "/kafka-root"
+          DEFAULT_JMX_USER: username
+          DEFAULT_JMX_PASSWORD: password
+          TOPIC_MODE: regex
+          TOPIC_REGEX: 'topic\d+'
+          TOPIC_BUCKET: '2/3'
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+      - name: nri-kafka
+        env:
+          METRICS: true
+          CLUSTER_NAME: testcluster1
+          KAFKA_VERSION: "1.0.0"
+          AUTODISCOVER_STRATEGY: zookeeper
+          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}]'
+          ZOOKEEPER_AUTH_SECRET: "username:password"
+          ZOOKEEPER_PATH: "/kafka-root"
+          DEFAULT_JMX_USER: username
+          DEFAULT_JMX_PASSWORD: password
+          TOPIC_MODE: regex
+          TOPIC_REGEX: 'topic\d+'
+          TOPIC_BUCKET: '3/3'
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+    ```
+  </Collapser>
+  <Collapser
+    id="example7"
+    title="CONSUMER PRODUCER"
+  >
+    This gives an example for collecting JMX metrics from Java consumers and producers:
+
+    ```
+    integrations:
+      - name: nri-kafka
+        env:
+          METRICS: "true"
+          CLUSTER_NAME: "testcluster3"
+          PRODUCERS: '[{"name": "myProducer", "host": "localhost", "port": 24, "username": "me", "password": "secret"}]'
+          CONSUMERS: '[{"name": "myConsumer", "host": "localhost", "port": 24, "username": "me", "password": "secret"}]'
+          DEFAULT_JMX_HOST: "localhost"
+          DEFAULT_JMX_PORT: "9999"
+        interval: 15s
+        labels:
+          env: production
+          role: kafka
+        inventory_source: config/kafka
+    ```
+  </Collapser>
+  <Collapser
+    id="example8"
+    title="CONSUMER OFFSET"
   >
     This configuration collects consumer offset Metrics and Inventory for the cluster:
 


### PR DESCRIPTION
Redesigning the Kafka integration configuration section.
Add a table with the config options and separate the configuration by the 3 kind of instances that can be set in order to get the different samples
Add example configurations
Add more information with clarifications about different aspects of the integration that use to appear as tickets by GTS.