### PR TITLE
chore: Updates supported versions of .NET Agent NServiceBus

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -534,13 +534,13 @@ If your application is hosted in ASP.NET Core, the agent automatically creates a
     id="messaging"
     title="Messaging"
   >
-    The agent automatically instruments these message systems:
+The agent automatically instruments these message systems:
 
-    NServiceBus 6.0 or higher:
+NServiceBus 6.0 or higher:
     
-    * Puts and takes on messages and [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing)
+    * Puts and takes on messages and [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing).
 
-    RabbitMQ 5.1.0 or higher:
+RabbitMQ 5.1.0 or higher:
 
     * Puts and takes on messages and queue purge. 
     * When receiving messages using an `IBasicConsumer`, the `EventingBasicConsumer` is the only implementation that is instrumented by the .NET agent. 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -538,7 +538,7 @@ If your application is hosted in ASP.NET Core, the agent automatically creates a
 
     NServiceBus 6.0 or higher:
     
-    * Puts and takes on messages and [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing)
+    * Puts and takes on messages and [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing)
 
     RabbitMQ 5.1.0 or higher:
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -536,6 +536,10 @@ If your application is hosted in ASP.NET Core, the agent automatically creates a
   >
     The agent automatically instruments these message systems:
 
+    NServiceBus 6.0 or higher:
+    
+    * Puts and takes on messages and [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing)
+
     RabbitMQ 5.1.0 or higher:
 
     * Puts and takes on messages and queue purge. 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -630,7 +630,7 @@ The .NET agent does not directly monitor datastore processes. Also, by default t
   
     NServiceBus 5.0 or higher:
     
-    * Puts and takes on messages and [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing)
+    * Puts and takes on messages and [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing)
 
     RabbitMQ 3.5 or higher:
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -622,27 +622,27 @@ The .NET agent does not directly monitor datastore processes. Also, by default t
     id="messaging"
     title="Messaging"
   >
-    The agent automatically instruments these message systems:
+The agent automatically instruments these message systems:
 
-    MSMQ:
+MSMQ:
 
-    * Puts and takes on messages
-  
-    NServiceBus 5.0 or higher:
-    
-    * Puts and takes on messages and [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing)
+* Puts and takes on messages.
 
-    RabbitMQ 3.5 or higher:
+NServiceBus 5.0 or higher:
 
-    * Puts and takes on messages and queue purge. 
-    * When receiving messages using an `IBasicConsumer`, the `EventingBasicConsumer` is the only implementation that is instrumented by the .NET agent. 
-    * `BasicGet` is instrumented, but the agent does not support [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) for `BasicGet`.
-    * The following methods are instrumented:
-      * IModel.BasicGet
-      * IModel.BasicPublish
-      * IModel.BasicComsume
-      * IModel.QueuePurge
-      * EventingBasicConsumer.HandleBasicDeliver
+* Puts and takes on messages and [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing).
+
+RabbitMQ 3.5 or higher:
+
+* Puts and takes on messages and queue purge. 
+* When receiving messages using an `IBasicConsumer`, the `EventingBasicConsumer` is the only implementation that is instrumented by the .NET agent. 
+* `BasicGet` is instrumented, but the agent does not support [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) for `BasicGet`.
+* The following methods are instrumented:
+  * IModel.BasicGet
+  * IModel.BasicPublish
+  * IModel.BasicComsume
+  * IModel.QueuePurge
+  * EventingBasicConsumer.HandleBasicDeliver
 
   </Collapser>
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -628,7 +628,7 @@ The .NET agent does not directly monitor datastore processes. Also, by default t
 
     * Puts and takes on messages
   
-    NServiceBus 5.0 (6.0 or higher not supported):
+    NServiceBus 5.0 or higher:
     
     * Puts and takes on messages and [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing)
 


### PR DESCRIPTION
## Give us some context

Note: We will not be releasing the agent till after the holiday break (like most everyone) so this is not in anyway urgent!

Updates our listed support for NServiceBus from 5.0 only to 5.0 or higher on both Framework and Core.

Resolves newrelic/newrelic-dotnet-agent#824