### PR TITLE
create h3 for yarn verify

### DIFF
--- a/src/content/docs/style-guide/writing-docs/writer-workflow/github-troubleshooting.mdx
+++ b/src/content/docs/style-guide/writing-docs/writer-workflow/github-troubleshooting.mdx
@@ -28,6 +28,7 @@ Here’s a few things you can check if your build is failing:
   * Image filenames are case-sensitive. Using the wrong capitalization results in a missing image in the doc.
   * Images with encoded values (like `%`) in the filename can be especially tricky, try to avoid them.
 
+### Diagnose markdown errors with yarn-verify [#yarn-verify]
 If you know which file is causing an error, you can further troubleshoot with the `yarn verify-mdx path/to/file.mdx` command. This command returns more information about the error than the normal Gatsby output. This includes things such as the specific character and line number causing the error. 
 
 <CollapserGroup>


### PR DESCRIPTION
This creates an h3 section for the yarn verify topic since it's a bit hard to find when skimming.