### PR TITLE
style(homepage): Change nav to refer to "log management"

### DIFF
--- a/src/nav/logs.yml
+++ b/src/nav/logs.yml
@@ -1,4 +1,4 @@
-title: Logs
+title: Log management
 path: /docs/logs
 pages:
   - title: Get started

--- a/src/nav/root.yml
+++ b/src/nav/root.yml
@@ -25,7 +25,7 @@ pages:
     path: /docs/infrastructure
   - title: Kubernetes and Pixie
     path: /docs/kubernetes-pixie
-  - title: Logs
+  - title: Log management
     path: /docs/logs
   - title: Mobile monitoring
     path: /docs/mobile-monitoring


### PR DESCRIPTION
Got some feedback from PMM that "log management" is generally easier to grok for folks than "logs." This is also how we refer to it in most other places on the site. 