### PR TITLE
Fix sample Dockerfile for .NET Agent Framework Apps

### DIFF
--- a/src/content/docs/apm/agents/net-agent/other-installation/install-net-agent-docker-container.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/install-net-agent-docker-container.mdx
@@ -104,18 +104,22 @@ ENTRYPOINT ["dotnet", "./<var>YOUR_APP_NAME</var>.dll"]
 ### Example Windows Dockerfile for .NET Framework application [#example-windows-dockerfile-framework]
 
 ```
-FROM microsoft/aspnet
+FROM mcr.microsoft.com/dotnet/framework/aspnet
 
 # Publish your application.
 COPY <var>your app to be published</var> /inetpub/wwwroot
 
-# Copy the New Relic .NET agent installer
-COPY ./NewRelicDotNetAgent_x64.msi /
+# Download the New Relic .NET agent installer
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;\
+ Invoke-WebRequest "https://download.newrelic.com/dot_net_agent/latest_release/NewRelicDotNetAgent_x64.msi"\
+ -UseBasicParsing -OutFile "NewRelicDotNetAgent_x64.msi"
 
-# Install the agent
-RUN powershell.exe Start-Process -Wait -FilePath msiexec -ArgumentList /i,\ 
-"C:\NewRelicDotNetAgent_x64.msi",\
-/qn,NR_LICENSE_KEY=<var>YOUR_LICENSE_KEY</var>
+# Install the New Relic .NET agent
+RUN Start-Process -Wait -FilePath msiexec -ArgumentList /i, "NewRelicDotNetAgent_x64.msi", /qn,\
+ NR_LICENSE_KEY=<var>YOUR_LICENSE_KEY</var>
+
+# Remove the New Relic .NET agent installer
+RUN Remove-Item "NewRelicDotNetAgent_x64.msi"
 
 # Set your application name
 ENV NEW_RELIC_APP_NAME=<var>YOUR_APP_NAME</var>


### PR DESCRIPTION
## Give us some context

The existing docker example for windows .NET framework apps no longer worked and needed to be updated. Improvements include:
- Agent installer is downloaded directly from New Relic
- Agent installer is now deleted after installation
- The source docker image references the new microsoft mcr registry