### PR TITLE
Add Browser Filter AjaxRequest Event doc

### DIFF
--- a/src/content/docs/browser/new-relic-browser/configuration/filter-ajax-request-events.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/filter-ajax-request-events.mdx
@@ -2,7 +2,7 @@
 title: 'Filter AjaxRequest events'
 metaDescription: "For New Relic browser monitoring: use the app settings page to filter which network calls are recorded as AjaxRequest events."
 ---
-In (TBD)[agent version 1211](https://docs.newrelic.com/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/) or higher, all network requests made by a page are recorded as `AjaxRequest` events. You can use the deny list configuration options in the **Application settings** page to filter which requests record events. 
+In [agent version 1211](https://docs.newrelic.com/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/) or higher, all network requests made by a page are recorded as `AjaxRequest` events. You can use the deny list configuration options in the **Application settings** page to filter which requests record events. 
 Regardless of this filter, all network requests are captured as metrics and available in the AJAX page.
 
 ## Using the Deny List

--- a/src/content/docs/browser/new-relic-browser/configuration/filter-ajax-request-events.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/filter-ajax-request-events.mdx
@@ -5,7 +5,7 @@ metaDescription: "For New Relic browser monitoring: use the app settings page to
 In [agent version 1211](https://docs.newrelic.com/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/) or higher, all network requests made by a page are recorded as `AjaxRequest` events. You can use the deny list configuration options in the **Application settings** page to filter which requests record events. 
 Regardless of this filter, all network requests are captured as metrics and available in the AJAX page.
 
-## Using the Deny List
+## Using the deny list
 Requests can be blocked in three ways:
   * To block recording of all `AjaxRequest` events, add the * wildcard. Example: `*`
   * To block recording of `AjaxRequest` events to a domain, enter just the domain name. Example: `example.com`
@@ -13,7 +13,7 @@ Requests can be blocked in three ways:
 
 The protocol, port, search and hash of a URL are ignored by the deny list.
 
-## Access the Deny List
+## Access the deny list
 To update the deny list of URLs your application will filter from creating events, go to the app settings page:
 1. Go to [one.newrelic.com](http://one.newrelic.com), and click **Browser**. 
 2. Select an app. 

--- a/src/content/docs/browser/new-relic-browser/configuration/filter-ajax-request-events.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/filter-ajax-request-events.mdx
@@ -1,0 +1,24 @@
+---
+title: 'Filter AjaxRequest events'
+metaDescription: "For New Relic browser monitoring: use the app settings page to filter which network calls are recorded as AjaxRequest events."
+---
+In agent version v1211 or higher, all network requests made by a page are recorded as AjaxRequest events. Included with this change is a new deny list configuration option available in the application settings page to filter which requests record events.
+Regardless of this filter, all network requests are captured as metrics and available in the AJAX Page.
+
+To update the deny list of URLs your application will filter from creating events, go to the app settings page:
+1. Go to [one.newrelic.com](http://one.newrelic.com), and click **Browser**. 
+2. Select an app. 
+3. On the left navigation, click **App settings**.
+4. Under **Ajax Request Deny List**, add the filters you would like to apply to your app.
+
+   <Callout variant="important">
+     Requests can be blocked in three ways:
+
+      * To block recording of all AjaxRequest events, add the * wildcard. Example: `*`
+      * To block recording of AjaxRequest events to a domain, enter just the domain name. Example: `example.com`
+      * To block recording of AjaxRequest events to a specific domain and path, enter the domain and path. Example: `example.com/path`
+
+     The protocol, port, search and hash of a URL are ignored by the deny list.
+   </Callout>
+5. Select **Save application settings** to update the agent configuration.
+6. [Redeploy the browser agent](/docs/browser/new-relic-browser/installation/upgrade-browser-agent) (either restarting the associated APM agent or updating the copy/paste browser installation).

--- a/src/content/docs/browser/new-relic-browser/configuration/filter-ajax-request-events.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/filter-ajax-request-events.mdx
@@ -2,23 +2,31 @@
 title: 'Filter AjaxRequest events'
 metaDescription: "For New Relic browser monitoring: use the app settings page to filter which network calls are recorded as AjaxRequest events."
 ---
-In agent version v1211 or higher, all network requests made by a page are recorded as AjaxRequest events. Included with this change is a new deny list configuration option available in the application settings page to filter which requests record events.
-Regardless of this filter, all network requests are captured as metrics and available in the AJAX Page.
+In (TBD)[agent version 1211](https://docs.newrelic.com/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/) or higher, all network requests made by a page are recorded as `AjaxRequest` events. You can use the deny list configuration options in the **Application settings** page to filter which requests record events. 
+Regardless of this filter, all network requests are captured as metrics and available in the AJAX page.
 
+## Using the Deny List
+Requests can be blocked in three ways:
+  * To block recording of all `AjaxRequest` events, add the * wildcard. Example: `*`
+  * To block recording of `AjaxRequest` events to a domain, enter just the domain name. Example: `example.com`
+  * To block recording of `AjaxRequest` events to a specific domain and path, enter the domain and path. Example: `example.com/path`
+
+The protocol, port, search and hash of a URL are ignored by the deny list.
+
+## Access the Deny List
 To update the deny list of URLs your application will filter from creating events, go to the app settings page:
 1. Go to [one.newrelic.com](http://one.newrelic.com), and click **Browser**. 
 2. Select an app. 
 3. On the left navigation, click **App settings**.
 4. Under **Ajax Request Deny List**, add the filters you would like to apply to your app.
-
-   <Callout variant="important">
-     Requests can be blocked in three ways:
-
-      * To block recording of all AjaxRequest events, add the * wildcard. Example: `*`
-      * To block recording of AjaxRequest events to a domain, enter just the domain name. Example: `example.com`
-      * To block recording of AjaxRequest events to a specific domain and path, enter the domain and path. Example: `example.com/path`
-
-     The protocol, port, search and hash of a URL are ignored by the deny list.
-   </Callout>
 5. Select **Save application settings** to update the agent configuration.
 6. [Redeploy the browser agent](/docs/browser/new-relic-browser/installation/upgrade-browser-agent) (either restarting the associated APM agent or updating the copy/paste browser installation).
+
+
+## Validation
+
+To validate whether the filters you have added work as expected, run a NRQL query for `AjaxRequest` events matching your filter.
+
+```
+FROM AjaxRequest SELECT * WHERE requestUrl LIKE `%example.com%`
+```

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -1708,6 +1708,8 @@ pages:
                 path: /docs/browser/new-relic-browser/configuration/rename-browser-apps
               - title: Domain settings
                 path: /docs/browser/new-relic-browser/configuration/monitor-or-block-specific-domains-subdomains
+              - title: Filter Ajax request events
+                path: /docs/browser/new-relic-browser/configuration/filter-ajax-request-events
               - title: Metrics by URL patterns
                 path: /docs/browser/new-relic-browser/configuration/group-browser-metrics-urls
               - title: License key and app ID


### PR DESCRIPTION
### Give us some context

The Browser Agent team is going to release a new version of the agent in the near future which increases the total number of AjaxRequest events captured. As part of this work, we added a new configuration to the UI to allow customers to specify a set of URLs which should not be recorded as AjaxRequest events.

The goal of this doc is to provide a reference on how to use this feature and provide support a resource to share with customers if they receive tickets.

We will need to leave this PR in draft form until the agent is publicly released (currently it is in testing in Staging) and we can update the doc with the correct agent version.