### PR TITLE
fix: duplicate anchor link

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/choose-your-aggregation-method.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/choose-your-aggregation-method.mdx
@@ -71,7 +71,7 @@ Event timer aggregation is based on a timer that counts down when a data point a
 
 Event timer is best for alerting on events that happen sporadically and with large gaps of time.
 
-## How event timer works [#event-flow-detail]
+## How event timer works [#event-timer-detail]
 
 Errors are a type of event that happens sporadically, unpredictably, and often with large gaps of time.
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
  * Anchor link for Event Timer detail section doesn't work because it's the same as for Event Flow (probably copy&paste error) 
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.