### PR TITLE
Remove beta callout in nerdgraph-workloads-api-tutorials.mdx

### DIFF
--- a/src/content/docs/apis/nerdgraph/tutorials/nerdgraph-workloads-api-tutorials.mdx
+++ b/src/content/docs/apis/nerdgraph/tutorials/nerdgraph-workloads-api-tutorials.mdx
@@ -10,10 +10,6 @@ redirects:
   - /docs/nerdgraph-workloads-tutorials
 ---
 
-<Callout title="BETA FEATURE">
-This feature is currently in beta.
-</Callout>
-
 New Relic allows you to group entities together in groupings called [workloads](/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-one-workloads-isolate-resolve-incidents-faster). This enables better monitoring of the full stack used by a team or project.
 
 Here we show you how to use our [NerdGraph API](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) to do some workloads-related tasks:


### PR DESCRIPTION
No longer in Beta.