### PR TITLE
chore: updating with trap support of v1 and v3

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/advanced-config.mdx
@@ -214,13 +214,19 @@ global:
             <tr>
               <td>version</td>
               <td></td>
-              <td>SNMP version to use. By default, it's set to `v2c`. (v3 is on the roadmap)</td>
+              <td>SNMP version to use. Options are `v1`, `v2c`, and `v3`. (Default: `v2c`)</td>
             </tr>
 
             <tr>
               <td>transport</td>
               <td></td>
               <td>SNMP transport protocol to use. The possible values are `TCP` and `UDP`. By default, it's set to `UDP`</td>
+            </tr>
+
+            <tr>
+              <td>v3_config</td>
+              <td></td>
+              <td>[SNMP v3 config](https://docs.newrelic.com/docs/network-performance-monitoring/setup-performance-monitoring/advanced-config/#snmpv3-config) to use. Only used if version is `v3`.</td>
             </tr>
           </tbody>
       </table>

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/advanced-config.mdx
@@ -226,7 +226,7 @@ global:
             <tr>
               <td>v3_config</td>
               <td></td>
-              <td>[SNMP v3 config](https://docs.newrelic.com/docs/network-performance-monitoring/setup-performance-monitoring/advanced-config/#snmpv3-config) to use. Only used if version is `v3`.</td>
+              <td>[SNMP v3 config](#snmpv3-config) to use. Only used if version is `v3`.</td>
             </tr>
           </tbody>
       </table>
@@ -374,7 +374,8 @@ discovery:
         title="SNMPv3 optional configuration"
       >
         Here's an example of `SNMPv3` configuration section for the `snmp-base.yaml` file:
-```yaml
+```
+yaml
   default_v3:
     user_name: userNamev3
     authentication_protocol: MD5


### PR DESCRIPTION
ref: https://github.com/kentik/ktranslate/pull/151

Updating notes on SNMP Trap config to show latest supported options for v1 and v3; referenced in the source PR above.

CC: @x8a 