### PR TITLE
fix(Alerts): amend Streaming Alerts key terms/concepts

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts.mdx
@@ -189,7 +189,7 @@ In order to make loss of signal detection more effective and to reduce unnecessa
 
 An [aggregation window](/docs/using-new-relic/welcome-new-relic/get-started/glossary#aggregation-window) is a specific block of time. We gather data points together in an aggregation window, before evaluating the data. A longer aggregation window can smooth out the data, since an outlier data point will have more data points to be aggregated with, giving it less of an influence on the aggregated data point that is sent for evaluation. When a data point arrives, its timestamp is used to put it in the proper aggregation window.
 
-You can set your aggregation window to anything between 15 seconds and 15 minutes, in 15-second increments. The default is `1` minute.
+You can set your aggregation window to anything between **30 seconds** and **15 minutes**. The default is **1 minute**.
 
 ### Delay/timer [#delay-timer]
 
@@ -197,7 +197,7 @@ The delay/timer setting controls how long the condition should wait before aggre
 
 The event flow and cadence methods use delay. Event timer uses timer.
 
-The delay default is `2 minutes`. The timer default is `1 minute` and has a minimum value of `5 seconds`.
+The delay default is **2 minutes**. The timer default is **1 minute** and has a minimum value of **5 seconds**.
 
 ### Loss of signal detection [#signal-loss]
 
@@ -207,7 +207,7 @@ In order to avoid unnecessary notifications, you can choose how long to wait bef
 
 ### Gap filling [#gap-filling]
 
-Gap filling lets you customize the values to use when your signals don't have any data. You can fill gaps in your data streams with `None`, the last value received, or a static value. The default is `None`.
+Gap filling lets you customize the values to use when your signals don't have any data. You can fill gaps in your data streams with the last value received, a static value, or else do nothing and leave the gap there. The default is `None`.
 
 Gaps in streaming data can be caused by network or host issues, a signal may be sparse, or some signals, such as error counts, may only have data when something is wrong. By filling the gaps with known values, the alert evaluation process can process those gaps and determine how they should affect the loss of signal evaluation.
 


### PR DESCRIPTION
## Give us some context

Amend Streaming Alerts key terms/concepts:

  - fix a couple of incorrectly specified values
  - fix formatting
  - clarify statement about gap filling