### PR TITLE
Remove mobile legacy cat

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Issues are a quick way to give us feedback about our docs. We'll review your iss
 
 If you'd like to get more directly involved, you can edit the docs yourself! Here's how:
 
-1. Every doc page on docs.newrelic.com has an **Edit page** button in the right sidebar and the footer. Click it to get started making a change. This will take you to GitHub and the source file for that doc page. 
+1. Every doc page on docs.newrelic.com has an **Edit page** button in the right sidebar and the footer. Click it to get started making a change. This will take you to GitHub and the source file for that doc page.
 2. Edit the file by clicking on the pencil icon. Make your changes, then click **Commit changes**. This will automatically create a fork in your GitHub account with the changes.
 3. Finally, follow the prompts to create a pull request and submit your changes for review. From there our writers will check out your pull request, comment with any feedback, and merge your change.
 
 If you'd like more information on how to edit our docs, see our [content contribution guide](https://docs.newrelic.com/docs/style-guide/writing-guidelines/create-edit-content/). Additionally, our [Style guide](https://docs.newrelic.com/docs/style-guide) will give you some insight into how we think about writing and documentation, as well as our flavor of Markdown.
 
-Reading the style guide is totally optional! Our writers are here to make sure everything is formatted and worded right. We're looking your technical insight and knowhow. Let us handle the little details for you.
+Reading the style guide is totally optional! Our writers are here to make sure everything is formatted and worded right. We're looking for your technical insight and knowhow. Let us handle the little details for you.
 
 If you'd like to go deeper with development, see our [Contributors guide](CONTRIBUTING.md) for information on how to fork our site, build it locally, and submit pull requests.
 

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-requests-page.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-requests-page.mdx
@@ -161,10 +161,8 @@ Accounts that do not have an Enterprise-level subscription see a different **HTT
     * Average throughput
     * Average data transfer
 
-    ![screen http requests details.png](./images/screen-http-requests-details_0.png "screen http requests details.png")
-
     <figcaption>
-      **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Network > HTTP requests > (select a request):** Here is an example of a selected HTTP request for an app monitored with mobile. To view details for the transaction, select **App server drill-down**.
+      **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Network > HTTP requests > (select a request):** Here is an example of a selected HTTP request for an app monitored with mobile.
     </figcaption>
 
     <table>
@@ -201,22 +199,6 @@ Accounts that do not have an Enterprise-level subscription see a different **HTT
           </td>
         </tr>
 
-        <tr>
-          <td>
-            View the [related app's transaction](/docs/applications-menu/transactions-dashboard)
-          </td>
-
-          <td>
-            <Callout variant="important">
-              This feature is not available when the related app has [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) enabled.
-            </Callout>
-
-            * To view the related app's transaction: Select **App server drill-down**, then view the **Transactions** page for the app associated with this HTTP request.
-            * To return to the **HTTP requests** page, select your browser's **Back** function.
-
-            ![icon app server.png](./images/icon-app-server_0.png "icon app server.png")
-          </td>
-        </tr>
       </tbody>
     </table>
   </Collapser>

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-requests-page.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-requests-page.mdx
@@ -161,10 +161,9 @@ Accounts that do not have an Enterprise-level subscription see a different **HTT
     * Average throughput
     * Average data transfer
 
-    <figcaption>
-      **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Network > HTTP requests > (select a request):** Here is an example of a selected HTTP request for an app monitored with mobile.
-    </figcaption>
-
+  
+    To view legacy details: **[one.newrelic.com](https://one.newrelic.com) > Mobile > (select an app) > Network > HTTP requests > (select a request): > Switch to legacy requests**. 
+  
     <table>
       <thead>
         <tr>


### PR DESCRIPTION
### Give us some context

* What problems does this PR solve?
 Removing references to features no longer supported in the Mobile APM UI
* Add any context that will help us review your changes
This is the docs page being modified: https://docs.newrelic.com/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-requests-page/#non-enterprise-http-requests

![image](https://user-images.githubusercontent.com/6980492/135933246-111f0b5c-b8f8-4aae-897e-233b174ef01e.png)
Annotated pieces of image are features of Legacy Cross Application Tracing, and will no longer be available.

### Are you making a change to site code?
Nope