### PR TITLE
Update workflow script to check for renamed files and invoke main

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -9,7 +9,7 @@ on:
 env:
   NODE_OPTIONS: '--max-old-space-size=4096'
   CHOKIDAR_USEPOLLING: 1
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
   test:

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -9,6 +9,7 @@ on:
 env:
   NODE_OPTIONS: '--max-old-space-size=4096'
   CHOKIDAR_USEPOLLING: 1
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
   test:

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -9,7 +9,7 @@ on:
 env:
   NODE_OPTIONS: '--max-old-space-size=4096'
   CHOKIDAR_USEPOLLING: 1
-  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   test:

--- a/scripts/actions/__tests__/check-for-outdated-translations.test.js
+++ b/scripts/actions/__tests__/check-for-outdated-translations.test.js
@@ -8,8 +8,10 @@ const {
 // Mock node-fetch so we can avoid calling out to GitHub
 jest.mock('node-fetch');
 jest.mock('../utils/github-api-helpers');
+jest.mock('../utils/check-args');
 
 global.process.exit = jest.fn();
+global.process.argv.push('--arg3', 'url');
 jest.spyOn(global.console, 'log').mockImplementation(() => {});
 
 // Helper function to mock a response from Github

--- a/scripts/actions/__tests__/check-for-outdated-translations.test.js
+++ b/scripts/actions/__tests__/check-for-outdated-translations.test.js
@@ -71,8 +71,7 @@ describe('Action: Check for outdated translations', () => {
     ]);
 
     await checkOutdatedTranslations();
-
-    expect(global.process.exit).toHaveBeenLastCalledWith(0);
+    expect(console.log).toHaveBeenCalledTimes(0);
   });
 
   test('should fail when files are found for deletion', async () => {

--- a/scripts/actions/check-for-outdated-translations.js
+++ b/scripts/actions/check-for-outdated-translations.js
@@ -103,6 +103,8 @@ const main = async () => {
   }
 };
 
-main();
+if (require.main === module) {
+  main();
+}
 
-module.exports = { checkOutdatedTranslations };
+module.exports = { main, checkOutdatedTranslations };

--- a/scripts/actions/check-for-outdated-translations.js
+++ b/scripts/actions/check-for-outdated-translations.js
@@ -34,12 +34,22 @@ const checkOutdatedTranslations = async (url) => {
     .reduce((files, file) => {
       const contents = fs.readFileSync(path.join(process.cwd(), file.filename));
       const { data } = frontmatter(contents);
-      return [...files, { path: file.filename, locales: data.translate || [] }];
+      return [
+        ...files,
+        {
+          path: file.filename,
+          locales: data.translate || [],
+        },
+      ];
     }, []);
 
   const removedMdxFileNames = mdxFiles
     .filter((f) => f.status === 'removed')
     .map(prop('filename'));
+
+  const renamedMdxFileNames = mdxFiles
+    .filter((f) => f.status === 'renamed')
+    .map(prop('previous_filename'));
 
   // if a locale was removed from the translate frontmatter, we want to remove the translated version of that file.
 
@@ -54,7 +64,15 @@ const checkOutdatedTranslations = async (url) => {
     doI18nFilesExist(name, ADDITIONAL_LOCALES)
   );
 
-  const orphanedI18nFiles = [...modifiedFiles, ...removedFiles];
+  const renamedFiles = renamedMdxFileNames.flatMap((name) =>
+    doI18nFilesExist(name, ADDITIONAL_LOCALES)
+  );
+
+  const orphanedI18nFiles = [
+    ...modifiedFiles,
+    ...removedFiles,
+    ...renamedFiles,
+  ];
 
   if (orphanedI18nFiles.length > 0) {
     orphanedI18nFiles.forEach((f) =>
@@ -85,4 +103,4 @@ const main = async () => {
   }
 };
 
-module.exports = main;
+main();

--- a/scripts/actions/check-for-outdated-translations.js
+++ b/scripts/actions/check-for-outdated-translations.js
@@ -104,3 +104,5 @@ const main = async () => {
 };
 
 main();
+
+module.exports = { checkOutdatedTranslations };


### PR DESCRIPTION
## Description

Updates the script behind the workflow step that checks a PR for files that changed and may need to be applied to corresponding i18n files. Updates it to also check for status of `renamed` which indicates a file was moved.

Also updates the script to invoke `main()`, since I think this was never actually run 

## Related issues / PRs
Related to https://github.com/newrelic/docs-website/issues/4232 
