### PR TITLE
Remove "need to change environment" bullet point

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/get-started-incident-intelligence.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/get-started-incident-intelligence.mdx
@@ -31,7 +31,7 @@ To set up an environment in Incident Intelligence, you need an administrator to 
 
 * **Who sets the environment?** Only administrators, and only for accounts where they have admin privileges.
 * **Can administrators set more than one environment?** They can set one environment per parent account and its child accounts. More than one can be set if an administrator has privileges for more than one parent account.
-* **Need to change the environment's associated account?** Reach out to your account executive or [our support team](http://support.newrelic.com) for help.
+
 
 <Callout variant="tip">
   Incident Intelligence is a cross-account product. This means you can send in data from any New Relic account or external source to correlate events.


### PR DESCRIPTION
While infrequent, when customers inevitably reach out to NR Support to move their II environment to another account, engineering has informed us (NR Support) that this is not actually possible and the customer needs to delete the environment via the incidentIntelligenceEnvironmentDeleteEnvironment NerdGraph API, then re-create it in the UI on the account that they want.

Since deleting the environment is not the same as moving the environment (there are configurations lost in deleting), I'm proposing that we simply take out mention of "moving" their environment completely.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.