### PR TITLE
fix(data dictionary): Add definitions for coreCount and processorCount

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
-const parse = require('rehype-parse');
 const path = require('path');
+const parse = require('rehype-parse');
 const unified = require('unified');
 const rehypeStringify = require('rehype-stringify');
 const addAbsoluteImagePath = require('./rehype-plugins/utils/addAbsoluteImagePath');

--- a/src/content/docs/style-guide/article-templates/data-dictionary-style-guidelines.mdx
+++ b/src/content/docs/style-guide/article-templates/data-dictionary-style-guidelines.mdx
@@ -40,8 +40,11 @@ To add a new data type:
 
 To add attributes: 
 
-1. Our goal is to avoid adding redundant attributes entries, so you should first check to see if there's an existing attribute that has the same name and same general definition as the one you're trying to add. If it exists, edit that file to include the new data type (under `events:`). If an existing attribute is fairly close in definition but not exact, try to edit the definition so it works for all associated data types.   
-2. If there is no existing attribute, create a new one. The easiest way is to copy an existing attribute file, edit all relevant fields to be accurate, and place it in the folder of the data type it's attached to (for example, [Transaction](https://github.com/newrelic/docs-website/tree/develop/src/data-dictionary/events/Transaction)). 
+1. Check if there's an existing attribute that has the same name and same general definition as the one you're trying to add. 
+  + If it exists, edit that file to include the new data type (under `events:`). 
+  + If an existing attribute is fairly close in definition but not exact, try to edit the definition so it works for all associated data types.   
+2. If there is no existing attribute, create a new one. 
+  + The easiest way is to copy an existing attribute file, edit all relevant fields to be accurate, and place it in the folder of the data type it's attached to (for example, [Transaction](https://github.com/newrelic/docs-website/tree/develop/src/data-dictionary/events/Transaction)). 
 3. When writing an attribute, try to keep it as concise as possible, and avoid using links. For more on that, see [Style](#style).  
 4. If the attribute has one of the units of measurement we use (like `units: percentage (%)`), add that to the front matter. For info on units, see [Units](#units).
 

--- a/src/content/docs/style-guide/article-templates/data-dictionary-style-guidelines.mdx
+++ b/src/content/docs/style-guide/article-templates/data-dictionary-style-guidelines.mdx
@@ -31,7 +31,7 @@ To add a new data type:
 
 1. Make a new folder in this directory, alongside the other directories:
     ```
-    /docs-website/tree/develop/src/data-dictionary/events
+    src/data-dictionary/events
     ```
 2. Duplicate a data type file (for example, this [Metric](https://github.com/newrelic/docs-website/blob/develop/src/data-dictionary/events/Metric/Metric.event-definition.md) data type), place it in the new folder, and fill it out with the new info. 
 3. For how to add attributes on a new data type, keep reading. 

--- a/src/data-dictionary/events/SystemSample/coreCount.md
+++ b/src/data-dictionary/events/SystemSample/coreCount.md
@@ -1,0 +1,9 @@
+---
+name: coreCount
+type: attribute
+units: count
+events:
+  - SystemSample
+---
+
+The number of cores within a single CPU. This corresponds with the `cpu cores` field in `/proc/cpuinfo` in Linux.

--- a/src/data-dictionary/events/SystemSample/coreCount.md
+++ b/src/data-dictionary/events/SystemSample/coreCount.md
@@ -6,4 +6,4 @@ events:
   - SystemSample
 ---
 
-The number of cores within a single CPU. This corresponds with the `cpu cores` field in `/proc/cpuinfo` in Linux.
+The number of cores within a single CPU. This corresponds with the 'cpu cores' field in /proc/cpuinfo in Linux.

--- a/src/data-dictionary/events/SystemSample/processorCount.md
+++ b/src/data-dictionary/events/SystemSample/processorCount.md
@@ -1,0 +1,9 @@
+---
+name: processorCount
+type: attribute
+units: count
+events:
+  - SystemSample
+---
+
+The total number of cores in all CPUs. This corresponds with the `processor` entry in `/proc/cpuinfo` in Linux.

--- a/src/data-dictionary/events/SystemSample/processorCount.md
+++ b/src/data-dictionary/events/SystemSample/processorCount.md
@@ -6,4 +6,4 @@ events:
   - SystemSample
 ---
 
-The total number of cores in all CPUs. This corresponds with the `processor` entry in `/proc/cpuinfo` in Linux.
+The total number of cores in all CPUs. This corresponds with the 'processor' entry in /proc/cpuinfo in Linux.


### PR DESCRIPTION
Adds definitions for these two attributes, see DOC-6300 for more info. 