### PR TITLE
chore(networks): Update last modified date for IPs

### DIFF
--- a/src/content/docs/using-new-relic/cross-product-functions/install-configure/networks.mdx
+++ b/src/content/docs/using-new-relic/cross-product-functions/install-configure/networks.mdx
@@ -13,7 +13,7 @@ redirects:
   - /docs/apm/new-relic-apm/getting-started/networks
 ---
 
-**This list is current. Last updated 31 May 2021.**
+**This list is current. Last updated September 28, 2021.**
 
 This is a list of the networks, IP addresses, domains, ports, and endpoints used by API clients or agents to communicate with New Relic. [TLS is required for all domains.](#tls)
 


### PR DESCRIPTION
There's a timestamp at the top of this doc that wasn't changed for the latest new IPs