### PR TITLE
docs(Alerts): updates Alerts NerdGraph docs for notificationChannels

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/alerts-nerdgraph/nerdgraph-api-notification-channels.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/alerts-nerdgraph/nerdgraph-api-notification-channels.mdx
@@ -236,6 +236,39 @@ The `notificationChannels` query allows you to paginate through all of your noti
     }
     ```
   </Collapser>
+  <Collapser
+    id="channels-with-policies"
+    title="List notification channels with their associated policies"
+  >
+    This example returns the ID, name, and type for every notification channel on the supplied account ID, as well as a list of every policy that is associated with that channel.
+
+    ```
+    {
+      actor {
+        account(id: <var>YOUR_ACCOUNT_ID</var>) {
+          alerts {
+            notificationChannels {
+              channels {
+                id
+                name
+                type
+                associatedPolicies {
+                  policies {
+                    id
+                    name
+                  }
+                  totalCount
+                }
+              }
+              nextCursor
+              totalCount
+            }
+          }
+        }
+      }
+    }
+    ```
+  </Collapser>
 </CollapserGroup>
 
 ## Create a notification channel [#create-channel]
@@ -790,7 +823,7 @@ mutation {
 ```
 
 <Callout variant="tip">
-  Removing an alert notification channel from a policy **does not** delete the policy because it might be used by other policies. On the other hand, deleting a channel will cause all associated channels to stop sending alert notifications to that channel.
+  Removing an alert notification channel from a policy **does not** delete the channel because it might be used by other policies. On the other hand, deleting a channel will cause all associated policies to stop sending alert notifications to that channel.
 </Callout>
 
 


### PR DESCRIPTION
## Give us some context

Updates Alerts NerdGraph docs for notificationChannels:

  - adds notes about support for retrieving policies with channels
  - clarifies a confusing statement about what happens when dissociating channels from policies