### PR TITLE
Update example (linux) Dockerfiles to use current .NET versions

### DIFF
--- a/src/content/docs/apm/agents/net-agent/other-installation/install-net-agent-docker-container.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/install-net-agent-docker-container.mdx
@@ -34,7 +34,8 @@ Requirements include:
 ### Example Linux Dockerfile
 
 ```
-FROM microsoft/dotnet:2.2-aspnetcore-runtime
+# Use the correct tagged version for your application's targeted runtime.  See https://hub.docker.com/_/microsoft-dotnet-aspnet/ 
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 
 # Publish your application.
 COPY <var>your app to be published</var> /app
@@ -64,14 +65,16 @@ ENTRYPOINT ["dotnet", "./<var>YOUR_APP_NAME</var>.dll"]
 ### Example Linux Multi-stage Dockerfile
 
 ```
-FROM microsoft/dotnet:2.2-sdk AS base
+# This example uses .NET 6.0.  For other versions, see https://hub.docker.com/_/microsoft-dotnet-sdk/
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS base
 
 # Build your application
 WORKDIR /src
 RUN dotnet new mvc -o <var>YOUR_APP_NAME</var>
-RUN dotnet build -c Release -o /app/ ./<var>YOUR_APP_NAME</var>
+RUN dotnet publish -c Release -o /app ./<var>YOUR_APP_NAME</var>
 
-FROM microsoft/dotnet:2.2-aspnetcore-runtime AS final
+# The runtime tag version should match the SDK tag version
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS final
 
 # Install the agent
 RUN apt-get update && apt-get install -y wget ca-certificates gnupg \


### PR DESCRIPTION
The current Dockerfile examples for using the .NET agent in Linux reference `.NET Core 2.2`, which is pretty old and has been unsupported by Microsoft for a while now.  This PR updates the examples to use `.NET 6.0` which is the latest LTS version of the platform.  It also adds some comments to help our customers find the right container base images appropriate for their use case.

I tested these examples on my system and everything worked as expected.