### PR TITLE
docs: fixed broken otel integrations link

### DIFF
--- a/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
+++ b/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
@@ -27,7 +27,7 @@ Here are some technical details about how New Relic [distributed tracing](/docs/
 
 ## Trace sampling [#sampling]
 
-How your traces are sampled will depend on your setup and the New Relic tracing tool you're using. For example, you may be using a [third-party telemetry service](/docs/integrations/open-source-telemetry-integrations) (like OpenTelemetry) to implement sampling of traces before your data gets to us. Or, if you're using [Infinite Tracing](/docs/understand-dependencies/distributed-tracing/infinite-tracing/introduction-infinite-tracing), you'd probably send us all your trace data and use our sampling.
+How your traces are sampled will depend on your setup and the New Relic tracing tool you're using. For example, you may be using a [third-party telemetry service](/docs/more-integrations/open-source-telemetry-integrations/get-started/introduction-new-relics-open-source-telemetry-integrations/) (like OpenTelemetry) to implement sampling of traces before your data gets to us. Or, if you're using [Infinite Tracing](/docs/understand-dependencies/distributed-tracing/infinite-tracing/introduction-infinite-tracing), you'd probably send us all your trace data and use our sampling.
 
 We have a few sampling strategies available:
 


### PR DESCRIPTION
This link returns a 404: https://docs.newrelic.com/docs/integrations/open-source-telemetry-integrations/

As best as I can determine the this link is attempting to route to: https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/get-started/introduction-new-relics-open-source-telemetry-integrations/

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.