### PR TITLE
fix(Alerts): Amended incorrect/duplicate id in Collapser in customize-your-webhook-payload

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/customize-your-webhook-payload.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/customize-your-webhook-payload.mdx
@@ -498,7 +498,7 @@ The following examples show a webhook payload using both the default dynamic var
   </Collapser>
 
   <Collapser
-    id="json-example"
+    id="form-example"
     title="Form webhook example"
   >
     <Callout variant="important">


### PR DESCRIPTION
## Give us some context

While reviewing some docs today, I noticed that the `id` assigned to the collapser for the form example had duplicated the one for the JSON example (this in "Customize your webhook payload"). De-duped and fixed the id for the form example.