### PR TITLE
feat(drop-rules): Add beta feature documentation to drop attributes on aggregates

### DIFF
--- a/src/content/docs/data-apis/manage-data/drop-data-using-nerdgraph.mdx
+++ b/src/content/docs/data-apis/manage-data/drop-data-using-nerdgraph.mdx
@@ -345,7 +345,7 @@ To verify it's working, wait 3 to 5 minutes for the rule to be picked up and for
     
 The first query should drop to 0 while the second query should continue to hold steady. For more information on how to see the impact this will have on your cardiinality, check out [Understand and query high cardinality metrics](/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics).
 
-### Restritions
+### Restrictions
 
 All restrictions that apply to `DROP_ATTRIBUTES` apply to `DROP_ATTRIBUTES_FROM_METRIC_AGGREGATES` with the additional restriction that you can only target the `Metric` data type. They also do not work on `Metric` queries targeting data created by an [events to metrics](/docs/data-ingest-apis/get-data-new-relic/metric-api/events-metrics-service-create-metrics) rule or on `Metric` queries targeting [timeslice data](/docs/data-apis/understand-data/metric-data/query-apm-metric-timeslice-data-nrql).
 

--- a/src/content/docs/data-apis/manage-data/drop-data-using-nerdgraph.mdx
+++ b/src/content/docs/data-apis/manage-data/drop-data-using-nerdgraph.mdx
@@ -296,12 +296,18 @@ Creating rules about sensitive data can leak information about what kinds of dat
 
 Only new data will be dropped. Existing data [cannot be edited or deleted](/docs/telemetry-data-platform/ingest-manage-data/manage-data/manage-data-retention#data-deletion).
 
-## Drop attributes on Dimensional Metric Rollups
+## Drop attributes on dimensional metric rollups
 <Callout title="Beta Feature">
   This feature is currently in beta. [Sign up here]() to request access!
 </Callout>
 
-[Dimensional metrics](/docs/data-apis/understand-data/new-relic-data-types/#metrics-conceptual) aggregate metrics into rollups for long term storage and as a way to optimize longer term queries. It is these aggregate data upon which [metric cardinality limits](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes) are applied. With this feature you can now decide which attributes you don't need for long term storage and query, but would like to maintain for real time queries. For example, adding `containerId` as an attribute can be useful for live troubleshooting or recent analysis, but may not be needed when querying over longer periods of time for larger trends. Due it how unique something like `containerId` can be, it can quickly drive you towards your [metric cardinality limits](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes) which when hit stops the synthesis of rollups for the remainder of that UTC day. With this feature, you can keep the high cardinality attributes on the raw data and drop it from rollups which gives you more control over how quickly you approach your cardinaliity limits.
+[Dimensional metrics](/docs/data-apis/understand-data/new-relic-data-types/#metrics-conceptual) aggregate metrics into rollups for long term storage and as a way to optimize longer term queries. [Metric cardinality limits](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes) are applied to this data. 
+
+You can use this feature to decide which attributes you don't need for long term storage and query, but would like to maintain for real time queries. 
+
+For example, adding `containerId` as an attribute can be useful for live troubleshooting or recent analysis, but may not be needed when querying over longer periods of time for larger trends. Due it how unique something like `containerId` can be, it can quickly drive you towards your [metric cardinality limits](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes) which when hit stops the synthesis of rollups for the remainder of that UTC day. 
+
+This feature also allows you to keep the [high cardinality](link to high cardinality deep dive) attributes on the raw data and drop it from rollups which gives you more control over how quickly you approach your cardinaliity limits.
 
 ### Usage
 
@@ -330,7 +336,7 @@ Here is an example NerdGraph request:
     }
     ```
  
-To verify it is working wait 3 to 5 minutes for the rule to be picked up and for aggregate data to be generated. Then assuming the example NRQL above is your drop rule, run the following queries:
+To verify it's working, wait 3 to 5 minutes for the rule to be picked up and for aggregate data to be generated. Then assuming the example NRQL above is your drop rule, run the following queries:
 
     ```
     SELECT count(containerId) FROM Metric WHERE metricName = 'some.metric' TIMESERIES SINCE 2 hours ago

--- a/src/content/docs/data-apis/manage-data/drop-data-using-nerdgraph.mdx
+++ b/src/content/docs/data-apis/manage-data/drop-data-using-nerdgraph.mdx
@@ -307,7 +307,7 @@ You can use this feature to decide which attributes you don't need for long term
 
 For example, adding `containerId` as an attribute can be useful for live troubleshooting or recent analysis, but may not be needed when querying over longer periods of time for larger trends. Due it how unique something like `containerId` can be, it can quickly drive you towards your [metric cardinality limits](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes) which when hit stops the synthesis of rollups for the remainder of that UTC day. 
 
-This feature also allows you to keep the [high cardinality](link to high cardinality deep dive) attributes on the raw data and drop it from rollups which gives you more control over how quickly you approach your cardinaliity limits.
+This feature also allows you to keep the [high cardinality](/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics/) attributes on the raw data and drop it from rollups which gives you more control over how quickly you approach your cardinaliity limits.
 
 ### Usage
 

--- a/src/content/docs/data-apis/manage-data/drop-data-using-nerdgraph.mdx
+++ b/src/content/docs/data-apis/manage-data/drop-data-using-nerdgraph.mdx
@@ -296,6 +296,53 @@ Creating rules about sensitive data can leak information about what kinds of dat
 
 Only new data will be dropped. Existing data [cannot be edited or deleted](/docs/telemetry-data-platform/ingest-manage-data/manage-data/manage-data-retention#data-deletion).
 
+## Drop attributes on Dimensional Metric Rollups
+<Callout title="Beta Feature">
+  This feature is currently in beta. [Sign up here]() to request access!
+</Callout>
+
+[Dimensional metrics](/docs/data-apis/understand-data/new-relic-data-types/#metrics-conceptual) aggregate metrics into rollups for long term storage and as a way to optimize longer term queries. It is these aggregate data upon which [metric cardinality limits](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes) are applied. With this feature you can now decide which attributes you don't need for long term storage and query, but would like to maintain for real time queries. For example, adding `containerId` as an attribute can be useful for live troubleshooting or recent analysis, but may not be needed when querying over longer periods of time for larger trends. Due it how unique something like `containerId` can be, it can quickly drive you towards your [metric cardinality limits](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes) which when hit stops the synthesis of rollups for the remainder of that UTC day. With this feature, you can keep the high cardinality attributes on the raw data and drop it from rollups which gives you more control over how quickly you approach your cardinaliity limits.
+
+### Usage
+
+**Drop attributes from dimensional metrics rollups** (with optional filter). This uses `DROP_ATTRIBUTES_FROM_METRIC_AGGREGATES` **action** type and uses NRQL of the form:
+  ```
+  SELECT <var>dropAttr1</var>, <var>dropAttr2</var> FROM Metric (WHERE <var>OPTIONAL_FILTER</var>)
+  ```
+  
+Here is an example NerdGraph request:
+    ```
+    mutation {
+        nrqlDropRulesCreate(accountId: <a href="/docs/accounts/install-new-relic/account-setup/account-id"><var>YOUR_ACCOUNT_ID</var></a>, rules: [
+            {
+                action: DROP_ATTRIBUTES_FROM_METRIC_AGGREGATES
+                nrql: "SELECT containerId FROM Metric WHERE metricName = 'some.metric'
+                description: "Removes the containerId from long term querys."
+            }
+        ])
+        {
+            successes { id }
+            failures {
+                submitted { nrql }
+                error { reason description }
+            }
+        }
+    }
+    ```
+ 
+To verify it is working wait 3 to 5 minutes for the rule to be picked up and for aggregate data to be generated. Then assuming the example NRQL above is your drop rule, run the following queries:
+
+    ```
+    SELECT count(containerId) FROM Metric WHERE metricName = 'some.metric' TIMESERIES SINCE 2 hours ago
+    SELECT count(containerId) FROM Metric WHERE metricName = 'some.metric' TIMESERIES SINCE 2 hours ago RAW
+    ```
+    
+The first query should drop to 0 while the second query should continue to hold steady. For more information on how to see the impact this will have on your cardiinality, check out [Understand and query high cardinality metrics](/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics).
+
+### Restritions
+
+All restrictions that apply to `DROP_ATTRIBUTES` apply to `DROP_ATTRIBUTES_FROM_METRIC_AGGREGATES` with the additional restriction that you can only target the `Metric` data type. They also do not work on `Metric` queries targeting data created by a [events to metrics](/docs/data-ingest-apis/get-data-new-relic/metric-api/events-metrics-service-create-metrics) rule or on `Metric` queries targeting [timeslice data](/docs/data-apis/understand-data/metric-data/query-apm-metric-timeslice-data-nrql).
+
 ## Learn more
 
 Recommendations for learning more:


### PR DESCRIPTION
### What problems does this PR solve?

This is a beta feature we are planning to pilot that will give customers more control over their cardinality by allowing them to drop attributes off of rollup data but keep it on the raw data that can be queried in the near term.

### Add any context that will help us review your changes such as testing notes, links to related docs, screenshots, etc.

I tried to link to as many relevant docs as I could. We don't have much on the `RAW` keyword other than the [Tip on this doc](https://docs.newrelic.com/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics/), which I do link to. I tried to have each section of the doc for the other drop rule types represented in this beta feature section so that once GA'd this should be pretty simply integrated into the format of the rest of the doc. I felt it was more clear to keep all the beta content together rather than sprinkle it throughout the document.