### PR TITLE
fix(infra integrations): add powerdns to nav file

### DIFF
--- a/src/nav/infrastructure.yml
+++ b/src/nav/infrastructure.yml
@@ -637,6 +637,8 @@ pages:
             path: /docs/infrastructure/host-integrations/host-integrations-list/postgresql-monitoring-integration
           - title: Port monitoring integration
             path: /docs/infrastructure/host-integrations/host-integrations-list/port-monitoring-integration
+          - title: PowerDNS monitoring integration
+            path: /docs/infrastructure/host-integrations/host-integrations-list/powerdns-monitoring-integration
           - title: RabbitMQ integration
             path: /docs/infrastructure/host-integrations/host-integrations-list/rabbitmq-monitoring-integration
           - title: Redis integration


### PR DESCRIPTION
Adding missing 'powerdns integration' doc to left nav