### PR TITLE
Fix left background color, current page highlighted

### DIFF
--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -57,15 +57,12 @@ const MainLayout = ({ data = {}, children, pageContext }) => {
       <Layout>
         <Layout.Sidebar
           css={css`
-            background: var(--secondary-background-color);
+            background: var(--primary-background-color);
             hr {
               border-color: var(--color-neutrals-300);
               .dark-mode & {
                 border-color: var(--color-dark-500);
               }
-            }
-            .dark-mode & {
-              background: var(--color-dark-100);
             }
           `}
         >


### PR DESCRIPTION
## Description

Changes background color of left nav to use same as primary background to blend in more. Also fixes issue where you could not see current page highlighted in corresponding left nav item.

## Related issues / PRs
Closes https://github.com/newrelic/docs-website/issues/5081
Closes https://github.com/newrelic/docs-website/issues/5093

## Screenshot(s)
![2021-11-30_12-40-49](https://user-images.githubusercontent.com/2952843/144125242-072da55e-01eb-4928-8616-1cc3b22664fe.png)

![2021-11-30_12-40-19](https://user-images.githubusercontent.com/2952843/144125262-a83f2c1b-f386-4284-a6e0-4ee67f16c0c8.png)
![2021-11-30_12-41-00](https://user-images.githubusercontent.com/2952843/144125288-09d8c46e-3105-4fb7-a776-458e985b1b08.png)
![2021-11-30_12-40-37](https://user-images.githubusercontent.com/2952843/144125304-4442bddb-74fe-49d8-89ef-2d61738d1639.png)


