### PR TITLE
chore(errors inbox): Copyedit formatting and style

### DIFF
--- a/src/content/docs/errors-inbox/errors-inbox.mdx
+++ b/src/content/docs/errors-inbox/errors-inbox.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Errors inbox: one inbox for all your errors'
-metaDescription: "New Relic Errors Inbox is an error tracking solution designed to put you in the driver’s seat when it comes to detecting, triaging, and resolving errors across your full application stack."
+metaDescription: "New Relic errors inbox is an error tracking solution designed to put you in the driver’s seat when it comes to detecting, triaging, and resolving errors across your full application stack."
 redirects:
   - /docs/error-tracking
   - /docs/apm/apm-ui-pages/errors-inbox/errors-inbox
@@ -8,7 +8,7 @@ redirects:
 
 New Relic errors inbox is a single place to proactively detect, triage, and take action on all the errors before they impact customers. Receive alerts whenever a critical, customer-impacting error arises via your preferred communication channel, like Slack.
 
-Resolve errors faster with errors from across your stack, including all APM, browser(RUM), mobile, and serverless (AWS Lambda) data, displayed on one screen. Errors are grouped to cut down on noise and collaborating across teams is easy with shared visibility to the same error data. 
+Resolve errors faster with errors from across your stack, including all APM, browser (RUM), mobile, and serverless (AWS Lambda) data, displayed on one screen. Errors are grouped to cut down on noise and collaborating across teams is easy with shared visibility to the same error data. 
 
 <Callout variant="important">
 Errors inbox is not available in the EU region.
@@ -137,7 +137,7 @@ Displays a log of the status changes and user assignments of an error group.
 The discussions provides room for detailed and organized collaboration. This is key to looping in collaborators and ensuring the entire team has the same context regardless of where they sit. Discussions includes:
 
 1. **Threaded conversations**: Reply directly to top level comments to tie replies to specific posts.
-2. **Comment deletion**: Delete comments. The content of the post will be removed, but the box will remain with the message “comment deleted.”
+2. **Comment deletion**: Delete comments. The content of the post will be removed, but the box will remain with the message **comment deleted**.
 3. **Markdown support**: Add styling and links to your comments in Markdown. 
 
 
@@ -150,10 +150,10 @@ Each inbox can be connected to a specific workspace and channel in Slack. To set
 
 1. If your Slack workspace does not have the [New Relic app](https://newrelic.slack.com/apps/AP92KQJS3-new-relic?tab=more_info) installed, do that first.
 2. From an inbox, select the **Inbox Settings** icon (looks like a gear) in the top right corner.
-3. Toggle the Slack button to "on" if it is "off".
-4. If no workspaces are available, click the "+" button to enable Slack with a one click Slack authentication.
+3. Toggle the Slack button to **on** if it is **off**.
+4. If no workspaces are available, click the <Icon name="fe-plus" /> plus button to enable Slack with a one click Slack authentication.
 5. Once authenticated, you will be able to select a Workspace and specific Channel to send notifications to.
-6. Click "Test" to ensure messages are being sent to the right channel.
+6. Click **Test** to ensure messages are being sent to the right channel.
 
 ## Connect errors inbox to CodeStream
 

--- a/src/content/docs/errors-inbox/errors-inbox.mdx
+++ b/src/content/docs/errors-inbox/errors-inbox.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Errors inbox: one inbox for all your errors'
-metaDescription: "New Relic errors inbox is an error tracking solution designed to put you in the driver’s seat when it comes to detecting, triaging, and resolving errors across your full application stack."
+metaDescription: "New Relic errors inbox is an error tracking solution designed to give you the tools to proactively detect, triage, and resolve errors across your full application stack."
 redirects:
   - /docs/error-tracking
   - /docs/apm/apm-ui-pages/errors-inbox/errors-inbox


### PR DESCRIPTION
Requesting @bradleycamacho as reviewer because errors inbox. In addition to the copy edits, I think we might want to take a fresh look at the metadescription, it feels pretty salesy:

> New Relic errors inbox is an error tracking solution designed to put you in the driver’s seat when it comes to detecting, triaging, and resolving errors across your full application stack.