### PR TITLE
fix: Add pre-IA history access instructions

### DIFF
--- a/src/content/docs/style-guide/writer-workflow/github-intro.mdx
+++ b/src/content/docs/style-guide/writer-workflow/github-intro.mdx
@@ -178,3 +178,14 @@ There are a few options for checking the history of a file:
 **Option 3: Git blame**
 
 Follow [Github's documentation](https://docs.github.com/en/github/managing-files-in-a-repository/managing-files-on-github/tracking-changes-in-a-file).
+
+<Callout variant="important">
+We had a large site restructure in October 2021 which lost most of file history for our docs. You can find an archived version of our site pre-rework in the [pre-IA-2021](https://github.com/newrelic/docs-website/tree/pre-IA-2021). You can navigate our the pre-rework version of our repo, including any now lost file history.
+
+Alternatively, you can use the following command in your terminal:
+```
+git log --follow "**/file_name_here.mdx"
+```
+
+This will output the commit history of that file. By default, it only shows the first few commits. You can scroll by pressing enter multiple times.
+ </Callout>

--- a/src/content/docs/style-guide/writer-workflow/github-intro.mdx
+++ b/src/content/docs/style-guide/writer-workflow/github-intro.mdx
@@ -187,5 +187,5 @@ Alternatively, you can use the following command in your terminal:
 git log --follow "**/file_name_here.mdx"
 ```
 
-This will output the commit history of that file. By default, it only shows the first few commits. You can scroll by pressing enter multiple times.
+This will output the commit history of that file. By default, it only shows the first few commits. You can scroll by pressing Return multiple times.
  </Callout>

--- a/src/content/docs/style-guide/writer-workflow/github-intro.mdx
+++ b/src/content/docs/style-guide/writer-workflow/github-intro.mdx
@@ -186,6 +186,11 @@ Alternatively, you can use the following command in your terminal:
 ```
 git log --follow "**/file_name_here.mdx"
 ```
-
 This will output the commit history of that file. By default, it only shows the first few commits. You can scroll by pressing Return multiple times.
+  
+For example, to find the commit history for  `vmware-vsphere-monitoring-integration.mdx`, I would run:
+```
+git log --follow "**/vmware-vsphere-monitoring-integration.mdx"
+```  
+
  </Callout>

--- a/src/content/docs/style-guide/writer-workflow/github-intro.mdx
+++ b/src/content/docs/style-guide/writer-workflow/github-intro.mdx
@@ -180,7 +180,7 @@ There are a few options for checking the history of a file:
 Follow [Github's documentation](https://docs.github.com/en/github/managing-files-in-a-repository/managing-files-on-github/tracking-changes-in-a-file).
 
 <Callout variant="important">
-We had a large site restructure in October 2021 which lost most of file history for our docs. You can find an archived version of our site pre-rework in the [pre-IA-2021](https://github.com/newrelic/docs-website/tree/pre-IA-2021). You can navigate our the pre-rework version of our repo, including any now lost file history.
+We had a large site restructure in October 2021 which lost most of the file history for our docs. You can find an archived version of our site pre-rework in the [pre-IA-2021](https://github.com/newrelic/docs-website/tree/pre-IA-2021) branch. By navigating the pre-rework version of our repo, you can find file history and more.
 
 Alternatively, you can use the following command in your terminal:
 ```


### PR DESCRIPTION
This adds instructions on how to access the file history for docs pre-IA rework. 