### PR TITLE
JMX : Add config V4 examples and reformat args

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/jmx-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/jmx-monitoring-integration.mdx
@@ -123,21 +123,21 @@ Configuration options are below. For examples, see [Example config](#example-con
 
 ### Integration configuration files [#host-connection]
 
-The configuration file has common settings applicable to all integrations like `interval`, `timeout`, `inventory_source`. To read all about these common settings refer to our [Configuration Format](/docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integrations-newer-configuration-format/#configuration-basics) document.
+The configuration file has common settings applicable to all integrations, such as `interval`, `timeout`, or `inventory_source`. To read all about these common settings refer to our [configuration format](/docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integrations-newer-configuration-format/#configuration-basics) document.
 
 <Callout variant="important">
-  If you are still using our Legacy configuration/definition files please refer to this [document](/docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integrations-standard-configuration-format/) for help.
+  If you're still using our legacy configuration/definition files, refer to the [standard configuration doc](/docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integrations-standard-configuration-format/) for help.
 </Callout>
 
 Specific settings related to JMX are defined using the `env` section of the configuration file. These settings control the connection to your JMX instance as well as other security settings and features. The list of valid settings is described in the next section of this document.
 
-Config options are below. For an example configuration, see [Example config file](#example-config).
+Config options are below. For an example configuration, see the [example config file](#example-config).
 
 ### JMX Instance Settings [#instance-settings]
 
-The JMX integration collects both Metrics(<strong>M</strong>) and Inventory(<strong>I</strong>) information. Check the **Applies To** column below to find which settings can be used for each specific collection.
+The JMX integration collects both metrics (**M**) and inventory (**I**) information. Check the **Applies To** column below to find which settings can be used for each specific collection.
 
-For an example, see [Host connection file example](#host-connection-example).
+For an example, see the [host connection file example](#host-connection-example).
 
 <table>
   <thead>
@@ -167,7 +167,7 @@ For an example, see [Host connection file example](#host-connection-example).
       The host JMX is running on.
     </td>
     <td>
-      localhost
+      `localhost`
     </td>
     <td style={{ "text-align": "center" }}>
       M/I
@@ -239,10 +239,10 @@ For an example, see [Host connection file example](#host-connection-example).
       **JMX_REMOTE**
     </td>
     <td>
-      (JBoss specific) whether or not to use the JMX remote URL connection format, connection defaults to JBoss Domain-mode if `true`.
+      (JBoss specific) Whether or not to use the JMX remote URL connection format. Connection defaults to JBoss Domain-mode if `true`.
     </td>
     <td>
-      false
+      `false`
     </td>
     <td style={{ "text-align": "center" }}>
       M/I
@@ -254,10 +254,10 @@ For an example, see [Host connection file example](#host-connection-example).
       **JMX_REMOTE_JBOSS_STANDLONE**
     </td>
     <td>
-      (JBoss specific) whether or not to use the JBoss standalone connection format, only relevant if `jmx_remote` is set.
+      (JBoss specific) Whether or not to use the JBoss standalone connection format. Only relevant if `jmx_remote` is set.
     </td>
     <td>
-      false
+      `false`
     </td>
     <td style={{ "text-align": "center" }}>
       M/I
@@ -334,7 +334,7 @@ For an example, see [Host connection file example](#host-connection-example).
       Collect all metrics on the local entity. Only use when monitoring localhost.
     </td>
     <td>
-      false
+      `false`
     </td>
     <td style={{ "text-align": "center" }}>
       M/I
@@ -409,7 +409,7 @@ For an example, see [Host connection file example](#host-connection-example).
       Set to `true` to enable Metrics only collection.
     </td>
     <td>
-      false
+      `false`
     </td>
     <td style={{ "text-align": "center" }}>
     </td>
@@ -423,7 +423,7 @@ For an example, see [Host connection file example](#host-connection-example).
       Set to `true` to enable Inventory only collection.
     </td>
     <td>
-      false
+      `false`
     </td>
     <td style={{ "text-align": "center" }}>
     </td>
@@ -434,14 +434,14 @@ For an example, see [Host connection file example](#host-connection-example).
 
 The values for these settings can be defined in several ways:
 * Adding the value directly in the config file. This is the most common way.
-* Replacing the values from environment variables using the `{{}}` notation. This requires infrastructure agent v1.14.0+. Read more [here](/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/#passthrough) or see example [below](#example4).
-* Using Secrets management. Use this to protect sensible information such as passwords to be exposed in plain text on the configuration file. For more information, see [Secrets management](https://docs.newrelic.com/docs/integrations/host-integrations/installation/secrets-management).
+* Replacing the values from environment variables using the `{{}}` notation. This requires infrastructure agent v1.14.0 or higher. Read more [here](/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/#passthrough) or see the [example below](#example4).
+* Using secrets management. Use this to protect sensible information (such as passwords) from being exposed in plain text on the configuration file. For more information, see [secrets management](/docs/integrations/host-integrations/installation/secrets-management).
 
+### Labels and custom attributes [#labels]
 
-### Labels/Custom Attributes [#labels]
+You can further decorate your metrics using labels. Labels allow you to add key/value pair attributes to your metrics, which you can then use to query, filter or group your metrics on.
 
-You can further decorate your metrics using labels. Labels allow you to add key/value pairs attributes to your metrics which you can then use to query, filter or group your metrics on.<br/>
-Our default sample config file includes examples of labels but, as they are not mandatory, you can remove, modify or add new ones of your choice.
+Our default sample config file includes examples of labels. These aren't mandatory, and you can remove, modify, or add new ones of your choice.
 
 ```
  labels:

--- a/src/content/docs/integrations/host-integrations/host-integrations-list/jmx-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/jmx-monitoring-integration.mdx
@@ -72,11 +72,11 @@ To install the JMX integration, follow the instructions for your environment:
        ```
     6. Edit the `jmx-config.yml` file as described in the [configuration settings](#config).
     7. [Restart the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
-    
+
     <Callout variant="important">
       If the sample files are not present in your installation, you can download them directly from the [GitHub repository](https://github.com/newrelic/nri-jmx).
     </Callout>
-    
+
   </Collapser>
 
   <Collapser
@@ -123,27 +123,331 @@ Configuration options are below. For examples, see [Example config](#example-con
 
 ### Integration configuration files [#host-connection]
 
-This is where the host connection and collection file information is defined. This configuration accepts the following arguments. For an example, see [Host connection file example](#host-connection-example).
-
-* `collection_files`: A comma-separated list of full file paths to the metric collection definition files. For on-host install, the default JVM metrics collection file is at `/etc/newrelic-infra/integrations.d/jvm-metrics.yml`.
-* Connection arguments:
-  * `jmx_host`: the host JMX is running on. Default: `localhost`.
-  * `jmx_pass`: the password for the JMX connection. Default: `""`.
-  * `jmx_port`: the port JMX is running on. Default: `9999`.
-  * `jmx_remote`: (JBoss specific) whether or not to use the JMX remote URL connection format, connection defaults to JBoss Domain-mode if `true`. Default: `false`.
-  * `jmx_remote_jboss_standlone`: (JBoss specific) whether or not to use the JBoss standalone connection format, only relevant if `jmx_remote` is set. Default: `false`.
-* `connection_url:`: full JMX endpoint URL. This replaces all connection arguments (above) by providing all parameters on one line. Example: `"service:jmx:rmi:///jndi/rmi://localhost:7199/jmxrmi"` .
-* `jmx_user`: the username for the JMX connection. Default: `""`.
-* `key_store`: the filepath of the keystore containing the JMX client's SSL certificate.
-* `key_store_password`: the password for the SSL key store.
-* `local_entity`: collect all metrics on the local entity. Only use when monitoring localhost. Default: `false`.
-* `timeout`: the timeout for individual JMX queries, in milliseconds.
-* `trust_store`: the filepath of the keystore containing the JMX server's SSL certificate.
-* `trust_store_password`: the password for the trust store.
+The configuration file has common settings applicable to all integrations like `interval`, `timeout`, `inventory_source`. To read all about these common settings refer to our [Configuration Format](/docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integrations-newer-configuration-format/#configuration-basics) document.
 
 <Callout variant="important">
-  With secrets management, you can configure on-host integrations with New Relic infrastructure's agent to use sensitive data (such as passwords) without having to write them as plain text into the integration's configuration file. For more information, see [Secrets management](/docs/integrations/host-integrations/installation/secrets-management).
+  If you are still using our Legacy configuration/definition files please refer to this [document](/docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integrations-standard-configuration-format/) for help.
 </Callout>
+
+Specific settings related to JMX are defined using the `env` section of the configuration file. These settings control the connection to your JMX instance as well as other security settings and features. The list of valid settings is described in the next section of this document.
+
+Config options are below. For an example configuration, see [Example config file](#example-config).
+
+### JMX Instance Settings [#instance-settings]
+
+The JMX integration collects both Metrics(<strong>M</strong>) and Inventory(<strong>I</strong>) information. Check the **Applies To** column below to find which settings can be used for each specific collection.
+
+For an example, see [Host connection file example](#host-connection-example).
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "150px" }}>
+      Setting
+    </th>
+    <th>
+      Description
+    </th>
+    <th>
+      Default
+    </th>
+    <th>
+      <nobr>Applies To</nobr>
+    </th>
+  </tr>
+  </thead>
+
+  <tbody>
+
+  <tr>
+    <td>
+      **JMX_HOST**
+    </td>
+    <td>
+      The host JMX is running on.
+    </td>
+    <td>
+      localhost
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **JMX_PORT**
+    </td>
+    <td>
+      The port JMX is running on.
+    </td>
+    <td>
+      9999
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **JMX_URI_PATH**
+    </td>
+    <td>
+      The path portion of the JMX Service URI. This is useful for nonstandard service uris.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **JMX_USER**
+    </td>
+    <td>
+      The username for the JMX connection.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **JMX_PASS**
+    </td>
+    <td>
+      The password for the JMX connection.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **JMX_REMOTE**
+    </td>
+    <td>
+      (JBoss specific) whether or not to use the JMX remote URL connection format, connection defaults to JBoss Domain-mode if `true`.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **JMX_REMOTE_JBOSS_STANDLONE**
+    </td>
+    <td>
+      (JBoss specific) whether or not to use the JBoss standalone connection format, only relevant if `jmx_remote` is set.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **CONNECTION_URL**
+    </td>
+    <td>
+      Full JMX endpoint URL. This replaces all connection arguments (above) by providing all parameters on one line.
+
+      Example: `"service:jmx:rmi:///jndi/rmi://localhost:7199/jmxrmi"`
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **COLLECTION_FILES**
+    </td>
+    <td>
+      A comma-separated list of full file paths to the metric collection definition files. For on-host install, the default JVM metrics collection file is at `/etc/newrelic-infra/integrations.d/jvm-metrics.yml`.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **KEY_STORE**
+    </td>
+    <td>
+      The filepath of the keystore containing the JMX client's SSL certificate.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **KEY_STORE_PASSWORD**
+    </td>
+    <td>
+      The password for the SSL key store.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **LOCAL_ENTITY**
+    </td>
+    <td>
+      Collect all metrics on the local entity. Only use when monitoring localhost.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TIMEOUT**
+    </td>
+    <td>
+      The timeout for individual JMX queries, in milliseconds.
+    </td>
+    <td>
+      10000
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TRUST_STORE**
+    </td>
+    <td>
+      The filepath of the keystore containing the JMX server's SSL certificate.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **TRUST_STORE_PASSWORD**
+    </td>
+    <td>
+      The password for the trust store.
+    </td>
+    <td>
+      N/A
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **METRIC_LIMIT**
+    </td>
+    <td>
+      Number of metrics that can be collected per entity. If this limit is exceeded the entity will not be reported. A limit of 0 implies no limit.
+    </td>
+    <td>
+      200
+    </td>
+    <td style={{ "text-align": "center" }}>
+      M/I
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **METRICS**
+    </td>
+    <td>
+      Set to `true` to enable Metrics only collection.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      **INVENTORY**
+    </td>
+    <td>
+      Set to `true` to enable Inventory only collection.
+    </td>
+    <td>
+      false
+    </td>
+    <td style={{ "text-align": "center" }}>
+    </td>
+  </tr>
+
+  </tbody>
+</table>
+
+The values for these settings can be defined in several ways:
+* Adding the value directly in the config file. This is the most common way.
+* Replacing the values from environment variables using the `{{}}` notation. This requires infrastructure agent v1.14.0+. Read more [here](/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/#passthrough) or see example [below](#example4).
+* Using Secrets management. Use this to protect sensible information such as passwords to be exposed in plain text on the configuration file. For more information, see [Secrets management](https://docs.newrelic.com/docs/integrations/host-integrations/installation/secrets-management).
+
+
+### Labels/Custom Attributes [#labels]
+
+You can further decorate your metrics using labels. Labels allow you to add key/value pairs attributes to your metrics which you can then use to query, filter or group your metrics on.<br/>
+Our default sample config file includes examples of labels but, as they are not mandatory, you can remove, modify or add new ones of your choice.
+
+```
+ labels:
+   env: production
+   role: jmx
+```
 
 ### Metrics collection files [#metrics-collection]
 
@@ -221,17 +525,17 @@ Example file configurations for an on-host install:
     title="Example host connection file"
   >
     ```
-    integration_name: com.newrelic.jmx
-
-    instances:
-      - name: jmx
-        command: all_data
-        arguments:
-          jmx_host: jmx-host.localnet
-          jmx_port: 9999
-          jmx_user: admin
-          jmx_pass: admin
-          collection_files: "/etc/newrelic-infra/integrations.d/jvm-metrics.yml,/etc/newrelic-infra/integrations.d/tomcat-metrics.yml"
+    integrations:
+    - name: nri-jmx
+      env:
+        COLLECTION_FILES: "/etc/newrelic-infra/integrations.d/jvm-metrics.yml,/etc/newrelic-infra/integrations.d/tomcat-metrics.yml"
+        JMX_HOST: jmx-host.localnet
+        JMX_PASS: admin
+        JMX_PORT: 9999
+        JMX_USER: admin
+      interval: 15s
+      labels:
+        env: production
     ```
   </Collapser>
 
@@ -242,7 +546,7 @@ Example file configurations for an on-host install:
     ```
     collect:
                 # The event type for this domain will be JavaLangSample
-              - domain: java.lang 
+              - domain: java.lang
                 beans:
                     # Collect all beans of type Threading
                   - query: type=Threading
@@ -259,16 +563,16 @@ Example file configurations for an on-host install:
                           # can not correctly infer the type
                         - attr_regex: "ThreadCpu.*Enabled"
                           metric_type: attribute
-                  - query: type=Memory 
+                  - query: type=Memory
                     attributes:
                           # Composite attributes can be collected with this syntax
-                        - HeapMemoryUsage.Max 
-                        - NonHeapMemoryUsage.Max 
+                        - HeapMemoryUsage.Max
+                        - NonHeapMemoryUsage.Max
                     # Queries can be wildcarded where
                   - query: type=GarbageCollector,name=*
                     # If a specific bean is unwanted, it can be excluded
                     # with a regex match pattern. Useful if using a wildcard query
-                    exclude_regex: 
+                    exclude_regex:
                           # This will match any bean where the name is YoungGen
                         - name=YoungGen
                     attributes:
@@ -278,7 +582,7 @@ Example file configurations for an on-host install:
                 # Domains can be wildcarded
               - domain: java.util.*
                 # If the domain is wildcarded, a custom event must be defined
-                event_type: JavaUtilSample 
+                event_type: JavaUtilSample
                 beans:
                       # If no attributes are defined, all are collected by default
                     - query: type=Logging
@@ -398,9 +702,9 @@ Each event contains the following metadata:
 Here's an example [NRQL](/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql) query taking advantage of metadata monitor all the collected JVM garbage collectors:
 
 ```
-SELECT latest(CollectionTime) 
-FROM JVMSample 
-FACET `key:name` 
+SELECT latest(CollectionTime)
+FROM JVMSample
+FACET `key:name`
 WHERE `key:type` = 'GarbageCollector'
 ```
 


### PR DESCRIPTION
Redesigning the JMX integration configuration section.
Add a table with the config options
Add example configurations