### PR TITLE
Missing Double Quote in Pixie Command

### DIFF
--- a/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/manage-pixie-data.mdx
+++ b/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/manage-pixie-data.mdx
@@ -73,7 +73,7 @@ kubectl create namespace newrelic ; helm upgrade --install newrelic-bundle newre
 If you're just upgrading an existing install, then this is a much simpler approach:
 
 ```
-helm upgrade newrelic-bundle newrelic/nri-bundle --reuse-values -n newrelic --set newrelic-pixie.excludeNamespacesRegex="default|kube-node-lease|kube-public|kube-system|newrelic|newrelic-custom-metrics|olm|px-operator
+helm upgrade newrelic-bundle newrelic/nri-bundle --reuse-values -n newrelic --set newrelic-pixie.excludeNamespacesRegex="default|kube-node-lease|kube-public|kube-system|newrelic|newrelic-custom-metrics|olm|px-operator"
 ```
 
 Learn more about the available parameters for the `newrelic-pixie` Helm chart [here](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie#chart-details).


### PR DESCRIPTION
Missing double quote after `px-operator`

helm upgrade newrelic-bundle newrelic/nri-bundle --reuse-values -n newrelic --set newrelic-pixie.excludeNamespacesRegex="default|kube-node-lease|kube-public|kube-system|newrelic|newrelic-custom-metrics|olm|px-operator"

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.