### PR TITLE
chore: Add new supported regions for Firelens log forwarding

### DIFF
--- a/src/content/docs/logs/forward-logs/aws-firelens-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/aws-firelens-plugin-log-forwarding.mdx
@@ -55,41 +55,61 @@ To forward your logs from FireLens to New Relic:
   <tbody>
     <tr>
       <td>
-        us-east-1
+        ap-northeast-1
       </td>
 
       <td>
-        `533243300146.dkr.ecr.us-east-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        us-east-2
-      </td>
-
-      <td>
-        `533243300146.dkr.ecr.us-east-2.amazonaws.com/newrelic/logging-firelens-fluentbit`
+        `533243300146.dkr.ecr.ap-northeast-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
       </td>
     </tr>
 
     <tr>
       <td>
-        us-west-1
+        ap-northeast-2
       </td>
 
       <td>
-        `533243300146.dkr.ecr.us-west-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
+        `533243300146.dkr.ecr.ap-northeast-2.amazonaws.com/newrelic/logging-firelens-fluentbit`
       </td>
     </tr>
 
     <tr>
       <td>
-        us-west-2
+        ap-northeast-3
       </td>
 
       <td>
-        `533243300146.dkr.ecr.us-west-2.amazonaws.com/newrelic/logging-firelens-fluentbit`
+        `533243300146.dkr.ecr.ap-northeast-3.amazonaws.com/newrelic/logging-firelens-fluentbit`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        ap-south-1
+      </td>
+
+      <td>
+        `533243300146.dkr.ecr.ap-south-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        ap-southeast-1
+      </td>
+
+      <td>
+        `533243300146.dkr.ecr.ap-southeast-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        ap-southeast-2
+      </td>
+
+      <td>
+        `533243300146.dkr.ecr.ap-southeast-2.amazonaws.com/newrelic/logging-firelens-fluentbit`
       </td>
     </tr>
 
@@ -110,6 +130,16 @@ To forward your logs from FireLens to New Relic:
 
       <td>
         `533243300146.dkr.ecr.eu-central-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        eu-north-1
+      </td>
+
+      <td>
+        `533243300146.dkr.ecr.eu-north-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
       </td>
     </tr>
 
@@ -145,11 +175,51 @@ To forward your logs from FireLens to New Relic:
 
     <tr>
       <td>
-        eu-north-1
+        sa-east-1
       </td>
 
       <td>
-        `533243300146.dkr.ecr.eu-north-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
+        `533243300146.dkr.ecr.sa-east-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        us-east-1
+      </td>
+
+      <td>
+        `533243300146.dkr.ecr.us-east-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        us-east-2
+      </td>
+
+      <td>
+        `533243300146.dkr.ecr.us-east-2.amazonaws.com/newrelic/logging-firelens-fluentbit`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        us-west-1
+      </td>
+
+      <td>
+        `533243300146.dkr.ecr.us-west-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        us-west-2
+      </td>
+
+      <td>
+        `533243300146.dkr.ecr.us-west-2.amazonaws.com/newrelic/logging-firelens-fluentbit`
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
This PR adds some new regions to which we replicate our log forwarding images for Firelens.