### PR TITLE
chore: update outdated information

### DIFF
--- a/src/content/docs/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
+++ b/src/content/docs/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
@@ -24,7 +24,7 @@ The New Relic Ruby agent automatically collects many metrics. It also includes a
 
 The easiest way to capture custom instrumentation is by tracing calls to a particular method. Tracing a method as described below will insert an additional node in your transaction traces for each invocation of that method, providing greater detail about where time is going in your transactions.
 
-Method tracers are software probes you can put on a method of any class. The probes use alias method chaining to insert themselves when the target methods execute and gather custom instrumentation on their performance.
+Method tracers are software probes you can put on a method of any class. The probes use module prepending to insert themselves when the target methods execute and gather custom instrumentation on their performance.
 
 ## Tracing in class definitions [#tracing-classes]
 
@@ -97,7 +97,7 @@ def slow_action
 end
 ```
 
-For more information, see [add_method_tracer in the New Relic RubyDoc](http://www.rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent/MethodTracer#trace_execution_scoped-instance_method) .
+For more information, see [trace_execution_scoped in the New Relic RubyDoc](http://www.rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent/MethodTracer#trace_execution_scoped-instance_method) .
 
 ## Naming transactions
 


### PR DESCRIPTION
`add_method_tracer` has been refactored to use a new strategy, module prepending, to accomplish its goals. @amhuntsman and I also noticed an error for the text of a link about `trace_execution_scoped`