### PR TITLE
fix(root nav): adding guides entry back

### DIFF
--- a/src/nav/root.yml
+++ b/src/nav/root.yml
@@ -6,6 +6,8 @@ pages:
     path: /docs/using-new-relic
   - title: New Relic One
     path: /docs/new-relic-one/use-new-relic-one
+  - title: Guides and best practices
+    path: docs/new-relic-solutions
   - title: Account and user management
     path: /docs/accounts
   - title: Data and APIs


### PR DESCRIPTION
Putting 'Guides and best practices' back in home page root nav. Follow up to DOC-7457.