### PR TITLE
style(whole site): Standardize macOS terminology

### DIFF
--- a/src/content/docs/apm/agents/go-agent/index.mdx
+++ b/src/content/docs/apm/agents/go-agent/index.mdx
@@ -57,7 +57,7 @@ redirects:
     title="Install the Go agent."
     icon="fe-list"
   >
-    Follow [standard installation procedures](/docs/agents/go-agent/get-started/get-new-relic-go) on [supported Golang versions](/docs/agents/go-agent/get-started/get-new-relic-go#requirements) for Linux, OS X, or Windows.
+    Follow [standard installation procedures](/docs/agents/go-agent/get-started/get-new-relic-go) on [supported Golang versions](/docs/agents/go-agent/get-started/get-new-relic-go#requirements) for Linux, macOS, or Windows.
   </LandingPageTile>
 
   <LandingPageTile

--- a/src/content/docs/apm/agents/java-agent/installation/update-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/installation/update-java-agent.mdx
@@ -169,7 +169,7 @@ These agent versions use an out-of-date protocol when communicating with New Rel
 
         This is a bugfix release for the [legacy Java SE 5.0 version](/docs/java/java-se-5) of the agent. Unless you are a Java SE5 user, use the latest version of the New Relic Java agent. This affects:
 
-        * Oracle Hotspot JVM version 5.0 for Linux, Solaris, Windows, OS X
+        * Oracle Hotspot JVM version 5.0 for Linux, Solaris, Windows, macOS
         * Oracle JRockit up to and including 1.6.0_50
       </td>
     </tr>

--- a/src/content/docs/apm/agents/php-agent/troubleshooting/php-installation-fails-os-x-1011-el-capitan.mdx
+++ b/src/content/docs/apm/agents/php-agent/troubleshooting/php-installation-fails-os-x-1011-el-capitan.mdx
@@ -1,11 +1,11 @@
 ---
-title: 'PHP installation fails on OS X 10.11 - El Capitan '
+title: 'PHP installation fails on macOS 10.11 (El Capitan)'
 type: troubleshooting
 tags:
   - Agents
   - PHP agent
   - Troubleshooting
-metaDescription: Start here if you encounter problems installing the New Relic agent for PHP on OS X v10.11 - El Capitan.
+metaDescription: Start here if you encounter problems installing the New Relic agent for PHP on macOS v10.11 El Capitan.
 redirects:
   - /docs/agents/php-agent/troubleshooting/php-installation-fails-os-x-1011-el-capitan
   - /docs/php-installation-fails-os-x-1011-el-capitan
@@ -13,7 +13,7 @@ redirects:
 
 ## Problem
 
-You attempt to install the PHP agent on OS X 10.11 - El Capitan, and it fails.
+You attempt to install the PHP agent on macOS 10.11 (El Capitan), and it fails.
 
 <CollapserGroup>
   <Collapser title="Failure with the install script">

--- a/src/content/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring.mdx
@@ -69,7 +69,7 @@ With infrastructure monitoring, modern operations teams get complete observabili
 
 We have a wide range of infrastructure monitoring solutions. Here's a summary: 
 
-* Our [infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent) for Linux, Windows, and MacOS operating systems.
+* Our [infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent) for Linux, Windows, and macOS operating systems.
 * Our [Kubernetes](/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure) and [Pixie](/docs/kubernetes-pixie/auto-telemetry-pixie/get-started-auto-telemetry-pixie) integrations.
 * Our [cloud integrations](/docs/infrastructure/infrastructure-integrations/get-started/introduction-infrastructure-integrations/#cloud-integrations) for Amazon, Azure, and Google Cloud Platform. 
 * Our [Prometheus integrations](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic).

--- a/src/content/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring.mdx
@@ -69,7 +69,7 @@ With infrastructure monitoring, modern operations teams get complete observabili
 
 We have a wide range of infrastructure monitoring solutions. Here's a summary: 
 
-* Our [infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent) for Linux, Windows, and macOS operating systems.
+* Our [infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent) for Linux, macOS, and Windows operating systems.
 * Our [Kubernetes](/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure) and [Pixie](/docs/kubernetes-pixie/auto-telemetry-pixie/get-started-auto-telemetry-pixie) integrations.
 * Our [cloud integrations](/docs/infrastructure/infrastructure-integrations/get-started/introduction-infrastructure-integrations/#cloud-integrations) for Amazon, Azure, and Google Cloud Platform. 
 * Our [Prometheus integrations](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic).

--- a/src/content/docs/logs/forward-logs/google-cloud-platform-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/google-cloud-platform-log-forwarding.mdx
@@ -136,7 +136,7 @@ To send your GCP logs to New Relic using our headerless API:
 
 To send your GCP logs to New Relic using a Dataflow job, you will use our Dataflow template. Before you begin, make sure you have the following tools on your local computer:
 
-* A Unix terminal for Linux or MacOS
+* A Unix terminal for Linux or macOS
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [Java JDK 8 or higher](https://adoptopenjdk.net/index.html)
 * [Apache Maven 3.2 or higher](https://maven.apache.org/). We've seen earlier versions fail during the compilation process.

--- a/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
@@ -411,7 +411,7 @@ For consistency across New Relic content, here are our general word usage guidel
   >
     The proper name for Apple's desktop operating system is `macOS`. 
     
-    Don't use the older product names `Mac OS X` or `OS X`.
+    Don't use the older product names `Mac OS`, `Mac OS X`, or `OS X`.
   </Collapser>
 
   <Collapser

--- a/src/nav/infrastructure.yml
+++ b/src/nav/infrastructure.yml
@@ -38,6 +38,11 @@ pages:
             path: /docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-manual-install-infrastructure-agent-linux
           - title: Agent running modes
             path: /docs/infrastructure/install-infrastructure-agent/linux-installation/linux-agent-running-modes
+      - title: macOS installation
+        path: /docs/infrastructure/install-infrastructure-agent/macos-installation
+        pages:
+          - title: Install for macOS
+            path: /docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos
       - title: Windows installation
         path: /docs/infrastructure/install-infrastructure-agent/windows-installation
         pages:
@@ -47,11 +52,6 @@ pages:
             path: /docs/infrastructure/install-infrastructure-agent/windows-installation/zip-assisted-install-infrastructure-agent-windows
           - title: Zip manual install
             path: /docs/infrastructure/install-infrastructure-agent/windows-installation/zip-manual-install-infrastructure-agent-windows
-      - title: MacOS installation
-        path: /docs/infrastructure/install-infrastructure-agent/macos-installation
-        pages:
-          - title: Install for MacOS
-            path: /docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos
       - title: Config management tools
         path: /docs/infrastructure/install-infrastructure-agent/config-management-tools
         pages:


### PR DESCRIPTION
Apple's official style is macOS, not Mac OS

* Our usage guidelines: https://docs.newrelic.com/docs/style-guide/quick-reference/usage-dictionary/#macos
* Example in use on Apple's site: https://www.apple.com/macos/monterey/