### PR TITLE
fix: add security to left nav

### DIFF
--- a/src/nav/root.yml
+++ b/src/nav/root.yml
@@ -44,6 +44,8 @@ pages:
     path: /attribute-dictionary
   - title: 'Release notes'
     path: '/docs/release-notes'
+  - title: Security and privacy
+    path: /docs/security
   - title: What's new?
     path: /whats-new
   - title: section-break


### PR DESCRIPTION
We had a hero request to add the security section back to the left nav. Closes #5082 