### PR TITLE
fix(style guide): Improve "edit doc" instructions

### DIFF
--- a/src/content/docs/style-guide/writer-workflow/tech-writer-workflow.mdx
+++ b/src/content/docs/style-guide/writer-workflow/tech-writer-workflow.mdx
@@ -14,14 +14,15 @@ This document will guide you through the entire workflow for editing the New Rel
 - [GitHub account](https://github.com/join)
 - [GitHub Desktop](https://desktop.github.com/)
 
-## Edit in the UI vs local build
+## Edit in the GitHub web editor vs local build
+
 Need to edit a doc? Use this table to decide where to work!
 
 <table>
   <thead>
       <tr>
         <th style={{ width: "400px" }}>
-        **Use the UI for:**            
+        **Use the GitHub web editor for:**            
         </th>
         <th style={{ width: "400px" }}>
         **Use the local build for:**

--- a/src/content/docs/style-guide/writer-workflow/tech-writer-workflow.mdx
+++ b/src/content/docs/style-guide/writer-workflow/tech-writer-workflow.mdx
@@ -51,18 +51,7 @@ Need to edit a doc? Use this table to decide where to work!
 
 **Continue reading for instructions on how to edit a doc locally.**
 
-## Work on a branch, not a fork [#branch-fork]
-Some teams work on branches, some teams work on forks; **the docs team works in branches**. As long as a branch has been pushed upstream, this allows us to work collaboratively and ensure that no work is ever lost when someone goes on vacation.
-
-To create a branch on the docs-website repo:
-1. Open GitHub Desktop
-2. Click on **Current branch: xxx**
-3. Click on **New Branch**
-4. You will be prompted to name your new branch. Descriptive names are best. It's a great way to quickly clue people in to what your work is all about. For example, if you are working on What’s New pages, you might name the branch **Whats-new-updates**.
-
-When you create a new branch, don't forget to add the Jira issue's key (DOC-1234) to the branch name and the PR title. 
-
-## Set up your local environment [#set-local]
+## 1. Set up your local environment [#set-local]
 
 Running the site locally makes testing and previewing large changes much easier. Here's how to get setup:
 
@@ -75,7 +64,7 @@ Running the site locally makes testing and previewing large changes much easier.
  
 You can ensure the repo was cloned by navigating to your local GitHub folder (the default is `~/Documents/github`). Once you have cloned the repo, you don't need to clone it again in the future.  
 
-## Run the site locally [#run-site]
+## 2. Run the site locally [#run-site]
 
 Build the site locally using the terminal to preview changes before opening a Pull Request. While it's **highly** recommended to build the site locally, this is technically an optional step. The site will automatically reflect any local changes once build. Node and Yarn are tools used to build the site on your local machine.
 
@@ -91,7 +80,7 @@ Build the site locally using the terminal to preview changes before opening a Pu
 3. The site will take a few minutes to build. Make yourself some tea or coffee. 
 4. Once it's built, you can access your preview site in your browser by navigating to [http://localhost:8000/](http://localhost:8000/)
 
-## Edit a doc [#edit-doc]
+## 3. Edit a doc [#edit-doc]
 Once your local environment and branch are set up, you're ready to edit a doc. Check out the style guide for writing guidelines.
 
 1. First, ensure your **Current Branch** in GitHub Desktop is set to the correct branch, not **Develop**.
@@ -99,14 +88,15 @@ Once your local environment and branch are set up, you're ready to edit a doc. C
 3. Edit the doc in your text editor of choice. You should write docs in markdown language. Reference the style guide for help with formatting markdown
 4. Save the file with your edits, then follow the same process for any other docs you wish to edit.
 
-## Commit your changes [#commit-changes]
+## 4. Commit your changes [#commit-changes]
 Once your edits are done, you can commit them. This stages your changes, which you will later push upstream to Github. By pushing your changes, everyone will have access to your branch and commits. 
 
 1. Navigate to GitHub Desktop. The left column should have a record of all the edits you have made to docs. 
 2. In the bottom left corner, name your commit and add a good description of your edits. It should be descriptive enough to ensure that someone can understand all the changes made by simply scanning this description.
 3. Click **Commit to [yourbranchname]**
 
-## Publish your commits [#publish-commits]
+## 5. Publish your commits [#publish-commits]
+
 Once you have committed your changes, you're almost ready to open your Pull Request.
 
 First, you need to ensure your branch is pushed upstream.
@@ -116,7 +106,7 @@ First, you need to ensure your branch is pushed upstream.
 
 This will push all your commits upstream and make them available to everyone else through the GitHub repository.
 
-## Open your pull request [#open-pr]
+## 6. Open your pull request [#open-pr]
 Now that your commits are available to everyone, you need to notify people that your changes are ready to be merged into the `develop` branch.
 
 To do this, you open a pull request:
@@ -160,3 +150,16 @@ Remember that you can almost always undo things. If you merge a PR, and then fin
 1. On the Pull requests tab in GitHub, click **Closed** on the tally bar to see all the issues and PRs that have alredy been merged. 
 2. Locate the PR you merged, and locate the Revert button.
 3. Click Revert. That creates a new PR, which needs to be merged. If you want to reopen it, you need to follow the link back to the original PR and either revert that or reopen it. 
+
+## Writers only: Work on a branch, not a fork [#branch-fork]
+
+Some teams work on branches, some teams work on forks; **the Docs team works in branches**. As long as a branch has been pushed upstream, this allows us to work collaboratively and ensure that no work is ever lost when someone goes on vacation.
+
+To create a branch on the docs-website repo:
+
+1. Open GitHub Desktop
+2. Click on **Current branch: xxx**
+3. Click on **New Branch**
+4. You will be prompted to name your new branch. Descriptive names are best. It's a great way to quickly clue people in to what your work is all about. For example, if you are working on What’s New pages, you might name the branch **Whats-new-updates**.
+
+When you create a new branch, don't forget to add the Jira issue's key (DOC-1234) to the branch name and the PR title. 

--- a/src/content/docs/style-guide/writing-guidelines/create-edit-content.mdx
+++ b/src/content/docs/style-guide/writing-guidelines/create-edit-content.mdx
@@ -17,42 +17,20 @@ redirects:
 
 We welcome your contributions, whether you are a New Relic employee or a New Relic user! And we don't want you to worry about style. When you edit a file, tech writers on our team review it for style, grammar, and formatting. That said, if you're curious about our style guidelines, you're welcome (but not obligated) [to take a look](/docs/style-guide/get-started/introduction-style-guide/).
 
-<Callout variant="tip">
-  If your draft needs to be released on a specific date or within a specific
-  timeframe (for example, right before a release), contact the Tech Docs `@hero`
-  in the [#documentation Slack
-  channel](https://newrelic.slack.com/messages/documentation/). If you're not a
-  New Relic employee, please [create a GitHub
-  issue](https://github.com/newrelic/docs-website/issues/new/choose).
-</Callout>
-
 ## Edit a doc [#edit-doc]
 
-If you see a minor problem in our documentation that you want to quickly fix, you can use GitHub to edit the file and submit your pull request. A member of the Tech Docs team will review your edit and publish your changes. We'll follow up with you if we have any questions.
-
-<Callout variant="important">
-  You need a GitHub account to edit docs. If you don’t have one, you can [create
-  it here](https://github.com/).
-</Callout>
+If you see a minor problem in our documentation that you want to quickly fix, you can use GitHub to edit the file and submit your pull request. A member of the Docs team will review your edit and publish your changes. We'll follow up with you if we have any questions.
 
 To edit existing content without building the site locally:
 
-1. Find a doc you'd like to edit.
-2. Click **Edit file** on the top corner of the right nav.
-3. In the GitHub file, click on the **pencil** icon within the code block on the top right corner to access the [markdown](https://en.wikipedia.org/wiki/Markdown) editor.
-4. Make your changes.
-5. Write a meaningful commit message and description, then commit your change by creating a new branch.
-6. Follow the prompts to submit your pull request. Please fill in as many details as possible in the provided template.
-7. And you're done!
+1. On the docs site, navigate to the doc you'd like to edit..
+2. Click **Edit page** on the top corner of the right nav.
+3. A GitHub page will open with the source of the doc. Click the  **pencil** icon in the top right.
+4. Make your edits (don't worry too much about formatting or grammar, we're happy to worry about that).
+5. At the bottom of the page, enter acommit message that describes your change, then click **Commit changes**.
+6. Follow the prompts to submit your pull request.
 
-A member of the Tech Docs team will let you know when we've published your changes.
-
-## For bigger projects [#bigger-projects]
-
-1. If you'd like to create an entirely new page of documentation, or move existing content, file a [Documentation Request](https://github.com/newrelic/docs-website/issues/new/choose), or contact us in the`#documentation` channel.
-2. The Documentation Team will review your request and follow up with you.
-3. If a new page is approved you may be asked to help write the page content.
-4. Follow the instructions above to submit a PR for your change.
+A member of the Docs team will review your pull request and comment with any feedback. Once we've merged your pull request into the **Develop** branch, your changes will go live with our next deploy (usually within a few hours).
 
 ## Create new docs [#creating-docs]
 
@@ -62,40 +40,32 @@ You can use [article templates](/docs/style-guide/article-templates) or [clone a
 2. In `/src/content/docs/`, find a good location for your doc.
 3. Using your text editor, create a new `.mdx` file or copy an existing doc.
 4. Write your content.
-5. Commit your changes and create a pull request.
+5. Optional: [Add your doc to the right nav `.yml` file](/docs/style-guide/processes-procedures/understand-edit-docs-site-structure/). The navigation files can be a bit hard to work with, so feel free to leave this step for a Docs writer to handle when they review your pull request.
+6. Commit your changes and create a pull request.
 
 The Tech Docs team has two heroes watching for new pull requests. We'll help you get the content finalized and make sure that it's in the right place.
 
 ## Clone (copy) an existing doc [#clone-doc]
 
-Once you've cloned the `docs-website` repository, use your text editor to copy an existing doc. Rename and edit the copy and then save it as a new doc.
+Once you've cloned the `docs-website` repository, use your text editor to copy an existing doc. Rename and edit the copy and then save it as a new doc. Your cloned doc automatically inherits the original doc's frontmatter content. Make sure to change that, too.
 
 If you want your cloned doc to be translated, follow standard procedures to [request translation](/docs/style-guide/writing-guidelines/docs-translation#request-translation).
 
-Your cloned doc automatically inherits the original doc's frontmatter content. Make sure to change that, too.
+## For bigger projects [#bigger-projects]
+
+If you're making larger changes like adding a whole new doc or editing many existing docs, it can be helpful to run the site locally. For instructions, see [Tech writer workflow](/docs/style-guide/writer-workflow/tech-writer-workflow/).
 
 ## Delete pages [#delete-doc]
 
 If you are comfortable with deleting the page yourself, go for it. If not, ask us by:
 
 1. [File an issue in the docs-website repo](https://github.com/newrelic/docs-website/issues/new/choose), or contact the @hero in the #documentation channel if you're a New Relic employee.
-2. The Documentation Team will review the request to delete an existing documentation page.
-3. If the deletion is approved, the Docs team will delete the page.
-
-## Add or update license documentation [#license-docs]
-
-To add or update New Relic license information, follow [standard procedures](#editing-workflow) to add or update documentation in the appropriate [**Licenses** category](/docs/licenses) on the [docs site](https://docs.newrelic.com).
+2. We'll take a look at your issue and help out.
 
 ## Private edits [#private-edits]
 
-If you have access to a private version of this repository, you can contribute and review content without sharing it publicly.
-
-Note that, with all of these steps, if you have SSH Keys set up, you will want to use the SSH URL (not the HTTPS URL).
+If you need to stage content for a private beta or limited release, contact the docs hero in the #documentation Slack channel.
 
 ## Request a future publication date (for New Relic employees) [#hold-for-release]
 
-For docs work related to unreleased features, please use our [beta repo](https://github.com/newrelic/beta-docs-site) (Internal New Relic link)
-
-If you create a new doc and submit a pull request in the private Docs repo and then contact the Tech Docs `@hero` in the [#documentation Slack channel](https://newrelic.slack.com/messages/documentation/).
-
-The Tech Docs hero will follow up with you to get any additional details needed so that we can get this content published at the right time.
+If your draft needs to be released on a specific date or within a specific timeframe (for example, right before a release), contact the Tech Docs @hero in the #documentation Slack channel. If you're not a New Relic employee, please [create a GitHub issue](https://github.com/newrelic/docs-website/issues/new/choose).

--- a/src/content/docs/style-guide/writing-guidelines/create-edit-content.mdx
+++ b/src/content/docs/style-guide/writing-guidelines/create-edit-content.mdx
@@ -23,10 +23,10 @@ If you see a minor problem in our documentation that you want to quickly fix, yo
 
 To edit existing content without building the site locally:
 
-1. On the docs site, navigate to the doc you'd like to edit..
+1. On the docs site, navigate to the doc you'd like to edit.
 2. Click **Edit page** on the top corner of the right nav.
-3. A GitHub page will open with the source of the doc. Click the  **pencil** icon in the top right.
-4. Make your edits (don't worry too much about formatting or grammar, we're happy to worry about that).
+3. A GitHub page will open with the source of the doc. Click the **pencil** icon in the top right.
+4. Make your edits (don't worry too much about formatting or grammar, we're happy to take care of that).
 5. At the bottom of the page, enter acommit message that describes your change, then click **Commit changes**.
 6. Follow the prompts to submit your pull request.
 


### PR DESCRIPTION
* Shuffle order of h2s in several style guide docs to surface more universally applicable info
* Simplify text for edit procedure to make it look less hard
* Reduce and simplify text related to licenses, scheduling edits, and private site. These procedures are uncommon, and giving them so much screen real estate makes things seem a bit hard