### PR TITLE
feat: exclusion file and tests

### DIFF
--- a/loadershim.js
+++ b/loadershim.js
@@ -1,3 +1,7 @@
+process.env.HUMAN_TRANSLATION_PROJECT_ID = 'HT_ID';
+process.env.MACHINE_TRANSLATION_PROJECT_ID = 'MT_ID';
+process.env.DB_CONNECTION_INFO = '{}';
+
 global.___loader = {
   enqueue: jest.fn(),
 };

--- a/scripts/actions/__tests__/add-files-to-translation-queue.test.js
+++ b/scripts/actions/__tests__/add-files-to-translation-queue.test.js
@@ -112,34 +112,23 @@ describe('add-files-to-translation-queue tests', () => {
       ]);
     });
 
-    test('Adds the relevant Project Id when there are multiple locales and only one `translate` in frontmatter', async () => {
-      const file = { filename: '/content/bar.mdx' };
-      mockReadFileSync(['jp']);
-      frontmatter.mockReturnValueOnce({
-        data: { type: 'landingPage', translate: ['jp'] },
-      });
-      const toBeTranslated = getLocalizedFileData(file);
-
-      expect(toBeTranslated).toEqual([
-        {
-          filename: '/content/bar.mdx',
-          contentType: 'landingPage',
-          locale: 'ja-JP',
-          project_id: 'HT_ID',
-        },
-      ]);
-    });
-
     test('Doesnt exclude any files from translation', async () => {
       const files = [
-        { filename: 'included/path/content/bar.mdx', locale: 'jp' },
-        { filename: 'included/path/content/foo.mdx', locale: 'jp' },
+        { filename: 'included/path/content/bar.mdx', locale: 'ja-JP' },
+        { filename: 'included/path/content/foo.mdx', locale: 'ko-KR' },
       ];
+      const originalAdd = jest.requireActual('../utils/constants.js');
+
+      jest.doMock('../utils/constants.js', () => {
+        return { ...originalAdd, LOCALE_IDS: MOCK_CONSTANTS.LOCALE_IDS };
+      });
+
+      const { excludeFiles } = require('../add-files-to-translation-queue');
       const includedFiles = excludeFiles(files, EXCLUSIONS);
 
       expect(includedFiles).toEqual([
-        { filename: 'included/path/content/bar.mdx', locale: 'jp' },
-        { filename: 'included/path/content/foo.mdx', locale: 'jp' },
+        { filename: 'included/path/content/bar.mdx', locale: 'ja-JP' },
+        { filename: 'included/path/content/foo.mdx', locale: 'ko-KR' },
       ]);
     });
 
@@ -148,21 +137,28 @@ describe('add-files-to-translation-queue tests', () => {
         {
           filename: 'included/path/content/bar.mdx',
           contentType: 'doc',
-          locale: 'kr',
+          locale: 'ko-KR',
         },
         {
           filename: 'excluded/path/content/bar.mdx',
           contentType: 'doc',
-          locale: 'jp',
+          locale: 'ja-JP',
         },
       ];
+      const originalAdd = jest.requireActual('../utils/constants.js');
+
+      jest.doMock('../utils/constants.js', () => {
+        return { ...originalAdd, LOCALE_IDS: MOCK_CONSTANTS.LOCALE_IDS };
+      });
+
+      const { excludeFiles } = require('../add-files-to-translation-queue');
       const includedFiles = excludeFiles(files, EXCLUSIONS);
 
       expect(includedFiles).toEqual([
         {
           filename: 'included/path/content/bar.mdx',
           contentType: 'doc',
-          locale: 'kr',
+          locale: 'ko-KR',
         },
       ]);
     });
