### PR TITLE
docs(Alerts): add NerdGraph example for searching Alert Policies by name

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/alerts-nerdgraph/nerdgraph-api-alerts-policies.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/alerts-nerdgraph/nerdgraph-api-alerts-policies.mdx
@@ -137,7 +137,7 @@ The `policiesSearch` query allows you to paginate through all of your policies p
   </Collapser>
 
   <Collapser
-    id=""
+    id="list-policies-by-id"
     title="Find all policies by selected ids"
   >
     The API allows policy queries by a sub-select of ids. This will only return the information for these policies that you provide.
@@ -154,6 +154,34 @@ The `policiesSearch` query allows you to paginate through all of your policies p
                 id
                 name
                 incidentPreference
+              }
+            }
+          }
+        }
+      }
+    }
+    ```
+  </Collapser>
+
+  <Collapser
+    id="find-policies-by-name"
+    title="Find all policies by name"
+  >
+    The API allows policy queries by name. Use `name` for matching by exact names or `nameLike` for a partial match. Both search criteria are case insensitive. This will only return the information for the policies that match the name supplied.
+
+    In this example, we want to find policies with "DevOps" in the name:
+
+    ```
+    {
+      actor {
+        account(id: <var>YOUR_ACCOUNT_ID</var>) {
+          alerts {
+            policiesSearch(searchCriteria: {
+              nameLike: "DevOps"
+            }) {
+              policies {
+                id
+                name
               }
             }
           }


### PR DESCRIPTION
## Give us some context

The NerdGraph API for Alerts Policies recently added support for `name` and `nameLike` searches. This adds an example for using the `nameLike` search criterion.