### PR TITLE
Used wrong word in recommendation

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
@@ -742,7 +742,7 @@ These API functions include links to the API Explorer, where you can create, upd
     id="create-nrql-conditions"
     title="Create NRQL conditions for policies"
   >
-    **Recommendation:** Due to the way NRQL data is streamed, set the `aggregation_method` to `EVENT_FLOW` and use the default settings of `1` for `aggregation_window` and `2` for `aggregation_timer`. `EVENT_FLOW` works in most use-cases, but for a discussion on which use cases work better with `EVENT_TIMER`, see [Which aggregation method to use?](https://discuss.newrelic.com/t/relic-solution-how-can-i-figure-out-which-aggregation-method-to-use/164288).
+    **Recommendation:** Due to the way NRQL data is streamed, set the `aggregation_method` to `EVENT_FLOW` and use the default settings of `1` for `aggregation_window` and `2` for `aggregation_delay`. `EVENT_FLOW` works in most use-cases, but for a discussion on which use cases work better with `EVENT_TIMER`, see [Which aggregation method to use?](https://discuss.newrelic.com/t/relic-solution-how-can-i-figure-out-which-aggregation-method-to-use/164288).
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_nrql_conditions/create) **Alerts Nrql Conditions > POST > Create**
 


### PR DESCRIPTION
changed `aggregation_timer` to `aggregation_delay`, since the former was incorrect for the recommendation given.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.