### PR TITLE
Log4j vulnerability can no longer be fixed with -D

### DIFF
--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-03.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-03.mdx
@@ -56,13 +56,13 @@ The following New Relic Java agent versions are affected:
 
 To remediate this vulnerability in the New Relic Java agent, we recommend customers take one of the following actions immediately:
 
-1. Upgrade your Java Agent to either version [6.5.1](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-651/) or [7.4.1](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-741/). These agent versions have been updated to use the remediated 2.15.0 version of the Apache Log4j framework.
+1. Upgrade your Java Agent to either version [6.5.2](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-651/) or [7.4.2](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-741/). These agent versions have been updated to use the remediated 2.15.0 version of the Apache Log4j framework.
 
 System Requirement: Java 8 or higher. If you are on Java 7 or earlier and unable to update to Java 8, please use the following workaround.
 
 OR
 
-2. [Apache has published workaround options](https://logging.apache.org/log4j/2.x/index.html), one of which we recommend for customers that are unable to update their version of log4j at this time. You should define the `log4j2.formatMsgNoLookups=true` system property as part of your application startup.
+2. [Apache has published workaround options](https://logging.apache.org/log4j/2.x/index.html), one of which we recommend for customers that are unable to update their version of log4j at this time.
 
 This step will remediate your New Relic Java agent only. Customers that are using affected versions of the log4j framework (versions 2.10 to 2.14.1) directly in their applications will also need to either upgrade log4j to version 2.15.0 or use the published workaround to remediate this issue for their application.
 


### PR DESCRIPTION
Log4j has updated their vulnerability information, the -D solutions or alternative work arounds don't work.
Also, New Relic released new agents with the log4j 2.16.0 instead of 2.15.0

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.