### PR TITLE
update example links

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
@@ -23,7 +23,11 @@ On this page, you will learn how to manually instrument your lambda function. It
     1. Download our Go agent package and place it in the same directory as your function.
     2. Install the agent: `go get -u github.com/newrelic/go-agent/v3/newrelic`.
     3. Install the nrlambda integration `go get -u github.com/newrelic/go-agent/v3/integrations/nrlambda`.
-    4. In your Lambda code, import our components, create an application, and update how you start your Lambda. See our [GitHub repo for an example of an instrumented Lambda](https://github.com/newrelic/go-agent/blob/master/_integrations/nrlambda/example/main.go).
+    4. In your Lambda code, import our components, create an application, and update how you start your Lambda. See our examples for example of an instrumented Lambda:
+    
+        - [Extension repo](https://github.com/newrelic/newrelic-lambda-extension/tree/main/examples/sam/go)
+        - [Go Agent repo](https://github.com/newrelic/go-agent/blob/master/_integrations/nrlambda/example/main.go)
+
     5. Optional: Add [custom events](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#custom-event) that will be associated with your Lambda invocation by using the [`RecordCustomEvent` API](/docs/agents/go-agent/features/create-custom-events-insights-go). For example:
 
         ```go

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
@@ -23,10 +23,10 @@ On this page, you will learn how to manually instrument your lambda function. It
     1. Download our Go agent package and place it in the same directory as your function.
     2. Install the agent: `go get -u github.com/newrelic/go-agent/v3/newrelic`.
     3. Install the nrlambda integration `go get -u github.com/newrelic/go-agent/v3/integrations/nrlambda`.
-    4. In your Lambda code, import our components, create an application, and update how you start your Lambda. See our examples for example of an instrumented Lambda:
+    4. In your Lambda code, import our components, create an application, and update how you start your Lambda. See our examples for an example of an instrumented Lambda:
     
         - [Extension repo](https://github.com/newrelic/newrelic-lambda-extension/tree/main/examples/sam/go)
-        - [Go Agent repo](https://github.com/newrelic/go-agent/blob/master/_integrations/nrlambda/example/main.go)
+        - [Go agent repo](https://github.com/newrelic/go-agent/blob/master/_integrations/nrlambda/example/main.go)
 
     5. Optional: Add [custom events](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#custom-event) that will be associated with your Lambda invocation by using the [`RecordCustomEvent` API](/docs/agents/go-agent/features/create-custom-events-insights-go). For example:
 


### PR DESCRIPTION
- Add link to newer example in Extension repo.
- More clearly communicate where examples live.
