### PR TITLE
chore: java-agent - rectifying mitigation procedures

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-651.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-651.mdx
@@ -12,11 +12,13 @@ downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/
 * Log4j 2.15.0, which fixes the security vulnerability [CVE-2021-44228](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q), is only compatible with Java 8+. Therefore, this version of the agent is not compatible with Java 7 and is only recommended if you are using Java 8+ and are otherwise unable to upgrade to Java agent 7.4.1.
 
 ### Mitigation for Java 7
-Java agent versions 4.12.0 through 6.5.0 (which support Java 7) use [Log4j 2.11.2](https://github.com/newrelic/newrelic-java-agent/blob/dc9f29ca94b453ea9e1132961b8e169588d1e665/newrelic-agent/build.gradle#L90) which falls into the affected range. For Java 7 users the recommended mitigation from [Apache Log4j Security Vulnerabilities](https://logging.apache.org/log4j/2.x/security.html) is to set either the system property `-Dlog4j2.formatMsgNoLookups=true` or the environment variable `LOG4J_FORMAT_MSG_NO_LOOKUPS=true`.
+Java agent versions 4.12.0 through 6.5.0 (which support Java 7) use [Log4j 2.11.2](https://github.com/newrelic/newrelic-java-agent/blob/dc9f29ca94b453ea9e1132961b8e169588d1e665/newrelic-agent/build.gradle#L90) which falls into the affected range. For Java 7 users the recommended mitigation from [Apache Log4j Security Vulnerabilities](https://logging.apache.org/log4j/2.x/security.html) is to set the system property `-Dlog4j2.formatMsgNoLookups=true`.
 
-> Mitigation: In releases {'>='}2.10, this behavior can be mitigated by setting either the system property `log4j2.formatMsgNoLookups` or the environment variable `LOG4J_FORMAT_MSG_NO_LOOKUPS` to `true`. For releases {'>='}2.7 and {'<='}2.14.1, all `PatternLayout` patterns can be modified to specify the message converter as `%m{nolookups}` instead of just `%m`. For releases {'>='}2.0-beta9 and {'<='}2.10.0, the mitigation is to remove the `JndiLookup` class from the classpath:
+> Mitigation: In releases {'>='}2.10, this behavior can be mitigated by setting the system property `log4j2.formatMsgNoLookups`. For releases {'>='}2.7 and {'<='}2.14.1, all `PatternLayout` patterns can be modified to specify the message converter as `%m{nolookups}` instead of just `%m`. For releases {'>='}2.0-beta9 and {'<='}2.10.0, the mitigation is to remove the `JndiLookup` class from the classpath:
 >
 > `zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class`
+
+**Note**: The alternate approach of defining the `LOG4J_FORMAT_MSG_NO_LOOKUPS=true` environment variable will not work with the NR Java Agent.
 
 ### Support statement:
 * New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and


### PR DESCRIPTION
## Give us some context
One of the proposed mitigation steps provided by log4j does not work for the Java agent.

Updating the release notes to reflect that.