### PR TITLE
5348 cache access token

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "mdast-util-heading-range": "^2.1.4",
     "mdast-util-to-hast": "^10.1.0",
     "mdast-util-to-string": "^1.1.0",
+    "node-cache": "^5.1.2",
     "node-fetch": "^2.6.1",
     "node-html-parser": "^2.0.0",
     "patch-package": "^6.2.2",

--- a/scripts/actions/__tests__/send-and-update-translation-queue.test.js
+++ b/scripts/actions/__tests__/send-and-update-translation-queue.test.js
@@ -198,7 +198,7 @@ describe('send-and-update-translation-queue tests', () => {
           targetLocaleIds: ['fake_locale_2'],
         });
 
-      await createJobs('fake_access_token')(['fake_locale_1', 'fake_locale_2']);
+      await createJobs(['fake_locale_1', 'fake_locale_2']);
 
       expect(vendorRequest.mock.calls.length).toBe(2);
       expect(addJob.mock.calls.length).toBe(2);
@@ -225,7 +225,7 @@ describe('send-and-update-translation-queue tests', () => {
         ],
       };
 
-      await createBatches('fake_access_token')(jobs, translationsPerLocale);
+      await createBatches(jobs, translationsPerLocale);
 
       expect(vendorRequest.mock.calls.length).toBe(1);
       expect(updateJob.mock.calls.length).toBe(1);
@@ -248,7 +248,7 @@ describe('send-and-update-translation-queue tests', () => {
         ],
       };
 
-      await uploadFiles(batches, translationsPerLocale, 'fake_access_token');
+      await uploadFiles(batches, translationsPerLocale);
 
       expect(updateTranslation.mock.calls.length).toBe(0);
     });
@@ -268,7 +268,7 @@ describe('send-and-update-translation-queue tests', () => {
         ],
       };
 
