### PR TITLE
AWS metric stream inventory not available

### DIFF
--- a/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -286,7 +286,7 @@ On a typical deployment, migrating from API polling to metric stream involves th
 4. Disable all unnecessary polling integrations in the previous AWS provider account. The following integrations still need to be enabled since they aren't fully replaced by metric streams:
   - AWS Billing, AWS CloudTrail, AWS Health, AWS Trusted Advisor.
 
-### Query, dashboard, and alert considerations [#considerations]
+### Query, dashboard, alert and inventory considerations [#considerations]
 
 AWS Metric Streams integration uses the Metric API to push metrics in the dimensional metric format.
 
@@ -295,9 +295,10 @@ Poll-based integrations push metrics based on events (for example, `ComputeSampl
 To assist in this transition, New Relic provides a mechanism (known as shimming) that transparently lets you write queries in any format. Then these queries are processed as expected based on the source that's available (metrics or events). This mechanism works both ways, from events to metrics, and viceversa. 
 
 Please consider the following when migrating from poll-based integrations:
-* Custom dashboards that use poll-based AWS integration events should work as expected. 
-* Alert conditions that use poll-based AWS events might need to be adapted with dimensional metric format. Use the NRQL source for the alert condition. 
-* Entities in New Relic Explorer might be duplicated for up to 24 hours.
+* **Dashboards**: Custom dashboards that use poll-based AWS integration events will still work as expected. 
+* **Alerts**: Alert conditions that use poll-based AWS events will still work. We recommend adapting those to the dimensional metric format (using NRQL as source). 
+* **Entities**: New Relic Explorer might show duplicated entities for up to 24 hours.
+* **Inventory**: the [Inventory page](/docs/infrastructure/infrastructure-ui-pages/infra-ui-pages/infrastructure-inventory-page-search-your-entire-infrastructure/) is not supported with AWS CloudWatch metric streams (inventory telemetry is not included in the stream). 
 
 ### Integrations not fully replaced by metric streams [#integrations-not-replaced-streams]
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

### Give us some context

* Adding inventory as a limitation in the CloudWatch metric stream integration.  

### Are you making a change to site code?

If you're changing site code (rather than the content of a doc), please follow
[conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.