### PR TITLE
docs: correct TraceMetadata namespace

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/tracemetadata-net-agent-api-0.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/tracemetadata-net-agent-api-0.mdx
@@ -13,8 +13,8 @@ redirects:
 
 ## Syntax
 
-```
-NewRelic.Api.Agent.NewRelic.TraceMetadata;
+```cs
+NewRelic.Api.Agent.TraceMetadata;
 ```
 
 Returns properties in the current execution environment used to support tracing.
@@ -81,10 +81,10 @@ Provides access to the following properties:
 
 ## Examples
 
-```
-NewRelic.Api.Agent.IAgent Agent = NewRelic.Api.Agent.NewRelic.GetAgent();
-var traceMetadata = Agent.TraceMetadata;
-var traceId = traceMetadata.TraceId;
-var spanId = traceMetadata.SpanId;
-var isSampled = traceMetadata.IsSampled;
+```cs
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+TraceMetadata traceMetadata = agent.TraceMetadata;
+string traceId = traceMetadata.TraceId;
+string spanId = traceMetadata.SpanId;
+bool isSampled = traceMetadata.IsSampled;
 ```


### PR DESCRIPTION
This is a follow up to my previous PR - https://github.com/newrelic/docs-website/pull/5435

The only change here is the namespace on line 17, the rest is duplicated from my previous PR to prevent any accidental merge conflicts.

Basil Abusamrah confirmed that the given namespace is incorrect on this doc. [Slack conversation](https://newrelic.slack.com/archives/C7HNR7WNR/p1640646166416300), [link to confirm namespace](https://github.com/newrelic/newrelic-dotnet-agent/blob/main/src/Agent/NewRelic.Api.Agent/TraceMetadata.cs).

Additionally, our docs use a simpler example syntax for creating an Agent instance than this doc did, [as you can see here](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/itransaction/#example-2) so I changed `NewRelic.Api.Agent.IAgent Agent = NewRelic.Api.Agent.NewRelic.GetAgent()` to `IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent()`

`agent` should be lower case because it's an instance.` bool` and `string` are preferred to `var` in c#.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.