### PR TITLE
chore: change Transactions heading id

### DIFF
--- a/src/content/docs/integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
+++ b/src/content/docs/integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
@@ -283,7 +283,7 @@ For selected OpenTelemetry languages, you can see information about your metrics
 
 ![Screen shot showing the metric explorer](./images/metric-explorer.png "Screen shot showing the metric explorer")
 
-### Transactions [#trx]
+### Transactions [#transactions]
 
 Use **Transactions** to identify slow or error transactions that might be causing a spike in your application's response time. To get a list of transactions: From the **Transaction Summary** page, select the transactions table.
 


### PR DESCRIPTION
Changing `#trx` to `#transactions` on the heading — "transactions" is the exact name of the nerdlet that provides this functionality, so by using the correct name here, we can link directly to this section of the docs from the app.
This comes into play when a user hasn't yet set up their instrumentation for Transactions yet; In the "empty state," the app will provide a link they can follow directly to these docs to help them get everything set up. (https://newrelic.atlassian.net/browse/APPEXP-3104)

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.