### PR TITLE
Corrected the meaning in Opening Sentence of Kinesis integration docs

### DIFF
--- a/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
+++ b/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
@@ -14,7 +14,7 @@ redirects:
   - /docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/stream-logs-using-kinesis-data-firehose
 ---
 
-If your log data is already being monitored by [Amazon Kinesis Data Firehose](https://docs.aws.amazon.com/firehose/latest/dev/what-is-this-service.html), you can use our Kinesis Data Firehose integration to forward and enrich your log data in New Relic. Kinesis Data Firehose is a service that can stream data in real time to a variety of destinations, including our platform.
+If your log data is already being monitored by [Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html), you can use our Kinesis Data Firehose integration to forward and enrich your log data in New Relic. Kinesis Data Firehose is a service that can stream data in real time to a variety of destinations, including our platform.
 
 Forwarding your Kinesis Data Firehose logs to New Relic will give you enhanced log management capabilities to collect, process, explore, query, and alert on your log data.
 

--- a/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
+++ b/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
@@ -16,7 +16,7 @@ redirects:
 
 If your log data is already being monitored by [Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html), you can use our Kinesis Data Firehose integration to forward and enrich your log data in New Relic. Kinesis Data Firehose is a service that can stream data in real time to a variety of destinations, including our platform.
 
-Forwarding your Kinesis Data Firehose logs to New Relic will give you enhanced log management capabilities to collect, process, explore, query, and alert on your log data.
+Forwarding your CloudWatch Logs or other logs compatible with a Kinesis stream to New Relic will give you enhanced log management capabilities to collect, process, explore, query, and alert on your log data.
 
 ## Create the delivery stream for New Relic [#create-delivery-stream]
 


### PR DESCRIPTION
## Corrected the opening sentence in the Kinesis log streaming doc

* The original implies that customers will be monitoring their logs using Kinesis
* In fact they will monitor their logs in CloudWatch Logs and use Kinesis to transport those logs to NR1