### PR TITLE
style(support offerings): Simplify and clarify callout language

### DIFF
--- a/src/content/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings.mdx
+++ b/src/content/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings.mdx
@@ -17,7 +17,7 @@ The New Relic Support Plan offers a variety of resources based on your service s
 These Support Plans apply only to your paid service subscription under an existing New Relic agreement. If you have questions about these New Relic Support Plans, contact your New Relic account representative.
 
 <Callout variant="important">
-NOTE: If you are a New Relic HIPAA customer, please be advised that you must follow the requirements specified in the Global Technical Support Section of [HIPAA enablement - what you need to know and do](/docs/security/security-privacy/compliance/hipaa-readiness-new-relic/#global-tech-support) when requesting support and engaging with the New Relic Global Technical Support team for assistance.
+If you are a New Relic HIPAA customer, please follow the requirements specified in the Global Technical Support Section of [HIPAA enablement - what you need to know and do](/docs/security/security-privacy/compliance/hipaa-readiness-new-relic/#global-tech-support) when you request support and engage with the New Relic Global Technical Support team.
 </Callout>
 
 <CollapserGroup>


### PR DESCRIPTION
This callout uses an all-caps `NOTE` which is not our style, and also is a bit over-written.