### PR TITLE
Add translation disclaimer

### DIFF
--- a/src/content/docs/licenses/translated-documentation/translation-disclaimer.mdx
+++ b/src/content/docs/licenses/translated-documentation/translation-disclaimer.mdx
@@ -1,0 +1,14 @@
+---
+title: Translation disclaimer
+tags:
+  - Licenses
+  - License information
+  - Translation
+metaDescription: 'Information about translations of New Relic documents'
+---
+
+The official version of the Documentation is in English. Portions of the New Relic Documentation may be translated for your convenience as shown on this site. 
+
+Translated content may contain errors, discrepancies, or differences created in the translation, are not binding, and have no legal effect for enforcement or compliance purposes. New Relic does not make any warranty, express or implied, as to the accuracy, reliability, or correctness of any translated Documentation from the English original to any other language. 
+
+Any guarantees or commitments in your Agreement with New Relic that the Services, products, or other offerings conform or are consistent with the Documentation do not apply to the extent to which the Documentation has been translated.

--- a/src/nav/licenses.yml
+++ b/src/nav/licenses.yml
@@ -155,3 +155,7 @@ pages:
             path: /docs/licenses/license-information/referenced-policies/service-level-availability-commitment
           - title: Pre-release policy
             path: /docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy
+  - title: Translated documentation
+    pages:
+      - title: Translation disclaimer
+        path: /docs/licenses/translated-documentation/translation-disclaimer


### PR DESCRIPTION
Add new category under licenses documentation that contains the disclaimer for translations.