### PR TITLE
chore(Logs): Move doc in taxonomy

### DIFF
--- a/src/content/docs/logs/log-management/troubleshooting/json-message-not-parsed.mdx
+++ b/src/content/docs/logs/log-management/troubleshooting/json-message-not-parsed.mdx
@@ -7,6 +7,7 @@ tags:
   - Troubleshooting
 metaDescription: 'New Relic Logs troubleshooting: JSON message isn''t being parsed.'
 redirects:
+  - /docs/logs/new-relic-logs/troubleshooting/json-message-not-parsed
   - /docs/logs/new-relic-logs/troubleshooting/json-message-not-parsed-0
 ---
 
@@ -21,4 +22,4 @@ Reasons this may be happening:
 * If the content is not a valid JSON, it won't be parsed. Instead it will be stored as a string and truncated if it exceeds the [character limit](/docs/logs/new-relic-logs/troubleshooting/log-message-truncated).
 * The content is a valid JSON but "stringified" with escape characters. If that's the case, it will first be evaluated as a string, meaning that it will be truncated to 4096 characters before being evaluated as JSON. The result of the truncation will be invalid JSON, and the data will be stored as a string.
 
-To solve this problem: send messages containing JSON that haven't been converted to a string. This content will be parsed even if the total length exceeds the [character limit](/docs/logs/new-relic-logs/troubleshooting/log-message-truncated). If the JSON contains arrays, they'll be flattened and stored as unparsed strings.
+To solve this problem, send messages containing JSON that haven't been converted to a string. This content will be parsed even if the total length exceeds the [character limit](/docs/logs/new-relic-logs/troubleshooting/log-message-truncated). If the JSON contains arrays, they'll be flattened and stored as unparsed strings.

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -2151,7 +2151,7 @@ pages:
               - title: Log message is truncated
                 path: /docs/logs/log-management/troubleshooting/log-message-truncated
               - title: JSON message not parsed
-                path: /docs/logs/new-relic-logs/troubleshooting/json-message-not-parsed
+                path: /docs/logs/log-management/troubleshooting/json-message-not-parsed
               - title: Live tail logging
                 path: /docs/logs/log-management/troubleshooting/view-log-messages-real-time-live-tail
               - title: Show surrounding logs


### PR DESCRIPTION
The JSON parsing troubleshooting doc was in the path /new-relic-logs/troubleshooting, which makes no sense. Moved it into the troubleshooting cat and updated the fso yml file