### PR TITLE
chore: Java - fixing typo in config docs

### DIFF
--- a/src/content/docs/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -4662,7 +4662,7 @@ Span configuration is set in the `span_events` stanza and can be [overridden](#S
 
 ## Jar collector
 
-The Java agent collects and information about jars and their versions on the application classpath.
+The Java agent collects information about jars and their versions on the application classpath.
 
 Jar collection configuration is set in the `jar_collector` stanza and can be [overridden](#System_Properties) by using a `newrelic.config.jar_collector` prefixed system property. Options include:
 


### PR DESCRIPTION
## Give us some context

Remove extra word in docs.