### PR TITLE
chore: updating Trap version support to remove v1 and add note on upcoming v3

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/advanced-config.mdx
@@ -214,7 +214,7 @@ global:
             <tr>
               <td>version</td>
               <td></td>
-              <td>SNMP version to use. The possible values are `v1` and `v2c`. By default, it's set to `v2c`</td>
+              <td>SNMP version to use. By default, it's set to `v2c`. (v3 is on the roadmap)</td>
             </tr>
 
             <tr>


### PR DESCRIPTION
This PR updates the SNMP Advanced config options for NPM to remove an error (v1 support) and add a note for upcoming v3 support