### PR TITLE
Correct Java agent configuration file examples using inconsistent indentation

### DIFF
--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -1160,7 +1160,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
     ```
     scala_futures_as_segments:
-            enabled: true
+      enabled: true
     ```
   </Collapser>
 </CollapserGroup>
@@ -2028,16 +2028,16 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
     ```
     transaction_tracer:
-              slow_query_whitelist:
-               'com.newrelic.instrumentation.cassandra-datastax-2.1.2'
+      slow_query_whitelist:
+        'com.newrelic.instrumentation.cassandra-datastax-2.1.2'
     ```
 
     For DataStax driver 3.0.0, add this rule to your allow list:
 
     ```
     transaction_tracer:
-              slow_query_whitelist:
-               'com.newrelic.instrumentation.cassandra-datastax-3.0.0'
+      slow_query_whitelist:
+        'com.newrelic.instrumentation.cassandra-datastax-3.0.0'
     ```
   </Collapser>
 
@@ -2075,16 +2075,16 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
     ```
     transaction_tracer:
-              collect_slow_queries_from:
-               'com.newrelic.instrumentation.cassandra-datastax-2.1.2'
+      collect_slow_queries_from:
+        'com.newrelic.instrumentation.cassandra-datastax-2.1.2'
     ```
 
     For DataStax driver 3.0.0, add this rule to your allow list:
 
     ```
     transaction_tracer:
-              collect_slow_queries_from:
-               'com.newrelic.instrumentation.cassandra-datastax-3.0.0'
+      collect_slow_queries_from:
+        'com.newrelic.instrumentation.cassandra-datastax-3.0.0'
     ```
   </Collapser>
 
@@ -2421,7 +2421,7 @@ Browser monitoring gives you insight into the performance real users are experie
 
     ```
     browser_monitoring:
-          disabled_auto_pages: /WEB-INF/jsp/testpage_1.jsp, /WEB-INF/jsp/testpage_2.jsp
+      disabled_auto_pages: /WEB-INF/jsp/testpage_1.jsp, /WEB-INF/jsp/testpage_2.jsp
     ```
   </Collapser>
 
@@ -2677,9 +2677,9 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     ```
     error_collector:
-          ignore_classes:
-            - "com.example.MyException"
-            - "com.example.DifferentException"
+      ignore_classes:
+        - "com.example.MyException"
+        - "com.example.DifferentException"
     ```
 
     An environment variable can be used to list exception class names you want to be ignored:
@@ -2732,12 +2732,12 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     ```
     error_collector:
-          ignore_messages:
-            com.example.MyException:
-              - "Some error message to ignore"
-              - "Some other error message to ignore"
-            com.example.DifferentException:
-              - "Some different error message to ignore"
+      ignore_messages:
+        com.example.MyException:
+          - "Some error message to ignore"
+          - "Some other error message to ignore"
+        com.example.DifferentException:
+          - "Some different error message to ignore"
     ```
 
     An environment variable can be used to list exception class names and messages you want to be ignored:
@@ -2785,7 +2785,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     ```
     error_collector:
-          ignore_status_codes: 404,507-511
+      ignore_status_codes: 404,507-511
     ```
   </Collapser>
 
@@ -2825,9 +2825,9 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     ```
     error_collector:
-          expected_classes:
-            - "com.example.MyException"
-            - "com.example.DifferentException"
+      expected_classes:
+        - "com.example.MyException"
+        - "com.example.DifferentException"
     ```
 
     An environment variable can be used to list expected exception class names:
@@ -2875,12 +2875,12 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     ```
     error_collector:
-          expected_messages:
-            com.example.MyException:
-              - "Some expected error message"
-              - "Some other expected error message"
-            com.example.DifferentException:
-              - "Some different expected error message"
+      expected_messages:
+        com.example.MyException:
+          - "Some expected error message"
+          - "Some other expected error message"
+        com.example.DifferentException:
+          - "Some different expected error message"
     ```
 
     An environment variable can be used to list expected exception class names and messages:
