### PR TITLE
fix(Accounts): Fixed broken nav link

### DIFF
--- a/src/nav/accounts.yml
+++ b/src/nav/accounts.yml
@@ -10,7 +10,7 @@ pages:
           - title: Sign up for New Relic
             path: /docs/accounts/accounts-billing/account-setup/create-your-new-relic-account
           - title: Choose your data center
-            path: /docs/accounts/accounts-billing/account-setup/create-your-new-relic-account/choose-your-data-center
+            path: /docs/accounts/accounts-billing/account-setup/choose-your-data-center
           - title: Troubleshoot password and login
             path: /docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems
           - title: Downgrade or cancel account


### PR DESCRIPTION
The data center link in the left nav was broken. A bad path in the YAML file.