### PR TITLE
Changing callout on infra-agent tarball install

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -567,7 +567,7 @@ For **custom** setup scenarios, you can install the infrastructure monitoring ag
 This is especially useful when you need to adapt the default installation settings to your environment, or to install the infrastructure monitoring agent on distributions that lack the `newrelic-infra` package in their repositories.
 
 <Callout variant="important">
-  Custom installation of the infrastructure agent using tarball files is not officially supported.
+  Note that custom installation of the infrastructure agent using tarball files is not officially supported.
 </Callout>
 
 ## Update the agent [#update]

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -567,7 +567,7 @@ For **custom** setup scenarios, you can install the infrastructure monitoring ag
 This is especially useful when you need to adapt the default installation settings to your environment, or to install the infrastructure monitoring agent on distributions that lack the `newrelic-infra` package in their repositories.
 
 <Callout variant="important">
-  Installing the agent using tarball files is officially supported only for the [AWS Graviton 2 processor](https://aws.amazon.com/ec2/graviton/).
+  Custom installation of the infrastructure agent using tarball files is not officially supported.
 </Callout>
 
 ## Update the agent [#update]


### PR DESCRIPTION
## Context

* This callout is outdated. The full standard agent is now supported on Graviton/ARM. Keeping the callout to highlight the custom installation via tarball is still not officially supported.