### PR TITLE
Chore: Add missing backtics to code references

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-810.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-810.mdx
@@ -30,7 +30,7 @@ downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.1.0.gem'
 
   * **Bugfix: allow add_method_tracer to be used on BasicObjects**
 
-    Previously, our add_method_tracer changes referenced `self.class` which is not available on BasicObjects. This has been fixed. Thanks to @toncid for bringing this issue to our attention.
+    Previously, our `add_method_tracer` changes referenced `self.class` which is not available on `BasicObjects`. This has been fixed. Thanks to @toncid for bringing this issue to our attention.
 
 
 ## Support statement


### PR DESCRIPTION
## Give us some context

Update Ruby 8.1.0 Release Notes to match an adjustment to the Changelog