### PR TITLE
move create and delete tip

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/monitor-downtimes-disable-monitoring-during-scheduled-maintenance-times.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/monitor-downtimes-disable-monitoring-during-scheduled-maintenance-times.mdx
@@ -23,11 +23,11 @@ Schedule **monitor downtimes** to specify times that your synthetic [monitors](/
   During synthetic monitor downtimes, your selected monitors stop running until their scheduled end time. To temporarily disable alerts without pausing your monitors, [mute them](/docs/synthetics/new-relic-synthetics/using-monitors/alerting-synthetics#mute) instead.
 </Callout>
 
+## Create recurring monitor downtimes [#create-window]
+
 <Callout variant="tip">
   The ability to add, edit, or delete monitor downtimes depends on [your access to features](/docs/accounts/accounts-billing/general-account-settings/factors-affecting-access-features-data).
 </Callout>
-
-## Create recurring monitor downtimes [#create-window]
 
 Create recurring monitor downtimes for routine monitor maintenance or regularly scheduled outages. To create a recurring monitor downtime:
 
@@ -57,11 +57,13 @@ Go to [**one.newrelic.com**](http://one.newrelic.com/) **> Synthetics > (select 
 
 You can view additional details in the **Results** and **Resources** sections.
 
+
+
+## Delete a monitor downtime [#delete]
+
 <Callout variant="tip">
   If you are unable to delete a window, check your [permissions](/docs/synthetics/new-relic-synthetics/administration/synthetics-permissions-user-groups).
 </Callout>
-
-## Delete a monitor downtime [#delete]
 
 To delete an existing monitor downtime:
 


### PR DESCRIPTION
Move delete tip in Monitor downtimes: Disable monitoring during scheduled maintenance times to make it similar to where the edit tip is located (below header, not above)

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Move create and delete tip to be consistent with where edit tip is located