### PR TITLE
Add whats new id deletion logic

### DIFF
--- a/scripts/actions/generate-whats-new-ids.js
+++ b/scripts/actions/generate-whats-new-ids.js
@@ -11,17 +11,23 @@ const generateWhatsNewIds = async () => {
   );
 
   return new Promise((resolve) => {
+    const currentWhatsNewPaths = [];
     vfileGlob('./src/content/whats-new/**/*.md').subscribe({
       next: (file) => {
         const slug = file.path
           .replace(/.*?src\/content/, '')
           .replace('.md', '');
-
+        currentWhatsNewPaths.push(slug);
         if (!data[slug]) {
           data[slug] = String(++largestID);
         }
       },
       complete: async () => {
+        Object.entries(data).forEach(([path]) => {
+          if (!currentWhatsNewPaths.includes(path)) {
+            delete data[path];
+          }
+        });
         file.contents = JSON.stringify(data, null, 2);
 
         await write(file, 'utf-8');


### PR DESCRIPTION
We have a script to generate new whats new IDs, but it didn't include any cleanup for what's new posts that get deleted. 
the `nr1-announcements` end-point doesn't care about this because it only matches IDs to existing posts, but the `nr1-announcements/ids` endpoint grabs the entire ID list which includes the deleted posts. this is was causing issue in the whats new nerdlet since they rely on the `/ids` endpoint to know when to delete a post