### PR TITLE
[i18n] Update home page banner, fso translations

### DIFF
--- a/src/components/HomepageBanner.js
+++ b/src/components/HomepageBanner.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { Button, Link } from '@newrelic/gatsby-theme-newrelic';
+import {
+  Button,
+  Link,
+  useTranslation,
+  Trans,
+} from '@newrelic/gatsby-theme-newrelic';
 import bannerForeground from '../images/bannerForeground.png';
 import bannerForegroundMobile from '../images/bannerForegroundMobile.svg';
 import relicsAtWork from '../images/photo-relics-at-work-01.png';
@@ -9,6 +14,7 @@ import relicsAtWorkMobile from '../images/relics-at-work--SM.png';
 const HomepageBanner = () => {
   const bannerHeight = '383px';
   const mobileBreakpoint = '450px';
+  const { t } = useTranslation();
 
   return (
     <section
@@ -55,6 +61,7 @@ const HomepageBanner = () => {
           css={css`
             font-size: 3rem;
             color: var(--color-neutrals-200);
+            white-space: pre-line;
             @media screen and (max-width: 850px) {
               font-size: 2.5rem;
             }
@@ -64,8 +71,7 @@ const HomepageBanner = () => {
             }
           `}
         >
-          Welcome to <br />
-          New Relic docs!
+          {t('home.banner.title')}
         </h1>
         <p
           css={css`
@@ -78,18 +84,20 @@ const HomepageBanner = () => {
             }
           `}
         >
-          We're here to help you monitor, debug, and improve your entire stack.
-          If you're new to New Relic, read our{' '}
-          <Link
-            to="/docs/using-new-relic/"
-            css={css`
-              color: var(--color-neutrals-200);
-            `}
-          >
-            Introduction to New Relic doc
-          </Link>
-          . Or get started right now by creating an account and installing a
-          quickstart:
+          <Trans i18nKey="home.banner.intro.p1">
+            We're here to help you monitor, debug, and improve your entire
+            stack. If you're new to New Relic, read our{' '}
+            <Link
+              to="/docs/using-new-relic/"
+              css={css`
+                color: var(--color-neutrals-200);
+              `}
+            >
+              Introduction to New Relic doc
+            </Link>
+            . Or get started right now by creating an account and installing a
+            quickstart:
+          </Trans>
         </p>
         <div
           css={css`
@@ -127,7 +135,7 @@ const HomepageBanner = () => {
               }
             `}
           >
-            Create a free account
+            {t('home.banner.button1')}
           </Button>
           <Button
             variant={Button.VARIANT.OUTLINE}
@@ -155,7 +163,7 @@ const HomepageBanner = () => {
               }
             `}
           >
-            Find your quickstart
+            {t('home.banner.button2')}
           </Button>
         </div>
       </div>

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -18,11 +18,15 @@
     "title": "What's new in New Relic"
   },
   "home": {
-    "title": "Welcome to New Relic",
-    "intro": {
-      "p1": "If you're new, follow these three steps to create an account and get going. (It's free!)",
-      "p2": "If you're catching up on the changes in New Relic One, start with this <2>transition guide</2>, or check out <4>what's new</4>.",
-      "p3": "Keep scrolling to read more about getting data into New Relic, our platform features, our observability solutions, and our alerting tools. Or, to get a wider view of our platform's capabilities, read <2>Intro to New Relic</2> or see our <5>guides and best practices</5>."
+    "banner": {
+      "title": "Welcome to \n New Relic docs!",
+      "intro": {
+        "p1": "We're here to help you monitor, debug, and improve your entire stack. If you're new to New Relic, read our <2>Introduction to New Relic doc</2>. Or get started right now by creating an account and installing a quickstart:",
+        "p2": "If you're catching up on the changes in New Relic One, start with this <2>transition guide</2>, or check out <4>what's new</4>.",
+        "p3": "Keep scrolling to read more about getting data into New Relic, our platform features, our observability solutions, and our alerting tools. Or, to get a wider view of our platform's capabilities, read <2>Intro to New Relic</2> or see our <5>guides and best practices</5>."
+      },
+      "button1": "Create a free account",
+      "button2": "Find your quickstart"
     },
     "welcome": {
       "t1": {

--- a/src/i18n/translations/jp/translation.json
+++ b/src/i18n/translations/jp/translation.json
@@ -57,20 +57,20 @@
       "title": "フルスタックオブザーバビリティ（Full-Stack Observability）",
       "description": "ソフトウェアスタック全体を通じて容易に問題を分析し、トラブルシュートします。",
       "t1": {
-        "title": "フルスタックオブザーバビリティの概要",
-        "description": "インフラストラクチャやサーバーコード、エンドユーザーアプリなど、あらゆるものについての深いインサイトを取得します。"
-      },
-      "t2": {
         "title": "APM",
         "description": "アプリのパフォーマンスや安定性についての、リアルタイムのトレンドを示すデータを取得します。"
       },
-      "t3": {
+      "t2": {
         "title": "Browser",
         "description": "ウェブサイトのパフォーマンスの測定やエラーの追跡、ユーザーのサイトとのインタラクションの把握を行います。"
       },
-      "t4": {
+      "t3": {
         "title": "分散トレーシング（Distributed Tracing）",
         "description": "分散化システムを通じてリクエストを追跡し、トレンドと異常値を検索します。"
+      },
+      "t4": {
+        "title": "Kubernetes and Pixie",
+        "description": "Get instant Kubernetes observability. "
       },
       "t5": {
         "title": "Kubernetes and Pixie",


### PR DESCRIPTION
## Description

Adds home page banner text to translations.json. Fixes FSO section to match between english and jp versions.

I'll make a follow up PR to add the japanese content to `src/i18n/jp/translations.json` when it comes back via @jmiraNR 

## Related issues / PRs
partially closes https://github.com/newrelic/docs-website/issues/5097
Closes https://github.com/newrelic/docs-website/issues/5098