### PR TITLE
Added linkedAccount to Serverless Framework steps

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own.mdx
@@ -124,6 +124,7 @@ In the long term, it's usually less work to integrate New Relic into your existi
     newRelic:
       accountId: your-new-relic-account-id-here
       apiKey: your-new-relic-personal-api-key-here
+      linkedAccount: your-new-relic-integration-account-name-here
   ```
   </Collapser>
   <Collapser


### PR DESCRIPTION
Testing has determined that the linkedAccount parameter is required when configuring the layer via Serverless Framework. Adding to doco.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.