### PR TITLE
Release notes for Go Agent v3.15.2

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-15-2.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-15-2.mdx
@@ -1,0 +1,14 @@
+---
+subject: Go agent
+releaseDate: '2021-12-06'
+version: 3.15.2
+downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.15.2'
+---
+
+## 3.15.2
+### Added
+* Strings logged via the Go Agent's built-in logger will have strings of the form `license_key=`*hex-string* changed to `license_key=[redacted]` before they are output, regardless of severity level, where *hex-string* means a sequence of upper- or lower-case hexadecimal digits and dots ('.'). This incorporates [PR #415](https://github.com/newrelic/go-agent/pull/415).
+
+### Support Statement
+New Relic recommends that you upgrade the agent regularly to ensure that you’re getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach end-of-life.
+

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-15-2.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-15-2.mdx
@@ -7,7 +7,7 @@ downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.15.2'
 
 ## 3.15.2
 ### Added
-* Strings logged via the Go Agent's built-in logger will have strings of the form `license_key=`*hex-string* changed to `license_key=[redacted]` before they are output, regardless of severity level, where *hex-string* means a sequence of upper- or lower-case hexadecimal digits and dots ('.'). This incorporates [PR #415](https://github.com/newrelic/go-agent/pull/415).
+* Strings logged via the Go agent's built-in logger will have strings of the form `license_key=`*hex-string* changed to `license_key=[redacted]` before they are output, regardless of severity level, where *hex-string* means a sequence of upper- or lower-case hexadecimal digits and dots ('.'). This incorporates [PR #415](https://github.com/newrelic/go-agent/pull/415).
 
 ### Support Statement
 New Relic recommends that you upgrade the agent regularly to ensure that you’re getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach end-of-life.


### PR DESCRIPTION
## 3.15.2
### Added
* Strings logged via the Go Agent's built-in logger will have strings of the form `license_key=`*hex-string* changed to `license_key=[redacted]` before they are output, regardless of severity level, where *hex-string* means a sequence of upper- or lower-case hexadecimal digits and dots ('.'). This incorporates [PR #415](https://github.com/newrelic/go-agent/pull/415).

### Support Statement
New Relic recommends that you upgrade the agent regularly to ensure that you’re getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach end-of-life.
