### PR TITLE
chore/npm advanced config

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -62,6 +62,7 @@ devices:
     engine_id: "80:00:01:01:0a:14:1e:28"
     match_attributes:
       if_interface_name: "^Ten.*|^Gig.*"
+      "!if_Alias": "[Uu]plink"
   # Sample of SNMP v1 device
   netbotz_snmpv1__10.10.0.203:
     device_name: netbotz_snmpv1
@@ -252,7 +253,7 @@ global:
             <tr>
               <td>match_attributes</td>
               <td></td>
-              <td>`attribute:regex` pairs to whitelist metrics. Pairs at this level will be appended to any pairs applied in the `global.match_attributes` attribute.</td>
+              <td>`attribute:regex` pairs to add metrics to allowlist. Pairs at this level will be appended to any pairs applied in the `global.match_attributes` attribute. Uses the [RE2](https://github.com/google/re2/wiki/Syntax) syntax and has a default `OR` operator. Prefix key with `!` to force to `AND` operators.</td>
             </tr>
             <tr>
               <td>monitor_admin_shut</td>
@@ -445,7 +446,7 @@ global:
           <tr>
             <td>match_attributes</td>
             <td></td>
-            <td>`attribute:regex` pairs to whitelist metrics. Pairs at this level will matched against all devices in the configuration file.</td>
+            <td>`attribute:regex` pairs to whitelist metrics. Pairs at this level will matched against all devices in the configuration file. Uses the [RE2](https://github.com/google/re2/wiki/Syntax) syntax and has a default `OR` operator. Prefix key with `!` to force to `AND` operators.</td>
           </tr>
           <tr>
             <td>response_time</td>
@@ -559,6 +560,67 @@ devices:
     user_tags:
       owning_team: dc_ops
 ```
+
+## The **match_attributes** attribute [#match_attributes-attribute]
+
+To support filtering of data that does not create value for your observability needs, you can set the `global.match_attributes.{}` and/or `devices.<deviceName>.match_attributes.{}` attribute map. 
+
+This will provide filtering at the **ktranslate** level, before shipping data to New Relic, giving you granular control over monitoring of things like interfaces.
+
+The default behavior of this map is an `OR` condition, but you can override this and force an `AND` operator by prefixing your key name with `!`. This is also useful to return only matched items and omit all `null` and `""` (empty) results. 
+
+<CollapserGroup>
+  <Collapser
+    id="default-or-null"
+    title="Default 'OR' with null and empty values"
+  >
+
+    Match when `if_Alias` begins with `Uplink` **OR** when `if_interface_name` begins with `Gig`, keep all `null` and `""` values:
+
+    ```yaml
+    devices:
+      deviceName:
+        ...
+        match_attributes:
+          if_Alias: "^Uplink.*"
+          if_interface_name: "^Gig.*"
+    ```
+
+  </Collapser>
+  <Collapser
+    id="and-no-null"
+    title="'AND', omit null and empty values"
+  >
+
+    Match when `if_Alias` begins with `Uplink` **AND** when `if_interface_name` begins with `Gig`, drop all `null` and `""` values:
+
+    ```yaml
+    devices:
+      deviceName:
+        ...
+        match_attributes:
+          if_Alias: "^Uplink.*"
+          "!if_interface_name": "^Gig.*"
+    ```
+
+  </Collapser>
+  <Collapser
+    id="single-no-null"
+    title="Single match, omit null and empty values"
+  >
+
+    Match when `if_Alias` begins with `Uplink`, drop all `null` and `""` values:
+
+    ```yaml
+    devices:
+      deviceName:
+        ...
+        match_attributes:
+          "!if_Alias": "^Uplink.*"
+    ```
+
+  </Collapser>
+</CollapserGroup>
 
 ## The **flow_only** attribute [#flow_only-attribute]
 

--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -426,7 +426,7 @@ global:
           <tr>
             <td>mibs_enabled</td>
             <td>✓</td>
-            <td>Array of all active MIBs the `ktranslate` docker image will poll. This list is automatically generated during discovery if the `discovery_add_mibs` attribute is `true`. MIBs not listed here will not be polled on any device in the configuration file.</td>
+            <td>Array of all active MIBs the `ktranslate` docker image will poll. This list is automatically generated during discovery if the `discovery_add_mibs` attribute is `true`. MIBs not listed here will not be polled on any device in the configuration file. You can specify a SNMP table directly in a MIB file using `MIB-NAME.tableName` syntax. Ex: `HOST-RESOURCES-MIB.hrProcessorTable`.</td>
           </tr>
           <tr>
             <td>timeout_ms</td>

--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -446,7 +446,7 @@ global:
           <tr>
             <td>match_attributes</td>
             <td></td>
-            <td>`attribute:regex` pairs to whitelist metrics. Pairs at this level will matched against all devices in the configuration file. Uses the [RE2](https://github.com/google/re2/wiki/Syntax) syntax and has a default `OR` operator. Prefix key with `!` to force to `AND` operators.</td>
+            <td>`attribute:regex` pairs to add metrics to allowlist. Pairs at this level will matched against all devices in the configuration file. Uses the [RE2](https://github.com/google/re2/wiki/Syntax) syntax and has a default `OR` operator. Prefix key with `!` to force to `AND` operators.</td>
           </tr>
           <tr>
             <td>response_time</td>

--- a/src/content/docs/network-performance-monitoring/advanced/ktranslate-container-health.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/ktranslate-container-health.mdx
@@ -245,7 +245,7 @@ The `-metrics` option captures the following performance metrics when polling de
         Top Level
       </td>
       <td>
-        Rate of internal health checks. Shows mostly that things are not deadlocked and should always be less than 0.
+        Rate of internal health checks. Shows mostly that things are not deadlocked and should always be greater than 0.
       </td>
     </tr>
     <tr>

--- a/src/content/docs/network-performance-monitoring/advanced/ktranslate-container-management.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/ktranslate-container-management.mdx
@@ -259,6 +259,18 @@ Below are the various options available during Docker runtime for the **ktransla
     </tr>
     <tr>
       <td>
+        `-dns`
+      </td>
+      <td>
+        Flag
+      </td>
+      <td></td>
+      <td>
+        Sets the `IP:Port` for **ktranslate** to use during DNS resolution of IP addresses. Setting this affects the results for the `dst_host` and `src_host` fields.
+      </td>
+    </tr>
+    <tr>
+      <td>
         `nr1.flow`
       </td>
       <td>


### PR DESCRIPTION
cc: @x8a  for review

updating some config options for NPM based on latest release:

 * `-dns` flag for container management
 * new options for `match_attributes` 
 * polling MIB tables directly

also fixing a small typo on the container health doc