### PR TITLE
Fixing the anchor

### DIFF
--- a/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
+++ b/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
@@ -30,7 +30,7 @@ Here's an example of using NuGet via Visual Studio to install the .NET agent:
 
    <CollapserGroup>
      <Collapser
-       id="nuget-linux"
+       id="nuget-framework"
        title="Environment variables for monitoring .NET Framework applications"
      >
        ```


### PR DESCRIPTION
The anchor for the `Environment variables for monitoring .NET Framework applications` collapsor, it was set to the linux anchor.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve? broken anchor
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc. n/a
* If your issue relates to an existing GitHub issue, please link to it. n/a