### PR TITLE
fix(Log API): Added info about blobs

### DIFF
--- a/src/content/docs/logs/log-management/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-management/log-api/introduction-log-api.mdx
@@ -365,9 +365,9 @@ Restrictions on logs sent to the Log API:
 
 * Payload total size: **1MB(10^6 bytes) maximum per POST**. We highly recommend using compression.
 * The payload must be encoded as **UTF-8**.
-* Number of attributes per event: 255 maximum
-* Length of attribute name: 255 characters
-* Length of attribute value: 4096 maximum character length
+* Number of attributes per event: 255 maximum.
+* Length of attribute name: 255 characters.
+* Length of attribute value: The first 4,094 characters are stored in NRDB as a `Log` event field with the same name, such as `message`. If the string value exceeds 4,094 characters, we store the long string as a [blob](/docs/logs/log-management/ui-data/long-logs-blobs.mdx).
 
 Some specific attributes have additional restrictions:
 

--- a/src/content/docs/logs/log-management/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-management/log-api/introduction-log-api.mdx
@@ -367,7 +367,7 @@ Restrictions on logs sent to the Log API:
 * The payload must be encoded as **UTF-8**.
 * Number of attributes per event: 255 maximum.
 * Length of attribute name: 255 characters.
-* Length of attribute value: The first 4,094 characters are stored in NRDB as a `Log` event field with the same name, such as `message`. If the string value exceeds 4,094 characters, we store the long string as a [blob](/docs/logs/log-management/ui-data/long-logs-blobs.mdx).
+* Length of attribute value: The first 4,094 characters are stored in NRDB as a `Log` event field with the same name, such as `message`. If the string value exceeds 4,094 characters, we store the long string as a [blob](/docs/logs/log-management/ui-data/long-logs-blobs).
 
 Some specific attributes have additional restrictions:
 

--- a/src/content/docs/logs/log-management/ui-data/long-logs-blobs.mdx
+++ b/src/content/docs/logs/log-management/ui-data/long-logs-blobs.mdx
@@ -30,7 +30,7 @@ For lengthy string values that are longer than can be stored in NRDB (4,094 char
         First 4,094 characters
       </td>
       <td>
-        The first 4,094 characters are stored in `Log` event field with the same name. So a long `message` value would have its first 4,094 characters stored in a `message` field.
+        The first 4,094 characters are stored in a `Log` event field with the same name. So a long `message` value would have its first 4,094 characters stored in a `message` field.
       </td>
     </tr>
 


### PR DESCRIPTION
From wizards-logging 11-05-21. Added info about how we use blobs if length exceeds 4096 characters.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.