### PR TITLE
Add optional parameter and reformat

### DIFF
--- a/src/content/docs/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -779,42 +779,40 @@ New Relic's Node.js agent includes additional API calls.
 
     Use this method to gracefully shut down the agent.
 
-    `options`
-
     <table>
       <tr>
-        <th>Name</th>
-        <th>Type</th>
-        <th>Attributes</th>
-        <th>Default</th>
-        <th>Description</th>
+        <th style={{ width: "180px" }}>Option name</th>
+        <th style={{ width: "100px" }}>Type</th>
+        <th style={{ width: "100px" }}>Attributes</th>
+        <th style={{ width: "50px" }}>Default</th>
+        <th style={{ width: "200px" }}>Description</th>
       </tr>
       <tr>
         <td>`collectPendingData`</td>
         <td>`boolean`</td>
-        <td><optional></td>
-        <td>false</td>
+        <td>Optional</td>
+        <td>`false`</td>
         <td>Tell the agent whether to send any pending data to the New Relic collector before shutting down.</td>
       </tr>
       <tr>
         <td>`collectPendingData`</td>
         <td>`boolean`</td>
-        <td><optional></td>
-        <td>false</td>
+        <td>Optional</td>
+        <td>`false`</td>
         <td>Tell the agent whether to send any pending data to the New Relic collector before shutting down.</td>
       </tr>
       <tr>
         <td>`timeout`</td>
         <td>`number`</td>
-        <td><optional></td>
-        <td>0</td>
+        <td>Optional</td>
+        <td>`0`</td>
         <td>The default time before forcing a shutdown. When `collectPendingData` is true, the agent will wait for a connection before shutting down. This timeout is useful for short lived processes, like AWS Lambda, in order to keep the process from staying open too long, while trying to connect.</td>
       </tr>
       <tr>
         <td>`waitForIdle`</td>
         <td>`boolean`</td>
-        <td><optional></td>
-        <td>false</td>
+        <td>Optional</td>
+        <td>`false`</td>
         <td>If true, the agent will not shut down until there are no active transactions.</td>
       </tr>
     </table>

--- a/src/content/docs/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -822,7 +822,7 @@ New Relic's Node.js agent includes additional API calls.
     **Example:**
 
     ```
-    newrelic.shutdown({collectPendingData: true, timeout: 3000}, (error) => {
+    newrelic.shutdown({collectPendingData: true, timeout: 10000}, (error) => {
         process.exit()
       })
     ```

--- a/src/content/docs/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -122,10 +122,10 @@ Here is a summary of the Request API calls for New Relic's Node.js agent.
 
   <Collapser
     id="controller"
