### PR TITLE
[WIP] PageViewTiming Cumulative Layout Shift (CLS) updates

### DIFF
--- a/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
+++ b/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
@@ -297,6 +297,29 @@ These metrics are supported by the following browser versions. For unsupported b
   </tbody>
 </table>
 
+## CumulativeLayoutShift [#cumulative-layout-shift]
+Cumulative Layout Shift (CLS) is a metric measuring the stability of the content on a webpage. For a complete description of CLS see: https://web.dev/cls/
+
+### How is CLS captured in New Relic
+Shifts in page layout as reported by the [Layout Instability API](https://developer.mozilla.org/en-US/docs/Web/API/Layout_Instability_API) are aggregated throughout the life of the page and reported as an attribute on all `PageViewTiming` events, representing the CLS value when that event occurred.
+Using this model, users can look at their CLS value at different points in the page's life, e.g. CLS values up until the first time users interact with the page or hides the page.
+
+### Approximating other CLS sources
+Lighthouse captures CLS value only up to the time when a page is loaded, which is useful in a development or lab environment.
+Users can approximate Lighthouse values by looking at the windowLoad `PageViewTiming` event.
+
+CrUX report uses values captured over the lifespan of the page, which is useful to analyze worst-case shifts in a RUM environment.
+Users can approximate CrUX values by looking at the CLS attribute on the windowUnload `PageViewTiming` event. These values will not be exactly the same because of different sample sets and a difference in how values from long-lived web pages are included. The New Relic Browser agent captures CLS when the page unloads, while CrUX collects and updates the metric throughout the lifespan of the page.
+
+### How CLS is aggregated
+As of July 2021, Google has updated the way CLS values are aggregated. Agent version v12xx use this method described here: [Evolving the CLS metric](https://web.dev/cls-web-tooling/)
+
+Browser agent v12xx and beyond:
+Layout shift values are captured in windows. Layout shifts that occurred within 1 second of each other, but no more than 5 seconds between the first and last shift are part of the same window. A CLS score represents the sum of layout shift values from the window with the highest sum of layout shift values.
+
+Prior to Browser agent v12xx:
+A CLS score represents the sum of all layout shifts that occurred up until that point in the page's life.
+
 ## Query your event data [#insights-queries]
 
 Here are some sample queries for the event data to help you get started.


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context
This is update adds details to the documentation on the behavior of the Cumulative Layout Shift metric:
* Updates were made by Google to the way CLS is captured. In an upcoming agent release (this PR will be updated when the version is known), the way CLS is captured will be updated to match.
* Added clarification on the way users can approximate CLS scores generated by other sources (Google Lighthouse, Google's CrUX report)