### PR TITLE
docs: update example code syntax

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/tracemetadata-net-agent-api-0.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/tracemetadata-net-agent-api-0.mdx
@@ -13,7 +13,7 @@ redirects:
 
 ## Syntax
 
-```
+```cs
 NewRelic.Api.Agent.NewRelic.TraceMetadata;
 ```
 
@@ -81,10 +81,10 @@ Provides access to the following properties:
 
 ## Examples
 
-```
-NewRelic.Api.Agent.IAgent Agent = NewRelic.Api.Agent.NewRelic.GetAgent();
-var traceMetadata = Agent.TraceMetadata;
-var traceId = traceMetadata.TraceId;
-var spanId = traceMetadata.SpanId;
-var isSampled = traceMetadata.IsSampled;
+```cs
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+TraceMetadata traceMetadata = agent.TraceMetadata;
+string traceId = traceMetadata.TraceId;
+string spanId = traceMetadata.SpanId;
+bool isSampled = traceMetadata.IsSampled;
 ```


### PR DESCRIPTION
Our docs use a simpler example syntax for creating an `Agent` instance than this doc did, [as you can see here](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/itransaction/#example-2) so I changed `NewRelic.Api.Agent.IAgent Agent = NewRelic.Api.Agent.NewRelic.GetAgent();` to `IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();`

`agent` should be lower case because it's an instance. `bool` and `string` are preferred to `var` in c#.

I'm also not sure about the namespace we show on this doc, looking at [the repo](https://github.com/newrelic/newrelic-dotnet-agent/blob/main/src/Agent/NewRelic.Api.Agent/TraceMetadata.cs) it looks like it should be `NewRelic.Api.Agent.TraceMetadata`. I'm checking on that.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.