### PR TITLE
chore(java-agent): 7.4.3 release notes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-743.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-743.mdx
@@ -1,0 +1,18 @@
+---
+subject: Java agent
+releaseDate: '2021-12-20'
+version: 7.4.3
+downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/7.4.3/'
+---
+
+### Fixes
+* Upgraded log4j to 2.17.0 to mitigate the security vulnerability [CVE-2021-45105](https://github.com/advisories/GHSA-p6xc-xr62-6r2g). [605](https://github.com/newrelic/newrelic-java-agent/issues/605)
+
+### Recommended Java versions
+* This fix is recommended if you are running on Java 8 - 17.
+
+### Support statement:
+* New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and
+  performance benefits. Additionally, older releases will no longer be supported when they reach
+  [end-of-life](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software/).
+


### PR DESCRIPTION
## Give us some context

New release of the Java agent addressing CVE-2021-45105.