### PR TITLE
Replace NRQL in GET example with working query

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests.mdx
@@ -122,7 +122,7 @@ To make a GET request, use the [`$http.get`](https://github.com/request/request#
     var myQueryKey = '{YOUR_QUERY_KEY}';
     var options = {
         //Define endpoint URI
-        uri: 'https://insights-api.newrelic.com/v1/accounts/'+myAccountID+'/query?nrql=SELECT%20average(amount)%20FROM%20SyntheticsEvent',
+        uri: 'https://insights-api.newrelic.com/v1/accounts/'+myAccountID+'/query?nrql=SELECT%20average(duration)%20FROM%20Transaction',
         //Define query key and expected data type.
         headers: {
         'X-Query-Key': myQueryKey,


### PR DESCRIPTION
The NRQL query in the existing example in invalid for most users (there is no SyntheticsEvent by default). If someone copies and pastes that code into their account, it will fail.