### PR TITLE
Added mention to metric explorer in Net agent doc

### DIFF
--- a/src/content/docs/apm/agents/net-agent/other-features/net-performance-metrics.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-features/net-performance-metrics.mdx
@@ -13,9 +13,9 @@ New Relic's .Net Agent collects metrics from the .Net runtime about the performa
 
 The full suite of .Net Performance Metrics is available .Net Agent versions 8.20 and higher.
 
-To view these metrics, create a custom [dashboard](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards).
+To view these metrics, create a custom [dashboard](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards). Alternatively, you may use the **Metric explorer** under **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > More views**. 
 
-## CPU Metrics
+## CPU Metrics [#cpu-metrics]
 
 The following CPU Metrics are collected:
 
@@ -24,7 +24,7 @@ The following CPU Metrics are collected:
 * **CPU/User Time**  
   The amount of time the process has spent executing application code.
 
-## Memory Metrics
+## Memory Metrics [#memory-metrics]
 
 The following Memory Metrics are collected:
 
@@ -48,7 +48,7 @@ The .Net Garbage collector runs in the background and is responsible for identif
   For .Net Framework applications, the Windows User under which your application runs must have access to windows performance counter data. Usually this is accomplished by adding the user to "Performance Monitor Users" and "Performance Log Users" groups. Insufficient permissions will result in the agent not collecting garbage collection metrics.
 </Callout>
 
-### Overall Metrics
+### Overall Metrics [#overall-metrics]
 
 Additionally, the following Garbage collection metrics are collected:
 
@@ -70,7 +70,7 @@ The following GC Gen0 metrics are collected:
 * **GC/Gen0/Collections**  
   The number of times Generation 0 Garbage Collection was executed by the garbage collector.
 
-### Generation - 1 Heap
+### Generation - 1 Heap [#gen-1-heap]
 
 The following GC Gen1 metrics are collected:
 
@@ -105,7 +105,7 @@ The following GC LOH metrics are collected:
 
 The .Net runtime manages a pool of threads. The following metrics provide visibility into the performance of an application in terms of the thread pool and may help identify areas of thread pool starvation. Thread pool starvation/contention occurs when there are not enough threads available to process the requests made by an application. The following [article](https://docs.microsoft.com/en-us/dotnet/standard/threading/the-managed-thread-pool) describes the various features of the managed thread pool. Please note that these metrics do _not_ include information about threads that are not managed by the thread pool.
 
-### Worker Threads
+### Worker Threads [#worker-threads]
 
 Worker threads are CPU-bound threads that are employed to perform work on behalf of a process.
 
@@ -114,7 +114,7 @@ Worker threads are CPU-bound threads that are employed to perform work on behalf
 * **Threadpool/Worker/InUse**  
   Identifies the number of worker threads that are currently in use by the process.
 
-### Completion Threads
+### Completion Threads [#completion-threads]
 
 Completion threads, sometimes referred to as I/O threads, are employed to monitor the completion of I/O operations.
 
@@ -123,7 +123,7 @@ Completion threads, sometimes referred to as I/O threads, are employed to monito
 * **Threadpool/Completion/InUse**  
   This metric identifies the number of completion threads currently in use by the process.
 
-### Throughput
+### Throughput [#throughput]
 
 Throughput metrics measure how much work has been requested to be performed on a different thread, the amount of work that has been started, and how much work is waiting for a thread pool resource to become available.
 


### PR DESCRIPTION
As reported in #5042, added a quick note on the Metric explorer in APM. 