### PR TITLE
chore(java-agent): correcting the CVE for the newest release

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-6.5.3.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-6.5.3.mdx
@@ -6,7 +6,7 @@ downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/
 ---
 
 ### Fixes
-* Changed log4j version to 2.12.3 to mitigate the security vulnerability [CVE-2021-45046](https://github.com/advisories/GHSA-7rjr-3q55-vv33). [605](https://github.com/newrelic/newrelic-java-agent/issues/605)
+* Changed log4j version to 2.12.3 to mitigate the security vulnerability [CVE-2021-45105](https://github.com/advisories/GHSA-p6xc-xr62-6r2g). [605](https://github.com/newrelic/newrelic-java-agent/issues/605)
 
 ### Mitigation for Java 7
 * This release is compatible with Java 7.


### PR DESCRIPTION
## Give us some context

The release notes for the java agent referenced the wrong CVE.