### PR TITLE
Usage of Instant Observability dashboards

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -229,17 +229,17 @@ The following services / namespaces are supported:
 
 ## Curated dashboards [#curated-dashboards]
 
-A set of dashboards for most popular AWS Services are available in the New Relic [Instant Observaiblity](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/new-relic-quickstarts-overview/). 
+A set of dashboards for the most popular AWS Services are available in New Relic [Instant Observaiblity](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/new-relic-quickstarts-overview/). 
 
 ### How to import dashboards [#import-dashboards]
 
 Follow these steps in order to browse and import dashboards:
-1. Access the **Instant Observaiblity** app from the top bar in New Relic One. 
-2. Search for any AWS service name, in example: SQS, RDS, ELB, EC2, etc.
+1. Click **Instant Observability** from the top bar in New Relic One. 
+2. Search for any AWS service name, such as **AWS SQS**, **AWS RDS**, **AWS ELB**, or **AWS EC2**.
 3. Access the AWS service tile.
-4. Click on **Install this quickstarts** and select the target account.
-5. Confirm that AWS metric stream is already configured by clicking **Done**.
-6. Browse and adapt the dashboard based on your use cases.
+4. Click **Install this quickstarts** and select your account.
+5. Click **Done** to confirm that AWS metric stream is already configured.
+6. Browse and adapt the dashboard according to your needs.
 
 Have an interesting dashboard to share with the community? See [contribution guidelines](https://github.com/newrelic/newrelic-quickstarts#getting-started) in the Instant Observability Github repository.
 


### PR DESCRIPTION
## Give us some context

* With the launch of New Relic Instant Observability, there's a new process for customers to import the AWS dashboards for CloudWatch metric streams.
* Updated the metric streams section that explain how to import these dashboards.