### PR TITLE
chore(java-agent): bumping download link to latest Java 7 agent

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -194,7 +194,7 @@ Before you install the Java agent, ensure your system meets these requirements:
     * Amazon Corretto JVM versions 8 and 11 for Linux, Windows, and macOS
     * Alibaba Dragonwell JVM versions 8 and 11 for Linux, Windows, and macOS
 
-    (Java 1.7) Compatible only with [Java agent 6.5.x](https://download.newrelic.com/newrelic/java-agent/newrelic-agent/6.5.2/newrelic-java-6.5.2.zip) \[ZIP | 15.4 MB] legacy agent:
+    (Java 1.7) Compatible only with [Java agent 6.5.x](https://download.newrelic.com/newrelic/java-agent/newrelic-agent/6.5.3/newrelic-java-6.5.3.zip) \[ZIP | 16.8 MB] legacy agent:
 
     * OpenJDK and AdoptOpenJDK JVM versions 7
     * IBM JVM version 7


### PR DESCRIPTION
We released a new version of the agent and need to update a link to point to that release.