### PR TITLE
fix(nav files): change title of 'solutions & best practices'

### DIFF
--- a/src/nav/new-relic-solutions.yml
+++ b/src/nav/new-relic-solutions.yml
@@ -1,4 +1,4 @@
-title: Solutions and best practices
+title: Guides and best practices
 path: /docs/new-relic-solutions
 pages:
   - title: Observability Maturity


### PR DESCRIPTION
DOC-7444. Changed title to 'Guides and best practices'. We think this is a better name for this section, especially if we are going to use it as a place to locate various general guides in future. 