### PR TITLE
Update configure-kubernetes-proxy.mdx

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/configure-kubernetes-proxy.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/configure-kubernetes-proxy.mdx
@@ -9,7 +9,7 @@ redirects:
   - /docs/integrations/kubernetes-integration/installation/configure-kubernetes-proxy
 ---
 
-If you are running our Kuberenetes integration with a proxy, you need to configure each component (the [infrastructure agent](/docs/infrastructure/install-infrastructure-agent), logging, Kubernetes events, etc.) to correctly work with your proxy.
+If you are running our Kubernetes integration with a proxy, you need to configure each component (the [infrastructure agent](/docs/infrastructure/install-infrastructure-agent), logging, Kubernetes events, etc.) to correctly work with your proxy.
 
 ## Install the infrastructure agent with a proxy [#infrastructure-agent]
 
@@ -32,7 +32,7 @@ There are three options to install the infrastructure agent with a proxy:
 
 If you’re using [log forwarding for the Kubernetes integration](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/kubernetes-plugin-log-forwarding), the plugin automatically detects the `HTTP_PROXY` and `HTTPS_PROXY` environment variables, and automatically uses them to set up the proxy configuration. For more information, see [how to customize the proxy, or bypass it](https://github.com/newrelic/newrelic-fluent-bit-output#proxy-support).
 
-## Install Kubernetes events [#Kubernetes-events]
+## Install Kubernetes events with a proxy [#Kubernetes-events]
 
 There are three options to install the [Kubernetes events integration](/docs/integrations/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration) with a proxy:
 
@@ -48,7 +48,7 @@ There are three options to install the [Kubernetes events integration](/docs/int
   * When installing [through the manifest](https://download.newrelic.com/infrastructure_agent/integrations/kubernetes/nri-kube-events-latest.yaml), to configure the proxy set the `NRIA_PROXY` in the environment variable section of the infra container.
   * Check the [deployment template](https://github.com/newrelic/helm-charts/blob/556d7d970d65ac1a9dcd30d6b7093b1e163cb281/charts/nri-kube-events/templates/deployment.yaml#L70) of the chart as an example of environment variable configuration.
 
-## Install the Prometheus OpenMetrics integration [#prometheus-openmetrics]
+## Install the Prometheus OpenMetrics integration with a proxy [#prometheus-openmetrics]
 
 There are three options to install the [Prometheus OpenMetric integration](/docs/integrations/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic) with a proxy:
 
@@ -73,6 +73,20 @@ There are three options to install the [Prometheus OpenMetric integration](/docs
     # emitter_proxy: "<a href="http://localhost:8888/">http://localhost:8888</a>"
     ```
 
-## Set the synthetics minion [#synthetics]
+## Set the synthetics minion to use a proxy [#synthetics]
 
 Check this README [on how to set the proxy](https://github.com/newrelic/helm-charts/tree/master/charts/synthetics-minion) for the [Synthetics minions](/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms).
+
+## Install the Pixie integration with a proxy [#pixie]
+
+There are two options to install the Pixie integration with a proxy:
+
+* Installing with chart `newrelic-pixie`:
+  * The proxy can be configured setting the configuration option `proxy` as described in the [values.yaml](https://github.com/newrelic/helm-charts/blob/334ce7ae4e9753acea9e35c5b923a6795cea262e/charts/newrelic-pixie/values.yaml#L32) of the chart.  
+  
+* Installing with chart `nri-bundle` as a dependency:
+  * The proxy can be configured setting the configuration option `newrelic-pixie.proxy`. The configuration option is passed [down to the dependency](https://github.com/newrelic/helm-charts/tree/master/charts/nri-bundle#configure-dependencies) `newrelic-pixie` modifying the `values.yaml` of `nri-bundle`:
+
+    ```
+    newrelic-pixie.proxy: https://user:password@hostname:port
+    ```


### PR DESCRIPTION
Add description of proxy settings for Pixie integration component of the nri-bundle chart.

Fix spelling of "Kubernetes".

Improve section headers, to clarify that each section of the docs relates specifically to the use of proxies with these integrations.