### PR TITLE
fix(AWS): note about global services

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream.mdx
@@ -148,6 +148,10 @@ To confirm you are receiving data from the Metric Streams, follow the steps belo
   * Account status dashboard. Useful to confirm that metric data is being received (errors, number of namespaces/metrics ingested, etc.)
   * Explore your data. Use the Data Explorer to find a specific set of metrics, access all dimensions available for a given metric and more.
 
+<Callout variant="tip">
+  AWS CloudWatch metrics for global services such as AWS S3 or AWS Billing are only availble in the **us-east-1** region. Make sure there's an active CloudWatch metric stream configured in that region. 
+ </Callout>
+
 ## Metrics naming convention [#metric-naming-convention]
 
 Metrics received from AWS CloudWatch are stored in New Relic as [dimensional metrics](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types/#dimensional-metrics) following this convention:


### PR DESCRIPTION
## Context

* Certain AWS services are global (and not per-region), in those cases, their metrics will only be available if customers connect a stream in us-east-1 region (AWS design decision). Added a note explaining this. 