### PR TITLE
Adding one missing explicit delay for AWS ELB

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/troubleshooting/metric-data-delays-amazon-aws-integrations.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/troubleshooting/metric-data-delays-amazon-aws-integrations.mdx
@@ -62,6 +62,7 @@ Depending on the Amazon AWS integration, New Relic Infrastructure may experience
         Explicit delays may come from these Infrastructure Amazon integrations:
 
         * [ALB](/docs/aws-alb-integration): 5 minutes
+        * [ELB](/docs/aws-elb-integration): 5 minutes
         * [CloudFront](/docs/infrastructure/amazon-integrations/amazon-integrations/aws-cloudfront-monitoring-integration): 1 minute
         * [RDS](/docs/infrastructure/amazon-integrations/amazon-integrations/aws-rds-monitoring-integration): 5 minutes
         * [SNS](/docs/infrastructure/amazon-integrations/amazon-integrations/aws-sns-monitoring-integration): 10 minutes


### PR DESCRIPTION
## Give us some context
* We detected the AWS ELB service also has an explicit delay of 5' which was not documented. Added. 