### PR TITLE
chore: added release notes for Node Agent v8.2.0 and v8.3.0

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-2-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-2-0.mdx
@@ -7,13 +7,13 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
 ## Notes
 
-* Added a new feature flag `unresolved_promise_cleanup` that defaults to true only when `new_promise_tracking` feature flag is set to `true`.  If disabled, this will help with performance of agent when an application has a lot of promises.  To disable set in your config `feature_flag.unresolved_promise_cleanup` to `false` or pass in the env var of `NEW_RELIC_FEATURE_FLAG_UNRESOLVED_PROMISE_CLEANUP=false` when starting application with agent.
+* Added a new feature flag `unresolved_promise_cleanup` that defaults to `true` only when `new_promise_tracking` feature flag is set to `true`.  If disabled, this will help with performance of agent when an application has a lot of promises.  To disable, in your config set `feature_flag.unresolved_promise_cleanup` to `false` or pass in the environment var of `NEW_RELIC_FEATURE_FLAG_UNRESOLVED_PROMISE_CLEANUP=false` when starting application with agent.
 
     **WARNING**: If you set `unresolved_promise_cleanup` to `false`, failure to resolve all promises in your application will result in memory leaks even if those promises are garbage collected
 
 * Supported using `connect` to route middleware calls.
 
-* Removed stubbed out tests in memcached unit tests
+* Removed stubbed out tests in memcached unit tests.
 
 * Refactored `dropTestCollections` in mongo versioned tests to await for all `dropCollection` operations to be finished before closing connection and returning.
 
@@ -27,7 +27,7 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
 * Added a pre-commit hook to check if package.json changes and run `oss third-party manifest` and `oss third-party notices`.  This will ensure the `third_party_manifest.json` and `THIRD_PARTY_NOTICES.md` up to date
 
-* Replaced `JSV` with `ajv` for JSON schema validation in tests
+* Replaced `JSV` with `ajv` for JSON schema validation in tests.
 
 * Removed `through` in lieu of core Node.js implementation of Transform stream in tests.
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-2-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-2-0.mdx
@@ -1,0 +1,33 @@
+---
+subject: Node.js agent
+releaseDate: '2021-08-25'
+version: 8.2.0
+downloadLink: 'https://www.npmjs.com/package/newrelic'
+---
+
+## Notes
+
+* Added a new feature flag `unresolved_promise_cleanup` that defaults to true only when `new_promise_tracking` feature flag is set to `true`.  If disabled, this will help with performance of agent when an application has a lot of promises.  To disable set in your config `feature_flag.unresolved_promise_cleanup` to `false` or pass in the env var of `NEW_RELIC_FEATURE_FLAG_UNRESOLVED_PROMISE_CLEANUP=false` when starting application with agent.
+
+    **WARNING**: If you set `unresolved_promise_cleanup` to `false`, failure to resolve all promises in your application will result in memory leaks even if those promises are garbage collected
+
+* Supported using `connect` to route middleware calls.
+
+* Removed stubbed out tests in memcached unit tests
+
+* Refactored `dropTestCollections` in mongo versioned tests to await for all `dropCollection` operations to be finished before closing connection and returning.
+
+* Ported remaining mocha tests in `test/unit/instrumentation` to exclusively use tap.
+
+* Added `@newrelic/eslint-config` to rely on a centralized eslint ruleset.
+
+* Removed integration tests for oracle.
+
+* Converted config unit tests to fully use tap API and extracted related tests into more-specific test files.
+
+* Added a pre-commit hook to check if package.json changes and run `oss third-party manifest` and `oss third-party notices`.  This will ensure the `third_party_manifest.json` and `THIRD_PARTY_NOTICES.md` up to date
+
+* Replaced `JSV` with `ajv` for JSON schema validation in tests
+
+* Removed `through` in lieu of core Node.js implementation of Transform stream in tests.
+

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-3-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-3-0.mdx
@@ -8,10 +8,10 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 ## Notes
 
 * Enabled Distributed Tracing (DT) by default.
-  * Added ability to configure the maximum number of spans that can be collected per minute via `span_events.max_samples_stored` and environment variable, `NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED`.
+  * Added ability to configure the maximum number of spans that can be collected per minute via `span_events.max_samples_stored` and environment variable `NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED`.
   * Added supportability metric SpanEvent/Limit.
 
-* Added support for properly setting the `host` and `port` for mongodb requests that are to cluster.
+* Added support for properly setting the `host` and `port` for clustered MongoDB requests.
 
 * Fixes issue where `.fastify` and `.default` properties would be missing from the `fastify` export when instrumented.
 
@@ -29,4 +29,4 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
 * Converted several unit tests to use the tap API.
 
-* Changed assertions for 2 http error msg tests to work with all versions of Node.js.
+* Changed assertions for two HTTP error message tests to work with all versions of Node.js.

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-3-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-3-0.mdx
@@ -1,0 +1,32 @@
+---
+subject: Node.js agent
+releaseDate: '2021-09-09'
+version: 8.3.0
+downloadLink: 'https://www.npmjs.com/package/newrelic'
+---
+
+## Notes
+
+* Enabled Distributed Tracing (DT) by default.
+  * Added ability to configure the maximum number of spans that can be collected per minute via `span_events.max_samples_stored` and environment variable, `NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED`.
+  * Added supportability metric SpanEvent/Limit.
+
+* Added support for properly setting the `host` and `port` for mongodb requests that are to cluster.
+
+* Fixes issue where `.fastify` and `.default` properties would be missing from the `fastify` export when instrumented.
+
+  Instrumentation now sets `.fastify` and `.default` properties to the wrapped `fastify` export function for fastify v3.
+
+* Added the following environment variables for the corresponding configuration items:
+  * **config item:** `transaction_events.max_samples_stored`
+**env var:** `NEW_RELIC_TRANSACTION_EVENTS_MAX_SAMPLES_STORED`
+
+  * **config item:** `custom_insights_events.max_samples_stored`
+**env var:** `NEW_RELIC_CUSTOM_INSIGHTS_EVENTS_MAX_SAMPLES_STORED`
+
+  * **config item:** `error_collector.max_event_samples_stored`
+**env var:** `NEW_RELIC_ERROR_COLLECTOR_MAX_EVENT_SAMPLES_STORED`
+
+* Converted several unit tests to use the tap API.
+
+* Changed assertions for 2 http error msg tests to work with all versions of Node.js.


### PR DESCRIPTION
* added release notes for Nodejs agent v8.2.0 and v8.3.0
