### PR TITLE
Restore I/O "Whats new?"  post publishing on 10-13-2021

### DIFF
--- a/src/content/whats-new/2021/10/instant-observability-10-13-21.md
+++ b/src/content/whats-new/2021/10/instant-observability-10-13-21.md
@@ -1,0 +1,43 @@
+---
+title: 'Get Instant Observability with New Relic I/O'
+summary: 'Leverage 400+ open source quickstarts to get started monitoring your stack'
+releaseDate: '2021-10-13'
+learnMoreLink: 'https://newrelic.com/blog/nerdlog/instant-observability-quickstarts'
+getStartedLink: 'https://onenr.io/06vjAmnD3jP'
+---
+<iframe width="560" height="315" src="https://www.youtube.com/watch?v=c9zprczTXj8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+We're excited to announce [New Relic Instant Observability (I/0)](https://newrelic.com/instant-observability), the fastest way to instrument, monitor, and analyze your technology stack while avoiding the burden of manual setup. It is a rich open source catalog of 400+ quickstarts (pre-built bundles of observability tools) contributed by experts around the world, reviewed by New Relic, and ready for you to install in a few clicks.
+
+# Solution overview
+No matter what technologies and tools you use in your stack, you can get more insights from your telemetry data in minutes. With New Relic I/O, you can:
+- **Reduce instrumentation toil** with an easy, guided installation
+- **Get started faster** with pre-built dashboards and alerts 
+- **Leverage best practices** from domain experts and technology partners
+
+**Quickstarts** can contain any combination of instrumentation, integrations, dashboards, and alerts. 
+Note that only full users will be able to access dashboards deployed from quickstarts. Every new account, including our [Free Forever](https://newrelic.com/pricing) tier, gets one full user absolutely free.
+
+# Demo
+Watch a quick demo and learn how to do a quickstart below:
+<iframe width="560" height="315" src="https://www.youtube.com/watch?v=sFt1Tx5qPRU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+# Get started
+- Install a quickstart from [New Relic I/O](https://onenr.io/06vjAmnD3jP).
+- If you don't have a New Relic account yet, browse the [public New Relic I/O catalog](https://newrelic.com/instant-observability).
+- Want to share your monitoring use case or best practices? New Relic Instant Observability is open source, so it’s easy to add to quickstarts or build a brand new one. Help drive the mission to democratize observability—and be featured as a quickstart author. [Contribute a quickstart!](https://github.com/newrelic/newrelic-observability-packs#readme)
+- Learn more by reading the [blog post](https://newrelic.com/blog/nerdlog/instant-observability-quickstarts).
+
+# Partner quickstarts
+We are proud to launch New Relic Instant Observability with pre-built quickstarts from five leading enterprise software partners. We have partnered closely with them to create quickstarts that help you extend your New Relic One experience:
+- **Kentik** is the network observability company. The [Kentik quickstarts ](https://developer.newrelic.com/instant-observability/?search=kentik)help network and development teams quickly identify and troubleshoot application performance issues correlated with network traffic performance and health data.
+
+- **Fastly** is an edge cloud platform that enables its customers to create great digital experiences quickly, securely, and reliably. With the [Fastly CDN quickstart](https://developer.newrelic.com/instant-observability/fastly-cdn/c5c5dd30-dcdf-46b6-9412-f9a1bba5a600/), you can monitor key metrics from Fastly's content delivery network that can help you improve service reliability and ensure great online experiences for end users.
+
+- **Lacework** is a data-driven security platform for the cloud that can collect, analyze, and accurately correlate data across an organization's AWS, Azure, GCP and Kubernetes environments, and narrow it down to the handful of security events that matter. The [Lacework quickstart](https://developer.newrelic.com/instant-observability/lacework/8a7a7220-e8ec-4959-b35d-0fe082be8039) bridges the gap between observability and security teams, and integrates with New Relic's database to surface security events and alerts directly in New Relic One.
+
+- **Cribl** is the observability pipeline company that lets customers parse and route any type of data. The [Cribl quickstart](https://developer.newrelic.com/instant-observability/cribl-logstream/e67f2859-80c1-4234-bbcf-bcbeeb31d70d/) allows you to get immediate visibility into your entire environment right from New Relic One without the need to create your own dashboards and alerts---simplifying your workflows and reducing time to value.
+
+- **Trend Micro** is a global cyber security leader. The [Trend Micro Cloud One quickstart](https://developer.newrelic.com/instant-observability/trendmicro-cloudone-conformity/c3ae3b79-260a-436f-ba25-1d97c61da3ad) ingests cloud security posture management (CSPM) data from Conformity into New Relic One to contextualize and correlate it with workload telemetry data, delivering AI-powered visualizations and quick insights. This allows security and cloud teams to immediately take action in improving their security and compliance postures.
+
+- **Gigamon** is the cloud visibility company. The Gigamon Hawk hybrid-cloud visibility and analytics platform provides access to - and extracts intelligence from all network traffic. The [Gigamon quickstart](https://developer.newrelic.com/instant-observability/gigamon-newrelic/d6b36ecf-bf99-475c-938f-370153db8e70) delivers advanced security capabilities that offer network detection and response to advanced threats, including shadow IT activities, crypto-mining and torrent activities, SSL cipher versions and expiration dates across both managed and unmanaged hosts, such as IoT/OT and containers.


### PR DESCRIPTION
I accidentally merged #4273 to develop today, but it is not scheduled to be released until 10/13/2021. So, I backed it out and this is the replacement PR.

We need to confirm that both of the videos and the blog links work before publishing on the morning of 10/13/2021.