### PR TITLE
fix(synth): edit to UI & req sections

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/private-locations-overview-monitor-internal-sites-add-new-locations.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/private-locations-overview-monitor-internal-sites-add-new-locations.mdx
@@ -96,12 +96,12 @@ How access works depends on your [user model](/docs/accounts/original-accounts-b
 
 Before [installing private minions](/docs/synthetics/new-relic-synthetics/private-locations/install-containerized-private-minions-cpms), you need to create a private location. To create a new private location:
 
-1. Ensure you meet the [requirements](#requirements), including activating the feature [by contacting your account representative](#compatibility-account-rep).
+1. Ensure you meet the [requirements](#requirements), including [account access requirements](#account-access). 
 2. Go to [**one.newrelic.com**](http://one.newrelic.com/) **> Synthetics > Private locations**. Then select <Icon name="fe-plus-circle"/>
    **Create private location**.
 
     <Callout variant="tip">
-    The Private locations sub menu becomes available after you create your first monitor.
+    The private locations sub menu becomes available after you create your first monitor.
     </Callout>
 
 3. Type a location name.

--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests.mdx
@@ -73,12 +73,13 @@ You can add or update secure credentials using the UI or the [Synthetics REST AP
 To add, view, edit, or delete a secure credential for a scripted browser or API test monitor from the UI:
 
 1. Go to [**one.newrelic.com**](http://one.newrelic.com/) **> Synthetics > Secure credentials**.
-2. Follow the UI instructions to add, edit, or delete a secure credential, then save any additions or changes you make.
+2. To add a new secure credential, look for the **Create secure credential +** button. If you have credentials already added, this button is at the top right. 
    * Tips for creating the **Key**: choose a username or other meaningful key name to identify the secure credential. Use alphanumeric or underscore `_` characters. Key names must be UPPERCASE.
    * Tips for creating the **Value**: Use any combination of alphanumeric or special characters. 10000 characters maximum. This field is not accessible via [the API](/docs/apis/synthetics-rest-api/secure-credentials-examples/use-synthetics-secure-credentials-apis).
-3. Associate the secure credential with a scripted browser or API test by [editing the script](#script-procedures).
+3. To edit an existing credential, click the ellipsis <Icon name="fe-more-horizontal"/> icon for options.
+4. Associate the secure credential with a scripted browser or API test by [editing the script](#script-procedures).
 
-After you add the secure credential to the script, the **Secure credentials** user interface shows how many scripted monitors use that credential. This number is approximate and only updates after a monitor with a secure credential has actually been run.
+After you add the secure credential to the script, the **Secure credentials** UI shows how many scripted monitors use that credential. This number is approximate and only updates after a monitor with a secure credential has actually been run.
 
 ## Update the script [#script-procedures]
 


### PR DESCRIPTION
Related to: 
• Previous hero work requesting fix to private locations requirements - no longer requires requesting access to the feature
• Hero work for https://github.com/newrelic/docs-website/issues/4225: adding clarification about where to find 'add secure credential' button (although there may be a UI glitch around this, but it was reported). 