### PR TITLE
Clark/2536 modify queue script

### DIFF
--- a/scripts/actions/add-files-to-translation-queue.js
+++ b/scripts/actions/add-files-to-translation-queue.js
@@ -17,7 +17,6 @@ const STATUS = {
 
 const LOCALE_IDS = {
   jp: 'ja-JP',
-  kr: 'kr-KR',
 };
 
 const translationDifference = (pendingFiles, prChanges) =>

--- a/scripts/actions/add-files-to-translation-queue.js
+++ b/scripts/actions/add-files-to-translation-queue.js
@@ -71,7 +71,6 @@ const main = async () => {
   const url = process.argv[2];
 
   const queue = await getTranslations({ status: STATUS.PENDING });
-  console.log('queue', queue);
   const prFileData = await fetchPaginatedGHResults(
     url,
     process.env.GITHUB_TOKEN
@@ -82,13 +81,10 @@ const main = async () => {
     .filter((f) => f.status !== 'removed');
 
   const allLocalizedFileData = changedMdxFileData.flatMap(getLocalizedFileData);
-  console.log('allLocalizedFileData', allLocalizedFileData);
   const fileDataToAddToQueue = translationDifference(
     queue,
     allLocalizedFileData
   );
-
-  console.log('File Data To Add To Queue:', fileDataToAddToQueue);
 
   await Promise.all(
     fileDataToAddToQueue.map(({ filename, locale, project_id }) =>

--- a/scripts/actions/translation_workflow/database.js
+++ b/scripts/actions/translation_workflow/database.js
@@ -92,8 +92,13 @@ const getStatuses = async (filters = {}) => {
  * @param {string} locale - string value of locale enum
  * @returns newly created translation
  */
-const addTranslation = async ({ slug, status, locale }) => {
-  const translation = await Models.Translation.create({ slug, status, locale });
+const addTranslation = async ({ slug, status, locale, project_id }) => {
+  const translation = await Models.Translation.create({
+    slug,
+    status,
+    locale,
+    project_id,
+  });
   return translation;
 };
 


### PR DESCRIPTION
Updates the script adding files to the translation queue to include the project id corresponding to Machine Translation or Human Translation depending on the files' frontmatter.

This solution will loop over the set of supported languages to see if the frontmatter contains any of the supported locales, if so, the project id will be the Human Translated project id; otherwise, Machine Translated.