### PR TITLE
Update forward-your-logs-using-infrastructure-agent.mdx

### DIFF
--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -386,37 +386,37 @@ logs:
  # Winlog log ingestion with eventId filters.
   - name: windows-security
     winlog:
-       channel: Security
-       collect-eventids:
+      channel: Security
+      collect-eventids:
         - 4624
         - 4265
         - 4700-4800
-       exclude-eventids:
+      exclude-eventids:
         - 4735
 
  # entries for the application, system, powershell, and SCOM channels
   - name: windows-application
     winlog:
-       channel: Application
+      channel: Application
   - name: windows-system
     winlog:
-       channel: System
+      channel: System
   - name: windows-pshell
     winlog:
-       channel: Windows Powershell
+      channel: Windows Powershell
   - name: scom
     winlog:
-       channel: Operations Manager
+      channel: Operations Manager
 
  # Entry for Windows Defender Logs
   - name: windows-defender
     winlog:
-       channel: Microsoft-Windows-Windows Defender/Operational
+      channel: Microsoft-Windows-Windows Defender/Operational
 
  # Entry for Windows Clustering Logs
   - name: windows-clustering
     winlog:
-       channel: Microsoft-Windows-FailoverClustering/Operational
+      channel: Microsoft-Windows-FailoverClustering/Operational
 
  # Entry for IIS logs with logtype attribute for automatic parsing
   - name: iis-log


### PR DESCRIPTION
Standardize YAML indentation to two spaces for winlog section

This section had some indentation effectively at one space and some at three spaces.

Result: it's difficult to understand how to properly create a custom config file with correct indentation levels (users mistaking 1 space for no spaces, etc).

A fix is to correct instances of three space indentations to two spaces, causing the next levels to correct themselves from one space to two spaces as a side effect (L391:393, etc)