### PR TITLE
feat: Add new relic mobile apps to the front index page of docs

### DIFF
--- a/src/content/docs/mobile-apps/new-relic-mobile-apps/android-app/introduction-new-relic-android-app.mdx
+++ b/src/content/docs/mobile-apps/new-relic-mobile-apps/android-app/introduction-new-relic-android-app.mdx
@@ -19,7 +19,7 @@ redirects:
 
 Requirements include:
 
-* Android 4.0 (Ice Cream Sandwich) or higher
+* Android 8.0 (Oreo) or higher
 * Screen size of 7 inches or less
 
 ## Install New Relic's mobile app [#installation]

--- a/src/content/docs/mobile-apps/new-relic-mobile-apps/ios-app/install-new-relic-ios-mobile-app.mdx
+++ b/src/content/docs/mobile-apps/new-relic-mobile-apps/ios-app/install-new-relic-ios-mobile-app.mdx
@@ -24,9 +24,9 @@ This section provides information about compatibility and requirements, basic in
 
 The New Relic iOS app allows you to view your New Relic applications, infrastructure data, key transactions, synthetic monitors, and alerts from an iPhone or iPad. Product requirements include:
 
-* iOS 7 or higher
-* iPhone users: iPhone 4S or higher
-* iPad users: iPad 2 or higher
+* iOS 13 or higher
+* iPhone users: iPhone SE or higher
+* iPad users: iPad Air 2 or higher
 
 You can also use an iPod touch, although resolution may be different.
 

--- a/src/data/homepage.yml
+++ b/src/data/homepage.yml
@@ -190,3 +190,17 @@ integrations:
       - name: StatsD
         icon: logo-statsd
         link: /docs/integrations/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2
+
+mobile_apps:
+  title: New Relic mobile apps
+  description: View the power of NR1 in the palm of your hand.
+  tiles:
+    - name: Android
+      icon: logo-android-color
+      link: /docs/mobile-apps/new-relic-mobile-apps/android-app/introduction-new-relic-android-app
+    - name: iOS
+      icon: logo-apple-color
+      link: /docs/mobile-apps/new-relic-mobile-apps/ios-app/introduction-ios-mobile-app
+    - name: tvOS
+      icon: logo-newrelic
+      link: /docs/mobile-apps/new-relic-mobile-apps/tvos-app/introduction-apple-tv-app

--- a/src/data/homepage.yml
+++ b/src/data/homepage.yml
@@ -193,7 +193,7 @@ integrations:
 
 mobile_apps:
   title: New Relic mobile apps
-  description: View the power of NR1 in the palm of your hand.
+  description: All the power of New Relic One in the palm of your hand.
   tiles:
     - name: Android
       icon: logo-android-color

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -145,6 +145,10 @@
       "title2": "Infrastructure and cloud platforms",
       "title3": "Open-source monitoring systems"
     },
+    "mobile_apps": {
+      "title": "New Relic mobile apps",
+      "description": "View the power of NR1 in the palm of your hand."
+    },
     "security": {
       "title": "Security, privacy, and legal information",
       "description": "Find out how we ensure security, data privacy, and compliance, and find our terms of service.",

--- a/src/i18n/translations/jp/translation.json
+++ b/src/i18n/translations/jp/translation.json
@@ -135,6 +135,10 @@
       "title2": "インフラストラクチャおよびクラウドプラットフォーム",
       "title3": "オープンソースモニタリングシステム"
     },
+    "mobile_apps": {
+      "title": "New Relic mobile apps",
+      "description": "View the power of NR1 in the palm of your hand."
+    },
     "security": {
       "title": "セキュリティ、プライバシー、および法的情報 ID",
       "description": "セキュリティ、データプライバシー、コンプライアンスを確保する方法と、利用規約をご覧ください。",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,7 +16,14 @@ import SurfaceLink from '../components/SurfaceLink';
 import TechTile from '../components/TechTile';
 import TechTileGrid from '../components/TechTileGrid';
 import NetworkPerformanceMonitoringBannerGA from '../components/NetworkPerformanceMonitoringBannerGA';
-import { tdp, fso, ai, security, integrations, mobile_apps } from '../data/homepage.yml';
+import {
+  tdp,
+  fso,
+  ai,
+  security,
+  integrations,
+  mobile_apps,
+} from '../data/homepage.yml';
 
 const HomePage = ({ data }) => {
   const {
@@ -221,7 +228,9 @@ const HomePage = ({ data }) => {
           icon="logo-newrelic"
           to="/docs/mobile-apps/new-relic-mobile-apps"
         />
-        <SectionDescription>{t('home.mobile_apps.description')}</SectionDescription>
+        <SectionDescription>
+          {t('home.mobile_apps.description')}
+        </SectionDescription>
         <TechTileGrid>
           {mobile_apps.tiles.map(({ name, icon, link }) => (
             <TechTile key={name} name={name} icon={icon} to={link} />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,7 +16,7 @@ import SurfaceLink from '../components/SurfaceLink';
 import TechTile from '../components/TechTile';
 import TechTileGrid from '../components/TechTileGrid';
 import NetworkPerformanceMonitoringBannerGA from '../components/NetworkPerformanceMonitoringBannerGA';
-import { tdp, fso, ai, security, integrations } from '../data/homepage.yml';
+import { tdp, fso, ai, security, integrations, mobile_apps } from '../data/homepage.yml';
 
 const HomePage = ({ data }) => {
   const {
@@ -214,6 +214,19 @@ const HomePage = ({ data }) => {
             See all 370+ integrations
           </Button>
         </div>
+      </Section>
+      <Section alternate layout={layout}>
+        <SectionTitle
+          title={t('home.mobile_apps.title')}
+          icon="logo-newrelic"
+          to="/docs/mobile-apps/new-relic-mobile-apps"
+        />
+        <SectionDescription>{t('home.mobile_apps.description')}</SectionDescription>
+        <TechTileGrid>
+          {mobile_apps.tiles.map(({ name, icon, link }) => (
+            <TechTile key={name} name={name} icon={icon} to={link} />
+          ))}
+        </TechTileGrid>
       </Section>
       <Section layout={layout}>
         <SectionTitle title={t('home.security.title')} />


### PR DESCRIPTION
## Give us some context

* I noticed the home page does not have any links to our new relic mobile apps, and it was quite impossible to know we have them, and in addition find any docs (except for release notes)
* View additional section under integration on the index page

<img width="521" alt="Screen Shot 2021-11-08 at 1 58 38 PM" src="https://user-images.githubusercontent.com/467588/140824958-49e98997-958c-42b2-9fe0-a4036cc7f039.png">
* https://newrelic.atlassian.net/browse/MOBAPPS-4233
* I also updated the minimum os versions required, since those have changed for the mobile apps.