### PR TITLE
Add intentions/recommendations for .NET app name API

### DIFF
--- a/src/content/docs/agents/net-agent/net-agent-api/set-application-name.mdx
+++ b/src/content/docs/agents/net-agent/net-agent-api/set-application-name.mdx
@@ -27,10 +27,10 @@ Compatible with all app types.
 
 ## Description
 
-Set the application name(s) reported to New Relic. For more information about application naming, see [Name your .NET application](/docs/agents/net-agent/installation-configuration/name-your-net-application).
+Set the application name(s) reported to New Relic. For more information about application naming, see [Name your .NET application](/docs/agents/net-agent/installation-configuration/name-your-net-application). This method is intended to be called once, during startup of an application.
 
 <Callout variant="important">
-  Updating the app name forces the agent to restart. The agent discards any unreported data associated with previous app names.
+  Updating the app name forces the agent to restart. The agent discards any unreported data associated with previous app names. Changing the app name multiple times during the lifecycle of an application is not recommended due to the associated data loss.
 </Callout>
 
 ## Parameters


### PR DESCRIPTION
### Give us some context

This clarifies the intended and recommended use for the SetApplicationName API provided by the .NET Agent. The intention is to avoid some problematic usage seen by GTS.

### Are you making a change to site code?

NOPE! :)