### PR TITLE
fix: add yarn-verify example

### DIFF
--- a/src/content/docs/style-guide/writer-workflow/github-troubleshooting.mdx
+++ b/src/content/docs/style-guide/writer-workflow/github-troubleshooting.mdx
@@ -26,7 +26,7 @@ Here’s a few things you can check if your build is failing:
   * Image filenames are case-sensitive. Using the wrong capitalization results in a missing image in the doc.
   * Images with encoded values (like `%`) in the filename can be especially tricky, try to avoid them.
 
-If you know which file is causing an error, you can further troubleshoot with the `yarn verify-mdx path/to/file.mdx` command. This command returns more information about the error than the normal Gatsby output does. This includes things such as the specific character and line number cuasing the error. 
+If you know which file is causing an error, you can further troubleshoot with the `yarn verify-mdx path/to/file.mdx` command. This command returns more information about the error than the normal Gatsby output. This includes things such as the specific character and line number causing the error. 
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/style-guide/writer-workflow/github-troubleshooting.mdx
+++ b/src/content/docs/style-guide/writer-workflow/github-troubleshooting.mdx
@@ -7,7 +7,7 @@ topics:
 Are you having problems [working on a doc in GitHub](/docs/style-guide/writer-workflow/tech-writer-workflow/)? Check out the following common issues.  
 
 ## GitHub authentication fails [#authentication-fail]
-If you suddenly find that you can no longer push to your remote branch in GitHub Desktop, you may have developed a problem with SSH. 
+If you suddenly find that you can no longer push to your remote branch in GitHub Desktop, you may have developed a problem with SSH.  
 
 If logging out of GitHub Desktop via Preferences doesn’t seem to help, you can confirm if you have an SSH issue by switching to the command line and trying to push manually. For example: `git push --set-upstream origin second-kafka-pr-for-issue-1123`
 

--- a/src/content/docs/style-guide/writer-workflow/github-troubleshooting.mdx
+++ b/src/content/docs/style-guide/writer-workflow/github-troubleshooting.mdx
@@ -26,6 +26,71 @@ Here’s a few things you can check if your build is failing:
   * Image filenames are case-sensitive. Using the wrong capitalization results in a missing image in the doc.
   * Images with encoded values (like `%`) in the filename can be especially tricky, try to avoid them.
 
+If you know which file is causing an error, you can further troubleshoot with the `yarn verify-mdx path/to/file.mdx` command. This command returns more information about the error than the normal Gatsby output does. This includes things such as the specific character and line number cuasing the error. 
+
+<CollapserGroup>
+  <Collapser
+    className="freq-link"
+    id="verify"
+    title="Example: Troubleshoot with yarn-verify"
+  >
+Let's pretend I've made a changes to multiple docs in my branch. When I try to either run the site locally or access the Gatsby Cloud build, I get the following error:
+    
+```
+Unexpected character = (U+003D) before name, expected a character that can start a name, such as a letter, $, or _/usr/src/app/www/src/content/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/aqm-implementation-guide.mdx: Unexpected character = (U+003D) before name, expected a character that can start a name, such as a letter, $, or _
+```
+    
+The error does tell me that the doc with an error is `/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/aqm-implementation-guide.mdx`. Other than that, all I know is that there is a `=` character messing things up somewhere. Cool, but this is a NRQL doc, there are a dozens of `=` characters.
+    
+So, I run `yarn verify-mdx src/content/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/aqm-implementation-guide.mdx`. This returns the following:
+    
+```
+reading src/content/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/aqm-implementation-guide.mdx
+{
+  "message": "Unexpected character `=` (U+003D) before name, expected a character that can start a name, such as a letter, `$`, or `_`",
+  "name": "284:227",
+  "reason": "Unexpected character `=` (U+003D) before name, expected a character that can start a name, such as a letter, `$`, or `_`",
+  "line": 284,
+  "column": 227,
+  "location": {
+    "start": {
+      "line": 284,
+      "column": 227,
+      "offset": 19129,
+      "index": 1
+    },
+    "end": {
+      "line": null,
+      "column": null
+    }
+  },
+  "source": "remark-mdx",
+  "ruleId": "unexpected-character",
+  "fatal": true
+}
+[
+```
+
+In this case, the relvant info is:
+```
+"line": 284,
+"column": 227,
+```
+    
+and
+    
+```
+"source": "remark-mdx",
+"ruleId": "unexpected-character",
+"fatal": true
+```
+    
+This tells me that there is an unexpected character in line 284, column 227. Then I can go to that section of the doc and further troubleshoot, knowing exactly where the error comes from. In this case, I likely just need to wrap a NRQL example in quotes.
+    
+
+</Collapser>
+</CollapserGroup>
+
 ## Issues with the local site [#local-site]
 If you're running with issues with your local build, try these options:
 


### PR DESCRIPTION
This adds an example of yarn-verify to our style guide.