### PR TITLE
docs: update link, add codeblock language

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/disablebrowsermonitoring-net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/disablebrowsermonitoring-net-agent-api.mdx
@@ -15,7 +15,7 @@ redirects:
 
 ## Syntax
 
-```
+```cs
 NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring([boolean $override])
 ```
 
@@ -25,7 +25,7 @@ Disable automatic injection of browser monitoring snippet on specific pages.
 
 Compatible with all agent versions.
 
-Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
+Must be called inside a [transaction](/docs/glossary/glossary/#transaction).
 
 ## Description
 
@@ -71,7 +71,7 @@ Add this call to disable the **automatic** injection of [browser monitoring](/do
 
 This example disables only the **automatic** injection of the snippet:
 
-```
+```cs
 NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring();
 ```
 
@@ -79,6 +79,6 @@ NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring();
 
 This example disables **both** automatic and manual injection of the snippet:
 
-```
+```cs
 NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring(true);
 ```


### PR DESCRIPTION
The `transaction` link didn't open to the `#transaction` section of the glossary, I think because it was an old URL that redirects. I updated the link.

I also added c# as the language identifier for the code blocks.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.