### PR TITLE
Improve windows .net core docker example

### DIFF
--- a/src/content/docs/apm/agents/net-agent/other-installation/install-net-agent-docker-container.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/install-net-agent-docker-container.mdx
@@ -133,13 +133,17 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 # Publish your application.
 COPY <var>your app to be published</var> /app
 
-# Copy the New Relic .NET agent installer
-COPY ./NewRelicDotNetAgent_x64.msi /
+# Download the New Relic .NET agent installer
+RUN powershell.exe [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;\
+ Invoke-WebRequest "https://download.newrelic.com/dot_net_agent/latest_release/NewRelicDotNetAgent_x64.msi"\
+ -UseBasicParsing -OutFile "NewRelicDotNetAgent_x64.msi"
 
-# Install the agent
-RUN Start-Process -Wait -FilePath msiexec -ArgumentList /i,
-"C:\NewRelicDotNetAgent_x64.msi",
-/qn, NR_LICENSE_KEY=<var>YOUR_LICENSE_KEY</var>
+# Install the New Relic .NET agent
+RUN powershell.exe Start-Process -Wait -FilePath msiexec -ArgumentList /i, "NewRelicDotNetAgent_x64.msi", /qn,\
+ NR_LICENSE_KEY=<var>YOUR_LICENSE_KEY</var>
+
+# Remove the New Relic .NET agent installer
+RUN powershell.exe Remove-Item "NewRelicDotNetAgent_x64.msi"
 
 # Enable the agent
 ENV CORECLR_ENABLE_PROFILING=1
@@ -147,10 +151,10 @@ ENV CORECLR_ENABLE_PROFILING=1
 # Set your application name
 ENV NEW_RELIC_APP_NAME=<var>YOUR_APP_NAME</var>
 
-# windowsservercore images may not include the .NET Core SDK or runtime
+# windows/servercore images may not include the .NET Core SDK or runtime
 RUN <var>dotnet sdk/runtime installer</var>
 
 WORKDIR /app
 
-ENTRYPOINT ["dotnet", ".\\<var>YOUR_APP_NAME</var>.dll"]
+ENTRYPOINT ["dotnet", ".\\<var>YOUR_APP_NAME.dll</var>"]
 ```


### PR DESCRIPTION
## Give us some context

The Windows .NET Core docker example needed `powershell.exe` to be prepended to several commands.  The example now dynamically downloads the agent as well