### PR TITLE
docs: format example code & add lang identifier

### DIFF
--- a/src/content/docs/new-relic-solutions/best-practices-guides/full-stack-observability/synthetic-monitoring-best-practices-guide.mdx
+++ b/src/content/docs/new-relic-solutions/best-practices-guides/full-stack-observability/synthetic-monitoring-best-practices-guide.mdx
@@ -105,12 +105,12 @@ Using scripted browsers, you can build complex monitoring workflows using the Se
 6. Set a notification method to alert your team when performance violations occur.
 7. You are now ready to write your script. (Below is an example of a script used to test the performance of a main navigation page.)
 
-```
+```js
 var assert = require('chai').assert;
 // script-wide timeout for all wait and waitandfind functions (in ms)
 var default_element_timeout = 190000;   //3 mins
-var default_pageload_timeout = 240000; //4 mins
-var navlinks = ["css-locator-1","css-locator-2"];
+var default_pageload_timeout = 240000;  //4 mins
+var navlinks = ["css-locator-1", "css-locator-2"];
 
 //sets element load timeout to 3 mins
 $browser.manage().timeouts().implicitlyWait(default_element_timeout);
@@ -118,23 +118,22 @@ $browser.manage().timeouts().implicitlyWait(default_element_timeout);
 $browser.manage().timeouts().pageloadTimeout(default_pageload_timeout);
 
 //test all the main nav page performances
-$browser.get("http://www.sitename.com").then(function(){
-return $browser.findelement($driver.by.classname("site-theme-example"));
-}).then(function(){
+$browser.get("http://www.sitename.com").then(function() {
+  return $browser.findelement($driver.by.classname("site-theme-example"));
+}).then(function() {
   //verifies the nav list has loaded
   return $browser.findelement($driver.by.classname("site-nav-list-example"));
-}).then(function(){
+}).then(function() {
   //loops through the navlinks array
-  navlinks.foreach(function(val, i, arr){
-  //finds and navigates to each navlink page
-  return
-$browser.findelement($driver.by.classname(navlinks[i])).click().then(function(){
-  //verifies that the nav list loaded before moving on
-  return $browser.findelement($driver.by.classname("site-nav-list-example")).then(function(){
-    //verifies that the page logo footer at bottom of page has loaded
-    return $browser.findelement($driver.by.classname("site-footer-logo"));
-    })
-   })
- })
+  navlinks.foreach(function(val, i, arr) {
+    //finds and navigates to each navlink page
+    return $browser.findelement($driver.by.classname(navlinks[i])).click().then(function() {
+      //verifies that the nav list loaded before moving on
+      return $browser.findelement($driver.by.classname("site-nav-list-example")).then(function() {
+        //verifies that the page logo footer at bottom of page has loaded
+        return $browser.findelement($driver.by.classname("site-footer-logo"));
+      });
+    });
+  });
 });
 ```


### PR DESCRIPTION
I formatted the JS codeblock, added missing `;`s, corrected indentation, and this `return` was broken up onto two lines making the code unreachable:

```js
 navlinks.foreach(function (val, i, arr) {
    //finds and navigates to each navlink page
    return
$browser.findelement($driver.by.classname(navlinks[i])).click().then(function () {
```

I also added the `js` language identifier to the codeblock so it will use the correct syntax highlighting.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.