### PR TITLE
chore: adding point release to the Java compatibility table

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -30,11 +30,11 @@ Before you install the Java agent, ensure your system meets these requirements:
   >
     <Callout variant="tip">
       The Java agent is compatible with any JVM-based language, including: Java, Scala, Kotlin, and Clojure. For instrumentation support for language-specific features, see the [Automatically instrumented frameworks and libraries](#auto-instrumented) section below.
-      
+
       In order to continue to innovate and efficiently provide new capabilities to our customers, we'll occasionally need to drop support for older JVM versions. When that happens, you can continue using a version of the agent that supports your older JVM version, but new features and fixes won't be included in those older agent versions. We recommend upgrading to a currently supported JVM version to take advantage of the latest agent releases. Please see the table of compatible agent versions to determine which JVM versions are compatible.
     </Callout>
-    
-    
+
+
     <table>
       <thead>
         <tr>
@@ -75,7 +75,7 @@ Before you install the Java agent, ensure your system meets these requirements:
           </td>
 
           <td>
-            Agent v3.0.0 to v6.5.0
+            Agent v3.0.0 to v6.5.0 and v6.5.2
           </td>
         </tr>
 
@@ -168,7 +168,7 @@ Before you install the Java agent, ensure your system meets these requirements:
             Agent v7.3.0 to current
           </td>
         </tr>
-        
+
         <tr>
           <td>
             Java 17
@@ -193,7 +193,7 @@ Before you install the Java agent, ensure your system meets these requirements:
     * Azul Zulu JVM versions 8 to 12 for Linux, Windows, and macOS
     * Amazon Corretto JVM versions 8 and 11 for Linux, Windows, and macOS
     * Alibaba Dragonwell JVM versions 8 and 11 for Linux, Windows, and macOS
-    
+
     (Java 1.7) Compatible only with [Java agent 6.5.x](https://download.newrelic.com/newrelic/java-agent/newrelic-agent/6.5.0/newrelic-java-6.5.0.zip) \[ZIP | 15.4 MB] legacy agent:
 
     * OpenJDK and AdoptOpenJDK JVM versions 7


### PR DESCRIPTION
## Give us some context
Adding the latest point release to the table.
6.5.1 is not compatible with Java 7.