### PR TITLE
fix(Logs): Debian 11 not supported

### DIFF
--- a/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent.mdx
@@ -92,6 +92,7 @@ The log forwarding feature is compatible with the following operating systems:
 
       <td>
         Version 9 ("Stretch") or higher
+        Exception: Version 11 is not supported.
       </td>
     </tr>
 


### PR DESCRIPTION
Updated the infra log forwarder doc to exclude Debian 11. This edit fixes https://github.com/newrelic/docs-website/issues/4062
