### PR TITLE
Adjust translation.json to incorporate correct children

### DIFF
--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -169,7 +169,7 @@
   "defaultRelatedContent": {
     "title": "For more help",
     "intro": "If you need more help, check out these support and learning resources:",
-    "list": "<0>Browse the <2>Explorers Hub</2> to get help from the community and join in discussions.</0><1>Find <2>answers on our sites and learn how to use our support portal</2>.</1><2>Run <2>New Relic Diagnostics</2>, our troubleshooting tool for Linux, Windows, and macOS.</2><3>Review New Relic's <1>data security</1> and <4>licenses</4> documentation.</3>"
+    "list": "<0>Browse the <2>Explorers Hub</2> to get help from the community and join in discussions.</0><1>Find <2>answers on our sites and learn how to use our support portal</2>.</1><2>Run <2>New Relic Diagnostics</2>, our troubleshooting tool for Linux, Windows, and macOS.</2><3>Review New Relic's <2>data security</2> and <6>licenses</6> documentation.</3>"
   },
   "subNav": {
     "homeLink": "Home",


### PR DESCRIPTION
We added to the DefaultRelatedContent component which threw off the numbering of the children in our translation component and caused some links to disappear. This adds the correct indexes
<img width="500" alt="Screen Shot 2021-10-27 at 2 31 43 PM" src="https://user-images.githubusercontent.com/39655074/139150391-f898f04b-bb53-4169-97fb-0068e96ec9f4.png">
