### PR TITLE
docs: clarify webhoook metadata format

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/customize-your-webhook-payload.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/customize-your-webhook-payload.mdx
@@ -224,6 +224,8 @@ We support these default dynamic webhook values. For your convenience, they are 
         `$METADATA`
 
         Currently used only for Synthetic monitoring multi-location failure conditions.
+
+        **Possible values:** (object)
       </td>
     </tr>
 


### PR DESCRIPTION
## Give us some context

* Clarifies that the Alerts webhook metadata value is an object rather than a string
* In response to customer report that this was not clear
