### PR TITLE
Added link to latest function

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -2062,6 +2062,7 @@ Use non-aggregator functions for non-numerical data in NRQL queries.
 
   <Collapser
     className="freq-link"
+    id="latest"
     title={<InlineCode>latest(attribute)</InlineCode>}
   >
     Use the `latest( )` function to return the most recent value for an attribute over a specified time range.


### PR DESCRIPTION
As reported in #3875, the description of latest doesn't have a link.

Tried locally, works fine.