### PR TITLE
Removing links to Unity

### DIFF
--- a/src/content/docs/apis/intro-apis/introduction-new-relic-apis.mdx
+++ b/src/content/docs/apis/intro-apis/introduction-new-relic-apis.mdx
@@ -396,7 +396,6 @@ New Relic tools and features, like APM, infrastructure monitoring, browser monit
 
             * [iOS](/docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-sdk-api-guide)
             * [Android](/docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-sdk-api-guide)
-            * [Unity](/docs/mobile-monitoring/new-relic-mobile-unity/install-configure/unity-sdk-api)
           </td>
         </tr>
 

--- a/src/i18n/content/jp/docs/apis/get-started/intro-apis/introduction-new-relic-apis.mdx
+++ b/src/i18n/content/jp/docs/apis/get-started/intro-apis/introduction-new-relic-apis.mdx
@@ -289,8 +289,7 @@ APMのようなNew Relic機能、インフラストラクチャモニター、�
             Mobile APIでは、独自コードのカスタムインストゥルメンテーションや、New Relicへのイベント送信を行うことができます。プラットフォーム固有のドキュメントをご覧ください。
 
             * [iOS](/docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-sdk-api-guide)
-            * [Android](/docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-sdk-api-guide)
-            * [Unity](/docs/mobile-monitoring/new-relic-mobile-unity/install-configure/unity-sdk-api)
+            * [Android](/docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-sdk-api-guide)          
           </td>
         </tr>
 

--- a/src/i18n/content/jp/docs/apis/intro-apis/introduction-new-relic-apis.mdx
+++ b/src/i18n/content/jp/docs/apis/intro-apis/introduction-new-relic-apis.mdx
@@ -341,8 +341,7 @@ APMのようなNew Relicツールと機能、Infrastructureモニタリング、
             Mobile APIでは、独自コードのカスタムインストゥルメントおよびNew Relicへのイベント送信ができます。プラットフォーム固有のドキュメントを参照してください。
 
             * [iOS](/docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-sdk-api-guide)
-            * [Android](/docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-sdk-api-guide)
-            * [Unity](/docs/mobile-monitoring/new-relic-mobile-unity/install-configure/unity-sdk-api)
+            * [Android](/docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-sdk-api-guide)            
           </td>
         </tr>
 


### PR DESCRIPTION
As reported in #4768, and as verified with the Browser team, removing references to Unity, which has been discontinued. 