### PR TITLE
feat: Add documentation for DelayedJob custom attributes

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/background-jobs/delayedjob-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/background-jobs/delayedjob-instrumentation.mdx
@@ -21,6 +21,40 @@ As long as the New Relic Ruby agent's gem or plugin is loaded before the `Delaye
 1. Go to **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Monitor > Transactions**.
 2. From the [APM **Transactions** page](/docs/apm/applications-menu/monitoring/transactions-page), select **Other transactions**.
 
+## Adding Custom Attributes [#custom-attributes]
+
+If you would like to add custom attributes to your DelayedJob transactions beyond what comes by default, you can write a DelayedJob plugin utilizing a lifecycle hook to add those attributes to the transaction for each executed job, like so:
+
+Create the plugin:
+
+```ruby
+module NewRelicInstrumenter
+  class DelayedJobPlugin < Delayed::Plugin
+    callbacks do |lifecycle|
+      lifecycle.around(:invoke_job) do |job, *args, &block|
+        # Forward the call to the next callback in the callback chain
+        ::NewRelic::Agent.add_custom_attributes(
+          {
+            # Any custom attributes go here -- from here you can access info
+            # about the job like run_at, created_at, etc
+            my_custom_attribute: "my_custom_attribute_value"
+          }
+        )
+        block.call(job, *args)
+      end
+    end
+  end
+end
+```
+
+Then, add the plugin to DelayedJob in the initializer in config/initializers/delayed_job.rb:
+
+```ruby
+require "new_relic_instrumenter"
+
+Delayed::Worker.plugins << NewRelicInstrumenter::DelayedJobPlugin
+```
+
 ## Troubleshooting
 
 The Ruby agent depends on being able to identify that it is running under `Delayed::Job` in order to correctly set up instrumentation. To do this, it examines the script name (the `$0` variable in Ruby) to see whether it ends with `delayed_job`.

--- a/src/content/docs/apm/agents/ruby-agent/background-jobs/delayedjob-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/background-jobs/delayedjob-instrumentation.mdx
@@ -23,9 +23,9 @@ As long as the New Relic Ruby agent's gem or plugin is loaded before the `Delaye
 
 ## Adding Custom Attributes [#custom-attributes]
 
-If you would like to add custom attributes to your DelayedJob transactions beyond what comes by default, you can write a DelayedJob plugin utilizing a lifecycle hook to add those attributes to the transaction for each executed job, like so:
+If you want to add custom attributes to your `Delayed::Job` transactions, you can write a `Delayed::Job` plugin through a lifecycle hook and add those attributes to the transaction for each executed job.
 
-Create the plugin:
+1. Create a plugin with the following structure:
 
 ```ruby
 module NewRelicInstrumenter
@@ -47,7 +47,7 @@ module NewRelicInstrumenter
 end
 ```
 
-Then, add the plugin to DelayedJob in the initializer in config/initializers/delayed_job.rb:
+2. Add the plugin to `Delayed::Job` in the initializer in the `config/initializers/delayed_job.rb` file:
 
 ```ruby
 require "new_relic_instrumenter"
@@ -55,7 +55,7 @@ require "new_relic_instrumenter"
 Delayed::Worker.plugins << NewRelicInstrumenter::DelayedJobPlugin
 ```
 
-## Troubleshooting
+## Troubleshooting [#troubleshooting]
 
 The Ruby agent depends on being able to identify that it is running under `Delayed::Job` in order to correctly set up instrumentation. To do this, it examines the script name (the `$0` variable in Ruby) to see whether it ends with `delayed_job`.
 


### PR DESCRIPTION
Adding a section with code samples on how to add custom attributes to DelayedJob transactions by using a DJ plugin.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

With the New Relic Ruby agent, it is easy and well-documented to add custom attributes to transactions from pieces of code like Rails controllers, services, etc. However, it is not well-documented how to do the same from DelayedJob when one wants to access fields that are DelayedJob-specific, like `run_at`, etc.

This PR adds a section with code snippets demonstrating how to accomplish this.

The original discussion on this occurred in https://github.com/newrelic/newrelic-ruby-agent/issues/834, which led to this pull request.