### PR TITLE
Minor fix: anchor identifier

### DIFF
--- a/src/content/docs/telemetry-data-platform/understand-data/event-data/nrauditevent-event-data-query-examples.mdx
+++ b/src/content/docs/telemetry-data-platform/understand-data/event-data/nrauditevent-event-data-query-examples.mdx
@@ -97,7 +97,7 @@ These examples show some of the ways you can run [NRQL](/docs/insights/nrql-new-
   </Collapser>
 
   <Collapser
-    id="synth-user"
+    id="workload-changes"
     title="Workloads: What changes were made to any workload configuration?"
   >
     To query what configuration changes were made to any workload, use the query below. The `targetId` attribute contains the GUID of the workload that was modified, which you can use for searches. Since changes on workloads are often automated, you might want to include the `actorType` attribute to know if the change was done directly by a user through the UI or through the API.


### PR DESCRIPTION
I've edited the id of a collapsible section, so the anchor link refers to workloads instead of synthetics.
It seems a minor fix although I don't know if there are direct links that take here. Perhaps the Docs team has statistics about the origin of clicks and knows?


<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.