### PR TITLE
chore: Removing time from release notes as it breaks date parsing for…

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-651.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-651.mdx
@@ -1,6 +1,6 @@
 ---
 subject: Java agent
-releaseDate: '2021-12-10 00:00:00'
+releaseDate: '2021-12-10'
 version: 6.5.1
 downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/6.5.1/'
 ---

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-741.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-741.mdx
@@ -1,6 +1,6 @@
 ---
 subject: Java agent
-releaseDate: '2021-12-10 00:00:01'
+releaseDate: '2021-12-10'
 version: 7.4.1
 downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/7.4.1/'
 ---


### PR DESCRIPTION
… an internal system

## Give us some context
Times were added to the releaseDate field to have the releases show in a particular order.

Though this broke an internal system that expected to have only the date there.

So the time is being removed.