### PR TITLE
fix(synthetics): customer request to call out some things

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests.mdx
@@ -5,7 +5,7 @@ tags:
   - Synthetic monitoring
   - Scripting monitors
 translate:
-  - jp
+  - jp 
 metaDescription: Use API test scripts to ensure your API endpoint is functioning correctly.
 redirects:
   - /docs/synthetics/new-relic-synthetics/scripting-monitors/writing-api-tests
@@ -15,7 +15,7 @@ redirects:
 
 Use synthetic monitoring's [API tests](/docs/synthetics/new-relic-synthetics/getting-started/types-synthetics-monitors) to monitor your API endpoint to ensure it is functioning correctly. New Relic uses the [http-request](https://github.com/request/request) module internally to make HTTP calls to your endpoint and validate the results.
 
-Here we present some example functions showing how to use the `$http` object to submit your request. For detailed documentation on the options available for this object, see the [http-request readme](https://github.com/request/request).
+Here we present some example functions showing how to use the `$http` object to submit your request. For detailed documentation on the options available for this object, see the [http-request readme](https://github.com/request/request). (Note that Request is deprecated, but these options still apply.)
 
 <Callout variant="tip">
   To view and share other API test examples, visit the [synthetics scripts](https://discuss.newrelic.com/tags/c/full-stack-observability/synthetic/81/script) section in Explorers Hub.
@@ -43,7 +43,7 @@ To start your script:
 
 * Declare a variable (such as `options`) to store your [request options object](http://github.com/request/request#requestoptions-callback).
 * Define request options such as the URL endpoint, and custom headers.
-* If you're setting SSL or agent options, see [SSL and agentOptions requirements](#use-agentOptions).
+* If you're setting SSL or agent options, see [SSL and agentOptions requirements](#use-agentOptions). We recommend using SSL to avoid exposing plain text credentials in your headers.
 
 <Callout variant="tip">
   For a full list of supported request options, see [request(options, callback)](https://github.com/request/request#requestoptions-callback) in the `http-request` documentation on GitHub.


### PR DESCRIPTION
Per customer request, this doc is now updated to point out that Request is deprecated and to recommend SSL.

