### PR TITLE
Add new page about calling NoticeError to get stack traces in .NET Agent

### DIFF
--- a/src/content/docs/agents/net-agent/troubleshooting/no-stack-traces-dotnet.mdx
+++ b/src/content/docs/agents/net-agent/troubleshooting/no-stack-traces-dotnet.mdx
@@ -1,0 +1,38 @@
+---
+title: No stack traces (.NET)
+type: troubleshooting
+tags:
+  - Agents
+  - NET agent
+  - Troubleshooting
+metaDescription: Troubleshooting steps for situations when stack traces are missing for error traces with your New Relic .NET app.
+---
+
+## Problem
+
+Depending on the situation, you may find [error traces](/docs/apm/applications-menu/error-analytics/error-analytics-manage-error-traces) in the APM UI that do not include stack traces for your .NET app.
+
+## Solution
+
+Depending on the situation, follow these troubleshooting procedures.
+
+<CollapserGroup>
+
+  <Collapser
+    id="500-errors"
+    title="No stack traces for 500 errors"
+  >
+    This is [normal behavior](#cause) for how the .NET agent handles 500 errors. To force stack traces to be reported, call the New Relic .NET API from your own code. Running the `NewRelic.NoticeError(Exception)` method will cause an error to be reported along with the stack backtrace represented by the `Exception`. For more information about this method and its overloads, see New Relic's [.NET agent API on GitHub.](https://docs.newrelic.com/docs/agents/net-agent/net-agent-api/noticeerror-net-agent-api/)
+  </Collapser>
+</CollapserGroup>
+
+## Cause
+
+Returning a `500` error means that the application server itself detected an error and set the HTTPS `500` status code.
+
+* If the error condition was detected and handled by application logic, there was no exception object and thus, no stack.
+* If there was an exception object at some point, but it was handled internally by the application code that set the `500` status on the response, then the exception never became visible to the .NET agent. There is no stack available for the .NET agent to report.
+
+When stack traces are reported, the error results from an exception that was not caught and handled within the application server logic. The .NET agent sees the unhandled exception during a monitored transaction, so it reports the stack trace.
+
+However, no stack traces appear for the `500` errors because the application server is handling the errors and then setting the status code. The application code itself does not retain any stack traces.

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -780,6 +780,8 @@ pages:
                     path: /docs/agents/net-agent/troubleshooting/no-data-appears-after-disabling-tls-10
                   - title: Resolve .NET and SCOM conflicts
                     path: /docs/agents/net-agent/troubleshooting/resolve-net-scom-conflicts
+                  - title: title: No stack traces 
+                    path: /docs/agents/net-agent/troubleshooting/no-stack-traces-dotnet
           - title: Node.js
             path: /docs/agents/nodejs-agent
             pages:

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -780,7 +780,7 @@ pages:
                     path: /docs/agents/net-agent/troubleshooting/no-data-appears-after-disabling-tls-10
                   - title: Resolve .NET and SCOM conflicts
                     path: /docs/agents/net-agent/troubleshooting/resolve-net-scom-conflicts
-                  - title: title: No stack traces 
+                  - title: No stack traces 
                     path: /docs/agents/net-agent/troubleshooting/no-stack-traces-dotnet
           - title: Node.js
             path: /docs/agents/nodejs-agent


### PR DESCRIPTION
### Give us some context

We are missing .net agent specific documentation for the requirement to call NoticeError in some situations when stack traces are desired. 

Resolves: newrelic/newrelic-dotnet-agent#681

### Are you making a change to site code?

No