### PR TITLE
fix(limits nav): un-indented a limits page to reduce clicks.

### DIFF
--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -58,9 +58,8 @@ pages:
         path: /docs/data-apis/manage-data/drop-data-using-nerdgraph
       - title: Know your data limits
         path: /docs/data-apis/manage-data/view-system-limits
-        pages:
-          - title: Query system limits
-            path: /docs/data-apis/manage-data/query-limits
+      - title: Query system limits
+        path: /docs/data-apis/manage-data/query-limits
       - title: NrIntegrationError event
         path: /docs/data-apis/manage-data/nrintegrationerror
   - title: Convert data to metrics


### PR DESCRIPTION
In support of the flatter navigation, removed a level of indent from one page in the nav.