### PR TITLE
small correction to postgres ohi doc

### DIFF
--- a/src/content/docs/integrations/host-integrations/host-integrations-list/postgresql-monitoring-integration.mdx
+++ b/src/content/docs/integrations/host-integrations/host-integrations-list/postgresql-monitoring-integration.mdx
@@ -281,7 +281,7 @@ The PostgreSQL integration collects both Metrics(<strong>M</strong>) and Invento
       M
     </td>
   </tr>
-    
+
   <tr>
     <td>
       **PGBOUNCER**
@@ -544,7 +544,7 @@ Example `postgresql-config.yml` file configuration:
 
     ```
     integrations:
-      - name: nri-mongodb
+      - name: nri-postgresql
         env:
           USERNAME: postgres
           PASSWORD: pass
@@ -569,7 +569,7 @@ Example `postgresql-config.yml` file configuration:
   >
     ```
     integrations:
-      - name: nri-mongodb
+      - name: nri-postgresql
         env:
           USERNAME: postgres
           PASSWORD: pass
@@ -598,7 +598,7 @@ Example `postgresql-config.yml` file configuration:
   >
     ```
     integrations:
-      - name: nri-mongodb
+      - name: nri-postgresql
         env:
           USERNAME: postgres
           PASSWORD: pass
@@ -633,7 +633,7 @@ Example `postgresql-config.yml` file configuration:
 
     ```
     integrations:
-      - name: nri-mongodb
+      - name: nri-postgresql
         env:
           USERNAME: postgres
           PASSWORD: pass


### PR DESCRIPTION
Small correction to our postgres ohi doc which by mistake was still referencing mongodb on the samples