### PR TITLE
chore: updating v3 example syntax and small readability edit

### DIFF
--- a/src/content/docs/network-performance-monitoring/troubleshooting/snmp-walk.mdx
+++ b/src/content/docs/network-performance-monitoring/troubleshooting/snmp-walk.mdx
@@ -41,7 +41,7 @@ Run one of the following depending on your SNMP device version:
     title="SNMP v3 example"
   >
   ```bash
-  snmpwalk -v 3 -On -l $LEVEL -u $USERNAME -a $AUTH_PROTOCOL -A $AUTH_PASSPHRASE -x $PRIV_PROTOCOL -X $PRIV_PASSPHRASE $IP_ADDRESS .1.3.6.1.2.1.1.2.0
+  snmpwalk -v 3 -l $LEVEL -u $USERNAME -a $AUTH_PROTOCOL -A $AUTH_PASSPHRASE -x $PRIV_PROTOCOL -X $PRIV_PASSPHRASE -ObentU -Cc $IP_ADDRESS .1.3.6.1.2.1.1.2.0
   ```
 
   Replacing the following settings as necessary: 
@@ -80,11 +80,11 @@ snmpwalk -v 2c -On -c $COMMUNITY $IP_ADDRESS . >> snmpwalk.out
 **SNMP v3 example**
 
 ```bash
-snmpwalk -v 3 -On -l $LEVEL -u $USERNAME -a $AUTH_PROTOCOL -A $AUTH_PASSPHRASE -x $PRIV_PROTOCOL -X $PRIV_PASSPHRASE $IP_ADDRESS . >> snmpwalk.out
+snmpwalk -v 3 -l $LEVEL -u $USERNAME -a $AUTH_PROTOCOL -A $AUTH_PASSPHRASE -x $PRIV_PROTOCOL -X $PRIV_PASSPHRASE -ObentU -Cc $IP_ADDRESS . >> snmpwalk.out
 ```
 
 The output of this command will be a file named `snmpwalk.out`, that lists every OID that the device responds to.
 
 <Callout variant="tip">
-On devices with a large number of interfaces, this SNMP walk takes more than 10 minutes to complete. 
+On devices with a large number of interfaces, this SNMP walk can take more than 10 minutes to complete. 
 </Callout>


### PR DESCRIPTION
updating the examples for v3 walks to support the proper output formatting.
also updated small sentence structure point on the last callout tip. 

cc: @x8a 