### PR TITLE
Update docs for infinite tracing FedRAMP support

### DIFF
--- a/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
+++ b/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
@@ -534,4 +534,4 @@ To ensure FedRAMP compliance for data sent via the [Trace API](/docs/distributed
 
 Notes about FedRAMP compliance for other trace data: 
 * Trace data is reported by some of our agents, like our APM agents, browser agent, and mobile agent. To enable FedRAMP compliance for that data, you would [enable FedRAMP for the applicable agent](#agents).
-* Currently [Infinite Tracing](/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing/) is not FedRAMP compliant.
+* To enable FedRAMP compliance for [Infinite Tracing](/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing/) you would create a new FedRAMP compliant trace observer from the [New Relic Edge app](https://one.newrelic.com/launcher/mtb-nerdlets.edge-launcher).

--- a/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
+++ b/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
@@ -534,4 +534,4 @@ To ensure FedRAMP compliance for data sent via the [Trace API](/docs/distributed
 
 Notes about FedRAMP compliance for other trace data: 
 * Trace data is reported by some of our agents, like our APM agents, browser agent, and mobile agent. To enable FedRAMP compliance for that data, you would [enable FedRAMP for the applicable agent](#agents).
-* To enable FedRAMP compliance for [Infinite Tracing](/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing/) you would create a new FedRAMP compliant trace observer from the [New Relic Edge app](https://one.newrelic.com/launcher/mtb-nerdlets.edge-launcher).
+* To enable FedRAMP compliance for [Infinite Tracing](/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing/), you would create a new FedRAMP compliant trace observer from the [New Relic Edge app](https://one.newrelic.com/launcher/mtb-nerdlets.edge-launcher).


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* New Relic has added the ability to select a FedRAMP compliant observer as of 9/17/2021 and these changes reflect that updated support, removing the old wording about it not being supported.