### PR TITLE
Link addition

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/mlops/bring-your-own/mlops-byo.mdx
+++ b/src/content/docs/alerts-applied-intelligence/mlops/bring-your-own/mlops-byo.mdx
@@ -12,7 +12,7 @@ New Relic has entered the [MLOps](/docs/alerts-applied-intelligence/mlops/get-st
 
 Once your production reaches a certain point in terms of the number of models it has to monitor, it becomes difficult to keep track of your data and model KPIs, resulting in even more complex systems. With **bring your own data (BYO)**, after just a few minutes, you can quickly send your model’s inference and metric data to the New Relic platform, directly from a notebook or any other environment.
 
-The `new-relic-ml-performance-monitoring`python package, based on [`newrelic-telemetry-sdk-python`](https://github.com/newrelic/newrelic-telemetry-sdk-python), allows you to send your model’s features and prediction values, as well as custom metrics, by simply adding a few lines to your code. 
+The [`ml-performance-monitoring`](https://github.com/newrelic-experimental/ml-performance-monitoring) python package, based on [`newrelic-telemetry-sdk-python`](https://github.com/newrelic/newrelic-telemetry-sdk-python), allows you to send your model’s features and prediction values, as well as custom metrics, by simply adding a few lines to your code. 
 
 Use the python package to send the following types of data to New Relic:
 


### PR DESCRIPTION
I added this link https://github.com/newrelic-experimental/ml-performance-monitoring to ml-performance-monitoring, which was missing
