### PR TITLE
fix(oma): Fix incorrect nrql queries

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/aqm-implementation-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/aqm-implementation-guide.mdx
@@ -280,8 +280,8 @@ Following are the descriptions of each KPI as well as sample NRQL queries that w
 | - | - | - |
 | Incident Count | Incident Count is the number of incidents generated over a period of time. By default we look at one week compared with the previous week. | FROM nrAQMIncident SELECT count(*) AS 'Incident Count' WHERE current_state='open' AND severity='CRITICAL' SINCE 1 WEEK AGO COMPARE WITH 1 WEEK AGO |
 | Incidents Duration | Incident Duration is the total sum of minutes that all the incidents accumulated over a period of time. The default is one week compared with the previous week. | FROM nrAQMIncident SELECT sum(duration)/(1000*60) AS 'Incident Minutes' WHERE current_state='closed' AND severity='CRITICAL' SINCE 1 WEEK AGO COMPARE WITH 1 WEEK AGO |
-| Mean-Time-to-Close (MTTC) | Average duration of incidents within the period of time measured. | FROM nrAQMIncident SELECT sum(duration)/(1000*60) AS 'Incident Minutes' WHERE current_state='closed' AND severity='CRITICAL' SINCE 1 WEEK AGO COMPARE WITH 1 WEEK AGO |
-| Percent Under Five Minutes | Percentage of incidents where the duration of the incident is under five minutes.  This can be an indicator of incident flapping. | FROM nrAQMIncident SELECT sum(duration)/(1000*60) AS 'Incident Minutes' WHERE current_state='closed' AND severity='CRITICAL' SINCE 1 WEEK AGO COMPARE WITH 1 WEEK AGO |
+| Mean-Time-to-Close (MTTC) | Average duration of incidents within the period of time measured. | FROM nrAQMIncident SELECT sum(duration/(1000*60)) AS 'Incident MTTC (minutes)' WHERE current_state='closed' AND severity='CRITICAL' SINCE 1 WEEK AGO COMPARE WITH 1 WEEK AGO |
+| Percent Under Five Minutes | Percentage of incidents where the duration of the incident is under five minutes.  This can be an indicator of incident flapping. | FROM nrAQMIncident SELECT percentage(count(*), WHERE duration <= 5*60*1000) AS '% Under 5min' WHERE current_state='closed' AND severity='CRITICAL' SINCE 1 WEEK AGO COMPARE WITH 1 WEEK AGO|
 
 ### Incident engagement
 | KPI | Description | NRQL |


### PR DESCRIPTION
A hero request came in requesting we fix both the  Mean-Time-to-Close and Percentage Under Five Minutes queries. 

This PR implements the request fix. I'm requesting someone from the OMA team approves this before we merge. 