### PR TITLE
style(PR/issue templates): Simplify issue templates and switch to H2s

### DIFF
--- a/.github/ISSUE_TEMPLATE/content-issue.md
+++ b/.github/ISSUE_TEMPLATE/content-issue.md
@@ -10,13 +10,8 @@ assignees: ''
 
 <!-- This repo is public. Anything you share here is visible to the world. -->
 
-### How can we make our docs better?
+## How can we make our docs better?
 
 * Is something confusing?
 * Is something inaccurate or missing?
 * Were you unable to complete a task? (What task?)
-
-### Anything else you'd like to share?
-
-Add other context like screenshots, links to other docs, and information about
-your environment (operating system, application framework, etc.).

--- a/.github/ISSUE_TEMPLATE/site-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/site-bug-report.md
@@ -10,29 +10,29 @@ assignees: ''
 diagnose your issue as quickly as possible. This repo is public. Anything you 
 share here is visible to the world. -->
 
-### Description
+## Description
 
 A clear and concise description of what the bug is.
 
-### Steps to reproduce
+## Steps to reproduce
 
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-### Expected behavior
+## Expected behavior
 
 A clear and concise description of what you expected to happen.
 
-### Screenshots
+## Screenshots
 
 If applicable, add screenshots to help explain your problem.
 
-### Additional context
+## Additional context
 
 Add any other context about the problem here.
 
-### Environment
+## Environment
 
 Run `gatsby info --clipboard` in your project directory and paste the output here.

--- a/.github/ISSUE_TEMPLATE/site-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/site-enhancement.md
@@ -13,18 +13,18 @@ share here is visible to the world. -->
 <!-- DISCLAIMER: Not every feature request will be worked on, but hearing about 
 what you want is important. Don't be afraid to add a feature request! -->
 
-### Is your feature request related to a problem? Please describe
+## Is your feature request related to a problem? Please describe
 
 A clear and concise description of what the problem is.
 
-### Describe the solution you'd like
+## Describe the solution you'd like
 
 A clear and concise description of what you want to happen. What is the expected outcome?
 
-### Describe why this important to you
+## Describe why this important to you
 
 Why should we work on this? What use cases does it support?
 
-### Additional context
+## Additional context
 
 Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,15 +4,12 @@
 もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
 日本語訳へのPRについてはまだ取り込む準備ができていません。-->
 
-### Give us some context
+Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
+in your commit messages and pull request title.
+
+## Give us some context
 
 * What problems does this PR solve?
 * Add any context that will help us review your changes such as testing notes,
   links to related docs, screenshots, etc.
 * If your issue relates to an existing GitHub issue, please link to it.
-
-### Are you making a change to site code?
-
-If you're changing site code (rather than the content of a doc), please follow
-[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
-in your commit messages and pull request title.


### PR DESCRIPTION
## Give us some context

* Further simplifies issue template for content issues
* Requests conventional commits for all PRs (content and eng PRs, rather than just eng)
* Changes the default heading size in issues and PRs to an h2 rather than an h3. The reason is a small boost to editor ergonomics: Docs on the docs site use h2s by default. 