### PR TITLE
docs: format code blocks and fix example code error

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/itransaction.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/itransaction.mdx
@@ -108,7 +108,7 @@ This section contains descriptions and parameters of three ITransaction methods:
 
 ### Syntax
 
-```
+```cs
 void AcceptDistributedHeaders(carrier, getter, transportType)
 ```
 
@@ -173,8 +173,16 @@ void AcceptDistributedHeaders(carrier, getter, transportType)
 
 ### Example
 
-```
-HttpContext httpContext = HttpContext.Current;IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();ITransaction currentTransaction = agent.CurrentTransaction;currentTransaction.AcceptDistributedTraceHeaders(httpContext, Getter, TransportType.HTTP);IEnumerable<string> Getter(HttpContext carrier, string key) {   string value = carrier.Request.Headers[key];   return value == null ? null : new string[] { value }; }
+```cs
+HttpContext httpContext = HttpContext.Current;
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+ITransaction currentTransaction = agent.CurrentTransaction;
+currentTransaction.AcceptDistributedTraceHeaders(httpContext, Getter, TransportType.HTTP);
+IEnumerable<string> Getter(HttpContext carrier, string key) 
+{ 
+    string value = carrier.Request.Headers[key];   
+    return value == null ? null : new string[] { value }; 
+}
 ```
 
 ## InsertDistributedTraceHeaders
@@ -183,7 +191,7 @@ HttpContext httpContext = HttpContext.Current;IAgent agent = NewRelic.Api.Agent.
 
 ### Syntax
 
-```
+```cs
 void InsertDistributedTraceHeaders(carrier, setter)
 ```
 
@@ -235,8 +243,12 @@ void InsertDistributedTraceHeaders(carrier, setter)
 
 ### Example
 
-```
-HttpWebRequest requestMessage = (HttpWebRequest)WebRequest.Create("https://remote-address");IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();ITransaction currentTransaction = agent.CurrentTransaction;var setter = new Action<HttpWebRequest, string, string>((carrier, key, value) =>  {    carrier.Headers?.Set(key, value);  });currentTransaction.InsertDistributedTraceHeaders(requestMessage, setter);
+```cs
+HttpWebRequest requestMessage = (HttpWebRequest)WebRequest.Create("https://remote-address");
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+ITransaction currentTransaction = agent.CurrentTransaction;
+var setter = new Action<HttpWebRequest, string, string>((carrier, key, value) => { carrier.Headers?.Set(key, value); });
+currentTransaction.InsertDistributedTraceHeaders(requestMessage, setter);
 ```
 
 ## AcceptDistributedTracePayload [#acceptdistributedtracepayload]
@@ -248,7 +260,7 @@ Accepts an incoming distributed trace payload from an upstream service. Calling 
 
 ### Syntax
 
-```
+```cs
 void AcceptDistributedPayload(payload, transportType)
 ```
 
@@ -305,8 +317,15 @@ void AcceptDistributedPayload(payload, transportType)
 
 ### Example
 
-```
-//Obtain the information from the request object from the upstream caller.//The method by which this information is obtain is specific to the transport //type being used. For example, in an HttpRequest, this information is//contained in the header.KeyValuePair<string, string> metadata = GetMetaDataFromRequest("requestPayload");IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); ITransaction transaction = agent.CurrentTransaction; transaction.AcceptDistributedTracePayload(metadata.Value, TransportType.Queue);
+```cs
+//Obtain the information from the request object from the upstream caller.
+//The method by which this information is obtain is specific to the transport 
+//type being used. For example, in an HttpRequest, this information is
+//contained in the 
+header.KeyValuePair<string, string> metadata = GetMetaDataFromRequest("requestPayload");
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
+ITransaction transaction = agent.CurrentTransaction; 
+transaction.AcceptDistributedTracePayload(metadata.Value, TransportType.Queue);
 ```
 
 ## CreateDistributedTracePayload (obsolete) [#createdistributedtracepayload]
@@ -317,7 +336,7 @@ Creates a distributed trace payload for inclusion in an outgoing request to a do
 
 ### Syntax
 
-```
+```cs
 IDistributedTracePayload CreateDistributedTracePayload()
 ```
 
@@ -332,8 +351,10 @@ An object that implements `IDistributedTracePayload` which provides access to th
 
 ### Example
 
-```
-IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); ITransaction transaction = agent.CurrentTransaction; IDistributedTracePayload payload = transaction.CreateDistributedTracePayload();
+```cs
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+ITransaction transaction = agent.CurrentTransaction;
+IDistributedTracePayload payload = transaction.CreateDistributedTracePayload();
 ```
 
 ## AddCustomAttribute
@@ -344,7 +365,7 @@ This method requires .NET agent version and .NET agent API [version 8.24.244.0](
 
 ### Syntax
 
-```
+```cs
 ITransaction AddCustomAttribute(string key, object value)
 ```
 
@@ -403,8 +424,13 @@ For details about supported data types, see the [Custom Attributes Guide](/docs/
 
 ### Example
 
-```
-IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); ITransaction transaction = agent.CurrentTransaction; transaction    .AddCustomAttribute("customerName","Bob Smith")    .AddCustomAttribute("currentAge",31)    .AddCustomAttribute("birthday", new DateTime(2000, 02, 14))    .AddCustomAttribute("waitTime", TimeSpan.FromMilliseconds(93842));
+```cs
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+ITransaction transaction = agent.CurrentTransaction;
+transaction.AddCustomAttribute("customerName","Bob Smith")
+    .AddCustomAttribute("currentAge",31)
+    .AddCustomAttribute("birthday", new DateTime(2000, 02, 14))
+    .AddCustomAttribute("waitTime", TimeSpan.FromMilliseconds(93842));
 ```
 
 ## CurrentSpan
@@ -413,8 +439,10 @@ Provides access to the currently executing [span](http://docs.newrelic.com/docs/
 
 ### Example
 
-```
-IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); ITransaction transaction = agent.CurrentTransaction; ISpan = currentSpan = transaction.CurrentSpan;
+```cs
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
+ITransaction transaction = agent.CurrentTransaction; 
+ISpan currentSpan = transaction.CurrentSpan;
 ```
 
 ## Examples


### PR DESCRIPTION
I formatted the codeblocks for readability and added language identifiers to those code blocks for when our docs site may enable syntax highlighting. 

I'm not sure what to make of this codeblock, it was one line and entirely a comment, a .NET person should probably be asked if this even makes sense or if it was supposed to be something else

```cs
//Obtain the information from the request object from the upstream caller.
//The method by which this information is obtain is specific to the transport 
//type being used. For example, in an HttpRequest, this information is
//contained in the 
header.KeyValuePair<string, string> metadata = GetMetaDataFromRequest("requestPayload");
IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
ITransaction transaction = agent.CurrentTransaction; 
transaction.AcceptDistributedTracePayload(metadata.Value, TransportType.Queue);
```

FIxed the last codeblock which contained `ISpan = currentSpan = transaction.CurrentSpan;` which is invalid syntax, changed it to `ISpan currentSpan = transaction.CurrentSpan;`

Per conversation with Shawn Kilburn on slack https://newrelic.slack.com/archives/C0DSGL3FZ/p1639770259110700

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.