@@ -2926,7 +2926,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     ```
     error_collector:
-          expected_status_codes: 415,500-506
+      expected_status_codes: 415,500-506
     ```
   </Collapser>
 
@@ -3056,7 +3056,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     ```
     error_collector:
-          ignoreErrorPriority: false
+      ignoreErrorPriority: false
     ```
   </Collapser>
 
@@ -3095,7 +3095,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     ```
     error_collector:
-          ignore_errors: some.other.MyException
+      ignore_errors: some.other.MyException
     ```
   </Collapser>
 </CollapserGroup>
@@ -3367,12 +3367,12 @@ Transaction events provide the data for displaying histograms and percentiles in
 
     ```
     transaction_events:
-           custom_request_headers:
-              -
-                header_name: "X-Custom-Header-1"
-              -
-                header_name: "X-Custom-Header-2"
-                header_alias: "CustomHeader2alias"
+      custom_request_headers:
+        -
+          header_name: "X-Custom-Header-1"
+        -
+          header_name: "X-Custom-Header-2"
+          header_alias: "CustomHeader2alias"
     ```
 
     In the first map set, `X-Custom-Header-1` is captured and reported by the agent as the header name for a corresponding value from the request object. The `header_name` will also be the name of the attribute sent to New Relic.
@@ -3485,15 +3485,15 @@ APM lets you [record custom event data](/docs/insights/insights-data-sources/cus
 
   ```
   custom_insights_events.enabled: true
-      custom_insights_events.max_samples_stored: 5000
+    custom_insights_events.max_samples_stored: 5000
   ```
 
   For agent versions 4.1.0 and above, the YAML configuration uses the nested stanza formatting:
 
   ```
   custom_insights_events:
-        enabled: false
-        max_samples_stored: 5000
+    enabled: false
+    max_samples_stored: 5000
   ```
 </Callout>
 
@@ -4237,11 +4237,11 @@ If you want to customize the circuit breaker, add the stanza under the `common` 
 
 ```
 common: &default_settings​
-    ​  <var>OTHER_CONFIG_SETTINGS</var>
-      circuitbreaker:
-        enabled: <var>true</var>
-        memory_threshold: <var>20</var>
-        gc_cpu_threshold: <var>10</var>
+  <var>OTHER_CONFIG_SETTINGS</var>
+  circuitbreaker:
+    enabled: <var>true</var>
+    memory_threshold: <var>20</var>
+    gc_cpu_threshold: <var>10</var>
 ```
 
 <CollapserGroup>
@@ -4421,7 +4421,7 @@ These options are set in the `message_tracer` stanza and can be [overridden](#Sy
 
     ```
     distributed_tracing:
-           enabled: true
+      enabled: true
     ```
 
     To enable this using a [system property](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#System_Properties), you would use:
@@ -4467,7 +4467,7 @@ These options are set in the `message_tracer` stanza and can be [overridden](#Sy
 
     ```
     distributed_tracing:
-           exclude_newrelic_header: true
+      exclude_newrelic_header: true
     ```
 
     To exclude `newrelic` headers using a [system property](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#System_Properties), you would use:
@@ -4524,8 +4524,8 @@ To turn on Infinite Tracing, enable distributed tracing and add the additional s
 
     ```
     infinite_tracing:
-        trace_observer:
-          host: <var>YOUR_TRACE_OBSERVER_HOST</var>
+      trace_observer:
+        host: <var>YOUR_TRACE_OBSERVER_HOST</var>
     ```
 
     You can also use the system property `newrelic.config.infinite_tracing.trace_observer.host` or the environment variable `NEW_RELIC_INFINITE_TRACING_TRACE_OBSERVER_HOST`.


### PR DESCRIPTION
Based on GitHub issue #4704, I corrected the yaml indentation in the Java configuration file doc. I confirmed with the Java team that the spacing should always use two spaces in our examples. 