### PR TITLE
fix(vsphere VM): Added "sample" to entity names where it was missing

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/vmware-vsphere-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/vmware-vsphere-monitoring-integration.mdx
@@ -273,15 +273,15 @@ For more on how to view and use your data, see [Understand integration data](/do
 
 The vSphere integration provides metric data attached to the following New Relic [events](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types#events-new-relic):
 
-* `VSphereHost`
-* `VSphereVm`
-* `VSphereDatastore`
-* `VSphereDatacenter`
-* `VSphereResourcePool`
-* `VSphereCluster`
-* `VSphereSnapshotVm`
+* `VSphereHostSample`
+* `VSphereVmSample`
+* `VSphereDatastoreSample`
+* `VSphereDatacenterSample`
+* `VSphereResourcePoolSample`
+* `VSphereClusterSample`
+* `VSphereSnapshotVmSample`
 
-### VSphereHost
+### VSphereHostSample
 
 <table>
   <thead>
@@ -604,7 +604,7 @@ The vSphere integration provides metric data attached to the following New Relic
   </tbody>
 </table>
 
-### VSphereVm [#vspherevirtualmachine]
+### VSphereVmSample [#vspherevirtualmachine]
 
 <table>
   <thead>
@@ -984,7 +984,7 @@ The vSphere integration provides metric data attached to the following New Relic
   </tbody>
 </table>
 
-### VSphereDatastore
+### VSphereDatastoreSample
 
 <table>
   <thead>
@@ -1145,7 +1145,7 @@ The vSphere integration provides metric data attached to the following New Relic
   </tbody>
 </table>
 
-### VSphereDatacenter
+### VSphereDatacenterSample
 
 <table>
   <thead>
@@ -1336,7 +1336,7 @@ The vSphere integration provides metric data attached to the following New Relic
   </tbody>
 </table>
 
-### VSphereResourcePool
+### VSphereResourcePoolSample
 
 <table>
   <thead>
@@ -1487,7 +1487,7 @@ The vSphere integration provides metric data attached to the following New Relic
   </tbody>
 </table>
 
-### VSphereCluster
+### VSphereClusterSample
 
 <table>
   <thead>
@@ -1778,7 +1778,7 @@ The vSphere integration provides metric data attached to the following New Relic
   </tbody>
 </table>
 
-### VSphereSnapshotVm [#vspheresnapshot]
+### VSphereSnapshotVmSample [#vspheresnapshot]
 
 <table>
   <thead>


### PR DESCRIPTION
This request came in via documentation slack channel and was confirmed by the agent hero.