### PR TITLE
chore: if not in frontmatter set isFeatured to false, cleanup unused code

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -79,9 +79,6 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         filter: { fileAbsolutePath: { regex: "/src/content/whats-new/" } }
       ) {
         nodes {
-          frontmatter {
-            isFeatured
-          }
           fields {
             slug
           }
@@ -266,13 +263,8 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
 
   whatsNewPosts.nodes.forEach((node) => {
     const {
-      frontmatter: { isFeatured },
       fields: { slug },
     } = node;
-
-    if (!isFeatured) {
-      node.frontmatter.isFeatured = false;
-    }
 
     createLocalizedRedirect({
       locales,
@@ -296,21 +288,14 @@ exports.createSchemaCustomization = ({ actions }) => {
     pages: [NavYaml!]!
     rootNav: Boolean!
   }
+  type MarkdownRemark implements Node {
+    frontmatter: Frontmatter
+  }
+  type Frontmatter {
+    isFeatured: Boolean
+  }
   `;
 
-  createTypes(typeDefs);
-};
-
-exports.createSchemaCustomization = ({ actions }) => {
-  const { createTypes } = actions;
-  const typeDefs = `
-    type MarkdownRemark implements Node {
-      frontmatter: Frontmatter
-    }
-    type Frontmatter {
-      isFeatured: Boolean
-    }
-  `;
   createTypes(typeDefs);
 };
 
@@ -329,6 +314,12 @@ exports.createResolvers = ({ createResolvers }) => {
       rootNav: {
         resolve: (source) =>
           hasOwnProperty(source, 'rootNav') ? source.rootNav : false,
+      },
+    },
+    Frontmatter: {
+      isFeatured: {
+        resolve: (source) =>
+          hasOwnProperty(source, 'isFeatured') ? source.isFeatured : false,
       },
     },
   });


### PR DESCRIPTION
## Description

Sets `isFeatured` frontmatter to `false` if not set at all in frontmatter. Relevant to What's New posts.

Additional cleanup for unused code.

Will want to let PLG know about the change since they use this field in https://docswebsitedevelop-clangwhatsnewfeaturedfix.gtsb.io/api/nr1/content/nr1-announcements.json