### PR TITLE
chore: create auto-comment bot

### DIFF
--- a/.github/workflows/auto-comment.yml
+++ b/.github/workflows/auto-comment.yml
@@ -1,0 +1,16 @@
+name: Auto Comment
+on: [issues, pull_request]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wow-actions/auto-comment@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pullRequestOpened: |
+            Hi @{{ author }} 👋
+            Thanks for your pull request! Your PR is in a queue, and a writer will take a look soon. We generally publish small edits within one business day, and larger edits within three days.
+
+          issuesOpened: |
+            Hi @{{ author }} 👋
+            Thank you for filing an issue! We will triage this issue within one business day, and then route it to the appropriate team so we can get it solved. 


### PR DESCRIPTION
This PR implements an action that comments on each PR and Issue opened. I was hoping I could find a way to exclude Docs team/DevEn PRs, but I couldn't figure it out 😓 

I would need some assistance from DevEn to set up the GH token. 


When a PR is opened:
```
Hi @{{ author }} 👋
Thanks for your pull request! Your PR is in a queue, and a writer will take a look soon. We generally publish small edits within one business day, and larger edits within three days.
```

When an issue is opened:
```
Hi @{{ author }} 👋
Thank you for filing an issue! We will triage this issue within one business day, and then route it to the appropriate team so we can get it solved. 
```
