### PR TITLE
Win 2022 support for infra-agent & log-fwd

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -142,7 +142,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        Windows Server 2012, 2016, 2019, 2022 and their service packs.
+        Windows Server 2012, 2016, 2019, and 2022, and their service packs.
 
         Windows 10 and their service packs.
       </td>

--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -142,7 +142,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        Windows Server 2012, 2016, and 2019, and their service packs.
+        Windows Server 2012, 2016, 2019, 2022 and their service packs.
 
         Windows 10 and their service packs.
       </td>

--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -147,7 +147,7 @@ The log forwarding feature is compatible with the following operating systems:
       </td>
 
       <td>
-        Windows Server 2012, 2016, and 2019, and their service packs.
+        Windows Server 2012, 2016, 2019, 2022 and their service packs.
 
         Windows 10
       </td>

--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -147,7 +147,7 @@ The log forwarding feature is compatible with the following operating systems:
       </td>
 
       <td>
-        Windows Server 2012, 2016, 2019, 2022 and their service packs.
+        Windows Server 2012, 2016, 2019, and 2022, and their service packs.
 
         Windows 10
       </td>


### PR DESCRIPTION
## Give us some context
* Win 2022 was released Sep-2021, adding support after validations via Guided Install & canary servers. 