### PR TITLE
Applied-Intelligence 'Notifications' docs - new custom helper for handlebars

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/notifications/message-templates.mdx
+++ b/src/content/docs/alerts-applied-intelligence/notifications/message-templates.mdx
@@ -173,7 +173,7 @@ Render 'y' or 'n':
 ```handlebars
 {{#replace needle haystack }}{{replacement}}{{/replace}}
   ```
-  with data:
+  using this data:
 ```json
 {
   "needle": "/dog/i",

--- a/src/content/docs/alerts-applied-intelligence/notifications/message-templates.mdx
+++ b/src/content/docs/alerts-applied-intelligence/notifications/message-templates.mdx
@@ -116,15 +116,15 @@ Render 'y' or 'n':
 
     <Collapser
     className="freq-link"
-    id="repalce"
+    id="replace"
     title="Replace"
   >
 
   The `replace` helper replaces instances of the first parameter in the second parameter with the child block.
 
-  Use `else` clause to specify what happends when no instance of the first parameter is found. If it is omitted an empty string will be generated.
+  Use `else` clause to specify what happens when no instance of the first parameter is found. If it is omitted an empty string will be generated.
 
-  Example #1 - try to replace the word `dog` by `cat` in the sentance `The dog likes to eat`:
+  Example #1: replace the word `dog` with `cat` in the sentence `The dog likes to eat`:
 
 ```handlebars
 {{#replace "dog" "The dog likes to eat"}}cat{{/replace}}
@@ -135,7 +135,7 @@ Render 'y' or 'n':
   The cat likes to eat
 ```
 
-  Example #2 - try to replace the word `cat` by `mouse` in the sentance `The dog likes to eat`:
+  Example #2: replace the word `cat` with `mouse` in the sentence `The dog likes to eat`:
 
 ```handlebars
 {{#replace "cat" "The dog likes to eat"}}mouse{{/replace}}
@@ -145,7 +145,7 @@ Render 'y' or 'n':
 ```
 ```
 
-  Example #3 - try to replace the word `cat` by `mouse` in the sentance `The dog likes to eat` with `There is no cat to replace` `elses` clause:
+  Example #3: replace the word `cat` with `mouse` in the sentence `The dog likes to eat`, using the `else` clause:
 
 ```handlebars
 {{#replace "cat" "The dog likes to eat"}}mouse{{else}}There is no cat to replace{{/replace}}
@@ -157,7 +157,7 @@ Render 'y' or 'n':
 ```
 
 
-  Example #4 - try to replace the word `dog` by `cat` in the sentance `The DOG likes to eat` while ignoring case:
+  Example #4: replace the word `dog` with `cat` in the sentence `The DOG likes to eat` while ignoring case:
 
 ```handlebars
 {{#replace "/dog/i" "The DOG likes to eat"}}cat{{/replace}}
@@ -168,7 +168,7 @@ Render 'y' or 'n':
   The cat likes to eat
 ```
 
-  Example #5 - try to replace the variable `{{needle}}` by the variable `{{replacement}}` in the variable `{{haystack}}`:
+  Example #5: replace the variable `{{needle}}` with the variable `{{replacement}}` in the variable `{{haystack}}`:
 
 ```handlebars
 {{#replace needle haystack }}{{replacement}}{{/replace}}

--- a/src/content/docs/alerts-applied-intelligence/notifications/message-templates.mdx
+++ b/src/content/docs/alerts-applied-intelligence/notifications/message-templates.mdx
@@ -14,7 +14,7 @@ The features described here are early access. You won't be able to use these fea
 For more information on related features, see our docs on [Alerts notification channels](/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts/), [Incident Intelligence destinations](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/incident-intelligence-destination-examples/), and [Proactive Detection notifications](https://docs.newrelic.com/docs/alerts-applied-intelligence/applied-intelligence/proactive-detection/proactive-detection-applied-intelligence/#set-up).
 </Callout>
 
-Notification message templates enable you to customize your notification event data before it's sent to your third-party destination. The templates map your custom values to the values used by your third-party destination. 
+Notification message templates enable you to customize your notification event data before it's sent to your third-party destination. The templates map your custom values to the values used by your third-party destination.
 
 This gives you full control over what data will be sent and where, as well as being able to fully engage with the services you use.
 
@@ -30,7 +30,7 @@ Message templates are written in a simple templating language called [Handlebars
 
 ## The variables menu [#variables-menu]
 
-All of the New Relic variable names are listed in the message template variables menu. The variables are grouped into subcategories. 
+All of the New Relic variable names are listed in the message template variables menu. The variables are grouped into subcategories.
 
 In the variables menu, type `{{` to select from a list of variables. As you type, variable names appear via autocomplete. The variable type is written on the right-hand side. You can add enriched data to these variables.
 
@@ -112,8 +112,82 @@ Render 'y' or 'n':
 {{eq a b yes='y' no='n'}}
 ```
 
-  </Collapser>  
-</CollapserGroup>
+  </Collapser>
+
+    <Collapser
+    className="freq-link"
+    id="repalce"
+    title="Replace"
+  >
+
+  The `replace` helper replaces instances of the first parameter in the second parameter with the child block.
+
+  Use `else` clause to specify what happends when no instance of the first parameter is found. If it is omitted an empty string will be generated.
+
+  Example #1 - try to replace the word `dog` by `cat` in the sentance `The dog likes to eat`:
+
+```handlebars
+{{#replace "dog" "The dog likes to eat"}}cat{{/replace}}
+```
+  to get:
+
+```
+  The cat likes to eat
+```
+
+  Example #2 - try to replace the word `cat` by `mouse` in the sentance `The dog likes to eat`:
+
+```handlebars
+{{#replace "cat" "The dog likes to eat"}}mouse{{/replace}}
+```
+  to get an empty string:
+
+```
+```
+
+  Example #3 - try to replace the word `cat` by `mouse` in the sentance `The dog likes to eat` with `There is no cat to replace` `elses` clause:
+
+```handlebars
+{{#replace "cat" "The dog likes to eat"}}mouse{{else}}There is no cat to replace{{/replace}}
+```
+  to get:
+
+```
+  There is no cat to replace
+```
+
+
+  Example #4 - try to replace the word `dog` by `cat` in the sentance `The DOG likes to eat` while ignoring case:
+
+```handlebars
+{{#replace "/dog/i" "The DOG likes to eat"}}cat{{/replace}}
+```
+  to get:
+
+```
+  The cat likes to eat
+```
+
+  Example #5 - try to replace the variable `{{needle}}` by the variable `{{replacement}}` in the variable `{{haystack}}`:
+
+```handlebars
+{{#replace needle haystack }}{{replacement}}{{/replace}}
+  ```
+  with data:
+```json
+{
+  "needle": "/dog/i",
+  "haystack": "The DOG likes to eat",
+  "replacement": "cat"
+}
+```
+  to get:
+
+```
+  The cat likes to eat
+```
+    </Collapser>
+  </CollapserGroup>
 
 ## Usage examples [#usage-examples]
 
@@ -220,7 +294,7 @@ In some cases, an attribute may be missing from the [variables menu](/docs/alert
 We can use the `#if` statement to set a fallback, such as:
 
 ```handlebars
-{{#if data.type}} {{ json data.type }} {{else}}"N/A"{{/if}} 
+{{#if data.type}} {{ json data.type }} {{else}}"N/A"{{/if}}
 ```
 
 would return the string `"N/A"`.


### PR DESCRIPTION
Note from @zuluecho9: This will be deleted and the changes from it included in https://github.com/newrelic/docs-website/pull/5179. 

Adds documentation for the new `replace` helper in handlebars for Applied-Intelligence 'Notifications'