### PR TITLE
Add release notes for Ruby Agent 8.1.0

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-810.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-810.mdx
@@ -28,6 +28,10 @@ downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.1.0.gem'
 
     Integers not wrapped in quotation marks can be passed to `error_collector.ignore_status_codes` in the `newrelic.yml` file. Our thanks goes to @elaguerta and @brammerl for resolving this issue!
 
+  * **Bugfix: allow add_method_tracer to be used on BasicObjects**
+
+    Previously, our add_method_tracer changes referenced `self.class` which is not available on BasicObjects. This has been fixed. Thanks to @toncid for bringing this issue to our attention.
+
 
 ## Support statement
 


### PR DESCRIPTION
This PR adds the release notes for our upcoming release 8.1.0 of the ruby agent.
