### PR TITLE
Improve documentation for .NET agent configuration

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -472,7 +472,7 @@ The `service` element supports the following attributes:
       </tbody>
     </table>
 
-    Block application shutdown until the agent sends all data from the latest harvest cycle.
+    Block application shutdown while the agent initiates a final harvest cycle and sends all data to New Relic.
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
## Give us some context

It was previously unclear as to whether or not the `sendDataOnExit` configuration option actually initiated a harvest cycle. This change clarifies the impact of this configuration option.