### PR TITLE
Add link from ticketing integrations to errors inbox

### DIFF
--- a/src/content/docs/using-new-relic/user-interface-functions/share-your-data/ticketing-integrations.mdx
+++ b/src/content/docs/using-new-relic/user-interface-functions/share-your-data/ticketing-integrations.mdx
@@ -20,9 +20,17 @@ redirects:
   - /docs/using-new-relic/user-interface-functions/share-your-data/ticketing-integrations-lighthouse-pivotal-tracker
 ---
 
-You can integrate New Relic with [Lighthouse](http://lighthouseapp.com). This is useful to create tickets about performance issues in APM's [transaction traces](/docs/apm/transactions/transaction-traces/introduction-transaction-traces) and [error analytics](/docs/apm/applications-menu/error-analytics/error-analytics-explore-events-behind-errors).
+You can integrate New Relic with Jira or [Lighthouse](http://lighthouseapp.com). This is useful to create tickets about performance issues in APM's [transaction traces](/docs/apm/transactions/transaction-traces/introduction-transaction-traces) and [error analytics](/docs/apm/applications-menu/error-analytics/error-analytics-explore-events-behind-errors).
 
-## Requirements
+## Jira [#jira]
+
+For details about our Jira integration, see [errors inbox](/docs/errors-inbox/errors-inbox#jira).
+
+## Lighthouse [#lighthouse-section]
+
+Here are details about the Lighthouse integration.
+
+### Requirements [#lighthouse-reqs]
 
 New Relic sends information to the ticketing system with webhooks. Make sure your system accepts traffic from New Relic's [webhook IPs](/docs/apm/new-relic-apm/getting-started/networks#webhooks).
 
@@ -31,7 +39,7 @@ In addition, Lighthouse setup requires:
 * The subdomain for your installation; for example, `https://subdomain.lighthouseapp.com`
 * Your Lighthouse account's email and password for ticket tracking
 
-## Integrate with New Relic [#procedures]
+### Integrate with New Relic [#procedures]
 
 To connect your New Relic account to Lighthouse:
 
@@ -42,9 +50,11 @@ To connect your New Relic account to Lighthouse:
 
 After your ticketing system has been integrated, the corresponding tab's health status indicator in New Relic's UI changes to green (enabled).
 
-## File tickets [#ticket]
+### File tickets [#ticket]
 
 To use the ticketing system integrated with your New Relic account:
 
 1. From the selected [APM transaction trace](/docs/apm/transactions/transaction-traces/transaction-trace-details) or [APM error trace](/docs/apm/applications-menu/error-analytics/error-analytics-manage-error-traces), select **File a ticket**.
 2. Follow standard procedures to create a ticket from your Lighthouse account.
+
+


### PR DESCRIPTION
We have an old doc about ticketing integrations that shows up in a Google search for "New Relic Jira integration" but it has no information about Jira! 

This is a PR that adds a Jira section to this ticketing doc. It simply sends users over to errors inbox, which does talk about Jira. The goal is to improve SEO.