### PR TITLE
Add upcoming PageViewTiming network and element attributes to data dictionary

### DIFF
--- a/src/data-dictionary/events/PageView/appName.md
+++ b/src/data-dictionary/events/PageView/appName.md
@@ -11,4 +11,4 @@ events:
   - PageViewTiming
 ---
 
-The name of the application that handled the request as shown in New Relic Browser.
+The name of the application that handled the request as shown in browser monitoring.

--- a/src/data-dictionary/events/PageView/pageRenderingDuration.md
+++ b/src/data-dictionary/events/PageView/pageRenderingDuration.md
@@ -6,4 +6,4 @@ events:
   - PageView
 ---
 
-The page rendering phase is the time between DOM completion (domContentLoadedEventEnd) and the window load event (loadEventEnd), in seconds. This phase measures browser-side processing and display of the page content.
+The page rendering phase is the time between DOM completion (`domContentLoadedEventEnd`) and the window load event (`loadEventEnd`), in seconds. This phase measures browser-side processing and display of the page content.

--- a/src/data-dictionary/events/PageView/pageUrl.md
+++ b/src/data-dictionary/events/PageView/pageUrl.md
@@ -11,4 +11,4 @@ events:
   - JavaScriptError
 ---
 
-The URL of the page that was loaded for the PageView. For example: http://www.newrelic.com. This URL does not include query parameters.
+The URL of the page that was loaded for the PageView, for example: http://www.newrelic.com. This URL does not include query parameters.

--- a/src/data-dictionary/events/PageView/regionCode.md
+++ b/src/data-dictionary/events/PageView/regionCode.md
@@ -11,6 +11,6 @@ events:
   - JavaScriptError
 ---
 
