### PR TITLE
chore: update default polling intervals

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/advanced-config.mdx
@@ -46,7 +46,7 @@ discovery:
   use_snmp_v1: false
   replace_devices: true
 global:
-  poll_time_sec: 300
+  poll_time_sec: 60
   timeout_ms: 5000
   retries: 0
   mibs_enabled:
@@ -120,7 +120,7 @@ global:
             <tr>
               <td>poll_time_sec</td>
               <td></td>
-              <td>Indicates the polling frequency in seconds. By default, it's set to `60`</td>
+              <td>Indicates the polling frequency in seconds. This setting is used to override the `global.poll_time_sec` attribute. </td>
             </tr>
 
             <tr>
@@ -334,7 +334,7 @@ discovery:
           <tr>
             <td>poll_time_sec</td>
             <td>✓</td>
-            <td>Time in seconds to poll devices. By default, it's set to `300`</td>
+            <td>Time in seconds to poll devices. By default, it's set to `60`</td>
           </tr>
 
           <tr>


### PR DESCRIPTION
updating the default poll intervals to match latest settings from [ktranslate container](https://github.com/kentik/ktranslate/pull/146)

cc @x8a 