### PR TITLE
GCP add NR domain id for strict org policies

### DIFF
--- a/src/content/docs/integrations/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic.mdx
+++ b/src/content/docs/integrations/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic.mdx
@@ -110,6 +110,8 @@ Integrating your GCP project with New Relic requires you to authorize New Relic 
     If you authorize New Relic to fetch data through a service account, we will call your GCP project APIs using a service account ID and its associated public/private key pair.
 
     New Relic manages a specific Google service account for your New Relic account; you do not need to create it or manage the associated private key. Just add the service account ID as a member with viewing permissions in your project.
+    
+    If your organization uses a [domain restriction constraint](https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains), the policy will need to be updated to allow the New Relic domain, `C02x1gp26`. 
 
     This authorization method is recommended, especially if your GCP project is managed by a team. It also guarantees that New Relic will collect labels and inventory attributes whenever possible.
   </Collapser>

--- a/src/content/docs/integrations/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic.mdx
+++ b/src/content/docs/integrations/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic.mdx
@@ -111,7 +111,7 @@ Integrating your GCP project with New Relic requires you to authorize New Relic 
 
     New Relic manages a specific Google service account for your New Relic account; you do not need to create it or manage the associated private key. Just add the service account ID as a member with viewing permissions in your project.
     
-    If your organization uses a [domain restriction constraint](https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains), the policy will need to be updated to allow the New Relic domain, `C02x1gp26`. 
+    If your organization uses a [domain restriction constraint](https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains), you will have to update the policy to allow the New Relic domain, `C02x1gp26`. 
 
     This authorization method is recommended, especially if your GCP project is managed by a team. It also guarantees that New Relic will collect labels and inventory attributes whenever possible.
   </Collapser>


### PR DESCRIPTION
Adding New Relic's directory customer id for customer's with strict organization policies.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve? 
Some customers have strict organization constrains which may restrict the ability to add the New Relic owned service account to their GCP Org. Providing this ID will allow customers with this type of configuration to unblock adding the service account
https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
Internal Slack conversation: https://newrelic.slack.com/archives/C03HARJSV/p1632501770341100

* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code? 
No

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.