### PR TITLE
fix: add PMM codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,7 @@
 *.js @newrelic/developer-enablement
 
 yarn.lock @newrelic/developer-enablement
+
+# Whats new files (pings individual project marketing managers)
+
+/src/content/whats-new @ishanmkh @jkinmonth @alexiskjones @molson10 @daynaslord

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@ yarn.lock @newrelic/developer-enablement
 
 # Whats new files (pings individual project marketing managers)
 
-/src/content/whats-new @ishanmkh @jkinmonth @alexiskjones @molson10 @daynaslord
+/src/content/whats-new/ @ishanmkh @jkinmonth @alexiskjones @molson10 @daynaslord


### PR DESCRIPTION
The PMMs have asked that they be assigned to review any PR that touches the What's New directory. This seemed like a great time to try out CodeOwners. Let me know if I did something wrong. 