### PR TITLE
feat: Upcoming Ec2 keep legacy metadata configuration option details

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-ec2-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-ec2-monitoring-integration.mdx
@@ -39,7 +39,7 @@ You can change the polling frequency and filter data using [configuration option
 * New Relic polling interval: 5 minutes
 * Amazon CloudWatch data interval: [1 minute or 5 minutes](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ebs-metricscollected.html), depending on CloudWatch plan
 
-### Note about legacy tag format
+### Note about legacy tag format [#legacy-tag-format]
 
 Starting October 27, 2021, EC2 instances that start being monitored by New Relic have only the following metadata [tag](/docs/new-relic-one/use-new-relic-one/core-concepts/use-tags-help-organize-find-your-data) formats: 
 


### PR DESCRIPTION
Update from @zuluecho9: This will go live sometime soon after October 26 and when it does, we want to update the doc w/ the new date. 

Hello! Ismael here from the Beyond team. This is some documentation for a soon to be live new option in the EC2 Integration configuration panel. Feedback/changes welcome if you have them. 
Talk to me in slack @ ihernandez
