### PR TITLE
add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# .github directory & its subdirectories
+/.github/ @newrelic/developer-enablement
+
+# all javascript files
+*.js @newrelic/developer-enablement
+
+yarn.lock @newrelic/developer-enablement


### PR DESCRIPTION
* add the dev team as code owners for .github folder, all javascript files,
  and the yark.lock to start.

Relates to: https://github.com/newrelic/docs-website/issues/3658