### PR TITLE
fix(agents): added a very short page to comply with AWS requirements

### DIFF
--- a/src/content/docs/agents/manage-apm-agents/configuration/support-arm-graviton-x86-64.mdx
+++ b/src/content/docs/agents/manage-apm-agents/configuration/support-arm-graviton-x86-64.mdx
@@ -1,0 +1,21 @@
+---
+title: "Agent support for ARM64/Graviton and x86_64"
+tags:
+  - Agents
+  - support
+  - Configuration
+metaDescription: 
+---
+
+The following New Relic agents support AWS Graviton processors using ARM64, as well as x86_64. 
+
+* Python agent
+* Ruby agent
+* Node agent
+* .NET agent
+* Go agent
+* PHP agent
+* Java agent
+* Infra agent
+* OHIs
+

--- a/src/nav/full-stack-observability.yml
+++ b/src/nav/full-stack-observability.yml
@@ -245,6 +245,8 @@ pages:
                     path: /docs/agents/manage-apm-agents/configuration/add-rename-remove-hosts
                   - title: Monitor background processes
                     path: /docs/agents/manage-apm-agents/configuration/monitor-background-processes
+                  - title: Agent support for ARM64/Graviton and x86_64
+                    path: /docs/agents/manage-apm-agents/configuration/support-arm-graviton-x86-64
               - title: Troubleshooting
                 path: /docs/agents/manage-apm-agents/troubleshooting
                 pages:


### PR DESCRIPTION
This is a short page to clarify parity of support, per [DOC-7464](https://www.google.com/url?q=https://newrelic.atlassian.net/browse/DOC-7464)