### PR TITLE
Highlight EOL & Specify Amazon Linux 2

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -29,7 +29,7 @@ The infrastructure agent supports these processor architectures:
 
 ## Operating systems
 
-The infrastructure agent supports these operating systems up to their manufacturer's end-of-life.
+The infrastructure agent supports these operating systems up to their <strong>manufacturer's end-of-life</strong>.
 
 <table>
   <thead>
@@ -47,7 +47,7 @@ The infrastructure agent supports these operating systems up to their manufactur
   <tbody>
     <tr>
       <td>
-        <ImageSizing width="32px" height="32px" verticalAlign="middle">![amazon linux.png](./images/amazon-linux.png "amazon linux")</ImageSizing>[Amazon Linux](/docs/infrastructure-install-amazon-linux-centos-debian-rhel-or-ubuntu)
+        <ImageSizing width="32px" height="32px" verticalAlign="middle">![amazon linux.png](./images/amazon-linux.png "amazon linux")</ImageSizing>[Amazon Linux 2](/docs/infrastructure-install-amazon-linux-centos-debian-rhel-or-ubuntu)
       </td>
 
       <td>


### PR DESCRIPTION
Amazon Linux 1 is EOL and is no longer supported. Updating requirements to specify that Amazon Linux 2 specifically, and highlighting the manufacturer's end-of-life to be more focused at the top of the section.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.