### PR TITLE
Update actionText data dictionary entry

### DIFF
--- a/src/data-dictionary/events/BrowserInteraction/actionText.md
+++ b/src/data-dictionary/events/BrowserInteraction/actionText.md
@@ -3,6 +3,9 @@ name: actionText
 type: attribute
 events:
   - BrowserInteraction
+  - AjaxRequest
+  - JavaScriptError
+  - BrowserTiming
 ---
 
-The text of the HTML element that was clicked when a browser interaction started.
+The text of the HTML element that was clicked when a browser interaction started. This attribute is added to `BrowserInteraction` events and any `AjaxRequest`, `JavaScriptError` and `BrowserTiming` events that occurred during that interaction.


### PR DESCRIPTION
## Give us some context

This PR updates the data dictionary to better reflect the behavior of the actionText attribute. actionText is added to BrowserInteraction events and represents either the text of the element that was clicked to trigger that interaction, or the value set using the [actionText API](https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/actiontext-browser-spa-api/) call. I'm unclear on the exact historical context of when this behavior was introduced but for at least the last few years the actionText attribute has been present not just on the BrowserInteraction event, but all events that are considered to be a part of the interaction. Those events could be AjaxRequests, JavaScriptErrors or BrowserTiming events.