-    title={<InlineCode>newrelic.setControllerName(name, \[action])</InlineCode>}
+    title={<InlineCode>newrelic.setControllerName(name, [action])</InlineCode>}
   >
 ```    
-newrelic.setControllerName(name, \[action])
+newrelic.setControllerName(name, [action])
 ```
 
     Name the current request using a controller-style pattern, optionally including the current controller action. If the action is omitted, New Relic will include the HTTP method (GET, POST, etc.) as the action. The rules for when you can call `newrelic.setControllerName()` are the same as they are for `newrelic.setTransactionName()`, including the [request naming requirements](#requirements).
@@ -141,10 +141,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
 <CollapserGroup>
   <Collapser
     id="instrument"
-    title={<InlineCode>newrelic.instrument(moduleName, onRequire \[, onError])</InlineCode>}
+    title={<InlineCode>newrelic.instrument(moduleName, onRequire [, onError])</InlineCode>}
   >
     ```
-    newrelic.instrument(moduleName, onRequire \[, onError])
+    newrelic.instrument(moduleName, onRequire [, onError])
     ```
 
     Sets an instrumentation callback for a specific module.
@@ -162,10 +162,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
 
   <Collapser
     id="instrumentDatastore"
-    title={<InlineCode>newrelic.instrumentDatastore(moduleName, onRequire \[, onError])</InlineCode>}
+    title={<InlineCode>newrelic.instrumentDatastore(moduleName, onRequire [, onError])</InlineCode>}
   >
     ```
-    newrelic.instrumentDatastore(moduleName, onRequire \[, onError])
+    newrelic.instrumentDatastore(moduleName, onRequire [, onError])
     ```
 
     Sets an instrumentation callback for a datastore module.
@@ -207,7 +207,7 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     title={<InlineCode>newrelic.instrumentMessages(moduleName, onRequire \[, onError])</InlineCode>}
   >
     ```
-    newrelic.instrumentMessages(moduleName, onRequire \[, onError])
+    newrelic.instrumentMessages(moduleName, onRequire [, onError])
     ```
 
     Sets an instrumentation callback for a message service client module.
@@ -217,10 +217,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
 
   <Collapser
     id="instrumentWebframework"
-    title={<InlineCode>newrelic.instrumentWebframework(moduleName, onRequire \[, onError])</InlineCode>}
+    title={<InlineCode>newrelic.instrumentWebframework(moduleName, onRequire [, onError])</InlineCode>}
   >
     ```
-    newrelic.instrumentWebframework(moduleName, onRequire \[, onError])
+    newrelic.instrumentWebframework(moduleName, onRequire [, onError])
     ```
 
     Sets an instrumentation callback for a web framework module.
@@ -250,10 +250,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
 
   <Collapser
     id="startBackgroundTransaction"
-    title={<InlineCode>newrelic.startBackgroundTransaction(name, \[group], handle)</InlineCode>}
+    title={<InlineCode>newrelic.startBackgroundTransaction(name, [group], handle)</InlineCode>}
   >
     ```
-    newrelic.startBackgroundTransaction(name, \[group], handle)
+    newrelic.startBackgroundTransaction(name, [group], handle)
     ```
 
     Instrument the specified background transaction. Using this API call, you can expand New Relic's instrumentation to [capture data from background transactions](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation#background-txn).
@@ -333,10 +333,10 @@ Use these API calls to [record additional arbitrary metrics](/docs/agents/nodejs
 
   <Collapser
     id="increment_metric"
-    title={<InlineCode>newrelic.incrementMetric(name, \[amount])</InlineCode>}
+    title={<InlineCode>newrelic.incrementMetric(name, [amount])</InlineCode>}
   >
     ```
-    newrelic.incrementMetric(name, \[amount])
+    newrelic.incrementMetric(name, [amount])
     ```
 
     Use `incrementMetric` to update a metric that acts as a simple counter. The count of the selected metric will be incremented by the specified amount, defaulting to 1.
@@ -390,10 +390,10 @@ Use these methods to interact directly with the current transaction:
 <CollapserGroup>
   <Collapser
     id="transaction-handle-end"
-    title={<InlineCode>transactionHandle.end(\[callback])</InlineCode>}
+    title={<InlineCode>transactionHandle.end([callback])</InlineCode>}
   >
     ```
-    transactionHandle.end(\[callback])
+    transactionHandle.end([callback])
     ```
 
     Use `transactionHandle.end` to end the transaction referenced by the handle instance.
@@ -756,10 +756,10 @@ New Relic's Node.js agent includes additional API calls.
 
   <Collapser
     id="noticeError"
-    title={<InlineCode>newrelic.noticeError(error, \[customParameters])</InlineCode>}
+    title={<InlineCode>newrelic.noticeError(error, [customParameters])</InlineCode>}
   >
     ```
-    newrelic.noticeError(error, \[customParameters])
+    newrelic.noticeError(error, [customParameters])
     ```
 
     Use this call if your app is doing its own error handling with domains or try/catch clauses, but you want all of the information about how many errors are coming out of the app to be centrally managed. Unlike other Node.js calls, this can be used outside of route handlers, but it will have additional context if called from within transaction scope.
@@ -771,10 +771,10 @@ New Relic's Node.js agent includes additional API calls.
 
   <Collapser
     id="shutdown"
-    title={<InlineCode>newrelic.shutdown(\[options], callback)</InlineCode>}
+    title={<InlineCode>newrelic.shutdown([options], callback)</InlineCode>}
   >
     ```
-    newrelic.shutdown(\[options], callback)
+    newrelic.shutdown([options], callback)
     ```
 
     Use this method to gracefully shut down the agent.

--- a/src/content/docs/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -781,9 +781,44 @@ New Relic's Node.js agent includes additional API calls.
 
     `options`
 
-    * `options.collectPendingData - type boolean` **-** Tell the agent whether to send any pending data to the New Relic collector before shutting down.
-    * `options.timeout - type number (ms)` **-** The default time before forcing a shutdown. When `collectPendingData` is true, the agent will wait for a connection before shutting down. This timeout is useful for short lived processes, like AWS Lambda, in order to keep the process from staying open too long, while trying to connect.
-
+    <table>
+      <tr>
+        <th>Name</th>
+        <th>Type</th>
+        <th>Attributes</th>
+        <th>Default</th>
+        <th>Description</th>
+      </tr>
+      <tr>
+        <td>`collectPendingData`</td>
+        <td>`boolean`</td>
+        <td><optional></td>
+        <td>false</td>
+        <td>Tell the agent whether to send any pending data to the New Relic collector before shutting down.</td>
+      </tr>
+      <tr>
+        <td>`collectPendingData`</td>
+        <td>`boolean`</td>
+        <td><optional></td>
+        <td>false</td>
+        <td>Tell the agent whether to send any pending data to the New Relic collector before shutting down.</td>
+      </tr>
+      <tr>
+        <td>`timeout`</td>
+        <td>`number`</td>
+        <td><optional></td>
+        <td>0</td>
+        <td>The default time before forcing a shutdown. When `collectPendingData` is true, the agent will wait for a connection before shutting down. This timeout is useful for short lived processes, like AWS Lambda, in order to keep the process from staying open too long, while trying to connect.</td>
+      </tr>
+      <tr>
+        <td>`waitForIdle`</td>
+        <td>`boolean`</td>
+        <td><optional></td>
+        <td>false</td>
+        <td>If true, the agent will not shut down until there are no active transactions.</td>
+      </tr>
+    </table>
+    
     **Example:**
 
     ```


### PR DESCRIPTION
### Give us some context

* What problems does this PR solve?

Customer questioned weather the parameters for the `shutdown()` method were optional or not, our Github API documentation makes this more clear and includes a parameter not listed on the docs site:

http://newrelic.github.io/node-newrelic/docs/API.html#shutdown

Reformatted to match the Github format - although it has been awhile since I did any HTML so may need some fixes!

### Are you making a change to site code?

No