### PR TITLE
Add remote write configuration for v2.26+

### DIFF
--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
@@ -56,7 +56,7 @@ Go to the [Prometheus remote write setup launcher in New Relic One](https://one.
    remote_write: 
    - url: https://metric-api.newrelic.com/prometheus/v1/write?X-License-Key=<var>YOUR_LICENSE_KEY</var>&prometheus_server=<var>YOUR_DATA_SOURCE_NAME</var>
    ```
-   *This passes credentials in the URL. We don't recommend using it.*
+   *This approach passes credentials in the URL. We don't recommend using it unless one of these other approaches doesn't work in your environment.*
 
    **European Union accounts:** If you're connecting from the EU, use the following URL:
 

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
@@ -39,7 +39,7 @@ Go to the [Prometheus remote write setup launcher in New Relic One](https://one.
    remote_write: 
    - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=<var>YOUR_DATA_SOURCE_NAME</var>  
      authorization:
-     credentials: YOUR_LICENSE_KEY
+       credentials: YOUR_LICENSE_KEY
    ```
 
    **Prometheus older than v2.26**

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
@@ -39,7 +39,7 @@ Go to the [Prometheus remote write setup launcher in New Relic One](https://one.
    remote_write: 
    - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=<var>YOUR_DATA_SOURCE_NAME</var>  
      authorization:
-       credentials: YOUR_LICENSE_KEY
+       credentials: <var>YOUR_LICENSE_KEY</var>
    ```
 
    **Prometheus older than v2.26**
@@ -56,7 +56,7 @@ Go to the [Prometheus remote write setup launcher in New Relic One](https://one.
    remote_write: 
    - url: https://metric-api.newrelic.com/prometheus/v1/write?X-License-Key=<var>YOUR_LICENSE_KEY</var>&prometheus_server=<var>YOUR_DATA_SOURCE_NAME</var>
    ```
-   *This approach is discouraged as it is preferable not to pass credentials in the url*
+   *This passes credentials in the URL. We don't recommend using it.*
 
    **European Union accounts:** If you're connecting from the EU, use the following URL:
 

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
@@ -34,18 +34,29 @@ Go to the [Prometheus remote write setup launcher in New Relic One](https://one.
 
    Use the following syntax:
 
+   **Prometheus v2.26 and newer**
+   ``` 
+   remote_write: 
+   - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=<var>YOUR_DATA_SOURCE_NAME</var>  
+     authorization:
+     credentials: YOUR_LICENSE_KEY
+   ```
+
+   **Prometheus older than v2.26**
    ```
    remote_write: 
    - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=<var>YOUR_DATA_SOURCE_NAME</var>  
      bearer_token:<var>YOUR_LICENSE_KEY</var>
    ```
-
-   OR
-
+   
+   OR 
+   
+   **Any Prometheus version**
    ```
    remote_write: 
    - url: https://metric-api.newrelic.com/prometheus/v1/write?X-License-Key=<var>YOUR_LICENSE_KEY</var>&prometheus_server=<var>YOUR_DATA_SOURCE_NAME</var>
    ```
+   *This approach is discouraged as it is preferable not to pass credentials in the url*
 
    **European Union accounts:** If you're connecting from the EU, use the following URL:
 


### PR DESCRIPTION
Prometheus made [changes](https://github.com/prometheus/prometheus/commit/8787f0aed79c5feffb0b18b6051e8ddd91d7bbce) to the preferred way to configure remote write credentials in v2.26. 
