### PR TITLE
Nov 18 release: Add .NET 6.0 compatibility

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -34,7 +34,7 @@ Before you install the New Relic .NET agent on [Windows](/docs/agents/net-agent/
     id="net-version"
     title="Microsoft .NET Core version"
   >
-    The .NET agent supports .NET Core versions 2.0, 2.1, 2.2, 3.0, 3.1, .NET 5.0 and .NET 6.0.
+    The .NET agent supports .NET Core versions 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0 and 6.0.
 
     <table style={{ width: "500px" }}>
       Table of minimum agent versions required per .NET Core version
@@ -136,7 +136,7 @@ Before you install the New Relic .NET agent on [Windows](/docs/agents/net-agent/
     id="target-framework"
     title="Target framework version"
   >
-    The .NET agent only supports applications targeting .NET Core 2.0, 2.1, 2.2, 3.0, 3.1, .NET 5.0 and .NET 6.0. You can find the target framework in your `.csproj` file:
+    The .NET agent only supports applications targeting .NET Core 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0 and 6.0. You can find the target framework in your `.csproj` file:
 
     Supported:
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -34,7 +34,7 @@ Before you install the New Relic .NET agent on [Windows](/docs/agents/net-agent/
     id="net-version"
     title="Microsoft .NET Core version"
   >
-    The .NET agent supports .NET Core versions 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0.
+    The .NET agent supports .NET Core versions 2.0, 2.1, 2.2, 3.0, 3.1, .NET 5.0 and .NET 6.0.
 
     <table style={{ width: "500px" }}>
       Table of minimum agent versions required per .NET Core version
@@ -111,6 +111,16 @@ Before you install the New Relic .NET agent on [Windows](/docs/agents/net-agent/
             \>= 8.35.0
           </td>
         </tr>
+
+        <tr>
+          <td>
+            .NET 6.0
+          </td>
+
+          <td>
+            \>= 9.2.0
+          </td>
+        </tr>
       </tbody>
     </table>
 
@@ -126,7 +136,7 @@ Before you install the New Relic .NET agent on [Windows](/docs/agents/net-agent/
     id="target-framework"
     title="Target framework version"
   >
-    The .NET agent only supports applications targeting .NET Core 2.0, 2.1, 2.2, 3.0, 3.1, and NET 5.0. You can find the target framework in your `.csproj` file:
+    The .NET agent only supports applications targeting .NET Core 2.0, 2.1, 2.2, 3.0, 3.1, .NET 5.0 and .NET 6.0. You can find the target framework in your `.csproj` file:
 
     Supported:
 
@@ -152,6 +162,10 @@ Before you install the New Relic .NET agent on [Windows](/docs/agents/net-agent/
 
     ```
     <TargetFramework>net5.0</TargetFramework>
+    ```
+
+    ```
+    <TargetFramework>net6.0</TargetFramework>
     ```
 
     <Callout variant="important">
@@ -225,7 +239,7 @@ Before you install the New Relic .NET agent on [Windows](/docs/agents/net-agent/
           </td>
 
           <td>
-            All x64 Linux distributions supported by the .NET Core 2.0+/.NET 5 runtime are supported by the .NET agent. For a full list, refer to Microsoft's documentation for the version of the runtime you are using.
+            All x64 Linux distributions supported by the .NET Core 2.0+/.NET 5+ runtime are supported by the .NET agent. For a full list, refer to Microsoft's documentation for the version of the runtime you are using.
           </td>
         </tr>
 
@@ -235,7 +249,7 @@ Before you install the New Relic .NET agent on [Windows](/docs/agents/net-agent/
           </td>
 
           <td>
-            All ARM64 Linux distributions supported by the .NET 5.0 runtime are supported by the .NET agent. For a full list, refer to Microsoft's documentation.
+            All ARM64 Linux distributions supported by the .NET 5+ runtime are supported by the .NET agent. For a full list, refer to Microsoft's documentation.
           </td>
         </tr>
       </tbody>
@@ -335,7 +349,7 @@ If your application is hosted in ASP.NET Core, the agent automatically creates a
   >
     The .NET agent automatically instruments these application frameworks:
 
-    * ASP.NET Core MVC 2.0, 2.1, 2.2, 3.0, 3.1, and 5.0 (includes Web API)
+    * ASP.NET Core MVC 2.0, 2.1, 2.2, 3.0, 3.1, 5.0 and 6.0 (includes Web API)
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
We're  getting ready to release version 9.2.0 of the .NET APM language agent and announce support of .NET 6, which went GA last week.  We need to update our compatibility and requirements for the .NET Core agent to reflect this.