### PR TITLE
Update CPM Helm Repo Link

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
@@ -394,7 +394,7 @@ To start the CPM, follow the applicable Docker or Kubernetes instructions.
        * If you are copying the charts for the first time:
 
          ```
-         helm repo add <var>YOUR_REPO_NAME</var> https://helm-charts.newrelic.com
+         helm repo add <var>YOUR_REPO_NAME</var> https://helm-charts.newrelic.com/charts
          ```
        * If you previously copied the Helm charts from the New Relic Helm repo, then get the latest:
 


### PR DESCRIPTION
* updating helm repo link to parity of instructions in NR1 UI

Resolves: docs/update-cpm-helm-repo-link

## Give us some context

* This just creates parity between the NR1 UI and the docs, as when "Create private location" call-to-action/button is clicked, a name + description have been filled out, and then the "Generate Key" button/call-to-action has been clicked - in the UI under the instructions of `helm repo add` the URL is different between the two, figured that the one in NR1 may be more accurate than the one given in the docs
**however**
I may be totally wrong with this edit 😅  - so feel free to close this if the NR1 UI actually needs it's URL to be updated instead of the docs 😅 
X-Reference Screenshot:
![Screen Shot 2021-12-27 at 1 20 37 PM](https://user-images.githubusercontent.com/5370752/147509744-a57dc412-0300-4c1b-90a9-4da1478a05a1.png)


Please also ignore this prior 'quick' page edit via:
https://github.com/newrelic/docs-website/commit/f842fb9661cfd3320ba51ffe49c9e69c66c57ac0
I had mistaken the commit message for a PR form 😅 😅 

These docs are awesome!  Props to everyone that's been able to make them what they are! 🎸 🚀 😄 