### PR TITLE
Corrected duplicate anchor

### DIFF
--- a/src/content/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing.mdx
@@ -32,7 +32,7 @@ Requirements differ depending on your [pricing plan](/docs/accounts/original-acc
 * New Relic One pricing: requires Pro or Enterprise edition. 
 * Original pricing: requires New Relic help to enable it for your organization. For questions, contact your New Relic account representative.  
 
-## Enable Infinite Tracing [#requirements]
+## Enable Infinite Tracing [#enable-infinite-tracing]
 
 When enabling Infinite Tracing, you should ideally enable it for all associated services. If you have a mix of Infinite Tracing and our standard tracing solutions enabled, traces will have [configuration conflict issues](/docs/understand-dependencies/distributed-tracing/troubleshooting/infinite-tracing-trace-configuration-conflicts).
 


### PR DESCRIPTION
One of our contributors noticed that we had two separate sections with the same  anchor using "#requirements."

I corrected this. I didn't see any links directly to requirements, so even if there were, there is an existing "requirements" anchor to catch the traffic.