### PR TITLE
fix(integrations): fix broken OSS sdk links

### DIFF
--- a/src/content/docs/data-apis/ingest-apis/telemetry-sdks-report-custom-telemetry-data.mdx
+++ b/src/content/docs/data-apis/ingest-apis/telemetry-sdks-report-custom-telemetry-data.mdx
@@ -201,6 +201,6 @@ If you need a Telemetry SDK in a language that does not currently exist or want 
 
 ## Integrations built with the Telemetry SDKs [#external-data]
 
-To see the integrations built using our Telemetry SDKs, see [Open source telemetry integrations](/docs/integrations/open-source-telemetry-integrations).
+To learn more about our integrations built using our Telemetry SDKs, see [Intro to open source telemetry integrations](/docs/more-integrations/open-source-telemetry-integrations/get-started/introduction-new-relics-open-source-telemetry-integrations).
 
 For all monitoring solutions, see our [New Relic Instant Observability](https://newrelic.com/instant-observability/).

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/get-started/introduction-new-relics-open-source-telemetry-integrations.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/get-started/introduction-new-relics-open-source-telemetry-integrations.mdx
@@ -15,9 +15,9 @@ New Relic provides open source integrations that report telemetry data from tele
 
 ## Types of integrations [#about]
 
-We have open source integrations that report data from OpenTelemetry, DropWizard, Prometheus, and [more](/docs/integrations/open-source-telemetry-integrations). With these solutions, you can aggregate all your telemetry data in one place: the New Relic platform.
+We have open source integrations that report data from OpenTelemetry, DropWizard, Prometheus, and more. With these solutions, you can aggregate all your telemetry data in one place: the New Relic platform.
 
-See [our list of open source telemetry integrations](/docs/integrations/open-source-telemetry-integrations) (to browse all New Relic solutions, see [New Relic Instant Observability](https://newrelic.com/instant-observability/)).
+Find our open source telemetry integrations in [New Relic Instant Observability](https://newrelic.com/instant-observability/).
 
 ## How they work
 


### PR DESCRIPTION
Fixes broken links to old auto-index pages. Closes #5147.