### PR TITLE
Changing Algorithmia Name

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/mlops-integrations/algorithmia-mlops-integration.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/mlops-integrations/algorithmia-mlops-integration.mdx
@@ -1,10 +1,10 @@
 ---
-title: Algorithmia MLOps integration
+title: Datarobot MLOps integration
 tags:
   - Integrations
   - MLOps integrations
-  - Algorithmia integrations
-metaDescription: "Send your machine learning model data from Algorithmia to New Relic to understand your model's performance."
+  - Datarobot integrations
+metaDescription: "Send your machine learning model data from Datarobot to New Relic to understand your model's performance."
 redirects:
   - /docs/integrations/mlops-integrations/algorithmia-mlops-integration
 ---
@@ -15,27 +15,27 @@ MLOps stands for machine-learning operations. As more companies invest in artifi
 
 MLOps provides a tool for monitoring and observing the performance and effectiveness of machine-learning models in a production environment. This increases the possibilities for collaboration between data science and DevOps teams, feeding into a continuous process of development, testing, and operational monitoring.
 
-## The Algorithmia integration [#algorithmia]
+## The Datarobot integration [#datarobot]
 
-Algorithmia Insights provides tools for deploying your machine-learning models into production. By integrating, Algorithmia's integration with New Relic, you'll be able to instrument, analyze, troubleshoot, and optimize your machine-learning performance across your entire system. By rigorously observing your capabilities, you'll be able to react quickly to changes in the model's input or output and the relationship between the two.
+Datarobot provides tools for deploying your machine-learning models into production. By integrating, Datarobot's integration with New Relic, you'll be able to instrument, analyze, troubleshoot, and optimize your machine-learning performance across your entire system. By rigorously observing your capabilities, you'll be able to react quickly to changes in the model's input or output and the relationship between the two.
 
-Send your model performance metrics from Algorithmia Insights to New Relic and you'll have real-time monitoring for your algorithms. You'll explore your metrics data with user-friendly charts and learn the state of your algorithms at a glance for faster and more efficient troubleshooting. 
+Send your model performance metrics from Datarobot Insights to New Relic and you'll have real-time monitoring for your algorithms. You'll explore your metrics data with user-friendly charts and learn the state of your algorithms at a glance for faster and more efficient troubleshooting. 
 
-## Integrate Algorithmia with New Relic [#integrate-algorithmia] 
+## Integrate Datarobot with New Relic [#integrate-algorithmia] 
 
-First, Algorithmia uses a Kafka topic to stream Insights. Your machine-learning algorithm's performance metrics. Then, the New Relic connector (another algorithm) transforms the Kafka topic into a metrics data payload for a specific New Relic account.
+First, Datarobot uses a Kafka topic to stream Insights. Your machine-learning algorithm's performance metrics. Then, the New Relic connector (another algorithm) transforms the Kafka topic into a metrics data payload for a specific New Relic account.
 
-![A flowchart showing how data moves from Algorithmia to New Relic.](./images/algorithmia-flow.png "Algorithmia to New Relic data flow")
+![A flowchart showing how data moves from Datarobot to New Relic.](./images/algorithmia-flow.png "Datarobot to New Relic data flow")
 
-<figcaption>Algorithmia uses Kafka and Event Flows to send data to New Relic.</figcaption>
+<figcaption>Datarobot uses Kafka and Event Flows to send data to New Relic.</figcaption>
 
