### PR TITLE
chore: note about AWS CloudTrail limitation

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-cloudtrail-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-cloudtrail-monitoring-integration.mdx
@@ -22,6 +22,10 @@ Besides these two types of data, New Relic does not collect any other data. This
 
 ## Activate integration [#requirements]
 
+<Callout variant="important">
+  The AWS CloudTrail integration collects data from **us-east-1 region only** by default. To enable all AWS regions please contact us at [support.newrelic.com](https://support.newrelic.com/). 
+</Callout>
+
 To enable this integration follow standard procedures to [Connect AWS services to New Relic](docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]


### PR DESCRIPTION
## Give us some context

* Due to performance reasons, AWS CloudTrail integration is not enabled on all AWS regions by default. This is currently enabled and monitored based on customers demand. Added a note explaining the limitation. 