### PR TITLE
chore: java configuration - removing conflicting duplicate entry

### DIFF
--- a/src/content/docs/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -2782,44 +2782,6 @@ These options are set in the `error_collector` stanza and unless noted otherwise
   </Collapser>
 
   <Collapser
-    id="ec-ignoreErrorPriority"
-    title="ignoreErrorPriority"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            false
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    With default ignoreErrorPriority as false, the agent reports the last error noticed if noticeError() is called multiple times in a transaction. If set to true, the agent reports the first error noticed if noticeError() is called multiple times in a transaction.
-
-    For example:
-
-    ```
-    error_collector:
-          ignoreErrorPriority: true
-    ```
-  </Collapser>
-
-  <Collapser
     id="ec-expected_classes"
     title="expected_classes"
   >


### PR DESCRIPTION
### Give us some context
This configuration property had 2 entries and they were conflicting.
Removing the erroneous one.

### Are you making a change to site code?
No
