### PR TITLE
Update instructions to list source maps via node

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-api.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-api.mdx
@@ -91,7 +91,7 @@ Here are some examples of using the npm module via the command line.
 
     ```
     npm install -g @newrelic/publish-sourcemap
-publish-sourcemap <var>PATH_TO_SOURCE_MAP_FILE (local or remote)</var> <var>PATH_TO_ORIGINAL_FILE</var> --apiKey=<var>YOUR_NEW_RELIC_USER_API_KEY</var> --applicationId=<var>YOUR_NEW_RELIC_APP_ID</var> --repoUrl=<var>GITHUB_REPOSITORY_URL</var> --buildCommit=<var>GIT_BUILD_COMMIT_HASH</var>
+publish-sourcemap <var>PATH_TO_SOURCE_MAP_FILE (local or remote)</var> <var>PATH_TO_ORIGINAL_FILE</var> --apiKey=<var>YOUR_NEW_RELIC_USER_KEY</var> --applicationId=<var>YOUR_NEW_RELIC_APP_ID</var> --repoUrl=<var>GITHUB_REPOSITORY_URL</var> --buildCommit=<var>GIT_BUILD_COMMIT_HASH</var>
     ```
   </Collapser>
 


### PR DESCRIPTION
* What problems does this PR solve?
   Fix the instructions to list source maps via node, because the instructions are wrong and different to npm instrucctions.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.


### Before:
`var listSourcemaps = require(‘@newrelic/publish-sourcemap’).listSourcemaps

    listSourcemaps({
      sourcemapPath: 'SOURCE_MAP_FULL_PATH',
      javascriptUrl: 'JS_URL',
      applicationId: <var>YOUR_NEW_RELIC_APP_ID</var>,
      apiKey: '<var>YOUR_NEW_RELIC_USER_API_KEY</var>',
    }, function (err, res) { console.log(err || res.body)})`

### After:
`    var listSourcemaps = require(‘@newrelic/publish-sourcemap’).listSourcemaps

    listSourcemaps({
      applicationId: <var>YOUR_NEW_RELIC_APP_ID</var>,
      apiKey: '<var>YOUR_NEW_RELIC_USER_API_KEY</var>',
      limit: [Max number of results to return || 20]: ,
      offset: [Number of results to skip before returning || 0]: ,
    }, function (err, res) { console.log(err || res.body)})`

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.