### PR TITLE
chore: Update docs release process

### DIFF
--- a/src/content/docs/style-guide/writer-workflow/github-intro.mdx
+++ b/src/content/docs/style-guide/writer-workflow/github-intro.mdx
@@ -137,7 +137,7 @@ To start a release:
 
 1. Create a branch based off develop. In Github Desktop, you can do this by clicking **Current branch** in the top header and then selecting devlop.
 2. Name the branch following this pattern: `daily-release/mm-dd-yy-time`. Here's an example: `daily-release/10-27-21-morning`. There are branch protections on all branches that follow the `daily-release/*` pattern.
-3. Create a Pull Request into main based from this branch. Pull requests default to merging into develop, so ensure you select main.
+3. Create a pull request into main based from this branch. Pull requests default to merging into develop, so ensure you select main.
 4. Wait until all the checks complete, and then merge the pull request.
 
 * Slackbot will remind us about this in #docs_deploys.

--- a/src/content/docs/style-guide/writer-workflow/github-intro.mdx
+++ b/src/content/docs/style-guide/writer-workflow/github-intro.mdx
@@ -130,8 +130,16 @@ As a **Hero or Sidekick**, make sure you attend to the following throughout your
 * Don't reference internal people by name. If they have a GH account, @mention their GH handle. If they don't, talk instead about teams ("talk to a browser team engineer" or "Support Engineer") rather than people.
 * You can mention the #documentation channel and hero.
 
