### PR TITLE
chore: note about max memory defined by default

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/infrastructure-agent-performance-overhead.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/infrastructure-agent-performance-overhead.mdx
@@ -96,9 +96,10 @@ As a general guideline, New Relic has collected benchmarks for some common types
 
 We are always improving the performance of the infrastructure agent. If you see unusually high agent performance overhead, get support at [support.newrelic.com](https://support.newrelic.com).
 
-## Manage data
+## Manage data [#manage-data]
 
-For how to adjust how much data our infrastructure monitoring ingests and reports, see [Manage infrastructure data](/docs/infrastructure/manage-your-data/data-instrumentation/manage-infrastructure-data-reporting).
+To learn how to adjust how much data our infrastructure monitoring ingests and reports, see [Manage infrastructure data](/docs/infrastructure/manage-your-data/data-instrumentation/manage-infrastructure-data-reporting).
 
-## Resource utilization
-On Linux systems, the Infrastructure Agent is installed with default settings for each supported service manager. A memory limit of 1 Gigabyte is enforced. Please consider reviewing and adjusting the default configuration based on your system requirements. 
+## Resource utilization [#resource-utilization]
+
+On Linux systems, infrastructure is installed with default settings for each supported service manager. A memory limit of 1 Gigabyte is enforced. Please consider reviewing and adjusting the default configuration based on your system requirements. 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/infrastructure-agent-performance-overhead.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/infrastructure-agent-performance-overhead.mdx
@@ -99,3 +99,6 @@ We are always improving the performance of the infrastructure agent. If you see 
 ## Manage data
 
 For how to adjust how much data our infrastructure monitoring ingests and reports, see [Manage infrastructure data](/docs/infrastructure/manage-your-data/data-instrumentation/manage-infrastructure-data-reporting).
+
+## Resource utilization
+On Linux systems, the Infrastructure Agent is installed with default settings for each supported service manager. A memory limit of 1 Gigabyte is enforced. Please consider reviewing and adjusting the default configuration based on your system requirements. 


### PR DESCRIPTION
## Give us some context

* When installing the infrastructure agent on Linux, a max memory limit of 1gb is enforced by service manager settings (systemd, upstart). GTS feedback received to document this default setting so that customers are aware. 