### PR TITLE
Download translation script updates

### DIFF
--- a/.github/workflows/check-translations-and-deserialize.yml
+++ b/.github/workflows/check-translations-and-deserialize.yml
@@ -21,6 +21,7 @@ jobs:
       TRANSLATION_VENDOR_PROJECT: ${{ secrets.TRANSLATION_VENDOR_PROJECT }}
       TRANSLATION_VENDOR_USER: ${{ secrets.TRANSLATION_VENDOR_USER }}
       TRANSLATION_VENDOR_SECRET: ${{ secrets.TRANSLATION_VENDOR_SECRET }}
+      TRANSLATION_TYPE: human
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -95,7 +96,7 @@ jobs:
         id: remove-batches
         run: |
           node ./scripts/actions/remove-completed-batch.js
-          
+
   fetch-machine-translated-content:
     name: Fetch machine translated content
     runs-on: ubuntu-latest
@@ -103,6 +104,7 @@ jobs:
       TRANSLATION_VENDOR_PROJECT: ${{ secrets.TRANSLATION_VENDOR_MT_PROJECT }}
       TRANSLATION_VENDOR_USER: ${{ secrets.TRANSLATION_VENDOR_MT_USER }}
       TRANSLATION_VENDOR_SECRET: ${{ secrets.TRANSLATION_VENDOR_MT_SECRET }}
+      TRANSLATION_TYPE: machine
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/scripts/actions/check-job-progress.js
+++ b/scripts/actions/check-job-progress.js
@@ -7,8 +7,9 @@ const {
 
 const { getAccessToken, vendorRequest } = require('./utils/vendor-request');
 const { fetchAndDeserialize } = require('./fetch-and-deserialize');
+const { configuration } = require('./configuration');
 
-const PROJECT_ID = process.env.TRANSLATION_VENDOR_PROJECT;
+const PROJECT_ID = configuration.TRANSLATION.VENDOR_PROJECT;
 
 const uniq = (arr) => [...new Set(arr)];
 const prop = (key) => (x) => x[key];

--- a/scripts/actions/check-job-progress.js
+++ b/scripts/actions/check-job-progress.js
@@ -105,7 +105,10 @@ const getBatchStatus = (accessToken) => async ({ batchUid, jobId }) => {
 const main = async () => {
   try {
     // load the items that we are being translated
-    const inProgressJobs = await getJobs({ status: 'IN_PROGRESS' });
+    const inProgressJobs = await getJobs({
+      status: 'IN_PROGRESS',
+      project_id: PROJECT_ID,
+    });
     const batchUids = inProgressJobs.map((job) => {
       return { batchUid: job.batch_uid, jobId: job.id };
     });

--- a/scripts/actions/configuration.js
+++ b/scripts/actions/configuration.js
@@ -1,0 +1,29 @@
+/**
+ * Module which holds configurable fields and their values for running scripts.
+ * At the moment, only contains configuration for translation workflow.
+ * @module configuration
+ * */
+
+const configuration = {
+  /** Translation configuration section. */
+  TRANSLATION: {
+    /** API endpoint for translation  vendor. */
+    VENDOR_API_URL: process.env.TRANSLATION_VENDOR_API_URL,
+    /** Project ID (from vendor) used for translation. */
+    VENDOR_PROJECT: process.env.TRANSLATION_VENDOR_PROJECT,
+    /** User ID (from  vendor) used for authentication */
+    VENDOR_USER: process.env.TRANSLATION_VENDOR_USER,
+    /** User secret (from vendor) used for authentication */
+    VENDOR_SECRET: process.env.TRANSLATION_VENDOR_SECRET,
+    /** Value indicating if configured for 'human' or 'machine' translation. Can also be undefined indicating neither or both. */
+    TYPE: process.env.TRANSLATION_TYPE,
+  },
+};
+
+module.exports = {
+  /**
+   * Configurable fields and their values for running scripts.
+   * At the moment, only contains configuration for translation workflow.
+   */
+  configuration,
+};

--- a/scripts/actions/deserialize-html.js
+++ b/scripts/actions/deserialize-html.js
@@ -11,6 +11,7 @@ const heading = require('hast-util-to-mdast/lib/handlers/heading');
 const u = require('unist-builder');
 const { last } = require('lodash');
 const yaml = require('js-yaml');
+const { configuration } = require('./configuration');
 
 const component = (h, node) => {
   if (!node.properties || !node.properties.dataType) {
@@ -74,6 +75,7 @@ const stripTranslateFrontmatter = () => {
       const frontmatterObj = yaml.load(tree.children[0].value);
       delete frontmatterObj.translate;
       delete frontmatterObj.redirects;
+      frontmatterObj.translationType = configuration.TRANSLATION.TYPE;
       const frontmatterStr = yaml
         .dump(frontmatterObj, { lineWidth: -1 })
         .trim();


### PR DESCRIPTION
## Summary

* For a run, only check one project at a time.  This means we run the script once for human translations, and once for machine translations
* add environment variable which indicates translation type when running script
* created new configuration module to be central place for configuration values for scripts. This represents a single place for setting & getting configuration values. We can also write JSDOCs for such pieces of code. I think this is a future facing improvement versus just using process.env.some_value.
* use new configuration module for type to add frontmatter when deserializing content.

## Links
Resolves: #4204