### PR TITLE
Update new-relic-infrastructure-agent-1193.mdx

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1193.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1193.mdx
@@ -9,7 +9,7 @@ A new version of the agent has been released. Follow standard procedures to [upd
 We recommend you to upgrade the agent every 3 months.
 
 ## Changed
-* Bump nri-rpometheus [#651](https://github.com/newrelic/infrastructure-agent/pull/651)
+* Bump nri-prometheus [#651](https://github.com/newrelic/infrastructure-agent/pull/651)
 * Bump nri-flex [#653](https://github.com/newrelic/infrastructure-agent/pull/653)
 * Bump fluent-bit [#632](https://github.com/newrelic/infrastructure-agent/pull/632)
 
@@ -19,4 +19,4 @@ We recommend you to upgrade the agent every 3 months.
 * [Entity status API](https://github.com/newrelic/infrastructure-agent/blob/1.19.3/docs/status_api.md#report-entity) [#635](https://github.com/newrelic/infrastructure-agent/pull/635)
 
 ## Fixed
-* Lazy loaded dimensional metrics harvester, to avoid memory consumption when no DM metrics are sent. [#648](https://github.com/newrelic/infrastructure-agent/pull/648)
+* Lazy loaded dimensional metrics harvester, to avoid memory consumption when no dimensional metrics are sent. [#648](https://github.com/newrelic/infrastructure-agent/pull/648)


### PR DESCRIPTION
Fixed spelling of nri-prometheus. Clarified the abbreviation "DM metrics" meaning dimensional metrics.

Parsing proprietary acronyms increases toil when trying to understand docs.