### PR TITLE
Fix: broken security storefront page links

### DIFF
--- a/src/content/docs/agents/c-sdk/get-started/apm-security-c-sdk.mdx
+++ b/src/content/docs/agents/c-sdk/get-started/apm-security-c-sdk.mdx
@@ -12,7 +12,7 @@ redirects:
 
 Due of the nature of the C SDK, you have direct control over what data is reported to New Relic. To ensure data privacy and to limit the types of information New Relic receives, no customer data is captured except what you supply in your API calls. In addition, the C SDK reports all data to New Relic over HTTPS.
 
-For more information about our security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+For more information about our security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 
 ## Default security settings [#default]
 

--- a/src/content/docs/agents/go-agent/get-started/apm-agent-security-go.mdx
+++ b/src/content/docs/agents/go-agent/get-started/apm-agent-security-go.mdx
@@ -11,7 +11,7 @@ The New Relic Go agent default security settings automatically provide [security
 
 If you want to restrict the information that New Relic receives, you can enable [high security mode](#restricted). If high security mode or the default settings do not work for your business needs, you can apply [custom](#custom) settings.
 
-For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 
 ## Default security settings [#default]
 

--- a/src/content/docs/agents/java-agent/getting-started/apm-agent-security-java.mdx
+++ b/src/content/docs/agents/java-agent/getting-started/apm-agent-security-java.mdx
@@ -18,7 +18,7 @@ The New Relic Java agent default security settings automatically provide [securi
 
 If you want to restrict the information that New Relic receives, you can enable [high security mode](#restricted). If high security mode or the default settings do not work for your business needs, you can apply [custom](#custom) settings.
 
-For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 
 ## Default security settings [#default]
 

--- a/src/content/docs/agents/manage-apm-agents/configuration/enable-configurable-security-policies.mdx
+++ b/src/content/docs/agents/manage-apm-agents/configuration/enable-configurable-security-policies.mdx
@@ -21,7 +21,7 @@ redirects:
 
 APM's configurable security policies gives you granular control over configuration options related to your account's data security. This document explains how to enable account-wide security policies and the options available.
 
-For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 
 ## Compatibility and requirements [#compatibility]
 

--- a/src/content/docs/agents/manage-apm-agents/configuration/high-security-mode.mdx
+++ b/src/content/docs/agents/manage-apm-agents/configuration/high-security-mode.mdx
@@ -12,7 +12,7 @@ redirects:
 
 New Relic's default APM agent settings provide a high level of security. However, you may need to guarantee that even if the default APM agent settings are overridden to be more permissive, no sensitive data will ever be sent to New Relic. If this is the case, then you will want to turn on APM's high security mode (also known as enterprise security mode).
 
-For more information about our security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+For more information about our security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 
 ## Requirements
 

--- a/src/content/docs/agents/net-agent/getting-started/apm-agent-security-net.mdx
+++ b/src/content/docs/agents/net-agent/getting-started/apm-agent-security-net.mdx
@@ -11,7 +11,7 @@ The New Relic .NET agent default security settings automatically provide [securi
 
 If you want to restrict the information that New Relic receives, you can enable [high security mode](#restricted). If high security mode or the default settings do not work for your business needs, you can apply [custom](#custom) settings.
 
-For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 
 ## Default security settings [#default]
 

--- a/src/content/docs/agents/nodejs-agent/getting-started/apm-agent-security-nodejs.mdx
+++ b/src/content/docs/agents/nodejs-agent/getting-started/apm-agent-security-nodejs.mdx
@@ -11,7 +11,7 @@ The New Relic Node.js agent default security settings automatically provide [sec
 
 If you want to restrict the information that New Relic receives, you can enable [high security mode](#restricted). If high security mode or the default settings do not work for your business needs, you can apply [custom](#custom) settings.
 
-For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 
 ## Default security settings [#default]
 

--- a/src/content/docs/agents/php-agent/getting-started/apm-agent-security-php.mdx
+++ b/src/content/docs/agents/php-agent/getting-started/apm-agent-security-php.mdx
@@ -11,7 +11,7 @@ The PHP agent default security settings automatically provide [security for your
 
 If you want to restrict the information that New Relic receives, you can enable [high security mode](#restricted). If high security mode or the default settings do not work for your business needs, you can apply [custom](#custom) settings.
 
-For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 
 ## Default security settings [#default]
 

--- a/src/content/docs/agents/python-agent/getting-started/apm-agent-security-python.mdx
+++ b/src/content/docs/agents/python-agent/getting-started/apm-agent-security-python.mdx
@@ -13,7 +13,7 @@ The Python agent default security settings automatically provide [security for y
 
 If you want to restrict the information that we ingest you can enable [high security mode](#restricted). If high security mode or the default settings do not work for your business needs, you can apply [custom](#custom) settings.
 
-For more information about security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+For more information about security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 
 ## Default security settings [#default]
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts.mdx
@@ -208,7 +208,7 @@ Besides the standard controls you'd expect from a complete alerting solution, we
 
 By default, Alerts doesn't record any personal data. In addition, it automatically sets [default permissions](/docs/alerts/new-relic-alerts/rules-limits-glossary/rules-limits-new-relic-alerts) for individual account users and access levels within account structures.
 
-For more information about our security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit our [security website](https://newrelic.com/why-new-relic/security).
+For more information about our security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit our [security website](https://newrelic.com/security).
 
 ## What's next? [#what-next]
 

--- a/src/content/docs/apis/intro-apis/introduction-new-relic-apis.mdx
+++ b/src/content/docs/apis/intro-apis/introduction-new-relic-apis.mdx
@@ -504,7 +504,7 @@ New Relic tools and features, like APM, infrastructure monitoring, browser monit
 
 Like any other New Relic product or service, you want to be confident that your APIs protect you and your customers' data privacy. The following are API resources related to New Relic account administration and usage.
 
-For more information about API capabilities, see the specific [New Relic API](#product-apis). For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+For more information about API capabilities, see the specific [New Relic API](#product-apis). For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 
 <table>
   <thead>

--- a/src/content/docs/browser/new-relic-browser/performance-quality/security-browser-monitoring.mdx
+++ b/src/content/docs/browser/new-relic-browser/performance-quality/security-browser-monitoring.mdx
@@ -17,7 +17,7 @@ redirects:
 
 [Browser monitoring](/docs/browser/new-relic-browser/getting-started/introduction-new-relic-browser) provides insights into how your application or site behaves when it is loaded in a web browser. Browser only records performance data, as explained in this document. It does **not** record any data used or stored by the monitored application unless you explicitly configure it to do so.
 
-For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 
 ## Reported data [#data]
 

--- a/src/content/docs/infrastructure/infrastructure-monitoring/infrastructure-security/infrastructure-security.mdx
+++ b/src/content/docs/infrastructure/infrastructure-monitoring/infrastructure-security/infrastructure-security.mdx
@@ -25,7 +25,7 @@ Every piece of information exchanged between your hosts and the [infrastructure 
 
 The infrastructure agent does not support [high security mode](/docs/agents/manage-apm-agents/configuration/high-security-mode).
 
-For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 
 ## Running modes [#root]
 

--- a/src/content/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations.mdx
+++ b/src/content/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations.mdx
@@ -234,4 +234,4 @@ Infrastructure integrations generate some basic types of data that you can [use 
   </tbody>
 </table>
 
-Our integrations are data agnostic; they have no knowledge of whether reported data contains personal information. For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+Our integrations are data agnostic; they have no knowledge of whether reported data contains personal information. For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/security-mobile-apps.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/security-mobile-apps.mdx
@@ -9,7 +9,7 @@ redirects:
   - /docs/mobile-monitoring/new-relic-mobile/getting-started/security-mobile-apps
 ---
 
-To protect your mobile application's security and your users' data privacy, New Relic only records performance data, as described in this document. We do not collect any data used or stored by the monitored app. For more information about New Relic's security measures, see our [security and data privacy documentation](/docs/security/new-relic-security/data-privacy/data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+To protect your mobile application's security and your users' data privacy, New Relic only records performance data, as described in this document. We do not collect any data used or stored by the monitored app. For more information about New Relic's security measures, see our [security and data privacy documentation](/docs/security/new-relic-security/data-privacy/data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 
 ## Data collection [#collection]
 

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-01.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-01.mdx
@@ -102,4 +102,4 @@ New Relic is committed to the security of our customers and their data. If you b
 Additional documentation resources include:.
 
 * [Node.js agent release notes](/docs/release-notes/agent-release-notes/nodejs-release-notes)
-* [NR Security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [NR Security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-02.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-02.mdx
@@ -105,4 +105,4 @@ New Relic is committed to the security of our customers and their data. If you b
 Additional documentation resources include:
 
 * [.NET agent release notes](/docs/release-notes/agent-release-notes/net-release-notes)
-* [New Relic security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [New Relic security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-03.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-03.mdx
@@ -89,4 +89,4 @@ Additional documentation resources include:.
 * [MongoDB Aggregate Pipeline](https://docs.mongodb.com/manual/core/aggregation-pipeline/)
 * [Ruby Agent Mongo Configuration](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#mongo)
 * [Ruby agent installation](/docs/agents/ruby-agent/installation/ruby-agent-installation)
-* [NR Security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [NR Security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-04.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-04.mdx
@@ -97,4 +97,4 @@ Additional documentation resources include:.
 * [Upgrade the .NET agent](/docs/agents/net-agent/installation-configuration/upgrade-net-agent)
 * [.NET agent Error Collector configuration](/docs/agents/net-agent/installation-configuration/net-agent-configuration#error_collector)
 * [MSDN: Windows Communication Foundation](https://msdn.microsoft.com/en-us/library/dd456779(v=vs.110).aspx)
-* [NR Security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [NR Security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-05.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-05.mdx
@@ -86,4 +86,4 @@ New Relic is committed to the security of our customers and their data. If you b
 Additional documentation resources include:.
 
 * [Upgrade the Java agent](/docs/agents/java-agent/installation/upgrade-java-agent)
-* [NR Security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [NR Security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-06.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-06.mdx
@@ -86,4 +86,4 @@ New Relic is committed to the security of our customers and their data. If you b
 Additional documentation resources include:.
 
 * [Upgrade the .NET agent](/docs/agents/net-agent/installation/update-net-agent)
-* [NR Security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [NR Security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-01.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-01.mdx
@@ -86,4 +86,4 @@ New Relic is committed to the security of our customers and their data. If you b
 Additional documentation resources include:.
 
 * [Upgrade the Python Agent](/docs/agents/python-agent/installation-configuration/upgrade-python-agent)
-* [NR Security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [NR Security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-02.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-02.mdx
@@ -87,4 +87,4 @@ New Relic is committed to the security of our customers and their data. If you b
 Additional documentation resources include:.
 
 * [Upgrade the Python Agent](/docs/agents/python-agent/installation-configuration/upgrade-python-agent)
-* [NR Security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [NR Security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-03.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-03.mdx
@@ -96,4 +96,4 @@ New Relic is committed to the security of our customers and their data. If you b
 Additional documentation resources include:.
 
 * [Upgrade Synthetics private location](/docs/synthetics/new-relic-synthetics/private-locations/private-locations-overview-monitor-internal-sites-add-new-locations)
-* [New Relic Security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [New Relic Security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-04.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-04.mdx
@@ -83,4 +83,4 @@ New Relic is committed to the security of our customers and their data. If you b
 Additional documentation resources include:.
 
 * [Upgrade the .NET agent](/docs/agents/net-agent/installation/update-net-agent)
-* [NR Security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [NR Security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-05.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-05.mdx
@@ -87,4 +87,4 @@ New Relic is committed to the security of our customers and their data. If you b
 Additional documentation resources include:.
 
 * [Update the Infrastructure agent](/docs/infrastructure/new-relic-infrastructure/installation/update-infrastructure-agent)
-* [NR Security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [NR Security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-06.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-06.mdx
@@ -78,4 +78,4 @@ New Relic is committed to the security of our customers and their data. If you b
 Additional documentation resources include:.
 
 * [Upgrade the Node.js agent](/docs/agents/nodejs-agent/installation-configuration/upgrade-nodejs-agent)
-* [NR Security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [NR Security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-07.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-07.mdx
@@ -130,4 +130,4 @@ Additional documentation resources include:.
 * [Upgrade the .NET agent](/docs/agents/net-agent/installation/update-net-agent)
 * [Upgrade the Java agent](/docs/agents/java-agent/installation/upgrade-java-agent)
 * [Upgrade the Python agent](/docs/agents/python-agent/installation-configuration/upgrade-python-agent)
-* [NR Security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [NR Security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-08.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-08.mdx
@@ -82,4 +82,4 @@ New Relic is committed to the security of our customers and their data. If you b
 Additional documentation resources include:.
 
 * [Upgrade the Node.js agent](/docs/agents/nodejs-agent/installation-configuration/upgrade-nodejs-agent)
-* [NR Security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [NR Security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-09.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-09.mdx
@@ -72,4 +72,4 @@ New Relic is committed to the security of our customers and their data. If you b
 Additional documentation resources include:.
 
 * [Upgrade the Java agent](/docs/agents/java-agent/installation/upgrade-java-agent)
-* [NR Security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [NR Security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-10.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-10.mdx
@@ -87,4 +87,4 @@ Additional documentation resources include:.
 * [Upgrade the .NET agent](/docs/agents/net-agent/installation/update-net-agent)
 * [Upgrade the Java agent](/docs/agents/java-agent/installation/upgrade-java-agent)
 * [Upgrade the Python agent](/docs/agents/python-agent/installation-configuration/upgrade-python-agent)
-* [NR Security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [NR Security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-11.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-11.mdx
@@ -88,4 +88,4 @@ Additional documentation resources include:
 * [Upgrade the .NET agent](/docs/agents/net-agent/installation/update-net-agent)
 * [Upgrade the Java agent](/docs/agents/java-agent/installation/upgrade-java-agent)
 * [Upgrade the Python agent](/docs/agents/python-agent/installation-configuration/upgrade-python-agent)
-* [NR Security](https://newrelic.com/why-new-relic/security "Link opens in a new window.")
+* [NR Security](https://newrelic.com/security "Link opens in a new window.")

--- a/src/content/docs/security/security-privacy/data-privacy/new-relic-personal-data-requests.mdx
+++ b/src/content/docs/security/security-privacy/data-privacy/new-relic-personal-data-requests.mdx
@@ -34,7 +34,7 @@ As you work with your customers' data, you may find these resources helpful:
 
 * For a complete overview of what data we record, what it's used for, and how long this data is stored, see the [New Relic Services Data Privacy Notice](https://newrelic.com/termsandconditions/services-notices).
 * For information about your compliance with privacy laws when you use our browser monitoring service, see our documentation about [New Relic cookies used for browser monitoring](/docs/browser/new-relic-browser/page-load-timing-resources/new-relic-cookies-used-browser#gdpr).
-* For more information about our data privacy and security measures, see our [data privacy documentation](/docs/security/new-relic-security/data-privacy/data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+* For more information about our data privacy and security measures, see our [data privacy documentation](/docs/security/new-relic-security/data-privacy/data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 
 ## Requests for personal data deletion [#submit-requests]
 

--- a/src/content/docs/security/security-privacy/information-security/security-bulletins.mdx
+++ b/src/content/docs/security/security-privacy/information-security/security-bulletins.mdx
@@ -14,7 +14,7 @@ redirects:
   - /docs/security/new-relic-security/information-security/security-bulletins
 ---
 
-This document contains important information regarding security vulnerabilities that could affect some versions of New Relic products and service. Security bulletins are a way for us to let you know about security vulnerabilities, remediation strategies, and applicable updates for affected software. For more information, see our documentation about [security, data privacy, and compliance](/docs/security), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+This document contains important information regarding security vulnerabilities that could affect some versions of New Relic products and service. Security bulletins are a way for us to let you know about security vulnerabilities, remediation strategies, and applicable updates for affected software. For more information, see our documentation about [security, data privacy, and compliance](/docs/security), or visit the [New Relic security website](https://newrelic.com/security).
 
 ## Get security notifications [#notifications]
 

--- a/src/content/docs/using-new-relic/cross-product-functions/diagnostics-cli-nrdiag/diagnostics-cli-licensing-security.mdx
+++ b/src/content/docs/using-new-relic/cross-product-functions/diagnostics-cli-nrdiag/diagnostics-cli-licensing-security.mdx
@@ -9,7 +9,7 @@ metaDescription: 'Like any other New Relic tool, the Diagnostics CLI service (nr
 
 Like any other New Relic tool, the Diagnostics CLI service is designed to protect you and your customers' data privacy. The Diagnostics CLI inspects system information and New Relic product artifacts (logs and config files) that are relevant for performing diagnostic checks that assess New Relic product configuration and operability.
 
-By default, this data is not transmitted to New Relic. You do have the option to upload this information to a support ticket over HTTPS. For more information about New Relic's security measures, see our [security and privacy documentation](/docs/security/security-privacy/data-privacy/data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+By default, this data is not transmitted to New Relic. You do have the option to upload this information to a support ticket over HTTPS. For more information about New Relic's security measures, see our [security and privacy documentation](/docs/security/security-privacy/data-privacy/data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 
 ## License agreements [#diagnostics-licenses]
 

--- a/src/content/docs/using-new-relic/cross-product-functions/troubleshooting/log-audit-all-data-your-new-relic-agent-transmits.mdx
+++ b/src/content/docs/using-new-relic/cross-product-functions/troubleshooting/log-audit-all-data-your-new-relic-agent-transmits.mdx
@@ -10,7 +10,7 @@ redirects:
   - /docs/agents/manage-apm-agents/configuration/log-audit-all-data-your-new-relic-agent-transmits
 ---
 
-Every New Relic agent includes strong safeguards to ensure [data security](/docs/accounts-partnerships/accounts/security/data-security). For example, New Relic automatically encrypts sensitive information before it is transmitted. For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/why-new-relic/security).
+Every New Relic agent includes strong safeguards to ensure [data security](/docs/accounts-partnerships/accounts/security/data-security). For example, New Relic automatically encrypts sensitive information before it is transmitted. For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
 
 If you need to record and view information about **all** data your app transmits to New Relic, you can enable audit logging for short periods of time. This is useful, for example, with debugging or auditing, when you need detailed information about what exactly is being transmitted.
 


### PR DESCRIPTION
Follow up to https://github.com/newrelic/docs-website/pull/4123, replacing all broken links. 