### PR TITLE
Remove Istio nav link since content directory is already gone

### DIFF
--- a/src/nav/integrations.yml
+++ b/src/nav/integrations.yml
@@ -30,8 +30,6 @@ pages:
     path: /docs/more-integrations/open-source-telemetry-integrations/dropwizard/dropwizard-reporter
   - title: Elixir
     path: /docs/more-integrations/open-source-telemetry-integrations/elixir/elixir-open-source-agent
-  - title: Istio
-    path: /docs/more-integrations/open-source-telemetry-integrations/istio/istio-adapter
   - title: Kamon
     path: /docs/more-integrations/open-source-telemetry-integrations/kamon/kamon-reporter
   - title: Micrometer


### PR DESCRIPTION
The left navigation link to Istio under "More integrations" wasn't removed when the Istio Adapter directory was removed. This is a clean-up task.