### PR TITLE
fix(Logs): Links to new docs

### DIFF
--- a/src/content/docs/release-notes/logs-release-notes/logs-21-08-30.mdx
+++ b/src/content/docs/release-notes/logs-release-notes/logs-21-08-30.mdx
@@ -4,26 +4,26 @@ releaseDate: '2021-08-30'
 version: '210830'
 ---
 
+### New public APIs
+
+* Public APIs are now available for [parsing](https://docs.newrelic.com/docs/logs/log-management/ui-data/parsing/) and pipeline configuration (such as [drop filters](https://docs.newrelic.com/docs/logs/log-management/ui-data/drop-data-drop-filter-rules/)). Documentation can be found within the NerdGraph API explorer. Additional external documentation is coming soon!
+
+### Headerless HTTP ingest
+
+*  Added support for [Headerless HTTP log ingest](https://docs.newrelic.com/docs/logs/log-management/log-api/introduction-log-api/#query-parameters). This enables Logs customers to send data to New Relic from sources that do not permit the customization of HTTP request headers (for example, `Api-Key` or `X-License-Key`).  This approach is most often used when forwarding logs from cloud-based platforms.
+
+### More data, more power
+
+* Increased maximum attribute value size. The Logs team recognizes that keeping all data from a log is extremely important, and so we are providing additional functionality to store more data and reduce the chances of truncation. Attributes can now store and display up to 128 kb, the first 4096 bytes of which are searchable. For more information, see our documentation about [finding data in long logs (blobs)](https://docs.newrelic.com/docs/logs/log-management/ui-data/long-logs-blobs/) and the [Log Event API](https://docs.newrelic.com/docs/logs/log-management/log-api/log-event-data/).
+* Added ARM support to our Helm-based [Kubernetes integration](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging).
+
+### Bug fixes
+
+* Fixed several styling issues in Logs UI.
+* Corrected typos on **Add Your Data** page.
+
 ### Notes
 
 In partnership with our customers, the New Relic log team has been rapidly innovating our log management capabilities since the initial release in 2019. Our goal is to give you the best log experience to advance observability and provide measurable impact to your business.
 
-Moving forward, we will be summarizing the most recent fixes and enhancements captured in this ongoing changelog. To stay up to date, subscribe to our [Logs RSS feed](/docs/release-notes/logs-release-notes/). More to come soon!
-
-### New public APIs
-
-* Public APIs are now available for [Parsing](https://docs.newrelic.com/docs/logs/log-management/ui-data/parsing/) and Pipeline Configuration (e.g. [drop filters](https://docs.newrelic.com/docs/logs/log-management/ui-data/drop-data-drop-filter-rules/)). Documentation can be found within the NerdGraph API explorer, additional external documentation will be made available in September.
-
-### Headerless HTTP Ingest
-
-*  Added support for [Headerless HTTP log ingest](https://docs.newrelic.com/docs/logs/log-management/log-api/introduction-log-api/#query-parameters). This enables Logs customers to send data to New Relic from sources that do not permit the customization of HTTP request headers (for example, `Api-Key` or `X-License-Key`).  This approach is most often used when forwarding logs from cloud-based platforms.
-
-### More Data, More Power
-
-* Increased maximum attribute value size. The Logs team recognizes that keeping all data from a log is extremely important, and so we are providing additional functionality to store more data and reduce the chances of truncation. Attributes can now store and display up to 128 kb, the first 4096 bytes of which are searchable.
-* Added ARM support to our Helm-based [Kubernetes integration](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging).
-
-### Bug Fixes
-
-* Fixed several styling issues in Logs UI.
-* Corrected typos on "Add Your Data" page. 
+To stay up to date the most recent fixes and enhancements, subscribe to our [Logs RSS feed](/docs/release-notes/logs-release-notes/). More to come soon!


### PR DESCRIPTION
The new docs have been published, so I've added links and made some minor style guide edits