### PR TITLE
docs: change getAgent to GetAgent

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/iagent.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/iagent.mdx
@@ -14,7 +14,7 @@ redirects:
 
 ## Syntax
 
-```
+```cs
 public interface IAgent
 ```
 
@@ -28,7 +28,7 @@ Compatible with all app types.
 
 ## Description
 
-Provides access to agent artifacts and methods, such as the currently executing transaction. To obtain a reference to `IAgent`, use [`getAgent`](/docs/agents/net-agent/net-agent-api/getagent).
+Provides access to agent artifacts and methods, such as the currently executing transaction. To obtain a reference to `IAgent`, use [`GetAgent`](/docs/agents/net-agent/net-agent-api/getagent).
 
 ### Properties
 
@@ -70,7 +70,7 @@ Provides access to agent artifacts and methods, such as the currently executing 
 
 ## Examples
 
-```
+```cs
 IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
 ITransaction transaction = agent.CurrentTransaction;
 ```


### PR DESCRIPTION
`getAgent` is not the same as `GetAgent`, getAgent would throw an error. I also added c# language identifiers to the code blocks

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.