### PR TITLE
chore: Java agent release notes 6.5.1 and 7.4.1

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-651.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-651.mdx
@@ -1,0 +1,15 @@
+---
+subject: Java agent
+releaseDate: '2021-12-10 00:00:00'
+version: 6.5.1
+downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/6.5.1/'
+---
+
+### Fixes
+* Upgraded log4j to 2.15.0 to mitigate the security vulnerability CVE-2021-44228. [605](https://github.com/newrelic/newrelic-java-agent/issues/605)
+
+### Support statement:
+* New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and
+  performance benefits. Additionally, older releases will no longer be supported when they reach
+  [end-of-life](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software/).
+

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-741.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-741.mdx
@@ -1,0 +1,15 @@
+---
+subject: Java agent
+releaseDate: '2021-12-10 00:00:01'
+version: 7.4.1
+downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/7.4.1/'
+---
+
+### Fixes
+* Upgraded log4j to 2.15.0 to mitigate the security vulnerability CVE-2021-44228. [605](https://github.com/newrelic/newrelic-java-agent/issues/605)
+
+### Support statement:
+* New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and
+  performance benefits. Additionally, older releases will no longer be supported when they reach
+  [end-of-life](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software/).
+


### PR DESCRIPTION
## Give us some context

Documentation on the Java agent releases that fix the security vulnerability:
https://www.cve.org/CVERecord?id=CVE-2021-44228