### PR TITLE
docs: clarify the array of status codes are ints

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -1319,7 +1319,7 @@ You can [manage how error are handled](/docs/agents/manage-apm-agents/agent-data
           </th>
 
           <td>
-            Array
+            Array of Integers
           </td>
         </tr>
 
@@ -1329,7 +1329,7 @@ You can [manage how error are handled](/docs/agents/manage-apm-agents/agent-data
           </th>
 
           <td>
-            `404`
+            `[404]`
           </td>
         </tr>
 
@@ -1478,7 +1478,7 @@ You can [manage how error are handled](/docs/agents/manage-apm-agents/agent-data
           </th>
 
           <td>
-            Array
+            Array of integers
           </td>
         </tr>
 


### PR DESCRIPTION
I had a customer ticket confused weather the codes should be an array of strings or nums, `["404","401"]` or `[404,401]` so I added that info. I also checked [the default value from the `lib/config/default.js`](https://github.com/newrelic/node-newrelic/blob/44b73f2b1fd549894474d1d37ab3b2f2d6e982ad/lib/config/default.js#L289) and it is an array with 404 in it, `[404]`, not just the int `404`. It's minor but I think that being explicit will help some people.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.