### PR TITLE
Remove dupe redirects

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/troubleshooting/aws-service-specific-api-rate-limiting.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/troubleshooting/aws-service-specific-api-rate-limiting.mdx
@@ -9,7 +9,6 @@ metaDescription: Troubleshooting procedures if you encountered a rate limit for 
 redirects:
   - /docs/integrations/amazon-integrations/troubleshooting/aws-service-specific-api-rate-limiting
   - /docs/infrastructure/infrastructure-integrations/troubleshooting/aws-service-specific-api-rate-limiting
-  - /docs/infrastructure/amazon-integrations/troubleshooting/aws-service-specific-api-rate-limiting
 ---
 
 ## Problem
@@ -28,19 +27,24 @@ After enabling Amazon integrations with New Relic Infrastructure, you encounter 
     Ensure that you are not collecting inventory information for the wrong ARN account. Verify that the ARN associated with your Infrastructure account is correct.
   </Collapser>
 
-  <Collapser
-    id="polling-frequency"
-    title="Change the polling frequency"
-  >
-    The [polling frequency](/docs/integrations/amazon-integrations/get-started/polling-intervals-aws-integrations) determines how often New Relic gathers data from your cloud provider. By default, the polling frequency is set to the maximum frequency that is available for each service. If you reach your API rate limit, you may want to [decrease the polling frequency.](/docs/integrations/new-relic-integrations/getting-started/configure-polling-frequency-data-collection-cloud-integrations#polling)
-  </Collapser>
+{' '}
+<Collapser id="polling-frequency" title="Change the polling frequency">
+  The [polling
+  frequency](/docs/integrations/amazon-integrations/get-started/polling-intervals-aws-integrations)
+  determines how often New Relic gathers data from your cloud provider. By
+  default, the polling frequency is set to the maximum frequency that is
+  available for each service. If you reach your API rate limit, you may want to
+  [decrease the polling
+  frequency.](/docs/integrations/new-relic-integrations/getting-started/configure-polling-frequency-data-collection-cloud-integrations#polling)
+</Collapser>
 
-  <Collapser
-    id="data-collection"
-    title="Filter your data"
-  >
-    You can set filters for each integration in order to specify which information you want captured. If you reach your API rate limit, you may want to [filter your data](/docs/integrations/new-relic-integrations/getting-started/configure-polling-frequency-data-collection-cloud-integrations#filter-data).
-  </Collapser>
+{' '}
+<Collapser id="data-collection" title="Filter your data">
+  You can set filters for each integration in order to specify which information
+  you want captured. If you reach your API rate limit, you may want to [filter
+  your
+  data](/docs/integrations/new-relic-integrations/getting-started/configure-polling-frequency-data-collection-cloud-integrations#filter-data).
+</Collapser>
 
   <Collapser
     id="usage"
@@ -52,6 +56,7 @@ After enabling Amazon integrations with New Relic Infrastructure, you encounter 
     2. Review the New Relic Insights dashboard, which appears automatically.
 
     The Insights dashboard includes a chart with your account's Amazon AWS API call count for the last month as well as the CloudWatch API calls (per AWS resource) for the last day. This information is the API usage for New Relic only. It does not include other AWS API or CloudWatch usage that may occur.
+
   </Collapser>
 </CollapserGroup>
 
@@ -63,5 +68,5 @@ Infrastructure Amazon integrations leverage the AWS monitoring APIs to gather in
 
 This may be caused by either of the following:
 
-* Enabling Amazon integrations on several plugins for the same service
-* Adding the incorrect [Role ARN](http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) to your AWS integrations
+- Enabling Amazon integrations on several plugins for the same service
+- Adding the incorrect [Role ARN](http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) to your AWS integrations

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-manual-install-infrastructure-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-manual-install-infrastructure-agent-linux.mdx
@@ -10,13 +10,15 @@ redirects:
   - /docs/infrastructure/new-relic-infrastructure/installation/manual-install-infrastructure-linux
   - /docs/infrastructure/install-configure-infrastructure/linux-installation/manual-install-infrastructure-linux
   - /docs/infrastructure/install-configure-manage-infrastructure/linux-installation/tarball-manual-install-infrastructure-linux
-  - /docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-manual-install-infrastructure-agent-linux
 ---
 
 Our custom Linux installation process for infrastructure monitoring allows you to tailor all aspects of the installation process, and to place files and folders on your filesystem. You have full control of the installation.
 
 <Callout variant="caution">
-  The manual install process is not supervised. If you opt for manual install, you are responsible for placing the different files in the correct folders, providing the correct parameterized configuration values, and ensuring the agent has all the permissions to execute.
+  The manual install process is not supervised. If you opt for manual install,
+  you are responsible for placing the different files in the correct folders,
+  providing the correct parameterized configuration values, and ensuring the
+  agent has all the permissions to execute.
 </Callout>
 
 ## Install the agent [#linux-manual-install]
@@ -34,6 +36,7 @@ Before installation, check the [compatibility and requirements](/docs/infrastruc
         Comments
       </th>
     </tr>
+
   </thead>
 
   <tbody>
@@ -56,6 +59,7 @@ Before installation, check the [compatibility and requirements](/docs/infrastruc
         As of [version 1.5.59](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1559), the infrastructure agent package includes the additional `newrelic-infra-service` binary, which is used to safely manage usual agent daemon process `newrelic-infra`.
       </td>
     </tr>
+
   </tbody>
 </table>
 
@@ -96,6 +100,7 @@ To install the agent:
        `-- run
            `-- newrelic-infra
    ```
+
 4. [Install the service script](#install-service-script).
 5. Optional: [Additional install steps](#install-options).
 
@@ -103,20 +108,20 @@ To install the agent:
 
 You can also carry out these additional steps:
 
-* [Change the location of the configuration file](#change-config-file).
-* [Change the location of the PID file](#change-pid).
-* [Change the user and runtime mode](#agent-running-mode).
-* [Configure the plugin directory](#configure-plugin).
-* [Configure the agent directory](#agent-directory).
-* [Configure the log file](#log-file).
-* [Change the location of the agent binary](#agent-binary).
+- [Change the location of the configuration file](#change-config-file).
+- [Change the location of the PID file](#change-pid).
+- [Change the user and runtime mode](#agent-running-mode).
+- [Configure the plugin directory](#configure-plugin).
+- [Configure the agent directory](#agent-directory).
+- [Configure the log file](#log-file).
+- [Change the location of the agent binary](#agent-binary).
 
 ## Install the service script [#install-service-script]
 
 Before you proceed to install the service script, you need to determine which service manager your system is using:
 
-* If you use one of the supported service managers (SystemD, SysV, and Upstart), use the service script provided in the tarball.
-* If you use a service manager we do not support, you must write your own service script.
+- If you use one of the supported service managers (SystemD, SysV, and Upstart), use the service script provided in the tarball.
+- If you use a service manager we do not support, you must write your own service script.
 
 <Callout variant="important">
   In case of doubt, check your Linux distribution's official documentation.
@@ -148,11 +153,14 @@ Before you proceed to install the service script, you need to determine which se
 
       Based on this output, Upstart is the service manager, since it's the command that obtained a return.
     </Callout>
+
   </Collapser>
 </CollapserGroup>
 
 <Callout variant="important">
-  Before copying the service manager script, check if you need to change the user, the path of the agent’s binary, or the pid file location. All these changes need to be reflected in the service script.
+  Before copying the service manager script, check if you need to change the
+  user, the path of the agent’s binary, or the pid file location. All these
+  changes need to be reflected in the service script.
 </Callout>
 
 If you use one of the supported service managers, install the service script for your host:
@@ -168,6 +176,7 @@ If you use one of the supported service managers, install the service script for
        ```
        systemctl enable newrelic-infra.service
        ```
+
   </Collapser>
 
   <Collapser
@@ -181,6 +190,7 @@ If you use one of the supported service managers, install the service script for
        update-rc.d newrelic-infra defaults
        update-rc.d newrelic-infra enable
        ```
+
   </Collapser>
 
   <Collapser
@@ -193,6 +203,7 @@ If you use one of the supported service managers, install the service script for
        ```
        initctl reload-configuration
        ```
+
   </Collapser>
 </CollapserGroup>
 
@@ -204,9 +215,9 @@ The infrastructure agent includes a configuration file, usually named `newrelic-
 
 By default, the agent searches for the configuration file in one of these locations:
 
-* `newrelic-infra.yml` (working directory root folder)
-* `/etc/newrelic-infra.yml`
-* `/etc/newrelic-infra/newrelic-infra.yml`
+- `newrelic-infra.yml` (working directory root folder)
+- `/etc/newrelic-infra.yml`
+- `/etc/newrelic-infra/newrelic-infra.yml`
 
 To specify a different location, use the `-config` flag command-line. For example:
 
@@ -238,6 +249,7 @@ To make this change permanent, edit the service script:
        `EXTRA_OPTS="-config config_file"` (with the quotation marks).
     4. Replace `config_file` with the path to the config file you want to use.
     5. Save the file.
+
   </Collapser>
 
   <Collapser
@@ -256,7 +268,8 @@ To make this change permanent, edit the service script:
 The infrastructure agent uses a `pid-file` to keep the process identification number (pid), which is used to identify a running instance of the agent. How to change the location of the `pid-file` depends on [how the agent is configured](/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#precedence).
 
 <Callout variant="important">
-  By default, we recommend that the agent creates the `pid-file`. You can edit the location if necessary.
+  By default, we recommend that the agent creates the `pid-file`. You can edit
+  the location if necessary.
 </Callout>
 
 To change the location of the `pid-file`:
@@ -283,6 +296,7 @@ To change the location of the `pid-file`:
     ```
     chown nri-agent:nri-agent /var/run/newrelic-infra-custom/
     ```
+
   </Collapser>
 
   <Collapser
@@ -298,6 +312,7 @@ To change the location of the `pid-file`:
     <Callout variant="tip">
       Use this approach if someone else takes care of the `pid-file` lifecycle. For example, our `init` script sets the `PIDFILE` variable for some service managers, such as SysV, because they handle the creation and content of the `pid-file`.
     </Callout>
+
   </Collapser>
 </CollapserGroup>
 
@@ -306,7 +321,9 @@ To change the location of the `pid-file`:
 The Linux agent runs as `root` by default, but it also supports running with users with less privileges: `PRIVILEGED` and `UNPRIVILEGED`. For more information, see our [documentation on agent running modes](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-linux#agent-mode-intro).
 
 <Callout variant="important">
-  To execute the agent as a non-root user (`PRIVILEGED` or `UNPRIVILEGED`), make sure to grant read/write access to the folders and files provided in the tarball.
+  To execute the agent as a non-root user (`PRIVILEGED` or `UNPRIVILEGED`), make
+  sure to grant read/write access to the folders and files provided in the
+  tarball.
 </Callout>
 
 To change the running mode:
@@ -314,44 +331,45 @@ To change the running mode:
 1. Edit the service script:
 
    <CollapserGroup>
-     <Collapser
-       id="mode-systemd"
-       title="Systemd"
-     >
-       1. Open the service script `./newrelic-infra/etc/init_scripts/systemd/newrelic-infra.service`.
-       2. Search for the line `[Service]`.
-       3. Add the line `User=user_name`, and replace `user_name` with the user that you want to execute the agent (`PRIVILEGED` or `UNPRIVILEGED`).
-       4. Save the file.
-     </Collapser>
+  <Collapser
+    id="mode-systemd"
+    title="Systemd"
+  >
+    1. Open the service script `./newrelic-infra/etc/init_scripts/systemd/newrelic-infra.service`.
+    2. Search for the line `[Service]`.
+    3. Add the line `User=user_name`, and replace `user_name` with the user that you want to execute the agent (`PRIVILEGED` or `UNPRIVILEGED`).
+    4. Save the file.
+  </Collapser>
+
+   {' '}
+   <Collapser id="mode-sysv" title="SysV">
+     1. Open the service script
+     `./newrelic-infra/etc/init_scripts/sysv/newrelic-infra`. 2. Search for the
+     line `USER=root`. 3. Replace `root` with the user that you want to execute
+     the agent (`PRIVILEGED` or `UNPRIVILEGED`). 4. Save the file.
+   </Collapser>
 
      <Collapser
-       id="mode-sysv"
-       title="SysV"
-     >
-       1. Open the service script `./newrelic-infra/etc/init_scripts/sysv/newrelic-infra`.
-       2. Search for the line `USER=root`.
-       3. Replace `root` with the user that you want to execute the agent (`PRIVILEGED` or `UNPRIVILEGED`).
-       4. Save the file.
-     </Collapser>
+    id="mode-upstart"
+    title="Upstart"
+  >
+    1. Open the service script `./newrelic-infra/etc/init_scripts/upstart/newrelic-infra`.
+    2. Search for the line `exec /usr/bin/newrelic-infra`.
+    3. Replace it with `exec su -s /bin/sh -c ‘exec “$0” “$@“’ user_name-- /usr/bin/newrelic-infra`.
+    4. Replace `user_name` with the user that you want to execute the agent (`PRIVILEGED` or `UNPRIVILEGED`).
+    5. Save the file.
+  </Collapser>
+</CollapserGroup>
 
-     <Collapser
-       id="mode-upstart"
-       title="Upstart"
-     >
-       1. Open the service script `./newrelic-infra/etc/init_scripts/upstart/newrelic-infra`.
-       2. Search for the line `exec /usr/bin/newrelic-infra`.
-       3. Replace it with `exec su -s /bin/sh -c ‘exec “$0” “$@“’ user_name-- /usr/bin/newrelic-infra`.
-       4. Replace `user_name` with the user that you want to execute the agent (`PRIVILEGED` or `UNPRIVILEGED`).
-       5. Save the file.
-     </Collapser>
-   </CollapserGroup>
 2. If you're running the agent as `PRIVILEGED`, you must give it [two additional Linux capabilities](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-linux):
+
    1. Make sure the `libcap` library is installed in your host. (You need the `setcap` and `getcap` commands that come with it.)
    2. Extract the contents of the tarball and execute the following command with root permission:
 
       ```
       setcap CAP_SYS_PTRACE,CAP_DAC_READ_SEARCH=+ep ./newrelic-infra/usr/bin/newrelic-infra
       ```
+
    3. The run mode will be selected based on the current user and the Kernel Capabilities assigned to it.
 
 ## Configure the plugin directory [#configure-plugin]
@@ -360,9 +378,9 @@ The infrastructure agent allows you to install [integrations](/docs/infrastructu
 
 To overwrite the predefined location of the integration configuration file, use one of the following methods:
 
-* Set the location in the `NRIA_PLUGIN_DIR` environment variable.
-* Set the custom path in the `newrelic-infra.yml` configuration file using the `plugin_dir` field.
-* Pass it as a command line argument using `-plugin_dir` when you run the `newrelic-infra` binary.
+- Set the location in the `NRIA_PLUGIN_DIR` environment variable.
+- Set the custom path in the `newrelic-infra.yml` configuration file using the `plugin_dir` field.
+- Pass it as a command line argument using `-plugin_dir` when you run the `newrelic-infra` binary.
 
 ## Configure the agent directory [#agent-directory]
 
@@ -370,34 +388,38 @@ The agent requires its own defined directory to run the installed [integrations]
 
 The agent directory has the following structure and content:
 
-* `LICENSE`: Text file containing the New Relic Infrastructure agent license.
-* `custom-integrations`: Directory that stores the installed the [custom integrations](/docs/integrations/integrations-sdk/getting-started/introduction-infrastructure-integrations-sdk).
-* `newrelic-integrations`: Directory that stores the [New Relic official integrations](/docs/infrastructure/integrations/types-integrations).
-* `data`: Directory where the agent stores cache data (inventory).
+- `LICENSE`: Text file containing the New Relic Infrastructure agent license.
+- `custom-integrations`: Directory that stores the installed the [custom integrations](/docs/integrations/integrations-sdk/getting-started/introduction-infrastructure-integrations-sdk).
+- `newrelic-integrations`: Directory that stores the [New Relic official integrations](/docs/infrastructure/integrations/types-integrations).
+- `data`: Directory where the agent stores cache data (inventory).
 
 <Callout variant="important">
-  The user [running the agent](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-linux#agent-mode-intro) must have read/write permissions to the agent directory.
+  The user [running the
+  agent](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-linux#agent-mode-intro)
+  must have read/write permissions to the agent directory.
 </Callout>
 
 To overwrite the predefined location of the agent directory, use one of the following methods:
 
-* Set the location in the `NRIA_AGENT_DIR` environment variable.
-* Set the custom path in the `newrelic-infra.yml` configuration file using the `agent_dir` field.
-* Pass it as a command line argument using `-agent_dir` when you run the `newrelic-infra` binary.
+- Set the location in the `NRIA_AGENT_DIR` environment variable.
+- Set the custom path in the `newrelic-infra.yml` configuration file using the `agent_dir` field.
+- Pass it as a command line argument using `-agent_dir` when you run the `newrelic-infra` binary.
 
 ## Configure the log file [#log-file]
 
 By default the agent stores the log files in `/var/db/newrelic-infra/newrelic-infra.log`.
 
 <Callout variant="important">
-  The user [running the agent](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-linux#agent-mode-intro) must have write permissions on the log file.
+  The user [running the
+  agent](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-linux#agent-mode-intro)
+  must have write permissions on the log file.
 </Callout>
 
 To overwrite the predefined location of the log file, use one of the following methods:
 
-* Set the location in the `NRIA_LOG_FILE` environment variable.
-* Set the custom path in the `newrelic-infra.yml` configuration file using the `log_file` field.
-* Pass it as a command line argument using `-log_file` when you run the `newrelic-infra` binary.
+- Set the location in the `NRIA_LOG_FILE` environment variable.
+- Set the custom path in the `newrelic-infra.yml` configuration file using the `log_file` field.
+- Pass it as a command line argument using `-log_file` when you run the `newrelic-infra` binary.
 
 ## Change the location of the agent binary [#agent-binary]
 
@@ -414,15 +436,12 @@ To change the location of the executable, edit the service script:
     4. Save the file.
   </Collapser>
 
-  <Collapser
-    id="binary-location-sysv"
-    title="SysV"
-  >
-    1. Open the service script `./newrelic-infra/etc/init_scripts/sysv/newrelic-infra`.
-    2. Search for the line `DAEMON=/usr/bin/$NAME`.
-    3. Replace the path.
-    4. Save the file.
-  </Collapser>
+{' '}
+<Collapser id="binary-location-sysv" title="SysV">
+  1. Open the service script
+  `./newrelic-infra/etc/init_scripts/sysv/newrelic-infra`. 2. Search for the
+  line `DAEMON=/usr/bin/$NAME`. 3. Replace the path. 4. Save the file.
+</Collapser>
 
   <Collapser
     id="binary-location-upstart"
@@ -439,7 +458,7 @@ To change the location of the executable, edit the service script:
 
 You may also want to:
 
-* [Add custom attributes](/docs/Infrastructure-configure-your-agent#conf-custom_attributes) to annotate your infrastructure data.
-* [Connect your AWS account](/docs/infrastructure-amazon-aws-ec2-integration#connect) if your servers are hosted on Amazon EC2.
-* Add other [infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) to collect data from external services.
-* Manually [start, stop, restart, or check the agent status](/docs/infrastructure-start-stop-restart-check-agent-status#linux).
+- [Add custom attributes](/docs/Infrastructure-configure-your-agent#conf-custom_attributes) to annotate your infrastructure data.
+- [Connect your AWS account](/docs/infrastructure-amazon-aws-ec2-integration#connect) if your servers are hosted on Amazon EC2.
+- Add other [infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) to collect data from external services.
+- Manually [start, stop, restart, or check the agent status](/docs/infrastructure-start-stop-restart-check-agent-status#linux).


### PR DESCRIPTION
two docs had a redirect for their own file path which caused them to be inaccessible on the site:

`/docs/infrastructure/amazon-integrations/troubleshooting/aws-service-specific-api-rate-limiting/`
`/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-manual-install-infrastructure-agent-linux/`

this removes those redirects and makes the pages accessible again
(also my code formatter went crazy, sorry)