### PR TITLE
Update custom-instrumentation-attributes-net.mdx

### DIFF
--- a/src/content/docs/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net.mdx
+++ b/src/content/docs/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net.mdx
@@ -107,8 +107,6 @@ protected void MethodWithinTransaction()
 
 <Callout variant="important">
  If some of your methods still do not show up in traces after adding the `[Trace]` attribute, you may also need to disable method inlining for some methods with `[MethodImpl(MethodImplOptions.NoInlining)]`
- 
- More information about method inlining can be found in [this Microsoft document](https://docs.microsoft.com/en-us/cpp/cpp/noinline?view=msvc-160). 
 </Callout>
 
 ## Properties for \[Transaction] [#properties]

--- a/src/content/docs/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net.mdx
+++ b/src/content/docs/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net.mdx
@@ -105,6 +105,12 @@ protected void MethodWithinTransaction()
 }
 ```
 
+<Callout variant="important">
+ If some of your methods still do not show up in traces after adding the `[Trace]` attribute, you may also need to disable method inlining for some methods with `[MethodImpl(MethodImplOptions.NoInlining)]`
+ 
+ More information about method inlining can be found in [this Microsoft document](https://docs.microsoft.com/en-us/cpp/cpp/noinline?view=msvc-160). 
+</Callout>
+
 ## Properties for \[Transaction] [#properties]
 
 The `Transaction` attribute supports the following properties:


### PR DESCRIPTION
After chatting with .NET agent engineers, added a note about how to disable method inlining. Method inlining can prevent methods from appearing distinctly in traces.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.