### PR TITLE
fix(aum): add info to okta about creating groups

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more.mdx
@@ -71,7 +71,7 @@ From the [authentication domain UI](#ui), you can set one of two options for how
 * **SCIM:** Our automated user management (AUM) feature allows you to use SCIM provisioning to import and manage users from your identity provider. 
 
 Notes on these settings: 
-  * You can't toggle the [**Source of users** setting](/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more/#source-users). This means if you want to change this for an authentication domain that's already been set up, you'll need to create a new one.  
+  * You can't toggle **Source of users**. This means if you want to change this for an authentication domain that's already been set up, you'll need to create a new one.  
   * When you first enable SCIM, the bearer token is generated and only shown once. If you need to view a bearer token later, the only way to do this is to generate a new one, which will invalidate the old one and any integrations using the old token.
 
 For how to set up SCIM, see [Automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign).

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more.mdx
@@ -68,9 +68,13 @@ To create a new domain from the authentication domain UI page, click **Create ne
 From the [authentication domain UI](#ui), you can set one of two options for how users are added to New Relic:
 
 * **Manual:** This means that your users are added manually to New Relic from the [**User management** UI](/docs/accounts/accounts-billing/new-relic-one-user-management/add-manage-users-groups-roles/#where). 
-* **SCIM:** Our automated user management (AUM) feature allows you to use SCIM provisioning to import and manage users from your identity provider. For instructions, see [Automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign).
+* **SCIM:** Our automated user management (AUM) feature allows you to use SCIM provisioning to import and manage users from your identity provider. 
 
-Note that once you enable SCIM for an authentication domain, you can't turn it off. This means that if you later want SCIM disabled for that domain, you must instead create a new one. 
+Notes on these settings: 
+  * You can't toggle the [**Source of users** setting](/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more/#source-users). This means if you want to change this for an authentication domain that's already been set up, you'll need to create a new one.  
+  * When you first enable SCIM, the bearer token is generated and only shown once. If you need to view a bearer token later, the only way to do this is to generate a new one, which will invalidate the old one and any integrations using the old token.
+
+For how to set up SCIM, see [Automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign).
 
 ## Authentication [#authentication]
 

--- a/src/content/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign.mdx
@@ -26,20 +26,18 @@ Benefits of enabling automated user management include:
 * Use of this feature requires SAML SSO, so once your users are added to New Relic, they can log in using your identity provider. 
 * Popular identity providers Azure AD, Okta, and OneLogin have dedicated New Relic apps, improving ease of enablement.  
 
-## Requirements [#requirements]
+## Requirements and recommendations [#requirements]
 
-Requirements and impacts:
+Requirements and recommendations:
 
 * Requires [Pro or Enterprise edition](https://newrelic.com/pricing).
+* Supports SAML 2.0 standard for single sign on (SSO).
+* Supports SCIM 2.0 standard.
 * [User model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model#user-models)-related requirements:
   * This feature requires you to be on our [New Relic One user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model#user-models) and creates users on that model. If you're on our [original user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model#user-models) (or otherwise can't seem to implement this feature), talk to your New Relic account representative.
   * Configuring AUM requires that a user have the [**Authentication domain manager** and the **Organization manager** role](/docs/accounts/accounts-billing/new-relic-one-user-management/new-relic-one-user-model-understand-user-structure/#standard-roles) (users in the [default group **Admin**](/docs/accounts/accounts-billing/new-relic-one-user-management/new-relic-one-user-model-understand-user-structure/#groups) have these).
-* Supports SAML 2.0 standard for single sign on (SSO).
-* Supports SCIM 2.0 standard. 
-* There are three identity providers that have a dedicated New Relic app: Azure AD, Okta, and OneLogin. For other identity providers, you can use our [SCIM API](/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management).
-* Notes on initial enabling of AUM:
-  * We don't currently support toggling SCIM on or off. If an authentication domain has already been set up with the source of users as **Manual**, you can't change it to SCIM.
-  * When first enabled, the bearer token is generated and only shown once. If you need to view a bearer token later, the only way to do this is to generate a new one, and that will invalidate the old one and any integrations using the old token.
+* There are three identity providers that have a New Relic app: Azure AD, Okta, and OneLogin. For other identity providers, you can use our [SCIM API](/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management).
+* Before enabling this, it helps to first set up [user groups](/docs/accounts/accounts/automated-user-management/roles-permissions-automated-user-management) in your identity provider service and think about which New Relic roles and accounts those groups will have access to. 
 
 ## Set up automated user management (AUM) [#how-to]
 

--- a/src/content/docs/accounts/accounts/automated-user-management/okta-scimsso-application-configuration.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/okta-scimsso-application-configuration.mdx
@@ -95,7 +95,7 @@ To manage your users' user type from Okta:
 2. Go into your Okta instance. The rest of these instructions are done from Okta.
 3. Next, you'll configure Okta to be able to send a new attribute `nrUserType`. Steps: 
 	* Go to the **Profile editor**. In the **Attributes** section, click **Add attribute**. 
-	* Set your settings to match the screenshot below. The only two fields that must match exactly are **External name** (value: `nrUserType`) and **External namespace** (value: `urn:ietf:params:scim:schemas:extension:newrelic:2.0:User`). The `variable` field doesn't matter. 
+	* Set your settings to match the screenshot below. The only two fields that must match exactly are **External name** (value: `nrUserType`) and **External namespace** (value: `urn:ietf:params:scim:schemas:extension:newrelic:2.0:User`). The `variable` value can be any value. 
 	
   ![Adding new attribute in Okta app](./images/okta-define-user-type.png "Adding new attribute in Okta app")
 

--- a/src/content/docs/accounts/accounts/automated-user-management/okta-scimsso-application-configuration.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/okta-scimsso-application-configuration.mdx
@@ -52,11 +52,11 @@ Configure Okta's New Relic SCIM/SSO application to automatically provision your 
 
 ## Step 4. Assign users and groups [#assign-users]
 
-Next, you'll assign users in Okta's New Relic application.
-
-Assigning users is done using two different tabs in the app. We recommend having your New Relic users selected on the **Assignments** tab and their associated groups selected on the **Push groups** tab.
+If you don't already have your user groups set up in Okta, you'll need to create them. These will be the groups that you'll later assign [access grants](/docs/accounts/accounts-billing/new-relic-one-user-management/add-manage-users-groups-roles/#understand-concepts) to in New Relic, which will be what gives those groups access to specific roles on specific accounts. To learn how to create groups, see [Okta's documentation on groups](https://help.okta.com/en/prod/Content/Topics/users-groups-profiles/usgp-about-groups.htm).
 
 ### Assignments tab
+
+Next, you'll assign users. Assigning users is done using two different tabs in the app. We recommend having your New Relic users selected on the **Assignments** tab and their associated groups selected on the **Push groups** tab.
 
 1. In the app, click on the **Assignments** tab.
 2. From the **Assignments** form, click on **Assign**.
@@ -95,7 +95,7 @@ To manage your users' user type from Okta:
 2. Go into your Okta instance. The rest of these instructions are done from Okta.
 3. Next, you'll configure Okta to be able to send a new attribute `nrUserType`. Steps: 
 	* Go to the **Profile editor**. In the **Attributes** section, click **Add attribute**. 
-	* Set your settings to match the screenshot below (except for the variable name, which is created automatically). The only two fields that must match exactly are **External name** and **External namespace**. The value for **External namespace** must be `urn:ietf:params:scim:schemas:extension:newrelic:2.0:User`
+	* Set your settings to match the screenshot below. The only two fields that must match exactly are **External name** (value: `nrUserType`) and **External namespace** (value: `urn:ietf:params:scim:schemas:extension:newrelic:2.0:User`). The `variable` field doesn't matter. 
 	
   ![Adding new attribute in Okta app](./images/okta-define-user-type.png "Adding new attribute in Okta app")
 

--- a/src/content/docs/accounts/accounts/automated-user-management/roles-permissions-automated-user-management.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/roles-permissions-automated-user-management.mdx
@@ -1,5 +1,5 @@
 ---
-title: Example of identity provider groups mapping to New Relic access grants 
+title: "Automated user management: How identity provider groups map to New Relic groups"
 tags:
   - Accounts
   - Accounts and billing
@@ -11,9 +11,9 @@ redirects:
 
 With [automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) (AUM), your users and groups in your identity provider (like OneLogin or Okta) are synchronized with New Relic.
 
-## How groups work with your users [#group-example]
+## How groups work [#group-example]
 
-When using [automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign), all group administration happens in your identity provider. If your existing groups logically map to access in New Relic, we recommend sending your existing groups. This makes providing and changing access to New Relic from your identity provider easy.
+When using [automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign), you create groups of users in your identity provider service. Later, on the New Relic side, you'll create [access grants](/docs/accounts/accounts-billing/new-relic-one-user-management/add-manage-users-groups-roles/#understand-concepts), which essentially state "Give this group access to this New Relic role on this New Relic account." 
 
 ![Diagram showing the relationship between roles and permissions](./images/Roles%26Permissions.png "Roles and permissions")
 


### PR DESCRIPTION
Few things: 

For Okta doc, added info about creating groups in okta. 
More generally, added in AUM requirements a note about wanting to figure out groups on identity provider side before implementing AUM. 
Added info in Okta doc about recent change that they need to create a 'variable' field. 