### PR TITLE
docs: Add in 3.79.1 release note for iOS mobile app

### DIFF
--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3791.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3791.mdx
@@ -1,0 +1,16 @@
+---
+subject: Mobile app for iOS
+releaseDate: '2021-10-15'
+version: 3.79.1
+downloadLink: 'https://apps.apple.com/app/id594038638'
+---
+
+### Notes
+
+Redesigned dashboard billboard threshold charts
+
+### New features
+
+* Improved iOS widgets with updated at, and since X minutes ago labels
+* Updated dashboard billboard charts, to provide a full color background if a threshold has been reached
+* Improved universal link behavior


### PR DESCRIPTION
* Adding in release note for version 3.79.1 of the iOS Mobile app
