### PR TITLE
Infrastructure agent release notes for 1.21.0 and update for 1.20.7

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1207.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1207.mdx
@@ -4,6 +4,10 @@ releaseDate: '2021-11-02'
 version: 1.20.7
 ---
 
+## Notes
+A new version of the agent has been released. Follow standard procedures to [update the Infrastructure agent](/docs/infrastructure/install-configure-manage-infrastructure/update-or-uninstall/update-infrastructure-agent).
+We recommend you to upgrade the agent every 3 months.
+
 ## Fixed
 * Make the `td-agent-bit` dependency required for SLES 12.5 [#786](https://github.com/newrelic/infrastructure-agent/pull/786)
 * Send inventory on secure forwarder mode [#796](https://github.com/newrelic/infrastructure-agent/pull/796)

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1210.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1210.mdx
@@ -1,0 +1,16 @@
+---
+subject: Infrastructure agent
+releaseDate: '2021-11-23'
+version: 1.21.0
+---
+
+## Notes
+A new version of the agent has been released. Follow standard procedures to [update the Infrastructure agent](/docs/infrastructure/install-configure-manage-infrastructure/update-or-uninstall/update-infrastructure-agent).
+We recommend you to upgrade the agent every 3 months.
+
+## Fixed
+- On-host integration reporting correct name for integration protocol v3 payloads (integrationName in event samples). [#823](https://github.com/newrelic/infrastructure-agent/pull/823)
+- Issue when inventory was not correctly reset on entityID change. Should fix issues when host is not visible in UI after changing the reporting license_key for an active agent. [#811](https://github.com/newrelic/infrastructure-agent/pull/811)
+
+## Added
+- Log the full path when loading config files. [#820](https://github.com/newrelic/infrastructure-agent/pull/820)

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1210.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1210.mdx
@@ -1,6 +1,6 @@
 ---
 subject: Infrastructure agent
-releaseDate: '2021-11-23'
+releaseDate: '2022-01-10'
 version: 1.21.0
 ---
 

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1210.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1210.mdx
@@ -9,8 +9,8 @@ A new version of the agent has been released. Follow standard procedures to [upd
 We recommend you to upgrade the agent every 3 months.
 
 ## Fixed
-- On-host integration reporting correct name for integration protocol v3 payloads (integrationName in event samples). [#823](https://github.com/newrelic/infrastructure-agent/pull/823)
-- Issue when inventory was not correctly reset on entityID change. Should fix issues when host is not visible in UI after changing the reporting license_key for an active agent. [#811](https://github.com/newrelic/infrastructure-agent/pull/811)
+- Correct name in on-host integration reporting for integration protocol v3 payloads (`integrationName` in event samples). [#823](https://github.com/newrelic/infrastructure-agent/pull/823)
+- Issue when inventory was not correctly reset on `entityID` change. Fixes issues when host is not visible in the UI after changing the reporting `license_key` for an active agent. [#811](https://github.com/newrelic/infrastructure-agent/pull/811)
 
 ## Added
-- Log the full path when loading config files. [#820](https://github.com/newrelic/infrastructure-agent/pull/820)
+- Logging of full path when loading config files. [#820](https://github.com/newrelic/infrastructure-agent/pull/820)

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1210.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1210.mdx
@@ -9,8 +9,8 @@ A new version of the agent has been released. Follow standard procedures to [upd
 We recommend you to upgrade the agent every 3 months.
 
 ## Fixed
-- Correct name in on-host integration reporting for integration protocol v3 payloads (`integrationName` in event samples). [#823](https://github.com/newrelic/infrastructure-agent/pull/823)
-- Issue when inventory was not correctly reset on `entityID` change. Fixes issues when host is not visible in the UI after changing the reporting `license_key` for an active agent. [#811](https://github.com/newrelic/infrastructure-agent/pull/811)
+- Corrects name in on-host integration reporting for integration protocol v3 payloads (`integrationName` in event samples). [#823](https://github.com/newrelic/infrastructure-agent/pull/823)
+- Fixes issue when inventory was not correctly reset when changing `entityID`, as host was not visible in the UI after changing the reporting `license_key` for an active agent. [#811](https://github.com/newrelic/infrastructure-agent/pull/811)
 
 ## Added
 - Logging of full path when loading config files. [#820](https://github.com/newrelic/infrastructure-agent/pull/820)


### PR DESCRIPTION
[TO BE MERGED AFTER AGENT RELEASE] - https://github.com/newrelic/infrastructure-agent/releases/tag/1.21.0
- Adding missing header for 1.20.7
- Adding new release notes for 1.21.0
