### PR TITLE
Updates to send translation script for using project_id

### DIFF
--- a/scripts/actions/send-and-update-translation-queue.js
+++ b/scripts/actions/send-and-update-translation-queue.js
@@ -19,8 +19,8 @@ const PROJECT_ID = process.env.TRANSLATION_VENDOR_PROJECT;
  */
 const getReadyToGoTranslationsForEachLocale = async () => {
   const [pendingTranslations, inProgressTranslations] = await Promise.all([
-    Database.getTranslations({ status: 'PENDING' }),
-    Database.getTranslations({ status: 'IN_PROGRESS' }),
+    Database.getTranslations({ status: 'PENDING', project_id: PROJECT_ID }),
+    Database.getTranslations({ status: 'IN_PROGRESS', project_id: PROJECT_ID }),
   ]);
 
   /*
@@ -28,7 +28,7 @@ const getReadyToGoTranslationsForEachLocale = async () => {
    * 1. It's in a pending state.
    * 2. There isn't a matching record whose status === 'IN_PROGRESS'. A record matches if there exists another record with the same slug and locale.
    *
-   * This is to avoid sending multiple translation requests for {hello_world.txt, ja-JP} as an example, and allows us have to an in progress translation, and one ready to go that is queued up in the database.
+   * This is to avoid sending multiple translation requests for {hello_world.txt, ja-JP} as an example, and allows us to have an in progress translation, and one ready to go that is queued up in the database.
    *
    * 3. The file (slug) that is associated with the translation record still exists.
    */
@@ -100,6 +100,7 @@ const createJobs = (accessToken) => async (locales) => {
         job_uid: jobResponse.translationJobUid,
         status: 'PENDING',
         locale: jobResponse.targetLocaleIds[0],
+        project_id: PROJECT_ID,
       });
     })
   );

--- a/scripts/actions/translation_workflow/database.js
+++ b/scripts/actions/translation_workflow/database.js
@@ -9,10 +9,11 @@ const Models = require('./models');
  * @param {string} job.job_uid - identifier of job from translation vendor
  * @param {string} job.status - string value of status enum
  * @param {string} job.locale - locale of job
+ * @param {string} job.project_id -- project id job is associated with (from translation vendor)
  * @returns newly created job
  */
-const addJob = async ({ job_uid, status, locale }) => {
-  const job = await Models.Job.create({ job_uid, status, locale });
+const addJob = async ({ job_uid, status, locale, project_id }) => {
+  const job = await Models.Job.create({ job_uid, status, locale, project_id });
   return job;
 };
 


### PR DESCRIPTION
* now only pull translation requests for a particular project_id
* when we create a job, also include project_id
* fixup comment

Resolves: #4816