### PR TITLE
ESA-625 Improve entity search queries

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
@@ -121,7 +121,7 @@ Entities in NerdGraph rely on [GraphQL interfaces](/docs/apis/graphql-api/gettin
     ```
     {
       actor {
-        entitySearch(<mark>queryBuilder</mark>: {type: APPLICATION}) {
+        entitySearch(<mark>queryBuilder</mark>: {domain: APM, type: APPLICATION}) {
           query
           results {
             entities {
@@ -176,7 +176,7 @@ Entities in NerdGraph rely on [GraphQL interfaces](/docs/apis/graphql-api/gettin
     ```
     {
       actor {
-        entitySearch(query: "name like 'nerdgraph'") {
+        entitySearch(query: "name like 'nerdgraph' and alertSeverity is not null") {
           results {
             entities {
               reporting
@@ -203,7 +203,7 @@ Entities in NerdGraph rely on [GraphQL interfaces](/docs/apis/graphql-api/gettin
     ```
     {
       actor {
-        entitySearch(query: "name like 'nerdgraph'") {
+        entitySearch(query: "name like 'nerdgraph' and domainType = 'APM-APPLICATION'") {
           results {
             entities {
               name


### PR DESCRIPTION
Entity search expressions in the examples in the [View entity data tutorial](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial/) don't display best query practices, and may induce users to misuse the search. This PR is an attempt to address this.