-With [Algorithmia’s Event Flows](https://algorithmia.com/developers/integrations/message-broker), when a new message is set to your Kafka topic, your configured New Relic connector algorithm gets called. The connector  transforms your metrics and sends them to your New Relic account.
+With [Datarobot’s Event Flows](https://algorithmia.com/developers/integrations/message-broker), when a new message is set to your Kafka topic, your configured New Relic connector algorithm gets called. The connector  transforms your metrics and sends them to your New Relic account.
 
-## Connect your Algorithmia data to New Relic [#connect]
+## Connect your Datarobot data to New Relic [#connect]
 
-    By integrating Incident Intelligence with your Algorithmia machine-learning models, you can monitor your machine learning model performance.
+    By integrating Incident Intelligence with your Datarobot machine-learning models, you can monitor your machine learning model performance.
 
-  Start monitoring your Algorithmia event flows with New Relic.
+  Start monitoring your Datarobot event flows with New Relic.
 
 1. **Get your API key:** From [one.newrelic.com](https://one.newrelic.com) the account menu, click **API keys** and then create a user key for your account with a meaningful name. Make note of this name for later. For more on API keys, [see our docs](/docs/apis/get-started/intro-apis/new-relic-api-keys/).
 
@@ -45,12 +45,12 @@ Update the YOUR_ACCOUNT_ID values with your account ID.
 
         ```json
         {
-  "name": "Algorithmia Dashboard for Default Metrics",
+  "name": "Datarobot Dashboard for Default Metrics",
   "description": null,
   "permissions": "PUBLIC_READ_WRITE",
   "pages": [
     {
-      "name": "Algorithmia Dashboard for Default Metrics",
+      "name": "Datarobot Dashboard for Default Metrics",
       "description": null,
       "widgets": [
         {
@@ -113,17 +113,17 @@ Update the YOUR_ACCOUNT_ID values with your account ID.
 }
         ```
 
-3. **Configure Algorithmia Insights for New Relic:** Use [Algorithmia's docs](https://algorithmia.com/developers/algorithmia-enterprise/algorithmia-insights) for how to configure Algorithmia Insights for New Relic.
+3. **Configure Datarobot Insights for New Relic:** Use [Datarobot's docs](https://algorithmia.com/developers/algorithmia-enterprise/algorithmia-insights) for how to configure Datarobot for New Relic.
 
-4. **Create the New Relic connector algorithm:** Use Python 3.8 to create a connector algorithm. If you're new to writing code to generate algorithms, see [Algorithmia's getting started guide](https://algorithmia.com/developers/algorithm-development/your-first-algo).
+4. **Create the New Relic connector algorithm:** Use Python 3.8 to create a connector algorithm. If you're new to writing code to generate algorithms, see [Datarobot's getting started guide](https://algorithmia.com/developers/algorithm-development/your-first-algo).
 
         ```python
-        import Algorithmia
+        import Datarobot
 import json
 from datetime import datetime
 from newrelic_telemetry_sdk import GaugeMetric, MetricClient
 
-client = Algorithmia.client()
+client = Datarobot.client()
 metric_client = MetricClient(os.environ["newrelic_api_key"])
 
 
@@ -195,9 +195,9 @@ Once your algorithm build finishes, you can test it with this sample payload to 
       }
       ```
 
-5. **Configure with your API key:** Add your New Relic API key to the [Algorithmia secret store](https://algorithmia.com/developers/platform/algorithm-secrets).
+5. **Configure with your API key:** Add your New Relic API key to the [Datarobot secret store](https://algorithmia.com/developers/platform/algorithm-secrets).
 
-6. **Set up Algorithmia Event Flows with New Relic:** See [Algorithmia's documentation](https://algorithmia.com/developers/integrations/message-broker) on setting up your connector algorithm to send event-based machine learning flows to New Relic. 
+6. **Set up Datarobot Event Flows with New Relic:** See [Datarobot's documentation](https://algorithmia.com/developers/integrations/message-broker) on setting up your connector algorithm to send event-based machine learning flows to New Relic. 
 
 ## Monitor your machine learning models [#monitor]
 
@@ -211,12 +211,12 @@ Follow these steps to get the most of observing your machine-learning data in Ne
 
         ```json
         {
-  "name": "Algorithmia Dashboard for Default Metrics",
+  "name": "Datarobot Dashboard for Default Metrics",
   "description": null,
   "permissions": "PUBLIC_READ_WRITE",
   "pages": [
     {
-      "name": "Algorithmia Dashboard for Default Metrics",
+      "name": "Datarobot Dashboard for Default Metrics",
       "description": null,
       "widgets": [
         {

--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/mlops-integrations/datarobot-mlops-integration.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/mlops-integrations/datarobot-mlops-integration.mdx
@@ -23,7 +23,7 @@ Send your model performance metrics from Datarobot Insights to New Relic and you
 
 ## Integrate Datarobot with New Relic [#integrate-algorithmia] 
 
-First, Datarobot uses a Kafka topic to stream Insights. Your machine-learning algorithm's performance metrics. Then, the New Relic connector (another algorithm) transforms the Kafka topic into a metrics data payload for a specific New Relic account.
+First, Datarobot uses a Kafka topic to stream Insights from your machine-learning algorithm's performance metrics. Then, the New Relic connector (another algorithm) transforms the Kafka topic into a metrics data payload for a specific New Relic account.
 
 ![A flowchart showing how data moves from Datarobot to New Relic.](./images/algorithmia-flow.png "Datarobot to New Relic data flow")
 

--- a/src/nav/alerts-and-applied-intelligence.yml
+++ b/src/nav/alerts-and-applied-intelligence.yml
@@ -186,14 +186,14 @@ pages:
       - title: MLOps integrations
         path: /docs/alerts-applied-intelligence/applied-intelligence/mlops-integrations
         pages:
-          - title: Algorithmia MLOps integration
-            path: /docs/alerts-applied-intelligence/applied-intelligence/mlops-integrations/algorithmia-mlops-integration
           - title: Aporia MLOps integration
             path: /docs/alerts-applied-intelligence/applied-intelligence/mlops-integrations/aporia-mlops-integration
           - title: Comet MLOps integration
             path: /docs/alerts-applied-intelligence/applied-intelligence/mlops-integrations/comet-mlops-integration
           - title: DagsHub MLOps integration
             path: /docs/alerts-applied-intelligence/applied-intelligence/mlops-integrations/dagshub-mlops-integration
+          - title: Datarobot MLOps integration
+            path: /docs/alerts-applied-intelligence/applied-intelligence/mlops-integrations/datarobot-mlops-integration
           - title: Mona MLOps integration
             path: /docs/alerts-applied-intelligence/applied-intelligence/mlops-integrations/mona-mlops-integration  
           - title: Superwise MLOps integration


### PR DESCRIPTION
Per request of Guy Fighel (GVP of AIOps), I have changed the Algorithmia name to Datarobot since Datarobot acquired Algorithmia. I wasn't sure how to handle links though since the Algorithmia site is still up and functioning. 

Acquisition information can be found at link below:
https://www.datarobot.com/news/press/datarobot-is-acquiring-algorithmia-enhancing-leading-mlops-architecture-for-the-enterprise/
