### PR TITLE
CloudWatch metric stream cost considerations

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -64,12 +64,14 @@ Our current system, which relies on individual integrations, runs on a polling f
   </tbody>
 </table>
 
-### Cost considerations
-The following aspects should be considered when evaluating the cost of the AWS CloudWatch metric streams integration with New Relic:
-* [AWS CloudWatch metric updates](https://aws.amazon.com/cloudwatch/pricing/), see "Metric Streams". 
-* [AWS Kinesis Firehose ingest](https://aws.amazon.com/kinesis/data-firehose/pricing/)
-* [AWS Kinesis Firehose data transfer](https://aws.amazon.com/kinesis/data-firehose/pricing/)
-* Optionally, custom tags and CloudWatch metrics enrichment with resource metadata is based on [AWS Config service](https://aws.amazon.com/config/pricing/). 
+### Cost considerations [#cost-considerations]
+
+Consider the following when evaluating the cost of the AWS CloudWatch metric streams integration with New Relic:
+
+* [AWS CloudWatch metric updates](https://aws.amazon.com/cloudwatch/pricing/). See **Metric Streams**. 
+* [AWS Kinesis Firehose ingest](https://aws.amazon.com/kinesis/data-firehose/pricing/).
+* [AWS Kinesis Firehose data transfer](https://aws.amazon.com/kinesis/data-firehose/pricing/).
+* Optionally, custom tags and CloudWatch metrics enrichment with resource metadata is based on the [AWS Config service](https://aws.amazon.com/config/pricing/). 
 
 ## Set up a Metric Stream to send CloudWatch metrics to New Relic [#set-up-metric-stream]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -64,6 +64,13 @@ Our current system, which relies on individual integrations, runs on a polling f
   </tbody>
 </table>
 
+### Cost considerations
+The following aspects should be considered when evaluating the cost of the AWS CloudWatch metric streams integration with New Relic:
+* [AWS CloudWatch metric updates](https://aws.amazon.com/cloudwatch/pricing/), see "Metric Streams". 
+* [AWS Kinesis Firehose ingest](https://aws.amazon.com/kinesis/data-firehose/pricing/)
+* [AWS Kinesis Firehose data transfer](https://aws.amazon.com/kinesis/data-firehose/pricing/)
+* Optionally, custom tags and CloudWatch metrics enrichment with resource metadata is based on [AWS Config service](https://aws.amazon.com/config/pricing/). 
+
 ## Set up a Metric Stream to send CloudWatch metrics to New Relic [#set-up-metric-stream]
 
 To stream CloudWatch metrics to New Relic you need to create Kinesis Data Firehose and point it to New Relic and then create a CloudWatch Metric Stream that sends metrics to that Firehose.


### PR DESCRIPTION
## Context

* Multiple customers requested details about costs that should be considered when evaluating the AWS CloudWatch metric stream integration. Added a reference on all services required on AWS side and links to the pricing pages. 