### PR TITLE
chore(style guide): Consistent punctuation in usage dictionary

### DIFF
--- a/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
@@ -10,6 +10,7 @@ redirects:
 ---
 
 For consistency across New Relic content, here are our general word usage guidelines:
+
 - We generally follow the [Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/), which is based on the Chicago Manual of Style.
 - We follow American English conventions, rather than British English ones.
 - We defer to the official product names for references to products. (For example, for Amazon Web Services (AWS), see [aws.amazon.com/products](https://aws.amazon.com/products/).) 
@@ -389,7 +390,7 @@ For consistency across New Relic content, here are our general word usage guidel
     id="infrastructure"
     title="infrastructure"
   >
-    Don't use, unless referring to the New Relic Infrastructure product. 
+    Avoid using generically, to avoid confusion with infrastructure monitoring.
     
     Instead, use an appropriate substitute such as `architecture`, `environment`, `system`, `host`, etc.
   </Collapser>
@@ -418,7 +419,7 @@ For consistency across New Relic content, here are our general word usage guidel
     id="master-account"
     title="master account"
   >
-    We previously used "master account" and "sub-account" but now we use [parent account](#parent-account) and child account. 
+    We previously used `master account` and `sub-account` but now we use [`parent account`](#parent-account) and `child account`. 
   </Collapser>
 
   <Collapser
@@ -453,7 +454,7 @@ For consistency across New Relic content, here are our general word usage guidel
     * Avoid phrasing that makes New Relic One sound like a separate product or a separate platform. There is a single New Relic platform through which our users interact with our products.
     * Avoid mentioning New Relic One where it can be avoided. For example, instead of saying "Use New Relic One workloads to...", you could instead say, "In New Relic, you can use workloads to..." and then in the doc explain where to find the feature. Another example: instead of referring to "The programmable New Relic One platform," we might say, "The New Relic platform is programmable: To start building, go to [one.newrelic.com](http://one.newrelic.com) and..."
     * Do not use `NR1` or `nr1` as an abbreviation of `New Relic One`. The only reason to use `nr1` is when referring to the `nr1` package or library (for example: a reference to the command `nr1 nerdpack:serve`).
-    * In general, we want to avoid overloading our docs with "New Relic".
+    * In general, we want to avoid overloading our docs with `New Relic`.
 
     For more details, see the [New Relic One messaging guidelines](https://docs.google.com/document/d/1AB2OzkoNhi6clq6xdQzadzG2dDc6ZnIkRRBOxUEb7JQ/edit#), the docs [glossary entry](/docs/using-new-relic/welcome-new-relic/get-started/glossary#new-relic-one), or the [New Relic One docs](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one).
   </Collapser>
@@ -621,7 +622,7 @@ For consistency across New Relic content, here are our general word usage guidel
     id="we"
     title="we"
   >
-    Say “we” and “our” when it works with the flow of your writing. Avoid overloading paragraphs with “New Relic” mentions, or reword so the focus is on the user, not New Relic. For example, avoid writing something like this:
+    Say `we` and `our` when it works with the flow of your writing. Avoid overloading paragraphs with `New Relic` mentions, or reword so the focus is on the user, not New Relic. For example, avoid writing something like this:
 
     ```
     New Relic recommends setting a startup timeout.
@@ -644,6 +645,6 @@ For consistency across New Relic content, here are our general word usage guidel
     id="you"
     title="you"
   >
-    We use “you” and “your” liberally in our docs. Addressing the reader directly makes for simpler, cleaner sentences. It also tends to expose lazy uses of passive construction and it helps users to understand procedures.
+    We use `you` and `your` liberally in our docs. Addressing the reader directly makes for simpler, cleaner sentences. It also tends to expose lazy uses of passive construction and it helps users to understand procedures.
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
Consistently use code formatting (backticks) instead of quote marks.