### PR TITLE
docs: fix typo, add last missing filetype

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/itransaction.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/itransaction.mdx
@@ -14,7 +14,7 @@ redirects:
 
 ## Syntax
 
-```
+```cs
 public interface ITransaction
 ```
 
@@ -187,7 +187,7 @@ IEnumerable<string> Getter(HttpContext carrier, string key)
 
 ## InsertDistributedTraceHeaders
 
-`ITransaction.InsertDistributedTraceHeaders` is used to implement distributed tracing. It modifies the carrier object that is passed in by adding W3C Trace Context headers and New Relic Distributed Trace headers. The New Relic headers can be disabled with &lt;`distributedTracing excludeNewrelicHeader="true" />` in the config. This method replaces the deprecated [`CreateDistributedTracePayload`](/docs/agents/net-agent/net-agent-api/itransaction#createdistributedtracepayload) method, which only creates New Relic Distributed Trace payloads.
+`ITransaction.InsertDistributedTraceHeaders` is used to implement distributed tracing. It modifies the carrier object that is passed in by adding W3C Trace Context headers and New Relic Distributed Trace headers. The New Relic headers can be disabled with `<distributedTracing excludeNewrelicHeader="true" />` in the config. This method replaces the deprecated [`CreateDistributedTracePayload`](/docs/agents/net-agent/net-agent-api/itransaction#createdistributedtracepayload) method, which only creates New Relic Distributed Trace payloads.
 
 ### Syntax
 


### PR DESCRIPTION
`<distributedTracing excludeNewrelicHeader="true" />` was written as "<`distributedTracing excludeNewrelicHeader="true" />`"

I also assed the `cs` language identifier to the one code example it was missing from.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.