### PR TITLE
docs(Alerts): more updates related to Streaming Methods release

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/alerts-nerdgraph/nerdgraph-api-nrql-condition-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/alerts-nerdgraph/nerdgraph-api-nrql-condition-alerts.mdx
@@ -56,31 +56,31 @@ Here's an example of creating a static condition:
 
 ```
 mutation {
-      alertsNrqlConditionStaticCreate(accountId: <var>YOUR_ACCOUNT_ID</var>, policyId: <var>YOUR_POLICY_ID</var>, condition: {
-        name: "Low Host Count - Catastrophic"
-        enabled: true
-        nrql: {
-          query: "SELECT uniqueCount(host) FROM Transaction WHERE appName='my-app-name'"
-        }
-        signal: {
-          aggregationWindow: 60
-          aggregationMethod: EVENT_FLOW
-          aggregationDelayu: 120
-        }
-        terms: {
-          threshold: 2
-          thresholdOccurrences: AT_LEAST_ONCE
-          thresholdDuration: 600
-          operator: BELOW
-          priority: CRITICAL
-        }
-        valueFunction: SINGLE_VALUE
-        violationTimeLimitSeconds: 86400
-      }) {
-        id
-        name
-      }
+  alertsNrqlConditionStaticCreate(accountId: <var>YOUR_ACCOUNT_ID</var>, policyId: <var>YOUR_POLICY_ID</var>, condition: {
+    name: "Low Host Count - Catastrophic"
+    enabled: true
+    nrql: {
+      query: "SELECT uniqueCount(host) FROM Transaction WHERE appName='my-app-name'"
     }
+    signal: {
+      aggregationWindow: 60
+      aggregationMethod: EVENT_FLOW
+      aggregationDelay: 120
+    }
+    terms: {
+      threshold: 2
+      thresholdOccurrences: AT_LEAST_ONCE
+      thresholdDuration: 600
+      operator: BELOW
+      priority: CRITICAL
+    }
+    valueFunction: SINGLE_VALUE
+    violationTimeLimitSeconds: 86400
+  }) {
+    id
+    name
+  }
+}
 ```
 
 ## NRQL baseline condition [#baseline-condition]
@@ -89,32 +89,32 @@ Here's an example of creating a baseline condition:
 
 ```
 mutation {
-      alertsNrqlConditionBaselineCreate(accountId: <var>YOUR_ACCOUNT_ID</var>, policyId: <var>YOUR_POLICY_ID</var>, condition: {
-        name: "Baseline Condition"
-        enabled: true
-        baselineDirection: UPPER_ONLY
-        nrql: {
-          query: "SELECT average(duration) FROM Transaction"
-        }
-        signal: {
-          aggregationWindow: 60
-          aggregationMethod: EVENT_FLOW
-          aggregationDelayu: 120
-        } 
-        terms: {
-          threshold: 13
-          thresholdDuration: 180
-          thresholdOccurrences: ALL
-          operator: ABOVE
-          priority: CRITICAL
-        }
-        violationTimeLimitSeconds: 86400
-      }) {
-        id
-        name
-        baselineDirection
-      }
+  alertsNrqlConditionBaselineCreate(accountId: <var>YOUR_ACCOUNT_ID</var>, policyId: <var>YOUR_POLICY_ID</var>, condition: {
+    name: "Baseline Condition"
+    enabled: true
+    baselineDirection: UPPER_ONLY
+    nrql: {
+      query: "SELECT average(duration) FROM Transaction"
     }
+    signal: {
+      aggregationWindow: 60
+      aggregationMethod: EVENT_FLOW
+      aggregationDelay: 120
+    }
+    terms: {
+      threshold: 13
+      thresholdDuration: 180
+      thresholdOccurrences: ALL
+      operator: ABOVE
+      priority: CRITICAL
+    }
+    violationTimeLimitSeconds: 86400
+  }) {
+    id
+    name
+    baselineDirection
+  }
+}
 ```
 
 ## NRQL outlier condition [#outlier-condition]
