### PR TITLE
Remove disallowed components from sample alert queries

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts.mdx
@@ -223,7 +223,7 @@ Here are some NRQL alert condition examples. For attribute definitions, see [Att
 
     ```
     FROM NrMTDConsumption SELECT latest(estimatedCost) 
-       WHERE productLine = 'DataPlatform' SINCE this month
+       WHERE productLine = 'DataPlatform'
     ```
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
NRQL alert conditions may not contain SINCE or UNTIL