### PR TITLE
fix typo in oracle integration doc

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
@@ -151,7 +151,7 @@ The configuration file has common settings applicable to all integrations like `
 
 Specific settings related to Oracle DB are defined using the `env` section of the configuration file. These settings control the connection to your Oracle DB instance as well as other security settings and features. The list of valid settings is described in the next section of this document.
 
-### MySQL Instance Settings [#instance-settings]
+### Oracle DB Instance Settings [#instance-settings]
 
 The Oracle DB integration collects both Metrics(**M**) and Inventory(**I**) information. In the table, use the **Applies To** column for the settings available to each collection:
 


### PR DESCRIPTION
Small fix in Oracle DB doc that still had a reference to Mysql by mistake