-## Merge from develop into main work (or, when do we publish?) [#merging-main]
-The Hero currently merges three times a day: At 9 AM, noon, and 3 PM Pacific.
+## Merge releases into main work (or, when do we publish?) [#merging-main]
+The Hero currently merges three times a day: At 9 AM (morning), 12 PM (noon), and 3 PM (afternoon) Pacific. We merge release branches into develop to avoid interuptions when someone merges into develop during a release. Read more about this workflow [here](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
+
+To start a release:
+
+1. Create a branch based off develop. In Github Desktop, you can do this by clicking **Current branch** in the top header and then selecting devlop.
+2. Name the branch following this pattern: `daily-release/mm-dd-yy-time`. Here's an example: `daily-release/10-27-21-morning`. There are branch protections on all branches that follow the `daily-release/*` pattern.
+3. Create a Pull Request into main based from this branch. Pull requests default to merging into develop, so ensure you select main.
+4. Wait until all the checks complete, and then merge the pull request.
+
 * Slackbot will remind us about this in #docs_deploys.
 * The hero (or delegate) is the one who should create a PR for this and merge it.
 

--- a/src/content/docs/style-guide/writer-workflow/github-intro.mdx
+++ b/src/content/docs/style-guide/writer-workflow/github-intro.mdx
@@ -135,9 +135,10 @@ The Hero currently merges three times a day: At 9 AM (morning), 12 PM (noon), an
 
 To start a release:
 
-1. Create a branch based off develop. In Github Desktop, you can do this by clicking **Current branch** in the top header and then selecting develop.
-2. Name the branch following this pattern: `daily-release/mm-dd-yy-time`. Here's an example: `daily-release/10-27-21-morning`. There are branch protections on all branches that follow the `daily-release/*` pattern.
-3. Create a pull request into main from your new daily release branch. You can do this in GitHub Desktop or on Github.com. Pull requests default to merging into develop, so ensure you select main as the `base` branch in the left side of the page.
+1. Create a branch based off develop Github Desktop by clicking **Current branch** in the top header, clicking **New Branch**, and then selecting develop.
+2. Name the branch following this pattern: `daily-release/mm-dd-yy-morning/noon/evening`. Here's an example: `daily-release/10-27-21-morning`.
+3. Push your changes up 
+3. Create a pull request into main from your new daily release branch.  Pull requests default to merging into develop, so ensure you select main as the `base` branch in the left side of the page.
 4. Wait until all the checks complete, and then merge the pull request.
 
 * Slackbot will remind us about this in #doc_site_deploys.

--- a/src/content/docs/style-guide/writer-workflow/github-intro.mdx
+++ b/src/content/docs/style-guide/writer-workflow/github-intro.mdx
@@ -137,8 +137,8 @@ To start a release:
 
 1. Create a branch based off develop Github Desktop by clicking **Current branch** in the top header, clicking **New Branch**, and then selecting develop.
 2. Name the branch following this pattern: `daily-release/mm-dd-yy-morning/noon/evening`. Here's an example: `daily-release/10-27-21-morning`.
-3. Push your changes up 
-3. Create a pull request into main from your new daily release branch.  Pull requests default to merging into develop, so ensure you select main as the `base` branch in the left side of the page.
+3. Push your changes by clicking **Push Origin** in GitHub Desktop.
+3. Create a pull request into main from your new daily release branch by .  Pull requests default to merging into develop, so ensure you select main as the `base` branch in the left side of the page.
 4. Wait until all the checks complete, and then merge the pull request.
 
 * Slackbot will remind us about this in #doc_site_deploys.

--- a/src/content/docs/style-guide/writer-workflow/github-intro.mdx
+++ b/src/content/docs/style-guide/writer-workflow/github-intro.mdx
@@ -135,7 +135,7 @@ The Hero currently merges three times a day: At 9 AM (morning), 12 PM (noon), an
 
 To start a release:
 
-1. Create a branch based off develop Github Desktop by clicking **Current branch** in the top header, clicking **New Branch**, and then selecting develop.
+1. Create a branch based off develop Github Desktop by clicking **Current Branch** in the top header, clicking **New Branch** in the dropdown, and then selecting **Develop**.
 2. Name the branch following this pattern: `daily-release/mm-dd-yy-morning/noon/evening`. Here's an example: `daily-release/10-27-21-morning`.
 3. Push your changes by clicking **Push Origin** in GitHub Desktop.
 4. Create a pull request into main from your new daily release branch by clicking **Create Pull Request**. This will open a pull request screen on [github.com](github.com). Pull requests default to merging into develop, so select main as the `base` branch in the left side of the page and then click `Submit Pull Request`.

--- a/src/content/docs/style-guide/writer-workflow/github-intro.mdx
+++ b/src/content/docs/style-guide/writer-workflow/github-intro.mdx
@@ -135,12 +135,12 @@ The Hero currently merges three times a day: At 9 AM (morning), 12 PM (noon), an
 
 To start a release:
 
-1. Create a branch based off develop. In Github Desktop, you can do this by clicking **Current branch** in the top header and then selecting devlop.
+1. Create a branch based off develop. In Github Desktop, you can do this by clicking **Current branch** in the top header and then selecting develop.
 2. Name the branch following this pattern: `daily-release/mm-dd-yy-time`. Here's an example: `daily-release/10-27-21-morning`. There are branch protections on all branches that follow the `daily-release/*` pattern.
-3. Create a pull request into main based from this branch. Pull requests default to merging into develop, so ensure you select main.
+3. Create a pull request into main from your new daily release branch. You can do this in GitHub Desktop or on Github.com. Pull requests default to merging into develop, so ensure you select main as the `base` branch in the left side of the page.
 4. Wait until all the checks complete, and then merge the pull request.
 
-* Slackbot will remind us about this in #docs_deploys.
+* Slackbot will remind us about this in #doc_site_deploys.
 * The hero (or delegate) is the one who should create a PR for this and merge it.
 
 ## Github labels [#labels]

--- a/src/content/docs/style-guide/writer-workflow/github-intro.mdx
+++ b/src/content/docs/style-guide/writer-workflow/github-intro.mdx
@@ -113,7 +113,7 @@ The docs board has the following columns:
 </table>
 
 As a **Hero or Sidekick**, make sure you attend to the following throughout your day:
-* Check in with the Hero/Sidekick at the start of your day (especially on Monday at the start of the week). Don’t forget to sync with the BCN hero if necessary.
+* Check in with the Hero/Sidekick at the start of your day (especially on Monday at the start of the week). Don’t forget to sync with the BCN Hero if necessary.
 * Watch for incoming PRs in #docs_deploys, and review everything in the Needs triage column. Drag cards from that column to the appropriate column.
 * Work through the cards in the  Hero: to do column.
 
@@ -131,18 +131,18 @@ As a **Hero or Sidekick**, make sure you attend to the following throughout your
 * You can mention the #documentation channel and hero.
 
 ## Merge releases into main work (or, when do we publish?) [#merging-main]
-The Hero currently merges three times a day: At 9 AM (morning), 12 PM (noon), and 3 PM (afternoon) Pacific. We merge release branches into develop to avoid interuptions when someone merges into develop during a release. Read more about this workflow [here](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
+The Hero currently merges three times a day: At 9 AM (morning), 12 PM (noon), and 3 PM (evening) Pacific. We merge release branches into develop to avoid interuptions when someone merges into develop during a release. Read more about this workflow [here](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
 
 To start a release:
 
 1. Create a branch based off develop Github Desktop by clicking **Current branch** in the top header, clicking **New Branch**, and then selecting develop.
 2. Name the branch following this pattern: `daily-release/mm-dd-yy-morning/noon/evening`. Here's an example: `daily-release/10-27-21-morning`.
 3. Push your changes by clicking **Push Origin** in GitHub Desktop.
-3. Create a pull request into main from your new daily release branch by .  Pull requests default to merging into develop, so ensure you select main as the `base` branch in the left side of the page.
-4. Wait until all the checks complete, and then merge the pull request.
+4. Create a pull request into main from your new daily release branch by clicking **Create Pull Request**. This will open a pull request screen on [github.com](github.com). Pull requests default to merging into develop, so select main as the `base` branch in the left side of the page and then click `Submit Pull Request`.
+5. Wait until all the checks complete, and then merge the pull request.
 
-* Slackbot will remind us about this in #doc_site_deploys.
-* The hero (or delegate) is the one who should create a PR for this and merge it.
+
+All branches that follow the `daily-release/mm-dd-yy-morning` pattern are [protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches). This means the branches can't be deleted or pushed to by non-admins.
 
 ## Github labels [#labels]
 


### PR DESCRIPTION
We have run into quite a few issues with our current release process. This new release process solves two main issues:

1. Merges to develop interrupting merges to main
2. Merges to develop breaking the Gatsby cloud builds for merges to main.

By adding an additional step, creating a release branch, we should be able to completely solve the two issues above. See this image for a visual understanding of how this will work:
![rel](https://user-images.githubusercontent.com/42678939/139128837-9d440507-4dea-45ae-97dd-de59c235a539.png)


~~DevEn is currently working on a few dev changes needed to implement this, so we should only roll this out once those are in place. ~~

All DevEn work is now complete. This is good to go as soon as the team gives the OK.
 
See #4569 for more context. 