### PR TITLE
Include Ruby configuration for Logger instrumentation

### DIFF
--- a/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -2125,6 +2125,18 @@ If `true`, the agent won't install Grape instrumentation.
   Controls auto-instrumentation of dalli gem for Memcache at start up.  May be one of [auto|prepend|chain|disabled].
   </Collapser>
 
+  <Collapser id="instrumentation-logger" title="instrumentation.logger">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"auto"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_LOGGER`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Ruby standard library Logger at start up.  May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
   <Collapser id="instrumentation-excon" title="instrumentation.excon">
     <table>
       <tbody>


### PR DESCRIPTION
This provides documentation for the new `instrumentation.logger` configuration for the Ruby agent introduced with https://github.com/newrelic/newrelic-ruby-agent/pull/798 that will be in the upcoming agent release.

cc @kaylareopelle @tannalynn