### PR TITLE
style(homepage): Put most root nav elements in alpha order

### DIFF
--- a/src/nav/root.yml
+++ b/src/nav/root.yml
@@ -10,39 +10,39 @@ pages:
     path: /docs/new-relic-solutions
   - title: Account and user management
     path: /docs/accounts
+  - title: Alerts and Applied Intelligence
+    path: /docs/alerts-applied-intelligence
+  - title: Application monitoring (APM)	 		
+    path: /docs/apm
+  - title: Browser monitoring
+    path: /docs/browser
+  - title: CodeStream
+    path: /docs/codestream
   - title: Data and APIs
     path: /docs/data-apis
   - title: Data dictionary
     path: /attribute-dictionary  	
-  - title: CodeStream
-    path: /docs/codestream
   - title: Distributed tracing
     path: /docs/distributed-tracing
   - title: Errors inbox
     path: /docs/errors-inbox
-  - title: Logs
-    path: /docs/logs
-  - title: Alerts and Applied Intelligence
-    path: /docs/alerts-applied-intelligence
   - title: Infrastructure monitoring
     path: /docs/infrastructure
   - title: Kubernetes and Pixie
     path: /docs/kubernetes-pixie
-  - title: Application monitoring (APM)	 		
-    path: /docs/apm
-  - title: Serverless monitoring
-    path: /docs/serverless-function-monitoring
+  - title: Logs
+    path: /docs/logs
   - title: Mobile monitoring
     path: /docs/mobile-monitoring
-  - title: Browser monitoring
-    path: /docs/browser
   - title: Network monitoring
     path: /docs/network-performance-monitoring
+  - title: 'Release notes'
+    path: '/docs/release-notes'
+  - title: Serverless monitoring
+    path: /docs/serverless-function-monitoring
   - title: Synthetic monitoring
     path: /docs/synthetics
   - title: What's new?
     path: /whats-new
-  - title: 'Release notes'
-    path: '/docs/release-notes'
   - title: 'See our 400+ quickstarts'
     path: 'https://newrelic.com/instant-observability'

--- a/src/nav/root.yml
+++ b/src/nav/root.yml
@@ -8,6 +8,7 @@ pages:
     path: /docs/new-relic-one/use-new-relic-one
   - title: Guides and best practices
     path: /docs/new-relic-solutions
+  - title: section-break
   - title: Account and user management
     path: /docs/accounts
   - title: Alerts and Applied Intelligence
@@ -36,13 +37,15 @@ pages:
     path: /docs/mobile-monitoring
   - title: Network monitoring
     path: /docs/network-performance-monitoring
-  - title: 'Release notes'
-    path: '/docs/release-notes'
   - title: Serverless monitoring
     path: /docs/serverless-function-monitoring
   - title: Synthetic monitoring
     path: /docs/synthetics
+  - title: section-break
+  - title: 'Release notes'
+    path: '/docs/release-notes'
   - title: What's new?
     path: /whats-new
+  - title: section-break
   - title: 'See our 400+ quickstarts'
     path: 'https://newrelic.com/instant-observability'


### PR DESCRIPTION
Currently the root nav is in a bit of a mix of alphabetical and importance order. This PR puts it in alpha order except the Learn, New Relic One, and Guides categories. 

I've got two possible organizations, the other one is in #4624 