### PR TITLE
fix(style guide): Remove prescriptive note that agent lists use bold

### DIFF
--- a/src/content/docs/style-guide/quick-reference/bold-or-code-not-italics.mdx
+++ b/src/content/docs/style-guide/quick-reference/bold-or-code-not-italics.mdx
@@ -44,28 +44,6 @@ Here are more specific guidelines our team uses.
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        APM Agent lists
-      </td>
-
-      <td className="fcenter">
-        <Icon name="fe-check"/>
-      </td>
-
-      <td/>
-
-      <td>
-        * **C SDK**
-        * **Go**
-        * **Java**
-        * **.NET**
-        * **Node.js**
-        * **PHP**
-        * **Python**
-        * **Ruby**
-      </td>
-    </tr>
 
     <tr>
       <td>
@@ -178,10 +156,6 @@ Here are more specific guidelines our team uses.
 
       <td>
         Go to **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Transactions**. For more information, see [UI paths](/docs/new-relic-only/basic-style-guide/writing-guidelines/usage-dictionary#ui-path).
-
-        <Callout variant="tip">
-          If you have a UI object (page, tab, etc.) that also has link formatting, then you don't need to add the bold formatting.
-        </Callout>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Don't think we need a special rule about bold for agent lists