### PR TITLE
docs: Add in 2.1.0 release note for New Relic Apple TV app.

### DIFF
--- a/src/content/docs/licenses/product-or-service-licenses/mobile-app-licenses/tvos-application-licenses.mdx
+++ b/src/content/docs/licenses/product-or-service-licenses/mobile-app-licenses/tvos-application-licenses.mdx
@@ -47,15 +47,15 @@ We love open-source software, and use the following in the New Relic for TV app.
 
     <tr>
       <td>
-        [Analytics](http://segment.com/)
+        [Alamofire](https://github.com/Alamofire/Alamofire)
       </td>
 
       <td>
-        [MIT](https://github.com/segmentio/analytics-ios/blob/master/LICENSE)
+        [MIT](https://github.com/Alamofire/Alamofire/blob/master/LICENSE)
       </td>
 
       <td>
-        Copyright © 2016 Segment.io, Inc.
+        Copyright © 2014-2021 Alamofire Software Foundation (http://alamofire.org/)
       </td>
     </tr>
 
@@ -75,6 +75,20 @@ We love open-source software, and use the following in the New Relic for TV app.
 
     <tr>
       <td>
+        [Charts](https://github.com/danielgindi/Charts)
+      </td>
+
+      <td>
+        [Apache License, Version 2.0](https://github.com/danielgindi/Charts/blob/master/LICENSE)
+      </td>
+
+      <td>
+        Copyright 2016-2019 Daniel Cohen Gindi & Philipp Jahoda
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         LoginManagerSDK
       </td>
 
@@ -83,7 +97,7 @@ We love open-source software, and use the following in the New Relic for TV app.
       </td>
 
       <td>
-        © 2010-2021 New Relic, Inc. All rights reserved.
+        Copyright © 2010-2021 New Relic, Inc. All rights reserved.
       </td>
     </tr>
 
@@ -111,7 +125,7 @@ We love open-source software, and use the following in the New Relic for TV app.
       </td>
 
       <td>
-        © 2010-2021 New Relic, Inc. All rights reserved.
+        Copyright © 2010-2021 New Relic, Inc. All rights reserved.
       </td>
     </tr>
 
@@ -125,7 +139,7 @@ We love open-source software, and use the following in the New Relic for TV app.
       </td>
 
       <td>
-        © 2010-2021 New Relic, Inc. All rights reserved.
+        Copyright © 2010-2021 New Relic, Inc. All rights reserved.
       </td>
     </tr>
 
@@ -153,7 +167,7 @@ We love open-source software, and use the following in the New Relic for TV app.
       </td>
 
       <td>
-        © 2010-2021 New Relic, Inc. All rights reserved.
+        Copyright © 2010-2021 New Relic, Inc. All rights reserved.
       </td>
     </tr>
 
@@ -181,7 +195,7 @@ We love open-source software, and use the following in the New Relic for TV app.
       </td>
 
       <td>
-        © 2010-2021 New Relic, Inc. All rights reserved.
+        Copyright © 2010-2021 New Relic, Inc. All rights reserved.
       </td>
     </tr>
 

--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-tvos-release-notes/newrelic-tvos-2010.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-tvos-release-notes/newrelic-tvos-2010.mdx
@@ -7,10 +7,10 @@ downloadLink: 'https://apps.apple.com/app/id1098396112'
 
 ### Notes
 
-Improved billboards to align with new red, yellow green backgrounds for thresholds
+Improved billboards to align with new red, yellow, and green backgrounds for thresholds
 
 ### Improvements
 
 * Fixes issue when charts would not refresh when cycling through a slideshow
-* Fixes bug where slideshow dashboards could potentially not show up on reboot if the account had many dashboards, and they were not favorited
+* Fixes bug where slideshow dashboards could potentially not show up on reboot if the account had many dashboards and they were not favorited
 

--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-tvos-release-notes/newrelic-tvos-2010.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-tvos-release-notes/newrelic-tvos-2010.mdx
@@ -1,0 +1,16 @@
+---
+subject: New Relic for tvOS
+releaseDate: '2021-10-18'
+version: 2.1.0
+downloadLink: 'https://apps.apple.com/app/id1098396112'
+---
+
+### Notes
+
+Improved billboards to align with new red, yellow green backgrounds for thresholds
+
+### Improvements
+
+* Fixes issue when charts would not refresh when cycling through a slideshow
+* Fixes bug where slideshow dashboards could potentially not show up on reboot if the account had many dashboards, and they were not favorited
+


### PR DESCRIPTION

## Give us some context

* Adds in 2.1.0 release note for AppleTV New Relic App
* Update licenses to latest version.
