### PR TITLE
Use devEn account for dev data instead of account 1

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -163,13 +163,13 @@ module.exports = {
           configs: {
             development: {
               instrumentationType: 'proAndSPA',
-              accountId: '10175106',
+              accountId: '10956800',
               trustKey: '1',
-              agentID: '23865145',
-              licenseKey: '528f970912',
-              applicationID: '23865145',
-              beacon: 'staging-bam.nr-data.net',
-              errorBeacon: 'staging-bam.nr-data.net',
+              agentID: '35094418',
+              licenseKey: 'NRJS-649173eb1a7b28cd6ab',
+              applicationID: '35094418',
+              beacon: 'staging-bam-cell.nr-data.net',
+              errorBeacon: 'staging-bam-cell.nr-data.net',
             },
             production: {
               instrumentationType: 'proAndSPA',


### PR DESCRIPTION
Our browser agent info was using account 1 and reporting development events there. This updates the config to use a new entity created under the devEn account