@@ -123,34 +123,34 @@ Here's an example of creating an outlier condition:
 
 ```
 mutation {
-      alertsNrqlConditionOutlierCreate(accountId: <var>YOUR_ACCOUNT_ID</var>, policyId: <var>YOUR_POLICY_ID</var>, condition: {
-        name: "Outlier Condition"
-        enabled: true
-        expectedGroups: 4
-        openViolationOnGroupOverlap: false
-        nrql: {
-          query: "SELECT average(duration) FROM Transaction FACET httpResponseCode"
-        }
-        signal: {
-          aggregationWindow: 60
-          aggregationMethod: EVENT_FLOW
-          aggregationDelayu: 120
-        }
-        terms: {
-          threshold: 1
-          thresholdDuration: 300
-          thresholdOccurrences: ALL
-          operator: ABOVE
-          priority: CRITICAL
-        }
-        violationTimeLimitSeconds: 86400
-      }) {
-        id
-        name
-        expectedGroups
-        openViolationOnGroupOverlap
-      }
+  alertsNrqlConditionOutlierCreate(accountId: <var>YOUR_ACCOUNT_ID</var>, policyId: <var>YOUR_POLICY_ID</var>, condition: {
+    name: "Outlier Condition"
+    enabled: true
+    expectedGroups: 4
+    openViolationOnGroupOverlap: false
+    nrql: {
+      query: "SELECT average(duration) FROM Transaction FACET httpResponseCode"
     }
+    signal: {
+      aggregationWindow: 60
+      aggregationMethod: EVENT_FLOW
+      aggregationDelay: 120
+    }
+    terms: {
+      threshold: 1
+      thresholdDuration: 300
+      thresholdOccurrences: ALL
+      operator: ABOVE
+      priority: CRITICAL
+    }
+    violationTimeLimitSeconds: 86400
+  }) {
+    id
+    name
+    expectedGroups
+    openViolationOnGroupOverlap
+  }
+}
 ```
 
 ## Update a condition [#update-condition]

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names.mdx
@@ -17,13 +17,12 @@ The [REST API endpoints](/docs/alerts/new-relic-alerts-beta/getting-started/rest
 
 ## Required and optional fields [#required]
 
-The API includes five types of New Relic Alerts conditions:
+The API includes four types of New Relic Alerts conditions:
 
 * APM
 * External services
 * NRQL
 * Synthetic monitoring
-* Plugins
 
 All of the fields used with a specific condition type are required except for these optional fields:
 
@@ -36,70 +35,6 @@ All of the fields used with a specific condition type are required except for th
 Not every field listed in this glossary is required for every condition type. The condition type for which a field must be used is listed in each description.
 
 <CollapserGroup>
- <Collapser
-    id="aggregation_delay"
-    title="aggregation_delay"
-    >
-      The length of time in seconds to wait for the aggregation window to fill with data. Required when using CADENCE or EVENT_FLOW `aggreation_method` types.
-
-      Used for:
-      * NRQL conditions
-
-  </Collapser>
-
-  <Collapser
-    id="aggregation_method"
-    title="aggregation_method"
-  >
-    New Relic aggregates data into windows, and needs to determine when the current window ends and the next one begins. The `aggregation_method` is the logic that tells us when we have all the data for a given aggregation window. Once the window is closed, the data is aggregated into a single point and evaluated against the threshold.
-    
-    This field is optional. One of the following three values can be specified:
-
-    * `EVENT_FLOW`: (Default) Each aggregation window will wait until it starts to see timestamps arrive that are past its own delay setting. Once this occurs, the data is published. Relies on the timestamps of arriving data, so wall-clock time is no longer relevant. Works best for sources that come in frequently and with low event spread (high througput metrics).
-
-    * `CADENCE`: Classic New Relic logic where each evaluation window waits exactly as long as the `aggregation_delay` setting, using the wall-clock time as a timer. `aggregation_delay` is required when using this option. Data arriving too late will be dropped, which can cause false alerts.
-
-    * `EVENT_TIMER`: Each aggregation window has a timer on it, set to the `aggregation_timer` value. The timer starts running as soon as the first data point appears for that aggregation window (based on the data point’s timestamp). The `aggregation_timer` is reset for each new data point that arrives for that window. Once the `aggregation_timer` reaches 0, the aggregation window is published. Ideal for sparse and batched data, such as cloud integrations and infrequent error logs.
-
-    Used for:
-    * NRQL conditions
-
-  </Collapser>
-
-  <Collapser
-    id="aggregation_timer"
-    title="aggregation_timer"
-  >
-    The length of time in seconds to wait after each data point is received, to ensure the entire batch is processed. Required when using the `EVENT_TIMER` `aggregation_method` type.
-
-    Used for:
-    * NRQL conditions
-
-  </Collapser>
-  <Collapser
-    id="aggregation_window"
-    title="aggregation_window"
-  >
-    Streaming alerts gather data together into specific amounts of time before running the function in the NRQL query. These windows of time are customizable.
-
-    The default is `1` minute. The maximum is `15` minutes.
-
-    Data points are collected together based on their timestamps and reported as a batch. The customizable aggregation window provides greater flexibility and fewer false violations when alerting on irregular or less frequent data points.
-
-    In the UI, under **Advanced signal settings**, this is the **Aggregation window** field.
-
-  </Collapser>
-
-  <Collapser
-    id="close_violations_on_expiration"
-    title="close_violations_on_expiration"
-  >
-    When `true`, this closes all currently open violations when no signal is heard within the `expiration_duration` time.
-
-    The default is `false`.
-
-  </Collapser>
-
   <Collapser
     id="condition-scope"
     title="condition_scope"
@@ -130,8 +65,8 @@ Not every field listed in this glossary is required for every condition type. Th
 
     * Conditions
     * External service conditions
+    * NRQL conditions
     * Synthetic monitoring conditions
-    * Plugin conditions
 
   </Collapser>
 
@@ -147,17 +82,6 @@ Not every field listed in this glossary is required for every condition type. Th
 
     * Conditions
     * External service conditions
-    * Plugin conditions
-
-  </Collapser>
-
-  <Collapser
-    id="evaluation_offset"
-    title="evaluation_offset"
-  >
-    Deprecated in favor of `aggregation_delay`. The offset is how long we wait for late data before evaluating each aggregation window. Waiting longer gives a more accurate signal but increases latency. The default is `3` minutes.
-
-    In the UI, under **Advanced signal settings**, this is the **Offset evaluation by** field.
 
   </Collapser>
 
@@ -174,11 +98,39 @@ Not every field listed in this glossary is required for every condition type. Th
   </Collapser>
 
   <Collapser
-    id="expiration_duration"
-    title="expiration_duration"
+    id="expiration_expiration_duration"
+    title="expiration[expiration_duration]"
   >
     How long to wait, in seconds, after the last data point is received by our platform before considering the signal as lost. This is based on the time when data arrives and not on data timestamps. The default is null. Add a value to enable loss of signal detection.
 
+    Used for:
+    * NRQL conditions
+
+  </Collapser>
+
+  <Collapser
+    id="expiration_close_violations_on_expiration"
+    title="expiration[close_violations_on_expiration]"
+  >
+    When `true`, this closes all currently open violations when no signal is heard within the `expiration_duration` time.
+
+    The default is `false`.
+
+    Used for:
+    * NRQL conditions
+
+  </Collapser>
+
+  <Collapser
+    id="expiration_open_violation_on_expiration"
+    title="expiration[open_violation_on_expiration]"
+  >
+    When true, this opens a loss of signal violation when no signal within the `expiration_duration` time.
+
+    The default is `false`.
+
+    Used for:
+    * NRQL conditions
   </Collapser>
 
   <Collapser
@@ -191,27 +143,6 @@ Not every field listed in this glossary is required for every condition type. Th
 
     * External service conditions
 
-  </Collapser>
-
-  <Collapser
-    id="fill_option"
-    title="fill_option"
-  >
-    For sporadic data, you can avoid false alerts by filling the gaps (empty windows) with synthetic data.
-
-    * `none`: (Default) Use this if you don’t want to take any action on empty aggregation windows. On evaluation, an empty aggregation window will reset the threshold duration timer. For example, if a condition says that all aggregation windows must have data points above the threshold for 5 minutes, and 1 of the 5 aggregation windows is empty, then the condition won’t be in violation.
-    * `static`: Use this if you’d like to insert a custom static value into the empty aggregation windows before they’re evaluated. This option has an additional, required parameter of `fillValue` that specifies what static value should be used. This defaults to 0.
-    * `last_value`: Use this to insert the last seen value before evaluation occurs. We maintain the state of the last seen value for 2 hours.
-
-    In the UI, under **Advanced signal settings**, this is the **Fill data gaps with** field.
-
-  </Collapser>
-
-  <Collapser
-    id="fill_value"
-    title="fill_value"
-  >
-    This is the value used by the `fill_option` custom value. The default is `0`.
   </Collapser>
 
   <Collapser
@@ -233,13 +164,6 @@ Not every field listed in this glossary is required for every condition type. Th
     The **metric** field is used for three alert categories. The exact parameters available for use depend on the setting in the [type](#type) field. These are listed below according to their alert [type](#type) field.
 
     <CollapserGroup>
-      <Collapser
-        id="alerts_plugin_conditions"
-        title="Alerts plugin conditions"
-      >
-        For Plugin conditions this is the **metric**, which has been defined in a plugin, that will be used to trigger a notification.
-      </Collapser>
-
       <Collapser
         id="alerts_conditions"
         title="Alerts conditions"
@@ -417,19 +341,6 @@ Not every field listed in this glossary is required for every condition type. Th
   </Collapser>
 
   <Collapser
-    id="metric_description"
-    title="metric_description"
-  >
-    This is a title for the metric which is displayed in notifications.
-
-    Make this descriptive and unique so the reader will understand the nature of plugin metric being used to trigger an alert.
-
-    Used for:
-
-    * Plugin conditions
-  </Collapser>
-
-  <Collapser
     id="monitor_id"
     title="monitor_id"
   >
@@ -452,8 +363,8 @@ Not every field listed in this glossary is required for every condition type. Th
 
     * Conditions
     * External service conditions
+    * NRQL conditions
     * Synthetic monitoring conditions
-    * Plugin conditions
   </Collapser>
 
   <Collapser
@@ -471,42 +382,11 @@ Not every field listed in this glossary is required for every condition type. Th
     id="nrql-since"
     title="nrql[since_value]"
   >
-    This is the timeframe (in minutes) in which to evaluate the specified NRQL query. `since_value` must be between `1` and `20`.
+    Deprecated in favor of an `aggregation_method` with either an `aggregation_delay` or `aggregation_timer`. This is the timeframe (in minutes) in which to evaluate the specified NRQL query. `since_value` must be between `1` and `20`.
 
     Used for:
 
     * NRQL conditions
-  </Collapser>
-
-  <Collapser
-    id="open_violation_on_expiration"
-    title="open_violation_on_expiration"
-  >
-    When true, this opens a loss of signal violation when no signal within the `expiration_duration` time.
-
-    The default is `False`.
-  </Collapser>
-
-  <Collapser
-    id="plugin_guid"
-    title="plugin[guid]"
-  >
-    This is the GUID of the plugin for which the trigger is being defined.
-
-    Used for:
-
-    * Plugin conditions
-  </Collapser>
-
-  <Collapser
-    id="plugin_id"
-    title="plugin[id]"
-  >
-    This is the ID of the plugin for which the trigger is being defined.
-
-    Used for:
-
-    * Plugin conditions
   </Collapser>
 
   <Collapser
@@ -519,45 +399,108 @@ Not every field listed in this glossary is required for every condition type. Th
 
     * Conditions
     * External service conditions
+    * NRQL conditions
     * Synthetic monitoring conditions
-    * Plugin conditions
   </Collapser>
 
   <Collapser
     id="signal_aggregation_delay"
-    title="signal[aggregation_window]"
+    title="signal[aggregation_delay]"
   >
-    The amount of time before aggregated data is evaluated. Default is **2 minutes**.
+    The length of time in seconds to wait for the aggregation window to fill with data. Required when using CADENCE or EVENT_FLOW `aggregation_method` types. Default is **120 seconds**.
 
     Used with event flow and cadence aggregation methods.
+
+    Used for:
+    * NRQL conditions
   </Collapser>
 
   <Collapser
     id="signal_aggregation_method"
-    title="signal[aggregation_window]"
+    title="signal[aggregation_method]"
   >
-    One of three data aggregation methods: event flow, event timer, and cadence.
+    New Relic aggregates data into windows, and needs to determine when the current window ends and the next one begins. The `aggregation_method` is the logic that tells us when we have all the data for a given aggregation window. Once the window is closed, the data is aggregated into a single point and evaluated against the threshold.
+
+    This field is optional. One of the following three values can be specified:
+
+    * `EVENT_FLOW`: (Default) Each aggregation window will wait until it starts to see timestamps arrive that are past its own delay setting. Once this occurs, the data is published. Relies on the timestamps of arriving data, so wall-clock time is no longer relevant. Works best for sources that come in frequently and with low event spread (high througput metrics).
+
+    * `CADENCE`: Classic New Relic logic where each evaluation window waits exactly as long as the `aggregation_delay` setting, using the wall-clock time as a timer. `aggregation_delay` is required when using this option. Data arriving too late will be dropped, which can cause false alerts.
+
+    * `EVENT_TIMER`: Each aggregation window has a timer on it, set to the `aggregation_timer` value. The timer starts running as soon as the first data point appears for that aggregation window (based on the data point’s timestamp). The `aggregation_timer` is reset for each new data point that arrives for that window. Once the `aggregation_timer` reaches 0, the aggregation window is published. Ideal for sparse and batched data, such as cloud integrations and infrequent error logs.
 
     The default is **Event flow**.
-    
+
+    Used for:
+    * NRQL conditions
+
   </Collapser>
 
   <Collapser
     id="signal_aggregation_timer"
-    title="signal[aggregation_window]"
+    title="signal[aggregation_timer]"
   >
-    The amount of time before aggregated data is evaluated. Default is **1 minute**.
+    The length of time in seconds to wait after each data point is received, to ensure the entire batch is processed. Required when using the `EVENT_TIMER` `aggregation_method` type. Default is **60 seconds**.
 
-    Used with Event timer aggregation method. 
-    
+    Used for:
+    * NRQL conditions
+
   </Collapser>
 
-    <Collapser
+  <Collapser
     id="signal_aggregation_window"
     title="signal[aggregation_window]"
   >
-    The duration in which data is collected together before being evaluated. Default is **1 minute**.
-    
+    Streaming alerts gather data together into specific amounts of time before running the function in the NRQL query. These windows of time are customizable.
+
+    Data points are collected together based on their timestamps and reported as a batch. The customizable aggregation window provides greater flexibility and fewer false violations when alerting on irregular or less frequent data points.
+
+    In the UI, under **Advanced signal settings**, this is the **Aggregation window** field.
+
+    Default is **60 seconds**. Maximum is 15 minutes.
+
+    Used for:
+    * NRQL conditions
+
+  </Collapser>
+
+  <Collapser
+    id="signal_evaluation_offset"
+    title="signal[evaluation_offset]"
+  >
+    Deprecated in favor of an `aggregation_method` with either an `aggregation_delay` or `aggregation_timer`. The offset is how long we wait for late data before evaluating each aggregation window. Waiting longer gives a more accurate signal but increases latency. The default is **3 aggregation windows**.
+
+    Used for:
+    * NRQL conditions
+
+  </Collapser>
+
+  <Collapser
+    id="signal_fill_option"
+    title="signal[fill_option]"
+  >
+    For sporadic data, you can avoid false alerts by filling the gaps (empty windows) with synthetic data.
+
+    * `none`: (Default) Use this if you don’t want to take any action on empty aggregation windows. On evaluation, an empty aggregation window will reset the threshold duration timer. For example, if a condition says that all aggregation windows must have data points above the threshold for 5 minutes, and 1 of the 5 aggregation windows is empty, then the condition won’t be in violation.
+    * `static`: Use this if you’d like to insert a custom static value into the empty aggregation windows before they’re evaluated. This option has an additional, required parameter of `fillValue` that specifies what static value should be used. This defaults to 0.
+    * `last_value`: Use this to insert the last seen value before evaluation occurs. We maintain the state of the last seen value for 2 hours.
+
+    In the UI, under **Advanced signal settings**, this is the **Fill data gaps with** field.
+
+    Used for:
+    * NRQL conditions
+
+  </Collapser>
+
+  <Collapser
+    id="signal_fill_value"
+    title="signal[fill_value]"
+  >
+    This is the value used by the `fill_option` custom value. The default is `0`.
+
+    Used for:
+    * NRQL conditions
+
   </Collapser>
 
   <Collapser
@@ -569,6 +512,7 @@ Not every field listed in this glossary is required for every condition type. Th
     Used for:
 
     * Conditions
+    * NRQL conditions
   </Collapser>
 
   <Collapser
@@ -585,7 +529,7 @@ Not every field listed in this glossary is required for every condition type. Th
 
     * Conditions
     * External service conditions
-    * Plugin conditions
+    * NRQL conditions
   </Collapser>
 
   <Collapser
@@ -601,7 +545,7 @@ Not every field listed in this glossary is required for every condition type. Th
 
     * Conditions
     * External service conditions
-    * Plugin conditions
+    * NRQL conditions
   </Collapser>
 
   <Collapser
@@ -616,7 +560,7 @@ Not every field listed in this glossary is required for every condition type. Th
 
     * Conditions
     * External service conditions
-    * Plugin conditions
+    * NRQL conditions
   </Collapser>
 
   <Collapser
@@ -632,7 +576,7 @@ Not every field listed in this glossary is required for every condition type. Th
 
     * Conditions
     * External service conditions
-    * Plugin conditions
+    * NRQL conditions
   </Collapser>
 
   <Collapser
@@ -793,7 +737,6 @@ Not every field listed in this glossary is required for every condition type. Th
     * Conditions
     * External service conditions
     * Synthetic monitoring conditions
-    * Plugin conditions
   </Collapser>
 
   <Collapser
@@ -821,19 +764,6 @@ Not every field listed in this glossary is required for every condition type. Th
     id="value_function"
     title="value_function"
   >
-    This is the value function used from the plugin metric. This may be one of the strings:
-
-    * min
-    * max
-    * average
-    * sample_size
-    * total
-    * percent
-
-    Used for:
-
-    * Plugin conditions
-
     When used for a [NRQL condition](/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api/rest-api-calls-new-relic-alerts#nrql-condition), the options are:
 
     * single_value (condition is evaluated based on each query's returned value)
@@ -844,14 +774,9 @@ Not every field listed in this glossary is required for every condition type. Th
     id="violation_time_limit_seconds"
     title="violation_time_limit_seconds"
   >
-    Use to automatically close instance-based violations after the number of seconds specified. Must be one of these values:
+    Use to automatically close instance-based violations after the number of seconds specified.
 
-    * 3600
-    * 7200
-    * 14400
-    * 28800
-    * 43200
-    * 86400
+    Default is **259,200 seconds** (3 days). Maximum is 30 days.
 
     Used for:
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions.mdx
@@ -55,7 +55,7 @@ Here are descriptions of the different types of conditions:
     id="nrql-conditions"
     title="NRQL query conditions"
   >
-    Use the UI or [Nerd-Graph API](/docs/alerts/alerts-nerdgraph/nerdgraph-examples/nerdgraph-api-alerts-nrql-conditions) to create NRQL conditions for [basic NRQL queries that return a number](/docs/new-relic-alerts-alert-nrql-queries).
+    Use the UI or [NerdGraph API](/docs/alerts/alerts-nerdgraph/nerdgraph-examples/nerdgraph-api-alerts-nrql-conditions) to create NRQL conditions for [basic NRQL queries that return a number](/docs/new-relic-alerts-alert-nrql-queries).
   </Collapser>
 
   <Collapser
@@ -193,7 +193,7 @@ After you save the condition, the currently selected policy lists all alert cond
 * [Rename the policy](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/name-or-rename-alert-policy).
 * [Disable](/docs/alerts/new-relic-alerts-beta/updating-alert-policies/disable-or-delete-alert-policies-conditions) any conditions in the policy, or delete the policy or any of its conditions.
 
-You may also manage your policies via [the policies Nerd-Graph API](/docs/alerts/alerts-nerdgraph/nerdgraph-examples/nerdgraph-api-alerts-policies).
+You may also manage your policies via [the policies NerdGraph API](/docs/alerts/alerts-nerdgraph/nerdgraph-examples/nerdgraph-api-alerts-policies).
 
 ## View existing conditions [#alert-condition-view]
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/update-or-disable-policies-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/update-or-disable-policies-conditions.mdx
@@ -29,11 +29,11 @@ Here's a quick reference for maintaining conditions. This includes the condition
     id="add-conditions"
     title="Add more conditions"
   >
-    To [add more conditions to a policy](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions): In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, **(select a policy)**, then click **Add a condition**.
+    To [add more conditions to a policy](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions): In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, select a policy, then click **Add a condition**.
 
     OR
 
-    To [copy a condition](/docs/alerts/new-relic-alerts-beta/updating-alert-policies/copy-alert-conditions) from any policy and add it to another policy: In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, **(select a policy)**, then click **Copy**.
+    To [copy a condition](/docs/alerts/new-relic-alerts-beta/updating-alert-policies/copy-alert-conditions) from any policy and add it to another policy: In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, select a policy, then click **Copy**.
   </Collapser>
 
   <Collapser
@@ -42,7 +42,7 @@ Here's a quick reference for maintaining conditions. This includes the condition
   >
     To copy an existing condition, including its [targets](/docs/apm/new-relic-apm/getting-started/glossary#alert-target) and [thresholds](/docs/apm/new-relic-apm/getting-started/glossary#alert-threshold), and add it to another policy for the selected account:
 
-    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, then **(select a policy)**.
+    1. In the **[one.newrelic.com](https://one.newrelic.com)** top nav, click **Alerts & AI**, click **Alert policies**, then select a policy.
     2. From the policy's list of one or more **Alert conditions**, click **Copy**.
     3. From the **Copy alert condition** list, search or scroll the list to select the policy where you want to add this condition.
     4. Optional: Change the condition's name if necessary.
@@ -55,7 +55,7 @@ Here's a quick reference for maintaining conditions. This includes the condition
     id="update-condition"
     title="Change a condition"
   >
-    To change a policy condition: In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, then **(select a policy)**. Then, from the list of **Alert conditions** for the selected policy:
+    To change a policy condition: In the **[one.newrelic.com](https://one.newrelic.com)** top nav, click **Alerts & AI**, click **Alert policies**, then select a policy. Then, from the list of **Alert conditions** for the selected policy:
 
     * To [change the condition's name](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions#rename-condition), click **Edit**.
     * To add, change, or remove targets (entities), select the name or number of targets for the condition, and then select **Browse and select targets**.
@@ -74,7 +74,7 @@ Here's a quick reference for maintaining conditions. This includes the condition
   >
     You can enable ![041715icon-condition-on](./images/041715icon-condition-on.png "Alerts v3: Condition enabled") or disable ![041715icon-condition-off](./images/041715icon-condition-off.png "Alerts v3: Condition disabled") any policy conditions, and the policy will continue to apply. To disable or re-enable a condition:
 
-    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, then **(select a policy)**. Then, from the list of **Alert conditions**, **(select a condition)**.
+    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, then select a policy. Then, from the list of **Alert conditions** select a condition).
     2. Click the **On/Off** switch to toggle it.
 
     <Callout variant="tip">
@@ -90,8 +90,8 @@ Here's a quick reference for maintaining conditions. This includes the condition
   >
     If a policy has multiple conditions, you can delete any or all of them, and the remaining conditions for the policy will continue to apply. To turn a condition off but keep it with the policy, [disable](/docs/alerts/new-relic-alerts-beta/updating-alert-policies/disable-or-delete-alert-policies-conditions#condition-on-off) it. To delete one or more conditions:
 
-    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, then **(select a policy)**.
-    2. From the list of **Alert conditions**, **(select a condition)**, then click **Delete**.
+    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, then select a policy.
+    2. From the list of **Alert conditions**, select a condition, then click **Delete**.
 
     <Callout variant="tip">
       If you don't see the delete button, your account admin may have disabled condition deletion for your organization.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/update-or-disable-policies-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/update-or-disable-policies-conditions.mdx
@@ -91,7 +91,7 @@ Here's a quick reference for maintaining conditions. This includes the condition
     If a policy has multiple conditions, you can delete any or all of them, and the remaining conditions for the policy will continue to apply. To turn a condition off but keep it with the policy, [disable](/docs/alerts/new-relic-alerts-beta/updating-alert-policies/disable-or-delete-alert-policies-conditions#condition-on-off) it. To delete one or more conditions:
 
     1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, then **(select a policy)**.
-    2. From the list of **Alert conditions**, **(select a condition)**, enable the condition if disabled, then click **Delete**.
+    2. From the list of **Alert conditions**, **(select a condition)**, then click **Delete**.
 
     <Callout variant="tip">
       If you don't see the delete button, your account admin may have disabled condition deletion for your organization.


### PR DESCRIPTION
## Give us some context

Alerts released the stream aggregation methods last week and we have been going through the public docs to get them up-to-date with the new features. The streaming methods effectively deprecate evaluation offset so we’ve been trying to get the examples and other associated docs to reflect the new state-of-the-art. While I’ve been in there making these changes, I’ve been cleaning up anything else that appears to be out-of-date or otherwise misrepresents how it all works.

List of updates related to Streaming Methods release:

  - big update + clean-up in REST API docs
  - fixes some typos in GraphQL examples
  - clean up formatting of code examples
  -  remove references to Plugin alerts (EOL'ed a while ago!)
  - other misc. typo fixes and clean-up