### PR TITLE
feat(APM/CodeStream): Add links to CodeStream env variables DOC-7574

### DIFF
--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
@@ -595,7 +595,7 @@ In this and the following examples, `config` represents your New Relic config st
   </Collapser>
 </CollapserGroup>
 
-If you're using New Relic APM and CodeStream, see [how to associate repositories](https://docs.newrelic.com/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags] with errors inbox.
+If you're using New Relic APM and CodeStream, see [how to associate repositories](/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags](/docs/codestream/start-here/codestream-new-relic/#buildsha) with errors inbox.
 
 ## Custom events configuration [#custom-insights-events-settings]
 

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
@@ -595,6 +595,8 @@ In this and the following examples, `config` represents your New Relic config st
   </Collapser>
 </CollapserGroup>
 
+If you're using New Relic APM and CodeStream, see [how to associate repositories](https://docs.newrelic.com/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags] with errors inbox.
+
 ## Custom events configuration [#custom-insights-events-settings]
 
 You can create custom events and make them available for querying and analysis.

--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -4085,7 +4085,7 @@ For agent versions 4.10.0 or higher the following environment variables are avai
   </Collapser>
 </CollapserGroup>
 
-If you're using New Relic APM and CodeStream, see [how to associate repositories](https://docs.newrelic.com/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags] with errors inbox.
+If you're using New Relic APM and CodeStream, see [how to associate repositories](/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags](/docs/codestream/start-here/codestream-new-relic/#buildsha) with errors inbox.
 
 ## Cloud platform utilization [#utilization]
 

--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -4085,6 +4085,8 @@ For agent versions 4.10.0 or higher the following environment variables are avai
   </Collapser>
 </CollapserGroup>
 
