### PR TITLE
Update configure-kubernetes-proxy.mdx

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/configure-kubernetes-proxy.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/configure-kubernetes-proxy.mdx
@@ -76,17 +76,3 @@ There are three options to install the [Prometheus OpenMetric integration](/docs
 ## Set the synthetics minion to use a proxy [#synthetics]
 
 Check this README [on how to set the proxy](https://github.com/newrelic/helm-charts/tree/master/charts/synthetics-minion) for the [Synthetics minions](/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms).
-
-## Install the Pixie integration with a proxy [#pixie]
-
-There are two options to install the Pixie integration with a proxy:
-
-* Installing with chart `newrelic-pixie`:
-  * The proxy can be configured setting the configuration option `proxy` as described in the [values.yaml](https://github.com/newrelic/helm-charts/blob/334ce7ae4e9753acea9e35c5b923a6795cea262e/charts/newrelic-pixie/values.yaml#L32) of the chart.  
-  
-* Installing with chart `nri-bundle` as a dependency:
-  * The proxy can be configured setting the configuration option `newrelic-pixie.proxy`. The configuration option is passed [down to the dependency](https://github.com/newrelic/helm-charts/tree/master/charts/nri-bundle#configure-dependencies) `newrelic-pixie` modifying the `values.yaml` of `nri-bundle`:
-
-    ```
-    newrelic-pixie.proxy: https://user:password@hostname:port
-    ```


### PR DESCRIPTION
Removed configuration for newrelic-pixie chart proxy settings. Although this works for the newrelic-pixie chart, it turns out that this does not actually propagate to Pixie components, therefore it could give the wrong impression to readers.

True proxy support for Pixie is under consideration at this time, and we'll be able to document it when supported.