### PR TITLE
Disable clickable links to auto index / landing pages in left nav

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -22,7 +22,6 @@ const autoLinkHeaders = {
 module.exports = {
   flags: {
     DEV_SSR: true,
-    PRESERVE_WEBPACK_CACHE: true,
     PRESERVE_FILE_DOWNLOAD_CACHE: true,
   },
   siteMetadata: {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "^2.0.0-next.8",
     "@mdx-js/react": "^2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "^3.3.0",
+    "@newrelic/gatsby-theme-newrelic": "^3.3.2",
     "@splitsoftware/splitio-react": "^1.2.4",
     "babel-jest": "^26.3.0",
     "common-tags": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "^2.0.0-next.8",
     "@mdx-js/react": "^2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "^3.3.2",
+    "@newrelic/gatsby-theme-newrelic": "^3.3.3",
     "@splitsoftware/splitio-react": "^1.2.4",
     "babel-jest": "^26.3.0",
     "common-tags": "^1.8.0",

--- a/src/@newrelic/gatsby-theme-newrelic/components/NavItem.js
+++ b/src/@newrelic/gatsby-theme-newrelic/components/NavItem.js
@@ -1,0 +1,181 @@
+import React, { useEffect, useLayoutEffect, useState, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/react';
+import { graphql, useStaticQuery } from 'gatsby';
+import { useLocation } from '@reach/router';
+
+import {
+  NavLink,
+  TextHighlight,
+  usePrevious,
+  useLocale,
+  useNavigation,
+  stripTrailingSlash,
+} from '@newrelic/gatsby-theme-newrelic';
+
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+const NavItem = ({
+  page,
+  __parent: parent,
+  __depth: depth = 0,
+  __root: root,
+}) => {
+  const locale = useLocale();
+  const location = useLocation();
+  const { searchTerm } = useNavigation();
+  const matchesSearch = searchTerm
+    ? matchesSearchTerm(page, searchTerm)
+    : false;
+  const pathname = stripTrailingSlash(location.pathname).replace(
+    new RegExp(`\\/${locale.locale}(?=\\/)`),
+    ''
+  );
+  const containsCurrentPage = useMemo(() => containsPage(page, pathname), [
+    page,
+    pathname,
+  ]);
+  const isCurrentPage = page.url === pathname;
+  const shouldExpand = isCurrentPage || containsCurrentPage;
+  const hasChangedPage = pathname !== usePrevious(pathname);
+  const [isExpanded, setIsExpanded] = useState(shouldExpand);
+  const toggle = (expanded) => !expanded;
+
+  const {
+    site: {
+      layout: { mobileBreakpoint },
+    },
+  } = useStaticQuery(graphql`
+    query {
+      site {
+        layout {
+          mobileBreakpoint
+        }
+      }
+    }
+  `);
+
+  useEffect(() => {
+    if (hasChangedPage) {
+      setIsExpanded(shouldExpand);
+    }
+  }, [hasChangedPage, shouldExpand]);
+
+  useEffect(() => {
+    if (matchesSearch && !shouldExpand) {
+      setIsExpanded(true);
+    }
+  }, [matchesSearch, shouldExpand, searchTerm]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!searchTerm) {
+      setIsExpanded(shouldExpand);
+    }
+  }, [searchTerm, shouldExpand]);
+
+  return (
+    <div
+      css={css`
+        --icon-size: 1.5rem;
+        --icon-spacing: 0.5rem;
+        --nav-link-padding: 1rem;
+        display: ${matchesSearch || !searchTerm ? 'block' : 'none'};
+        padding-left: ${parent == null ? '0' : 'var(--nav-link-padding)'};
+
+        ${mobileBreakpoint &&
+        css`
+          @media screen and (max-width: ${mobileBreakpoint}) {
+            padding-left: 0;
+          }
+        `}
+      `}
+    >
+      <NavLink
+        active={isCurrentPage}
+        to={page.pages?.length > 0 ? null : page.url}
+        icon={page.icon}
+        isExpanded={isExpanded}
+        expandable={page.pages?.length > 0}
+        onClick={() => {
+          setIsExpanded(() => !isExpanded);
+        }}
+        onToggle={() => setIsExpanded(toggle)}
+        mobileBreakpoint={mobileBreakpoint}
+        css={css`
+          padding-left: ${root?.icon
+            ? 'calc(var(--icon-size) + var(--icon-spacing))'
+            : 'var(--nav-link-padding)'};
+
+          ${mobileBreakpoint &&
+          css`
+            @media screen and (max-width: ${mobileBreakpoint}) {
+              --border-width: 4px;
+
+              padding-left: ${getMobilePadding({ parent, depth })};
+            }
+          `}
+        `}
+      >
+        {searchTerm ? (
+          <TextHighlight text={page.title} match={searchTerm} />
+        ) : (
+          page.title
+        )}
+      </NavLink>
+
+      {isExpanded &&
+        page.pages?.map((child) => (
+          <NavItem
+            key={child.url || child.title}
+            page={child}
+            __parent={page}
+            __depth={depth + 1}
+            __root={depth === 0 ? page : root}
+          />
+        ))}
+    </div>
+  );
+};
+
+const page = PropTypes.shape({
+  title: PropTypes.string.isRequired,
+  icon: PropTypes.string,
+  url: PropTypes.string,
+  pages: PropTypes.arrayOf(PropTypes.object),
+});
+
+NavItem.propTypes = {
+  __parent: page,
+  __depth: PropTypes.number,
+  page: page.isRequired,
+  __root: page,
+};
+
+const getMobilePadding = ({ parent, depth }) => {
+  if (parent == null) {
+    return 'calc(var(--nav-link-padding) - var(--border-width))';
+  }
+
+  return parent?.icon
+    ? `calc(${depth} * var(--nav-link-padding) + var(--icon-size) + var(--icon-spacing) - var(--border-width))`
+    : `calc(${depth + 1} * var(--nav-link-padding) - var(--border-width))`;
+};
+
+const containsPage = (page, url) => {
+  if (page.url === url) {
+    return true;
+  }
+
+  if (page.pages == null || page.pages.length === 0) {
+    return false;
+  }
+
+  return page.pages.some((child) => containsPage(child, url));
+};
+
+const matchesSearchTerm = (page, searchTerm) =>
+  new RegExp(searchTerm, 'i').test(page.title) ||
+  (page.pages || []).some((child) => matchesSearchTerm(child, searchTerm));
+
+export default NavItem;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3483,10 +3483,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-3.3.0.tgz#66ba001657f5f6b8f96d52a3dd20ec958830b708"
-  integrity sha512-f6Kp2A3JCkLyHUE+NdeQPw7nC4MVyuhpMfWp+rGYCPZdkpCa/ohxvn5Z6+zybCy/pSy1ok8hE68T2AkqFqjCow==
+"@newrelic/gatsby-theme-newrelic@^3.3.2":
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-3.3.2.tgz#acdda922bb1ddef6e22627c10d61ecb5c8e411a0"
+  integrity sha512-pWboMGplw3S+oySFY8xLVe/se4cPrb8pyTvg7kpz3lXFEDuvSxS1QvEQDycZ/i1ORsz56NA3s+Bf0Q/e3kxzgw==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3483,10 +3483,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-3.3.2.tgz#acdda922bb1ddef6e22627c10d61ecb5c8e411a0"
-  integrity sha512-pWboMGplw3S+oySFY8xLVe/se4cPrb8pyTvg7kpz3lXFEDuvSxS1QvEQDycZ/i1ORsz56NA3s+Bf0Q/e3kxzgw==
+"@newrelic/gatsby-theme-newrelic@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-3.3.3.tgz#ca9f880ba37f6301eb1b7b85f032b678f3129b84"
+  integrity sha512-hQ3m/Of13dHbT0hhVuWudR5GCs6SthtctjqRPhXVW7Bryrc101PT56a8f+xxlbTAy7+0WakAgHWrszoBv2deHA==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
## Description

Shadows the theme's `NavItem` component and does not set a URL in the `to` prop if the item has children (aka, not a leaf node 🤓 ). 

## Related issues / PRs
Closes https://github.com/newrelic/docs-website/issues/4516

## Screenshot(s)

https://user-images.githubusercontent.com/2952843/138965143-9a4f5d52-503b-421a-814e-30565d4d46db.mp4


