### PR TITLE
fix: add home page left nav info

### DIFF
--- a/src/content/docs/style-guide/writing-docs/processes-procedures/edit-homepage.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/edit-homepage.mdx
@@ -64,3 +64,21 @@ You'll make changes to both [homepage.yml](https://github.com/newrelic/docs-webs
     ```
 4. Save, build locally, commit, PR. 
 
+## Edit the home page left nav [#left-nav]
+
+The left nav of the home page is controlled by `src/nav/root.yml`. This is a basic `yml` file, similar to our taxonomy files. Each link on the left nav needs a `title` and a `path`:
+
+```
+  - title: Welcome to New Relic
+    path: /docs/using-new-relic
+  - title: New Relic One
+    path: /docs/new-relic-one/use-new-relic-one
+  - title: Guides and best practices
+    path: /docs/new-relic-solutions
+  - title: section-break
+  - title: Alerts and Applied Intelligence  
+    path: /docs/alerts-applied-intelligence
+```
+
+You can add a new link by following the pattern above or delete a link by removing the corresponding title and path. Section breaks are added by including a `- title: section-break` line. The left nav reflects the exact order of `root.yml`, so it's easy to organize it as needed.
+  


### PR DESCRIPTION
Add a section to our style guide on editing the home page left nav. 