### PR TITLE
Add Fastify as supported framework (Node.js agent)

### DIFF
--- a/src/content/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -141,6 +141,7 @@ Errors resulting in unhandled rejections are not scoped to the transaction that 
 * [Connect](https://www.npmjs.com/package/connect)
 * [Hapi](https://www.npmjs.com/package/hapi)
 * [Koa](https://www.npmjs.com/package/koa) 2.0.0 or higher ([external module](https://github.com/newrelic/node-newrelic-koa) loaded with the agent)
+* [Fastify](https://www.npmjs.com/package/fastify)
 
 If you are using a supported framework with default routers, the Node.js agent can read these frameworks' route names as is. However, if you want more specific names than are provided by your framework, you may want to use one or more of the tools New Relic provides with the [Node.js transaction naming API](/docs/nodejs/nodejs-transaction-naming-api).
 


### PR DESCRIPTION
As of [v8.5.0](https://github.com/newrelic/node-newrelic/pull/948#issue-1024236933) of the Node.js agent, Fastify is a supported framework.

- Closes https://github.com/newrelic/node-newrelic/issues/930