### PR TITLE
Added '-r newrelic' startup script to install docs

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
@@ -64,6 +64,15 @@ To install the Node.js agent:
    * Customize the `license_key` setting with [your license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).
    * Customize the [`app_name`](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#app_name) setting with one or more [meaningful app names](/docs/apm/new-relic-apm/installation-and-configuration/naming-your-application).
 6. Add `require('newrelic');` as the first line of your app's main module.
+
+<Callout variant="important">
+  If you are using [Babel](https://babeljs.io/docs/en/index.html) or a similar transpiler you can safeguard against any issues related to module load order by utilizing the [Node command line option '-r'](https://nodejs.org/api/cli.html#-r---require-module) to preload the 'newrelic' module at application startup. For example, if your application's entry point is `./dist/server.js` then you would use the require flag like so:
+
+```
+node -r newrelic ./dist/server.js
+```
+</Callout>
+
 7. Optional: For additional [Node.js runtime-level statistics](/docs/agents/nodejs-agent/supported-features/node-vms-statistics-page), ensure the [`@newrelic/native-metrics` package is installed](/docs/agents/nodejs-agent/supported-features/node-vm-measurements).
 8. Generate some traffic, then wait a few minutes for data to appear in the [APM UI](/docs/apm/applications-menu/monitoring/apm-overview-page).
 


### PR DESCRIPTION
Issues around module load order are a high ticket driver and adding this require flag to their scripts can safeguard against this common issue caused by Babel. I threw it in a callout but you can use whatever layout you deem best.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.