### PR TITLE
fix: Replace links to Instrument Everything page

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring.mdx
@@ -141,13 +141,13 @@ If you don't want to use our [guided install](#quick), the simplest way to insta
 <TechTileGrid>
   <TechTile
     name="Amazon Linux"
-    to="https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJzZXR1cC1uZXJkbGV0LnNldHVwLW9zIiwiZGF0YVNvdXJjZSI6IkFNQVpPTl9MSU5VWCJ9"
+    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything"
     icon={<img src={amazonlinux} alt="amazonlinux.png"/>}
   />
 
   <TechTile
     name="CentOS"
-    to="https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJzZXR1cC1uZXJkbGV0LnNldHVwLW9zIiwiZGF0YVNvdXJjZSI6IkNFTlRPUyJ9"
+    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything"
     icon={<img src={centos} alt="amazonlinux.png"/>}
   />
 
@@ -159,31 +159,31 @@ If you don't want to use our [guided install](#quick), the simplest way to insta
 
   <TechTile
     name="Debian"
-    to="https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJzZXR1cC1uZXJkbGV0LnNldHVwLW9zIiwiZGF0YVNvdXJjZSI6IkRFQklBTiJ9"
+    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything"
     icon={<img src={debian} alt="amazonlinux.png"/>}
   />
 
   <TechTile
     name="RHEL"
-    to="https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJzZXR1cC1uZXJkbGV0LnNldHVwLW9zIiwiZGF0YVNvdXJjZSI6IlJIRUwifQ=="
+    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything"
     icon={<img src={redHatNew2} alt="amazonlinux.png"/>}
   />
 
   <TechTile
     name="SLES"
-    to="https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJzZXR1cC1uZXJkbGV0LnNldHVwLW9zIiwiZGF0YVNvdXJjZSI6IlNMRVMifQ=="
+    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything"
     icon={<img src={suse} alt="amazonlinux.png"/>}
   />
 
   <TechTile
     name="Ubuntu"
-    to="https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJzZXR1cC1uZXJkbGV0LnNldHVwLW9zIiwiZGF0YVNvdXJjZSI6IlVCVU5UVSJ9"
+    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything"
     icon={<img src={ubuntu} alt="amazonlinux.png"/>}
   />
 
   <TechTile
     name="Windows"
-    to="https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJzZXR1cC1uZXJkbGV0LnNldHVwLW9zIiwiZGF0YVNvdXJjZSI6IldJTkRPV1MifQ=="
+    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything"
     icon={<img src={windows} alt="amazonlinux.png"/>}
   />
 </TechTileGrid>

--- a/src/content/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring.mdx
@@ -141,50 +141,50 @@ If you don't want to use our [guided install](#quick), the simplest way to insta
 <TechTileGrid>
   <TechTile
     name="Amazon Linux"
-    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything"
-    icon={<img src={amazonlinux} alt="amazonlinux.png"/>}
+    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything&state=17f97073-d0d5-7a83-28af-13e3115dc508"
+    icon={<img src={amazonlinux} alt="Amazon Linux"/>}
   />
 
   <TechTile
     name="CentOS"
-    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything"
-    icon={<img src={centos} alt="amazonlinux.png"/>}
+    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything&state=e9e347c9-813c-abfd-1d33-2c1cb1326195"
+    icon={<img src={centos} alt="CentOS"/>}
   />
 
   <TechTile
     name="Container (Docker)"
-    to="/docs/infrastructure/new-relic-infrastructure/data-instrumentation/monitor-containers-underlying-hosts-coreos"
+    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything&state=38a2cea3-0472-0fe7-d9df-6a897777731d"
     icon={<img src={dockerLogoCrop} alt="Docker"/>}
   />
 
   <TechTile
     name="Debian"
-    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything"
-    icon={<img src={debian} alt="amazonlinux.png"/>}
+    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything&state=0d9d2431-ed10-c3aa-d815-d824923f05db"
+    icon={<img src={debian} alt="Debian"/>}
   />
 
   <TechTile
     name="RHEL"
-    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything"
-    icon={<img src={redHatNew2} alt="amazonlinux.png"/>}
+    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything&state=c7061991-0944-1d6a-56e2-27f576d3cd43"
+    icon={<img src={redHatNew2} alt="Red Hat"/>}
   />
 
   <TechTile
     name="SLES"
-    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything"
-    icon={<img src={suse} alt="amazonlinux.png"/>}
+    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything&state=bcf5d183-bbad-01e4-dd82-b8dca2274d82"
+    icon={<img src={suse} alt="SLES"/>}
   />
 
   <TechTile
     name="Ubuntu"
-    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything"
-    icon={<img src={ubuntu} alt="amazonlinux.png"/>}
+    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything&state=3255499e-7daa-e169-4154-1f5c24fd8043"
+    icon={<img src={ubuntu} alt="Ubuntu"/>}
   />
 
   <TechTile
     name="Windows"
-    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything"
-    icon={<img src={windows} alt="amazonlinux.png"/>}
+    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything&state=a72d02fa-4e70-3f8d-641a-d208d6844939"
+    icon={<img src={windows} alt="Windows"/>}
   />
 </TechTileGrid>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
The old links to the setup instructions do not work anymore, it has been replaced with the Instrument Everything page filtered by OS, because the user may need to select an account and that depends on this page, the instructions are already scoped by account.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.