### PR TITLE
Removed NRQL from exceptions

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/view-entity-health-status-find-entities-without-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/view-entity-health-status-find-entities-without-alert-conditions.mdx
@@ -26,7 +26,6 @@ With alerts you can easily tell whether an entity (the target for the notificati
 
 The health status indicator doesn't apply for:
 
-* [NRQL alert conditions](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions)
 * Infrastructure entities
 * [Dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards)
 * Entities targeted by labels


### PR DESCRIPTION
NRQL alert conditions can now change traffic lights, so long as something is faceted on so that each facet represents one entity (e.g. FACET hostname, FACET appName, FACET appId, etc.)

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.