### PR TITLE
Updating Kubernetes CPM Configuration Options Displayed

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
@@ -506,13 +506,24 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
       </thead>
 
       <tbody>
+
         <tr>
           <td>
             `synthetics.privateLocationKey`
           </td>
 
           <td>
-            **REQUIRED.** UUID of the Private Location, as found on the Private Location Web page.
+            **REQUIRED if `synthetics.privateLocationKeySecretName` is not set** UUID / [Private Location Key](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms#private-location-key) of the Private Location, as found on the Private Location Web page.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `synthetics.privateLocationKeySecretName`
+          </td>
+
+          <td>
+            **REQUIRED if `synthetics.privateLocationKey` is not set** name of the Kubernetes Secret that contains a key called privateLocationKey with the authentication key associated with your Synthetics Private Location
           </td>
         </tr>
 
@@ -525,6 +536,68 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
             Number of replicas to maintain with your StatefulSet installation
 
             Default: `1.`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `imagePullSecrets`
+          </td>
+
+          <td>
+            The name of a Secret object used to pull an image from a specified container registry
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `fullnameOverride`
+          </td>
+
+          <td>
+            Name override used for your StatefulSet installation in place of the default
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `appVersionOverride`
+          </td>
+
+          <td>
+            Release version of CPM to use in place of the version specified in [Chart.yml](https://github.com/newrelic/helm-charts/blob/master/charts/synthetics-minion)
+          </td>
+       </tr>
+      
+        <tr>
+          <td>
+            `synthetics.minionLogLevel`
+          </td>
+
+          <td>
+            When contacting New Relic Support, they may ask you to increase this to `"DEBUG"` or `"TRACE"`.
+
+            Default: `INFO.`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `synthetics.heavyWorkers`
+          </td>
+
+          <td>
+            The number of concurrent workers the minion will use to run heavy jobs (`BROWSER`, `SCRIPT_BROWSER`, `SCRIPT_API`). If undefined, the minion will use the value `2`. The maximum allowed value for this variable is `50`. For more information on monitor types, see [Types of Synthetics monitors](/docs/synthetics/new-relic-synthetics/getting-started/types-synthetics-monitors).
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `synthetics.lightweightWorkers`
+          </td>
+
+          <td>
+            The number of workers the minion will use to run lightweight jobs (`SIMPLE` ping jobs). If undefined, the minion will use `25 * synthetics.heavyWorkers`. Where `synthetics.heavyWorkers` is number defined in the previous environment variable. The maximum allowed value for this variable is `1250`. For more information on monitor types, see [Types of synthetic monitors](/docs/synthetics/new-relic-synthetics/getting-started/types-synthetics-monitors).
           </td>
         </tr>
 
@@ -554,21 +627,31 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
 
         <tr>
           <td>
-            `synthetics.minionApiProxy`
+            `synthetics.minionVsePassphrase`
           </td>
 
           <td>
-            Format: `"host:port"`.
+            If set, enables **verified script execution** and uses this value as a **passphrase**.
           </td>
         </tr>
 
         <tr>
           <td>
-            `synthetics.minionApiProxyAuth`
+            `synthetics.minionVsePassphraseSecretName`
           </td>
 
           <td>
-            Format: `"username:password"` - Support HTTP Basic Auth + additional authentication protocols supported by Chrome.
+            If set, enables verified script execution and uses this value to retrieve the passphrase from a Kubernetes secret with a key called minionVsePassphrase.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `synthetics.minionApiProxy`
+          </td>
+
+          <td>
+            Format: `"host:port"`.
           </td>
         </tr>
 
@@ -584,6 +667,17 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
 
         <tr>
           <td>
+            `synthetics.minionApiProxyAuth`
+          </td>
+
+          <td>
+            Format: `"username:password"` - Support HTTP Basic Auth + additional authentication protocols supported by Chrome.
+          </td>
+        </tr>
+
+
+        <tr>
+          <td>
             `synthetics.minionCheckTimeout`
           </td>
 
@@ -596,13 +690,25 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
 
         <tr>
           <td>
-            `synthetics.minionLogLevel`
+            `synthetics.minionUserDefinedEnvVariable`
           </td>
 
           <td>
-            When contacting New Relic Support, they may ask you to increase this to `"DEBUG"` or `"TRACE"`.
+            Format: [Example](#vars-scripted-monitors).
 
-            Default: `INFO.`
+            A locally hosted set of user defined key value pairs.
+          </td>
+        </tr>
+        
+        <tr>
+          <td>
+            `synthetics.minionJVMOpts`
+          </td>
+
+          <td>
+            Passes command line options to the internal JVM.
+
+            Default: `-server -XX:-UsePerfData`
           </td>
         </tr>
 
@@ -618,43 +724,163 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
 
         <tr>
           <td>
-            `synthetics.minionUserDefinedEnvVariable`
+            `image.repository`
           </td>
 
           <td>
-            Format: [Example](#vars-scripted-monitors).
+            The container to pull.            
 
-            A locally hosted set of user defined key value pairs.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `synthetics.heavyWorkers`
-          </td>
-
-          <td>
-            The number of concurrent workers the minion will use to run heavy jobs (`BROWSER`, `SCRIPT_BROWSER`, `SCRIPT_API`). If undefined, the minion will use the value `2`. The maximum allowed value for this variable is `50`. For more information on monitor types, see [Types of Synthetics monitors](/docs/synthetics/new-relic-synthetics/getting-started/types-synthetics-monitors).
+            Default: `quay.io/newrelic/synthetics-minion`
           </td>
         </tr>
 
         <tr>
           <td>
-            `synthetics.lightweightWorkers`
+            `image.pullPolicy`
           </td>
 
           <td>
-            The number of workers the minion will use to run lightweight jobs (`SIMPLE` ping jobs). If undefined, the minion will use `25 * synthetics.heavyWorkers`. Where `synthetics.heavyWorkers` is number defined in the previous environment variable. The maximum allowed value for this variable is `1250`. For more information on monitor types, see [Types of synthetic monitors](/docs/synthetics/new-relic-synthetics/getting-started/types-synthetics-monitors).
+            The pull policy.          
+
+            Default: `IfNotPresent`
           </td>
         </tr>
 
         <tr>
           <td>
-            `synthetics.minionVsePassphrase`
+            `persistence.claimName`
           </td>
 
           <td>
-            If set, enables **verified script execution** and uses this value as a **passphrase**.
+            The name of the PVC to use. If undefined or not set Statefulset will dynamically create a PVC for each replica
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `persistence.storageClass`
+          </td>
+
+          <td>
+            Override the StorageClass for VolumeClaimTemplates (relevant only if claimName is undefined or empty). For more details see: [persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1)
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `persistence.accessMode`
+          </td>
+
+          <td>
+            Access mode to be defined for the PVC (relevant only if claimName is undefined or empty).
+
+            Default: `ReadWriteOnce`
+          </td>
+        </tr>
+        
+        <tr>
+          <td>
+            `persistence.annotations`
+          </td>
+
+          <td>
+            Annotations to add to the PVC (relevant only if claimName is undefined or empty).
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `persistence.size`
+          </td>
+
+          <td>
+            Size to be defined for the PVC (relevant only if claimName is undefined or empty.)
+
+            Default: `10Gi`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `persistence.permanentData`
+          </td>
+
+          <td>
+            Path on the volume to the permanent data storage directory. See Permanent data storage [documentation](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration#permanent-data-volume) for more.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `persistence.customModules`
+          </td>
+
+          <td>
+            Path on the volume to the custom modules directory. See Custom Modules [documentation](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration#custom-modules) for more.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `persistence.userDefinedVariables`
+          </td>
+
+          <td>
+            Path on the volume to the user-defined-variable.json file. See User Defined Variables [documentation](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration#vars-scripted-monitors) for more.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `serviveAccount.create`
+          </td>
+
+          <td>
+            If true, a service account would be created and assigned to the deployment
+
+            Default: `false`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `serviveAccount.name`
+          </td>
+
+          <td>
+            The service account to assign to the deployment. If `serviveAccount.create` is true then this name will be used when creating the service account
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `serviveAccount.annotations`
+          </td>
+
+          <td>
+            The annotations to add to the service account if `serviveAccount.create` is set to true.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `removeJobsLog`
+          </td>
+
+          <td>
+            Default Kubernetes does not include a jobs/log resource. Set this to true to remove it from the role if needed
+
+            Default: `false`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `headlessService.serviceName`
+          </td>
+
+          <td>
+            The name of the headless service to associate to the StatefulSet. If not set a name is generated using the fullname template.
           </td>
         </tr>
 
@@ -678,7 +904,8 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
 
             Default: `2379`
           </td>
-        </tr>
+        </tr> 
+
       </tbody>
     </table>
   </Collapser>

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
@@ -513,7 +513,7 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            **REQUIRED if `synthetics.privateLocationKeySecretName` is not set** UUID / [Private Location Key](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms#private-location-key) of the Private Location, as found on the Private Location Web page.
+            **REQUIRED if `synthetics.privateLocationKeySecretName` is not set**. UUID/[Private location key](/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms#private-location-key) of the private location, as found on the private location web page.
           </td>
         </tr>
 
@@ -523,7 +523,7 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            **REQUIRED if `synthetics.privateLocationKey` is not set** name of the Kubernetes Secret that contains a key called privateLocationKey with the authentication key associated with your Synthetics Private Location
+            **REQUIRED if `synthetics.privateLocationKey` is not set**. Name of the Kubernetes secret that contains the key `privateLocationKey`, which contains the authentication key associated with your Synthetics private location.
           </td>
         </tr>
 
@@ -545,7 +545,7 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            The name of a Secret object used to pull an image from a specified container registry
+            The name of the secret object used to pull an image from a specified container registry.
           </td>
         </tr>
 
@@ -555,7 +555,7 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            Name override used for your StatefulSet installation in place of the default
+            Name override used for your `StatefulSet` installation, replacing the default.
           </td>
         </tr>
 
@@ -565,9 +565,9 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            Release version of CPM to use in place of the version specified in [Chart.yml](https://github.com/newrelic/helm-charts/blob/master/charts/synthetics-minion)
+            Release version of CPM to use instead of the version specified in [chart.yml](https://github.com/newrelic/helm-charts/blob/master/charts/synthetics-minion).
           </td>
-       </tr>
+        </tr>
       
         <tr>
           <td>
@@ -575,7 +575,7 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            When contacting New Relic Support, they may ask you to increase this to `"DEBUG"` or `"TRACE"`.
+            If contacting New Relic Support, they may ask you to increase this to `"DEBUG"` or `"TRACE"`.
 
             Default: `INFO.`
           </td>
@@ -597,7 +597,7 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            The number of workers the minion will use to run lightweight jobs (`SIMPLE` ping jobs). If undefined, the minion will use `25 * synthetics.heavyWorkers`. Where `synthetics.heavyWorkers` is number defined in the previous environment variable. The maximum allowed value for this variable is `1250`. For more information on monitor types, see [Types of synthetic monitors](/docs/synthetics/new-relic-synthetics/getting-started/types-synthetics-monitors).
+            The number of workers the minion will use to run lightweight jobs (`SIMPLE` ping jobs). If undefined, the minion will use `25 * synthetics.heavyWorkers`, where `synthetics.heavyWorkers` is number defined in the previous environment variable. The maximum allowed value for this variable is `1,250`. For more information on monitor types, see [Types of synthetic monitors](/docs/synthetics/new-relic-synthetics/getting-started/types-synthetics-monitors).
           </td>
         </tr>
 
@@ -631,7 +631,7 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            If set, enables **verified script execution** and uses this value as a **passphrase**.
+            If set, it enables **verified script execution**, and uses this value as a **passphrase**.
           </td>
         </tr>
 
@@ -696,7 +696,7 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           <td>
             Format: [Example](#vars-scripted-monitors).
 
-            A locally hosted set of user defined key value pairs.
+            A locally hosted set of user-defined key value pairs.
           </td>
         </tr>
         
@@ -752,7 +752,7 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            The name of the PVC to use. If undefined or not set Statefulset will dynamically create a PVC for each replica
+            The name of the PVC to use. If undefined or not set, `Statefulset` will dynamically create a PVC for each replica.
           </td>
         </tr>
 
@@ -762,7 +762,7 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            Override the StorageClass for VolumeClaimTemplates (relevant only if claimName is undefined or empty). For more details see: [persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1)
+            Overrides `StorageClass` for `VolumeClaimTemplates`, relevant only if `claimName` is undefined or empty. For more details see [persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1).
           </td>
         </tr>
 
@@ -772,9 +772,9 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            Access mode to be defined for the PVC (relevant only if claimName is undefined or empty).
+            Access mode to be defined for the PVC, relevant only if `claimName` is undefined or empty.
 
-            Default: `ReadWriteOnce`
+            Default: `ReadWriteOnce`.
           </td>
         </tr>
         
@@ -784,7 +784,7 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            Annotations to add to the PVC (relevant only if claimName is undefined or empty).
+            Annotations to add to the PVC, relevant only if `claimName` is undefined or empty.
           </td>
         </tr>
 
@@ -794,9 +794,9 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            Size to be defined for the PVC (relevant only if claimName is undefined or empty.)
+            Size to be defined for the PVC, relevant only if `claimName` is undefined or empty.
 
-            Default: `10Gi`
+            Default: `10Gi`.
           </td>
         </tr>
 
@@ -806,7 +806,7 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            Path on the volume to the permanent data storage directory. See Permanent data storage [documentation](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration#permanent-data-volume) for more.
+            Path on the volume to the permanent data storage directory. For more details, see [permanent data storage](/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration#permanent-data-volume).
           </td>
         </tr>
 
@@ -816,7 +816,7 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            Path on the volume to the custom modules directory. See Custom Modules [documentation](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration#custom-modules) for more.
+            Path on the volume to the custom modules directory. For more details, see [custom modules](/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration#custom-modules).
           </td>
         </tr>
 
@@ -826,39 +826,39 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            Path on the volume to the user-defined-variable.json file. See User Defined Variables [documentation](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration#vars-scripted-monitors) for more.
+            Path on the volume to the `user-defined-variable.json` file. For more details, see [user defined variables](/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration#vars-scripted-monitors).
           </td>
         </tr>
 
         <tr>
           <td>
-            `serviveAccount.create`
+            `serviceAccount.create`
           </td>
 
           <td>
-            If true, a service account would be created and assigned to the deployment
+            If true, a service account is created and assigned to the deployment.
 
-            Default: `false`
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `serviveAccount.name`
-          </td>
-
-          <td>
-            The service account to assign to the deployment. If `serviveAccount.create` is true then this name will be used when creating the service account
+            Default: `false`.
           </td>
         </tr>
 
         <tr>
           <td>
-            `serviveAccount.annotations`
+            `serviceAccount.name`
           </td>
 
           <td>
-            The annotations to add to the service account if `serviveAccount.create` is set to true.
+            The service account to assign to the deployment. If `serviceAccount.create` is true, then this name is used when creating the service account.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `serviceAccount.annotations`
+          </td>
+
+          <td>
+            The annotations to add to the service account if `serviceAccount.create` is set to `true`.
           </td>
         </tr>
 
@@ -868,9 +868,9 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            Default Kubernetes does not include a jobs/log resource. Set this to true to remove it from the role if needed
+            Default Kubernetes doesn't include a jobs/log resource. Set this to `true` to remove it from the role if needed.
 
-            Default: `false`
+            Default: `false`.
           </td>
         </tr>
 
@@ -880,7 +880,7 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            The name of the headless service to associate to the StatefulSet. If not set a name is generated using the fullname template.
+            The name of the headless service to associate to the `StatefulSet`. If not set a name is generated using the fullname template.
           </td>
         </tr>
 
@@ -890,19 +890,19 @@ Environmental variables allow you to fine-tune the CPM configuration to meet you
           </td>
 
           <td>
-            The AppArmor profile name that will be applied to the Minion and Runner pods. If set, then the AppArmor profile must exist on the Kubernetes node(s) for this to work.
+            The `AppArmor` profile name that will be applied to the Minion and Runner pods. If set, then the AppArmor profile must exist on the Kubernetes node(s) for this to work.
           </td>
         </tr>
 
         <tr>
           <td>
-            podSecurityContextRunAsUser
+            `podSecurityContextRunAsUser`
           </td>
 
           <td>
             A UID that can be set to either `0 (root)` or between `[2000, 4000]`, inclusive. If set, runs the CPM as the given UID.
 
-            Default: `2379`
+            Default: `2379`.
           </td>
         </tr> 
 


### PR DESCRIPTION
Hi there,

Really enjoy reading through these docs!
Stumbled on the synthetics-minion helm chart [here](https://github.com/newrelic/helm-charts/tree/master/charts/synthetics-minion) and saw that there seems to be a lot more options listed for configuration of the containerized private minion than what is currently displayed via the docs so I figured I'd whip up a small PR to create more parity between the two.

But!  I may be totally off, and perhaps some things aren't shouldn't be carried over into the docs :sweat_smile: 
Super willing to iterate, adjust, or even close this PR if these items aren't needed!

Big kudos to everyone that has spent so much time making these docs as awesome as they are!