### PR TITLE
chore: 'update the newrelic.yml' named anchor shown on subtitle

### DIFF
--- a/src/content/docs/agents/ruby-agent/installation/ruby-agent-installation-rails-plugin.mdx
+++ b/src/content/docs/agents/ruby-agent/installation/ruby-agent-installation-rails-plugin.mdx
@@ -39,7 +39,7 @@ After installing the agent, copy the `newrelic.yml` file into the `config` sub
   As part of the installation process, change the default [application name](/docs/site/naming-your-application) to a meaningful name.
 </Callout>
 
-## Update the newrelic.yml file [#Updating_newrelic.yml]
+## Update the newrelic.yml file [#Updating_newrelicyml]
 
 Whenever you update the agent, double-check that your Ruby agent configuration file (`config/newrelic.yml`) is up to date: Open the default `newrelic.yml` file that lives in the Ruby agent's plugin folder (`vendor/plugins/newrelic-ruby-agent/newrelic.yml`). Look for new configuration options that are not in your `config/newrelic.yml` file.
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
Fix named anchor shown on [`update the newrelic.yml` subtitle](https://docs.newrelic.com/docs/agents/ruby-agent/installation/ruby-agent-installation-rails-plugin/#update-the-newrelicyml-file-updating_newrelicyml)

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

Original document
![image](https://user-images.githubusercontent.com/4939738/133881197-a63835d0-e38e-42a9-adc7-e87e51be6b15.png)

Document that I modified
![image](https://user-images.githubusercontent.com/4939738/133881205-884939b1-0d5e-4d07-ac7d-7ef3b9c30c27.png)


* If your issue relates to an existing GitHub issue, please link to it.
#3962 


### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.