### PR TITLE
chore: update name in workflow so distinguishable in github ui

### DIFF
--- a/.github/workflows/send-content-to-machine-translate.yml
+++ b/.github/workflows/send-content-to-machine-translate.yml
@@ -1,4 +1,4 @@
-name: Send content to be translated
+name: Send content to be machine translated
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Description

Super minor change to update MT workflow name that sends content to be translated so it's obvious in github UI which is which

## Screenshot(s)
![2021-12-15_17-15-47](https://user-images.githubusercontent.com/2952843/146289921-e9b0b299-e7fe-452a-a721-0c8629e131cc.png)