### PR TITLE
fix(tags): adding allowed characters

### DIFF
--- a/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/use-tags-help-organize-find-your-data.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/use-tags-help-organize-find-your-data.mdx
@@ -62,7 +62,9 @@ Format requirements and limits for tags:
 * The following are maximum character length for tags:
   * Key: 128 characters
   * Value: 256 characters
-* When [using our API to add tags](/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial), a dash (`-`) in a tag key is interpreted as a minus symbol. If your tag key has a dash, use back ticks around it (like `` `key-name` ``).
+* Allowed characters: 
+  * Characters must be UTF-8.
+  * When [using NerdGraph to add tags](/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial), a dash (`-`) in a tag key is interpreted as a minus symbol. If your tag key has a dash, use back ticks around it (like `` `key-name` ``).
 
 ## Best practices and tips [#tag-best-practices]
 


### PR DESCRIPTION
Based on issue https://github.com/newrelic/docs-website/issues/5187, adding allowed characters in tag doc's requirements. 