### PR TITLE
Update High CPU usage alert condition

### DIFF
--- a/src/content/docs/integrations/elastic-container-service-integration/understand-use-data/ecs-integration-recommended-alert-conditions.mdx
+++ b/src/content/docs/integrations/elastic-container-service-integration/understand-use-data/ecs-integration-recommended-alert-conditions.mdx
@@ -17,7 +17,7 @@ Here are some recommended ECS alert conditions. To add these alerts, go to the [
 
 * High CPU usage
 
-  * NRQL: FROM ContainerSample SELECT cpuUsed / cpuLimitCores
+  * NRQL: FROM ContainerSample SELECT cpuUsedCoresPercent
   * Critical: > 90% for 5 minutes
 * High memory usage
 


### PR DESCRIPTION
* What problems does this PR solve?
You are now reporting a cpuUsedCoresPercent metric which I've confirmed is equivalent to cpuUsedCores/cpuLimitCores. Due to that, you should actually be able to query the cpuUsedCoresPercent metric directly. 
`cpuUsed` doesn't exist

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
See my support ticket Request #472305

### Are you making a change to site code?
No