### PR TITLE
chore: errors inbox updates

### DIFF
--- a/src/content/docs/errors-inbox/errors-inbox.mdx
+++ b/src/content/docs/errors-inbox/errors-inbox.mdx
@@ -18,26 +18,31 @@ Errors inbox is not available in the EU region.
 
 Errors inbox provides a unified error tracking experience to detect and triage errors:
 
-- View and triage issues across applications and services that your team cares about.
+- View and triage issues across applications and services that your team cares about for faster error resolutions.
 - Proactive notifications with detailed error information in Slack
-- Error profiles to show similarities between error events and surface the root cause.
+- Error profiles to show similarities between error events and surface the root cause by analyzing attributes.
 - Analyze errors in context of the full stack and resolve errors with precision.
-- Triage and tackle errors, including APM, browser, mobile, and AWS Lambda Functions.
+- APM, browser, mobile, and AWS Lambda Functions errors are all captured in the same inbox.
 
 ## Set up errors inbox [#get-started]
 
 To enable errors inbox, follow these steps below. Afterwards, errors groups should start to appear in your inbox.
 
 1. From [one.newrelic.com](one.newrelic.com) select **More** in the top right and click **Errors inbox** from the dropdown.
-2. If this is your first time accessing errors inbox, you will be prompted to select a [workload](/docs/new-relic-one/use-new-relic-one/workloads/workloads-isolate-resolve-incidents-faster/) in the top left. 
+2. If this is your first time accessing errors inbox, you will be prompted to select a [workload](/docs/new-relic-one/use-new-relic-one/workloads/workloads-isolate-resolve-incidents-faster/) in the top left.
+3. If you have no workloads set up, you will be prompted [to create one](/docs/new-relic-one/use-new-relic-one/workloads/use-workloads/) before you can use errors inbox. 
 
-Once you select your workload, your inbox should populate with error groups. If you have no workloads set up, you will [need to create one](/docs/new-relic-one/use-new-relic-one/workloads/use-workloads/) before you can use errors inbox.
+Once you select your workload, your inbox should populate with error groups.
 
 ![This is an image of the main errors inbox UI](./images/errors-ui.png "ui-main")
 
 <figcaption>[one.newrelic.com](one.newrelic.com) > **More** > ** Errors inbox**</figcaption>
 
-### Errors groups
+## Monitor errors
+
+Once you've set up your errors inbox, you can begin proactively monitoring all errors in your stack:
+
+### Error groups
 
 Error groups are sets of events that make up a unique error.  Error groups are stored long term and contain metrics, activity log, discussions, and basic information about the unique error. Error groups are tied to the [entity](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/), making a change to the state of an error group in one errors inbox will impact all other inboxes that contain that entity.
 
@@ -63,9 +68,16 @@ You can also use the feedback tool in NR1 to share error groups that could use i
   </Collapser>
 </CollapserGroup>
 
+### Occurrences
+
+Your errors inbox displays the total number of occurrences of each error group within the selected timeframe. The corresponding sparkline chart displays the total number of occurrences per day over the selected timeframe as you hover over it.
+
+### Sort By Filter
+Using the dropdown in the top right, you can sort the list of grouped errors by the number of occurrences or by the error that was last seen (latest first).
+
 ## Triage errors
 
-### Statuses
+### Errors status
 
 Errors inbox enables you to triage error groups right from the main screen or from the error details page.  Triaging helps remove the noise from your errors inbox, and let’s you focus on the high impact errors that need attention.
 
@@ -73,24 +85,6 @@ You can set one of three statuses, and filter your inbox by status.
 - Unresolved: This is the default status of error groups.
 - Resolved: Setting an error as resolved will hide it from the default inbox view unless filters are updated to include resolved errors.  If events matching the error group fingerprint occur after marking an error group as resolved, it will automatically unresolve.  This can be useful for identifying regressions.
 - Ignored: Ignored will hide the error group from the inbox view unless filters are updated to include ignored errors, or until you stop ignoring the error group. 
-
-
-## Assign errors
-
-You can assign an error group to anyone.  Simply select the user from the assign dropdown menu.  You may also assign an error to any email address, even if they aren’t a New Relic user.
-
-You can update the filter in errors inbox to show only errors assigned to yourself, or a teammate.  
-
-Currently assigning an error group to a user does not send a notification. Notifications of assignment and changes to error groups will be coming soon.
-
-## Monitor your errors
-Once you've set up your errors inbox, you can begin proactively monitoring all errors in your stack:
-
-1. **Error groups**: Your errors inbox automatically groups your errors so you can easily review all the unique errors within your system.
-2. **Occurrences**: Your errors inbox displays the total number of occurrences of each errors within the selected timeframe. The corresponding sparkline chart displays the total number of occurrences per day over the selected timeframe.
-3. **Status**: You can set the status of an error by selecting the dropdown and choosing either **Unresolved**, **Resolve**, or **Ignore**. You can ignore errors to reduce noise, leave it unresolved, or proactively resolve the error.
-4. **Assign errors**: Assign errors directly to individuals. 
-5. **Sort by**: You can sort the list of grouped errors by number of occurrences or by the error that was last seen (latest first).
 
 ## Error details [#error-details]
 
@@ -144,9 +138,20 @@ The discussions provides room for detailed and organized collaboration. This is 
   </Collapser>  
 </CollapserGroup>
 
+
+## Assign errors
+
+You can assign an error group to anyone. Simply select the user from the assign dropdown menu. You may also assign an error to any email address, even if they aren’t a New Relic user.
+
+You can update the filter in errors inbox to show only errors assigned to yourself, or a teammate.  
+
+<Callout variant="important">
+Currently assigning an error group to a user does not send a notification. Notifications of assignment and changes to error groups will be coming soon.
+</Callout>
+
 ## Connect an inbox to Slack [#slack]
 
-Each inbox can be connected to a specific workspace and channel in Slack. To set this up, follow the steps below.
+When connected to Slack, new and resurfaced error groups will be sent to a Slack channel within seconds of them occurring.  This enables your team to quickly identify any new errors or regressions, and resolve them quickly with direct links to the stack trace.
 
 1. If your Slack workspace does not have the [New Relic app](https://newrelic.slack.com/apps/AP92KQJS3-new-relic?tab=more_info) installed, do that first.
 2. From an inbox, select the **Inbox Settings** icon (looks like a gear) in the top right corner.


### PR DESCRIPTION
This implements some updates to the errors inbox doc as requested by the PMM.

Reviewer, I would just focus on typos and briefly scanning the rest. I have a JIRA to take a deep look and rework this doc in the next sprint.