-      await uploadFiles(batches, translationsPerLocale, 'fake_access_token');
+      await uploadFiles(batches, translationsPerLocale);
 
       expect(addTranslationsJobsRecord.mock.calls.length).toBe(1);
       expect(addTranslationsJobsRecord.mock.calls[0]).toEqual([
@@ -292,7 +292,7 @@ describe('send-and-update-translation-queue tests', () => {
         ],
       };
 
-      await uploadFiles(batches, translationsPerLocale, 'fake_access_token');
+      await uploadFiles(batches, translationsPerLocale);
 
       expect(updateTranslation.mock.calls.length).toBe(1);
       expect(updateTranslation.mock.calls[0]).toEqual([

--- a/scripts/actions/fetch-and-deserialize.js
+++ b/scripts/actions/fetch-and-deserialize.js
@@ -1,3 +1,4 @@
+'use strict';
 const AdmZip = require('adm-zip');
 const vfile = require('vfile');
 const { writeSync } = require('to-vfile');
@@ -8,6 +9,7 @@ const fetch = require('node-fetch');
 
 const deserializedHtml = require('./deserialize-html');
 const createDirectories = require('../utils/migrate/create-directories');
+const { getAccessToken } = require('./utils/vendor-request');
 
 const localesMap = {
   'ja-JP': 'jp',
@@ -51,7 +53,7 @@ const writeFilesSync = (vfiles) => {
   });
 };
 
-const fetchTranslatedFilesZip = async (fileUris, locale, accessToken) => {
+const fetchTranslatedFilesZip = async (fileUris, locale) => {
   const fileUriStr = fileUris.reduce((str, uri) => {
     return str.concat(`&fileUris[]=${encodeURIComponent(uri)}`);
   }, '');
@@ -63,14 +65,14 @@ const fetchTranslatedFilesZip = async (fileUris, locale, accessToken) => {
     {
       method: 'GET',
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        Authorization: `Bearer ${await getAccessToken()}`,
       },
     }
   );
 };
 
-const fetchAndDeserialize = (accessToken) => async ({ locale, fileUris }) => {
-  const response = await fetchTranslatedFilesZip(fileUris, locale, accessToken);
+const fetchAndDeserialize = async ({ locale, fileUris }) => {
+  const response = await fetchTranslatedFilesZip(fileUris, locale);
 
   const buffer = await response.buffer();
 

--- a/scripts/actions/fetch-and-deserialize.js
+++ b/scripts/actions/fetch-and-deserialize.js
@@ -112,8 +112,4 @@ const fetchAndDeserialize = async ({ locale, fileUris }) => {
   writeFilesSync(files);
 };
 
-if (process.env.CI) {
-  fetchAndDeserialize();
-}
-
 module.exports = { writeFilesSync, fetchAndDeserialize };

--- a/scripts/actions/remove-completed-batch.js
+++ b/scripts/actions/remove-completed-batch.js
@@ -52,8 +52,6 @@ const setInProgressToDone = async () => {
  * @returns {Promise}
  */
 const removePageContext = async (fileUris) => {
-  const accessToken = await getAccessToken();
-
   const fileNames = fileUris.map((fileUri) => {
     const filepath = fileUri.replace(`src/content/`, '');
     const slug = filepath.replace(`.mdx`, '');
@@ -64,7 +62,6 @@ const removePageContext = async (fileUris) => {
   const { items } = await vendorRequest({
     method: 'GET',
     endpoint: `https://api.smartling.com/context-api/v2/projects/${PROJECT_ID}/contexts`,
-    accessToken,
   });
 
   // Find the smartling context to be removed. This includes context manually
@@ -86,7 +83,7 @@ const removePageContext = async (fileUris) => {
       const options = {
         method: 'DELETE',
         headers: {
-          Authorization: `Bearer ${accessToken}`,
+          Authorization: `Bearer ${await getAccessToken()}`,
         },
       };
 

--- a/scripts/actions/translation_workflow/testing/wait_for_translation.js
+++ b/scripts/actions/translation_workflow/testing/wait_for_translation.js
@@ -1,12 +1,10 @@
 const Database = require('../database');
-const { getAccessToken, vendorRequest } = require('../../utils/vendor-request');
+const { vendorRequest } = require('../../utils/vendor-request');
 
 const PROJECT_ID = process.env.TRANSLATION_VENDOR_PROJECT;
 
 (async () => {
   // wait for translation job to complete.
-  const accessToken = await getAccessToken();
-
   const [job] = await Database.getJobs();
   const translationJobUid = job.job_uid;
 
@@ -17,7 +15,6 @@ const PROJECT_ID = process.env.TRANSLATION_VENDOR_PROJECT;
     const jobData = await vendorRequest({
       method: 'GET',
       endpoint: `/jobs-api/v3/projects/${PROJECT_ID}/jobs/${translationJobUid}`,
-      accessToken,
     });
 
     const { jobStatus } = jobData;

--- a/scripts/actions/utils/vendor-request.js
+++ b/scripts/actions/utils/vendor-request.js
@@ -108,7 +108,6 @@ const getAccessToken = async () => {
  * @param {Object} options
  * @param {"GET"|"POST"} options.method The HTTP method used in the request.
  * @param {string} options.endpoint
- * @param {string} options.accessToken
  * @param {Object} [options.body]
  * @param {Object} [options.contentType]
  * @returns {Promise<Object>} The result after making the request.
@@ -116,7 +115,6 @@ const getAccessToken = async () => {
 const vendorRequest = async ({
   method,
   endpoint,
-  accessToken,
   body = {},
   contentType = 'application/json',
 }) => {
@@ -125,7 +123,7 @@ const vendorRequest = async ({
   const options = {
     method,
     headers: {
-      Authorization: `Bearer ${accessToken}`,
+      Authorization: `Bearer ${await getAccessToken()}`,
       'Content-Type': contentType,
     },
   };
@@ -188,10 +186,10 @@ const sendPageContext = async (fileUri, accessToken) => {
  *
  * @param {string} locale The locale that this file should be translated to.
  * @param {string} batchUid The batch that is expecting this file.
- * @param {string} accessToken
  * @returns {(translation: Translation) => Promise<{code: string, slug: string, locale: string>}
  */
-const uploadFile = (locale, batchUid, accessToken) => async (translation) => {
+const uploadFile = (locale, batchUid) => async (translation) => {
+  const accessToken = await getAccessToken();
   const mdx = fs.readFileSync(path.join(process.cwd(), translation.slug));
   const html = await serializeMDX(mdx);
 

--- a/scripts/actions/utils/vendor-request.js
+++ b/scripts/actions/utils/vendor-request.js
@@ -71,33 +71,33 @@ const makeRequest = async (url, options, nthTry = 1) => {
 const getAccessToken = async () => {
   const cachedToken = cache.get('access_token');
   if (cachedToken != undefined) {
-    console.log('using cached token');
+    console.log('using cached access token');
     return cachedToken;
-  } else {
-    const url = new URL(
-      '/auth-api/v2/authenticate',
-      process.env.TRANSLATION_VENDOR_API_URL
-    );
-
-    const options = {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        userIdentifier: process.env.TRANSLATION_VENDOR_USER,
-        userSecret: process.env.TRANSLATION_VENDOR_SECRET,
-      }),
-    };
-
-    console.log('grabbing access token');
-    const { accessToken } = await makeRequest(url, options);
-
-    console.log('setting cached token');
-    cache.set('access_token', accessToken, 60 * 4);
-
-    return accessToken;
   }
+
+  const url = new URL(
+    '/auth-api/v2/authenticate',
+    process.env.TRANSLATION_VENDOR_API_URL
+  );
+
+  const options = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      userIdentifier: process.env.TRANSLATION_VENDOR_USER,
+      userSecret: process.env.TRANSLATION_VENDOR_SECRET,
+    }),
+  };
+
+  console.log('grabbing access token');
+  const { accessToken } = await makeRequest(url, options);
+
+  console.log('setting cached token');
+  cache.set('access_token', accessToken, 60 * 4);
+
+  return accessToken;
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4420,15 +4420,15 @@ clone-stats@^1.0.0:
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-1.0.0.tgz#b3782dff8bb5474e18b9b6bf0fdfe782f8777680"
   integrity sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=
 
+clone@2.x, clone@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
 clone@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
-
-clone@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
 cloneable-readable@^1.0.0:
   version "1.1.3"
@@ -11430,6 +11430,13 @@ node-addon-api@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.2.0.tgz#117cbb5a959dff0992e1c586ae0393573e4d2a87"
   integrity sha512-eazsqzwG2lskuzBqCGPi7Ac2UgOoMz8JVOXVhTvvPDYhthvNpefx8jWD8Np7Gv+2Sz0FlPWZk0nJV0z598Wn8Q==
+
+node-cache@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
+  integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
+  dependencies:
+    clone "2.x"
 
 node-eta@^0.9.0:
   version "0.9.0"


### PR DESCRIPTION
## Summary
This PR introduces a change to start caching the access token in getAccessToken. Additionally, getting the access token is now almost entirely encapsulated in vendor-request.js.

Now, most of the scripts don't have to even worry about access tokens -- getting and caching the token is handled in one spot. This is reflected with the changes to vendorRequest method signature, and removal of access token code usage.

We push the generation of access tokens deeper into the code, closer to where we actually need to use it. Rather than our high level scripts caring about getting & managing an access token, we leave that concern in our lower level vendor api code.

Now, every time vendorRequest is called, we call getAccessToken internally. getAccessToken will automatically generate & store valid access tokens with the caching change -- an initial request will generate a valid token, then subsequent requests will use the cached token. once the token expires, we will go out and get another one and repeat the cycle.

important to note -- the expiration for the token is set to 4 minutes in an attempt to give us a bit of leeway for using a token and not having it expire while we use it or attempt to use it.

## The Fix
How does this address the auth issues we ran into? 

Code that calls getAccessToken no longer needs to worry about the 5 minute expiration, since the internal caching is 4 minutes & retrieves a new token automatically.

## Links
Relates to: #5348 