-The specific administrative division within a country where the PageView event occurred. In the United States, regions correspond to state codes, such as WA or NY. Outside the United States, a country's regions correspond to numerical codes.
+The specific administrative division within a country where the `PageView` event occurred. In the United States, regions correspond to state codes, such as WA or NY. Outside the United States, a country's regions correspond to numerical codes.
 
 In the United States, regions correspond to [state codes](http://pe.usps.gov/text/pub28/28apb.htm "Link opens in a new window.") ; for example, `WA` or `NY`. Outside the United States, a country's regions correspond to [numerical codes](https://www.maxmind.com/download/geoip/misc/region_codes.csv "Link opens in a new window.") .

--- a/src/data-dictionary/events/PageView/webAppDuration.md
+++ b/src/data-dictionary/events/PageView/webAppDuration.md
@@ -6,6 +6,6 @@ events:
   - PageView
 ---
 
-The total server-side response time for the top-level resource of the PageView (in seconds) as measured by the APM agent.
+The total server-side response time for the top-level resource of the `PageView` (in seconds) as measured by the APM agent.
 
 This does not include network time to transmit the request or receive the response, or server-side request queueing time. The webAppDuration is measured by the APM agent and must be injected into the browser monitoring script before the request is fully finished. Its end point is slightly before before the end point used to calculate the duration attribute on Transactions, so webAppDuration will be slightly less than the duration attribute on Transactions in practice.

--- a/src/data-dictionary/events/PageViewTiming/elementId.md
+++ b/src/data-dictionary/events/PageViewTiming/elementId.md
@@ -5,6 +5,4 @@ events:
   - PageViewTiming
 ---
 
-This is the ID, if specified, of the largestContentfulPaint element. This value will only be reported with the LCP metric. This value can be null or empty.
-
-This is the ID, if specified, of the `largestContentfulPaint` element. This value will only be reported with the LCP metric. This value can be null or empty.
+This is the ID, if specified, of the `largestContentfulPaint` element. This value will only be reported with the LCP metric. This value can be null or empty and is captured from the [`LargestContentfulPaint.id` property](https://developer.mozilla.org/en-US/docs/Web/API/LargestContentfulPaint/id).

--- a/src/data-dictionary/events/PageViewTiming/elementSize.md
+++ b/src/data-dictionary/events/PageViewTiming/elementSize.md
@@ -5,6 +5,4 @@ events:
   - PageViewTiming
 ---
 
-This is the reported size of the largestContentfulPaint element. This value will only be reported with the LCP metric.
-
-This is the reported size of the `largestContentfulPaint` element. This value will only be reported with the LCP metric.
+This is the reported size of the `largestContentfulPaint` element. This value will only be reported with the LCP metric and is captured from the [`LargestContentfulPaint.size` property](https://developer.mozilla.org/en-US/docs/Web/API/LargestContentfulPaint/size).

--- a/src/data-dictionary/events/PageViewTiming/elementTagName.md
+++ b/src/data-dictionary/events/PageViewTiming/elementTagName.md
@@ -1,0 +1,8 @@
+---
+name: elementTagName
+type: attribute
+events:
+  - PageViewTiming
+---
+
+This is the tag name of the `largestContentfulPaint` element. This value will only be reported with the LCP metric and is captured from the [`LargestContentfulPaint.element.tagName` property](https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName).

--- a/src/data-dictionary/events/PageViewTiming/elementUrl.md
+++ b/src/data-dictionary/events/PageViewTiming/elementUrl.md
@@ -1,0 +1,8 @@
+---
+name: elementUrl
+type: attribute
+events:
+  - PageViewTiming
+---
+
+This is the request url of the `largestContentfulPaint` element, if the element is an image. This value will only be reported with the LCP metric. The value is captured from the [`LargestContentfulPaint.url` property](https://developer.mozilla.org/en-US/docs/Web/API/LargestContentfulPaint/url) (if present).

--- a/src/data-dictionary/events/PageViewTiming/firstInteraction.md
+++ b/src/data-dictionary/events/PageViewTiming/firstInteraction.md
@@ -10,7 +10,7 @@ A timing that captures when customers begin to engage with a website, such as cl
 
 First interaction is a timing that captures when customers begin to engage with a website, such as clicking a button or typing in a box. The first interaction timing is rounded down to the nearest second. This attribute only occurs when the value of the `timingName` attribute is `firstInteraction`.
 
-Events are handled at the document level with `addEventListener()`. (Clicking an empty page will cause an interaction to fire.) Valid event `type` values include:
+Events are handled at the document level with `addEventListener()`. Clicking an empty page will cause an interaction to fire. Valid event `type` values include:
 
 *   `pointerdown`
 *   `mousedown`

--- a/src/data-dictionary/events/PageViewTiming/networkDownlink.md
+++ b/src/data-dictionary/events/PageViewTiming/networkDownlink.md
@@ -1,0 +1,10 @@
+---
+name: networkDownlink
+type: attribute
+events:
+  - PageViewTiming
+---
+
+This is the estimated effective bandwidth in megabits per second at the time the PageViewTiming event was captured. This value will only be reported with the `largestContentfulPaint` and `firstInteraction` events on compatible browsers.
+
+The value is captured from the NetworkInformation API. For a full browser compatibility table and description see MDN Web Docs: [NetworkInformation.downlink](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlink)

--- a/src/data-dictionary/events/PageViewTiming/networkDownlink.md
+++ b/src/data-dictionary/events/PageViewTiming/networkDownlink.md
@@ -7,4 +7,4 @@ events:
 
 This is the estimated effective bandwidth in megabits per second at the time the PageViewTiming event was captured. This value will only be reported with the `largestContentfulPaint` and `firstInteraction` events on compatible browsers.
 
-The value is captured from the NetworkInformation API. For a full browser compatibility table and description see MDN Web Docs: [NetworkInformation.downlink](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlink)
+The value is captured from the NetworkInformation API. For a full browser compatibility table and description see the [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/downlink).

--- a/src/data-dictionary/events/PageViewTiming/networkEffectiveType.md
+++ b/src/data-dictionary/events/PageViewTiming/networkEffectiveType.md
@@ -1,0 +1,10 @@
+---
+name: networkEffectiveType
+type: attribute
+events:
+  - PageViewTiming
+---
+
+This is the effective connection type ('slow-2g', '2g', '3g' or '4g'), of the current network connection at the time the PageViewTiming event was captured. This value will only be reported with the `largestContentfulPaint` and `firstInteraction` events on compatible browsers.
+
+The value is captured from the NetworkInformation API. For a full browser compatibility table and description see MDN Web Docs: [NetworkInformation.effectiveType](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/effectiveType). See also [Effective connection type](https://developer.mozilla.org/en-US/docs/Glossary/Effective_connection_type) for a description of each type.

--- a/src/data-dictionary/events/PageViewTiming/networkRtt.md
+++ b/src/data-dictionary/events/PageViewTiming/networkRtt.md
@@ -1,0 +1,10 @@
+---
+name: networkRtt
+type: attribute
+events:
+  - PageViewTiming
+---
+
+This is the estimated round trip time, in milliseconds, of the current network connection at the time the PageViewTiming event was captured. This value will only be reported with the `largestContentfulPaint` and `firstInteraction` events on compatible browsers.
+
+The value is captured from the NetworkInformation API. For a full browser compatibility table and description see MDN Web Docs: [NetworkInformation.rtt](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/rtt)

--- a/src/data-dictionary/events/PageViewTiming/networkRtt.md
+++ b/src/data-dictionary/events/PageViewTiming/networkRtt.md
@@ -7,4 +7,4 @@ events:
 
 This is the estimated round trip time, in milliseconds, of the current network connection at the time the PageViewTiming event was captured. This value will only be reported with the `largestContentfulPaint` and `firstInteraction` events on compatible browsers.
 
-The value is captured from the NetworkInformation API. For a full browser compatibility table and description see MDN Web Docs: [NetworkInformation.rtt](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/rtt)
+The value is captured from the NetworkInformation API. For a full browser compatibility table and description see the [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/rtt).

--- a/src/data-dictionary/events/PageViewTiming/networkType.md
+++ b/src/data-dictionary/events/PageViewTiming/networkType.md
@@ -1,0 +1,10 @@
+---
+name: networkType
+type: attribute
+events:
+  - PageViewTiming
+---
+
+This is the type of the current network connection at the time the PageViewTiming event was captured. This value will only be reported with the `largestContentfulPaint` and `firstInteraction` events on compatible browsers.
+
+The value is captured from the NetworkInformation API. For a full browser compatibility table and description see MDN Web Docs: [NetworkInformation.type](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/type)

--- a/src/data-dictionary/events/PageViewTiming/networkType.md
+++ b/src/data-dictionary/events/PageViewTiming/networkType.md
@@ -7,4 +7,4 @@ events:
 
 This is the type of the current network connection at the time the PageViewTiming event was captured. This value will only be reported with the `largestContentfulPaint` and `firstInteraction` events on compatible browsers.
 
-The value is captured from the NetworkInformation API. For a full browser compatibility table and description see MDN Web Docs: [NetworkInformation.type](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/type)
+The value is captured from the NetworkInformation API. For a full browser compatibility table and description see the [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/type).


### PR DESCRIPTION
## Give us some context

As part of our upcoming release, the Browser agent will now include:
* Information about the element that caused a largestContentfulPaint event
* Information about the current network connection when largestContentfulPaint and firstInteraction events occurred.

Both of these attributes give customers more context on the state of the application when these events occurred. Both new data sources also have equivalent MDN documentation, which is linked in each individual attribute description:
* Element information comes from existing LCP event we capture: https://developer.mozilla.org/en-US/docs/Web/API/LargestContentfulPaint
* Network information is captured from the NetworkInformation API and appended to the events when they occur: https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API

One last note is I removed what appeared to be duplicate text from the existing elementId and elementSize markdown files, if this was intentional let me know and I can replace it!

Related GitHub Issues:

https://github.com/newrelic/newrelic-browser-agent/issues/144
https://github.com/newrelic/newrelic-browser-agent/issues/145