### PR TITLE
Update add-detail-transactions-xml-net.mdx

### DIFF
--- a/src/content/docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net.mdx
+++ b/src/content/docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net.mdx
@@ -67,8 +67,6 @@ Extension files define a number of tracer factories in an instrumentation elemen
 
 <Callout variant="important">
  If some of your methods still do not show up in traces after adding XML custom instrumentation, you may also need to disable method inlining for some methods with `[MethodImpl(MethodImplOptions.NoInlining)]`
-
- More information about method inlining can be found in [this Microsoft document](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.methodimploptions?view=net-5.0). 
 </Callout>
 
 

--- a/src/content/docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net.mdx
+++ b/src/content/docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net.mdx
@@ -65,6 +65,13 @@ Extension files define a number of tracer factories in an instrumentation elemen
 6. If your app is IIS-hosted, restart IIS.
 7. For non-IIS applications, restart your application's host process or the application itself.
 
+<Callout variant="important">
+ If some of your methods still do not show up in traces after adding XML custom instrumentation, you may also need to disable method inlining for some methods with `[MethodImpl(MethodImplOptions.NoInlining)]`
+
+ More information about method inlining can be found in [this Microsoft document](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.methodimploptions?view=net-5.0). 
+</Callout>
+
+
 ## Ignore a transaction [#blocking-instrumentation]
 
 You can stop a transaction from being reported by using a custom instrumentation file. Whenever an ignored method is called, the .NET agent ignores the entire parent transaction. This is the same as calling `IgnoreTransaction()`.


### PR DESCRIPTION
After chatting with .NET agent engineers, added a note about how to disable method inlining. Method inlining can prevent methods from appearing distinctly in traces.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.