### PR TITLE
chore: Java agent - adding missing JFR properties in config file

### DIFF
--- a/src/content/docs/agents/java-agent/configuration/java-agent-config-file-template.mdx
+++ b/src/content/docs/agents/java-agent/configuration/java-agent-config-file-template.mdx
@@ -44,7 +44,7 @@ common: &default_settings
   # Set the name of your application as you'd like it show up in New Relic.
   # If enable_auto_app_naming is false, the agent reports all data to this application.
   # Otherwise, the agent reports only background tasks (transactions for non-web applications)
-  # to this application. To report data to more than one application 
+  # to this application. To report data to more than one application
   # (useful for rollup reporting), separate the application names with ";".
   # For example, to report data to "My Application" and "My Application 2" use this:
   # app_name: My Application;My Application 2
@@ -116,26 +116,26 @@ common: &default_settings
   #<a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#cfg-proxy_password">proxy_password</a>: password
   #<a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#cfg-proxy_scheme">proxy_scheme</a>: https
 
-  # Limits the number of lines to capture for each stack trace. 
+  # Limits the number of lines to capture for each stack trace.
   # Default is 30
   <a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#max-stack-trace-lines">max_stack_trace_lines</a>: 30
 
   # Provides the ability to configure the attributes sent to New Relic. These
-  # attributes can be found in transaction traces, traced errors, Insight's 
+  # attributes can be found in transaction traces, traced errors, Insight's
   # transaction events, and Insight's page views.
   <a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#attributes">attributes</a>:
-  
+
     # When true, attributes will be sent to New Relic. The default is true.
     <a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#cfg-attributes-enabled">enabled</a>: true
-    
-    #A comma separated list of attribute keys whose values should 
+
+    #A comma separated list of attribute keys whose values should
     # be sent to New Relic.
     #<a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#cfg-attributes-include">include</a>:
-    
-    # A comma separated list of attribute keys whose values should 
+
+    # A comma separated list of attribute keys whose values should
     # not be sent to New Relic.
     #<a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#cfg-attributes-exclude">exclude</a>:
-    
+
 
   # Transaction tracer captures deep information about slow
   # transactions and sends this to the New Relic service once a
@@ -181,7 +181,7 @@ common: &default_settings
     # Default is true.
     <a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#tt-explain_enabled">explain_enabled</a>: true
 
-    # Threshold for query execution time below which query plans will not 
+    # Threshold for query execution time below which query plans will not
     # not be captured.  Relevant only when `explain_enabled` is true.
     # Default is 0.5 seconds.
     <a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#tt-explain_threshold">explain_threshold</a>: 0.5
@@ -214,7 +214,7 @@ common: &default_settings
     <a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#ec-ignore_status_codes">ignore_status_codes</a>: 404
 
   # Transaction Events are used for Histograms and Percentiles. Unaggregated data is collected
-  # for each web transaction and sent to the server on harvest. 
+  # for each web transaction and sent to the server on harvest.
   <a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#Transaction_Events">transaction_events</a>:
 
     # Set to false to disable transaction events.
@@ -254,7 +254,7 @@ common: &default_settings
   # New Relic Real User Monitoring gives you insight into the performance real users are
   # experiencing with your website. This is accomplished by measuring the time it takes for
   # your users' browsers to download and render your web pages by injecting a small amount
-  # of JavaScript code into the header and footer of each page. 
+  # of JavaScript code into the header and footer of each page.
   <a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#Browser_Monitoring">browser_monitoring</a>:
 
     # By default the agent automatically inserts API calls in compiled JSPs to
@@ -265,7 +265,7 @@ common: &default_settings
     <a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#bm-auto_instrument">auto_instrument</a>: true
 
   <a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#Custom_Instrumentation">class_transformer</a>:
-    # This instrumentation reports the name of the user principal returned from 
+    # This instrumentation reports the name of the user principal returned from
     # HttpServletRequest.getUserPrincipal() when servlets and filters are invoked.
     <a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#servlet-user">com.newrelic.instrumentation.servlet-user</a>:
       enabled: false
@@ -287,6 +287,23 @@ common: &default_settings
       org.springframework.data.convert.ClassGeneratingEntityInstantiator$ObjectInstantiatorClassGenerator,
       org.mvel2.optimizers.impl.asm.ASMAccessorOptimizer$ContextClassLoader,
       gw.internal.gosu.compiler.SingleServingGosuClassLoader,
+
+  # Real-time profiling using Java Flight Recorder (JFR).
+  # This feature reports dimensional metrics to the ingest endpoint configured by
+  # metric_ingest_uri and events to the ingest endpoint configured by event_ingest_uri.
+  # Both ingest endpoints default to US production but they will be automatically set to EU
+  # production when using an EU license key. Other ingest endpoints can be configured manually.
+  # Requires a JVM that provides the JFR library.
+  <a href="/docs/agents/java-agent/features/real-time-profiling-java-using-jfr-metrics/">jfr</a>:
+
+    # Set to true to enable Real-time profiling with JFR.
+    # Default is false.
+    <a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#jfr-enabled">enabled</a>: false
+
+    # Set to true to enable audit logging which will display all JFR metrics and events in each harvest batch.
+    # Audit logging is extremely verbose and should only be used for troubleshooting purposes.
+    # Default is false.
+    <a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#jfr-audit_logging">audit_logging</a>: false
 
   # User-configurable custom labels for this agent.  Labels are name-value pairs.
   # There is a maximum of 64 labels per agent.  Names and values are limited to 255 characters.


### PR DESCRIPTION
### Give us some context
JFR feature was added to the agent some time ago, but the configuration template file was not updated with the respective params.
This adds those params.
Sorry for the removal of white space.

### Are you making a change to site code?
No