### PR TITLE
Update logs intro: fix attribute name restrictions

### DIFF
--- a/src/content/docs/logs/log-management/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-management/log-api/introduction-log-api.mdx
@@ -358,9 +358,8 @@ Some specific attributes have additional restrictions:
 
 * `accountId`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
 * `entity.guid`, `entity.name`, and `entity.type`: These attributes are used internally to identify entities. Any values submitted with these keys in the attributes section of a metric data point may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities. For more information please refer to [Entity synthesis](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#entity-synthesis).
-* [`appId`](/docs/apis/rest-api-v2/requirements/find-product-id#apm): Value must be an integer. If it is not an integer, the attribute name and value will be dropped during ingest.
-* `eventType`: Can be a combination of alphanumeric characters, `_` underscores, and `:` colons.
-* `timestamp`: Must be a Unix epoch timestamp. You can define timestamps either in seconds or in milliseconds.
+* `eventType`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
+* `timestamp`: This is an numeric Unix epoch timestamp. You can define timestamps either in seconds or in milliseconds.
 
 <Callout variant="important">
   Payloads with timestamps older than 48 hours may be dropped.


### PR DESCRIPTION
Howdy from the Logging Team! Just noticed something that needs updating: the Log ingestion pipeline allows `appId`, but `eventType` gets dropped.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.