### PR TITLE
Update uvicorn.mdx

### DIFF
--- a/src/content/docs/apm/agents/python-agent/web-frameworks-servers/uvicorn.mdx
+++ b/src/content/docs/apm/agents/python-agent/web-frameworks-servers/uvicorn.mdx
@@ -18,7 +18,7 @@ Read about the requirements and tips for integrating our Python agent with an ap
 If you start your app with `python app.py` and use our Python agent **version 5.20.0.149** or higher, you can use the recommended [admin script integration method](/docs/agents/python-agent/installation-configuration/python-agent-installation#integration). For example:
 
 ```
-NEW_RELIC_CONFIG_FILE=<var>path/to/</var>newrelic.ini newrelic-admin run-python uvicorn path_to_app
+NEW_RELIC_CONFIG_FILE=<var>path/to/</var>newrelic.ini newrelic-admin run-program uvicorn path_to_app
 ```
 
 ## Python agent API [#api]


### PR DESCRIPTION
docs only change fixing a typo on this page https://docs.newrelic.com/docs/apm/agents/python-agent/web-frameworks-servers/uvicorn/

If you run the given command, you get the following error
```
/usr/local/bin/python: can't open file 'uvicorn': [Errno 2] No such file or directory
```
and indeed running the help command gives you (I have removed the irrelevant parts)
```sh
# newrelic-admin run-python --help
usage: /usr/local/bin/python [option] ... [-c cmd | -m mod | file | -] [arg] ...
-c cmd : program passed in as string (terminates option list)
file   : program read from script file
```
which means that `newrelic-admin run-python` expects a `file` or a `-c cmd`. `uvicorn` is not a file but a command, so I propose the follwoing fix.
