### PR TITLE
Remove ampersand in left navigation

### DIFF
--- a/src/nav/new-relic-solutions.yml
+++ b/src/nav/new-relic-solutions.yml
@@ -5,7 +5,7 @@ pages:
     pages:
       - title: Introduction
         path: /docs/new-relic-solutions/observability-maturity
-      - title: Uptime, performance & reliability
+      - title: Uptime, performance, and reliability
         path: /docs/new-relic-solutions/observability-maturity/uptime-performance-reliability
         pages:
           - title: Alert quality management


### PR DESCRIPTION
Related to https://github.com/newrelic/docs-website/pull/4733, I had forgotten to remove an ampersand in the left navigation.

Here is how the left navigation link looks now: Uptime, performance, and reliability.