### PR TITLE
chore(pr comment bot): Gatsby Cloud preview

### DIFF
--- a/.github/workflows/auto-comment.yml
+++ b/.github/workflows/auto-comment.yml
@@ -10,6 +10,7 @@ jobs:
           pullRequestOpened: |
             Hi @{{ author }} 👋
             Thanks for your pull request! Your PR is in a queue, and a writer will take a look soon. We generally publish small edits within one business day, and larger edits within three days.
+            Gatsby Cloud will automatically generate a preview of your request, and will comment with a link when the preview is ready (usually 20 to 30 minutes).
 
           issuesOpened: |
             Hi @{{ author }} 👋


### PR DESCRIPTION
Would address the question we got in #documentation about previews. Might just be overkill though?