### PR TITLE
feat: infra-agent for macOS is now GA

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -25,7 +25,7 @@ The infrastructure agent supports these processor architectures:
 * **Linux**: 64-bit for x86 processor architectures (also requires 64-bit package manager and dependencies)
 * **Windows**: both 32 and 64-bit for x86 processor architectures
 * **ARM**: arm64 architecture including [AWS Graviton 2 processor](https://aws.amazon.com/ec2/graviton/) is supported on compatible Linux operating sytems. On-host integrations are also supported (with the exception of the Oracle integration).
-* **macOS** (Beta): 64-bit x86 processor (M1 processor is not supported yet). 
+* **macOS**: 64-bit x86 processor (M1 processor is not supported yet). 
 
 ## Operating systems
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
@@ -11,7 +11,7 @@ metaDescription: 'Install New Relic infrastructure monitoring agent for macOS us
 
 import macOS from './images/mac-osx-logo.png'
 
-With New Relic's infrastructure monitoring agent for macOS (Beta), you can monitor key performance metrics on macOS hosts. The agent can run on your own hardware or in cloud systems such as Amazon EC2.
+With New Relic's infrastructure monitoring agent for macOS, you can monitor key performance metrics on macOS hosts. The agent can run on your own hardware or in cloud systems such as Amazon EC2.
 
 The infrastructure monitoring agent [is compatible](/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent) with all generally available, Apple supported macOS versions.
 
@@ -19,14 +19,13 @@ The infrastructure monitoring agent [is compatible](/docs/infrastructure/install
   To use infrastructure monitoring and the rest of our [observability platform](https://one.newrelic.com), join the New Relic family! [Sign up](https://newrelic.com/signup) to create your free account in only a few seconds. Then ingest up to 100GB of data for free each month. Forever.
 </Callout>
 
-## Install for macOS (Beta) [#install-macos]
+## Install for macOS [#install-macos]
 
 Before installation, be sure to review the [requirements](/docs/infrastructure/new-relic-infrastructure/getting-started/compatibility-requirements-new-relic-infrastructurets). Then, to install the infrastructure monitoring agent for macOS, you can use our [Guided Install](/docs/full-stack-observability/observe-everything/get-started/new-relic-guided-install-overview/), or follow the instructions in this document to complete a basic installation.
 
-## Limitations (Beta) [#limitations]
+## Limitations [#limitations]
 
 The following capabilities of the infrastructure agent are not yet available on macOS:
-  * [Process Monitoring](/attribute-dictionary/?event=ProcessSample). 
   * [Log forwarder](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent/).
   * [On-host integrations](/docs/integrations/host-integrations/get-started/introduction-host-integrations/) (including built-in integrations such as Docker and Flex).
   * Automated deployment via Configuration Management tools (Chef, Ansible, Puppet).


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* The Infrastructure Agent for macOS is now GA. Removing limitations solved with the GA release and any mention about  being in "Beta". 