### PR TITLE
Minor Update to AWS Cloudwatch Metric stream doc

### DIFF
--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -86,10 +86,9 @@ Next, set up the metric stream using the [CloudFormation template](https://conso
   * Source: Direct PUT or other sources
   * Data transformation: Disabled
   * Record format conversion: Disabled
-  * Destination: Third-party service provider
+  * Destination: New Relic
   * Ensure the following settings are defined:
-    * Third-party service provider: New Relic - Metrics
-    * New Relic configuration
+    * New Relic configuration (Destination Settings)
       * HTTP endpoint URL - US Datacenter: `https://aws-api.newrelic.com/cloudwatch-metrics/v1`
       * HTTP endpoint URL - EU Datacenter: `https://aws-api.eu01.nr-data.net/cloudwatch-metrics/v1`
       * API key: Enter your [license key](/docs/accounts/accounts-billing/account-setup/new-relic-license-key/)


### PR DESCRIPTION
Looks like the AWS Kinesis Firehose steps have had some minor updates. You no longer select third party service, you can select New Relic directly.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.