### PR TITLE
chore(codestream): Change line wraps to match rest of site, tweak formatting

### DIFF
--- a/src/content/docs/codestream/codestream-integrations/msteams-integration.mdx
+++ b/src/content/docs/codestream/codestream-integrations/msteams-integration.mdx
@@ -5,97 +5,63 @@ description: "How to connect CodeStream to your Microsoft Teams channel."
 
 Connect New Relic CodeStream to your Microsoft Teams channel.
 
-When you post a codemark your teammates will get notified via the activity feed,
-and potentially via email. Sometimes, though, you might want to share to
-Microsoft Teams as well. This would allow you to reach people who haven’t yet
-joined CodeStream, or maybe don’t spend a lot of time in their IDE. 
+When you post a codemark your teammates will get notified via the activity feed, and potentially via email. Sometimes, though, you might want to share to Microsoft Teams as well. This would allow you to reach people who haven’t yet joined CodeStream, or maybe don’t spend a lot of time in their IDE. 
 
 ## Connect to Microsoft Teams [#connect]
 
-1. [Click here to install the CodeStream
-   app](https://teams.microsoft.com/l/app/7cf49ab7-8b65-4407-b494-f02b525eef2b?source=store-copy-link)
-   or go to apps in your Microsoft Teams sidebar and search for CodeStream.
-
-1. Once installed you should see the following popup for the CodeStream app,
-   click the **Add** button. Note, do not expand it and select the options to add
-   to team or chat. Simply click Add.
-
+1. [Click here to install the CodeStream app](https://teams.microsoft.com/l/app/7cf49ab7-8b65-4407-b494-f02b525eef2b?source=store-copy-link) or go to apps in your Microsoft Teams sidebar and search for CodeStream.
+2. Once installed you should see the following popup for the CodeStream app, click the **Add** button. Note, do not expand it and select the options to add to team or chat. Simply click Add.
 	![Add App](/images/MSTCSAppPage.png)
 
-1. This will take you to your private chat with the CodeStream bot, and you’ll
-   see the CodeStream logo appear in the Teams sidebar. Type `signin` in this
-   chat and submit.
-
+3. This will take you to your private chat with the CodeStream bot, and you’ll see the CodeStream logo appear in the Teams sidebar. Type `signin` in this chat and submit.
 	![Signin Command](/images/MSTSigninMsg.png)
 
-1. A post from the bot will appear in the stream, along with a **Sign in** button.
-
+4. A post from the bot will appear in the stream, along with a **Sign in** button.
 	![Signin Button](/images/MSTSigninButton.png)
 
-1. Click the button and you’re taken to the web and prompted to sign into
-   CodeStream. 
-
+5. Click the button and you’re taken to the web and prompted to sign into CodeStream. 
 	![Sign into CodeStream](/images/MSTCSSigninPage.png)
 
-1. After signing in, you're given a token that you’ll need to copy and
-   paste into your chat with the CodeStream bot back in MS Teams. 
+6. After signing in, you're given a token that you’ll need to copy and paste into your chat with the CodeStream bot back in MS Teams. 
 
 	![Signin Token](/images/MSTSigninToken.png)
 
-1. Paste the token into the chat and submit.
+7. Paste the token into the chat and submit.
 
 	![Token Message](/images/MSTTokenMsg.png)
 
-1. Go to a channel in which you’d like to share, type `@`, and then select **Get
-   bots** in the popup. 
+8. Go to a channel in which you’d like to share, type `@`, and then select **Get bots** in the popup. 
 
 	![Get Bots](/images/MSTGetBots.png)
 
-1. Select the CodeStream bot from the list (you can search for it if you need to),
-   and then click **Add**.
+9. Select the CodeStream bot from the list (you can search for it if you need to), and then click **Add**.
 
 	![Add a Bot](/images/MSTAddABot.png)
 
-1. Return to the channel and @mention the CodeStream bot with the `connect`
-   command. Repeat this in any channel that you'd like to share to.
+10. Return to the channel and @mention the CodeStream bot with the `connect` command. Repeat this in any channel that you'd like to share to.
 
 	![Connect Bot](/images/MSTConnectBot1.png)
 
-1. Once you get the following confirmation, you’re ready to share to Teams from
-   CodeStream.
+11. Once you get the following confirmation, you’re ready to share to Teams from CodeStream.
 
 	![Upload App](/images/MSTConnected1.png)
 
-1. When you return to CodeStream you'll now be able to share to the channels
-   that you just connected.
+12. When you return to CodeStream you'll now be able to share to the channels that you just connected.
 
 	![Select Channel](/images/MSTSelectChannel.png)
 
 ## Participate in CodeStream from Microsoft Teams [#participate]
 
-When you share to Microsoft Teams, not only does it notify your teammates about the
-codemark, but they can use it to jump directly into their IDEs to participate in
-the conversation on CodeStream.
+When you share to Microsoft Teams, not only does it notify your teammates about the codemark, but they can use it to jump directly into their IDEs to participate in the conversation on CodeStream.
 
 ![Share on Teams](/images/ShareOnMST1.png)
 
 ### Open in IDE [#open-ide]
 
-Click **Open in IDE** to view both the code and the discussion right inside your
-IDE. You’re taken through a CodeStream web page where you can choose
-which IDE to open. CodeStream remembers your selection the next time
-you view a discussion from the same repository. You’re then taken to the
-appropriate source file in your IDE, scrolled to the relevant block of code,
-with the discussion displayed in the CodeStream pane. If you don’t happen to
-have that repository open in your IDE, CodeStream will automatically open
-the source file for you (assuming you’ve opened that repository previously, with
-CodeStream installed, so that we know where to find it).
+Click **Open in IDE** to view both the code and the discussion right inside your IDE. You’re taken through a CodeStream web page where you can choose which IDE to open. CodeStream remembers your selection the next time you view a discussion from the same repository. You’re then taken to the appropriate source file in your IDE, scrolled to the relevant block of code, with the discussion displayed in the CodeStream pane. If you don’t happen to have that repository open in your IDE, CodeStream will automatically open the source file for you (assuming you’ve opened that repository previously, with CodeStream installed, so that we know where to find it).
 
-If you’re using a JetBrains IDE, install the
-[Toolbox app](https://www.jetbrains.com/toolbox-app/) so that CodeStream can
-deep link into the IDE.
+If you’re using a JetBrains IDE, install the [Toolbox app](https://www.jetbrains.com/toolbox-app/) so that CodeStream can deep link into the IDE.
 
 ### Open on GitHub (or Bitbucket or GitLab) [#open-github]
 
-If the code block is from a repository hosted on GitHub, Bitbucket, or GitLab, this
-button will take you to the corresponding block of code on that hosting service.
+If the code block is from a repository hosted on GitHub, Bitbucket, or GitLab, this button will take you to the corresponding block of code on that hosting service.

--- a/src/content/docs/codestream/codestream-integrations/notifications.mdx
+++ b/src/content/docs/codestream/codestream-integrations/notifications.mdx
@@ -35,9 +35,9 @@ Click the **Open** button to open the discussion so that you can participate.
 
 CodeStream offers the following notifications that can be turned on and off via the checkboxes at the bottom of the page.
 
-* Notify me about outstanding feedback requests - Get an email reminder about open feedback requests assigned to you that you haven't responded to in the last 24 hours.
-* Notify me about new unreviewed commits from teammates when I pull - Any time you pull, if there are new commits from a teammate on the current branch you'll get a toast notification. Click the **Review** button to start reviewing your teammate's changes and provide feedback.
-* Send me weekly emails summarizing my activity - Sent every Monday with information about you and your organization's activity for the previous week.
+* **Notify me about outstanding feedback requests**: Get an email reminder about open feedback requests assigned to you that you haven't responded to in the last 24 hours.
+* **Notify me about new unreviewed commits from teammates when I pull**: Any time you pull, if there are new commits from a teammate on the current branch you'll get a toast notification. Click the **Review** button to start reviewing your teammate's changes and provide feedback.
+* **Send me weekly emails summarizing my activity**: Sent every Monday with information about you and your organization's activity for the previous week.
 
 If you've connected to GitHub or GitHub Enterprise to leverage CodeStream's [pull request integration](/docs/codestream/how-use-codestream/pull-requests), you'll also be notified when a pull request is assigned to you or you are added as a reviewer.
 

--- a/src/content/docs/codestream/codestream-integrations/notifications.mdx
+++ b/src/content/docs/codestream/codestream-integrations/notifications.mdx
@@ -3,30 +3,21 @@ title: CodeStream notifications
 description: "How to get CodeStream notifications."
 ---
 
-New Relic CodeStream will notify you about comments, issues, and feedback requests that you
-follow, and you can choose whether you want to be notified via email, desktop
-(for the VS Code and JetBrains extensions only), or both. Look for the notifications option under your user profile menu at the top of the CodeStream pane.
+New Relic CodeStream will notify you about comments, issues, and feedback requests that you follow, and you can choose whether you want to be notified via email, desktop (for the VS Code and JetBrains extensions only), or both. Look for the notifications option under your user profile menu at the top of the CodeStream pane.
 
 ## Notification settings [#settings]
 
 ![Notification Settings](/images/NotificationSettings4.png)
 
-By default, you're set to automatically follow any comment, issue, or feedback
-request that you created, where you’ve been mentioned (either in the original
-post or in a subsequent reply), or to which you’ve replied. 
+By default, you're set to automatically follow any comment, issue, or feedback request that you created, where you’ve been mentioned (either in the original post or in a subsequent reply), or to which you’ve replied. 
 
-You can always choose to follow or unfollow any individual comment, issue, or
-feedback request via its ellipses menu.
+You can always choose to follow or unfollow any individual comment, issue, or feedback request via its ellipses menu.
 
 ## Follow or unfollow [#follow]
 
 ![Unfollow](/images/CodemarkMenu-Unfollow.png)
 
-Email notifications are sent immediately. You can participate in the discussion
-by replying to the email. Your reply will get added to CodeStream as a 
-reply to the appropriate comment, issue, or feedback request. Be sure that when
-you reply you're doing so from the same email address where the notification
-was sent (that is, your email address listed in **My Organization** on CodeStream). 
+Email notifications are sent immediately. You can participate in the discussion by replying to the email. Your reply will get added to CodeStream as a  reply to the appropriate comment, issue, or feedback request. Be sure that when you reply you're doing so from the same email address where the notification was sent (that is, your email address listed in **My Organization** on CodeStream). 
 
 You can unfollow a codemark or code review by clicking the link at the bottom of the email.
 
@@ -34,22 +25,17 @@ You can unfollow a codemark or code review by clicking the link at the bottom of
 
 ## Desktop notifications [#desktop]
 
-If you’re using CodeStream in VS Code or a JetBrains IDE you can also receive
-desktop notifications in the IDE for comment, issue, or feedback requests that you
-follow.
+If you’re using CodeStream in VS Code or a JetBrains IDE you can also receive desktop notifications in the IDE for comment, issue, or feedback requests that you follow.
 
 ![Desktop Notification](/images/DesktopNotification2.png)
 
-Click the **Open** button to open the discussion so that you can
-participate.
+Click the **Open** button to open the discussion so that you can participate.
 
 ## Other notifications [#other]
 
 CodeStream offers the following notifications that can be turned on and off via the checkboxes at the bottom of the page.
 
-* Notify me about outstanding feedback requests - Get an
-email reminder about open feedback requests assigned to you that you haven't
-responded to in the last 24 hours.
+* Notify me about outstanding feedback requests - Get an email reminder about open feedback requests assigned to you that you haven't responded to in the last 24 hours.
 * Notify me about new unreviewed commits from teammates when I pull - Any time you pull, if there are new commits from a teammate on the current branch you'll get a toast notification. Click the **Review** button to start reviewing your teammate's changes and provide feedback.
 * Send me weekly emails summarizing my activity - Sent every Monday with information about you and your organization's activity for the previous week.
 

--- a/src/content/docs/codestream/codestream-integrations/slack-integration.mdx
+++ b/src/content/docs/codestream/codestream-integrations/slack-integration.mdx
@@ -5,89 +5,54 @@ description: "How to connect CodeStream to your Slack channel."
 
 Connect New Relic CodeStream to your team's Slack channel.
 
-When you post a comment, issue, or feedback request, your teammates are
-notified via the activity feed, and potentially via email. Sometimes, though,
-you might want to share to Slack as well. This allows you to reach people
-who haven’t yet joined CodeStream or maybe don’t spend a lot of time in their
-IDE. 
+When you post a comment, issue, or feedback request, your teammates are notified via the activity feed, and potentially via email. Sometimes, though, you might want to share to Slack as well. This allows you to reach people who haven’t yet joined CodeStream or maybe don’t spend a lot of time in their IDE. 
 
 ## Share to Slack [#share]
- 
-When posting a comment, issue, or feedback request, click the Slack link at
-the bottom of the form to take you off to the web to authenticate with one of
-your Slack workspaces. 
+
+When posting a comment, issue, or feedback request, click the Slack link at the bottom of the form to take you off to the web to authenticate with one of your Slack workspaces. 
 
 ![Connect to Share](/images/NewCodemark-NotConnected2.png)
 
-Once you’ve connected to a workspace, select the channel or
-direct message you'd like to share to.
+Once you’ve connected to a workspace, select the channel or direct message you'd like to share to.
 
 ![Select Channel](/images/PostTo-Slack.png)
 
-By default, CodeStream will remember if and where you last shared to and the form will
-default to the same selection the next time. If you’d like to choose a default
-channel to use based on the repository you're in, click the gear menu at the
-top of the post to popup, and then set the default behavior for each
-repository.
+By default, CodeStream will remember if and where you last shared to and the form will default to the same selection the next time. If you’d like to choose a default channel to use based on the repository you're in, click the gear menu at the top of the post to popup, and then set the default behavior for each repository.
 
-You can also share an existing post to Slack, even one created by a
-teammate. Go to a comment, issue, or feedback request and look for the
-**Share** option under the ellipses menu.
+You can also share an existing post to Slack, even one created by a teammate. Go to a comment, issue, or feedback request and look for the **Share** option under the ellipses menu.
 
-Look for the **Shared To** section to keep track of where a post has been shared.
-Click on an entry to go straight to that conversation on Slack.
+Look for the **Shared To** section to keep track of where a post has been shared. Click on an entry to go straight to that conversation on Slack.
 
 ![Shared To Section](/images/SharedTo.png)
 
 ## Participate from Slack [#participate]
 
-A comment, issue, or feedback request shared to Slack is much more powerful than
-a simple notification. Your teammates can participate in the discussion right
-from Slack.
+A comment, issue, or feedback request shared to Slack is much more powerful than a simple notification. Your teammates can participate in the discussion right from Slack.
 
 ![Codemark on Slack](/images/ShareOnSlack1.png)
 
 ### View discussions and reply [#discussions]
 
-Your teammates can click **View Discussion & Reply** to add a reply.That
-reply is posted to CodeStream. Any previous replies are displayed as
-well so that they can catch up on the entire discussion. 
+Your teammates can click **View Discussion & Reply** to add a reply.That reply is posted to CodeStream. Any previous replies are displayed as well so that they can catch up on the entire discussion. 
 
 ![Reply from Slack](images/ReplyFromSlack.gif)
 
-Your teammates don’t need to be CodeStream users in order to
-participate in discussions via Slack.
+Your teammates don’t need to be CodeStream users in order to participate in discussions via Slack.
 
 ### Open in IDE [#open-idea]
 
-Click **Open in IDE** to view both the code and the discussion right inside your
-IDE. You’re first taken through a CodeStream web page where you’ll choose
-which IDE to open. CodeStream remember your selection the next time
-you view a discussion from the same repository. You’re then taken to the
-appropriate source file in your IDE, scrolled to the relevant block of code,
-with the discussion displayed in the CodeStream pane. If you don’t happen to
-have that repository open in your IDE, CodeStream automatically opens
-the source file for you (assuming you’ve opened that repository previously, with
-CodeStream installed, so that we know where to find it).
+Click **Open in IDE** to view both the code and the discussion right inside your IDE. You’re first taken through a CodeStream web page where you’ll choose which IDE to open. CodeStream remember your selection the next time you view a discussion from the same repository. You’re then taken to the appropriate source file in your IDE, scrolled to the relevant block of code, with the discussion displayed in the CodeStream pane. If you don’t happen to have that repository open in your IDE, CodeStream automatically opens the source file for you (assuming you’ve opened that repository previously, with CodeStream installed, so that we know where to find it).
 
-If you’re using a JetBrains IDE, install the
-[Toolbox App](https://www.jetbrains.com/toolbox-app/) so that CodeStream can
-deep link into the IDE.
+If you’re using a JetBrains IDE, install the [Toolbox App](https://www.jetbrains.com/toolbox-app/) so that CodeStream can deep link into the IDE.
 
 ### Open on GitHub (or Bitbucket or GitLab) [#open-github]
 
-If the code block is from a repository hosted on GitHub, Bitbucket, or GitLab,
-this button will take you to the corresponding block of code on that hosting
-service.
+If the code block is from a repository hosted on GitHub, Bitbucket, or GitLab, this button will take you to the corresponding block of code on that hosting service.
 
 ## Resolve codemarks and feedback requests [#resolve]
 
-When a codemark or feedback request gets resolved, approved, rejected, or
-reopened, a reply is automatically posted to any corresponding conversations on
-Slack.
+When a codemark or feedback request gets resolved, approved, rejected, or reopened, a reply is automatically posted to any corresponding conversations on Slack.
 
 ![Resolved on Slack](/images/ResolvedOnSlack.png)
 
-Many organizations have non-developers that participate in discussions, or at
-least passively monitor them, through Slack, and these notifications help keep
-those people in the loop as discussions or feedback requests get resolved.
+Many organizations have non-developers that participate in discussions, or at least passively monitor them, through Slack, and these notifications help keep those people in the loop as discussions or feedback requests get resolved.

--- a/src/content/docs/codestream/codestream-settings/account-settings.mdx
+++ b/src/content/docs/codestream/codestream-settings/account-settings.mdx
@@ -7,26 +7,20 @@ New Relic CodeStream account settings let you make changes to your personal acco
 
 ## Account overview [#overview]
 
-The **Account** menu is located under the ellipses menu at the top of the CodeStream
-pane. The account menu includes options for viewing your profile and changing your
-profile photo, username, full name, and email address. 
+The **Account** menu is located under the ellipses menu at the top of the CodeStream pane. The account menu includes options for viewing your profile and changing your profile photo, username, full name, and email address. 
 
 ![Account Settings](/images/AccountSettings2.png)
 
-When you change your email address, the old one will remain in effect
-until you click the link in the confirmation email that's sent to you.
+When you change your email address, the old one will remain in effect until you click the link in the confirmation email that's sent to you.
 
-If you'd like to cancel your CodeStream account, find that option 
-under **Other Actions**.
+If you'd like to cancel your CodeStream account, find that option  under **Other Actions**.
 
 ## Account profile [#profile]
 
-If you click a headshot from anywhere in CodeStream (such as, the activity feed or a
-discussion thread) you're taken to that person's profile page.
+If you click a headshot from anywhere in CodeStream (such as, the activity feed or a discussion thread) you're taken to that person's profile page.
 
 ![Profile Page](/images/ProfilePage3.png)
 
-When viewing your own profile page, hover over entries for username, email
-address, phone number, works on, or the profile photo to see a pencil icon that enables you to make changes to those fields.
+When viewing your own profile page, hover over entries for username, email address, phone number, works on, or the profile photo to see a pencil icon that enables you to make changes to those fields.
 
 ![Edit Profile](/images/EditProfile.png)

--- a/src/content/docs/codestream/codestream-settings/team-administration.mdx
+++ b/src/content/docs/codestream/codestream-settings/team-administration.mdx
@@ -41,10 +41,10 @@ Admins can control how both feedback request assignments and approvals work for 
 
 By default, the person requesting feedback can decide how approvals work, but you can, instead, set a default behavior for all feedback requests for the organization.
 
-* Any reviewer can approve - Anyone can approve the feedback request, regardless of how many reviewers are assigned.
-* All reviewers must approve individually - Each assigned reviewer must individually approve the feedback request before it’s considered approved.
+* **Any reviewer can approve**: Anyone can approve the feedback request, regardless of how many reviewers are assigned.
+* **All reviewers must approve individually**: Each assigned reviewer must individually approve the feedback request before it’s considered approved.
 
-You can also decide if and how CodeStream suggests reviewers. Round-robin will cycle through all developers in the organization. Random will randomly assign the feedback request to any developer in the organization. The Authorship options will suggest up to three reviewers based on the developers who wrote the lines of code impacted by the changes, as well as other developers who may have committed to the branch.
+You can also decide if and how CodeStream suggests reviewers. **Round-robin** will cycle through all developers in the organization. **Random** will randomly assign the feedback request to any developer in the organization. The **Authorship** options will suggest up to three reviewers based on the developers who wrote the lines of code impacted by the changes, as well as other developers who may have committed to the branch.
 
 ## Change your organization's name [#change-name]
 

--- a/src/content/docs/codestream/codestream-settings/team-administration.mdx
+++ b/src/content/docs/codestream/codestream-settings/team-administration.mdx
@@ -7,9 +7,7 @@ New Relic CodeStream provides several tools for managing the teammates in your o
 
 ## Manage people and roles [#manage]
 
-Click [My Organization](/docs/codestream/how-use-codestream/my-organization) menu at the
-top of the CodeStream pane to invite people to your organization and assign or
-remove admin privileges.
+Click [My Organization](/docs/codestream/how-use-codestream/my-organization) menu at the top of the CodeStream pane to invite people to your organization and assign or remove admin privileges.
 
 ![Admin Privileges](/images/AdminRights2.png)
 
@@ -19,54 +17,34 @@ Click **Blame Map** to define code ownership with your organization.
 
 ![Blame Map](/images/MyOrgBlameMap.png)
 
-By default, when you comment on code, CodeStream mentions (or offers to email)
-the author or authors of the code you're commenting on. If that person has left the
-company it might not be the right thing to do. 
+By default, when you comment on code, CodeStream mentions (or offers to email) the author or authors of the code you're commenting on. If that person has left the company it might not be the right thing to do. 
 
-Non-admins are able to
-set up blame maps for themselves to handle situations where the email address
-they use to commit code is different than the one they used to sign up for
-CodeStream.
+Non-admins are able to set up blame maps for themselves to handle situations where the email address they use to commit code is different than the one they used to sign up for CodeStream.
 
 ## Organization settings [#organization-settings]
 
-If you're an organization admin, look for the **Organization Admin** menu under the
-headshot menu at the top of the CodeStream pane.
+If you're an organization admin, look for the **Organization Admin** menu under the headshot menu at the top of the CodeStream pane.
 
 ![Organization Settings](/images/OrganizationSettings.png)
 
 ## Onboarding settings [#onboarding]
 
-Domain-based joining allows anyone with email addresses on the specified domains
-to join your CodeStream organization without being first invited. Not only does
-this make it very easy to get your teammates on board, but it ensures that
-they'll be part of your organization (as opposed to accidentally creating their
-own).
+Domain-based joining allows anyone with email addresses on the specified domains to join your CodeStream organization without being first invited. Not only does this make it very easy to get your teammates on board, but it ensures that they'll be part of your organization (as opposed to accidentally creating their own).
 
 ![Domain-based Joining](/images/OnboardingDomainJoining.png)
 
 ## Feedback request assignment and approval [#feedback-requests]
 
-Admins can control how both feedback request assignments and approvals work
-for your organization. 
+Admins can control how both feedback request assignments and approvals work for your organization. 
 
 ![Feedback Request Settings](/images/FRTeamSettings.png)
 
-By default, the person requesting feedback can decide how approvals work, but
-you can, instead, set a default behavior for all feedback requests for the
-organization.
+By default, the person requesting feedback can decide how approvals work, but you can, instead, set a default behavior for all feedback requests for the organization.
 
-* Any reviewer can approve - Anyone can approve the feedback request,
-  regardless of how many reviewers are assigned.
-* All reviewers must approve individually - Each assigned reviewer must
-  individually approve the feedback request before it’s considered approved.
+* Any reviewer can approve - Anyone can approve the feedback request, regardless of how many reviewers are assigned.
+* All reviewers must approve individually - Each assigned reviewer must individually approve the feedback request before it’s considered approved.
 
-You can also decide if and how CodeStream suggests reviewers. Round-robin will
-cycle through all developers in the organization. Random will randomly assign
-the feedback request to any developer in the organization. The Authorship
-options will suggest up to three reviewers based on the developers who wrote the
-lines of code impacted by the changes, as well as other developers who may have
-committed to the branch.
+You can also decide if and how CodeStream suggests reviewers. Round-robin will cycle through all developers in the organization. Random will randomly assign the feedback request to any developer in the organization. The Authorship options will suggest up to three reviewers based on the developers who wrote the lines of code impacted by the changes, as well as other developers who may have committed to the branch.
 
 ## Change your organization's name [#change-name]
 
@@ -76,8 +54,6 @@ Update the name of your CodeStream organization at any time.
 
 ## Export your data [#export] 
 
-There's a lightweight export tool for getting your organization's discussions out of
-CodeStream. Click the icon to copy all of your data to the clipboard so that you can paste it elsewhere.
+There's a lightweight export tool for getting your organization's discussions out of CodeStream. Click the icon to copy all of your data to the clipboard so that you can paste it elsewhere.
 
 ![Data Export](/images/DataExport.png)
-

--- a/src/content/docs/codestream/codestream-ui-overview/activity-feed.mdx
+++ b/src/content/docs/codestream/codestream-ui-overview/activity-feed.mdx
@@ -3,39 +3,27 @@ title: CodeStream activity feed
 metaDescription: "The CodeStream activity feed provides a continually updated list of new comments, issues, and feedback requests."
 ---
 
-The activity feed is the definitive place to find out about new comments, issues,
-and feedback requests posted by your teammates or new replies to existing
-discussions. When you’re not on the activity feed, you can always tell whether
-or not there’s anything new by looking for a badge on the activity feed icon. A
-blue badge with a white dot means that there are new discussions or replies. A blue badge with a number inside means that there are new discussions or
-replies where you’ve been mentioned.
+The activity feed is the definitive place to find out about new comments, issues, and feedback requests posted by your teammates or new replies to existing discussions. When you’re not on the activity feed, you can always tell whether or not there’s anything new by looking for a badge on the activity feed icon. A
+blue badge with a white dot means that there are new discussions or replies. A blue badge with a number inside means that there are new discussions or replies where you’ve been mentioned.
 
 ![Activity Feed Badge](/images/ActivityFeedWithBadge3.png)
 
-CodeStream’s section in your IDE’s status bar also let’s you know when
-there are new messages in the feed. A dot to the right of your username means
-there are new messages and a number means there are new mentions.
+CodeStream’s section in your IDE’s status bar also let’s you know when there are new messages in the feed. A dot to the right of your username means there are new messages and a number means there are new mentions.
 
 ![Status Bar](/images/StatusBarWithMentions2.png)
 
 The filter at the top of the activity feed controls what you see
 in the feed.
 
-* Activity from everyone in my organization - See all of the 
-  activity from your organization. We only recommend this for small
-  organizations.
-* Activity associated with code open in my IDE (default) - See
-  discussions related to code in the repositories you have open in your IDE. 
-* Activity associated with code in selected folder - Use this option if your team is working within monorepos. See discussions
-  related to code in the currently selected folder.
+* **Activity from everyone in my organization**: See all of the  activity from your organization. We only recommend this for small organizations.
+* **Activity associated with code open in my IDE (default)**: See discussions related to code in the repositories you have open in your IDE. 
+* **Activity associated with code in selected folder**: Use this option if your team is working within monorepos. See discussions related to code in the currently selected folder.
 
 Regardless of your filter settings, you'll always be notified when you're @mentioned.
 
 ![Activity Feed Filters](/images/ActivityFeedFilters.png)
 
-As you might expect, new stuff gets added to the top of the feed, even if it’s a
-new reply to a very old discussion. CodeStream also adds a blue border to the left of new activity to flag it for you. For example, here’s a new
-comment at the top of the feed.
+As you might expect, new stuff gets added to the top of the feed, even if it’s a new reply to a very old discussion. CodeStream also adds a blue border to the left of new activity to flag it for you. For example, here’s a new comment at the top of the feed.
 
 ![New Comment in Feed](/images/ActivityFeed-NewCodemark.png)
 
@@ -43,13 +31,8 @@ Here's a new reply to a comment. Only the replies have a blue border, because th
 
 ![New Replies in Feed](/images/ActivityFeed-NewOldReplies.png)
 
-**See 1 earlier reply** means that there's an earlier reply
-that's already seen. Only new, unread replies are displayed in the main
-activity feed view, but you can click on that link to see the full discussion
-thread and add a new reply of your own.
+**See 1 earlier reply** means that there's an earlier reply that's already seen. Only new, unread replies are displayed in the main activity feed view, but you can click on that link to see the full discussion thread and add a new reply of your own.
 
 ![Expanded Comment](/images/CodemarkViewWithReplies1.png)
 
-The activity feed goes all the way back to the beginning of time for your team,
-but if you’re looking for specific, older codemarks you might be better off using our [filter and search](/docs/codestream/codestream-ui-overview/filter-search) tools.
-
+The activity feed goes all the way back to the beginning of time for your team, but if you’re looking for specific, older codemarks you might be better off using our [filter and search](/docs/codestream/codestream-ui-overview/filter-search) tools.

--- a/src/content/docs/codestream/codestream-ui-overview/codemarks-section.mdx
+++ b/src/content/docs/codestream/codestream-ui-overview/codemarks-section.mdx
@@ -3,24 +3,15 @@ title: CodeStream codemarks section
 metaDescription: "The codemarks section provides a list of open, resolved, and archived CodeStream comments."
 ---
 
-Whether they originated in a pull request, a feedback request, or through ad hoc
-code comments/issues, codemarks are the
-[discussions](/docs/codestream/how-use-codestream/discuss-code) that annotate your codebase. The
-codemarks section of the CodeStream pane lists all of the codemarks in your
-current repository for easy reference. Different sections and colors separate
-the codemarks by their status: open, resolved, or archived.
+Whether they originated in a pull request, a feedback request, or through ad hoc code comments/issues, codemarks are the [discussions](/docs/codestream/how-use-codestream/discuss-code) that annotate your codebase. The codemarks section of the CodeStream pane lists all of the codemarks in your current repository for easy reference. Different sections and colors separate the codemarks by their status: open, resolved, or archived.
 
 ![Codemarks Section](/images/CodemarksSection1.png)
 
-Click any item in the codemarks section to review its details and discussion. With the exception of
-pull-request comments, bubbles to the right show the number of replies.
+Click any item in the codemarks section to review its details and discussion. With the exception of pull-request comments, bubbles to the right show the number of replies.
 
-By default, all codemarks from the current repository are displayed, but you can
-change the filter to show all codemarks in the current branch, codemarks in the
-current folder, or codemarks in the currently selected file. 
+By default, all codemarks from the current repository are displayed, but you can change the filter to show all codemarks in the current branch, codemarks in the current folder, or codemarks in the currently selected file. 
 
-Codemarks from feedback and pull requests only appear when you've selected the
-current file filter.
+Codemarks from feedback and pull requests only appear when you've selected the current file filter.
 
 ![Codemarks Section Settings](/images/CodemarksSectionSettings1.png)
 
@@ -28,27 +19,13 @@ When you hover over the codemarks section heading, icons appear at the right.
 
 ![Codemarks Section Header](/images/CodemarksSectionHeader.png)
 
-The codemarks header includes options to create a code comment or issue. You can also choose to
-view the codemarks in a spatial view, instead of in a list. If you've ever
-commented on a Google Doc, spatial view will be a familiar concept. The
-discussions are displayed alongside the blocks of code they refer to, and as you
-scroll the source file the discussions scroll as well. It's a great way to
-review codemarks in a section of a file you're about to work on.
+The codemarks header includes options to create a code comment or issue. You can also choose to view the codemarks in a spatial view, instead of in a list. If you've ever commented on a Google Doc, spatial view will be a familiar concept. The discussions are displayed alongside the blocks of code they refer to, and as you scroll the source file the discussions scroll as well. It's a great way to review codemarks in a section of a file you're about to work on.
 
 ![Spatial View](/images/CodemarksSectionSpatial.png)
 
 Click the gear icon for more controls over the list.
 
-* Wrap multi-line comments - Rather than showing a truncated portion of the
-  codemark, the list shows the whole post is displayed.
-* Show tags - Any applicable tags will be displayed with each codemark.
-* Sort comments by - By default, Codemarks are ordered by date, but when the
-  filter is set to current file you can sort by line number (such as, their
-  order in the file).
-* Show icons in editor gutter - In addition to appearing in the list in the
-  codemarks section, codemarks are also represented as icons in the editor
-  gutter alongside the blocks of code they refer to. You can determine which
-  types of codemarks, and which statuses, you want to have displayed there. By
-  default, codemarks from feedback requests are displayed, but pull request
-  comments are not. Resolved codemarks are also displayed by default, but
-  archived codemarks are not.
+* **Wrap multi-line comments**: Rather than showing a truncated portion of the codemark, the list shows the whole post is displayed.
+* **Show tags**: Any applicable tags will be displayed with each codemark.
+* **Sort comments by**: By default, Codemarks are ordered by date, but when the filter is set to current file you can sort by line number (such as, their order in the file).
+* **Show icons in editor gutter**: In addition to appearing in the list in the codemarks section, codemarks are also represented as icons in the editor gutter alongside the blocks of code they refer to. You can determine which types of codemarks, and which statuses, you want to have displayed there. By default, codemarks from feedback requests are displayed, but pull request comments are not. Resolved codemarks are also displayed by default, but archived codemarks are not.

--- a/src/content/docs/codestream/codestream-ui-overview/codestream-sidebar.mdx
+++ b/src/content/docs/codestream/codestream-ui-overview/codestream-sidebar.mdx
@@ -3,8 +3,7 @@ title: CodeStream sidebar overview
 metaDescription: "Here's an overview of the CodeStream sidebar sections."
 ---
 
-The New Relic CodeStream sidebar surfaces all the items you need to see, and do, in a
-customizable tree-based view that is always available. 
+The New Relic CodeStream sidebar surfaces all the items you need to see, and do, in a customizable tree-based view that is always available. 
 
 ![A screenshot of the CodeStream sidebar sections](./images/Sidebar3.png "The CodeStream sidebar sections.")
 
@@ -14,11 +13,11 @@ customizable tree-based view that is always available.
 
 Here's a quick overview of the sidebar sections:
 
-* [Pull requests](/docs/codestream/codestream-ui-overview/pull-requests-section) - If your team uses GitHub or GitHub Enterprise to host your code, you'll see all of your open pull requests listed here. Click a specific pull request to start reviewing or editing it.
-* [Feedback requests](/docs/codestream/codestream-ui-overview/feedback-requests-section) - If you've been assigned a feedback request or you've requested feedback from someone else, find those listed here.
-* [Codemarks](/docs/codestream/codestream-ui-overview/codemarks-section) - Codemarks are the discussions that annotate your codebase. Codemarks are created pull requests, feedback requests, or through ad hoc code comments/issues. All of the codemarks in your current repository are listed for reference.
-* [Observability](/docs/codestream/codestream-ui-overview/observability-section) - Track errors assigned to you in New Relic One and discover recent errors in the repositories you have open in your IDE.
-* [Issues](/docs/codestream/codestream-ui-overview/issues-section) - See all of your open issues, across multiple services, in one place. Click a specific issue to update its status, create a feature branch to do your work, and update your status on Slack.
+* **[Pull requests](/docs/codestream/codestream-ui-overview/pull-requests-section)**: If your team uses GitHub or GitHub Enterprise to host your code, you'll see all of your open pull requests listed here. Click a specific pull request to start reviewing or editing it.
+* **[Feedback requests](/docs/codestream/codestream-ui-overview/feedback-requests-section)**: If you've been assigned a feedback request or you've requested feedback from someone else, find those listed here.
+* **[Codemarks](/docs/codestream/codestream-ui-overview/codemarks-section)**: Codemarks are the discussions that annotate your codebase. Codemarks are created pull requests, feedback requests, or through ad hoc code comments/issues. All of the codemarks in your current repository are listed for reference.
+* **[Observability](/docs/codestream/codestream-ui-overview/observability-section)**: Track errors assigned to you in New Relic One and discover recent errors in the repositories you have open in your IDE.
+* **[Issues](/docs/codestream/codestream-ui-overview/issues-section)**: See all of your open issues, across multiple services, in one place. Click a specific issue to update its status, create a feature branch to do your work, and update your status on Slack.
 
 The CodeStream sidebar is completely customizable: 
 
@@ -51,9 +50,7 @@ Here are descriptions of each menu item:
 
 <figcaption>The header menu items provide different options for creating and discovering content in your organization. From left to right: **Create**, **Activity feed**, **My organization**, and **Filter & search**.</figcaption>
 
-* **+** (Compose) - Click to create a code comment/issue, request feedback on changes, or to create a pull request.
-* [Activity feed](/docs/codestream/codestream-ui-overview/activity-feed) - The activity feed will let you know about new code comments/issues and feedback requests, as well as replies to existing ones.
-* [My organization](/docs/codestream/codestream-ui-overview/myorganization) - See who is in your CodeStream organization, invite new members, and create blame maps.
-* [Filter & search](/docs/codestream/codestream-ui-overview/filter-and-search) - The filter a search tools enable you to slice and dice your team’s collection of code comments, issues, and feature requests however you see fit.
-
-
+* **+** (Compose): Click to create a code comment/issue, request feedback on changes, or to create a pull request.
+* **[Activity feed](/docs/codestream/codestream-ui-overview/activity-feed)**: The activity feed will let you know about new code comments/issues and feedback requests, as well as replies to existing ones.
+* **[My organization](/docs/codestream/codestream-ui-overview/myorganization)**: See who is in your CodeStream organization, invite new members, and create blame maps.
+* **[Filter & search](/docs/codestream/codestream-ui-overview/filter-and-search)**: The filter a search tools enable you to slice and dice your team’s collection of code comments, issues, and feature requests however you see fit.

--- a/src/content/docs/codestream/codestream-ui-overview/feedback-requests-section.mdx
+++ b/src/content/docs/codestream/codestream-ui-overview/feedback-requests-section.mdx
@@ -17,7 +17,7 @@ By default, the person requesting feedback can decide how approvals work, but
 you can also set a default behavior for all feedback requests for your
 organization.
 
-* Any reviewer can approve - Anyone can approve the feedback request, regardless of how many reviewers have been assigned.
-* All reviewers must approve individually - Each assigned reviewer must individually approve the feedback request before it’s considered approved.
+* **Any reviewer can approve**: Anyone can approve the feedback request, regardless of how many reviewers have been assigned.
+* **All reviewers must approve individually**: Each assigned reviewer must individually approve the feedback request before it’s considered approved.
 
-You can also decide if and how CodeStream suggests reviewers. Round-robin will cycle through all developers in the organization. Random will randomly assign the feedback request to any developer in the organization. The authorship options suggest up to three reviewers based on the developers who wrote the lines of code impacted by the changes, as well as other developers who may have committed to the branch.
+You can also decide if and how CodeStream suggests reviewers. **Round-robin** will cycle through all developers in the organization. **Random** will randomly assign the feedback request to any developer in the organization. The **Authorship** options suggest up to three reviewers based on the developers who wrote the lines of code impacted by the changes, as well as other developers who may have committed to the branch.

--- a/src/content/docs/codestream/codestream-ui-overview/feedback-requests-section.mdx
+++ b/src/content/docs/codestream/codestream-ui-overview/feedback-requests-section.mdx
@@ -13,9 +13,7 @@ When you hover over the **Feedback Requests** section heading, you'll see a **+*
 
 ![Feedback Request Settings](/images/FRTeamSettings.png)
 
-By default, the person requesting feedback can decide how approvals work, but
-you can also set a default behavior for all feedback requests for your
-organization.
+By default, the person requesting feedback can decide how approvals work, but you can also set a default behavior for all feedback requests for your organization.
 
 * **Any reviewer can approve**: Anyone can approve the feedback request, regardless of how many reviewers have been assigned.
 * **All reviewers must approve individually**: Each assigned reviewer must individually approve the feedback request before it’s considered approved.

--- a/src/content/docs/codestream/codestream-ui-overview/feedback-requests-section.mdx
+++ b/src/content/docs/codestream/codestream-ui-overview/feedback-requests-section.mdx
@@ -3,20 +3,13 @@ title: CodeStream feedback requests
 metaDescription: "The CodeStream feedback requests section list all of your open feedback requests."
 ---
 
-New Relic CodeStream's feedback requests section lists all of the open feedback
-requests that have been assigned to you or that
-you've requested, as well as any of your recent feedback requests that have been
-approved or where changes have been requested. 
+New Relic CodeStream's feedback requests section lists all of the open feedback requests that have been assigned to you or that you've requested, as well as any of your recent feedback requests that have been approved or where changes have been requested. 
 
 ![Feedback Requests Section](/images/FRSection1.png)
 
-Click a feedback request to jump in and start reviewing or to see your teammate’s
-comments on your work.
+Click a feedback request to jump in and start reviewing or to see your teammate’s comments on your work.
 
-When you hover overthe **Feedback Requests** section heading, you'll see a **+** icon
-to create a new feedback request. If you're an admin you'll also see a gear
-icon to control how both feedback request assignments and approvals work for
-your organization. 
+When you hover over the **Feedback Requests** section heading, you'll see a **+** icon to create a new feedback request. If you're an admin you'll also see a gear icon to control how both feedback request assignments and approvals work for your organization. 
 
 ![Feedback Request Settings](/images/FRTeamSettings.png)
 
@@ -24,14 +17,7 @@ By default, the person requesting feedback can decide how approvals work, but
 you can also set a default behavior for all feedback requests for your
 organization.
 
-* Any reviewer can approve - Anyone can approve the feedback request,
-  regardless of how many reviewers have been assigned.
-* All reviewers must approve individually - Each assigned reviewer must
-  individually approve the feedback request before it’s considered approved.
+* Any reviewer can approve - Anyone can approve the feedback request, regardless of how many reviewers have been assigned.
+* All reviewers must approve individually - Each assigned reviewer must individually approve the feedback request before it’s considered approved.
 
-You can also decide if and how CodeStream suggests reviewers. Round-robin will
-cycle through all developers in the organization. Random will randomly assign
-the feedback request to any developer in the organization. The authorship
-options suggest up to three reviewers based on the developers who wrote the
-lines of code impacted by the changes, as well as other developers who may have
-committed to the branch.
+You can also decide if and how CodeStream suggests reviewers. Round-robin will cycle through all developers in the organization. Random will randomly assign the feedback request to any developer in the organization. The authorship options suggest up to three reviewers based on the developers who wrote the lines of code impacted by the changes, as well as other developers who may have committed to the branch.

--- a/src/content/docs/codestream/codestream-ui-overview/filter-search.mdx
+++ b/src/content/docs/codestream/codestream-ui-overview/filter-search.mdx
@@ -61,23 +61,23 @@ You can also use advanced search syntax to create your own searches and you can 
         </tr>
         <tr>
             <td>`author:@`</td>
-            <td>Returns all comments, issues and feedback requests authored by you (@me) or any teammate (@username).</td>
+            <td>Returns all comments, issues and feedback requests authored by you (`@me`) or any teammate (`@username`).</td>
         </tr>
         <tr>
             <td>`mentions:@`</td>
-            <td>Returns all comments, issues, and feedback requests where you (@me) or any teammate (@username) have been mentioned in either the title or description.</td>
+            <td>Returns all comments, issues, and feedback requests where you (`@me`) or any teammate (`@username`) have been mentioned in either the title or description.</td>
         </tr>
         <tr>
             <td>`impacts:@`</td>
-            <td>Returns all feedback requests that cover code that you (@me) or any teammate (@username) have touched.</td>
+            <td>Returns all feedback requests that cover code that you (`@me`) or any teammate (`@username`) have touched.</td>
         </tr>
         <tr>
             <td>`assignee:@`</td>
-            <td>Returns all issues and feedback requests assigned to you (@me) or a teammate (@username).</td>
+            <td>Returns all issues and feedback requests assigned to you (`@me`) or a teammate (`@username`).</td>
         </tr>
         <tr>
             <td>`reviewer:@`</td>
-            <td>Returns all issues and feedback requests assigned to you (@me) or a teammate (@username).</td>
+            <td>Returns all issues and feedback requests assigned to you (`@me`) or a teammate (`@username`).</td>
         </tr>
         <tr>
             <td>`tag:`</td>

--- a/src/content/docs/codestream/codestream-ui-overview/filter-search.mdx
+++ b/src/content/docs/codestream/codestream-ui-overview/filter-search.mdx
@@ -3,10 +3,7 @@ title: CodeStream filter and search tool
 metaDescription: "The CodeStream filter and search tool helps you find specific comments, issues, and feedback requests."
 ---
 
-New Relic CodeStream's filter and search tools enable you to slice and dice your organization's collection of
-comments, issues, and feedback requests however you see fit. By default, you’ll
-get a view of any open issues or feedback requests assigned to you, followed by
-all open issues and feedback requests.
+New Relic CodeStream's filter and search tools enable you to slice and dice your organization's collection of comments, issues, and feedback requests however you see fit. By default, you’ll get a view of any open issues or feedback requests assigned to you, followed by all open issues and feedback requests.
 
 ## UI overview [#ui]
 
@@ -20,36 +17,119 @@ CodeStream provides a number of powerful predefined filters to make things easy.
 
 ![Hover for Details](/images/Filters2.png)
 
-You can also use advanced search syntax to create
-your own searches and you can save them for future use via the bookmark icon at
-the right side of the search box.
+You can also use advanced search syntax to create your own searches and you can save them for future use via the bookmark icon at the right side of the search box.
 
 ![Hover for Details](/images/SavedFilter1.png)
 
 ## Advanced search syntax [#advanced-search]
 
-- `status:open` - Returns all open comments, issues, and feedback requests.
-- `status:closed` - Returns all resolved comments and issues.
-- `status:approved` - Returns all approved feedback requests.
-- `type:issue` - Returns all issues.
-- `type:comment` - Returns all comments.
-- `type:fr` - Returns all feedback requests.
-- `is:` - Use `open`, `closed`, `approved`, `issue`, `comment`, or `fr` for the same results as the status and type filters above.
-- `author:@` - Returns all comments, issues and feedback requests authored by you (@me) or any teammate (@username).
-- `mentions:@` - Returns all comments, issues, and feedback requests where you (@me) or any teammate (@username) have been mentioned in either the title or description.
-- `impacts:@` - Returns all feedback requests that cover code that you (@me) or any teammate (@username) have touched.
-- `assignee:@` - Returns all issues and feedback requests assigned to you (@me) or a teammate (@username).
-- `reviewer:@` - Returns all issues and feedback requests assigned to you (@me) or a teammate (@username).
-- `tag:` - Returns all comments, issues, and feedback requests with a specific tag. Use quotes around multi-word tags (for example, `tag:"api server"`). You can combine multiple tags to create an AND query. For example, `tag:blue tag:green` will return items that have both blue and green tags.
-- `no:tag` - Returns all comments, issues, and feedback requests that have no tags.
-- `branch:` - Returns all comments, issues, and feedback requests created against the specified branch.
-- `commit:` - Returns all comments, issues, and feedback requests that include code with the specified commit ID.
-- `repo:` - Returns all comments, issues, and feedback requests created against code in the specified repository.
-- `created:today` - Returns all comments, issues, and feedback requests created today.
-- `created:yesterday` - Returns all comments, issues, and feedback requests created yesterday.
-- `created:YYYY-MM-D`D - Returns all comments, issues, and feedback requests created on a specific date.
-- `created:<YYYY-MM-DD` - Returns all comments, issues, and feedback requests created before a specific date.
-- `created:>YYYY-MM-DD` - Returns all comments, issues, and feedback requests created after a specific date.
-- `updated:YYYY-MM-DD` - Returns all comments, issues, and feedback requests updated on a specific date.
-- `updated:<YYYY-MM-DD` - Returns all comments, issues, and feedback requests updated before a specific date.
-- `updated:>YYYY-MM-DD` - Returns all comments, issues, and feedback requests updated after a specific date.
+<table>
+    <thead>
+        <tr>
+            <th style={{ width: "200px" }}>Syntax</th>
+            <th>Definition</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>`status:open`</td>
+            <td>Returns all open comments, issues, and feedback requests.</td>
+        </tr>
+        <tr>
+            <td>`status:closed`</td>
+            <td>Returns all resolved comments and issues.</td>
+        </tr>
+        <tr>
+            <td>`status:approved`</td>
+            <td>Returns all approved feedback requests.</td>
+        </tr>
+        <tr>
+            <td>`type:issue`</td>
+            <td>Returns all issues.</td>
+        </tr>
+        <tr>
+            <td>`type:comment`</td>
+            <td>Returns all comments.</td>
+        </tr>
+        <tr>
+            <td>`type:fr`</td>
+            <td>Returns all feedback requests.</td>
+        </tr>
+        <tr>
+            <td>`is:`</td>
+            <td>Use `open`, `closed`, `approved`, `issue`, `comment`, or `fr` for the same results as the status and type filters above.</td>
+        </tr>
+        <tr>
+            <td>`author:@`</td>
+            <td>Returns all comments, issues and feedback requests authored by you (@me) or any teammate (@username).</td>
+        </tr>
+        <tr>
+            <td>`mentions:@`</td>
+            <td>Returns all comments, issues, and feedback requests where you (@me) or any teammate (@username) have been mentioned in either the title or description.</td>
+        </tr>
+        <tr>
+            <td>`impacts:@`</td>
+            <td>Returns all feedback requests that cover code that you (@me) or any teammate (@username) have touched.</td>
+        </tr>
+        <tr>
+            <td>`assignee:@`</td>
+            <td>Returns all issues and feedback requests assigned to you (@me) or a teammate (@username).</td>
+        </tr>
+        <tr>
+            <td>`reviewer:@`</td>
+            <td>Returns all issues and feedback requests assigned to you (@me) or a teammate (@username).</td>
+        </tr>
+        <tr>
+            <td>`tag:`</td>
+            <td>Returns all comments, issues, and feedback requests with a specific tag. Use quotes around multi-word tags (for example, `tag:"api server"`). You can combine multiple tags to create an AND query. For example, `tag:blue tag:green` will return items that have both blue and green tags.</td>
+        </tr>
+        <tr>
+            <td>`no:tag`</td>
+            <td>Returns all comments, issues, and feedback requests that have no tags.</td>
+        </tr>
+        <tr>
+            <td>`branch:`</td>
+            <td>Returns all comments, issues, and feedback requests created against the specified branch.</td>
+        </tr>
+        <tr>
+            <td>`commit:`</td>
+            <td>Returns all comments, issues, and feedback requests that include code with the specified commit ID.</td>
+        </tr>
+        <tr>
+            <td>`repo:`</td>
+            <td>Returns all comments, issues, and feedback requests created against code in the specified repository.</td>
+        </tr>
+        <tr>
+            <td>`created:today`</td>
+            <td>Returns all comments, issues, and feedback requests created today.</td>
+        </tr>
+        <tr>
+            <td>`created:yesterday`</td>
+            <td>Returns all comments, issues, and feedback requests created yesterday.</td>
+        </tr>
+        <tr>
+            <td>`created:YYYY-MM-DD`</td>
+            <td>Returns all comments, issues, and feedback requests created on a specific date.</td>
+        </tr>
+        <tr>
+            <td>`created:<YYYY-MM-DD`</td>
+            <td>Returns all comments, issues, and feedback requests created before a specific date.</td>
+        </tr>
+        <tr>
+            <td>`created:>YYYY-MM-DD`</td>
+            <td>Returns all comments, issues, and feedback requests created after a specific date.</td>
+        </tr>
+        <tr>
+            <td>`updated:YYYY-MM-DD`</td>
+            <td>Returns all comments, issues, and feedback requests updated on a specific date.</td>
+        </tr>
+        <tr>
+            <td>`updated:<YYYY-MM-DD`</td>
+            <td>Returns all comments, issues, and feedback requests updated before a specific date.</td>
+        </tr>
+        <tr>
+            <td>`updated:>YYYY-MM-DD`</td>
+            <td>Returns all comments, issues, and feedback requests updated after a specific date.</td>
+        </tr>
+    </tbody>
+</table>

--- a/src/content/docs/codestream/codestream-ui-overview/issues-section.mdx
+++ b/src/content/docs/codestream/codestream-ui-overview/issues-section.mdx
@@ -7,8 +7,7 @@ New Relic CodeStream issues are where you'll see the issues from your external c
 
 ## Connect your service to CodeStream [#connect]
 
-If you're not already connected to an external service, this
-section lists all of the available, supported services:
+If you're not already connected to an external service, this section lists all of the available, supported services:
 
 * Asana
 * Azure DevOps
@@ -23,8 +22,7 @@ section lists all of the available, supported services:
 
 ## Manage your issues [#manage-issues]
 
-Once you’ve connected to your team’s issue-tracking or code-hosting services, all of the issues assigned
-to you are listed in the issues section.
+Once you’ve connected to your team’s issue-tracking or code-hosting services, all of the issues assigned to you are listed in the issues section.
 
 ![Issues Section](/images/IssuesSection.png)
 
@@ -32,24 +30,19 @@ Your organization can use multiple external services at once. Select the one you
 
 ![Select Providers](/images/Tasks-MultipleProviders.png)
 
-Click an issue to start working on it. You can create a feature
-branch, update the ticket status, and even update your status on Slack.
+Click an issue to start working on it. You can create a feature branch, update the ticket status, and even update your status on Slack.
 
 ![Start Work](/images/IssuesStartWork.png)
 
-Hover over an issue's row to see an option to view the issue on
-your issue-tracking service toward the end of the row. 
+Hover over an issue's row to see an option to view the issue on your issue-tracking service toward the end of the row. 
 
-For many services you can also filter the list. For example, if you’re connected
-to Trello, you can filter to see a specific list or set of lists. 
+For many services you can also filter the list. For example, if you’re connected to Trello, you can filter to see a specific list or set of lists. 
 
 ![Filter Issues](/images/IssuesFilter.png)
 
-For Jira, Jira Server, GitHub, GitHub Enterprise, GitLab, and GitLab Self-managed you can even create custom
-filters. 
+For Jira, Jira Server, GitHub, GitHub Enterprise, GitLab, and GitLab Self-managed you can even create custom filters. 
 
-There are some special
-guidelines when creating a custom query for [GitHub and GitHub Enterprise](/docs/codestream/codestream-ui-overview/pull-requests-section/#github) or for [GitLab and GitLab Self-Managed](/docs/codestream/codestream-ui-overview/pull-requests-section/#gitlab).
+There are some special guidelines when creating a custom query for [GitHub and GitHub Enterprise](/docs/codestream/codestream-ui-overview/pull-requests-section/#github) or for [GitLab and GitLab Self-Managed](/docs/codestream/codestream-ui-overview/pull-requests-section/#gitlab).
 
 ![Customer Filter](/images/IssuesCustomFilter.png)
 
@@ -59,13 +52,10 @@ Hover over the section's heading for more options.
 
 Click the refresh button to update the list with any recently added tickets.
 
-Click **New issue** (although it may be labelled differently based on the selected
-service) to create a issue in your issue-tracking service right from CodeStream.
-You can even associate that ticket with a block of code in your editor.
+Click **New issue** (although it may be labelled differently based on the selected service) to create a issue in your issue-tracking service right from CodeStream. You can even associate that ticket with a block of code in your editor.
 
 ![New Card](/images/IssuesNewTrello.png)
 
-If you need to work on something that doesn’t have an associated ticket, you can
-click **Start ad-hoc Work** to get started without a ticket.
+If you need to work on something that doesn’t have an associated ticket, you can click **Start Ad-hoc Work** to get started without a ticket.
 
 ![Ad-hoc Work](/images/IssuesStartAdHoc.png)

--- a/src/content/docs/codestream/codestream-ui-overview/my-organization.mdx
+++ b/src/content/docs/codestream/codestream-ui-overview/my-organization.mdx
@@ -9,11 +9,9 @@ New Relic CodeStream provides a number of tools for managing your organization.
 
 ![My Organization Menu](./images/MyOrgMenu.png)
 
-In the header, click the **My Organization** menu button to see who's in your New Relic CodeStream
-organization, invite new members, and create blame maps. 
+In the header, click the **My Organization** menu button to see who's in your New Relic CodeStream organization, invite new members, and create blame maps. 
 
-Admins are identified in the teammates list. If you're an admin,
-there's a dropdown to assign or remove admin privileges to any member.
+Admins are identified in the teammates list. If you're an admin, there's a dropdown to assign or remove admin privileges to any member.
 
 ![Organization Members](./images/MyOrgMembers.png)
 
@@ -23,32 +21,18 @@ Click **Invite Teammates** to invite new members to your organization.
 
 ![Reinvite](./images/MyOrgInvite.png)
 
-The outstanding invitations section lists all open invitations. The
-right side of each row has links to remove the invitation or to resend the invite.
+The outstanding invitations section lists all open invitations. The right side of each row has links to remove the invitation or to resend the invite.
 
-Click **reinvite** to send another invitation via email. You
-can also hover over the reinvite link for the option to generate an email
-yourself.
+Click **reinvite** to send another invitation via email. You can also hover over the reinvite link for the option to generate an email yourself.
 
-The suggested teammates section, only available for admins, is a list
-of possible teammates derived from the commit history of your open repositories.
-At the right side of each row are links to remove the suggestion from the list
-or to invite the person.
+The suggested teammates section, only available for admins, is a list of possible teammates derived from the commit history of your open repositories. At the right side of each row are links to remove the suggestion from the list or to invite the person.
 
 ## Blame map [#blame]
 
-Click **Blame Map** to add email addresses that you use for committing code that
-may be different from the email address you used to sign up for CodeStream. For
-example, your CodeStream email address might be dave@acme.com, but you might
-also commit code as `dave@webmail.com`. 
+Click **Blame Map** to add email addresses that you use for committing code that may be different from the email address you used to sign up for CodeStream. For example, your CodeStream email address might be dave@acme.com, but you might also commit code as `dave@webmail.com`. 
 
-Click **Add mapping**, enter your Git email
-address, and then select your entry from the list of organization members. That
-way, when someone comments on code committed by dave@webmail.com, CodeStream
-will know to at-mention you (such as, `dave@acme.com`).
+Click **Add mapping**, enter your Git email address, and then select your entry from the list of organization members. That way, when someone comments on code committed by dave@webmail.com, CodeStream will know to at-mention you (such as, `dave@acme.com`).
 
 ![Blame Map](./images/MyOrgBlameMap.png)
 
-While non-admins can only create blame maps for themselves, admins can create
-blame maps for any member of the organization. This is useful for reassigning
-code ownership when people leave the organization.
+While non-admins can only create blame maps for themselves, admins can create blame maps for any member of the organization. This is useful for reassigning code ownership when people leave the organization.

--- a/src/content/docs/codestream/codestream-ui-overview/observability-section.mdx
+++ b/src/content/docs/codestream/codestream-ui-overview/observability-section.mdx
@@ -24,6 +24,7 @@ Once you have your user key, in **Observability** click **Connect to New Relic O
 <figcaption>Once you've connected New Relic to CodeStream, you'll see observed errors directly in CodeStream.</figcaption>
 
 These sections help you and your team manage and see your errors in different ways:
+
 * **Errors assigned to me**: If an error has been assigned to you, you'll see it here.
 * **Recent errors in**: Each repository you have open in your IDE will have its own grouping of errors. If your repository URL is mapped to more than one entity you're observing in New Relic, a dropdown lets you filter by entity.
 * **Select entity from New Relic**: Use this to connect a repository in your IDE with an entity you're observing with New Relic.

--- a/src/content/docs/codestream/codestream-ui-overview/permalinks.mdx
+++ b/src/content/docs/codestream/codestream-ui-overview/permalinks.mdx
@@ -7,45 +7,27 @@ New Relic CodeStream's permalinks can be shared with anyone, whether it's via Sl
 
 ## Permalinks for sharing anywhere [#permalinks]
 
-CodeStream has built-in mechanisms for sharing to Slack, Microsoft Teams, or
-issue-tracking services, like Jira, Trello, etc., but you can also grab the link
-for any comment, issue or feedback request to share it elsewhere. An existing
-Jira ticket. A wiki. A thread in your messaging service. Whatever the case may
-be, just look for the **Copy link** option under the ellipses menu.
+CodeStream has built-in mechanisms for sharing to Slack, Microsoft Teams, or issue-tracking services, like Jira, Trello, etc., but you can also grab the link for any comment, issue or feedback request to share it elsewhere. An existing Jira ticket. A wiki. A thread in your messaging service. Whatever the case may be, just look for the **Copy link** option under the ellipses menu.
 
 ![Copy Link](/images/CodemarkMenu-CopyLink.png)
 
-Whenever someone clicks the link, after authenticating with CodeStream,
-they'll automatically be redirected through the web to their IDE, where the
-discussion is automatically opened. In the case of a comment or issue, the
-source file opens and scrolls to the corresponding block of code.
+Whenever someone clicks the link, after authenticating with CodeStream, they'll automatically be redirected through the web to their IDE, where the discussion is automatically opened. In the case of a comment or issue, the source file opens and scrolls to the corresponding block of code.
 
-CodeStream does its best to determine which IDE to open, largely based on the
-IDE that you last used to access CodeStream. However, you can always return to
-the web page that was opened and select any IDE you'd like to use. Your selection will be
-remembered the next time you open a discussion associated with
-the same repository.
+CodeStream does its best to determine which IDE to open, largely based on the IDE that you last used to access CodeStream. However, you can always return to the web page that was opened and select any IDE you'd like to use. Your selection will be remembered the next time you open a discussion associated with the same repository.
 
 ![Permalink Page](/images/OpenInIDE.png)
 
-If you’re using a JetBrains IDE, install the
-[Toolbox app](https://www.jetbrains.com/toolbox-app/) so that CodeStream can
-deep link into the IDE.
+If you’re using a JetBrains IDE, install the [Toolbox app](https://www.jetbrains.com/toolbox-app/) so that CodeStream can deep link into the IDE.
 
 ## Permalinks for code blocks [#code-blocks]
 
-Sometimes you don’t necessarily want to comment on a block of code, but instead
-just want to easily share the code with a teammate. CodeStream's permalinks are
-living links that always point to the code in question, even if it's
-moved to a different location in the file.
+Sometimes you don’t necessarily want to comment on a block of code, but instead just want to easily share the code with a teammate. CodeStream's permalinks are living links that always point to the code in question, even if it's moved to a different location in the file.
 
-Select the code in your editor and then click the **Get Permalink** button to get a permalink for
-that code.
+Select the code in your editor and then click the **Get Permalink** button to get a permalink for that code.
 
 ![Get Permalink](/images/GetPermalink1.png)
 
-Decide whether you want the permalink to be public or private, with private
-permalinks requiring CodeStream authentication before the code can be viewed.
+Decide whether you want the permalink to be public or private, with private permalinks requiring CodeStream authentication before the code can be viewed.
 
 ![New Permalink](/images/NewPermalink2.png)
 
@@ -53,8 +35,6 @@ Copy your permalink and paste it anywhere you'd like to share the block of code.
 
 ![Copy Permalink](/images/CopyPermalink.png)
 
-Like with comments, issues and feedback requests, whenever someone clicks the permalink, they're automatically redirected through the web to their
-IDE, where the source file will be opened and scrolled to the corresponding
-block of code.
+Like with comments, issues and feedback requests, whenever someone clicks the permalink, they're automatically redirected through the web to their IDE, where the source file will be opened and scrolled to the corresponding block of code.
 
 ![Permalink Page](/images/PermalinkPage4.png)

--- a/src/content/docs/codestream/codestream-ui-overview/pull-requests-section.mdx
+++ b/src/content/docs/codestream/codestream-ui-overview/pull-requests-section.mdx
@@ -4,93 +4,70 @@ metaDescription: The CodeStream pull requests section is a GitHub-specific tool 
 ---
 
 <Callout variant="important">
-The Pull Requests section currently only supports GitHub, GitHub
-Enterprise, GitLab, and GitLab Self-Managed. Unless you're already connected to one of those services, the
-section will only appear if you have a repository from one these services open
-in your IDE.
+The **Pull Requests** section currently only supports GitHub, GitHub Enterprise, GitLab, and GitLab Self-Managed. Unless you're already connected to one of those services, the section will only appear if you have a repository from one these services open in your IDE.
 </Callout>
 
-The Pull Requests section of the CodeStream pane lists all open pull requests
+The **Pull Requests** section of the CodeStream pane lists all open pull requests
 that are relevant to you, and gives you the ability to control the list via
 custom queries. 
 
 ![Pull Requests Section](/images/PullRequestsSection.png)
 
-By default, you'll see your pull requests broken out into the following
-sections, which are really just default queries.
+By default, you'll see your pull requests broken out into the following sections, which are really just default queries.
 
-* Waiting on My Review - Open pull requests where you are a reviewer, or a
-  requested reviewer.
-* Assigned to Me - Open pull requests assigned to you.
-* Created by Me - Open pull requests created by you.
-* Recent - The five most recent pull requests created by you, regardless of
-  status.
+* **Waiting on My Review**: Open pull requests where you are a reviewer, or a requested reviewer.
+* **Assigned to Me**: Open pull requests assigned to you.
+* **Created by Me**: Open pull requests created by you.
+* **Recent**: The five most recent pull requests created by you, regardless of status.
 
 Click on any pull request in the list to edit, review or even merge the
-code. When you hover over a pull request's row
-you'll see more details, including the repo, branches and status. You'll also
-see an option to view the pull request on your code-hosting service toward the
-end of the row. 
+code. When you hover over a pull request's row you'll see more details, including the repo, branches and status. You'll also see an option to view the pull request on your code-hosting service toward the end of the row. 
 
-Hover over any section's heading for options to refresh the list, edit the
-section's query, or to delete the section.
+Hover over any section's heading for options to refresh the list, edit the section's query, or to delete the section.
 
 ![Query Header](/images/PRQueryHeader.png)
 
-The first section actually allows you to load any pull request via URL. Just
-grab the URL of any pull request, paste it in, and you can view it right inside
-CodeStream.
+The first section actually allows you to load any pull request via URL. Just grab the URL of any pull request, paste it in, and you can view it right inside CodeStream.
 
 ![Load PR from URL](/images/PRLoadFromURL.png)
 
-When you hover over the Pull Requests section heading, icons appear at the
-right.
+When you hover over the Pull Requests section heading, icons appear at the right.
 
 ![Pull Requests Section Header](/images/PRSectionHeader.png)
 
-Options there include the ability to refresh all the sections (i.e., queries) at
-once, create a new pull request, and to create a new section based on a custom
-query. Note that there are some special guidelines when creating a custom query
-for [GitHub and GitHub Enterprise](#github) or for [GitLab and
-GitLab Self-Managed](#gitlab).
+Options there include the ability to refresh all the sections (i.e., queries) at once, create a new pull request, and to create a new section based on a custom query. Note that there are some special guidelines when creating a custom query for [GitHub and GitHub Enterprise](#github) or for [GitLab and GitLab Self-Managed](#gitlab).
 
 ![Custom Query](/images/PRCustomQuery.png)
 
-Click on the gear icon for more options, including the ability to see pull
-requests from all repositories, and not just those associated with repositories
-open in your IDE, and the ability to include labels in the list.
+Click on the gear icon for more options, including the ability to see pull requests from all repositories, and not just those associated with repositories open in your IDE, and the ability to include labels in the list.
 
 ![Pull Request Section Settings](/images/PRSectionSettings.png)
 
 ## GitHub custom queries [#github]
 
-By default, GitHub's search API does a global search across all of
-GitHub. As a result, you'll need to make sure that your query includes at least
-one of the following qualifiers to make sure that the result set is
-appropriately limited.
+By default, GitHub's search API does a global search across all of GitHub. As a result, you'll need to make sure that your query includes at least one of the following qualifiers to make sure that the result set is appropriately limited.
 
-* user:USERNAME
-* org:ORGNAME
-* repo:USERNAME/REPOSITORY
-* author:USERNAME
-* assignee:USERNAME
-* mentions:USERNAME
-* team:ORGNAME/TEAMNAME
-* commenter:USERNAME
-* involves:USERNAME
-* reviewed-by:USERNAME
-* review-requested:USERNAME
-* team-review-requested:TEAMNAME
-* project:PROJECT_BOARD
+* `user:USERNAME`
+* `org:ORGNAME`
+* `repo:USERNAME/REPOSITORY`
+* `author:USERNAME`
+* `assignee:USERNAME`
+* `mentions:USERNAME`
+* `team:ORGNAME/TEAMNAME`
+* `commenter:USERNAME`
+* `involves:USERNAME`
+* `reviewed-by:USERNAME`
+* `review-requested:USERNAME`
+* `team-review-requested:TEAMNAME`
+* `project:PROJECT_BOARD`
 
-More details about GitHub's search syntax can be [found
-here](https://docs.github.com/en/github/searching-for-information-on-github/searching-issues-and-pull-requests).
+More details about GitHub's search syntax can be [found here](https://docs.github.com/en/github/searching-for-information-on-github/searching-issues-and-pull-requests).
 
 ## GitLab custom queries [#gitlab]
 
 All searches are done using `attribute=value` format with an `&` between each parameter. For parameters with a space in them (e.g. `labels=foo,help wanted`) leave them as is (do not put any quotes in the parameter). You can use `@me` to specify your user id and user name otherwise they can be found on GitLab. All filters, by default, have parameter `scope=all` (see [Minimum Qualifiers](#minimum)). To overwrite this, use `scope=X`. See examples given below.
 
-### Merge Request Search Syntax
+### Merge request search syntax
 
 ```
 state=opened&author_id=@me
@@ -135,7 +112,7 @@ scope=assigned_to_me&not[labels]=duplicate&not[milestone]=review
 | `project_id` | integer | Returns merge requests for the given project. |
 | `group_id` | integer | Returns merge requests for the given group. |
 
-### Issue Search Syntax
+### Issue search syntax
 
 ```
 state=opened&author_id=@me
@@ -177,48 +154,36 @@ project_id=23&state=opened&assignee_id=@me
 | `project_id` | integer | Returns issues for the given project. |
 | `group_id` | integer | Returns issues for the given group. |
 
-### Searching By Project
+### Searching by project
 
-To search in a specific project use parameter `project_id=X`. Project IDs are
-listed when viewing the project on GitLab. Searching through a project, by
-default, uses `scope=all` and will return all merge requests or issues for the
-project specified. Only one project_id may be listed at a time.
+To search in a specific project use parameter `project_id=X`. Project IDs are listed when viewing the project on GitLab. Searching through a project, by default, uses `scope=all` and will return all merge requests or issues for the project specified. Only one `project_id` may be listed at a time.
 
 ```
 project_id=23&state=opened&assignee_id=@me
 iids[]=1&project_id=473&labels=bug
 ```
 
-### Searching By Group
+### Searching by group
 
-To search in a specific group use parameter `group_id=X`. Group IDs are listed
-when viewing the group on GitLab. Searching through a group, by default, uses
-`scope=all` and will return all merge request or issues for the group specified.
-Only one group_id may be listed at a time.
+To search in a specific group use parameter `group_id=X`. Group IDs are listed when viewing the group on GitLab. Searching through a group, by default, uses `scope=all` and will return all merge request or issues for the group specified. Only one `group_id` may be listed at a time.
 
 ```
 group_id=23&state=opened&assignee_id=@me
 iids[]=1&group_id=473&labels=bug
 ```
 
-### Minimum Qualifiers [#minimum]
+### Minimum qualifiers [#minimum]
 
-By default, custom filters use `scope=all` which searches across all of GitLab.
-To avoid pulling all merge requests or issues listed on GitLab, you will need to
-refine this search using at least one of the following qualifiers:
+By default, custom filters use `scope=all` which searches across all of GitLab. To avoid pulling all merge requests or issues listed on GitLab, you will need to refine this search using at least one of the following qualifiers:
 
-* scope=assigned\_to\_me
-* scope=created\_by\_me
-* project_id
-* group_id
-* author_id
-* author_username
-* assignee_id
-* assignee_username
-* my\_reaction\_emoji
+* `scope=assigned\_to\_me`
+* `scope=created\_by\_me`
+* `project_id`
+* `group_id`
+* `author_id`
+* `author_username`
+* `assignee_id`
+* `assignee_username`
+* `my\_reaction\_emoji`
 
-
-Search syntax is derived from GitLab's custom search API. Refer to GitLab's
-documentation for more details on [merge request
-searches](https://docs.gitlab.com/ee/api/merge_requests.html) or [issue
-searches](https://docs.gitlab.com/ee/api/issues.html).
+Search syntax is derived from GitLab's custom search API. Refer to GitLab's documentation for more details on [merge request searches](https://docs.gitlab.com/ee/api/merge_requests.html) or [issue searches](https://docs.gitlab.com/ee/api/issues.html).

--- a/src/content/docs/codestream/how-use-codestream/discuss-code.mdx
+++ b/src/content/docs/codestream/how-use-codestream/discuss-code.mdx
@@ -7,20 +7,11 @@ redirects:
 
 ## What is a codemark? [#codemark]
 
-Quite simply, a codemark is a discussion connected to the code. It could be a
-question, a suggestion, a bug report, or documentation. All of these discussions
-are saved, anchored to the blocks of code they refer to, so that they can be
-leveraged in the future. It could be a new developer joining the team, a
-developer trying to fix a bug in someone else’s code, or even just you trying to
-remember why you made that change six months ago. Whatever the case, CodeStream
-helps you understand the code by surfacing the discussions in a contextual way.
+Quite simply, a codemark is a discussion connected to the code. It could be a question, a suggestion, a bug report, or documentation. All of these discussions are saved, anchored to the blocks of code they refer to, so that they can be leveraged in the future. It could be a new developer joining the team, a developer trying to fix a bug in someone else’s code, or even just you trying to remember why you made that change six months ago. Whatever the case, CodeStream helps you understand the code by surfacing the discussions in a contextual way.
 
 ![Codemark](/images/CodemarkInGutter1.png)
 
-Even as a file changes over time, the codemarks remain connected to the
-code. Add some new lines of code above the code block, make edits to the code,
-or even cut-and-paste the entire block to a different section of the file, and
-you’ll see the codemark move along with your changes.
+Even as a file changes over time, the codemarks remain connected to the code. Add some new lines of code above the code block, make edits to the code, or even cut-and-paste the entire block to a different section of the file, and you’ll see the codemark move along with your changes.
 
 ## Create a codemark [#create]
 
@@ -28,61 +19,41 @@ To create a codemark, select a block of code in your editor and then click one o
 
 ![New Codemark](/images/DiscussCode1-VSC.gif)
 
-If you're using a JetBrains IDE, such as IntelliJ, you can also create a
-codemark via the **+** button that appears in the editor's gutter when you
-select a block of code. When you're viewing a diff, for either a feedback
-request or a pull request, the button will also appear when you hover over the
-gutter to make it easy to comment on a single line.
+If you're using a JetBrains IDE, such as IntelliJ, you can also create a codemark via the **+** button that appears in the editor's gutter when you select a block of code. When you're viewing a diff, for either a feedback request or a pull request, the button will also appear when you hover over the gutter to make it easy to comment on a single line.
 
 ![New Codemark in JetBrains](/images/Compose-JB.gif)
 
-Even when the CodeStream pane is closed or not in view, you can create a
-codemark via the CodeStream options in either the lightbulb or context menus.
+Even when the CodeStream pane is closed or not in view, you can create a codemark via the CodeStream options in either the lightbulb or context menus.
 
 ![Context Menu](/images/ContextMenu4.png)
 
 You can also look for the **+** menu at the top of the CodeStream pane.
 
-Need to reach teammates that don’t spend a lot of time in the IDE? Or maybe some
-teammates that aren’t yet on CodeStream? You can optionally share a codemark out
-to Slack or Microsoft Teams. The Slack integration even allows your teammates to
-reply directly from Slack.
+Need to reach teammates that don’t spend a lot of time in the IDE? Or maybe some teammates that aren’t yet on CodeStream? You can optionally share a codemark out to Slack or Microsoft Teams. The Slack integration even allows your teammates to reply directly from Slack.
 
 ![Share on Slack or Teams](/images/SharingOptions1.png)
 
 ## Comment codemarks [#comments]
 
-Comment codemarks are the all-purpose codemark for linking any type of discussion to a block of code.
-Ask a question. Make a suggestion. Document some code. Make note of key sections
-of the codebase. The possibilities are endless.
+Comment codemarks are the all-purpose codemark for linking any type of discussion to a block of code. Ask a question. Make a suggestion. Document some code. Make note of key sections of the codebase. The possibilities are endless.
 
 ![Comment Codemark](/images/CodemarkComment6.png)
 
 ## Issue codemarks [#issues]
 
-When something needs to get done there’s a better chance of it happening
-if it’s captured as an issue with someone’s name attached. Assign issues as a
-way of reporting bugs or manage your tech debt by capturing items as tracked
-issues instead of inline FIXMEs. 
+When something needs to get done there’s a better chance of it happening if it’s captured as an issue with someone’s name attached. Assign issues as a way of reporting bugs or manage your tech debt by capturing items as tracked issues instead of inline FIXMEs. 
 
 ![Issue Codemark](/images/CodemarkIssue7.png)
 
-If your team uses Asana, Azure DevOps, Bitbucket (cloud), Clubhouse, GitHub
-(cloud or Enterprise), GitLab (cloud or Self-Managed), Jira (cloud or Server),
-Linear, Trello, or YouTrack (cloud) for tracking issues, you can create an issue on one
-of those services directly from CodeStream. Select the service you use from
-the dropdown at the top of the codemark form.
+If your team uses Asana, Azure DevOps, Bitbucket (cloud), Clubhouse, GitHub (cloud or Enterprise), GitLab (cloud or Self-Managed), Jira (cloud or Server), Linear, Trello, or YouTrack (cloud) for tracking issues, you can create an issue on one of those services directly from CodeStream. Select the service you use from the dropdown at the top of the codemark form.
 
 ![Issue Tracking Services](/images/IssueTrackingIntegrations2.png)
 
-After going through the authentication process with the selected service, you can select a destination for your issue. For example, with Jira
-you'll be able to select the appropriate issue type and project.
+After going through the authentication process with the selected service, you can select a destination for your issue. For example, with Jira you'll be able to select the appropriate issue type and project.
 
 ![Jira Selections](/images/NewIssue-JiraOptions1.png)
 
-Once the issue has been created on CodeStream, it includes a link to the
-issue that was created on the external service. In the example, you'll see
-the URL for the issue on Jira.
+Once the issue has been created on CodeStream, it includes a link to the issue that was created on the external service. In the example, you'll see the URL for the issue on Jira.
 
 ![Linked Issue](/images/LinkedIssues.png)
 
@@ -92,49 +63,27 @@ The issue on Jira includes a link to open the relevant code in your IDE.
 
 ## Bring the right people into the discussion [#discuss]
 
-When you create a codemark, CodeStream automatically mentions the people that
-most recently touched the code you're commenting on. They may be the best
-people to answer your question, but you can, of course, remove those mentions
-and manually mention someone else if appropriate.
+When you create a codemark, CodeStream automatically mentions the people that most recently touched the code you're commenting on. They may be the best people to answer your question, but you can, of course, remove those mentions and manually mention someone else if appropriate.
 
 ![Auto Mention](/images/CodemarkCompose.png)
 
-It may be the case that the people that have touched the code aren't yet on
-CodeStream, in which case CodeStream will provide checkboxes to have them
-notified via email. They can reply to the email to have their comment
-posted to CodeStream and, of course, they can install CodeStream to participate
-from their IDE.
+It may be the case that the people that have touched the code aren't yet on CodeStream, in which case CodeStream will provide checkboxes to have them notified via email. They can reply to the email to have their comment posted to CodeStream and, of course, they can install CodeStream to participate from their IDE.
 
 ## Work with different versions of the code [#different-versions]
 
-Maybe you’re on a feature branch, have local changes, or simply haven’t pulled
-in a while. There are countless reasons why the code you’re looking at might be
-different than what a teammate is looking at. As a result, there will be
-plenty of times when the code referenced in a codemark doesn’t match what you
-have locally.
+Maybe you’re on a feature branch, have local changes, or simply haven’t pulled in a while. There are countless reasons why the code you’re looking at might be different than what a teammate is looking at. As a result, there will be plenty of times when the code referenced in a codemark doesn’t match what you have locally.
 
-CodeStream recognizes these situations and includes the original version of the
-code block (such as, at the time the codemark was created), the current version, and
-a diff.
+CodeStream recognizes these situations and includes the original version of the code block (such as, at the time the codemark was created), the current version, and a diff.
 
 ![Compare and Apply](/images/CodemarkWithDiff1.png)
 
-Keep in mind that with CodeStream you can discuss any line of code, in any
-source file, at any time, even if it’s code that you just typed into your editor
-and haven’t yet committed. CodeStream empowers you to discuss code at the very
-earliest stages of the development process.
+Keep in mind that with CodeStream you can discuss any line of code, in any source file, at any time, even if it’s code that you just typed into your editor and haven’t yet committed. CodeStream empowers you to discuss code at the very earliest stages of the development process.
 
 ## Resolve codemarks [#resolve]
 
-Although not required, both comment and issue codemarks can be resolved. The
-[codemarks](../features/codemarks-section) section of the CodeStream pane breaks
-out codemarks into open, resolved and archived sections. Green, purple, and
-gray icons are used to represent those different states. If you see a lot of
-open/green codemarks in the CodeStream pane, that means that your teammates are
-being blocked by discussions and issues that haven't been resolved. 
+Although not required, both comment and issue codemarks can be resolved. The [codemarks](../features/codemarks-section) section of the CodeStream pane breaks out codemarks into open, resolved and archived sections. Green, purple, and gray icons are used to represent those different states. If you see a lot of open/green codemarks in the CodeStream pane, that means that your teammates are being blocked by discussions and issues that haven't been resolved. 
 
-You can add a comment at the same time you resolve the codemark and you can
-also archive the codemark at the same time.
+You can add a comment at the same time you resolve the codemark and you can also archive the codemark at the same time.
 
 ![Resolve Codemark](/images/ResolveCodemark.png)
 
@@ -144,31 +93,21 @@ Advanced features include multiple range codemarks, file attachments, tags, and 
 
 ### Multiple ranges [#ranges]
 
-Many discussions about code involve more than just one block of code and
-concepts are often best presented when you can refer to multiple code locations
-at once. Here are a few examples of multi-range codemark at work:
+Many discussions about code involve more than just one block of code and concepts are often best presented when you can refer to multiple code locations at once. Here are a few examples of multi-range codemark at work:
 
-* A change to a function is being contemplated that will impact its name. Each
-  instance of the function call can now be referenced in one discussion. 
-* A React component and its CSS styling aren’t interacting well and you want to
-  ask the team for input. You might select the div and the CSS rules you think
-  should apply, so your teammates know exactly what you’re talking about.
-* Clients which make API calls to the server might get an unexpected result.
-  Select the code where you’re making the API call, and the handler in the API
-  server, to connect the two actions together.
+* A change to a function is being contemplated that will impact its name. Each instance of the function call can now be referenced in one discussion. 
+* A React component and its CSS styling aren’t interacting well and you want to ask the team for input. You might select the div and the CSS rules you think should apply, so your teammates know exactly what you’re talking about.
+* Clients which make API calls to the server might get an unexpected result. Select the code where you’re making the API call, and the handler in the API server, to connect the two actions together.
 
 To create a multi-range codemark, click **+ Add Code Block**.
 
 ![Add Code Block](/images/CodemarkAddRange1.png)
 
-Then select another block of code from the same file, a different file, or
-even a different repo.
+Then select another block of code from the same file, a different file, or even a different repo.
 
 ![Select Range](/images/CodemarkSelectRange.png)
 
-You can intersperse the difference code blocks in your post by referring to each
-one as `[#N]` (or click the pin icon from one of the code blocks to insert the
-markdown for you), as in the following example.
+You can intersperse the difference code blocks in your post by referring to each one as `[#N]` (or click the pin icon from one of the code blocks to insert the markdown for you), as in the following example.
 
 ![Referencing Code Blocks](/images/ReferenceCodeBlocks.png)
 
@@ -176,32 +115,24 @@ Here's how that example is rendered.
 
 ![Multi-Range Codemark](/images/MultiRangeCodemark.png)
 
-Once you've created the codemark, you can jump between the different
-locations by clicking the jump icon at the bottom right of each code block.
+Once you've created the codemark, you can jump between the different locations by clicking the jump icon at the bottom right of each code block.
 
-When you edit a codemark, you can add and remove code blocks and you
-can change the location of any of the code blocks by clicking the dashed square
-icon.
+When you edit a codemark, you can add and remove code blocks and you can change the location of any of the code blocks by clicking the dashed square icon.
 
 ### File attachments [#attachments]
 
-Enrich your discussions about code by attaching files directly to code blocks.
-Think about how much more compelling your comments and documentation become when
-you attach:
+Enrich your discussions about code by attaching files directly to code blocks. Think about how much more compelling your comments and documentation become when you attach:
 
 * A spec to guide the development of a new feature
 * A log file to help debug an issue in the code
 * A mockup to help clarify some UI work
 * A screenshot to highlight a problem
 
-When creating a code comment or issue, you can attach a file by
-dragging-and-dropping onto the description field, pasting from your clipboard,
-or by clicking the paperclip icon.
+When creating a code comment or issue, you can attach a file by dragging-and-dropping onto the description field, pasting from your clipboard, or by clicking the paperclip icon.
 
 ![Attach File](/images/AttachFile.png)
 
-Images can even be displayed inline using markdown. Click the pin icon to
-the right of the attachment and CodeStream will insert the markdown for you.
+Images can even be displayed inline using markdown. Click the pin icon to the right of the attachment and CodeStream will insert the markdown for you.
 
 ![Markdown](/images/ImageMarkdown.png)
 
@@ -209,35 +140,25 @@ Now your teammate knows exactly what you’re looking for.
 
 ![Inline Display](/images/InlineImage.png)
 
-You can click on files in the attachments section to either download it or open it in
-the appropriate application.
+You can click on files in the attachments section to either download it or open it in the appropriate application.
 
 ### Add tags [#tags]
 
-Look for the tag icon inside the codemark compose box to either select a tag or
-create a tag using any combination of color and text label.
+Look for the tag icon inside the codemark compose box to either select a tag or create a tag using any combination of color and text label.
 
 ![Tags Popup](/images/TagsPopup.png)
 
-Tags are a great way to broadly organize and group your organization's
-codemarks and the possibilities here are endless. 
+Tags are a great way to broadly organize and group your organization's codemarks and the possibilities here are endless. 
 
-You can also filter
-by tag on the [Filter & Search page](/docs/codestream/codestream-ui-overview/filter-search/).
+You can also filter by tag on the [Filter & Search page](/docs/codestream/codestream-ui-overview/filter-search/).
 
 ### Related codemarks [#related]
 
-Click the CodeStream icon in the codemark compose form to select other
-related codemarks to attach them to the current codemark. This
-establishes a connection between different parts of a codebase. For example, when
-a change to one part of the codebase would require a change to another part,
-identify the dependency by creating two related codemarks.
+Click the CodeStream icon in the codemark compose form to select other related codemarks to attach them to the current codemark. This establishes a connection between different parts of a codebase. For example, when a change to one part of the codebase would require a change to another part, identify the dependency by creating two related codemarks.
 
 ![Related Codemarks](/images/AddCodelink.png)
 
-Once you’ve added the related codemarks they’ll be displayed in a related
-section and you can click on any one to jump to that codemark and the
-corresponding section of the code.
+Once you’ve added the related codemarks they’ll be displayed in a related section and you can click on any one to jump to that codemark and the corresponding section of the code.
 
 ![codemark with Related](/images/CodemarkWithRelated.png)
 
@@ -247,31 +168,11 @@ Click the ellipses menu for any codemark and you'll see options to manage the co
 
 ![Codemark Menu](/images/CodemarkMenu2.png)
 
-* Share - In addition to sharing to Slack or Teams at the time you create a
-  codemark, you can also share it anytime later.
-* Follow/Unfollow - Follow a codemark to be notified when its updated. Unfollow to stop receiving
-  notifications.
-* Copy link - Get a [permalink](/docs/codestream/codestream-ui-overview/permalinks/) for the codemark to
-  share it anywhere.
-* Archive - If there’s a codemark that you don’t think is important enough to be
-  on permanent display in a given file, but you don’t want to completely delete
-  it, you can archive it instead. Settings in the [codemarks
-  section](/docs/codestream/codestream-ui-overview/codemarks-section/) allow you to easily see all archived
-  codemarks.
-* Edit - Only the codemark's author can edit it.
-* Delete - Only the codemark's author can delete it, but we encourage you to
-  archive instead of deleting unless you're positive the codemark won't have any
-  future value.
-* Inject as Inline Comment - If you'd like a specific codemark to become part of
-  the repo use this option to have it added as an inline comment. You can select
-  the appropriate format, and then indicate if you want to include timestamps,
-  replies, or to have the comment wrapped at 80 characters. You can also elect
-  to have the codemark archived once it's been added as an inline comment.
-* Reposition codemark - In most cases, a codemark will automatically remain
-  linked to the block of code it refers to as the file changes over time. For
-  example, if you cut the block of code and paste it at a different location in
-  the file, the codemark will move right along with it. There are some
-  scenarios, however, that CodeStream isn't able to handle automatically. For
-  example, if you pasted the block of code into a different file. In these
-  cases, Reposition codemark allows you to select the new location of the block
-  of code so that the codemark is displayed properly.
+* **Share**: In addition to sharing to Slack or Teams at the time you create a codemark, you can also share it anytime later.
+* **Follow/Unfollow**: Follow a codemark to be notified when its updated. Unfollow to stop receiving notifications.
+* **Copy link**: Get a [permalink](/docs/codestream/codestream-ui-overview/permalinks/) for the codemark to share it anywhere.
+* **Archive**: If there’s a codemark that you don’t think is important enough to be on permanent display in a given file, but you don’t want to completely delete it, you can archive it instead. Settings in the [codemarks section](/docs/codestream/codestream-ui-overview/codemarks-section/) allow you to easily see all archived codemarks.
+* **Edit**: Only the codemark's author can edit it.
+* **Delete**: Only the codemark's author can delete it, but we encourage you to archive instead of deleting unless you're positive the codemark won't have any future value.
+* **Inject as Inline Comment**: If you'd like a specific codemark to become part of the repo use this option to have it added as an inline comment. You can select the appropriate format, and then indicate if you want to include timestamps, replies, or to have the comment wrapped at 80 characters. You can also elect to have the codemark archived once it's been added as an inline comment.
+* **Reposition codemark**: In most cases, a codemark will automatically remain linked to the block of code it refers to as the file changes over time. For example, if you cut the block of code and paste it at a different location in the file, the codemark will move right along with it. There are some scenarios, however, that CodeStream isn't able to handle automatically. For example, if you pasted the block of code into a different file. In these cases, the **Reposition** codemark allows you to select the new location of the block of code so that the codemark is displayed properly.

--- a/src/content/docs/codestream/how-use-codestream/discuss-code.mdx
+++ b/src/content/docs/codestream/how-use-codestream/discuss-code.mdx
@@ -81,7 +81,7 @@ Keep in mind that with CodeStream you can discuss any line of code, in any sourc
 
 ## Resolve codemarks [#resolve]
 
-Although not required, both comment and issue codemarks can be resolved. The [codemarks](../features/codemarks-section) section of the CodeStream pane breaks out codemarks into open, resolved and archived sections. Green, purple, and gray icons are used to represent those different states. If you see a lot of open/green codemarks in the CodeStream pane, that means that your teammates are being blocked by discussions and issues that haven't been resolved. 
+Although not required, both comment and issue codemarks can be resolved. The [codemarks](/docs/codestream/codestream-ui-overview/codemarks-section/) section of the CodeStream pane breaks out codemarks into open, resolved and archived sections. Green, purple, and gray icons are used to represent those different states. If you see a lot of open/green codemarks in the CodeStream pane, that means that your teammates are being blocked by discussions and issues that haven't been resolved. 
 
 You can add a comment at the same time you resolve the codemark and you can also archive the codemark at the same time.
 

--- a/src/content/docs/codestream/how-use-codestream/performance-monitoring.mdx
+++ b/src/content/docs/codestream/how-use-codestream/performance-monitoring.mdx
@@ -71,9 +71,7 @@ Even without the build SHA configured, you can still investigate the error, but 
 
 If you do have build SHAs configured, but the version of the code you're on locally doesn't contain that commit, CodeStream will let you know so that you can more effectively investigate and resolve the error.
 
-CodeStream will also let you know if the error doesn’t have a stack trace
-associated with it. This happens with older errors when the stack trace has
-aged out on New Relic One.
+CodeStream will also let you know if the error doesn’t have a stack trace associated with it. This happens with older errors when the stack trace has aged out on New Relic One.
 
 ## Other collaboration tools [#other-tools]
 
@@ -87,8 +85,6 @@ In an error discussion, use the `...` **More actions** dropdown to share the dis
 
 All of the repositories you currently have open in your IDE are listed in the **select a repo** dropdown.
 
-If you don’t see the repository you want listed, open it in your IDE and it will
-automatically get added to the list. If you’re working with a fork, make sure you select the upstream remote.
+If you don’t see the repository you want listed, open it in your IDE and it will automatically get added to the list. If you’re working with a fork, make sure you select the upstream remote.
 
-To avoid having to do this manual association every time you open an error, you can [make these
-associations via your APM agent's environment variables](/docs/codestream/start-here/codestream-new-relic/#repo-url).
+To avoid having to do this manual association every time you open an error, you can [make these associations via your APM agent's environment variables](/docs/codestream/start-here/codestream-new-relic/#repo-url).

--- a/src/content/docs/codestream/how-use-codestream/pull-requests.mdx
+++ b/src/content/docs/codestream/how-use-codestream/pull-requests.mdx
@@ -3,16 +3,11 @@ title: Manage pull requests in CodeStream
 metaDescription: "How to create and review pull requests with New Relic CodeStream."
 ---
 
-For most development teams, the final step in the development process is a pull
-request. Even if your team has decided to use New Relic CodeStream's feedback
-requests as a replacement for, and not just a precursor to,
-your end-of-cycle PR-based code reviews, CodeStream allows you to keep all of
-that workflow inside your IDE.
+For most development teams, the final step in the development process is a pull request. Even if your team has decided to use New Relic CodeStream's feedback requests as a replacement for, and not just a precursor to, your end-of-cycle PR-based code reviews, CodeStream allows you to keep all of that workflow inside your IDE.
 
 ## Pull request workflow [#workflow]
 
-There are four elements of CodeStream's pull request workflow. The
-following table outlines which code-hosting services are supported for each element.
+There are four elements of CodeStream's pull request workflow. The following table outlines which code-hosting services are supported for each element.
 
 Feature|Supported Services
 -------------|-------
@@ -23,46 +18,25 @@ Display pull request comments as code annotations|GitHub, GitLab, Bitbucket
 
 ## Create a pull request [#create]
 
-To open a pull request at any time, click the **+** button at the top of the
-CodeStream pane or the **+** button in the header of the Pull Requests
-section. You can also use a keyboard shortcut (`ctlr+shift+/` `p`, `ctrl+/`
-`p` on a Mac, and `m` if you're a GitLab user). CodeStream 
-provides you with tree view, list view, and diff view options for
-reviewing your changes before opening the pull request.
+To open a pull request at any time, click the **+** button at the top of the CodeStream pane or the **+** button in the header of the Pull Requests section. You can also use a keyboard shortcut (`ctlr+shift+/` `p`, `ctrl+/` `p` on a Mac, and `m` if you're a GitLab user). CodeStream  provides you with tree view, list view, and diff view options for reviewing your changes before opening the pull request.
 
 ![Open a Pull Request](/images/OpenPullRequest1.png)
 
-With a single click you can name the pull request based on the last commit
-message, the branch name, or, if you started work by selecting a
-ticket, the ticket title. If you have a ticket selected, you can
-also explicitly tie the ticket to the pull request and CodeStream will include
-a link to the ticket in the pull request's description. Before submitting the
-pull request, you can review your changes by clicking on any of the files
-listed below the form.
+With a single click you can name the pull request based on the last commit message, the branch name, or, if you started work by selecting a ticket, the ticket title. If you have a ticket selected, you can also explicitly tie the ticket to the pull request and CodeStream will include a link to the ticket in the pull request's description. Before submitting the pull request, you can review your changes by clicking on any of the files listed below the form.
 
-To create a pull request across forks, click the **compare across forks** link
-at the top of the page and the form will update to allow you to select both the
-base and head repositories.
+To create a pull request across forks, click the **compare across forks** link at the top of the page and the form will update to allow you to select both the base and head repositories.
 
-You can also create a pull request from within a CodeStream feedback request.
-Once the feedback request has been approved, you’ll see an option to open a pull
-request at the top.
+You can also create a pull request from within a CodeStream feedback request. Once the feedback request has been approved, you’ll see an option to open a pull request at the top.
 
 ![Open pull request from feedback request](/images/OpenPRfromFR.png)
 
-Before you can create a pull request, make sure that any changes
-included in the feedback request have been committed and pushed. Also, if the
-feature branch you’re working on doesn’t have a remote tracking branch you’ll be
-given the option to set that as part of creating the pull request.
+Before you can create a pull request, make sure that any changes included in the feedback request have been committed and pushed. Also, if the feature branch you’re working on doesn’t have a remote tracking branch you’ll be given the option to set that as part of creating the pull request.
 
-When you create a pull request from a feedback request, CodeStream connects the
-dots between the two by adding a link to the pull request in the feedback
-request.
+When you create a pull request from a feedback request, CodeStream connects the dots between the two by adding a link to the pull request in the feedback request.
 
 ![Link to Pull Request](/images/LinkToPullRequest.png)
 
-Add a link to the feedback request, along with information about who
-did the review and when, in the description of the pull request.
+Add a link to the feedback request, along with information about who did the review and when, in the description of the pull request.
 
 ![Link to Feedback Request](/images/LinkToFeedbackRequest.png)
 
@@ -72,29 +46,21 @@ did the review and when, in the description of the pull request.
 The ability to review pull requests is currently not available for Bitbucket.
 </Callout>
 
-Regardless of where the pull request was created, you can edit, review, and even
-merge it from within CodeStream. CodeStream brings GitHub and GitLab into your IDE, so there's zero learning curve. If you know how to work
-with pull requests on GitHub or GitLab, you'll know how to do it in CodeStream
-as well.
+Regardless of where the pull request was created, you can edit, review, and even merge it from within CodeStream. CodeStream brings GitHub and GitLab into your IDE, so there's zero learning curve. If you know how to work with pull requests on GitHub or GitLab, you'll know how to do it in CodeStream as well.
 
 You can edit a GitHub pull request's details, such as reviewers, assignees and labels.
 
 ![Pull Request Details](/images/PRDetails-GH.png)
 
-For a GitLab merge request, you can use edit mode (via the dropdown at the top
-of the page) or use the sidebar.
+For a GitLab merge request, you can use edit mode (via the dropdown at the top of the page) or use the sidebar.
 
 ![Merge Request Details](/images/PRDetails-GL.png)
 
-By default, you can only add a single reviewer and a single assignee to a GitLab
-merge request. If your organization supports multiple reviewers and assignees,
-click the gear menu in the heading of the Merge Requests section of the
-CodeStream pane to enable this.
+By default, you can only add a single reviewer and a single assignee to a GitLab merge request. If your organization supports multiple reviewers and assignees, click the gear menu in the heading of the **Merge Requests** section of the CodeStream pane to enable this.
 
 ![Multiple Reviewers and Assignees](/images/MultipleSetting-GL.png)
 
-Review the conversation and add comments with the ability to @mention your
-collaborators. 
+Review the conversation and add comments with the ability to @mention your collaborators. 
 
 ![Pull Request Conversation](/images/PRConversation-GH.png)
 
@@ -102,12 +68,7 @@ View the changes, add comments, and submit a review.
 
 ![Pull Request Changes](/images/PRChanges-GH.png)
 
-CodeStream does improve upon the GitHub/GitLab experience in a couple of
-important ways. On GitHub and GitLab you can only view the changes as a series
-of diff hunks. CodeStream provides that view as well, but if you'd prefer to
-see the changes in the context of the full file you can use either list view or tree view. Select the code you
-want to comment on and then click the Comment button (or select Comment from
-the context menu).
+CodeStream does improve upon the GitHub/GitLab experience in a couple of important ways. On GitHub and GitLab you can only view the changes as a series of diff hunks. CodeStream provides that view as well, but if you'd prefer to see the changes in the context of the full file you can use either list view or tree view. Select the code you want to comment on and then click the **Comment** button (or select **Comment** from the context menu).
 
 ![Add Comment](/images/PRComment-GH.png)
 
@@ -115,41 +76,22 @@ When commenting, you can either add a single comment or start a review.
 
 ![Start a Review](/images/PRCommentForm-GH.png)
 
-With CodeStream, you can comment on lines of code
-that haven't changed. You can select any lines of code in the diff and not just
-those that are part of the changeset. These comments are added as a
-single comment to the pull request and aren't part of any review you may have
-in progress.
+With CodeStream, you can comment on lines of code that haven't changed. You can select any lines of code in the diff and not just those that are part of the changeset. These comments are added as a single comment to the pull request and aren't part of any review you may have in progress.
 
-All the power of GitHub pull requests and GitLab merge requests, and then some,
-right in your IDE.
+All the power of GitHub pull requests and GitLab merge requests, and then some, right in your IDE.
 
 ## Leverage pull request comments [#pr-comments]
 
-Once the pull request has been approved and the code has been merged, that's
-usually the end of life for any comments in that pull request. Although there's
-often useful information in those comments that may have long-term value, they're rarely seen again. CodeStream gives those comments a second life by
-displaying them alongside the blocks of code that they refer to. 
+Once the pull request has been approved and the code has been merged, that's usually the end of life for any comments in that pull request. Although there's often useful information in those comments that may have long-term value, they're rarely seen again. CodeStream gives those comments a second life by displaying them alongside the blocks of code that they refer to. 
 
 ![Pull Request Comment](/images/PRComment-Gutter1.png)
 
-To have pull request comments displayed as annotations in your codemarks, as well
-as in the Codemarks section of the CodeStream pane, click the gear icon in
-that section and check **Show comments from pull requests**. When you
-first check that box, if you haven’t already authenticated with your
-code-hosting service, you’ll be prompted to do so.
+To have pull request comments displayed as annotations in your codemarks, as well as in the **Codemarks** section of the CodeStream pane, click the gear icon in that section and check **Show comments from pull requests**. When you first check that box, if you haven’t already authenticated with your code-hosting service, you’ll be prompted to do so.
 
 ![Show Pull Request Comments](/images/CodemarksSection-Settings.png)
 
-Comments from merged PRs will appear next to the blocks of code they refer to.
-Comments from open PRs will also be included if you are on a relevant branch.
-For example, if the open PR is a request to merge the feature/some-name branch into
-main, you’ll see comments from that PR if you've checked out either
-feature/some-name or main, but not when you’re on any other branch.
+Comments from merged PRs will appear next to the blocks of code they refer to. Comments from open PRs will also be included if you are on a relevant branch. For example, if the open PR is a request to merge the feature/some-name branch into main, you’ll see comments from that PR if you've checked out either feature/some-name or main, but not when you’re on any other branch.
 
-As the code evolves, the location of each comment is automatically updated so
-that it remains linked to the block of code it refers to.
+As the code evolves, the location of each comment is automatically updated so that it remains linked to the block of code it refers to.
 
-PR comments for a given file are updated roughly every 30 minutes, so
-new comments may not appear right away. You can force an update by restarting
-your IDE.
+PR comments for a given file are updated roughly every 30 minutes, so new comments may not appear right away. You can force an update by restarting your IDE.

--- a/src/content/docs/codestream/how-use-codestream/request-feedback.mdx
+++ b/src/content/docs/codestream/how-use-codestream/request-feedback.mdx
@@ -3,211 +3,113 @@ title: Request feedback on CodeStream
 metaDescription: "How to review and request feedback from your teammates, as well as how to make direct code changes."
 ---
 
-New Relic CodeStream's feedback requests are powerful enough to use for traditional
-end-of-cycle code reviews, but at the same time they're so easy and flexible
-that you can use them throughout the development process to get quick feedback
-on work-in-progress. You can even use feedback requests for uncommitted your changes.
+New Relic CodeStream's feedback requests are powerful enough to use for traditional end-of-cycle code reviews, but at the same time they're so easy and flexible that you can use them throughout the development process to get quick feedback on work-in-progress. You can even use feedback requests for uncommitted your changes.
 
-Traditional code review happens at the end of the development cycle, when you’re
-looking to get the changes merged. Not only are end-of-cycle code reviews much
-more burdensome on your teammates, but you run the risk of identifying issues so
-late in the game that you end up having to decide between blowing up your
-schedule or taking on technical debt.
+Traditional code review happens at the end of the development cycle, when you’re looking to get the changes merged. Not only are end-of-cycle code reviews much more burdensome on your teammates, but you run the risk of identifying issues so late in the game that you end up having to decide between blowing up your schedule or taking on technical debt.
 
-Whether you’re at the beginning of a project, with just some stubbed out
-functions, are mid-way through a work in progress, or are ready for a final
-review of a finished project, CodeStream enables feedback at any point
-during the development cycle. CodeStream handles the complexity of sharing your
-current status, including pushed commits, local commits, and staged and saved
-changes. Your teammates can provide feedback from their IDE, with no need to
-switch applications, and no need to switch branches or pull changes.
+Whether you’re at the beginning of a project, with just some stubbed out functions, are mid-way through a work in progress, or are ready for a final review of a finished project, CodeStream enables feedback at any point during the development cycle. CodeStream handles the complexity of sharing your current status, including pushed commits, local commits, and staged and saved changes. Your teammates can provide feedback from their IDE, with no need to switch applications, and no need to switch branches or pull changes.
 
-By the time you get to the formal code review/pull request at the end of the
-development cycle, it’s far less painful and more of a formality because issues
-have been raised, discussed, and resolved all along the way.
+By the time you get to the formal code review/pull request at the end of the development cycle, it’s far less painful and more of a formality because issues have been raised, discussed, and resolved all along the way.
 
 ## Request feedback [#request-feedback]
 
-To request feedback at any time, regardless of the current state of your work,
-click the **+ Create** button at the top of the CodeStream pane, or the **+ Request Feedback** 
-button in the header of the Feedback Requests section. You can also use a
-keyboard shortcut (`ctlr+shift+/` `r` or `ctrl+/` `r` on a Mac).
+To request feedback at any time, regardless of the current state of your work, click the **+ Create** button at the top of the CodeStream pane, or the **+ Request Feedback**  button in the header of the Feedback Requests section. You can also use a keyboard shortcut (`ctlr+shift+/` `r` or `ctrl+/` `r` on a Mac).
 
 ![Request a Review](/images/RequestFeedback.png)
 
-With a single click you can name the feedback request based on the last commit
-message, the branch name, or, if you [started work by selecting a
-ticket](/docs/codestream/how-use-codestream/start-work/), the ticket title. CodeStream assumes that you are
-requesting feedback on changes in the repository/branch of the file you've currently selected
-in your editor. If you have multiple repositories open in your IDE, you can
-change this via the repository dropdown at the very top of the feedback request form. 
+With a single click you can name the feedback request based on the last commit message, the branch name, or, if you [started work by selecting a ticket](/docs/codestream/how-use-codestream/start-work/), the ticket title. CodeStream assumes that you are requesting feedback on changes in the repository/branch of the file you've currently selected in your editor. If you have multiple repositories open in your IDE, you can change this via the repository dropdown at the very top of the feedback request form. 
 
-Depending on your organization's
-settings, CodeStream may suggest specific reviewers. Based on the commit history of the code
-being changed, the suggestions may even include someone that isn't yet on your
-CodeStream team. In that case, they'd be notified by email. Hover over a
-reviewer’s name to see more details or to remove them. If multiple reviewers are
-assigned you may also have the option to determine whether any of them can
-approve the review or if each one has to approve it individually.
+Depending on your organization's settings, CodeStream may suggest specific reviewers. Based on the commit history of the code being changed, the suggestions may even include someone that isn't yet on your CodeStream team. In that case, they'd be notified by email. Hover over a reviewer’s name to see more details or to remove them. If multiple reviewers are assigned you may also have the option to determine whether any of them can approve the review or if each one has to approve it individually.
 
 ![Suggested Reviewers](/images/ReviewAssignment.png)
 
-The Changed Files section lists all of the files that have been added, removed,
-or modified. Click any file to view a diff if you want to review your changes
-before submitting the feedback request.
+The **Changed Files** section lists all of the files that have been added, removed, or modified. Click any file to view a diff if you want to review your changes before submitting the feedback request.
 
 ![Changed Files](/images/ChangedFiles1.png)
 
-If you have a file that’s not suitable for review, such as a checked-in binary
-file, you can hover over any file and click the **x** to exclude that file from the
-feedback request. That file will be moved to a list below the form. 
-New files are, by default, excluded from the feedback request, but you can hover
-over their entry in the list and click **+** to add them.
+If you have a file that’s not suitable for review, such as a checked-in binary file, you can hover over any file and click the **x** to exclude that file from the feedback request. That file will be moved to a list below the form.  New files are, by default, excluded from the feedback request, but you can hover over their entry in the list and click **+** to add them.
 
 ![Excluded Files](/images/ExcludeFromReview.png)
 
-Hover over an excluded file and click the trashcan to permanently exclude it
-from all future feedback requests. Permanently excluding files creates a
-`.codestreamignore` file in the repository. If you think your teammates will also
-want to exclude these files (for example, a package-lock.json or other system-generated
-file), you can commit and push the file so that they can make use of it as well.
+Hover over an excluded file and click the trashcan to permanently exclude it from all future feedback requests. Permanently excluding files creates a `.codestreamignore` file in the repository. If you think your teammates will also want to exclude these files (for example, a package-lock.json or other system-generated file), you can commit and push the file so that they can make use of it as well.
 
-The changes represented across the selected files are broken out into four
-different categories, allowing you to select exactly what you would like to
-include in the feedback request. This includes changes that haven't been pushed,
-or even committed.
+The changes represented across the selected files are broken out into four different categories, allowing you to select exactly what you would like to include in the feedback request. This includes changes that haven't been pushed, or even committed.
 
 The four categories are:
+
 * Saved changes
 * Staged changes
 * Local commits
 * Pushed commits
 
-Commits are listed in descending order across the Local Commits and
-Pushed Commits sections. If you uncheck the box for a commit, it will automatically
-uncheck the boxes for all of its preceding commits. In other words, the commits
-included in the feedback request must be consecutive. Only your commits are
-checked by default, but you can include any of them in your review. 
+Commits are listed in descending order across the **Local Commits** and **Pushed Commits** sections. If you uncheck the box for a commit, it will automatically uncheck the boxes for all of its preceding commits. In other words, the commits included in the feedback request must be consecutive. Only your commits are checked by default, but you can include any of them in your review. 
 
 <Callout variant="tip">
-Make
-sure the email address in your git configuration matches your CodeStream email
-address. Or set up a [blame map](/docs/codestream/how-use-codestream/my-organization/#blame-map) to map
-your git email address to you CodeStream email address.
+Make sure the email address in your git configuration matches your CodeStream email address. Or set up a [blame map](/docs/codestream/how-use-codestream/my-organization/#blame-map) to map your git email address to you CodeStream email address.
 </Callout>
 
-Optionally, you can share your feedback request out to either Slack or
-Microsoft Teams.
+Optionally, you can share your feedback request out to either Slack or Microsoft Teams.
 
-When you submit your feedback request, your teammates will be notified via the
-activity feed, with anyone assigned as a reviewer being @mentioned so that
-they’ll also receive an email notification. 
+When you submit your feedback request, your teammates will be notified via the activity feed, with anyone assigned as a reviewer being @mentioned so that they’ll also receive an email notification. 
 
 ## Provide feedback [#provide-feedback]
 
-The best part of CodeStream's feedback requests is that having your teammates
-look over your code doesn't put any extra burden on them. There's no need for them to
-set aside their own work to switch branches or pull changes and no need to for
-them to leave their IDE. As long as they have the appropriate repository, they can open the feedback request and start reviewing your changes.
+The best part of CodeStream's feedback requests is that having your teammates look over your code doesn't put any extra burden on them. There's no need for them to set aside their own work to switch branches or pull changes and no need to for them to leave their IDE. As long as they have the appropriate repository, they can open the feedback request and start reviewing your changes.
 
 ![Reviewing Changes](/images/FRDiff.png)
 
-Click any file in the Changed Files section to review the changes. The changes are 
-presented with a diff in your editor. You can step through the changes in
-the file using your IDE's native navigation or click the up/down arrows at the top of your IDE. For JetBrains IDEs, CodeStream only supports the side-by-side diff viewer.
+Click any file in the **Changed Files** section to review the changes. The changes are  presented with a diff in your editor. You can step through the changes in the file using your IDE's native navigation or click the up/down arrows at the top of your IDE. For JetBrains IDEs, CodeStream only supports the side-by-side diff viewer.
 
 ![Navigate Changes](/images/NavigateChanges.png)
 
-Typically, the diff will represent the changes in the branch associated with the
-feedback request (such as, a feature/topic branch) against the base branch,
-at the point at which the feature branch was created. With CodeStream
-diffs this may not always be the case, because the developer may not have included
-all of their changes in the feedback request. As a result, the version of the
-files that the changes are being diff’ed against may, in fact, also include
-changes that aren’t in the base branch. This is important in order to provide
-continuity.
+Typically, the diff will represent the changes in the branch associated with the feedback request (such as, a feature/topic branch) against the base branch, at the point at which the feature branch was created. With CodeStream diffs this may not always be the case, because the developer may not have included all of their changes in the feedback request. As a result, the version of the files that the changes are being diff’ed against may, in fact, also include changes that aren’t in the base branch. This is important in order to provide continuity.
 
 ### Comments and change requests [#comments]
 
-If you have a general comment about the changes, add a reply to the
-feedback request's thread.
+If you have a general comment about the changes, add a reply to the feedback request's thread.
 
 ![Reply to a Review](/images/FRReply.png)
 
-If you want to comment on the actual changes, select some code from the
-right side of the diff and then click the comment button that appears in the
-CodeStream pane next to your selection. You can also use a keyboard shortcut
-(`ctlr+shift+/` `c` or `ctrl+/` `c` on a Mac) after selecting some code.
+If you want to comment on the actual changes, select some code from the right side of the diff and then click the comment button that appears in the CodeStream pane next to your selection. You can also use a keyboard shortcut (`ctlr+shift+/` `c` or `ctrl+/` `c` on a Mac) after selecting some code.
 
 ![Comment on Changes](/images/QS-FeedbackRequest.png)
 
-Since you have the full file context, you aren’t limited to commenting on just
-the lines of code that were changed. For example, you might notice another part of
-the file that needs work as well or that you simply want to reference.
+Since you have the full file context, you aren’t limited to commenting on just the lines of code that were changed. For example, you might notice another part of the file that needs work as well or that you simply want to reference.
 
-Whether it’s a general comment or a comment on code, you can mark it as a change
-request to let the developer know that it’s required before you’ll approve the
-changes. 
+Whether it’s a general comment or a comment on code, you can mark it as a change request to let the developer know that it’s required before you’ll approve the changes. 
 
-While you're providing feedback, you can even comment on files that aren't
-part of the changeset and they'll get added as a reply to the review. This is
-helpful to be able to point your teammate to another location in the codebase
-that might need improving.
+While you're providing feedback, you can even comment on files that aren't part of the changeset and they'll get added as a reply to the review. This is helpful to be able to point your teammate to another location in the codebase that might need improving.
 
 ![Request a Change](/images/ReviewChgReqCheck.png)
 
-All of the change requests associated with the the feedback request are
-summarized in a section at the top, in addition to being part of the discussion
-thread. This is where they'll get marked complete when the work is done.
+All of the change requests associated with the the feedback request are summarized in a section at the top, in addition to being part of the discussion thread. This is where they'll get marked complete when the work is done.
 
 ![Change Requests](/images/ReviewChgReqSection1.png)
 
-Look for the green and red buttons at the top to either approve the changes or
-request additional changes. If there are any open change
-requests, the approve button will be replaced by a blue button that shows
-the number. You can still approve the changes, but we wanted to make sure you
-were aware of the outstanding work.
+Look for the green and red buttons at the top to either approve the changes or request additional changes. If there are any open change requests, the approve button will be replaced by a blue button that shows the number. You can still approve the changes, but we wanted to make sure you were aware of the outstanding work.
 
 ![Outstanding Change Requests](/images/ApproveWithChgReqs3.png)
 
-When there are multiple reviewers, and an approval is required from each,
-CodeStream makes it very clear when there are still outstanding approvals. The
-blue button at the top right shows how many approvals are outstanding. The green thumbs up on the headshots of reviewers indicates that they've 
-already approved your changes.
+When there are multiple reviewers, and an approval is required from each, CodeStream makes it very clear when there are still outstanding approvals. The blue button at the top right shows how many approvals are outstanding. The green thumbs up on the headshots of reviewers indicates that they've  already approved your changes.
 
 ![Outstanding Approvals](/images/ReviewIncomplete.png)
 
 ## Add more code changes [#add-changes]
 
-A typical workflow involves the reviewer leaving some comments or suggesting
-some changes and then the developer responding to that feedback with more
-changes to the code. To continue the process, click the blue **Amend** button to add
-your changes.
+A typical workflow involves the reviewer leaving some comments or suggesting some changes and then the developer responding to that feedback with more changes to the code. To continue the process, click the blue **Amend** button to add your changes.
 
 ![Amend Review](/images/FRAmend1.png)
 
-Similar to when you originally submitted the feedback request, you can choose from your
-saved and staged changes and your local and pushed commits. Any open change
-requests are also listed so you can mark off any that are addressed by
-your update.
+Similar to when you originally submitted the feedback request, you can choose from your saved and staged changes and your local and pushed commits. Any open change requests are also listed so you can mark off any that are addressed by your update.
 
 ![Amend Review Form](/images/ReviewAmendForm.png)
 
-By default, when the reviewer goes back into the feedback request, they’ll be
-looking at the complete changeset (such as, changes across all updates) as they go
-through the diffs for each file. They can also view the diffs
-for any individual update.
+By default, when the reviewer goes back into the feedback request, they’ll be looking at the complete changeset (such as, changes across all updates) as they go through the diffs for each file. They can also view the diffs for any individual update.
 
 ![Amend Review Form](/images/ReviewCheckpoints.png)
 
-The feedback review process can continue across as many updates as needed to get to the
-final approval of your changes. Once the feedback request has been
-approved, you can [create a pull request](/docs/codestream/how-use-codestream/pull-requests) from within CodeStream
-to get your code merged. 
+The feedback review process can continue across as many updates as needed to get to the final approval of your changes. Once the feedback request has been approved, you can [create a pull request](/docs/codestream/how-use-codestream/pull-requests) from within CodeStream to get your code merged. 
 
 <Callout variant="tip">
-The feedback request can't be amended or
-reopened once a pull request has been created.
+The feedback request can't be amended or reopened once a pull request has been created.
 </Callout>
-
-

--- a/src/content/docs/codestream/how-use-codestream/request-feedback.mdx
+++ b/src/content/docs/codestream/how-use-codestream/request-feedback.mdx
@@ -31,7 +31,7 @@ If you have a file that’s not suitable for review, such as a checked-in binary
 
 ![Excluded Files](/images/ExcludeFromReview.png)
 
-Hover over an excluded file and click the trashcan to permanently exclude it from all future feedback requests. Permanently excluding files creates a `.codestreamignore` file in the repository. If you think your teammates will also want to exclude these files (for example, a package-lock.json or other system-generated file), you can commit and push the file so that they can make use of it as well.
+Hover over an excluded file and click the trashcan to permanently exclude it from all future feedback requests. Permanently excluding files creates a `.codestreamignore` file in the repository. If you think your teammates will also want to exclude these files (for example, a `package-lock.json` or other system-generated file), you can commit and push the file so that they can make use of it as well.
 
 The changes represented across the selected files are broken out into four different categories, allowing you to select exactly what you would like to include in the feedback request. This includes changes that haven't been pushed, or even committed.
 

--- a/src/content/docs/codestream/how-use-codestream/start-work.mdx
+++ b/src/content/docs/codestream/how-use-codestream/start-work.mdx
@@ -3,22 +3,13 @@ title: Start your new work with CodeStream
 metaDescription: "Learn how New Relic CodeStream can simplify your workflow."
 ---
 
-When you want to get started on some new work, whether it’s a modest bug fix or
-a major new feature, there are a lot of steps and different services involved.
-Go to your issue tracking service, find all of the issues assigned to you,
-select one to work on, and update its status. Now head to your terminal, or
-GitHub, to create a feature branch. And lastly, update your status on Slack to
-let your teammates know what you’re working on. With New Relic CodeStream, you can do this
-all in one step, right from your IDE.
+When you want to get started on some new work, whether it’s a modest bug fix or a major new feature, there are a lot of steps and different services involved. Go to your issue tracking service, find all of the issues assigned to you, select one to work on, and update its status. Now head to your terminal, or GitHub, to create a feature branch. And lastly, update your status on Slack to let your teammates know what you’re working on. With New Relic CodeStream, you can do this all in one step, right from your IDE.
 
-To get started, go to the **Issues** section in the CodeStream pane and connect
-to your team’s issue tracking service.
+To get started, go to the **Issues** section in the CodeStream pane and connect to your team’s issue tracking service.
 
 ![Connect Issue Tracker](/images/IssuesSection-Connect.png)
 
-Once you’re connected, you’ll be able to see all of the issues assigned to you,
-filtered by project, board, list, and others, customized as you see fit. You can even connect to
-multiple services.
+Once you’re connected, you’ll be able to see all of the issues assigned to you, filtered by project, board, list, and others, customized as you see fit. You can even connect to multiple services.
 
 ![List of Issues](/images/IssuesSection-Backlog.png)
 
@@ -30,23 +21,14 @@ Click an issue to get started working on it.
 
 ![Start Work](/images/StartWork2.png)
 
-If your team uses a feature branch Git workflow, you can create a branch to do
-your work on. Use the dropdowns to either change the base branch or edit the
-name of the feature branch.
+If your team uses a feature branch Git workflow, you can create a branch to do your work on. Use the dropdowns to either change the base branch or edit the name of the feature branch.
 
 ![Branch Details](/images/StartWork-BranchOptions.png)
 
-If you’re an admin, you can set up a branch naming template for your
-organization so that your feature branches are named consistently.
+If you’re an admin, you can set up a branch naming template for your organization so that your feature branches are named consistently.
 
 ![Branch Template](/images/StartWork-BranchTemplate2.png)
 
-Depending on which issue-tracking service you use, you can also update
-the issue's status. For example, if you use Trello, you can move the
-selected card to another list (for example, “In Progress”).
+Depending on which issue-tracking service you use, you can also update the issue's status. For example, if you use Trello, you can move the selected card to another list (for example, **In Progress**).
 
-If you need to work on something that doesn’t have an associated issue you can
-either click **Start ad-hoc Work** to get started without one or click **New
-issue** to create an issue on your issue tracking service right from CodeStream.
-You can even associate your issue with a specific block of code in your editor.
-
+If you need to work on something that doesn’t have an associated issue you can either click **Start ad-hoc Work** to get started without one or click **New issue** to create an issue on your issue tracking service right from CodeStream. You can even associate your issue with a specific block of code in your editor.

--- a/src/content/docs/codestream/start-here/codestream-new-relic.mdx
+++ b/src/content/docs/codestream/start-here/codestream-new-relic.mdx
@@ -5,11 +5,7 @@ metaDescription: "Read about the useful ways CodeStream and New Relic work toget
 
 CodeStream and New Relic One work together to give you insight into your code's errors, as well as making it easier to get started instrumenting your code with our APM agents.
 
-With CodeStream connected to New Relic One, you can jump from a
-stack trace error directly to the offending line of code in
-your IDE. Once in your IDE, you can navigate the stack trace and [collaborate
-with your teammates to resolve the
-issue](/docs/codestream/how-use-codestream/performance-monitoring).
+With CodeStream connected to New Relic One, you can jump from a stack trace error directly to the offending line of code in your IDE. Once in your IDE, you can navigate the stack trace and [collaborate with your teammates to resolve the issue](/docs/codestream/how-use-codestream/performance-monitoring).
 
 <Callout title="Preview release">
 CodeStream's integration with New Relic One is a preview release limited to New Relic One accounts on our US data center, and your use is subject to the pre-release policy. (This does not apply to all other CodeStream functionality.)
@@ -20,6 +16,7 @@ CodeStream's integration with New Relic One is a preview release limited to New 
 Before you can take advantage of New Relic's observability features in CodeStream, you'll need to connect them.
 
 Requirements for connecting CodeStream and New Relic:
+
 * [New Relic account](https://newrelic.com/signup) (If you don't have a New Relic account, sign up at [newrelic.com/signup](https://newrelic.com/signup). It's free, forever!)
 * [New Relic user key](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher)
 
@@ -36,6 +33,7 @@ New Relic users can share stacktrace errors on CodeStream. Once you've connected
 After you connect CodeStream and New Relic, use workloads and errors inbox to jump to the offending code in your IDE.
 
 Requirements for opening stack trace errors in your IDE:
+
 * [New Relic account](https://newrelic.com/signup) (If you don't have a New Relic account, sign up at [newrelic.com/signup](https://newrelic.com/signup). It's free, forever!)
 * [New Relic user key](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher)
 * [CodeStream and New Relic connection](#connect)
@@ -56,13 +54,12 @@ From **[one.newrelic.com/](https://one.newrelic.com/)**, go to **Errors Inbox**,
 
 ## APM errors and CodeStream [#apm]
 
-In order to view stack trace errors in your IDE, CodeStream needs to know what
-repository the error is associated with and, ideally, which version of the code
-generated the error.
+In order to view stack trace errors in your IDE, CodeStream needs to know what repository the error is associated with and, ideally, which version of the code generated the error.
 
 ## Associate repositories with errors [#repo-url]
 
 Once you've started monitoring for APM, mobile, browser, or Lambda, you should create repository entities and associate them with entities for all of your services. In order to create a repository entity you'll need to provide the repository's remote URL. For example, the remote URL can be in either the SSH or HTTPS format:
+
 * `git@github.com:newrelic/beta-docs-site.git`
 * `https://github.com/newrelic/beta-docs-site.git`
 
@@ -72,12 +69,7 @@ It's possible to add the same GitHub repository more than once, if you're using 
 For example, `https://github.com/tuna/repo` and `git@github.com:tuna/repo` are the same repo, with different protocols.
 </Callout>
 
-If you try to open an error in your IDE and there isn't an associated
-repository, CodeStream will prompt you to make an association and save that
-association for all errors from the given entity on New Relic. However, it would
-be preferably to use one of the following methods since they require less
-ongoing manual effort and eliminate the possibility of end-user mistakes, such
-as misconfigured remote URLs.
+If you try to open an error in your IDE and there isn't an associated repository, CodeStream will prompt you to make an association and save that association for all errors from the given entity on New Relic. However, it would be preferably to use one of the following methods since they require less ongoing manual effort and eliminate the possibility of end-user mistakes, such as misconfigured remote URLs.
 
 <CollapserGroup>
   <Collapser
@@ -92,11 +84,7 @@ as misconfigured remote URLs.
   </Collapser>
 
   <Collapser
-    className="freq-link" id="repo-ui" title="Use the UI" > Once you've started
-    sending data to New Relic, use the UI to connect your related repository. Go
-    to the APM Summary page via **[one.newrelic.com](https://one.newrelic.com) >
-    Explorer > Services - APM > (select an app)**, then look for the
-    Repositories section at the bottom-right.
+    className="freq-link" id="repo-ui" title="Use the UI" > Once you've started sending data to New Relic, use the UI to connect your related repository. Go to the APM Summary page via **[one.newrelic.com](https://one.newrelic.com) > Explorer > Services - APM > (select an app)**, then look for the **Repositories** section at the bottom-right.
 
      ![A screenshot of the connect repository button.](./images/connect-repo1.png "The connect repository button.")
 
@@ -128,8 +116,9 @@ mutation {
   }
 }
 ```
-In order to find the entity you create, you can use a query like the following.  Note that the URL you
-provided to `referenceEntityCreateOrUpdateRepository` gets saved as an entity tag.
+
+In order to find the entity you create, you can use a query like the following.  Note that the URL you provided to `referenceEntityCreateOrUpdateRepository` gets saved as an entity tag.
+
 ```
 {
   actor {
@@ -151,11 +140,13 @@ provided to `referenceEntityCreateOrUpdateRepository` gets saved as an entity ta
 }
 
 ```
+
 **Step 2: Associate the repository entity to your application entity**
 
 First, find the GUID for the application you want to associate your repository to.  
 
 Parameters:
+
 * `sourceEntityGuid` - the entity GUID of the application
 * `targetEntityGuid` - the entity GUID of your repository
 * `type` - always `BUILT_FROM`
@@ -197,12 +188,12 @@ To see all entities related to your repository you can do a query like this:
     }
   }
 }
-
 ```
 
 **Step 3: Cleanup (if needed)**
 
 Delete a repository with the following query:
+
 ```
 mutation DeleteRepository {
   entityDelete(guids: "[ENTITY_GUID_HERE]]") {
@@ -213,7 +204,6 @@ mutation DeleteRepository {
     }
   }
 }
-
 ```
 
   </Collapser>
@@ -222,8 +212,7 @@ mutation DeleteRepository {
 
 ## Associate build SHAs or release tags with errors [#buildsha]
 
-To use CodeStream's **Open in IDE** with your APM stack trace errors, use environment variables to configure your APM agent with your application's [commit sha](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection)
-and/or your [release tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) associated with the running version of your software.  
+To use CodeStream's **Open in IDE** with your APM stack trace errors, use environment variables to configure your APM agent with your application's [commit sha](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection) and/or your [release tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) associated with the running version of your software.  
 
 CodeStream only needs the first seven characters of your commit sha (for example, `734713b`) to make this connection, but you can include the entire sha.  
 

--- a/src/content/docs/codestream/start-here/codestream-user-guide.mdx
+++ b/src/content/docs/codestream/start-here/codestream-user-guide.mdx
@@ -10,15 +10,7 @@ to get started with New Relic CodeStream.
 
 ## 1. Install the CodeStream extension in your IDE and sign up. [#install]
 
-Install CodeStream for [VS
-Code](https://marketplace.visualstudio.com/items?itemName=CodeStream.codestream),
-[Visual
-Studio](https://marketplace.visualstudio.com/items?itemName=CodeStream.codestream-vs) or
-[JetBrains](https://plugins.jetbrains.com/plugin/12206-codestream). The CodeStream pane
-automatically appears in the sidebar for VS Code or in a tool window at the
-right side for JetBrains or Visual Studio. Click **Sign Up and Create a
-team** if you're the first person from your team to join CodeStream or paste in
-your invitation code if you were invited to a team already on CodeStream.
+Install CodeStream for [VS Code](https://marketplace.visualstudio.com/items?itemName=CodeStream.codestream), [Visual Studio](https://marketplace.visualstudio.com/items?itemName=CodeStream.codestream-vs) or [JetBrains](https://plugins.jetbrains.com/plugin/12206-codestream). The CodeStream pane automatically appears in the sidebar for VS Code or in a tool window at the right side for JetBrains or Visual Studio. Click **Sign Up and Create a team** if you're the first person from your team to join CodeStream or paste in your invitation code if you were invited to a team already on CodeStream.
 
 ![Sign up for CodeStream](/images/QS-SignUp3.png)
 
@@ -26,18 +18,13 @@ your invitation code if you were invited to a team already on CodeStream.
 
 ## 2. Connect your tools [#connect]
 
-Create and review pull requests on GitHub, GitLab or Bitbucket. Create issues on
-Jira, Trello, and other issue trackers. Share code discussions on Slack or
-Microsoft Teams. CodeStream brings the tools you use every day together in your
-IDE. Click on your headshot at the top of the CodeStream pane and go to the
-Integrations page to get all of your tools connected.
+Create and review pull requests on GitHub, GitLab or Bitbucket. Create issues on Jira, Trello, and other issue trackers. Share code discussions on Slack or Microsoft Teams. CodeStream brings the tools you use every day together in your IDE. Click on your headshot at the top of the CodeStream pane and go to the Integrations page to get all of your tools connected.
 
 ![Integrations](/images/QS-Integrations.png)
 
 ## 3. Discuss any block of code, at any time [#discuss]
 
-Whether you're trying to understand someone else's code or getting help with
-some code you just wrote, just select the code and ask your question.
+Whether you're trying to understand someone else's code or getting help with some code you just wrote, just select the code and ask your question.
 
 ![Discuss Code](/images/QS-DiscussCode1.png)
 
@@ -45,27 +32,19 @@ some code you just wrote, just select the code and ask your question.
 
 ## 4. Get feedback on your work in progress [#feedback]
 
-Select "Request Feedback" from the "+" menu at any time in the development
-cycle, whether it’s a quick look over some work in progress (even uncommitted
-code!) or a formal review of a completed effort.
+Select **Request Feedback** from the **+** menu at any time in the development cycle, whether it’s a quick look over some work in progress (even uncommitted code!) or a formal review of a completed effort.
 
 ![Feedback Request](/images/QS-FeedbackRequest.png)
 
-Teammates can review your changes right in their IDE, with no need to switch
-branches or set aside their own work. [Learn more about feedback
-requests.](/docs/codestream/how-use-codestream/feedback-requests-section)
+Teammates can review your changes right in their IDE, with no need to switch branches or set aside their own work. [Learn more about feedback requests.](/docs/codestream/how-use-codestream/feedback-requests-section)
 
 ## 5. Create or review a pull request [#pr]
 
-Look for the Pull Requests section of the CodeStream sidebar to review an open
-pull request. Just click on a pull request (or load one from URL) to get a
-complete GitHub experience right in your IDE!
+Look for the **Pull Requests** section of the CodeStream sidebar to review an open pull request. Just click on a pull request (or load one from URL) to get a complete GitHub experience right in your IDE!
 
 ![Pull Request](/images/QS-PullRequest.png)
 
-Note that you can create a pull request in GitHub, GitLab or Bitbucket, but
-support for reviewing pull requests is currently only available for GitHub
-(cloud or Enterprise). [Learn more about pull requests.](/docs/codestream/how-use-codestream/pull-requests-section)
+Note that you can create a pull request in GitHub, GitLab or Bitbucket, but support for reviewing pull requests is currently only available for GitHub (cloud or Enterprise). [Learn more about pull requests.](/docs/codestream/how-use-codestream/pull-requests-section)
 
 ## Help and feedback [#help]
 

--- a/src/content/docs/codestream/start-here/install-codestream.mdx
+++ b/src/content/docs/codestream/start-here/install-codestream.mdx
@@ -51,8 +51,7 @@ You can install CodeStream for your specific IDE or install it through our Insta
 
 Create and review pull requests on GitHub, GitLab, or Bitbucket. Create issues on Jira, Trello, and other issue trackers. Investigate errors reported to New Relic One. Share code discussions on Slack or Microsoft Teams. CodeStream brings the tools you use every day together in your IDE. 
 
-Click your headshot at the top of the CodeStream pane, then click
-**Integrations** to connect all of your tools to CodeStream.
+Click your headshot at the top of the CodeStream pane, then click **Integrations** to connect all of your tools to CodeStream.
 
 ![A screenshot of some of the tools you can connect to CodeStream, such as Bitbucket and GitHUb.](./images/QS-Integrations.png "Some of the tools you can connect to CodeStream, such as Bitbucket and GitHUb.")
 
@@ -62,8 +61,7 @@ Once you've installed CodeStream, to connect to New Relic, you'll need your [New
 
 ## Discuss any block of code, at any time [#discuss-code]
 
-Whether you're trying to understand someone else's code or getting help with
-some code you just wrote, select the code and click the comment button to ask your question.
+Whether you're trying to understand someone else's code or getting help with some code you just wrote, select the code and click the comment button to ask your question.
 
 ![A screenshot of some selected code with the CodeStream add comment button.](./images/QS-DiscussCode1.png "Some selected code with the CodeStream add comment button. Use this to discuss and collaborate on code in your repository.")
 
@@ -71,26 +69,19 @@ some code you just wrote, select the code and click the comment button to ask yo
 
 ## Get feedback on your work in progress [#get-feedback]
 
-Click the **+** menu then click **Request Feedback** at any time in the development
-cycle, whether it’s a quick look over some work in progress (even uncommitted
-code) or a formal review of a completed effort.
+Click the **+** menu then click **Request Feedback** at any time in the development cycle, whether it’s a quick look over some work in progress (even uncommitted code) or a formal review of a completed effort.
 
 ![A screenshot of the Request Feedback highlighted in the + Create menu.](./images/QS-FeedbackRequest2.png "The Request Feedback highlighted in the + Create menu.")
 
-Teammates can review your changes right in their IDE, with no need to switch
-branches or set aside their own work. [Learn more about feedback
-requests.](/docs/codestream/how-use-codestream/feedback-requests)
+Teammates can review your changes right in their IDE, with no need to switch branches or set aside their own work. [Learn more about feedback requests.](/docs/codestream/how-use-codestream/feedback-requests)
 
 ## Create or review a pull request [#pull-request]
 
-In the CodeStream sidebar, look for the **Pull Requests** section to review an open
-pull request. Select a pull request (or load one from URL) to get a
-complete GitHub experience right in your IDE.
+In the CodeStream sidebar, look for the **Pull Requests** section to review an open pull request. Select a pull request (or load one from URL) to get a complete GitHub experience right in your IDE.
 
 ![A screenshot of a GitHub pull request in CodeStream.](./images/QS-PullRequest.png "A GitHub pull request in CodeStream.")
 
-You can create a pull request in GitHub, GitLab, or Bitbucket, but
-support for reviewing pull requests is currently only available for GitHub. [Learn more about pull requests.](/docs/codestream/how-use-codestream/pull-requests/)
+You can create a pull request in GitHub, GitLab, or Bitbucket, but support for reviewing pull requests is currently only available for GitHub. [Learn more about pull requests.](/docs/codestream/how-use-codestream/pull-requests/)
 
 ## Help and feedback [#help]
 

--- a/src/content/docs/codestream/start-here/sign-up-codestream.mdx
+++ b/src/content/docs/codestream/start-here/sign-up-codestream.mdx
@@ -7,46 +7,29 @@ To get the most out of CodeStream's collaboration tools, create an organization 
 
 ## Create an account [#account]
 
-If you already have the CodeStream extension [installed in your
-IDE](/docs/codestream/start-here/install-codestream), you can start the sign up process from the CodeStream pane.
+If you already have the CodeStream extension [installed in your IDE](/docs/codestream/start-here/install-codestream), you can start the sign up process from the CodeStream pane.
 
 ![Create an account](./images/CreateAnAccount6.png)
 
-There are two ways to sign up for CodeStream. You can sign up with a set of CodeStream credentials (such as, email
-address and password). Alternatively, you can sign up using your GitHub, GitLab, or Bitbucket
-(cloud versions only) account. 
+There are two ways to sign up for CodeStream. You can sign up with a set of CodeStream credentials (such as, email address and password). Alternatively, you can sign up using your GitHub, GitLab, or Bitbucket (cloud versions only) account. 
 
-Signing up via your code host also connects your repositories to CodeStream. If the email address you're using with your code host isn't your work email,
-you should create CodeStream-specific credentials instead.
+Signing up via your code host also connects your repositories to CodeStream. If the email address you're using with your code host isn't your work email, you should create CodeStream-specific credentials instead.
 
-If you sign up via CodeStream, your next step will be to confirm your email
-address by entering a code sent to you via email. You can paste the
-code into any of the boxes rather than typing each number individually.
+If you sign up via CodeStream, your next step will be to confirm your email address by entering a code sent to you via email. You can paste the code into any of the boxes rather than typing each number individually.
 
 ![Confirm Email](./images/EmailConfirmation1.png)
 
 ## CodeStream organizations [#organizations]
 
-A CodeStream organization is where you and your teammates will discuss
-code. Similar to a Slack workspace, all of the developers in your company are in the same CodeStream organization. CodeStream's activity feed keeps things relevant for you by showing activity related to the code you have open in your IDE.
-The discussions about code build up a knowledge base that is a company-wide
-resource, so the only reason to have multiple organizations on CodeStream is if
-you truly need separation. For example, you might have an organization for your
-day job and another for an open-source project you work on. Or maybe you're a
-consultant that's a member of different CodeStream organizations for each of
-your clients.
+A CodeStream organization is where you and your teammates will discuss code. Similar to a Slack workspace, all of the developers in your company are in the same CodeStream organization. CodeStream's activity feed keeps things relevant for you by showing activity related to the code you have open in your IDE. 
+
+The discussions about code build up a knowledge base that is a company-wide resource, so the only reason to have multiple organizations on CodeStream is if you truly need separation. For example, you might have an organization for your day job and another for an open-source project you work on. Or maybe you're a consultant that's a member of different CodeStream organizations for each of your clients.
 
 ## Create or join an organization [#create-org]
 
-If you're invited to join an organization on CodeStream, 
-sign up with the same email address the invitation was sent to. You'll
-automatically be added to that organization.
+If you're invited to join an organization on CodeStream, sign up with the same email address the invitation was sent to. You'll automatically be added to that organization.
 
-If you're the first person from your company to sign up for CodeStream you can
-go ahead and create a new organization. Otherwise, there may be existing
-CodeStream organizations available for you to join based on your email domain.
-If you think your company is already on CodeStream, but don't see an
-organization to join, make sure that you've signed up with your work email.
+If you're the first person from your company to sign up for CodeStream you can go ahead and create a new organization. Otherwise, there may be existing CodeStream organizations available for you to join based on your email domain. If you think your company is already on CodeStream, but don't see an organization to join, make sure that you've signed up with your work email.
 
 ![Create or join an organization](./images/CreateOrJoinOrg.png)
 
@@ -60,7 +43,6 @@ Collaboration is a team sport so invite your teammates to join you on CodeStream
 
 ![Invite teammates](./images/InviteTeammates.png)
 
-CodeStream will offer up some suggestions based on the commit history of the
-repositories you have open in your IDE.
+CodeStream will offer up some suggestions based on the commit history of the repositories you have open in your IDE.
 
 Now you're ready to start using CodeStream.

--- a/src/content/docs/codestream/start-here/what-is-codestream.mdx
+++ b/src/content/docs/codestream/start-here/what-is-codestream.mdx
@@ -11,55 +11,32 @@ CodeStream's integration with New Relic One is a preview release limited to New 
 
 ## Discuss code just like commenting on a Google Doc [#discuss]
 
-Simply select a block of code and type your question or comment. Teammates can
-participate in the discussion right from their IDE and you can optionally share
-the discussion on Slack or Microsoft Teams so teammates can participate from
-their chat clients as well. 
+Simply select a block of code and type your question or comment. Teammates can participate in the discussion right from their IDE and you can optionally share the discussion on Slack or Microsoft Teams so teammates can participate from their chat clients as well. 
 
 ![CodeStream](./images/DiscussCode1-VSC.gif)
 
-CodeStream turns conversation into documentation by capturing all of the
-discussion about your code and saving it with your code. And the real magic is
-that the discussions are automatically repositioned as your code changes, even
-across branches. All with zero effort on your part.
+CodeStream turns conversation into documentation by capturing all of the discussion about your code and saving it with your code. And the real magic is that the discussions are automatically repositioned as your code changes, even across branches. All with zero effort on your part.
 
 ## Get feedback on work-in-progress with pre-PR code review [#feedback]
 
-CodeStream's lightweight feedback requests let you have someone look over your
-changes regardless of the current state of your repo, without the friction of
-committing, pushing, or issuing a pull request.
+CodeStream's lightweight feedback requests let you have someone look over your changes regardless of the current state of your repo, without the friction of committing, pushing, or issuing a pull request.
 
 ![Feedback Request](./images/FRRequest-VSC.gif)
 
-Your teammates can review your changes right in their IDE, with full file
-context, and with no need to set aside their current work to switch branches or
-pull the latest. 
+Your teammates can review your changes right in their IDE, with full file context, and with no need to set aside their current work to switch branches or pull the latest. 
 
 ![Review Changes](./images/FRPerform-VSC.gif)
 
-CodeStream’s feedback requests are so easy that you can start doing them
-throughout the development process instead of waiting until the end. You’re a
-few days into a sprint and have some work stubbed out? Maybe some work that
-hasn’t even been committed? Request feedback on your work in progress so that
-you can identify and resolve issues early instead of saving those gotchas for
-when you need to get the code merged.
+CodeStream’s feedback requests are so easy that you can start doing them throughout the development process instead of waiting until the end. You’re a few days into a sprint and have some work stubbed out? Maybe some work that hasn’t even been committed? Request feedback on your work in progress so that you can identify and resolve issues early instead of saving those gotchas for when you need to get the code merged.
 
 ## Create and review pull requests [#prs]
 
-For most development teams, the final step in the development process is a pull
-request. Even if your team has decided to use CodeStream's [feedback
-requests](/docs/codestream/how-use-codestream/request-feedback) as a replacement for, and not just a precursor to,
-your end-of-cycle PR-based code reviews, you can create and review pull
-requests right inside your IDE.
+For most development teams, the final step in the development process is a pull request. Even if your team has decided to use CodeStream's [feedback requests](/docs/codestream/how-use-codestream/request-feedback) as a replacement for, and not just a precursor to, your end-of-cycle PR-based code reviews, you can create and review pull requests right inside your IDE.
 
 ![Review a Pull Request](./images/PullRequest-VSC.gif)
 
 ## Monitor your code’s performance in production [#performance-monitoring]
 
-Your pursuit of software quality doesn’t end once the code has been merged.
-Connect CodeStream to your New Relic One account and you can either jump from an
-error on New Relic One into your IDE or you can discover errors in CodeStream's 
-Observability section. Navigate the stack trace to find the
-offending code and collaborate with your teammates to resolve the issue.
+Your pursuit of software quality doesn’t end once the code has been merged. Connect CodeStream to your New Relic One account and you can either jump from an error on New Relic One into your IDE or you can discover errors in CodeStream's Observability section. Navigate the stack trace to find the offending code and collaborate with your teammates to resolve the issue.
 
 ![Monitor Performance](./images/Observability-VSC.gif)

--- a/src/content/docs/codestream/troubleshooting/client-logs.mdx
+++ b/src/content/docs/codestream/troubleshooting/client-logs.mdx
@@ -20,4 +20,4 @@ Copy all of the output you see and save it in a text file.
 
 1. Go to **Tools > Options > CodeStream** and make sure your log level is set to at least `Debug`. If it is set to `Info`, `Errors`, or `Silent`, change it to `Debug`, then restart Visual Studio.
 2. Reproduce the issue.
-3. Grab `vs-extension.log` and `vs-agent.log` from `%localappdata%\CodeStream\Logs` as well as the ActivityLog.xml from `%AppData%\Microsoft\VisualStudio\16.0_<RandomText>` for Visual Studio 2019 or `%AppData%\Microsoft\VisualStudio\15.0_<RandomText>` for Visual Studio 2017.
+3. Grab `vs-extension.log` and `vs-agent.log` from `%localappdata%\CodeStream\Logs` as well as the `ActivityLog.xml` from `%AppData%\Microsoft\VisualStudio\16.0_<RandomText>` for Visual Studio 2019 or `%AppData%\Microsoft\VisualStudio\15.0_<RandomText>` for Visual Studio 2017.

--- a/src/content/docs/codestream/troubleshooting/client-logs.mdx
+++ b/src/content/docs/codestream/troubleshooting/client-logs.mdx
@@ -3,35 +3,21 @@ title: Where can I find my CodeStream client-side logs?
 metaDescription: "Find your CodeStream log files."
 ---
 
-As part of submitting a bug report on our
-[GitHub repo](https://github.com/TeamCodeStream/CodeStream/issues) it would be very
-helpful if you'd also include your log files. Follow these instructions for your IDE to get your log
-files. You can attach the log files to the
-GitHub issue or, if you’d prefer, you can email them to support@codestream.com
-and reference the GitHub issue number in the subject.
+As part of submitting a bug report on our [GitHub repo](https://github.com/TeamCodeStream/CodeStream/issues) it would be very helpful if you'd also include your log files. Follow these instructions for your IDE to get your log files. You can attach the log files to the GitHub issue or, if you’d prefer, you can email them to support@codestream.com and reference the GitHub issue number in the subject.
 
 ## JetBrains [#jetbrains]
 
-Reproduce the issue and then in your IDE go to **Help > Collect Logs and
-  Diagnostic Data**. This will open the finder where you should see a newly
-  created zip file.
+1. Reproduce the issue.
+2. In your IDE go to **Help > Collect Logs and Diagnostic Data**. This will open the finder where you should see a newly created zip file.
 
 ## VS Code [#vscode]
 
-Reproduce the issue and then open the Output view in VS Code (**View: Toggle
-  Output** from the command palette) and select **CodeStream (Agent)** from the
-  dropdown menu at the top-right. Copy all of the output you see and save it in
-  a text file.
+1. Reproduce the issue.
+2. Open the **Output** view in VS Code (**View: Toggle Output** from the command palette) and select **CodeStream (Agent)** from the dropdown menu at the top-right. 
+Copy all of the output you see and save it in a text file.
 
 ## Visual Studio [#visual-studio]
 
-Go to **Tools > Options > CodeStream** and make sure your log level is set to at
-  least `Debug`. If it is set to `Info`, `Errors`, or `Silent`, change it to
-  `Debug`, then restart Visual Studio.
-
-Reproduce the issue.
-
-Grab `vs-extension.log` and `vs-agent.log` from `%localappdata%\CodeStream\Logs`
-  as well as the ActivityLog.xml from
-  `%AppData%\Microsoft\VisualStudio\16.0_<RandomText>` for Visual Studio 2019 or
-  `%AppData%\Microsoft\VisualStudio\15.0_<RandomText>` for Visual Studio 2017.
+1. Go to **Tools > Options > CodeStream** and make sure your log level is set to at least `Debug`. If it is set to `Info`, `Errors`, or `Silent`, change it to `Debug`, then restart Visual Studio.
+2. Reproduce the issue.
+3. Grab `vs-extension.log` and `vs-agent.log` from `%localappdata%\CodeStream\Logs` as well as the ActivityLog.xml from `%AppData%\Microsoft\VisualStudio\16.0_<RandomText>` for Visual Studio 2019 or `%AppData%\Microsoft\VisualStudio\15.0_<RandomText>` for Visual Studio 2017.

--- a/src/content/docs/codestream/troubleshooting/git-issues.mdx
+++ b/src/content/docs/codestream/troubleshooting/git-issues.mdx
@@ -8,30 +8,16 @@ Git-related warnings.
 
 ## Repo isn’t managed by Git or Git can't be found [#not-found]
 
-While technically not a requirement, key elements of CodeStream’s functionality
-depend on your repository being managed by Git or a Git-hosting service like
-GitHub. If you’re not using Git, CodeStream won't be able to connect the
-comments and issues you create to the appropriate blocks of code in your source
-files. This means that comments and issues will appear in the activity feed and
-in search results, but they won't appear in the codemarks
-section when your teammates are viewing the source file.
+While technically not a requirement, key elements of Code Stream’s functi onal ity depend on your repository being managed by Git or a Git-hosting service likeGitHub. If you’re not using Git, CodeStream won't be able to connect thecomments and issues you create to the appropriate blocks of code in your sourcefiles. This means that comments and issues will appear in the activity feed andin search results, but they won't appear in the codemarkssection when your teammates are viewing the source file.
 
-This error could also mean that Git isn’t in your PATH. If so, please
-add it to your PATH and then restart your IDE.
+This error could also mean that Git isn’t in your PATH. If so, please add it to your PATH and then restart your IDE.
 
 ## Repo doesn’t have a remote URL [#no-remote-url]
 
-The remote URL is part of what allows CodeStream to tie the code block from your
-message to the appropriate file and location in the corresponding repo in your IDE. If CodeStream isn't able to identify the repository your
-teammate has open as the same one in which you created your comment or issue, they
-won't be able to see the comment or issue.
+The remote URL is part of what allows CodeStream to tie the code block from your message to the appropriate file and location in the corresponding repo in your IDE. If CodeStream isn't able to identify the repository your teammate has open as the same one in which you created your comment or issue, they won't be able to see the comment or issue.
 
-From the command line, use `git remote -v` to confirm whether or not you have a
-remote URL configured for your repository. If there's no remote URL, find out
-the correct URL and then specify the remote URL via `git remote add origin <remote URL>`.
+From the command line, use `git remote -v` to confirm whether or not you have a remote URL configured for your repository. If there's no remote URL, find out the correct URL and then specify the remote URL via `git remote add origin <remote URL>`.
 
 ## Unsaved file [#unsaved]
 
-As with files not managed by Git, CodeStream won't be able to link a
-comment or issue to a block of code in a new, unsaved file. Go ahead and save the
-file before creating your first comment or issue.
+As with files not managed by Git, CodeStream won't be able to link a comment or issue to a block of code in a new, unsaved file. Go ahead and save the file before creating your first comment or issue.

--- a/src/content/docs/codestream/troubleshooting/github-org-repos.mdx
+++ b/src/content/docs/codestream/troubleshooting/github-org-repos.mdx
@@ -3,22 +3,12 @@ title: Why aren't PRs and issues from all of my GitHub organizations listed in C
 metaDescription: "How to make sure all of your GitHub organizations are listed in CodeStream."
 ---
 
-When you connect to GitHub you should see all of your open pull requests in the
-**Pull Requests** section of the CodeStream pane, as well as all issues assigned to
-you in the **Issues** section. If pull requests or issues from any of your GitHub
-organizations are missing, it's probably because at the time you authenticated
-with GitHub and you didn't grant access to all of your organizations.
+When you connect to GitHub you should see all of your open pull requests in the **Pull Requests** section of the CodeStream pane, as well as all issues assigned to you in the **Issues** section. If pull requests or issues from any of your GitHub organizations are missing, it's probably because at the time you authenticated with GitHub and you didn't grant access to all of your organizations.
 
 ![GitHub Authentication](/images/GitHubAuth.png)
 
-If you didn't click the **Grant** button at authentication time, on
-GitHub go to **Settings > Applications** and click the **Authorized OAuth
-Apps** tab. From there, click the CodeStream application. On the following
-page, click the **Grant** button next to any organizations that you'd like to be
-able to access from CodeStream. 
+If you didn't click the **Grant** button at authentication time, on GitHub go to **Settings > Applications** and click the **Authorized OAuth Apps** tab. From there, click the CodeStream application. On the following page, click the **Grant** button next to any organizations that you'd like to be able to access from CodeStream. 
 
-In some instances, you'll see a **Request**
-button instead of **Grant**, which means that the owner of your GitHub organization
-will need to grant you access.
+In some instances, you'll see a **Request** button instead of **Grant**, which means that the owner of your GitHub organization will need to grant you access.
 
 ![GitHub OAuth Apps](/images/GitHubOAuthApps.png)

--- a/src/content/docs/codestream/troubleshooting/glsm-version.mdx
+++ b/src/content/docs/codestream/troubleshooting/glsm-version.mdx
@@ -7,8 +7,9 @@ If you add `/api/v4/version` to the end of the URL for your GitLab Self-Managed 
 
 For example, our URL is `http://gitlab.codestream.us/api/v4/version`, which results in:
 
-`version:	"13.6.4"`
-
-`revision:  "2754dab2b1b"`
+```
+version:	"13.6.4"
+revision:  "2754dab2b1b"
+```
 
 If you'd like to use CodeStream's integration with merge requests from GitLab Self-managed, you'll need version 12.10 or later.

--- a/src/content/docs/codestream/troubleshooting/glsm-version.mdx
+++ b/src/content/docs/codestream/troubleshooting/glsm-version.mdx
@@ -3,15 +3,12 @@ title: Determine the version of your GitLab Self-Managed instance for CodeStream
 metaDescription: "How to find the version of your GitLab Self-Managed instance."
 ---
 
-If you add `/api/v4/version` to the end of the URL for your GitLab Self-Managed
-instance the resulting page will show you your version information. 
+If you add `/api/v4/version` to the end of the URL for your GitLab Self-Managed instance the resulting page will show you your version information. 
 
-For example,
-our URL is `http://gitlab.codestream.us/api/v4/version`, which results in:
+For example, our URL is `http://gitlab.codestream.us/api/v4/version`, which results in:
 
 `version:	"13.6.4"`
 
 `revision:  "2754dab2b1b"`
 
-If you'd like to use CodeStream's integration with merge requests from
-GitLab Self-managed, you'll need version 12.10 or later.
+If you'd like to use CodeStream's integration with merge requests from GitLab Self-managed, you'll need version 12.10 or later.

--- a/src/content/docs/codestream/troubleshooting/jira-server-integration.mdx
+++ b/src/content/docs/codestream/troubleshooting/jira-server-integration.mdx
@@ -6,7 +6,7 @@ metaDescription: "How to configure the CodeStream connection to your Jira server
 <Callout variant="caution">
 Recent versions of Jira Server (8.14.0 or higher) support the use of API Tokens to access the Jira Server REST API. We recommend you use API Tokens if possible to avoid the more complicated setup described here. [Check your Jira Server version](jira-server-version/).
 
-You must be a Jira administrator in order to configure this integration. To determine if you have the proper permissions in order to proceed, look for the Jira settings menu (cog icon, most likely at the top-right, next to your profile and settings menu icon) and make sure there's an "Applications" option there. If you don't have the Settings menu, or the Applications option, then you won't be able to configure the integration.
+You must be a Jira administrator in order to configure this integration. To determine if you have the proper permissions in order to proceed, look for the Jira settings menu (cog icon, most likely at the top-right, next to your profile and settings menu icon) and make sure there's an **Applications** option there. If you don't have the **Settings** menu, or the **Applications** option, then you won't be able to configure the integration.
 
 This integration requires that your Jira Server instance be at a publicly accessible URL.
 </Callout>
@@ -25,20 +25,26 @@ In a terminal, use `openssl` to generate your public/private key pair, using the
 
 1. Generate a 1024-bit private key:
 
-    ```openssl genrsa -out jira_privatekey.pem 1024```
+    ```
+    openssl genrsa -out jira_privatekey.pem 1024
+  ```
 2.  Create an X509 certificate:
 
-    ```openssl req -newkey rsa:1024 -x509 -key jira_privatekey.pem -out jira_publickey.cer -days 365```
-
+    ```
+    openssl req -newkey rsa:1024 -x509 -key jira_privatekey.pem -out jira_publickey.cer -days 365
+    ```
   Enter whatever information you see fit to accompany the certificate.
 
 3. Extract the private key (PKCS8 format) to the `jira_privatekey.pcks8` file:
 
-    ```openssl pkcs8 -topk8 -nocrypt -in jira_privatekey.pem -out jira_privatekey.pcks8```
-
+    ```
+    openssl pkcs8 -topk8 -nocrypt -in jira_privatekey.pem -out jira_privatekey.pcks8
+    ```
 4. Extract the public key from the certificate to the `jira_publickey.pem` file:
 
-    ```openssl x509 -pubkey -noout -in jira_publickey.cer > jira_publickey.pem```
+    ```
+    openssl x509 -pubkey -noout -in jira_publickey.cer > jira_publickey.pem
+    ```
 
 ## Create an application link [#create-application-link]
 
@@ -48,6 +54,7 @@ Follow these steps to create your application link within Jira Server.
 2. Where it says **Enter the URL of the application you want to link**, enter any URL you want, for example, `http://example.com/`. Then click **Create new link**.
 3. You will likely see a warning starting with: **No response was received from the URL you entered**. You can ignore the warning; click **Continue**.
 4. Fill out the form as you see here, or as you like. None of the data entered here really matters, except to make sure that **Create incoming link** is checked. The **Application Name** can be whatever name works best for you to identify the link. Then click **Continue**.
+
     ![Create Jira Server Application Link](/images/CreateJiraServerApplicationLink1.png)
 
 5. On the next dialog, enter any unique string you want for the **Consumer Key**. It does not need to be secure or encoded, just something fairly easy to remember. Make a note of what you enter here; it will be needed when you go to set up the integration with Jira Server from CodeStream. For **Consumer Name**, you can enter anything meaningful to you, like "CodeStream app". The important field to fill out correctly is **Public Key**. Copy the full text of the contents of the **jira_publickey.pem** file you created in Step #1. Paste this into the **Public Key** field, then click **Continue**.

--- a/src/content/docs/codestream/troubleshooting/jira-server-integration.mdx
+++ b/src/content/docs/codestream/troubleshooting/jira-server-integration.mdx
@@ -4,7 +4,7 @@ metaDescription: "How to configure the CodeStream connection to your Jira server
 ---
 
 <Callout variant="caution">
-Recent versions of Jira Server (>=8.14.0) support the use of API Tokens to access the Jira Server REST API. We recommend you use API Tokens if possible to avoid the more complicated setup described here. [Check your Jira Server version](jira-server-version/).
+Recent versions of Jira Server (8.14.0 or higher) support the use of API Tokens to access the Jira Server REST API. We recommend you use API Tokens if possible to avoid the more complicated setup described here. [Check your Jira Server version](jira-server-version/).
 
 You must be a Jira administrator in order to configure this integration. To determine if you have the proper permissions in order to proceed, look for the Jira settings menu (cog icon, most likely at the top-right, next to your profile and settings menu icon) and make sure there's an "Applications" option there. If you don't have the Settings menu, or the Applications option, then you won't be able to configure the integration.
 
@@ -13,7 +13,7 @@ This integration requires that your Jira Server instance be at a publicly access
 
 New Relic CodeStream can integrate with Jira Server using Atlassian’s published REST API. To enable CodeStream to integrate with your Jira Server installation, set up a CodeStream application link. This application link serves as a conduit for users to authenticate against their Jira Server account without ever having to enter their credentials in CodeStream.
 
-Jira Server uses the OAuth standard (version 1.0a) for client authorization. For reference, this page from Atlassian describes the process: [https://developer.atlassian.com/server/jira/platform/oauth/](https://developer.atlassian.com/server/jira/platform/oauth/). \
+Jira Server uses the OAuth standard (version 1.0a) for client authorization. For reference, [See Atlassian's documentation](https://developer.atlassian.com/server/jira/platform/oauth/). 
 
 However, you don't need to follow the full instructions on that page. The relevant instructions are duplicated and simplified here for clarity. 
 
@@ -23,43 +23,38 @@ You'll need the `openssl` command-line tool to generate a public/private key pai
 
 In a terminal, use `openssl` to generate your public/private key pair, using these steps:
 
-* Generate a 1024-bit private key:
+1. Generate a 1024-bit private key:
 
-  `openssl genrsa -out jira_privatekey.pem 1024`
+    ```openssl genrsa -out jira_privatekey.pem 1024```
+2.  Create an X509 certificate:
 
-* Create an X509 certificate:
-
-  `openssl req -newkey rsa:1024 -x509 -key jira_privatekey.pem -out jira_publickey.cer -days 365`
+    ```openssl req -newkey rsa:1024 -x509 -key jira_privatekey.pem -out jira_publickey.cer -days 365```
 
   Enter whatever information you see fit to accompany the certificate.
 
-* Extract the private key (PKCS8 format) to the `jira_privatekey.pcks8` file:
+3. Extract the private key (PKCS8 format) to the `jira_privatekey.pcks8` file:
 
-  `openssl pkcs8 -topk8 -nocrypt -in jira_privatekey.pem -out jira_privatekey.pcks8`
+    ```openssl pkcs8 -topk8 -nocrypt -in jira_privatekey.pem -out jira_privatekey.pcks8```
 
-* Extract the public key from the certificate to the `jira_publickey.pem` file:
+4. Extract the public key from the certificate to the `jira_publickey.pem` file:
 
-  `openssl x509 -pubkey -noout -in jira_publickey.cer > jira_publickey.pem`
+    ```openssl x509 -pubkey -noout -in jira_publickey.cer > jira_publickey.pem```
 
 ## Create an application link [#create-application-link]
 
 Follow these steps to create your application link within Jira Server.
 
-* In Jira, navigate to **Jira settings** (gear icon in upper-right), click **Applications**. Enter your administrator password, if needed. Then select **Application links** under **Integrations**, in the left sidebar.
+1. In Jira, navigate to **Jira settings** (gear icon in upper-right), click **Applications**. Enter your administrator password, if needed. Then select **Application links** under **Integrations**, in the left sidebar.
+2. Where it says **Enter the URL of the application you want to link**, enter any URL you want, for example, `http://example.com/`. Then click **Create new link**.
+3. You will likely see a warning starting with: **No response was received from the URL you entered**. You can ignore the warning; click **Continue**.
+4. Fill out the form as you see here, or as you like. None of the data entered here really matters, except to make sure that **Create incoming link** is checked. The **Application Name** can be whatever name works best for you to identify the link. Then click **Continue**.
+    ![Create Jira Server Application Link](/images/CreateJiraServerApplicationLink1.png)
 
-* Where it says **Enter the URL of the application you want to link**, enter any URL you want, for example, `http://example.com/`. Then click **Create new link**.
-
-* You will likely see a warning starting with: **No response was received from the URL you entered**. You can ignore the warning; click **Continue**.
-
-* Fill out the form as you see here, or as you like. None of the data entered here really matters, except to make sure that **Create incoming link** is checked. The **Application Name** can be whatever name works best for you to identify the link. Then click **Continue**.
-
-![Create Jira Server Application Link](/images/CreateJiraServerApplicationLink1.png)
-
-* On the next dialog, enter any unique string you want for the **Consumer Key**. It does not need to be secure or encoded, just something fairly easy to remember. Make a note of what you enter here; it will be needed when you go to set up the integration with Jira Server from CodeStream. For **Consumer Name**, you can enter anything meaningful to you, like "CodeStream app". The important field to fill out correctly is **Public Key**. Copy the full text of the contents of the **jira_publickey.pem** file you created in Step #1. Paste this into the **Public Key** field, then click **Continue**.
+5. On the next dialog, enter any unique string you want for the **Consumer Key**. It does not need to be secure or encoded, just something fairly easy to remember. Make a note of what you enter here; it will be needed when you go to set up the integration with Jira Server from CodeStream. For **Consumer Name**, you can enter anything meaningful to you, like "CodeStream app". The important field to fill out correctly is **Public Key**. Copy the full text of the contents of the **jira_publickey.pem** file you created in Step #1. Paste this into the **Public Key** field, then click **Continue**.
 
 ![Jira Server Link Applications](/images/JiraServerLinkApplications1.png)
 
-* The application link you created should now show like this:
+The application link you created should now show like this:
 
 ![Jira Server Application Link Created](/images/JiraServerApplicationLinkCreated1.png)
 
@@ -70,8 +65,8 @@ Now you're ready to set up the integration from CodeStream to Jira Server for yo
 1. In CodeStream, go to the **Integrations** panel by clicking the menu next to your username in the top-left. Then click **Jira Server** under **Issue Providers**.
 2. Since you won't be using API Tokens with your Jira Server integration, click at the top where it says **Click here if your organization uses a version of Jira Server older than...** to configure Jira Server using the OAuth method described herein.
 3. Fill out the form:
-  * For **Jira Server Base URL**, enter the URL used to access your Jira Server installation as known to your internal network, in the form http(s)://host:port. 
-  * For **Consumer Key**, use the consumer key you entered when created the application link, from Step #2, above. Then copy the full contents of the private key, in PCKS8 format, that you created in Step #1 above. The file should be called **jira_privatekey.pcks8**. Paste those contents into the **Private Key** field, then click **Submit**.
+    * For **Jira Server Base URL**, enter the URL used to access your Jira Server installation as known to your internal network, in the form http(s)://host:port. 
+    * For **Consumer Key**, use the consumer key you entered when created the application link, from Step #2, above. Then copy the full contents of the private key, in PCKS8 format, that you created in Step #1 above. The file should be called **jira_privatekey.pcks8**. Paste those contents into the **Private Key** field, then click **Submit**.
   ![Configure Jira Server](/images/ConfigureJiraServer1.png)
 
 4. You'll then be taken to your Jira Server instance, where you'll approve access to your account using the application link. When you are finished, return to your IDE and you should see something similar to this:

--- a/src/content/docs/codestream/troubleshooting/jira-server-integration.mdx
+++ b/src/content/docs/codestream/troubleshooting/jira-server-integration.mdx
@@ -67,21 +67,14 @@ Follow these steps to create your application link within Jira Server.
 
 Now you're ready to set up the integration from CodeStream to Jira Server for your team, using the application link you created. Assuming you have signed up for CodeStream and have the extension open in your IDE:
 
-* In CodeStream, go to the **Integrations** panel by clicking the menu next to your username in the top-left. Then click **Jira Server** under **Issue Providers**.
+1. In CodeStream, go to the **Integrations** panel by clicking the menu next to your username in the top-left. Then click **Jira Server** under **Issue Providers**.
+2. Since you won't be using API Tokens with your Jira Server integration, click at the top where it says **Click here if your organization uses a version of Jira Server older than...** to configure Jira Server using the OAuth method described herein.
+3. Fill out the form:
+  * For **Jira Server Base URL**, enter the URL used to access your Jira Server installation as known to your internal network, in the form http(s)://host:port. 
+  * For **Consumer Key**, use the consumer key you entered when created the application link, from Step #2, above. Then copy the full contents of the private key, in PCKS8 format, that you created in Step #1 above. The file should be called **jira_privatekey.pcks8**. Paste those contents into the **Private Key** field, then click **Submit**.
+  ![Configure Jira Server](/images/ConfigureJiraServer1.png)
 
-* Since you won't be using API Tokens with your Jira Server integration, click at the top where it says **Click here if your organization uses a version of Jira Server older than...** to configure Jira Server using the OAuth method described herein.
+4. You'll then be taken to your Jira Server instance, where you'll approve access to your account using the application link. When you are finished, return to your IDE and you should see something similar to this:
+  ![Completed Jira Server Integration](/images/CompletedJiraServerIntegration1.png)
 
-* Fill out the form as follows. For **Jira Server Base URL**, enter the URL used to access your Jira Server installation as known to your internal network, in the form http(s)://host:port. For **Consumer Key**, use the consumer key you entered when created the application link, from Step #2, above. Then copy the full contents of the private key, in PCKS8 format, that you created in Step #1 above. The file should be called **jira_privatekey.pcks8**. Paste those contents into the **Private Key** field, then click **Submit**.
-
-![Configure Jira Server](/images/ConfigureJiraServer1.png)
-
-* You'll then be taken to your Jira Server instance, where you'll approve access to your account using the application link. When you are finished, return to your IDE and you should see something similar to this:
-
-![Completed Jira Server Integration](/images/CompletedJiraServerIntegration1.png)
-
-* Now that the integration has been set up for your organization, other users
-  will NOT have to go through the process described above. Other users in your
-  organization will see the integration with your Jira Server (specified by
-  host) alongside other available integrations. Initiating this integration will
-  only require your other users to allow the CodeStream application link to
-  access their account, as you did in the final step.
+5. Now that the integration has been set up for your organization, other users will NOT have to go through the process described above. Other users in your organization will see the integration with your Jira Server (specified by host) alongside other available integrations. Initiating this integration will only require your other users to allow the CodeStream application link to access their account, as you did in the final step.

--- a/src/content/docs/codestream/troubleshooting/jira-server-version.mdx
+++ b/src/content/docs/codestream/troubleshooting/jira-server-version.mdx
@@ -7,4 +7,4 @@ Most pages on Jira Server show the version number in the footer of the page. Her
 
 ![Jira Server Version](/images/JiraServerVersion.png)
 
-Most pages should have this information in the footer. For example the default system dashboard, but you can also try checking the About Jira page under the Help menu.
+Most pages should have this information in the footer. For example the default system dashboard, but you can also try checking the **About Jira** page under the **Help** menu.

--- a/src/content/docs/codestream/troubleshooting/keychain-issues.mdx
+++ b/src/content/docs/codestream/troubleshooting/keychain-issues.mdx
@@ -3,21 +3,14 @@ title: Why do I have to sign into CodeStream every time I restart my JetBrains I
 metaDescription: "How to prevent having to sign into your JetBrains IDE every time you restart it."
 ---
 
-If you have to sign into New Relic CodeStream every time you restart your JetBrains IDE
-or open a new project, it's likely that the IDE isn't saving and/or retrieving
-the authentication token from your local password safe. 
+If you have to sign into New Relic CodeStream every time you restart your JetBrains IDE or open a new project, it's likely that the IDE isn't saving and/or retrieving the authentication token from your local password safe. 
 
-[This JetBrains article](https://www.jetbrains.com/help/idea/reference-ide-settings-password-safe.html)
-provides details on how you can check to make sure that it is properly
-configured.
+[This JetBrains article](https://www.jetbrains.com/help/idea/reference-ide-settings-password-safe.html) provides details on how you can check to make sure that it is properly configured.
 
-For example, if you're on a Mac the **in native Keychain** option is the one you'd
-want to use, as shown in the screenshot below.
+For example, if you're on a Mac the **in native Keychain** option is the one you'd want to use, as shown in the screenshot below.
 
 ![Passwords](/images/JBPasswords.png)
 
-If the native keychain is already selected, it's also possible that the first time
-you were prompted to allow the IDE keychain access that you denied it. If that's
-the case, you can go into the **Keychain Access**k app and correct it.
+If the native keychain is already selected, it's also possible that the first time you were prompted to allow the IDE keychain access that you denied it. If that's the case, you can go into the **Keychain Access**k app and correct it.
 
 ![Keychain Access](/images/KeychainAccess.png)

--- a/src/content/docs/codestream/troubleshooting/proxy-support.mdx
+++ b/src/content/docs/codestream/troubleshooting/proxy-support.mdx
@@ -3,24 +3,18 @@ title: CodeStream proxy support
 metaDescription: "Troubleshoot a common CodeStream connectivity issue."
 ---
 
-If you're experiencing connectivity issues with the New Relic CodeStream extension, it
-could be because you’re behind a network proxy and CodeStream isn't configured
-to work with it. To find CodeStream’s settings in your IDE:
+If you're experiencing connectivity issues with the New Relic CodeStream extension, it could be because you’re behind a network proxy and CodeStream isn't configured to work with it. To find CodeStream’s settings in your IDE:
 
-* VS Code - Go to **Settings** and search for CodeStream.
-* Visual Studio - Go to **Tools > Options > CodeStream**.
-* JetBrains - Go to **Settings/Preferences > Tools > CodeStream**.
+* VS Code: Go to **Settings** and search for CodeStream.
+* Visual Studio: Go to **Tools > Options > CodeStream**.
+* JetBrains: Go to **Settings/Preferences > Tools > CodeStream**.
 
-Look for the **Proxy Support** setting and make sure it is set to **on**. You will
-also need to disable Strict SSL checking since your CodeStream extension won’t
-see the SSL/TLS certificates as coming from a legitimate certificate authority. 
+Look for the **Proxy Support** setting and make sure it is set to **on**. You will also need to disable Strict SSL checking since your CodeStream extension won’t see the SSL/TLS certificates as coming from a legitimate certificate authority. 
 
 Here's what these settings look like in VS Code. 
 
 ![Proxy Settings](/images/ProxySettings1.png)
 
-If you have proxy support configured in your IDE, CodeStream will first try to
-inherit those settings. Otherwise, CodeStream will inherit proxy settings from
-your operating system/environment.
+If you have proxy support configured in your IDE, CodeStream will first try to inherit those settings. Otherwise, CodeStream will inherit proxy settings from your operating system/environment.
 
 After changing your settings, restart your IDE.


### PR DESCRIPTION
I made a LOT of formatting/style changes, but they basically all boil down to:

* Make all paragraphs into single lines, rather than multiple lines, to create a more consistent editor experience (@paperclypse guessing this was an artifact of the way CodeStream did it on their old docs site but LMK if I'm missing something)
* Use bold formatting everywhere for UI elements, where I noticed it
* Tweak list styles to more closely match other docs on the site
* Reformat a few lists and tables to use OL rather than UL

I've validated the formatting by checking each doc in Gatsby Cloud preview. I'd suggest reviewer do the same rather than trying to review line-by-line in the diff.