### PR TITLE
fix(nav): add licenses directory to home page left nav

### DIFF
--- a/src/nav/root.yml
+++ b/src/nav/root.yml
@@ -49,7 +49,7 @@ pages:
   - title: Security and privacy
     path: /docs/security
   - title: Licenses
-    path: /licenses
+    path: /docs/licenses
   - title: What's new?
     path: /whats-new
   - title: section-break

--- a/src/nav/root.yml
+++ b/src/nav/root.yml
@@ -44,12 +44,12 @@ pages:
     path: /docs/data-apis
   - title: Data dictionary
     path: /attribute-dictionary
-  - title: Licenses
-    path: /licenses
   - title: 'Release notes'
     path: '/docs/release-notes'
   - title: Security and privacy
     path: /docs/security
+  - title: Licenses
+    path: /licenses
   - title: What's new?
     path: /whats-new
   - title: section-break

--- a/src/nav/root.yml
+++ b/src/nav/root.yml
@@ -44,6 +44,8 @@ pages:
     path: /docs/data-apis
   - title: Data dictionary
     path: /attribute-dictionary
+  - title: Licenses
+    path: /licenses
   - title: 'Release notes'
     path: '/docs/release-notes'
   - title: Security and privacy


### PR DESCRIPTION
This adds the licenses category to the left nav of the home page per hero request. 