### PR TITLE
Fix mistake observability maturity conflict override

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/introduction.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/introduction.mdx
@@ -9,6 +9,8 @@ tags:
   - Innovation and growth
   - Implementation guide
 metaDescription: Observability Maturity landing page
+redirects:
+  - /docs/new-relic-solutions/observability-maturity
 ---
 
 <LandingPageHero>

--- a/src/content/docs/new-relic-solutions/observability-maturity/introduction.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: Observability Maturity
+title: Observability maturity
 type: landingPage
 tags:
   - Observability maturity
@@ -8,7 +8,7 @@ tags:
   - Customer experience
   - Innovation and growth
   - Implementation guide
-metaDescription: Observability Maturity landing page
+metaDescription: Observability maturity landing page
 redirects:
   - /docs/new-relic-solutions/observability-maturity
 ---

--- a/src/nav/new-relic-solutions.yml
+++ b/src/nav/new-relic-solutions.yml
@@ -1,11 +1,11 @@
 title: Guides and best practices
 path: /docs/new-relic-solutions
 pages:
-  - title: Observability Maturity
+  - title: Observability maturity
     pages:
       - title: Introduction
         path: /docs/new-relic-solutions/observability-maturity
-      - title: Uptime, Performance & Reliability
+      - title: Uptime, performance & reliability
         path: /docs/new-relic-solutions/observability-maturity/uptime-performance-reliability
         pages:
           - title: Alert quality management


### PR DESCRIPTION
When I was working on previous changes in #4614, I had a git conflict and mistakenly overrode changes in #4625.

This PR corrects those capitalization overwrites, as well as changes the name of the file to "introduction.mdx" instead of "index.mds." The name change is because that file is no longer on a parent node.

The reviewer should make sure that the following two headings are now sentence case in the navigation:

"Observability maturity"
" Uptime, performance & reliability"

Also, please confirm that the redirect from the old index.mdx resolves to the introduction topic: /docs/new-relic-solutions/observability-maturity