### PR TITLE
Update addToTrace doc

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/addtotrace-browser-agent-api.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/addtotrace-browser-agent-api.mdx
@@ -88,7 +88,7 @@ var obj = {
 ```
 
  <Callout variant="important">
-The number of events shared this way is limited by the Browser agent harvest cycle. [Here is the last update on that limit](https://docs.newrelic.com/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1026/#:~:text=Adjusted%20PageAction%20limits,events%20per%20harvest.). 
+The number of events shared this way is limited by the Browser agent harvest cycle. [Here is the last update on that limit](https://docs.newrelic.com/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1026/#:~:text=Adjusted%20PageAction%20limits,events%20per%20harvest). 
  </Callout>
 
 

--- a/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/addtotrace-browser-agent-api.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/addtotrace-browser-agent-api.mdx
@@ -34,6 +34,8 @@ Custom events within [browser session traces](/docs/browser/new-relic-browser/br
 * If a session trace currently **is** in progress, this adds an object with a user-defined name, start time, and other optional fields.
 * If you make this call and a session trace **is not** already in progress, this will not cause browser to capture a trace.
 
+Note: The number of events shared this way is limited by the Browser agent harvest cycle. [Here is the last update on that limit](https://docs.newrelic.com/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1026/#:~:text=Adjusted%20PageAction%20limits,events%20per%20harvest). 
+
 ## Parameters
 
 <table>
@@ -87,8 +89,5 @@ var obj = {
 }
 ```
 
- <Callout variant="important">
-The number of events shared this way is limited by the Browser agent harvest cycle. [Here is the last update on that limit](https://docs.newrelic.com/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1026/#:~:text=Adjusted%20PageAction%20limits,events%20per%20harvest). 
- </Callout>
 
 

--- a/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/addtotrace-browser-agent-api.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/addtotrace-browser-agent-api.mdx
@@ -86,3 +86,7 @@ var obj = {
   // Defaults to empty string
 }
 ```
+
+## Note 
+
+The number of events shared this way is limited by the Browser agent harvest cycle. [Here is the last update on that limit](https://docs.newrelic.com/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1026/#:~:text=Adjusted%20PageAction%20limits,events%20per%20harvest.). 

--- a/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/addtotrace-browser-agent-api.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/addtotrace-browser-agent-api.mdx
@@ -87,6 +87,8 @@ var obj = {
 }
 ```
 
-## Note 
-
+ <Callout variant="important">
 The number of events shared this way is limited by the Browser agent harvest cycle. [Here is the last update on that limit](https://docs.newrelic.com/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1026/#:~:text=Adjusted%20PageAction%20limits,events%20per%20harvest.). 
+ </Callout>
+
+


### PR DESCRIPTION
Include harvest cycle limit

<!-- Thanks for contributing to our docs! -->

### Give us some context

* What problems does this PR solve?
This informs API users of a limitation. 
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
Yes, [the harvest cycle limitation is mentioned here](https://docs.newrelic.com/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1026/#:~:text=Adjusted%20PageAction%20limits,events%20per%20harvest.). 
* If your issue relates to an existing GitHub issue, please link to it.
none that I know of 
