### PR TITLE
chore(Logs): Move logs in context to L2

### DIFF
--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -2160,7 +2160,7 @@ pages:
                 path: /docs/logs/log-management/troubleshooting/log-message-truncated
               - title: Show surrounding logs
                 path: /docs/logs/log-management/troubleshooting/find-issues-cause-or-impact-surrounding-logs
-      - title: Logs in context
+      - title: Forward logs
         pages:
           - title: Enable log monitoring in New Relic
             path: /docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic
@@ -2191,27 +2191,27 @@ pages:
                 path: /docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/heroku-log-forwarding
               - title: Azure logs ARM template
                 path: /docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/azure-log-forwarding
-          - title: Configure logs in context
-            path: /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-apm-agents
-            pages:
-              - title: C SDK configure logs in context
-                path: /docs/logs/enable-log-management-new-relic/configure-logs-context/c-sdk-configure-logs-context
-              - title: Go configure logs in context
-                path: /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-go
-              - title: Java configure logs in context
-                path: /docs/logs/enable-log-management-new-relic/configure-logs-context/java-configure-logs-context-all
-              - title: NET configure logs in context
-                path: /docs/logs/enable-log-management-new-relic/configure-logs-context/net-configure-logs-context-all
-              - title: Node.js configure logs in context
-                path: /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-nodejs
-              - title: PHP configure logs in context
-                path: /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-php
-              - title: Python configure logs in context
-                path: /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-python
-              - title: Ruby configure logs in context
-                path: /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-ruby
-              - title: APM agent APIs for logs in context
-                path: /docs/logs/enable-log-management-new-relic/configure-logs-context/annotate-logs-logs-context-using-apm-agent-apis
+      - title: Logs in context
+        path: /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-apm-agents
+        pages:
+          - title: C SDK configure logs in context
+            path: /docs/logs/enable-log-management-new-relic/configure-logs-context/c-sdk-configure-logs-context
+          - title: Go configure logs in context
+            path: /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-go
+          - title: Java configure logs in context
+            path: /docs/logs/enable-log-management-new-relic/configure-logs-context/java-configure-logs-context-all
+          - title: NET configure logs in context
+            path: /docs/logs/enable-log-management-new-relic/configure-logs-context/net-configure-logs-context-all
+          - title: Node.js configure logs in context
+            path: /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-nodejs
+          - title: PHP configure logs in context
+            path: /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-php
+          - title: Python configure logs in context
+            path: /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-python
+          - title: Ruby configure logs in context
+            path: /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-ruby
+          - title: APM agent APIs for logs in context
+            path: /docs/logs/enable-log-management-new-relic/configure-logs-context/annotate-logs-logs-context-using-apm-agent-apis
   - title: Mobile monitoring
     path: /docs/mobile-monitoring
     pages:


### PR DESCRIPTION
For DOC7339. Rename existing FSO > Logs > Logs in context taxonomy to "Forward logs" and keep the enable/log forwarder docs there. Add a new "Logs in context" category under FSO > Logs and shift all logs in context docs one level to the left.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.