@@ -172,21 +168,28 @@ describe('add-files-to-translation-queue tests', () => {
         {
           filename: 'included/path/content/bar.mdx',
           contentType: 'excludedType',
-          locale: 'kr',
+          locale: 'ko-KR',
         },
         {
           filename: 'included/path/content/bar.mdx',
           contentType: 'doc',
-          locale: 'jp',
+          locale: 'ja-JP',
         },
       ];
+      const originalAdd = jest.requireActual('../utils/constants.js');
+
+      jest.doMock('../utils/constants.js', () => {
+        return { ...originalAdd, LOCALE_IDS: MOCK_CONSTANTS.LOCALE_IDS };
+      });
+
+      const { excludeFiles } = require('../add-files-to-translation-queue');
       const includedFiles = excludeFiles(files, EXCLUSIONS);
 
       expect(includedFiles).toEqual([
         {
           filename: 'included/path/content/bar.mdx',
           contentType: 'doc',
-          locale: 'jp',
+          locale: 'ja-JP',
         },
       ]);
     });
@@ -196,26 +199,33 @@ describe('add-files-to-translation-queue tests', () => {
         {
           filename: 'included/path/content/bar.mdx',
           contentType: 'doc',
-          locale: 'kr',
+          locale: 'ko-KR',
         },
         {
           filename: 'included/path/content/bar.mdx',
           contentType: 'excludedType',
-          locale: 'jp',
+          locale: 'ja-JP',
         },
         {
           filename: 'excluded/path/content/bar.mdx',
           contentType: 'doc',
-          locale: 'jp',
+          locale: 'ja-JP',
         },
       ];
+      const originalAdd = jest.requireActual('../utils/constants.js');
+
+      jest.doMock('../utils/constants.js', () => {
+        return { ...originalAdd, LOCALE_IDS: MOCK_CONSTANTS.LOCALE_IDS };
+      });
+
+      const { excludeFiles } = require('../add-files-to-translation-queue');
       const includedFiles = excludeFiles(files, EXCLUSIONS);
 
       expect(includedFiles).toEqual([
         {
           filename: 'included/path/content/bar.mdx',
           contentType: 'doc',
-          locale: 'kr',
+          locale: 'ko-KR',
         },
       ]);
     });

