### PR TITLE
fix(APM): Removed broken link

### DIFF
--- a/src/content/docs/apm/index.mdx
+++ b/src/content/docs/apm/index.mdx
@@ -58,7 +58,6 @@ redirects:
 
 
     * Use [real time streaming](/docs/agents/manage-apm-agents/agent-data/real-time-streaming) to query and visualize data in near real time.
-    * Monitor your apps and related hosts as a color-coded [health map](/docs/using-new-relic/cross-product-functions/troubleshooting/introduction-health-maps).
     * Review [deployment impacts](/docs/apm/applications-menu/events/deployments-page-view-impact-your-app-users) in our UI or [REST API](/docs/apis/rest-api-v2/application-examples-v2).
   </LandingPageTile>
 


### PR DESCRIPTION
Health maps was end-of-lifed in the summer 2021.

Closes #5065 