### PR TITLE
chore: deprecate CAT in Node.js agent documentation.

### DIFF
--- a/src/content/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -3299,9 +3299,7 @@ The Node.js agent variables that control [cross application tracing](/docs/apm/t
 </CollapserGroup>
 
 <Callout variant="important">
-  Cross Application Tracing (CAT) has been deprecated and will be removed in a future major release.
-  For cross-service visibility, we recommend using [Distributed Tracing](#distributed-tracing) which is enabled by default
-  as of v8.3.0 of the agent. Before enabling, read the [transition guide](/docs/transition-guide-distributed-tracing).
+  Cross application tracing (CAT) has been deprecated and will be removed in a future major release. For cross-service visibility, we recommend using [distributed tracing](#distributed-tracing), which is enabled by default as of agent version 8.3.0. Before enabling, read the [transition guide](/docs/transition-guide-distributed-tracing).
 </Callout>
 
 ## Error message redaction variables [#err-message-redact]
@@ -3358,8 +3356,6 @@ The Node.js agent variables that control error message redaction appear in the `
 </Callout>
 
 [Distributed tracing](/docs/intro-distributed-tracing) lets you see the path that a request takes as it travels through a distributed system. When configuring via the config file, place the following option in the `distributed_tracing` section.
-
-When distributed tracing is enabled, you can collect [span events](/docs/apm/distributed-tracing/ui-data/span-event).
 
 <CollapserGroup>
   <Collapser
@@ -3454,7 +3450,7 @@ When distributed tracing is enabled, you can collect [span events](/docs/apm/dis
 
 ## Span events
 
-[Span events](/docs/apm/distributed-tracing/ui-data/span-event) are reported for [distributed tracing](#distributed-tracing). Distributed tracing must be enabled to report span events. Span configuration is set in the `span_events` stanza. Options include:
+[Span data](/docs/apm/distributed-tracing/ui-data/span-event) is reported for [distributed tracing](#distributed-tracing). Distributed tracing must be enabled to report spans. Span configuration is set in the `span_events` stanza. Options include:
 
 <CollapserGroup>
   <Collapser
@@ -3536,7 +3532,7 @@ When distributed tracing is enabled, you can collect [span events](/docs/apm/dis
       </tbody>
     </table>
 
-    This setting can be used to turn reporting of attributes on or off for span events. If `attributes.enabled` at the root level is `false`, no attributes will be sent to span events regardless on how this is set.
+    This setting can be used to turn reporting of attributes on or off for spans. If `attributes.enabled` at the root level is `false`, no attributes will be sent with spans regardless on how this is set.
   </Collapser>
 
   <Collapser
@@ -3577,7 +3573,7 @@ When distributed tracing is enabled, you can collect [span events](/docs/apm/dis
       </tbody>
     </table>
 
-    If attributes are enabled for span events, all attribute keys found in this list will be attached to span events. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+    If attributes are enabled for spans, all attribute keys found in this list will be attached to spans. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
   </Collapser>
 
   <Collapser
@@ -3618,7 +3614,7 @@ When distributed tracing is enabled, you can collect [span events](/docs/apm/dis
       </tbody>
     </table>
 
-    All attribute keys found in this list will not be sent with span events. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+    All attribute keys found in this list will not be sent with spans. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
   </Collapser>
 </CollapserGroup>
 
@@ -3669,7 +3665,7 @@ When distributed tracing is enabled, you can collect [span events](/docs/apm/dis
 
 ## Infinite Tracing
 
-To turn on Infinite Tracing, enable distributed tracing (set `distributed_tracing` to `enabled: true`) and add the additional settings below. For an example, see [Language Agents: Configure Distributed Tracing](/docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing#node-config).
+To turn on Infinite Tracing, enable distributed tracing (set `distributed_tracing` to `enabled: true`) and add the additional settings below. For an example, see [Language agents: configure distributed tracing](/docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing#node-config).
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -3261,7 +3261,7 @@ This section defines the Node.js agent variables in the order they typically app
   </Collapser>
 </CollapserGroup>
 
-## Cross application tracing [#cross-app-tracing] (DEPRECATED)
+## Cross application tracing (DEPRECATED) [#cross-app-tracing] 
 
 The Node.js agent variables that control [cross application tracing](/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces) typically appear in the `cross_application_tracer` section of your app's `newrelic.js` configuration file:
 

--- a/src/content/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -3261,7 +3261,7 @@ This section defines the Node.js agent variables in the order they typically app
   </Collapser>
 </CollapserGroup>
 
-## Cross application tracing [#cross-app-tracing]
+## Cross application tracing [#cross-app-tracing] (DEPRECATED)
 
 The Node.js agent variables that control [cross application tracing](/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces) typically appear in the `cross_application_tracer` section of your app's `newrelic.js` configuration file:
 
@@ -3288,7 +3288,7 @@ The Node.js agent variables that control [cross application tracing](/docs/apm/t
           </th>
 
           <td>
-            `true`
+            `false`
           </td>
         </tr>
       </tbody>
@@ -3297,6 +3297,12 @@ The Node.js agent variables that control [cross application tracing](/docs/apm/t
     When set to `true`, allows tracing of transactions across more than one New Relic-monitored applications.
   </Collapser>
 </CollapserGroup>
+
+<Callout variant="important">
+  Cross Application Tracing (CAT) has been deprecated and will be removed in a future major release.
+  For cross-service visibility, we recommend using [Distributed Tracing](#distributed-tracing) which is enabled by default
+  as of v8.3.0 of the agent. Before enabling, read the [transition guide](/docs/transition-guide-distributed-tracing).
+</Callout>
 
 ## Error message redaction variables [#err-message-redact]
 
@@ -3378,7 +3384,7 @@ When distributed tracing is enabled, you can collect [span events](/docs/apm/dis
           </th>
 
           <td>
-            `false`
+            `true`
           </td>
         </tr>
 


### PR DESCRIPTION
Deprecate CAT in Node.js agent documentation.
  * Notes deprecation.
  * Recommends DT and shares transition doc.
  * Updates default config values for CAT and DT.