### PR TITLE
update translation testing, models

### DIFF
--- a/scripts/actions/translation_workflow/models/job.js
+++ b/scripts/actions/translation_workflow/models/job.js
@@ -54,6 +54,10 @@ module.exports = (sequelize, DataTypes) => {
           deferrable: Deferrable.INITIALLY_IMMEDIATE,
         },
       },
+      project_id: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
     },
     {
       createdAt: 'date_created',

--- a/scripts/actions/translation_workflow/models/translation.js
+++ b/scripts/actions/translation_workflow/models/translation.js
@@ -44,6 +44,10 @@ module.exports = (sequelize, DataTypes) => {
           deferrable: Deferrable.INITIALLY_IMMEDIATE,
         },
       },
+      project_id: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
     },
     {
       createdAt: 'date_created',

--- a/scripts/actions/translation_workflow/models/typedefs.js
+++ b/scripts/actions/translation_workflow/models/typedefs.js
@@ -6,6 +6,7 @@
  * @property {number} status - numeric value of status enum
  * @property {Date} date_created timestamp indicating when record was created
  * @property {Date} date_modified timestamp indicating when record was last updated
+ * @property {string} project_id identifier of project from translation vendor job is associated with
  */
 
 /**
@@ -28,7 +29,8 @@
  * @property {string} status numeric value of status enum
  * @property {number} locale numeric value of locale enum
  * @property {Date} date_created timestamp indicating when record was created
- * @property {Date} date_modified
+ * @property {Date} date_modified timestamp indicating when record was last updated
+ * @property {string} project_id identifier of project from translation vendor translation is associated with
  */
 
 /**

--- a/scripts/actions/translation_workflow/testing/creation_and_cleanup.sql
+++ b/scripts/actions/translation_workflow/testing/creation_and_cleanup.sql
@@ -25,6 +25,7 @@ CREATE TABLE translations(
   date_created TIMESTAMP NOT NULL,
   date_modified TIMESTAMP NOT NULL,
 	locale TEXT NOT NULL,
+  project_id TEXT,
   PRIMARY KEY(id),
   -- pr number
   CONSTRAINT fk_locale
@@ -43,6 +44,7 @@ CREATE TABLE jobs(
   locale TEXT NOT NULL,
   date_created TIMESTAMP NOT NULL,
   date_modified TIMESTAMP NOT NULL,
+  project_id TEXT,
   PRIMARY KEY(id),
   CONSTRAINT fk_status
     FOREIGN KEY(status)


### PR DESCRIPTION
## Summary

* updated testing scripts to include new `project_id` column in translation and jobs tables
* updated models to match

Did some testing to see how we could make changes to production and work with changing code in the feature branch. As long as the `project_id` column can be null, we can add the new columns w/o impacting the current workflows. A constraint on the column would be nice, but is more difficult to work around.

Resolves: #2538