+If you're using New Relic APM and CodeStream, see [how to associate repositories](https://docs.newrelic.com/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags] with errors inbox.
+
 ## Cloud platform utilization [#utilization]
 
 These options are set in the `utilization` stanza and can be overridden by using a `newrelic.config.utilization` prefixed system property.

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -204,7 +204,7 @@ NEWRELIC_LOG_DIRECTORY=<var>path\to\a\directory</var> (Insert a directory where 
 NEWRELIC_LOG_LEVEL=<var>off|error|warn|info|debug|finest|all<var>
 ```
 
-If you're using New Relic APM and CodeStream, see [how to associate repositories](https://docs.newrelic.com/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags] with errors inbox.
+If you're using New Relic APM and CodeStream, see [how to associate repositories](/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags](/docs/codestream/start-here/codestream-new-relic/#buildsha) with errors inbox.
 
 ## Setup options, newrelic.config [#setup]
 

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -204,6 +204,8 @@ NEWRELIC_LOG_DIRECTORY=<var>path\to\a\directory</var> (Insert a directory where 
 NEWRELIC_LOG_LEVEL=<var>off|error|warn|info|debug|finest|all<var>
 ```
 
+If you're using New Relic APM and CodeStream, see [how to associate repositories](https://docs.newrelic.com/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags] with errors inbox.
+
 ## Setup options, newrelic.config [#setup]
 
 Use these options to setup and configure your agent via the newrelic.config file. The New Relic .NET agent supports the following categories of setup options:

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -61,6 +61,8 @@ Here are detailed descriptions of each configuration method:
     Most configuration settings in `newrelic.js` have equivalent environment variables. These are useful, for example, if your agent runs in a PaaS environment such as Heroku or Microsoft Azure. Node.js agent environment variables always start with `NEW_RELIC_`.
 
     Where available, these environment variables are documented below under individual config options as the **Environ variable**. There are also two rarely used settings that can [only be configured via environment variables](#environment-variable-overrides).
+
+    If you're using New Relic APM and CodeStream, see [how to associate repositories](https://docs.newrelic.com/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags] with errors inbox.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -62,7 +62,7 @@ Here are detailed descriptions of each configuration method:
 
     Where available, these environment variables are documented below under individual config options as the **Environ variable**. There are also two rarely used settings that can [only be configured via environment variables](#environment-variable-overrides).
 
-    If you're using New Relic APM and CodeStream, see [how to associate repositories](https://docs.newrelic.com/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags] with errors inbox.
+    If you're using New Relic APM and CodeStream, see [how to associate repositories](/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags](/docs/codestream/start-here/codestream-new-relic/#buildsha) with errors inbox.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -728,7 +728,7 @@ These settings are available in the `newrelic.ini` file.
   </Collapser>
 </CollapserGroup>
 
-If you're using New Relic APM and CodeStream, see [how to associate repositories](https://docs.newrelic.com/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags] with errors inbox.
+If you're using New Relic APM and CodeStream, see [how to associate repositories](/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags](/docs/codestream/start-here/codestream-new-relic/#buildsha) with errors inbox.
 
 ## Daemon .ini settings [#inivar-daemon-settings]
 

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -728,6 +728,8 @@ These settings are available in the `newrelic.ini` file.
   </Collapser>
 </CollapserGroup>
 
+If you're using New Relic APM and CodeStream, see [how to associate repositories](https://docs.newrelic.com/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags] with errors inbox.
+
 ## Daemon .ini settings [#inivar-daemon-settings]
 
 The values of these settings control the daemon startup. When the agent detects that the daemon needs to be started, it will convert these options into the appropriate command line options for the daemon.

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -73,7 +73,7 @@ Here are detailed descriptions of each configuration method:
 
     For simple configurations, you can use the environment variables in conjunction with [server-side configuration](#server-side-configuration) and avoid the agent config file altogether. This is the default setup with [Heroku](/docs/agents/python-agent/hosting-services/python-agent-heroku), where installing the New Relic add-on automatically populates the necessary environment variables.
 
-    If you're using New Relic APM and CodeStream, see [how to associate repositories](https://docs.newrelic.com/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags] with errors inbox.
+    If you're using New Relic APM and CodeStream, see [how to associate repositories](/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags](/docs/codestream/start-here/codestream-new-relic/#buildsha) with errors inbox.
 
     <table>
       <thead>

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -73,6 +73,8 @@ Here are detailed descriptions of each configuration method:
 
     For simple configurations, you can use the environment variables in conjunction with [server-side configuration](#server-side-configuration) and avoid the agent config file altogether. This is the default setup with [Heroku](/docs/agents/python-agent/hosting-services/python-agent-heroku), where installing the New Relic add-on automatically populates the necessary environment variables.
 
+    If you're using New Relic APM and CodeStream, see [how to associate repositories](https://docs.newrelic.com/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags] with errors inbox.
+
     <table>
       <thead>
         <tr>

--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -23,6 +23,8 @@ The primary (default) method to configure the Ruby agent is via the configuratio
 1. Add the prefix `NEW_RELIC_` to the setting's name.
 2. Replace any periods `.` with underscores `_`.
 
+If you're using New Relic APM and CodeStream, see [how to associate repositories](https://docs.newrelic.com/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags] with errors inbox.
+
 You can also configure a few values in the UI via [server-side configuration](/docs/agents/manage-apm-agents/configuration/server-side-agent-configuration).
 
 The Ruby agent follows this order of precedence for configuration:

--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -23,8 +23,6 @@ The primary (default) method to configure the Ruby agent is via the configuratio
 1. Add the prefix `NEW_RELIC_` to the setting's name.
 2. Replace any periods `.` with underscores `_`.
 
-If you're using New Relic APM and CodeStream, see [how to associate repositories](https://docs.newrelic.com/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags] with errors inbox.
-
 You can also configure a few values in the UI via [server-side configuration](/docs/agents/manage-apm-agents/configuration/server-side-agent-configuration).
 
 The Ruby agent follows this order of precedence for configuration:

--- a/src/content/docs/codestream/start-here/codestream-new-relic.mdx
+++ b/src/content/docs/codestream/start-here/codestream-new-relic.mdx
@@ -233,7 +233,6 @@ For more on how to set these variables, here are specific configuration details 
 * [Node.js](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/)
 * [PHP](/docs/agents/php-agent/configuration/php-agent-configuration/)
 * [Python](/docs/agents/python-agent/configuration/python-agent-configuration/)
-* [Ruby](/docs/agents/ruby-agent/configuration/ruby-agent-configuration/)
 
 ## Install APM agents with CodeStream [#install-agents]
 


### PR DESCRIPTION
Because these APM environment variables are CodeStream-specific, I thought it was better to keep in one place, instead of documenting them in each APM agent docs.

I did add links to the CodeStream docs from the relevant APM config docs.