### PR TITLE
chore: increase date element size

### DIFF
--- a/src/templates/whatsNew.js
+++ b/src/templates/whatsNew.js
@@ -55,7 +55,7 @@ const WhatsNewTemplate = ({ data, location, pageContext }) => {
       >
         <div
           css={css`
-            font-size: 0.75rem;
+            font-size: 1rem;
             margin-bottom: 1rem;
             color: var(--color-dark-600);
             display: flex;
@@ -64,7 +64,7 @@ const WhatsNewTemplate = ({ data, location, pageContext }) => {
         >
           <Icon
             name="fe-calendar"
-            size="0.75rem"
+            size="1rem"
             css={css`
               position: relative;
               top: 1px;


### PR DESCRIPTION
Increased the text and icon size in the date element. 

<img width="963" alt="Screen Shot 2021-10-11 at 3 28 29 PM" src="https://user-images.githubusercontent.com/47728020/136862757-54aff858-76f7-4b63-8e34-1a385ce1673b.png">

There were a lot of suggestions in this ticket for what to do make the date stand out.  I am starting simple and looking for feedback. 

Closes https://github.com/newrelic/docs-website/issues/3178
