### PR TITLE
Removed spurious link and added two new links.

### DIFF
--- a/src/content/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts.mdx
+++ b/src/content/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts.mdx
@@ -225,7 +225,7 @@ SELECT derivative(totalApiBytesSent, 1 minute) FROM Metric
 
 #### Query gauge metrics [#query-gauges]
 
-When New Relic converts cumulative sums to gauges, you can query them using either the `latest()` or `derivative()` NRQL functions. The function you choose depends on whether you want to see the raw value or compute the rate of change. More information about querying these metrics is available in [View and query your metrics](/docs/telemetry-data-platform/understand-data/metric-data/query-metric-data-type/#view-and-query).
+When New Relic converts cumulative sums to gauges, you can query them using either the [`latest()`](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#latest) or [`derivative()`](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#derivative) NRQL functions. The function you choose depends on whether you want to see the raw value or compute the rate of change. 
 
 #### Query histogram metrics [#query-histograms]
 


### PR DESCRIPTION
This is a PR to remove a confusing link to the NRQL pages and replace it with individual links to the derivative() and latest() functions.