### PR TITLE
Applied-Intelligence 'Notifications' docs - new Email Integration and minors

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/notifications/destinations.mdx
+++ b/src/content/docs/alerts-applied-intelligence/notifications/destinations.mdx
@@ -24,7 +24,7 @@ The supported destination platforms include:
 * ServiceNow
 * Slack
 * Webhook
-* Coming soon: Email 
+* Email 
 
 
 For more on these and other destinations, see [notification integrations](/docs/alerts-applied-intelligence/notifications/notification-integrations).

--- a/src/content/docs/alerts-applied-intelligence/notifications/message-templates.mdx
+++ b/src/content/docs/alerts-applied-intelligence/notifications/message-templates.mdx
@@ -255,7 +255,7 @@ Iterate a variable of type array and aggregate the values into a string:
 {{#each tags}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}
 ```
 
-The result contains the tags, seperated by commas(trailing comma is omitted):
+The result contains the tags, seperated by commas (the trailing comma is omitted):
 
 ```shell
 infra, team

--- a/src/content/docs/alerts-applied-intelligence/notifications/message-templates.mdx
+++ b/src/content/docs/alerts-applied-intelligence/notifications/message-templates.mdx
@@ -30,13 +30,13 @@ Message templates are written in a simple templating language called [Handlebars
 
 ## The variables menu [#variables-menu]
 
-All of the New Relic variable names are listed in the message template variables menu. The variables are grouped into subcategories.
+The New Relic variable names are listed in the message template variables menu. The variables are grouped into subcategories. 
 
 In the variables menu, type `{{` to select from a list of variables. As you type, variable names appear via autocomplete. The variable type is written on the right-hand side. You can add enriched data to these variables.
 
 ![A screenshot of the variables menu that. shows the breadth of variable options available.](./images/notification-custom-variables.png "The variables menu that shows the breadth of variable options available.")
 
-<figcaption>The variables menu shows all of the options you have when mapping New Relic notification fields onto the fields in your external service.</figcaption>
+<figcaption>The variables menu shows the options you have when mapping New Relic notification fields onto the fields in your external service.</figcaption>
 
 ## Use the Handlebars syntax [#handlebars-syntax]
 
@@ -46,7 +46,7 @@ The Handlebars language provides many features in addition to basic variable rep
 
 ## Helper functions [#help-functions]
 
-Our message templates support all of the Handlebars [built-in helpers](https://handlebarsjs.com/guide/builtin-helpers.html).
+Our message templates support the Handlebars [built-in helpers](https://handlebarsjs.com/guide/builtin-helpers.html).
 
 In addition, we've added other helpers that might be useful to you.
 
@@ -99,7 +99,7 @@ Compares variables a and b, renders 'yes' or 'no':
 
 {{#eq a b}} yes {{else}} no {{/eq}}
 
-Compares String value "a" to variable b, renders 'yes' or 'no':
+Compares string value "a" to variable b, renders 'yes' or 'no':
 
 {{#eq "a" b}} yes {{else}} no {{/eq}}
 
@@ -249,13 +249,13 @@ This would return the first value from the array:
 
 ### Iterate through an array [#iterate-array]
 
-Iterate a variable of type array and aggregate the values such as:
+Iterate a variable of type array and aggregate the values into a string:
 
 ```handlebars
 {{#each tags}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}
 ```
 
-This would return all of the values from each tag:
+The result contains the tags, seperated by commas(trailing comma is omitted):
 
 ```shell
 infra, team
@@ -275,7 +275,7 @@ This would return a JSON such as:
 }
 ```
 
-Iterate the `data` variable, then aggregate the object’s entries to a String:
+Iterate the `data` variable, then aggregate the object’s entries to a string:
 
 ```handlebars
 {{#each data}}{{@key}}: {{this}}{{#unless @last}}, {{/unless}}{{/each}}

--- a/src/content/docs/alerts-applied-intelligence/notifications/notification-integrations.mdx
+++ b/src/content/docs/alerts-applied-intelligence/notifications/notification-integrations.mdx
@@ -274,15 +274,16 @@ If the webhook payload conforms a valid Json, you can send a test notification t
     title="Email"
   >
 **Send email notifications to users.**
-## Configure the Email settings [#configure-email-settings]
+      
+## Configure the email settings [#configure-email-settings]
 
 Add one or more recipients. Users with New Relic accounts can be found via autocomplete when searching for their name or email address.
 
 To add a user without a New Relic account or email distribution list, add the full email address.
 
-Every recipient will be translated into a 'destination'. You can follow the email notifications per distination in the [notifications-log](/docs/alerts-applied-intelligence/notifications/destinations/#notifications-log)
+Every recipient will be translated into a 'destination'. You can follow the email notifications per destination in the [notifications-log](/docs/alerts-applied-intelligence/notifications/destinations/#notifications-log)
 
-![A screenshot of the Email settings.](./images/email_settings.png "Email settings")
+![A screenshot of the email settings.](./images/email_settings.png "Email settings")
 
 ### Send a test notification [#email-test]
 

--- a/src/content/docs/alerts-applied-intelligence/notifications/notification-integrations.mdx
+++ b/src/content/docs/alerts-applied-intelligence/notifications/notification-integrations.mdx
@@ -268,4 +268,26 @@ If the webhook payload conforms a valid Json, you can send a test notification t
 <figcaption>We recommend sending a test notification to make sure that everything's connected correctly.</figcaption>
 
   </Collapser>
+    <Collapser
+    className="freq-link"
+    id="email"
+    title="Email"
+  >
+**Send email notifications to users.**
+## Configure the Email settings [#configure-email-settings]
+
+Add one or more recipients. Users with New Relic accounts can be found via autocomplete when searching for their name or email address.
+
+To add a user without a New Relic account or email distribution list, add the full email address.
+
+Every recipient will be translated into a 'destination'. You can follow the email notifications per distination in the [notifications-log](/docs/alerts-applied-intelligence/notifications/destinations/#notifications-log)
+
+![A screenshot of the Email settings.](./images/email_settings.png "Email settings")
+
+### Send a test notification [#email-test]
+
+You can send a test notification to make sure the email notifications reach the inbox.
+
+
+  </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
This contains update for the Applied-Intelligence 'Notifications' docs

New docs for the new Email integration and minor phrasing changes to the 'templates' page 
