### PR TITLE
Update manage-synthetics-monitors-rest-api.mdx

### DIFF
--- a/src/content/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api.mdx
+++ b/src/content/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api.mdx
@@ -209,7 +209,7 @@ https://synthetics.eu.newrelic.com/synthetics/api
     Query arguments:
 
     * `offset`: The monitor count offset. Defaults to 0. For example, if you have 40 monitors and you use an offset value of 20, it will return monitors 21-40.
-    * `limit`: The number of results per page, maximum 100. Defaults to 20.
+    * `limit`: The number of results per page, maximum 100. Defaults to 50.
 
     You can include these in your cURL command as follows:
 


### PR DESCRIPTION
When making a request to the "get all monitors" endpoint, I notice that with no limit specified, 50 monitors are returned, not 20.
