### PR TITLE
Update start-stop-restart-infrastructure-agent.mdx

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/start-stop-restart-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/start-stop-restart-infrastructure-agent.mdx
@@ -91,20 +91,21 @@ For [Windows Server](/docs/infrastructure/new-relic-infrastructure/installation/
 ## macOS: Start, stop, restart, or check agent status [#macOS]
 
 * Stop or start the agent:
-  ```
-    brew services stop newrelic-infra-agent
-    brew services start newrelic-infra-agent
-  ```
 
-* Restart the agent:
   ```
-    brew services restart newrelic-infra-agent
+  brew services stop newrelic-infra-agent
+  brew services start newrelic-infra-agent
+  ```
+* Restart the agent:
+
+  ```
+  brew services restart newrelic-infra-agent
   ```
 * Check status of the agent:
-  ```
-    brew services list
-  ```
 
+  ```
+  brew services list
+  ```
 
 ## Customize agent logs [#logging]
 


### PR DESCRIPTION
Fix indentation in macOS section (stop/start commands were not matching each other)

Standardized indentation in the rest of the macOS section although it was not breaking layout (each section had one line of commands, multiple lines with this indentation would have broken layout as with start/stop)