### PR TITLE
RabbitMQ adapt documentation to config V4

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/rabbitmq-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/rabbitmq-monitoring-integration.mdx
@@ -140,21 +140,17 @@ There are several ways to configure the integration, depending on how it was ins
 
 For an example configuration, see [Example config file](#example-config).
 
+The configuration file has common settings applicable to all integrations like `interval`, `timeout`, `inventory_source`. To read all about these common settings refer to our [Configuration Format](/docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integrations-newer-configuration-format/#configuration-basics) document.
+
 <Callout variant="important">
-  With secrets management, you can configure on-host integrations with New Relic infrastructure's agent to use sensitive data (such as passwords) without having to write them as plain text into the integration's configuration file. For more information, see [Secrets management](/docs/integrations/host-integrations/installation/secrets-management).
+  If you are still using our Legacy configuration/definition files please refer to this [document](/docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integrations-standard-configuration-format/) for help.
 </Callout>
 
-### Commands
-
-The configuration provides three commands:
-
-* `all`: collects all performance metric data, inventory (configuration) data, and event data
-* `inventory`: collects only inventory (configuration) data
-* `events`: collects only event data
+Specific settings related to RabbitMQ are defined using the `env` section of the configuration file. These settings control the connection to your RabbitMQ instance as well as other security settings and features. The list of valid settings is described in the next section of this document.
 
 **Cluster environments**
 
-In cluster environments, only one node should use the `all` command; the rest should use the `inventory` command.
+In cluster environments, only one node should use `METRICS=false` and `INVENTORY=false` ; the rest should use `INVENTORY=true` and `METRICS=false`.
 
 If you're running a cluster environment in Kubernetes, you need to deploy RabbitMQ as a [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/), and configure the agent to query all the metrics from the RabbitMQ pod. Set the autodiscovery matching condition [in the config file](https://github.com/newrelic/nri-rabbitmq/blob/master/rabbitmq-config.yml.k8s_sample) to this value:
 
@@ -166,90 +162,461 @@ discovery:
       podName: rabbitmq-0
 ```
 
-### Arguments
+### RabbitMQ Instance Settings [#instance-settings]
 
-The integration accepts the following arguments:
+The RabbitMQ integration collects both Metrics(<strong>M</strong>) and Inventory(<strong>I</strong>) information. Check the **Applies To** column below to find which settings can be used for each specific collection:
 
-* `hostname`: hostname or IP of the RabbitMQ management plugin. Default: localhost.
-* `port`: port number of the RabbitMQ management plugin. Default: 15672.
-* `username`: user that is connecting to RabbitMQ management plugin.
-* `password`: password to connect to RabbitMQ management plugin.
-* `use_ssl`: option to connect using SSL. Default: false.
-* `ca_bundle_dir/ca_bundle_file`: location of SSL certificate on the host.
-* `node_name_override`: overrides the local node name instead of retrieving it from RabbitMQ.
-* `config_path`: absolute path to the RabbitMQ configuration file.
-* `queues`: queue names to collect in the format of a JSON array of strings. If a queue name exactly matches (case sensitive) one of these, it will be collected.
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
 
-  Example:
+  <tbody>
+  <tr>
+    <td>
+      **HOSTNAME**
+    </td>
+    <td>
+      Hostname or IP of the RabbitMQ management plugin.
+    </td>
+    <td>
+      localhost
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
 
-  ```
-  queues: '["myQueue1","myQueue2"]'
-  ```
-* `queues_regexes`: queue names to collect in the format of a JSON array of REGEX strings. If a queue name matches one of these, it will be collected.
+  <tr>
+    <td>
+      **PORT**
+    </td>
+    <td>
+      Port number of the RabbitMQ management plugin.
+    </td>
+    <td>
+      15672
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
 
-  Example:
+  <tr>
+    <td>
+      **USERNAME**
+    </td>
+    <td>
+      User that is connecting to RabbitMQ management plugin.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
 
-  ```
-  queues_regexes: '["queue[0-9]+",".*"]'
-  ```
-* `exchanges`: exchange names to collect in the format of a JSON array of strings. If an exchange name exactly matches (case sensitive) one of these, it will be collected.
-* `exchanges_regexes`: queue names to collect in the format of a JSON array of REGEX strings. If an exchange name matches one of these it will be collected.
-* `vhosts`: vhost names to collect in the format of a JSON array of strings. If a vhost name exactly matches (case sensitive) one of these, it will be included. This also affects only collecting entities belonging to vhosts specified.
-* `vhosts_regexes`: vhost names to collect in the format of a JSON array of REGEX strings. If a vhost name matches one of these the vhost and any entities belonging to this vhost will be collected.
+  <tr>
+    <td>
+      **PASSWORD**
+    </td>
+    <td>
+      Password to connect to RabbitMQ management plugin.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
 
-### Labels
+  <tr>
+    <td>
+      **MANAGEMENT_PATH_PREFIX**
+    </td>
+    <td>
+      RabbitMQ Management Prefix.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
 
-Labels are optional, custom tags used to identify collections of data. For example:
+  <tr>
+    <td>
+      **USE_SSL**
+    </td>
+    <td>
+      Option to connect using SSL.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
 
-* `env`: label to identify the environment. For example: `production`.
-* `role`: label to identify which role is accessing the data.
+  <tr>
+    <td>
+      **CA_BUNDLE_DIR**
+    </td>
+    <td>
+      Location of SSL certificate on the host.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
 
-### Example configuration [#example-config]
+  <tr>
+    <td>
+      **CA_BUNDLE_FILE**
+    </td>
+    <td>
+      Location of SSL certificate on the host.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **NODE_NAME_OVERRIDE**
+    </td>
+    <td>
+      Overrides the local node name instead of retrieving it from RabbitMQ.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **CONFIG_PATH**
+    </td>
+    <td>
+      Absolute path to the RabbitMQ configuration file.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **QUEUES**
+    </td>
+    <td>
+      Queue names to collect in the format of a JSON array of strings. If a queue name exactly matches (case sensitive) one of these, it will be collected.
+
+      Example:
+      ```
+      queues: '["myQueue1","myQueue2"]'
+      ```
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **QUEUES_REGEXES**
+    </td>
+    <td>
+      Queue names to collect in the format of a JSON array of REGEX strings. If a queue name matches one of these, it will be collected.
+
+      Example:
+      ```
+      queues_regexes: '["queue[0-9]+",".*"]'
+      ```
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **EXCHANGES**
+    </td>
+    <td>
+      Exchange names to collect in the format of a JSON array of strings. If an exchange name exactly matches (case sensitive) one of these, it will be collected.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **EXCHANGES_REGEXES**
+    </td>
+    <td>
+      Exchanges names to collect in the format of a JSON array of REGEX strings. If an exchange name matches one of these it will be collected.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **VHOSTS**
+    </td>
+    <td>
+      Vhost names to collect in the format of a JSON array of strings. If a vhost name exactly matches (case sensitive) one of these, it will be included. This also affects only collecting entities belonging to vhosts specified.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **VHOSTS_REGEXES**
+    </td>
+    <td>
+      Vhost names to collect in the format of a JSON array of REGEX strings. If a vhost name matches one of these the vhost and any entities belonging to this vhost will be collected.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **METRICS**
+    </td>
+    <td>
+      Set to `true` to enable Metrics only collection.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **INVENTORY**
+    </td>
+    <td>
+      Set to `true` to enable Inventory only collection.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+    </td>
+  </tr>
+
+
+  <tr>
+    <td>
+      **EVENTS**
+    </td>
+    <td>
+      Set to `true` to enable Events only collection.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+
+The values for these settings can be defined in several ways:
+* Adding the value directly in the config file. This is the most common way.
+* Replacing the values from environment variables using the `{{}}` notation. This requires infrastructure agent v1.14.0+. Read more [here](/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/#passthrough).
+* Using Secrets management. Use this to protect sensible information such as passwords to be exposed in plain text on the configuration file. For more information, see [Secrets management](https://docs.newrelic.com/docs/integrations/host-integrations/installation/secrets-management).
+
+### Labels/Custom Attributes [#labels]
+
+Environment variables can be used to control config settings, such as your license key, and are then passed through to the Infrastructure agent. For instructions on how to use this feature, see [Configure the Infrastructure agent](/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#passthrough).
+You can further decorate your metrics using labels. Labels allow you to add key/value pairs attributes to your metrics which you can then use to query, filter or group your metrics on.<br/>
+Our default sample config file includes examples of labels but, as they are not mandatory, you can remove, modify or add new ones of your choice.
+
+```
+ labels:
+   env: production
+   role: rabbitmq
+```
+
+## Example configuration [#example-config]
 
 Here's an example configuration file:
 
 <CollapserGroup>
   <Collapser
-    id="example-config"
-    title="rabbitmq-config-sample.yml"
+    id="example-config1"
+    title="BASIC CONFIGURATION WITH SSL"
   >
-    ````
-    integration_name: com.newrelic.rabbitmq
+    ```
+    integrations:
+      - name: nri-rabbitmq
+        env:
+          HOSTNAME: localhost
+          PORT: 15672
+          USERNAME: admin
+          PASSWORD: admin
+          CA_BUNDLE_DIR: /path/to/bundle/dir/
+          NODE_NAME_OVERRIDE: local_node_name
+          CONFIG_PATH: /path/to/config/file/rabbitmq.conf
+          USE_SSL: true
 
-    instances:
-      - name: <var>ADD_LUSTER_NAME</var>
-        # Available commands are "all", "metrics", and "inventory"
-        command: all
-        arguments:
-          # Hostname or IP of RabbitMQ host
-          hostname: <var>ADD_HOSTNAME</var>
-          port: <var>mANAGEMENT_UI_PORT</var>
-          username: <var>MANAGEMENT_UI_USERNAME</var>
-          password: <var>MANAGEMENT_UI_PASSWORD</var>
-          ca_bundle_dir: <var>CA_BUNDLE_DIRECTORY</var>
-          ca_bundle_file: <var>CA_BUNDLE_FILE</var>
-          node_name_override: <var>LOCAL_NODE_NAME</var>
-          config_path: <var>/path/to/config/file/rabbitmq.conf</var>
-          # Boolean value, option to connect using SSL
-          use_ssl: false
-          # JSON array of queue names to collect
-          queues: <var>ARRAY_OF_QUEUE_NAMES</var>
-          # JSON array of regexes, matching queue names will be collected
-          queues_regexes: <var>ARRAY_OF_QUEUE_REGEXES</var>
-          # JSON array of exchange names to collect
-          exchanges: <var>ARRAY_OF_EXCHANGE_NAMES</var>
-          # JSON array of regexes, matching exchange names will be collected
-          exchanges_regexes: <var>ARRAY_OF_EXCHANGE_REGEXES</var>
-          # JSON array of vhost names to collect
-          vhosts: <var>ARRAY_OF_VHOST_NAMES</var>
-          # JSON array of regexes, entities assigned to vhosts matching a regex
-          # will be collected
-          vhosts_regexes: <var>ARRAY_OF_HOST_REGEXE</var>
+          QUEUES: '["myQueue1","myQueue2"]'
+          QUEUES_REGEXES: '["queue[0-9]+",".*"]'
+
+          EXCHANGES: '["exchange1","exchange2"]'
+          EXCHANGES_REGEXES: '["exchange[0-9]+",".*"]'
+
+          VHOSTS: '["vhost1","vhost2"]'
+          VHOSTS_REGEXES: '["vhost[0-9]+",".*"]'
+        interval: 15s
         labels:
           env: production
           role: rabbitmq
+        inventory_source: config/rabbitmq
     ```
-    ````
+  </Collapser>
+  <Collapser
+    id="example-config2"
+    title="METRICS ONLY"
+  >
+    ```
+    integrations:
+      - name: nri-rabbitmq
+        env:
+          METRICS: true
+          HOSTNAME: localhost
+          PORT: 15672
+          USERNAME: admin
+          PASSWORD: admin
+          NODE_NAME_OVERRIDE: local_node_name
+
+          QUEUES: '["myQueue1","myQueue2"]'
+          QUEUES_REGEXES: '["queue[0-9]+",".*"]'
+
+          EXCHANGES: '["exchange1","exchange2"]'
+          EXCHANGES_REGEXES: '["exchange[0-9]+",".*"]'
+
+          VHOSTS: '["vhost1","vhost2"]'
+          VHOSTS_REGEXES: '["vhost[0-9]+",".*"]'
+        interval: 15s
+        labels:
+          env: production
+          role: rabbitmq
+        inventory_source: config/rabbitmq
+    ```
+  </Collapser>
+  <Collapser
+    id="example-config3"
+    title="INVENTORY ONLY"
+  >
+    ```
+    integrations:
+      - name: nri-rabbitmq
+        env:
+          INVENTORY: true
+          HOSTNAME: localhost
+          PORT: 15672
+          USERNAME: admin
+          PASSWORD: admin
+          NODE_NAME_OVERRIDE: local_node_name
+          CONFIG_PATH: /path/to/config/file/rabbitmq.conf
+
+          QUEUES: '["myQueue1","myQueue2"]'
+          QUEUES_REGEXES: '["queue[0-9]+",".*"]'
+
+          EXCHANGES: '["exchange1","exchange2"]'
+          EXCHANGES_REGEXES: '["exchange[0-9]+",".*"]'
+
+          VHOSTS: '["vhost1","vhost2"]'
+          VHOSTS_REGEXES: '["vhost[0-9]+",".*"]'
+        interval: 15s
+        labels:
+          env: production
+          role: rabbitmq
+        inventory_source: config/rabbitmq
+    ```
+  </Collapser>
+  <Collapser
+    id="example-config4"
+    title="EVENTS ONLY"
+  >
+    ```
+    integrations:
+      - name: nri-rabbitmq
+        env:
+          EVENTS: true
+          HOSTNAME: localhost
+          PORT: 15672
+          USERNAME: admin
+          PASSWORD: admin
+          NODE_NAME_OVERRIDE: local_node_name
+        interval: 15s
+        labels:
+          env: production
+          role: rabbitmq
+        inventory_source: config/rabbitmq
+    ```
   </Collapser>
 </CollapserGroup>
 
@@ -954,7 +1321,7 @@ The integration captures the configuration parameters of RabbitMQ in the `/etc/r
   Be aware that any sensitive information that you put into the `rabbit.conf` file will appear on the Infrastructure **Inventory** page. This includes items such as the following from AWS:
 
   ```
-  cluster_formation.aws.secret_key, 
+  cluster_formation.aws.secret_key,
   cluster_formation.aws.access_key_id
   ```
 </Callout>


### PR DESCRIPTION
Redesigning the RabbitMQ integration configuration section.
Add a table with the config options
Add example configurations