### PR TITLE
fix(Docs homepage): Updated NRQL chart link

### DIFF
--- a/src/data/homepage.yml
+++ b/src/data/homepage.yml
@@ -16,7 +16,7 @@ popular_content:
     - title: Solutions and best practices
       path: /docs/new-relic-solutions
     - title: Examine NRQL queries used to build New Relic charts
-      path: /docs/new-relic-one/use-new-relic-one/ui-data/basic-ui-features/
+      path: /docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language/#what-is-nrql
     - title: Build on New Relic One
       path: /docs/new-relic-one/use-new-relic-one/build-new-relic-one/build-custom-new-relic-one-application/
 


### PR DESCRIPTION
The NRQL link in the popular content section was pointing to a less useful doc. It should be more useful now.

This came in as a hero request.