### PR TITLE
chore: theme update to bring in new 404 page with search functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "^2.0.0-next.8",
     "@mdx-js/react": "^2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "^3.2.0",
+    "@newrelic/gatsby-theme-newrelic": "^3.3.0",
     "@splitsoftware/splitio-react": "^1.2.4",
     "babel-jest": "^26.3.0",
     "common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3483,10 +3483,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-3.2.0.tgz#d8ea63cb315a1a88f9b4af66e342e1d762247572"
-  integrity sha512-eTEdfaNS2rGtO81+CtJG1qnKX9FLqd94NgNUYpH9BVl1+XpuRVaDtuhR7UhfOA1gG4dVE7R/cvNjWyfphr6Cyw==
+"@newrelic/gatsby-theme-newrelic@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-3.3.0.tgz#66ba001657f5f6b8f96d52a3dd20ec958830b708"
+  integrity sha512-f6Kp2A3JCkLyHUE+NdeQPw7nC4MVyuhpMfWp+rGYCPZdkpCa/ohxvn5Z6+zybCy/pSy1ok8hE68T2AkqFqjCow==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
## Summary
Update the theme version to bring in the new 404 page with search functionality implemented [here](https://github.com/newrelic/gatsby-theme-newrelic/pull/505)

Example page: https://docswebsitedevelop-404pageupdate.gtsb.io/amazon/ubuntu

## Screenshots

![Screen Shot 2021-10-21 at 5 00 01 PM](https://user-images.githubusercontent.com/70179215/138372707-4c04a01b-d33c-4c35-9c3b-18991d781fed.png)

Resolves: #4183