### PR TITLE
chore(Java agent API): Highlighted info on headers

### DIFF
--- a/src/content/docs/apm/agents/java-agent/api-guides/guide-using-java-agent-api.mdx
+++ b/src/content/docs/apm/agents/java-agent/api-guides/guide-using-java-agent-api.mdx
@@ -225,6 +225,22 @@ Distributed tracing lets you see the path that a request takes as it travels thr
   <tbody>
     <tr>
       <td>
+        Learn about the type-specific headers of an inbound or outbound message. 
+      </td>
+
+      <td>
+        ```
+        <a href="http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/Headers.html">Headers</a>
+        ```
+
+        For a provided implementation of `Headers` use `ConcurrentHashMapHeaders`. 
+        
+        See an example of W3C trace context headers implementation in [DT API usage with Kafka](https://github.com/newrelic/newrelic-java-examples/tree/main/newrelic-java-agent/distributed-tracing/kafka-examples).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         Create and insert distributed tracing headers into a `Headers` data structure. This API will insert both `newrelic` and W3C Trace Context headers (`traceparent` & `tracestate`), unless the agent is explicitly [configured to exclude `newrelic` headers](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#dt-exclude_newrelic_header).
       </td>
 
@@ -253,19 +269,7 @@ Distributed tracing lets you see the path that a request takes as it travels thr
 
     <tr>
       <td>
-        The type-specific headers of an inbound or outbound message. For a provided implementation of `Headers` use `ConcurrentHashMapHeaders`.
-      </td>
-
-      <td>
-        ```
-        <a href="http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/Headers.html">Headers</a>
-        ```
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        A utility class that provides enum constants for defining the transport type when accepting distributed tracing headers.
+        Understand a utility class that provides enum constants for defining the transport type when accepting distributed tracing headers.
       </td>
 
       <td>


### PR DESCRIPTION
As reported in #4654, the info about `headers` is somewhat hidden in the [Java agent API guide](https://docs.newrelic.com/docs/apm/agents/java-agent/api-guides/guide-using-java-agent-api/). This PR fixes this, and adds a link to an example. 