--- a/scripts/actions/__tests__/add-files-to-translation-queue.test.js
+++ b/scripts/actions/__tests__/add-files-to-translation-queue.test.js
@@ -38,8 +38,8 @@ This is a test file
 };
 
 const EXCLUSIONS = {
-  excludePath: { 'ja-JP': ['excluded/path'] },
-  excludeType: { 'ja-JP': ['excludedType'] },
+  excludePath: { jp: ['excluded/path'], kr: ['excluded/path'] },
+  excludeType: { jp: ['excludedType'], kr: ['excludedType'] },
 };
 
 const mockReadFileSync = (translate = []) => {
@@ -123,35 +123,37 @@ describe('add-files-to-translation-queue tests', () => {
       expect(toBeTranslated).toEqual([
         {
           filename: '/content/bar.mdx',
-          fileType: 'landingPage',
+          contentType: 'landingPage',
           locale: 'ja-JP',
           project_id: 'HT_ID',
         },
       ]);
     });
-    test('Doesnt exclude any files', async () => {
+
+    test('Doesnt exclude any files from translation', async () => {
       const files = [
-        { filename: 'included/path/content/bar.mdx', locale: 'ja-JP' },
-        { filename: 'included/path/content/foo.mdx', locale: 'ja-JP' },
+        { filename: 'included/path/content/bar.mdx', locale: 'jp' },
+        { filename: 'included/path/content/foo.mdx', locale: 'jp' },
       ];
       const includedFiles = excludeFiles(files, EXCLUSIONS);
 
       expect(includedFiles).toEqual([
-        { filename: 'included/path/content/bar.mdx', locale: 'ja-JP' },
-        { filename: 'included/path/content/foo.mdx', locale: 'ja-JP' },
+        { filename: 'included/path/content/bar.mdx', locale: 'jp' },
+        { filename: 'included/path/content/foo.mdx', locale: 'jp' },
       ]);
     });
+
     test('Excludes files under a set path', async () => {
       const files = [
         {
           filename: 'included/path/content/bar.mdx',
-          fileType: 'doc',
-          locale: 'ja-JP',
+          contentType: 'doc',
+          locale: 'kr',
         },
         {
           filename: 'excluded/path/content/bar.mdx',
-          fileType: 'doc',
-          locale: 'ja-JP',
+          contentType: 'doc',
+          locale: 'jp',
         },
       ];
       const includedFiles = excludeFiles(files, EXCLUSIONS);
@@ -159,8 +161,8 @@ describe('add-files-to-translation-queue tests', () => {
       expect(includedFiles).toEqual([
         {
           filename: 'included/path/content/bar.mdx',
-          fileType: 'doc',
-          locale: 'ja-JP',
+          contentType: 'doc',
+          locale: 'kr',
         },
       ]);
     });
@@ -169,13 +171,13 @@ describe('add-files-to-translation-queue tests', () => {
       const files = [
         {
           filename: 'included/path/content/bar.mdx',
-          fileType: 'excludedType',
-          locale: 'ja-JP',
+          contentType: 'excludedType',
+          locale: 'kr',
         },
         {
           filename: 'included/path/content/bar.mdx',
-          fileType: 'doc',
-          locale: 'ja-JP',
+          contentType: 'doc',
+          locale: 'jp',
         },
       ];
       const includedFiles = excludeFiles(files, EXCLUSIONS);
@@ -183,8 +185,8 @@ describe('add-files-to-translation-queue tests', () => {
       expect(includedFiles).toEqual([
         {
           filename: 'included/path/content/bar.mdx',
-          fileType: 'doc',
-          locale: 'ja-JP',
+          contentType: 'doc',
+          locale: 'jp',
         },
       ]);
     });
@@ -193,18 +195,18 @@ describe('add-files-to-translation-queue tests', () => {
       const files = [
         {
           filename: 'included/path/content/bar.mdx',
-          fileType: 'doc',
-          locale: 'ja-JP',
+          contentType: 'doc',
+          locale: 'kr',
         },
         {
           filename: 'included/path/content/bar.mdx',
-          fileType: 'excludedType',
-          locale: 'ja-JP',
+          contentType: 'excludedType',
+          locale: 'jp',
         },
         {
           filename: 'excluded/path/content/bar.mdx',
-          fileType: 'doc',
-          locale: 'ja-JP',
+          contentType: 'doc',
+          locale: 'jp',
         },
       ];
       const includedFiles = excludeFiles(files, EXCLUSIONS);
@@ -212,8 +214,8 @@ describe('add-files-to-translation-queue tests', () => {
       expect(includedFiles).toEqual([
         {
           filename: 'included/path/content/bar.mdx',
-          fileType: 'doc',
-          locale: 'ja-JP',
+          contentType: 'doc',
+          locale: 'kr',
         },
       ]);
     });

--- a/scripts/actions/__tests__/add-files-to-translation-queue.test.js
+++ b/scripts/actions/__tests__/add-files-to-translation-queue.test.js
@@ -1,19 +1,9 @@
 'use strict';
-const {
-  describe,
-  expect,
-  test,
-  beforeEach,
-  afterEach,
-} = require('@jest/globals');
+const { describe, expect, test, beforeEach } = require('@jest/globals');
 
 const fs = require('fs');
-const path = require('path');
 const frontmatter = require('@github-docs/frontmatter');
-const {
-  getLocalizedFileData,
-  excludeFiles,
-} = require('../add-files-to-translation-queue');
+const { getLocalizedFileData } = require('../add-files-to-translation-queue');
 
 const MOCK_CONSTANTS = {
   LOCALE_IDS: {
@@ -37,11 +27,6 @@ This is a test file
 `;
 };
 
-const EXCLUSIONS = {
-  excludePath: { jp: ['excluded/path'], kr: ['excluded/path'] },
-  excludeType: { jp: ['excludedType'], kr: ['excludedType'] },
-};
-
 const mockReadFileSync = (translate = []) => {
   const mdx = mockMdx(translate);
   fs.readFileSync.mockReturnValueOnce(mdx);
@@ -52,6 +37,23 @@ describe('add-files-to-translation-queue tests', () => {
     jest.resetAllMocks();
     jest.resetModules();
   });
+
+  const setup = () => {
+    const EXCLUSIONS = {
+      excludePath: { jp: ['excluded/path'], kr: ['excluded/path'] },
+      excludeType: { jp: ['excludedType'], kr: ['excludedType'] },
+    };
+    const originalAdd = jest.requireActual('../utils/constants.js');
+
+    jest.doMock('../utils/constants.js', () => {
+      return { ...originalAdd, LOCALE_IDS: MOCK_CONSTANTS.LOCALE_IDS };
+    });
+
+    jest.mock('../utils/helpers');
+    const { getExclusions } = require('../utils/helpers');
+
+    getExclusions.mockReturnValue(EXCLUSIONS);
+  };
 
   describe('Queue translations', () => {
     test('Adds the Human Translation Project Id for locale under `translate` in frontmatter', async () => {
@@ -117,14 +119,10 @@ describe('add-files-to-translation-queue tests', () => {
         { filename: 'included/path/content/bar.mdx', locale: 'ja-JP' },
         { filename: 'included/path/content/foo.mdx', locale: 'ko-KR' },
       ];
-      const originalAdd = jest.requireActual('../utils/constants.js');
-
-      jest.doMock('../utils/constants.js', () => {
-        return { ...originalAdd, LOCALE_IDS: MOCK_CONSTANTS.LOCALE_IDS };
-      });
-
+      setup();
       const { excludeFiles } = require('../add-files-to-translation-queue');
-      const includedFiles = excludeFiles(files, EXCLUSIONS);
+
+      const includedFiles = excludeFiles(files);
 
       expect(includedFiles).toEqual([
         { filename: 'included/path/content/bar.mdx', locale: 'ja-JP' },
@@ -145,14 +143,10 @@ describe('add-files-to-translation-queue tests', () => {
           locale: 'ja-JP',
         },
       ];
-      const originalAdd = jest.requireActual('../utils/constants.js');
-
-      jest.doMock('../utils/constants.js', () => {
-        return { ...originalAdd, LOCALE_IDS: MOCK_CONSTANTS.LOCALE_IDS };
-      });
+      setup();
 
       const { excludeFiles } = require('../add-files-to-translation-queue');
-      const includedFiles = excludeFiles(files, EXCLUSIONS);
+      const includedFiles = excludeFiles(files);
 
       expect(includedFiles).toEqual([
         {
@@ -176,14 +170,10 @@ describe('add-files-to-translation-queue tests', () => {
           locale: 'ja-JP',
         },
       ];
-      const originalAdd = jest.requireActual('../utils/constants.js');
-
-      jest.doMock('../utils/constants.js', () => {
-        return { ...originalAdd, LOCALE_IDS: MOCK_CONSTANTS.LOCALE_IDS };
-      });
+      setup();
 
       const { excludeFiles } = require('../add-files-to-translation-queue');
-      const includedFiles = excludeFiles(files, EXCLUSIONS);
+      const includedFiles = excludeFiles(files);
 
       expect(includedFiles).toEqual([
         {
@@ -212,14 +202,10 @@ describe('add-files-to-translation-queue tests', () => {
           locale: 'ja-JP',
         },
       ];
-      const originalAdd = jest.requireActual('../utils/constants.js');
-
-      jest.doMock('../utils/constants.js', () => {
-        return { ...originalAdd, LOCALE_IDS: MOCK_CONSTANTS.LOCALE_IDS };
-      });
+      setup();
 
       const { excludeFiles } = require('../add-files-to-translation-queue');
-      const includedFiles = excludeFiles(files, EXCLUSIONS);
+      const includedFiles = excludeFiles(files);
 
       expect(includedFiles).toEqual([
         {

--- a/scripts/actions/__tests__/add-files-to-translation-queue.test.js
+++ b/scripts/actions/__tests__/add-files-to-translation-queue.test.js
@@ -1,0 +1,221 @@
+'use strict';
+const {
+  describe,
+  expect,
+  test,
+  beforeEach,
+  afterEach,
+} = require('@jest/globals');
+
+const fs = require('fs');
+const path = require('path');
+const frontmatter = require('@github-docs/frontmatter');
+const {
+  getLocalizedFileData,
+  excludeFiles,
+} = require('../add-files-to-translation-queue');
+
+const MOCK_CONSTANTS = {
+  LOCALE_IDS: {
+    jp: 'ja-JP',
+    kr: 'ko-KR',
+  },
+};
+
+jest.mock('fs');
+jest.mock('path');
+jest.mock('@github-docs/frontmatter');
+jest.mock('../translation_workflow/database');
+jest.mock('../utils/vendor-request');
+
+const mockMdx = (translate = []) => {
+  return `---
+title: A test file
+${translate.length ? `translate:\n  - ${translate.join('\n  - ')}` : ''}
+---
+This is a test file
+`;
+};
+
+const EXCLUSIONS = {
+  excludePath: { 'ja-JP': ['excluded/path'] },
+  excludeType: { 'ja-JP': ['excludedType'] },
+};
+
+const mockReadFileSync = (translate = []) => {
+  const mdx = mockMdx(translate);
+  fs.readFileSync.mockReturnValueOnce(mdx);
+};
+
+describe('add-files-to-translation-queue tests', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.resetModules();
+  });
+
+  describe('Queue translations', () => {
+    test('Adds the Human Translation Project Id for locale under `translate` in frontmatter', async () => {
+      const file = { filename: '/content/bar.mdx' };
+      mockReadFileSync(['jp']);
+      frontmatter.mockReturnValueOnce({ data: { translate: ['jp'] } });
+      const toBeTranslated = getLocalizedFileData(file);
+
+      expect(toBeTranslated).toEqual([
+        { filename: '/content/bar.mdx', locale: 'ja-JP', project_id: 'HT_ID' },
+      ]);
+    });
+
+    test('Adds the Machine Translation Project Id when there is no `translate` in frontmatter', async () => {
+      const file = { filename: '/content/bar.mdx' };
+      mockReadFileSync();
+      frontmatter.mockReturnValueOnce({ data: {} });
+      const toBeTranslated = getLocalizedFileData(file);
+
+      expect(toBeTranslated).toEqual([
+        { filename: '/content/bar.mdx', locale: 'ja-JP', project_id: 'MT_ID' },
+      ]);
+    });
+
+    test('Adds the relevant Project Id when there are multiple locales and only one `translate` in frontmatter', async () => {
+      const file = { filename: '/content/bar.mdx' };
+      const originalAdd = jest.requireActual('../utils/constants.js');
+
+      jest.doMock('../utils/constants.js', () => {
+        return { ...originalAdd, LOCALE_IDS: MOCK_CONSTANTS.LOCALE_IDS };
+      });
+
+      const {
+        getLocalizedFileData,
+      } = require('../add-files-to-translation-queue');
+      const fs = require('fs');
+      const frontmatter = require('@github-docs/frontmatter');
+
+      jest.doMock('fs');
+      jest.doMock('@github-docs/frontmatter');
+
+      const mdx = mockMdx(['jp']);
+      fs.readFileSync.mockReturnValueOnce(mdx);
+      frontmatter.mockReturnValueOnce({ data: { translate: ['jp'] } });
+
+      const toBeTranslated = getLocalizedFileData(file);
+      expect(toBeTranslated).toEqual([
+        {
+          filename: '/content/bar.mdx',
+          locale: 'ja-JP',
+          project_id: 'HT_ID',
+        },
+        {
+          filename: '/content/bar.mdx',
+          locale: 'ko-KR',
+          project_id: 'MT_ID',
+        },
+      ]);
+    });
+
+    test('Adds the relevant Project Id when there are multiple locales and only one `translate` in frontmatter', async () => {
+      const file = { filename: '/content/bar.mdx' };
+      mockReadFileSync(['jp']);
+      frontmatter.mockReturnValueOnce({
+        data: { type: 'landingPage', translate: ['jp'] },
+      });
+      const toBeTranslated = getLocalizedFileData(file);
+
+      expect(toBeTranslated).toEqual([
+        {
+          filename: '/content/bar.mdx',
+          fileType: 'landingPage',
+          locale: 'ja-JP',
+          project_id: 'HT_ID',
+        },
+      ]);
+    });
+    test('Doesnt exclude any files', async () => {
+      const files = [
+        { filename: 'included/path/content/bar.mdx', locale: 'ja-JP' },
+        { filename: 'included/path/content/foo.mdx', locale: 'ja-JP' },
+      ];
+      const includedFiles = excludeFiles(files, EXCLUSIONS);
+
+      expect(includedFiles).toEqual([
+        { filename: 'included/path/content/bar.mdx', locale: 'ja-JP' },
+        { filename: 'included/path/content/foo.mdx', locale: 'ja-JP' },
+      ]);
+    });
+    test('Excludes files under a set path', async () => {
+      const files = [
+        {
+          filename: 'included/path/content/bar.mdx',
+          fileType: 'doc',
+          locale: 'ja-JP',
+        },
+        {
+          filename: 'excluded/path/content/bar.mdx',
+          fileType: 'doc',
+          locale: 'ja-JP',
+        },
+      ];
+      const includedFiles = excludeFiles(files, EXCLUSIONS);
+
+      expect(includedFiles).toEqual([
+        {
+          filename: 'included/path/content/bar.mdx',
+          fileType: 'doc',
+          locale: 'ja-JP',
+        },
+      ]);
+    });
+
+    test('Excludes specific file types', async () => {
+      const files = [
+        {
+          filename: 'included/path/content/bar.mdx',
+          fileType: 'excludedType',
+          locale: 'ja-JP',
+        },
+        {
+          filename: 'included/path/content/bar.mdx',
+          fileType: 'doc',
+          locale: 'ja-JP',
+        },
+      ];
+      const includedFiles = excludeFiles(files, EXCLUSIONS);
+
+      expect(includedFiles).toEqual([
+        {
+          filename: 'included/path/content/bar.mdx',
+          fileType: 'doc',
+          locale: 'ja-JP',
+        },
+      ]);
+    });
+
+    test('Excludes files and file types under a set path', async () => {
+      const files = [
+        {
+          filename: 'included/path/content/bar.mdx',
+          fileType: 'doc',
+          locale: 'ja-JP',
+        },
+        {
+          filename: 'included/path/content/bar.mdx',
+          fileType: 'excludedType',
+          locale: 'ja-JP',
+        },
+        {
+          filename: 'excluded/path/content/bar.mdx',
+          fileType: 'doc',
+          locale: 'ja-JP',
+        },
+      ];
+      const includedFiles = excludeFiles(files, EXCLUSIONS);
+
+      expect(includedFiles).toEqual([
+        {
+          filename: 'included/path/content/bar.mdx',
+          fileType: 'doc',
+          locale: 'ja-JP',
+        },
+      ]);
+    });
+  });
+});

--- a/scripts/actions/add-files-to-translation-queue.js
+++ b/scripts/actions/add-files-to-translation-queue.js
@@ -47,12 +47,16 @@ const getExclusions = () => {
  * @returns {Object[]} The files that should be included
  */
 const excludeFiles = (fileData, exclusions) => {
-  return fileData.filter(
-    ({ filename, locale, contentType }) =>
-      !exclusions.excludePath[locale]?.some((path) =>
+  return fileData.filter(({ filename, locale, contentType }) => {
+    const localeKey = Object.keys(LOCALE_IDS).find(
+      (localeKey) => LOCALE_IDS[localeKey] === locale
+    );
+    return (
+      !exclusions.excludePath[localeKey]?.some((path) =>
         filename.startsWith(path)
-      ) && !exclusions.excludeType[locale]?.some((type) => contentType === type)
-  );
+      ) && !exclusions.excludeType[localeKey]?.some((type) => contentType === type)
+    );
+  });
 };
 
 /**

--- a/scripts/actions/add-files-to-translation-queue.js
+++ b/scripts/actions/add-files-to-translation-queue.js
@@ -48,13 +48,13 @@ const getExclusions = () => {
  */
 const excludeFiles = (fileData, exclusions) => {
   return fileData.filter(
-    ({ filename, locale, fileType }) =>
-      !exclusions.excludePath[locale]?.some((exclus) =>
-        filename.includes(exclus)
-      ) &&
-      !exclusions.excludeType[locale]?.some((exclus) => fileType === exclus)
+    ({ filename, locale, contentType }) =>
+      !exclusions.excludePath[locale]?.some((path) =>
+        filename.startsWith(path)
+      ) && !exclusions.excludeType[locale]?.some((type) => contentType === type)
   );
 };
+
 /**
  * Determines if a particular locale should be human or machine translated based on the files frontmatter.
  *
@@ -72,11 +72,11 @@ const getLocalizedFileData = (prFile) => {
   const contents = fs.readFileSync(path.join(process.cwd(), prFile.filename));
   const { data } = frontmatter(contents);
   const checkLocale = getProjectId(data.translate);
-  const fileType = data.type;
+  const contentType = data.type;
 
   return Object.keys(LOCALE_IDS).map((locale) => ({
     ...prFile,
-    fileType,
+    contentType,
     locale: LOCALE_IDS[locale],
     project_id: checkLocale(locale),
   }));

--- a/scripts/actions/translation_workflow/testing/script.sh
+++ b/scripts/actions/translation_workflow/testing/script.sh
@@ -10,7 +10,7 @@ export GITHUB_TOKEN='' # token with no permissions
 
 # # step 1
 URL="https://api.github.com/repos/newrelic/docs-website/pulls/3271/files"
-yarn get-translated-files $URL
+yarn add-files-to-translate $URL
 
 # # step 2
 export TRANSLATION_VENDOR_API_URL=https://api.smartling.com

--- a/scripts/actions/utils/constants.js
+++ b/scripts/actions/utils/constants.js
@@ -1,0 +1,10 @@
+const LOCALE_IDS = {
+  jp: 'ja-JP',
+};
+
+const EXCLUSIONS_FILE = 'scripts/utils/docs-content-tools/i18n-exclusions.yml';
+
+module.exports = {
+  LOCALE_IDS,
+  EXCLUSIONS_FILE,
+};

--- a/scripts/actions/utils/docs-content-tools/i18n-exclusions.yml
+++ b/scripts/actions/utils/docs-content-tools/i18n-exclusions.yml
@@ -1,0 +1,6 @@
+excludePath:
+  ja-JP:
+    - /whats-new
+excludeType:
+  ja-JP:
+    - landingPage

--- a/scripts/actions/utils/helpers.js
+++ b/scripts/actions/utils/helpers.js
@@ -1,0 +1,16 @@
+const yaml = require('js-yaml');
+const fs = require('fs');
+const path = require('path');
+const { EXCLUSIONS_FILE } = require('./constants');
+
+/**
+ * Loads the Exclusions yaml file and converts it to a JSON object.
+ * @returns {Object} The Exclusions yaml file as a JSON object.
+ */
+const getExclusions = () => {
+  return yaml.load(fs.readFileSync(path.join(process.cwd(), EXCLUSIONS_FILE)));
+};
+
+module.exports = {
+  getExclusions,
+};


### PR DESCRIPTION
This adds the ability to exclude files under specific paths, and of specific types which are configured using a YAML file.

This also adds tests to the add-files-to-translation-queue workflow as there weren't any before, and adds tests for excluding files/types