### PR TITLE
Replace old-fashioned, pre-v3 application creation method with current method

### DIFF
--- a/src/content/docs/apm/agents/go-agent/instrumentation/create-custom-metrics-go.mdx
+++ b/src/content/docs/apm/agents/go-agent/instrumentation/create-custom-metrics-go.mdx
@@ -23,13 +23,14 @@ We recommend to use the [Metric API](/docs/data-apis/ingest-apis/metric-api/intr
 
 1. Instantiate your application by running the following:
 
-   ```
-   cfg := newrelic.NewConfig("Your App Name", mustGetEnv("<var>NEW_RELIC_LICENSE_KEY</var>"))
-       cfg.Logger = newrelic.NewDebugLogger(os.Stdout)
+  ```
+  app, err := newrelic.NewApplication(
+    newrelic.ConfigAppName("<var>Your Application Name</var>"),
+    newrelic.ConfigLicense("<var>NEW_RELIC_LICENSE_KEY</var>"),
+    newrelic.ConfigDebugLogger(os.Stdout),
+  )
+  ```
 
-       var err error
-       app, err = newrelic.NewApplication(cfg)
-   ```
 2. After instantiating your app, create a custom metric with the following code:
 
    ```


### PR DESCRIPTION
This documentation never got updated years ago when v3 of the Go Agent was released.