### PR TITLE
Java Agent 7.3.0 release changes

### DIFF
--- a/src/content/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -156,6 +156,16 @@ Before you install the Java agent, ensure your system meets these requirements:
           </td>
         </tr>
 
+
+        <tr>
+          <td>
+            Java 16
+          </td>
+
+          <td>
+            Agent v7.3.0 to current
+          </td>
+        </tr>        
       </tbody>
     </table>
 
@@ -265,7 +275,7 @@ The agent automatically instruments these frameworks and libraries:
     * Thrift 0.8.0 to latest
     * Vert.x 3.2.0 to 3.8.3
     * ZIO
-      - Scala 2.13: 1.0.9 to latest 1.x
+      - Scala 2.13: 1.0.9 to 2.0.0-M2
   </Collapser>
 
   <Collapser
@@ -279,16 +289,16 @@ The agent automatically instruments these frameworks and libraries:
     * AsyncHttpClient 2.0.0-RC1 to latest
     * gRPC 1.4.0 to 1.39.0
     * HTTP4s Blaze client
-      - Scala 2.12: 0.21 - 1.0
-      - Scala 2.13: 0.21 - 1.0
+      - Scala 2.12: 0.21 - 0.23.0-M1
+      - Scala 2.13: 0.21 - 0.23.0-M1
     * HTTP4s Blaze server
-      - Scala 2.12: 0.21
-      - Scala 2.13: 0.21
+      - Scala 2.12: 0.21 - 0.22.0-M8
+      - Scala 2.13: 0.21 - 0.22.0-M8
     * HttpAsyncClient 4.1 to latest
     * Apache Httpclient from 3.0 to latest
     * java.net.HttpURLConnection
     * JMS and Spring-JMS 1.1 to latest
-    * [Kafka Clients](/docs/agents/java-agent/instrumentation/use-kafka-message-queues) 0.10.0.0 to latest (for metric and event data)
+    * [Kafka Clients](/docs/agents/java-agent/instrumentation/use-kafka-message-queues) 0.10.0.0 to 2.8.1 (for metric and event data)
     * [Kafka Clients](/docs/agents/java-agent/instrumentation/use-kafka-message-queues) 0.11.0.0 to latest (for distributed tracing, metric, and event data)
     * OkHttp 3.x to 4.3.x
     * Ning AsyncHttpClient 1.x


### PR DESCRIPTION



### Give us some context
7.3.0 Releases on 9/30.  These are updates to the Java Agent compatibility docs related to the 7.3.0 release.

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.