### PR TITLE
Fixing wrong link to CLI doc

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/update-serverless-monitoring-aws-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/update-serverless-monitoring-aws-lambda.mdx
@@ -10,7 +10,7 @@ After [enabling our monitoring for AWS Lambda](/docs/serverless-function-monitor
 
 There are two ways to do this:
 
-* [Update via CLI](#update-cli): Use this if you enabled our Lambda monitoring using our [CLI tool](/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-new-relic-monitoring-aws-lambda#cli).
+* [Update via CLI](#update-cli): Use this if you enabled our Lambda monitoring using our [CLI tool](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking/#rec).
 * [Update via AWS Serverless Application Repository](#update-sar): Use this if you enabled using the [manual procedure](/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-new-relic-monitoring-aws-lambda#manual-nr-lambda).
 
 <Callout variant="important">


### PR DESCRIPTION
As reported in #documentation, the link to the CLI tool explanation in https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/update-serverless-monitoring-aws-lambda/ takes the reader to a wrong doc. Fixing this with the PR.