### PR TITLE
Fixing Infra proxy settings example

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -4025,7 +4025,7 @@ For infrastructure agent version 1.3.1 or higher, the precedence of the proxy co
     Example:
 
     ```
-    https://proxy_user.access_10@proxy_01:1080
+    https://user:pass@host:port
     ```
   </Collapser>
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -4025,7 +4025,7 @@ For infrastructure agent version 1.3.1 or higher, the precedence of the proxy co
     Example:
 
     ```
-    https://user:pass@host:port
+    https://proxy_user:access_10@proxy_01:1080
     ```
   </Collapser>
 


### PR DESCRIPTION
As reported in #documentation, the example for the Infra proxy settings is misleading. 