### PR TITLE
fix: JSON bugs and add steps

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/monitor-private-locations.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/monitor-private-locations.mdx
@@ -27,7 +27,10 @@ Before following the instructions in this guide, ensure you have:
 * Checks scheduled to run at that location
 * An [alert policy](/docs/alerts/new-relic-alerts/configuring-alert-policies) for the private location, with a configured [notification channel](/docs/alerts/new-relic-alerts/managing-notification-channels/notification-channels-control-where-send-alerts#slack) to notify your team when a violation occurs
 
-The Private Minion dashboard example can be imported to your account using the [Dashboard API](/docs/insights/insights-api/manage-dashboards/insights-dashboard-api) with the following JSON:
+The following Private Minion dashboard example JSON can be imported to your account using:
+
+- the [Import a dashboard button](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/#dashboards-import)
+- the [Dashboard API](/docs/insights/insights-api/manage-dashboards/insights-dashboard-api)
 
 <CollapserGroup>
   <Collapser
@@ -35,1105 +38,1094 @@ The Private Minion dashboard example can be imported to your account using the [
     title="Private Minion dashboard JSON"
   >
     ```
-{
-  "name": "Synthetics Private Minions",
-  "description": "Details on events from SyntheticPrivateLocationStatus, SyntheticsPrivateMinion, SyntheticCheck, SyntheticRequest, NrAuditEvent, plus a page for Performance Analysis.",
-  "permissions": "PUBLIC_READ_WRITE",
-  "pages": [
     {
-      "name": "SyntheticPrivateLocationStatus",
-      "description": null,
-      "widgets": [
+      "name": "Synthetics Private Minions",
+      "description": "Details on events from SyntheticPrivateLocationStatus, SyntheticsPrivateMinion, SyntheticCheck, SyntheticRequest, NrAuditEvent, plus a page for Performance Analysis.",
+      "permissions": "PUBLIC_READ_WRITE",
+      "pages": [
         {
-          "visualization": {
-            "id": "viz.bar"
-          },
-          "layout": {
-            "column": 1,
-            "row": 1,
-            "height": 8,
-            "width": 3
-          },
-          "title": "pending checks by location",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
+          "name": "SyntheticPrivateLocationStatus",
+          "description": "Details on the private location queue.",
+          "widgets": [
+            {
+              "visualization": {
+                "id": "viz.bar"
+              },
+              "layout": {
+                "column": 1,
+                "row": 1,
+                "height": 8,
+                "width": 3
+              },
+              "title": "pending checks by location",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT latest(checksPending) FROM SyntheticsPrivateLocationStatus FACET name"
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
             },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT latest(checksPending) FROM SyntheticsPrivateLocationStatus FACET name"
-              }
-            ]
-          },
-          "linkedEntityGuids": [
-            "MzI1NjA5M3xWSVp8REFTSEJPQVJEfDMwNTI5NzE"
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 4,
+                "row": 1,
+                "height": 4,
+                "width": 9
+              },
+              "title": "private location queue",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT average(checksPending) FROM SyntheticsPrivateLocationStatus FACET name TIMESERIES max SINCE 2 weeks ago"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 4,
+                "row": 5,
+                "height": 4,
+                "width": 9
+              },
+              "title": "rate of queue growth",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT clamp_min(derivative(checksPending,1 minute),0) as 'queue growth rate' FROM SyntheticsPrivateLocationStatus FACET name TIMESERIES MAX SINCE 2 weeks ago"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.table"
+              },
+              "layout": {
+                "column": 1,
+                "row": 9,
+                "height": 4,
+                "width": 12
+              },
+              "title": "audit events for private locations",
+              "rawConfiguration": {
+                "dataFormatters": [],
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT * from NrAuditEvent WHERE targetType = 'PRIVATE_LOCATION' SINCE 2 days ago LIMIT MAX"
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
+            }
           ]
         },
         {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 4,
-            "row": 1,
-            "height": 4,
-            "width": 9
-          },
-          "title": "private location queue",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
+          "name": "SyntheticsPrivateMinion",
+          "description": "Details on the minion instances.",
+          "widgets": [
+            {
+              "visualization": {
+                "id": "viz.table"
+              },
+              "layout": {
+                "column": 1,
+                "row": 1,
+                "height": 3,
+                "width": 3
+              },
+              "title": "private locations",
+              "rawConfiguration": {
+                "dataFormatters": [],
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT latest(timestamp),uniqueCount(minionId) - 1 as 'restarts' from SyntheticsPrivateMinion since 2 days ago FACET minionLocation"
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
             },
-            "legend": {
-              "enabled": true
+            {
+              "visualization": {
+                "id": "viz.table"
+              },
+              "layout": {
+                "column": 4,
+                "row": 1,
+                "height": 3,
+                "width": 7
+              },
+              "title": "minion details",
+              "rawConfiguration": {
+                "dataFormatters": [],
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT latest(minionId),latest(timestamp) as 'last seen',latest(minionStartTimestamp) as 'started',uniqueCount(minionId) - 1 as 'restarts',latest(minionIpv4),latest(minionJobsQueued),latest(minionJobsFinished),100*latest(minionJobsFailed)/latest(minionJobsQueued) as 'job failure rate',latest(minionJobsRunning),latest(minionJobsTimedout),latest(minionJobsSkipped),latest(minionJobsInternalEngineError),latest(minionWorkers),latest(minionProcessors),latest(minionPhysicalMemoryUsedBytes/(1024*1024*1024)) as 'used memory (GiB)',latest(minionPhysicalMemoryTotalBytes/(1024*1024*1024)) as 'total memory (GiB)',latest(minionPhysicalMemoryTotalBytes/(1024*1024*1024))/latest(minionWorkers) as 'memory (GiB) per heavy worker' FROM SyntheticsPrivateMinion FACET minionBuildNumber,minionLocation,minionOsVersion,minionContainerSystemVersion,minionHostname LIMIT 100 SINCE 2 days ago"
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
             },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT average(checksPending) FROM SyntheticsPrivateLocationStatus FACET name TIMESERIES max SINCE 2 weeks ago"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
+            {
+              "visualization": {
+                "id": "viz.area"
+              },
+              "layout": {
+                "column": 11,
+                "row": 1,
+                "height": 3,
+                "width": 2
+              },
+              "title": "minion instances over time",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT uniqueCount(minionId) as 'minions' from SyntheticsPrivateMinion since 2 days ago TIMESERIES MAX "
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 1,
+                "row": 4,
+                "height": 3,
+                "width": 4
+              },
+              "title": "CPU utilization (%)",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT max(minionProcessorsUsagePercentage) AS 'CPU load %' FROM SyntheticsPrivateMinion TIMESERIES AUTO"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 5,
+                "row": 4,
+                "height": 3,
+                "width": 4
+              },
+              "title": "memory utilization (%)",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT max(minionPhysicalMemoryUsedPercentage) AS 'used memory %' FROM SyntheticsPrivateMinion TIMESERIES AUTO"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 9,
+                "row": 4,
+                "height": 3,
+                "width": 4
+              },
+              "title": "free memory (GiB)",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT max(minionPhysicalMemoryFreeBytes / (1024*1024*1024)) AS 'free (GiB)' FROM SyntheticsPrivateMinion TIMESERIES AUTO"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 1,
+                "row": 7,
+                "height": 3,
+                "width": 2
+              },
+              "title": "jobs per minute",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT clamp_min(derivative(minionJobsFinished,1 minute),0) FROM SyntheticsPrivateMinion FACET minionLocation TIMESERIES MAX SINCE 2 weeks ago"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 3,
+                "row": 7,
+                "height": 3,
+                "width": 2
+              },
+              "title": "skipped jobs",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT average(minionJobsSkipped) as 'skipped jobs' FROM SyntheticsPrivateMinion FACET minionLocation SINCE 2 weeks ago TIMESERIES MAX"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": false
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 5,
+                "row": 7,
+                "height": 3,
+                "width": 4
+              },
+              "title": "count of Internal Engine Errors (IEE) vs failed jobs",
+              "rawConfiguration": {
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT average(minionJobsInternalEngineError) as 'IEE',average(minionJobsFailed) as 'failed jobs' FROM SyntheticsPrivateMinion TIMESERIES MAX SINCE 2 weeks ago"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": false
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.stacked-bar"
+              },
+              "layout": {
+                "column": 9,
+                "row": 7,
+                "height": 3,
+                "width": 4
+              },
+              "title": "rate of Internal Engine Errors (IEE) vs failed jobs",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT 100*average(minionJobsInternalEngineError)/average(minionJobsFailed) as 'IEE',100*(average(minionJobsFailed)-average(minionJobsInternalEngineError))/average(minionJobsFailed) as 'failed jobs' FROM SyntheticsPrivateMinion TIMESERIES AUTO SINCE 2 weeks ago"
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
             }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 4,
-            "row": 5,
-            "height": 4,
-            "width": 9
-          },
-          "title": "rate of queue growth",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": true
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT clamp_min(derivative(checksPending,1 minute),0) as 'queue growth rate' FROM SyntheticsPrivateLocationStatus FACET name TIMESERIES MAX SINCE 2 weeks ago"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
-            }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.table"
-          },
-          "layout": {
-            "column": 1,
-            "row": 9,
-            "height": 4,
-            "width": 12
-          },
-          "title": "audit events for private locations",
-          "rawConfiguration": {
-            "dataFormatters": [],
-            "facet": {
-              "showOtherSeries": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT * from NrAuditEvent WHERE targetType = 'PRIVATE_LOCATION' SINCE 2 days ago LIMIT MAX"
-              }
-            ]
-          },
-          "linkedEntityGuids": null
-        }
-      ]
-    },
-    {
-      "name": "SyntheticsPrivateMinion",
-      "description": null,
-      "widgets": [
-        {
-          "visualization": {
-            "id": "viz.table"
-          },
-          "layout": {
-            "column": 1,
-            "row": 1,
-            "height": 3,
-            "width": 3
-          },
-          "title": "private locations",
-          "rawConfiguration": {
-            "dataFormatters": [],
-            "facet": {
-              "showOtherSeries": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT latest(timestamp),uniqueCount(minionId) - 1 as 'restarts' from SyntheticsPrivateMinion since 2 days ago FACET minionLocation"
-              }
-            ]
-          },
-          "linkedEntityGuids": [
-            "MzI1NjA5M3xWSVp8REFTSEJPQVJEfDMwNTI5NzI"
           ]
         },
         {
-          "visualization": {
-            "id": "viz.table"
-          },
-          "layout": {
-            "column": 4,
-            "row": 1,
-            "height": 3,
-            "width": 7
-          },
-          "title": "minion details",
-          "rawConfiguration": {
-            "dataFormatters": [],
-            "facet": {
-              "showOtherSeries": false
+          "name": "SyntheticCheck",
+          "description": "Details on job results.",
+          "widgets": [
+            {
+              "visualization": {
+                "id": "viz.table"
+              },
+              "layout": {
+                "column": 1,
+                "row": 1,
+                "height": 3,
+                "width": 6
+              },
+              "title": "non-ping monitor details by location",
+              "rawConfiguration": {
+                "dataFormatters": [],
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT uniqueCount(monitorId) as 'monitors with results',uniqueCount(monitorId)/rate(uniqueCount(id), 1 minute) as 'avg job frequency (m)',average(nr.internalQueueDuration+nr.executionDuration)/1e3 as 'avg duration (s)' FROM SyntheticCheck WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS%' FACET location "
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
             },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT latest(minionId),latest(timestamp) as 'last seen',latest(minionStartTimestamp) as 'started',uniqueCount(minionId) - 1 as 'restarts',latest(minionIpv4),latest(minionJobsQueued),latest(minionJobsFinished),100*latest(minionJobsFailed)/latest(minionJobsQueued) as 'job failure rate',latest(minionJobsRunning),latest(minionJobsTimedout),latest(minionJobsSkipped),latest(minionJobsInternalEngineError),latest(minionWorkers),latest(minionProcessors),latest(minionPhysicalMemoryUsedBytes/(1024*1024*1024)) as 'used memory (GiB)',latest(minionPhysicalMemoryTotalBytes/(1024*1024*1024)) as 'total memory (GiB)',latest(minionPhysicalMemoryTotalBytes/(1024*1024*1024))/latest(minionWorkers) as 'memory (GiB) per heavy worker' FROM SyntheticsPrivateMinion FACET minionBuildNumber,minionLocation,minionOsVersion,minionContainerSystemVersion,minionHostname LIMIT 100 SINCE 2 days ago"
-              }
-            ]
-          },
-          "linkedEntityGuids": [
-            "MzI1NjA5M3xWSVp8REFTSEJPQVJEfDMwNTI5NzI"
+            {
+              "visualization": {
+                "id": "viz.table"
+              },
+              "layout": {
+                "column": 7,
+                "row": 1,
+                "height": 3,
+                "width": 6
+              },
+              "title": "top 5 non-ping errors",
+              "rawConfiguration": {
+                "dataFormatters": [],
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT count(error) as 'count',latest(monitorName),average((nr.internalQueueDuration+nr.executionDuration)/1e3) as 'avg job duration (s)',max(timestamp) as 'last occurrence' FROM SyntheticCheck WHERE type != 'SIMPLE' AND result = 'FAILED' AND location NOT LIKE 'AWS%' FACET error LIMIT 5"
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.table"
+              },
+              "layout": {
+                "column": 1,
+                "row": 4,
+                "height": 3,
+                "width": 6
+              },
+              "title": "ping monitor details by location",
+              "rawConfiguration": {
+                "dataFormatters": [],
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT uniqueCount(monitorId) as 'monitors with results',uniqueCount(monitorId)/rate(uniqueCount(id), 1 minute) as 'avg job frequency (m)',average(nr.internalQueueDuration+nr.executionDuration)/1e3 as 'avg duration (s)' FROM SyntheticCheck WHERE type = 'SIMPLE' AND location NOT LIKE 'AWS%' FACET location "
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.table"
+              },
+              "layout": {
+                "column": 7,
+                "row": 4,
+                "height": 3,
+                "width": 6
+              },
+              "title": "top 5 ping errors",
+              "rawConfiguration": {
+                "dataFormatters": [],
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT count(error) as 'count',latest(monitorName),average((nr.internalQueueDuration+nr.executionDuration)/1e3) as 'avg job duration (s)',max(timestamp) as 'last occurrence' FROM SyntheticCheck WHERE type = 'SIMPLE' AND result = 'FAILED' AND location NOT LIKE 'AWS%' FACET error LIMIT 5"
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.table"
+              },
+              "layout": {
+                "column": 1,
+                "row": 7,
+                "height": 6,
+                "width": 6
+              },
+              "title": "monitor details",
+              "rawConfiguration": {
+                "dataFormatters": [],
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT uniqueCount(id) as 'results',uniqueCount(location)/rate(uniqueCount(id), 1 minute) as 'avg job frequency (m)',average(nr.internalQueueDuration+nr.executionDuration)/1e3 as 'avg duration (s)' FROM SyntheticCheck WHERE location NOT LIKE 'AWS%' FACET monitorName,monitorId,type LIMIT MAX"
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.area"
+              },
+              "layout": {
+                "column": 7,
+                "row": 7,
+                "height": 3,
+                "width": 6
+              },
+              "title": "top 5 errors by monitor type",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT count(*) FROM SyntheticCheck WHERE error IS NOT NULL AND location NOT LIKE 'AWS%' FACET error,type TIMESERIES AUTO SINCE 2 weeks ago LIMIT 5"
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 7,
+                "row": 10,
+                "height": 3,
+                "width": 6
+              },
+              "title": "non-ping duration with monitor count",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT average(nr.internalQueueDuration+nr.executionDuration/1e3) as 'avg job duration (s)',uniqueCount(monitorId) as 'monitor count' FROM SyntheticCheck WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS%' TIMESERIES AUTO"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 1,
+                "row": 13,
+                "height": 3,
+                "width": 2
+              },
+              "title": "job results",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT count(*) FROM SyntheticCheck WHERE location NOT LIKE 'AWS%' FACET result TIMESERIES AUTO"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 3,
+                "row": 13,
+                "height": 3,
+                "width": 2
+              },
+              "title": "duration by result",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT average(nr.internalQueueDuration+nr.executionDuration/1e3) as 'avg job duration (s)' FROM SyntheticCheck WHERE location NOT LIKE 'AWS%' FACET result TIMESERIES AUTO"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 5,
+                "row": 13,
+                "height": 3,
+                "width": 2
+              },
+              "title": "job rate by result",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT rate(uniqueCount(id), 1 minute) as 'job rate' FROM SyntheticCheck WHERE location NOT LIKE 'AWS%' FACET result TIMESERIES AUTO"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 7,
+                "row": 13,
+                "height": 3,
+                "width": 2
+              },
+              "title": "duration by type",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT average(nr.internalQueueDuration+nr.executionDuration/1e3) as 'avg job duration (s)' FROM SyntheticCheck WHERE location NOT LIKE 'AWS%' FACET type TIMESERIES AUTO"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 9,
+                "row": 13,
+                "height": 3,
+                "width": 2
+              },
+              "title": "job rate by type",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT rate(uniqueCount(id), 1 minute) as 'job rate' FROM SyntheticCheck WHERE location NOT LIKE 'AWS%' FACET cases(WHERE type = 'SIMPLE' as 'ping',WHERE type != 'SIMPLE' as 'non-ping') TIMESERIES AUTO"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 11,
+                "row": 13,
+                "height": 3,
+                "width": 2
+              },
+              "title": "duration by type, result",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT average(nr.internalQueueDuration+nr.executionDuration/1e3) as 'avg job duration (s)' FROM SyntheticCheck WHERE location NOT LIKE 'AWS%' FACET cases(WHERE type != 'SIMPLE' as 'non-ping',WHERE type = 'SIMPLE' as 'ping'),result TIMESERIES AUTO"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            }
           ]
         },
         {
-          "visualization": {
-            "id": "viz.stacked-bar"
-          },
-          "layout": {
-            "column": 11,
-            "row": 1,
-            "height": 3,
-            "width": 2
-          },
-          "title": "minion instances over time",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
+          "name": "SyntheticRequest",
+          "description": "Details on responses.",
+          "widgets": [
+            {
+              "visualization": {
+                "id": "viz.table"
+              },
+              "layout": {
+                "column": 1,
+                "row": 1,
+                "height": 6,
+                "width": 5
+              },
+              "title": "jobs per minion",
+              "rawConfiguration": {
+                "dataFormatters": [],
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT uniqueCount(jobId) as 'jobs' FROM SyntheticRequest WHERE location NOT LIKE 'AWS%' FACET location,minion,minionId"
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
             },
-            "legend": {
-              "enabled": false
+            {
+              "visualization": {
+                "id": "viz.area"
+              },
+              "layout": {
+                "column": 6,
+                "row": 1,
+                "height": 6,
+                "width": 4
+              },
+              "title": "top 5 error response codes",
+              "rawConfiguration": {
+                "dataFormatters": [],
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT count(responseCode) as 'responses' FROM SyntheticRequest WHERE responseCode NOT IN (200,201,202,203,204,300,301,302,303,304) AND responseCode IS NOT NULL AND location NOT LIKE 'AWS%' FACET responseCode,responseStatus TIMESERIES AUTO LIMIT 5"
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
             },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT uniqueCount(minionId) as 'minions' from SyntheticsPrivateMinion since 2 days ago TIMESERIES MAX "
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 10,
+                "row": 1,
+                "height": 6,
+                "width": 3
+              },
+              "title": "job rate",
+              "rawConfiguration": {
+                "dataFormatters": [],
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT rate(uniqueCount(jobId), 1 minute) as 'job rate' FROM SyntheticRequest WHERE location NOT LIKE 'AWS%' TIMESERIES AUTO"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.table"
+              },
+              "layout": {
+                "column": 1,
+                "row": 7,
+                "height": 4,
+                "width": 12
+              },
+              "title": "audit events for monitors",
+              "rawConfiguration": {
+                "dataFormatters": [],
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT * from NrAuditEvent WHERE targetType = 'MONITOR' SINCE 2 days ago LIMIT MAX"
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
             }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 1,
-            "row": 4,
-            "height": 3,
-            "width": 4
-          },
-          "title": "CPU utilization (%)",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT max(minionProcessorsUsagePercentage) AS 'CPU load %' FROM SyntheticsPrivateMinion TIMESERIES AUTO"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
-            }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 5,
-            "row": 4,
-            "height": 3,
-            "width": 4
-          },
-          "title": "memory utilization (%)",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT max(minionPhysicalMemoryUsedPercentage) AS 'used memory %' FROM SyntheticsPrivateMinion TIMESERIES AUTO"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
-            }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 9,
-            "row": 4,
-            "height": 3,
-            "width": 4
-          },
-          "title": "free memory (GiB)",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT max(minionPhysicalMemoryFreeBytes / (1024*1024*1024)) AS 'free (GiB)' FROM SyntheticsPrivateMinion TIMESERIES AUTO"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
-            }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 1,
-            "row": 7,
-            "height": 3,
-            "width": 2
-          },
-          "title": "jobs per minute",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": true
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT clamp_min(derivative(minionJobsFinished,1 minute),0) FROM SyntheticsPrivateMinion FACET minionLocation TIMESERIES MAX SINCE 2 weeks ago"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
-            }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 3,
-            "row": 7,
-            "height": 3,
-            "width": 2
-          },
-          "title": "skipped jobs",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": true
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT average(minionJobsSkipped) as 'skipped jobs' FROM SyntheticsPrivateMinion FACET minionLocation SINCE 2 weeks ago TIMESERIES MAX"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": false
-            }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 5,
-            "row": 7,
-            "height": 3,
-            "width": 4
-          },
-          "title": "count of Internal Engine Errors (IEE) vs failed jobs",
-          "rawConfiguration": {
-            "legend": {
-              "enabled": true
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT average(minionJobsInternalEngineError) as 'IEE',average(minionJobsFailed) as 'failed jobs' FROM SyntheticsPrivateMinion TIMESERIES MAX SINCE 2 weeks ago"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": false
-            }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.stacked-bar"
-          },
-          "layout": {
-            "column": 9,
-            "row": 7,
-            "height": 3,
-            "width": 4
-          },
-          "title": "rate of Internal Engine Errors (IEE) vs failed jobs",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": true
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT 100*average(minionJobsInternalEngineError)/average(minionJobsFailed) as 'IEE',100*(average(minionJobsFailed)-average(minionJobsInternalEngineError))/average(minionJobsFailed) as 'failed jobs' FROM SyntheticsPrivateMinion TIMESERIES AUTO SINCE 2 weeks ago"
-              }
-            ]
-          },
-          "linkedEntityGuids": null
-        }
-      ]
-    },
-    {
-      "name": "SyntheticCheck",
-      "description": null,
-      "widgets": [
-        {
-          "visualization": {
-            "id": "viz.table"
-          },
-          "layout": {
-            "column": 1,
-            "row": 1,
-            "height": 3,
-            "width": 6
-          },
-          "title": "non-ping monitor details by location",
-          "rawConfiguration": {
-            "dataFormatters": [],
-            "facet": {
-              "showOtherSeries": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT uniqueCount(monitorId) as 'monitors with results',uniqueCount(monitorId)/rate(uniqueCount(id), 1 minute) as 'avg job frequency (m)',average(nr.internalQueueDuration+nr.executionDuration)/1e3 as 'avg duration (s)' FROM SyntheticCheck WHERE type != 'SIMPLE' FACET location "
-              }
-            ]
-          },
-          "linkedEntityGuids": [
-            "MzI1NjA5M3xWSVp8REFTSEJPQVJEfDMwNTI5NzM"
           ]
         },
         {
-          "visualization": {
-            "id": "viz.table"
-          },
-          "layout": {
-            "column": 7,
-            "row": 1,
-            "height": 3,
-            "width": 6
-          },
-          "title": "top 5 non-ping errors",
-          "rawConfiguration": {
-            "dataFormatters": [],
-            "facet": {
-              "showOtherSeries": false
+          "name": "Performance Analysis",
+          "description": "Determine if there are enough heavy worker threads.",
+          "widgets": [
+            {
+              "visualization": {
+                "id": "viz.bar"
+              },
+              "layout": {
+                "column": 1,
+                "row": 1,
+                "height": 3,
+                "width": 4
+              },
+              "title": "minions (hosts) by location",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT uniqueCount(minionId) as 'minions' FROM SyntheticsPrivateMinion FACET minionLocation SINCE 5 minutes ago"
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
             },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT count(error) as 'count',latest(monitorName),average((nr.internalQueueDuration+nr.executionDuration)/1e3) as 'avg job duration (s)',max(timestamp) as 'last occurrence' FROM SyntheticCheck WHERE type != 'SIMPLE' AND result = 'FAILED' FACET error LIMIT 5"
-              }
-            ]
-          },
-          "linkedEntityGuids": [
-            "MzI1NjA5M3xWSVp8REFTSEJPQVJEfDMwNTI5NzM"
+            {
+              "visualization": {
+                "id": "viz.table"
+              },
+              "layout": {
+                "column": 5,
+                "row": 1,
+                "height": 3,
+                "width": 6
+              },
+              "title": "count of heavy worker threads and cpu cores",
+              "rawConfiguration": {
+                "dataFormatters": [],
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT latest(minionWorkers),latest(minionProcessors) FROM SyntheticsPrivateMinion FACET minionHostname,minionLocation SINCE 5 minutes ago"
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.markdown"
+              },
+              "layout": {
+                "column": 11,
+                "row": 1,
+                "height": 3,
+                "width": 2
+              },
+              "title": "",
+              "rawConfiguration": {
+                "text": "See [this Google sheet](https://docs.google.com/spreadsheets/d/1k2Aw11r6-S8pIpXQUINQZ0T5qlxS8iSwSo9t9GKDvzc/edit?usp=sharing) to assist in calculating how many workers will be needed based on the values on this page. This will help you to assess the required size of each host (scaling up) and how many hosts you need (scaling out).\n\nFor more info:  \nhttps://discuss.newrelic.com/t/relic-solution-scaling-and-rightsizing-for-the-cpm/123999"
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.bar"
+              },
+              "layout": {
+                "column": 1,
+                "row": 4,
+                "height": 3,
+                "width": 4
+              },
+              "title": "non-ping monitors",
+              "rawConfiguration": {
+                "dataFormatters": [],
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT uniqueCount(monitorId) as 'non-ping monitors' FROM SyntheticCheck WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS%' FACET location SINCE 2 days ago"
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 5,
+                "row": 4,
+                "height": 3,
+                "width": 6
+              },
+              "title": "non-ping avg job duration and timeout",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT average((nr.internalQueueDuration+nr.executionDuration)/1e3) FROM SyntheticCheck WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS%' FACET location,cases(WHERE error NOT LIKE '%timeout%' as 'job duration (s)', WHERE error LIKE '%timeout%' as 'job timeout (s)') SINCE 2 days ago TIMESERIES AUTO"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.bar"
+              },
+              "layout": {
+                "column": 1,
+                "row": 7,
+                "height": 3,
+                "width": 4
+              },
+              "title": "non-ping jobs per minute",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT rate(uniqueCount(id), 1 minute) as 'job rate' FROM SyntheticCheck WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS%' FACET location SINCE 2 days ago"
+                  }
+                ]
+              },
+              "linkedEntityGuids": null
+            },
+            {
+              "visualization": {
+                "id": "viz.line"
+              },
+              "layout": {
+                "column": 5,
+                "row": 7,
+                "height": 3,
+                "width": 6
+              },
+              "title": "job timeout rate by location",
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 1,
+                    "query": "SELECT 100*latest(minionJobsTimedout)/latest(minionJobsReceived) as 'job timeout rate' FROM SyntheticsPrivateMinion FACET minionLocation TIMESERIES AUTO SINCE 2 days ago"
+                  }
+                ],
+                "yAxisLeft": {
+                  "zero": true
+                }
+              },
+              "linkedEntityGuids": null
+            }
           ]
-        },
-        {
-          "visualization": {
-            "id": "viz.table"
-          },
-          "layout": {
-            "column": 1,
-            "row": 4,
-            "height": 3,
-            "width": 6
-          },
-          "title": "ping monitor details by location",
-          "rawConfiguration": {
-            "dataFormatters": [],
-            "facet": {
-              "showOtherSeries": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT uniqueCount(monitorId) as 'monitors with results',uniqueCount(monitorId)/rate(uniqueCount(id), 1 minute) as 'avg job frequency (m)',average(nr.internalQueueDuration+nr.executionDuration)/1e3 as 'avg duration (s)' FROM SyntheticCheck WHERE type = 'SIMPLE' FACET location "
-              }
-            ]
-          },
-          "linkedEntityGuids": [
-            "MzI1NjA5M3xWSVp8REFTSEJPQVJEfDMwNTI5NzM"
-          ]
-        },
-        {
-          "visualization": {
-            "id": "viz.table"
-          },
-          "layout": {
-            "column": 7,
-            "row": 4,
-            "height": 3,
-            "width": 6
-          },
-          "title": "top 5 ping errors",
-          "rawConfiguration": {
-            "dataFormatters": [],
-            "facet": {
-              "showOtherSeries": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT count(error) as 'count',latest(monitorName),average((nr.internalQueueDuration+nr.executionDuration)/1e3) as 'avg job duration (s)',max(timestamp) as 'last occurrence' FROM SyntheticCheck WHERE type = 'SIMPLE' AND result = 'FAILED' FACET error LIMIT 5"
-              }
-            ]
-          },
-          "linkedEntityGuids": [
-            "MzI1NjA5M3xWSVp8REFTSEJPQVJEfDMwNTI5NzM"
-          ]
-        },
-        {
-          "visualization": {
-            "id": "viz.table"
-          },
-          "layout": {
-            "column": 1,
-            "row": 7,
-            "height": 6,
-            "width": 6
-          },
-          "title": "monitor details",
-          "rawConfiguration": {
-            "dataFormatters": [],
-            "facet": {
-              "showOtherSeries": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT uniqueCount(id) as 'results',rate(uniqueCount(id), 1 minute)/uniqueCount(location) as 'avg job frequency (m)',average(nr.internalQueueDuration+nr.executionDuration)/1e3 as 'avg duration (s)' FROM SyntheticCheck FACET monitorName,monitorId,type LIMIT MAX"
-              }
-            ]
-          },
-          "linkedEntityGuids": [
-            "MzI1NjA5M3xWSVp8REFTSEJPQVJEfDMwNTI5NzM"
-          ]
-        },
-        {
-          "visualization": {
-            "id": "viz.area"
-          },
-          "layout": {
-            "column": 7,
-            "row": 7,
-            "height": 3,
-            "width": 6
-          },
-          "title": "top 5 errors by monitor type",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT count(*) FROM SyntheticCheck WHERE error IS NOT NULL FACET error,type TIMESERIES AUTO SINCE 2 weeks ago LIMIT 5"
-              }
-            ]
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 7,
-            "row": 10,
-            "height": 3,
-            "width": 6
-          },
-          "title": "non-ping duration with monitor count",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": true
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT average(nr.internalQueueDuration+nr.executionDuration/1e3) as 'avg job duration (s)',uniqueCount(monitorId) as 'monitor count' FROM SyntheticCheck WHERE type != 'SIMPLE' TIMESERIES AUTO"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
-            }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 1,
-            "row": 13,
-            "height": 3,
-            "width": 2
-          },
-          "title": "job results",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": true
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT count(*) FROM SyntheticCheck FACET result TIMESERIES AUTO"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
-            }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 3,
-            "row": 13,
-            "height": 3,
-            "width": 2
-          },
-          "title": "duration by result",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": true
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT average(nr.internalQueueDuration+nr.executionDuration/1e3) as 'avg job duration (s)' FROM SyntheticCheck FACET result TIMESERIES AUTO"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
-            }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 5,
-            "row": 13,
-            "height": 3,
-            "width": 2
-          },
-          "title": "job rate by result",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": true
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT rate(uniqueCount(id), 1 minute) as 'job rate' FROM SyntheticCheck FACET result TIMESERIES AUTO"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
-            }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 7,
-            "row": 13,
-            "height": 3,
-            "width": 2
-          },
-          "title": "duration by type",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": true
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT average(nr.internalQueueDuration+nr.executionDuration/1e3) as 'avg job duration (s)' FROM SyntheticCheck FACET type TIMESERIES AUTO"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
-            }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 9,
-            "row": 13,
-            "height": 3,
-            "width": 2
-          },
-          "title": "job rate by type",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": true
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT rate(uniqueCount(id), 1 minute) as 'job rate' FROM SyntheticCheck FACET cases(WHERE type = 'SIMPLE' as 'ping',WHERE type != 'SIMPLE' as 'non-ping') TIMESERIES AUTO"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
-            }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 11,
-            "row": 13,
-            "height": 3,
-            "width": 2
-          },
-          "title": "duration by type, result",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": true
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT average(nr.internalQueueDuration+nr.executionDuration/1e3) as 'avg job duration (s)' FROM SyntheticCheck FACET cases(WHERE type != 'SIMPLE' as 'non-ping',WHERE type = 'SIMPLE' as 'ping'),result TIMESERIES AUTO"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
-            }
-          },
-          "linkedEntityGuids": null
-        }
-      ]
-    },
-    {
-      "name": "SyntheticRequest",
-      "description": null,
-      "widgets": [
-        {
-          "visualization": {
-            "id": "viz.table"
-          },
-          "layout": {
-            "column": 1,
-            "row": 1,
-            "height": 6,
-            "width": 5
-          },
-          "title": "jobs per minion",
-          "rawConfiguration": {
-            "dataFormatters": [],
-            "facet": {
-              "showOtherSeries": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT uniqueCount(jobId) as 'jobs' FROM SyntheticRequest FACET location,minion,minionId"
-              }
-            ]
-          },
-          "linkedEntityGuids": [
-            "MzI1NjA5M3xWSVp8REFTSEJPQVJEfDMwNTI5NzQ"
-          ]
-        },
-        {
-          "visualization": {
-            "id": "viz.area"
-          },
-          "layout": {
-            "column": 6,
-            "row": 1,
-            "height": 6,
-            "width": 4
-          },
-          "title": "top 5 error response codes",
-          "rawConfiguration": {
-            "dataFormatters": [],
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": true
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT count(responseCode) as 'responses' FROM SyntheticRequest WHERE responseCode NOT IN (200,201,202,203,204,300,301,302,303,304) AND responseCode IS NOT NULL FACET responseCode,responseStatus TIMESERIES AUTO LIMIT 5"
-              }
-            ]
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 10,
-            "row": 1,
-            "height": 6,
-            "width": 3
-          },
-          "title": "job rate",
-          "rawConfiguration": {
-            "dataFormatters": [],
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT rate(uniqueCount(jobId), 1 minute) as 'job rate' FROM SyntheticRequest TIMESERIES AUTO"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
-            }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.table"
-          },
-          "layout": {
-            "column": 1,
-            "row": 7,
-            "height": 4,
-            "width": 12
-          },
-          "title": "audit events for monitors",
-          "rawConfiguration": {
-            "dataFormatters": [],
-            "facet": {
-              "showOtherSeries": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT * from NrAuditEvent WHERE targetType = 'MONITOR' SINCE 2 days ago LIMIT MAX"
-              }
-            ]
-          },
-          "linkedEntityGuids": null
-        }
-      ]
-    },
-    {
-      "name": "Performance Analysis",
-      "description": null,
-      "widgets": [
-        {
-          "visualization": {
-            "id": "viz.bar"
-          },
-          "layout": {
-            "column": 1,
-            "row": 1,
-            "height": 3,
-            "width": 4
-          },
-          "title": "minions (hosts) by location",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT uniqueCount(minionId) as 'minions' FROM SyntheticsPrivateMinion FACET minionLocation SINCE 5 minutes ago"
-              }
-            ]
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.table"
-          },
-          "layout": {
-            "column": 5,
-            "row": 1,
-            "height": 3,
-            "width": 6
-          },
-          "title": "count of heavy worker threads and cpu cores",
-          "rawConfiguration": {
-            "dataFormatters": [],
-            "facet": {
-              "showOtherSeries": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT latest(minionWorkers),latest(minionProcessors) FROM SyntheticsPrivateMinion FACET minionHostname,minionLocation SINCE 5 minutes ago"
-              }
-            ]
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.markdown"
-          },
-          "layout": {
-            "column": 11,
-            "row": 1,
-            "height": 3,
-            "width": 2
-          },
-          "title": "",
-          "rawConfiguration": {
-            "text": "See [this Google sheet](https://docs.google.com/spreadsheets/d/1k2Aw11r6-S8pIpXQUINQZ0T5qlxS8iSwSo9t9GKDvzc/edit?usp=sharing) to assist in calculating how many workers will be needed based on the values on this page. This will help you to assess the required size of each host (scaling up) and how many hosts you need (scaling out).\n\nFor more info:  \nhttps://discuss.newrelic.com/t/relic-solution-scaling-and-rightsizing-for-the-cpm/123999"
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.bar"
-          },
-          "layout": {
-            "column": 1,
-            "row": 4,
-            "height": 3,
-            "width": 4
-          },
-          "title": "non-ping monitors",
-          "rawConfiguration": {
-            "dataFormatters": [],
-            "facet": {
-              "showOtherSeries": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT uniqueCount(monitorId) as 'non-ping monitors' FROM SyntheticCheck WHERE type != 'SIMPLE' FACET location SINCE 2 days ago"
-              }
-            ]
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 5,
-            "row": 4,
-            "height": 3,
-            "width": 6
-          },
-          "title": "non-ping avg job duration and timeout",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": true
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT average((nr.internalQueueDuration+nr.executionDuration)/1e3) FROM SyntheticCheck WHERE type != 'SIMPLE' FACET location,cases(WHERE error NOT LIKE '%timeout%' as 'job duration (s)', WHERE error LIKE '%timeout%' as 'job timeout (s)') SINCE 2 days ago TIMESERIES AUTO"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
-            }
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.bar"
-          },
-          "layout": {
-            "column": 1,
-            "row": 7,
-            "height": 3,
-            "width": 4
-          },
-          "title": "non-ping jobs per minute",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT rate(uniqueCount(id), 1 minute) as 'job rate' FROM SyntheticCheck WHERE type != 'SIMPLE' FACET location SINCE 2 days ago"
-              }
-            ]
-          },
-          "linkedEntityGuids": null
-        },
-        {
-          "visualization": {
-            "id": "viz.line"
-          },
-          "layout": {
-            "column": 5,
-            "row": 7,
-            "height": 3,
-            "width": 6
-          },
-          "title": "job timeout rate by location",
-          "rawConfiguration": {
-            "facet": {
-              "showOtherSeries": false
-            },
-            "legend": {
-              "enabled": true
-            },
-            "nrqlQueries": [
-              {
-                "accountId": 1,
-                "query": "SELECT 100*latest(minionJobsTimedout)/latest(minionJobsReceived) as 'job timeout rate' FROM SyntheticsPrivateMinion FACET minionLocation TIMESERIES AUTO SINCE 2 days ago"
-              }
-            ],
-            "yAxisLeft": {
-              "zero": true
-            }
-          },
-          "linkedEntityGuids": null
         }
       ]
     }
-  ]
-}
     ```
   </Collapser>
 </CollapserGroup>
 
+Steps to import:
+
+1. Copy the Dashboard JSON and paste into a text editor.
+2. Replace `"accountId": 1,` with your New Relic account ID for each occurrence in the JSON code.
+3. Copy the Dashboard JSON from your text editor and import using one of the methods described above.
+4. Edit any charts that you'd like to use [facet filtering](/docs/query-your-data/explore-query-data/dashboards/filter-new-relic-one-dashboards-facets/) with.
+
 <Callout variant="tip">
-  Replace `"accountId": 1,` with your own New Relic account ID for each occurrence in the JSON code.
+  If your private locations exist in a parent account and Synthetics monitors in a sub account, insert the parent account ID for NRQL queries that use `SyntheticPrivateLocationStatus` and `SyntheticsPrivateMinion`, and the sub account ID for queries that use `SyntheticCheck` and `SyntheticRequest`.
 </Callout>
 
 ## Are my private minions online? [#are_my_minions_online]


### PR DESCRIPTION
- `linkedEntityGuids` are specific to customer's newly created dashboard, so no way to know ahead of time, just set to `null` instead and let customer choose what to filter on.
- provide more details on how to associate account IDs with each event type, especially in cases where the private locations and monitors live in different accounts.