### PR TITLE
Add benchmark example for ARM64

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/infrastructure-agent-performance-overhead.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/infrastructure-agent-performance-overhead.mdx
@@ -82,9 +82,9 @@ As a general guideline, New Relic has collected benchmarks for some common types
     id="arm64"
     title="Linux ARM64 host"
   >
-    The agent has similar performance overhead on ARM64 (Graviton 2) host on EC2 when compared with AMD64 machines.
+    The agent has similar performance overhead on an ARM64 (Graviton 2) host on EC2 when compared with AMD64 machines.
 
-    Benchmark based on an [Amazon EC2 t3.2xlarge vs. t4g.2xlarge](https://aws.amazon.com/ec2/instance-types/) instances.
+    The benchmark is based on [Amazon EC2 t3.2xlarge vs. t4g.2xlarge](https://aws.amazon.com/ec2/instance-types/) instances.
 
     Default Amazon Linux 2 EC2 instance with infrastructure agent default settings:
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/infrastructure-agent-performance-overhead.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/infrastructure-agent-performance-overhead.mdx
@@ -77,6 +77,21 @@ As a general guideline, New Relic has collected benchmarks for some common types
     * **Resident Memory**: 30 MB
     * **Storage on disk**: about 50 MB
   </Collapser>
+  
+  <Collapser
+    id="arm64"
+    title="Linux ARM64 host"
+  >
+    The agent has similar performance overhead on ARM64 (Graviton 2) host on EC2 when compared with AMD64 machines.
+
+    Benchmark based on an [Amazon EC2 t3.2xlarge vs. t4g.2xlarge](https://aws.amazon.com/ec2/instance-types/) instances.
+
+    Default Amazon Linux 2 EC2 instance with infrastructure agent default settings:
+
+    * **CPU**: about 0.1% on ARM vs 0.13% AMD
+    * **Virtual memory**: about 0.75GB ARM vs 1 GB AMD
+    * **Resident memory**: 20MB ARM vs 22 MB AMD
+  </Collapser>
 </CollapserGroup>
 
 We are always improving the performance of the infrastructure agent. If you see unusually high agent performance overhead, get support at [support.newrelic.com](https://support.newrelic.com).

--- a/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/infrastructure-agent-performance-overhead.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/infrastructure-agent-performance-overhead.mdx
@@ -86,7 +86,7 @@ As a general guideline, New Relic has collected benchmarks for some common types
 
     The benchmark is based on [Amazon EC2 t3.2xlarge vs. t4g.2xlarge](https://aws.amazon.com/ec2/instance-types/) instances.
 
-    Default Amazon Linux 2 EC2 instance with infrastructure agent default settings:
+    Amazon Linux 2 EC2 instance with infrastructure agent default settings:
 
     * **CPU**: about 0.1% on ARM vs 0.13% AMD
     * **Virtual memory**: about 0.75GB ARM vs 1 GB AMD


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* Adding a new benchmark scenario running default infra-agent on default EC2 AL2 instance (AMD vs ARM) as a reference for customers adoption ARM instances.

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.