### PR TITLE
Clarify that logs in context isn't available in APM UI for PHP

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php.mdx
@@ -47,7 +47,7 @@ Our PHP agent monitors your application to help you [identify and solve performa
 * Examine [database query traces](/docs/apm/transactions/transaction-traces/sql-statements)
 * Examine [error traces](/docs/apm/applications-menu/events/viewing-apm-errors-error-traces)
 
-**View logs for your APM and infrastructure data**
+**View logs for your infrastructure data**
 
 Bring your logs and application's data together to make troubleshooting easier and faster. No need to switch to another UI page in New Relic One.
 

--- a/src/content/docs/logs/logs-context/annotate-logs-logs-context-using-apm-agent-apis.mdx
+++ b/src/content/docs/logs/logs-context/annotate-logs-logs-context-using-apm-agent-apis.mdx
@@ -88,6 +88,9 @@ APM agent APIs:
       <td>
         * [newrelic_get_trace_metadata](/docs/apm/agents/php-agent/php-agent-api/newrelicgettracemetadata/)
         * [newrelic_get_linking_metadata](/docs/apm/agents/php-agent/php-agent-api/newrelicgetlinkingmetadata/)
+        <Callout variant="tip">
+        For PHP, logs in context is only supported from the distributed tracing UI, not in the **Logs** tab of the APM UI.
+        </Callout>
       </td>
     </tr>
     <tr>

--- a/src/content/docs/logs/logs-context/annotate-logs-logs-context-using-apm-agent-apis.mdx
+++ b/src/content/docs/logs/logs-context/annotate-logs-logs-context-using-apm-agent-apis.mdx
@@ -90,9 +90,9 @@ APM agent APIs:
         * [newrelic_get_linking_metadata](/docs/apm/agents/php-agent/php-agent-api/newrelicgetlinkingmetadata/)
 
 
-<Callout variant="tip">
-For PHP, logs in context is only supported from the distributed tracing UI, not in the **Logs** tab of the APM UI.
-</Callout>
+        <Callout variant="tip">
+        For PHP, logs in context is only supported from the distributed tracing UI, not in the **Logs** tab of the APM UI.
+        </Callout>
       </td>
     </tr>
     <tr>

--- a/src/content/docs/logs/logs-context/annotate-logs-logs-context-using-apm-agent-apis.mdx
+++ b/src/content/docs/logs/logs-context/annotate-logs-logs-context-using-apm-agent-apis.mdx
@@ -88,9 +88,11 @@ APM agent APIs:
       <td>
         * [newrelic_get_trace_metadata](/docs/apm/agents/php-agent/php-agent-api/newrelicgettracemetadata/)
         * [newrelic_get_linking_metadata](/docs/apm/agents/php-agent/php-agent-api/newrelicgetlinkingmetadata/)
-        <Callout variant="tip">
-        For PHP, logs in context is only supported from the distributed tracing UI, not in the **Logs** tab of the APM UI.
-        </Callout>
+
+
+<Callout variant="tip">
+For PHP, logs in context is only supported from the distributed tracing UI, not in the **Logs** tab of the APM UI.
+</Callout>
       </td>
     </tr>
     <tr>

--- a/src/content/docs/logs/logs-context/annotate-logs-logs-context-using-apm-agent-apis.mdx
+++ b/src/content/docs/logs/logs-context/annotate-logs-logs-context-using-apm-agent-apis.mdx
@@ -89,10 +89,8 @@ APM agent APIs:
         * [newrelic_get_trace_metadata](/docs/apm/agents/php-agent/php-agent-api/newrelicgettracemetadata/)
         * [newrelic_get_linking_metadata](/docs/apm/agents/php-agent/php-agent-api/newrelicgetlinkingmetadata/)
 
-
-        <Callout variant="tip">
         For PHP, logs in context is only supported from the distributed tracing UI, not in the **Logs** tab of the APM UI.
-        </Callout>
+   
       </td>
     </tr>
     <tr>

--- a/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
@@ -104,7 +104,7 @@ If the logs from your application do not include fields like `trace.id` and `spa
 After you set up APM logs in context, make the most of your logging data:
 
 * Explore the logging data across your platform with our [Logs UI](/docs/logs/log-management/ui-data/use-logs-ui/).
-* You can view your logs in context data in [distributed tracing](/docs/apm/distributed-tracing/ui-data/understand-use-distributed-tracing-data), but note that for PHP, logs in context data doesn't appear in the **Logs** tab of the APM UI.
+* View your logs in context data in [distributed tracing](/docs/apm/distributed-tracing/ui-data/understand-use-distributed-tracing-data). Note that for PHP, logs in context data doesn't appear in the **Logs** tab of the APM UI.
 * Get deeper visibility into both your application and your platform performance data by forwarding your logs with our [infrastructure monitoring agent](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent/). Review your [infrastructure logs](/docs/logs/log-management/ui-data/use-logs-ui/#links) in the UI.
 * Set up [alerts](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions/).
 * [Query your data](/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data/) and [create dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/).

--- a/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
@@ -104,7 +104,7 @@ If the logs from your application do not include fields like `trace.id` and `spa
 After you set up APM logs in context, make the most of your logging data:
 
 * Explore the logging data across your platform with our [Logs UI](/docs/logs/log-management/ui-data/use-logs-ui/).
-* See your logs in context of your app's performance in the [APM UI](/docs/logs/log-management/ui-data/use-logs-ui/#links). Troubleshoot [errors](/docs/apm/apm-ui-pages/error-analytics/errors-page-find-fix-verify-problems/) with [distributed tracing](/docs/apm/distributed-tracing/ui-data/understand-use-distributed-tracing-data), stack traces, application logs, and more.
+* You can view your logs in context data in [distributed tracing](/docs/apm/distributed-tracing/ui-data/understand-use-distributed-tracing-data), but note that for PHP, logs in context data doesn't appear in the **Logs** tab of the APM UI.
 * Get deeper visibility into both your application and your platform performance data by forwarding your logs with our [infrastructure monitoring agent](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent/). Review your [infrastructure logs](/docs/logs/log-management/ui-data/use-logs-ui/#links) in the UI.
 * Set up [alerts](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions/).
 * [Query your data](/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data/) and [create dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/).


### PR DESCRIPTION
We had a contributor mention that logs in context isn't available for PHP apps directly in the Logs tab of APM. It is only supported in the distributed tracing pages.