### PR TITLE
Removing beta and adding note about all AWS metrics supported

### DIFF
--- a/src/content/docs/integrations/amazon-integrations/get-started/aws-integrations-metrics.mdx
+++ b/src/content/docs/integrations/amazon-integrations/get-started/aws-integrations-metrics.mdx
@@ -8,13 +8,10 @@ redirects:
   - /docs/aws-metrics
 ---
 
-<Callout title="BETA FEATURE">
-This feature is currently in beta.
-</Callout>
-
 ## Amazon Web Services Metrics [#aws-metrics-table]
 
-The following table contains the metrics we collect for AWS.
+The following table contains the metrics we collect from AWS API Polling integrations.
+AWS CloudWatch metric stream integration is the recommended solution to ingest AWS services metrics. For a complete list of available metrics, check the AWS documentation listing CloudWatch metrics for each AWS service.  
 
 <table>
   <tbody>
@@ -28,7 +25,7 @@ The following table contains the metrics we collect for AWS.
       </th>
 
       <th style={{ width: "275px" }}>
-        Sample Metric Name (previous)
+        Sample / Event Name (previous)
       </th>
     </tr>
 

--- a/src/content/docs/integrations/amazon-integrations/get-started/aws-integrations-metrics.mdx
+++ b/src/content/docs/integrations/amazon-integrations/get-started/aws-integrations-metrics.mdx
@@ -10,8 +10,9 @@ redirects:
 
 ## Amazon Web Services Metrics [#aws-metrics-table]
 
-The following table contains the metrics we collect from AWS API Polling integrations.
-AWS CloudWatch metric stream integration is the recommended solution to ingest AWS services metrics. For a complete list of available metrics, check the AWS documentation listing CloudWatch metrics for each AWS service.  
+We recommend using the [AWS CloudWatch Metric Streams integration](/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream/) to ingest AWS services' metrics. For a complete list of available metrics, check the CloudWatch metrics listing documentation for each AWS service.  
+
+The following table contains the metrics we collect from AWS API Polling integrations:
 
 <table>
   <tbody>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* This page is automatically generated based on conversion files we have for AWS API Polling integrations. We want to remove the beta callout and mention the full list of metrics should now be obtained from AWS (all metrics can be ingested with metric streams). 

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.