### PR TITLE
fix(Alerts): update Alerts loss-of-signal examples to use aggregationMethod

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling.mdx
@@ -110,7 +110,8 @@ mutation {
       }
       signal {
         aggregationWindow: 60
-        evaluationOffset: 3
+        aggregationMethod: EVENT_FLOW
+        aggregationDelay: 120
       }
       terms: [{
         threshold: 2
@@ -198,7 +199,8 @@ mutation {
       violationTimeLimitSeconds: 28800
       signal: {
         aggregationWindow: 60,
-        evaluationOffset: 3, 
+        aggregationMethod: EVENT_FLOW,
+        aggregationDelay: 120,
         <mark>fillOption: STATIC,</mark>
         <mark>fillValue: 1</mark>
       }


### PR DESCRIPTION
## Give us some context

With the streaming aggregation method support rolling out this week, trying to update the NerdGraph examples that are out there to use the `aggregationMethod` field instead of `evaluationOffset`.