### PR TITLE
Update ruby-agent-requirements-supported-frameworks.mdx

### DIFF
--- a/src/content/docs/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -220,7 +220,7 @@ Web servers supported by the Ruby agent include:
 
 ## Web frameworks [#web_frameworks]
 
-The Ruby agent does not support experimental versions. Web frameworks supported by the Ruby agent include:
+The Ruby agent does not support experimental versions. Web frameworks supported by the Ruby agent are listed below. Please note that Grape, Padrino, and Sinatra are not supported for Ruby 3.0+.
 
 <table>
   <thead>
@@ -744,6 +744,7 @@ APM's Ruby agent also supports:
 * Dalli
 * Memcache-Client
 * Sunspot
+* Yajl-Ruby:1.1.0 or higher
 
 ## Connect the agent to other parts of New Relic [#digital-intelligence-platform]
 


### PR DESCRIPTION
- Add statement that Padrino, Grape, and Sinatra are not supported in Ruby 3.
- Add line for support for Yajl-Ruby

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.