### PR TITLE
fix: remove old support emails

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems.mdx
@@ -43,7 +43,7 @@ New Relic requires a valid email address and a [valid password](/docs/accounts-p
     4. When you receive a confirmation email from New Relic, select the password reset link, and [follow New Relic's password requirements](/docs/accounts-partnerships/accounts/account-maintenance/change-passwords-user-preferences#requirements) to complete the process to reset your password.
 
     <Callout variant="important">
-      The password reset link expires after 12 hours. If you do not quickly receive an email from New Relic, check your [spam filters](/docs/accounts-partnerships/accounts/account-setup/create-your-new-relic-account#email-whitelist), contact your organization's email administrator for troubleshooting suggestions, get support at [support.newrelic.com](https://support.newrelic.com), or send an email to `account_recovery@newrelic.com`.
+      The password reset link expires after 12 hours. If you do not quickly receive an email from New Relic, check your [spam filters](/docs/accounts-partnerships/accounts/account-setup/create-your-new-relic-account#email-whitelist), contact your organization's email administrator for troubleshooting suggestions, get support at [support.newrelic.com](https://support.newrelic.com).
     </Callout>
   </Collapser>
 
@@ -51,14 +51,14 @@ New Relic requires a valid email address and a [valid password](/docs/accounts-p
     id="reset-password"
     title="Reset password."
   >
-    If you forgot your own password or need to request a password reset for your account email, you can use New Relic's [self-service options](#forgot-password). Admin-level users cannot reset passwords for other users. If you need to reset someone else's password, get support at [support.newrelic.com](https://support.newrelic.com), or send an email to `account_recovery@newrelic.com`.
+    If you forgot your own password or need to request a password reset for your account email, you can use New Relic's [self-service options](#forgot-password). Admin-level users cannot reset passwords for other users. If you need to reset someone else's password, get support at [support.newrelic.com](https://support.newrelic.com).
   </Collapser>
 
   <Collapser
     id="account-login-errors"
     title="Password error messages."
   >
-    If you complete the signup process and are unable to log in to your account due to password error messages, get support at [support.newrelic.com](https://support.newrelic.com/home), or send an email to `account_recovery@newrelic.com`.
+    If you complete the signup process and are unable to log in to your account due to password error messages, get support at [support.newrelic.com](https://support.newrelic.com/home).
   </Collapser>
 
   <Collapser
@@ -68,7 +68,7 @@ New Relic requires a valid email address and a [valid password](/docs/accounts-p
     If you want to change your password but you see a message that the password reset link expired, try using a private browser or clearing your browser cache and cookies.
 
     <Callout variant="important">
-      The password reset link expires after 12 hours. If you do not quickly receive an email from New Relic after you select the reset link, check your [spam filters](/docs/accounts-partnerships/accounts/account-setup/create-your-new-relic-account#email-whitelist), contact your organization's email administrator for troubleshooting suggestions, get support at [support.newrelic.com](https://support.newrelic.com), or send an email to `account_recovery@newrelic.com`.
+      The password reset link expires after 12 hours. If you do not quickly receive an email from New Relic after you select the reset link, check your [spam filters](/docs/accounts-partnerships/accounts/account-setup/create-your-new-relic-account#email-whitelist), contact your organization's email administrator for troubleshooting suggestions, get support at [support.newrelic.com](https://support.newrelic.com).
     </Callout>
   </Collapser>
 
@@ -99,21 +99,21 @@ New Relic requires a valid email address and a [valid password](/docs/accounts-p
     If you don't receive an email from New Relic:
 
     * Check your [spam filters](/docs/accounts-partnerships/accounts/account-setup/create-your-new-relic-account#email-whitelist). If applicable, [add New Relic to your email allow list](/docs/accounts/accounts/account-maintenance/account-email-settings#email-whitelist).
-    * Get support at [support.newrelic.com](https://support.newrelic.com/home), or send an email to `account_recovery@newrelic.com`.
+    * Get support at [support.newrelic.com](https://support.newrelic.com/home).
   </Collapser>
 
   <Collapser
     id="forgot-email"
     title="Email address does not work or email error messages."
   >
-    If you complete the signup process and are unable to log in to your account due to email or password error messages, get support at [support.newrelic.com](https://support.newrelic.com/home), or send an email to `account_recovery@newrelic.com`.
+    If you complete the signup process and are unable to log in to your account due to email or password error messages, get support at [support.newrelic.com](https://support.newrelic.com/home).
   </Collapser>
 
   <Collapser
     id="account-exists"
     title="Received message that your email account already exists."
   >
-    If you are trying to create a new account and receive a message that your email account already exists, get support at [support.newrelic.com](https://support.newrelic.com/home), or send an email to `account_recovery@newrelic.com`.
+    If you are trying to create a new account and receive a message that your email account already exists, get support at [support.newrelic.com](https://support.newrelic.com/home).
   </Collapser>
 
   <Collapser
@@ -129,7 +129,7 @@ New Relic requires a valid email address and a [valid password](/docs/accounts-p
       **Private browsing**, also known as **incognito mode**, is a privacy feature to disable browsing history and the web cache. To open a private browsing window, you can use the keyboard shortcut `CTRL+Shift+N` on Windows and `Command+Shift+N` on Mac for most browsing applications.
     </Callout>
 
-    If this still doesn't solve your problem, get support at [support.newrelic.com](https://support.newrelic.com/home), or send an email to `account_recovery@newrelic.com`.
+    If this still doesn't solve your problem, get support at [support.newrelic.com](https://support.newrelic.com/home).
   </Collapser>
 
   <Collapser
@@ -172,7 +172,7 @@ Some general system problems and solutions:
 
     * Bypass your password manager.
     * Use a different browser to sign up with New Relic.
-    * Get support at [support.newrelic.com](https://support.newrelic.com/home), or send an email to `account_recovery@newrelic.com`.
+    * Get support at [support.newrelic.com](https://support.newrelic.com/home).
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/accounts/accounts/account-maintenance/change-passwords-user-preferences.mdx
+++ b/src/content/docs/accounts/accounts/account-maintenance/change-passwords-user-preferences.mdx
@@ -37,4 +37,4 @@ Special characters allowed include `~` `` ` `` `!` `@` `#` `$` `%` `^` `&` `*` `
 
 ## Reset password [#reset]
 
-If you forgot your own password or need to request a password reset, you can use New Relic's [self-service options](/docs/accounts-partnerships/accounts/account-setup/troubleshoot-password-email-address-login-problems#forgot-password). Admins can't reset passwords for other users. If you need to reset someone else's password, get support at [support.newrelic.com](https://support.newrelic.com), or send an email to `account_recovery@newrelic.com`.
+If you forgot your own password or need to request a password reset, you can use New Relic's [self-service options](/docs/accounts-partnerships/accounts/account-setup/troubleshoot-password-email-address-login-problems#forgot-password). Admins can't reset passwords for other users. If you need to reset someone else's password, get support at [support.newrelic.com](https://support.newrelic.com).


### PR DESCRIPTION
We had a request to remove some old support emails from our docs. This should remove them all!