### PR TITLE
Left navigation follow ups

### DIFF
--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -731,7 +731,7 @@ pages:
                 path: /docs/apm/agents/php-agent/configuration/proxy-daemon-newreliccfg-settings
           - title: PHP agent API
             pages:
-              - title: API guide
+              - title: PHP agent API guide
                 path: /docs/apm/agents/php-agent/php-agent-api/guide-using-php-agent-api
               - title: newrelic_accept_distributed_trace_headers
                 path: /docs/apm/agents/php-agent/php-agent-api/newrelicacceptdistributedtraceheaders
@@ -940,7 +940,7 @@ pages:
                 path: /docs/apm/agents/python-agent/back-end-services/python-agent-celery
           - title: Python agent API            
             pages:
-              - title: Guide to the API
+              - title: Python agent API guide
                 path: /docs/apm/agents/python-agent/python-agent-api/guide-using-python-agent-api
               - title: Python agent API different call forms
                 path: /docs/apm/agents/python-agent/python-agent-api/python-agent-api-different-call-forms

--- a/src/nav/mobile.yml
+++ b/src/nav/mobile.yml
@@ -232,8 +232,6 @@ pages:
         pages:
           - title: iOS SDK API guide
             path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/ios-sdk-api-guide
-          - title: Add custom data
-            path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/add-custom-data
           - title: currentSessionId
             path: /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/current-session-id
           - title: incrementAttribute


### PR DESCRIPTION
I removed a dummy link about adding custom data in the iOS navigation taxonomy.

Also, I renamed a few links for consistency.