### PR TITLE
fix: docs-issues-migrate

### DIFF
--- a/src/content/docs/style-guide/writer-workflow/github-intro.mdx
+++ b/src/content/docs/style-guide/writer-workflow/github-intro.mdx
@@ -144,7 +144,10 @@ Every issue needs these labels:
   - `from_internal`: A Relic created it.
   - `from_external`: A user opened it in the repo OR it came in through #customer-feedback process.
   - `from_tw`: One of us created it (unless we were passing along #customer-feedback).
-- `Optional`: Jira’d: Issues that have a corresponding Jira ticket. Make sure you leave the Jira number in the comments of the issue (for example, DOC-1234).
+- `Optional`: 
+  - `docs-issues-migrate`: Issues that are too large in scope for the docs team to handle without product team expertise. This label alerts the docs issues team to migrate these issues into the customer feedback channel where they will be triaged and sent to product teams. 
+  - `Jira’d`: Issues that have a corresponding Jira ticket. Make sure you leave the Jira number in the comments of the issue (for example, DOC-1234).
+
 
 Every pull request needs these labels:
 - Always add `content`


### PR DESCRIPTION
Adds info to the style guide about docs issues labels