### PR TITLE
fix(Log management): LOGGING-6831: Log patterns is now "best effort"

### DIFF
--- a/src/content/docs/logs/ui-data/find-unusual-logs-log-patterns.mdx
+++ b/src/content/docs/logs/ui-data/find-unusual-logs-log-patterns.mdx
@@ -77,11 +77,11 @@ If you see **Patterns are turned off** in your Logs UI, click **Configure patter
 
     <tr>
       <td>
-        Parsing limits
+        Log pattern matching limits
       </td>
 
       <td>
-        We have a system of safety limits on memory and CPU resources when processing logs and their patterns. These parsing limits can have an impact on the data you get. For more information, see our documentation about [parsing limits](/docs/logs/ui-data/parsing/#limits).
+        We have a system of safety limits on memory and CPU resources when matching logs to patterns. These matching limits can have an impact on the percentage of logs that are able to be grouped into log patterns. However, log pattern matching is a "best effort" process: it is not an error if not all of your logs have the opportunity to be grouped by patterns. You will still get value from the grouping that is able to be done within resource limits.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Currently an NR Integration Error is generated when Log Patterns is short circuited due to a lack of processing time available. This error isn't something customers can do anything about; they don't control the patterns logic. All this does is create confusion with customers, who in turn ask their sales team who then ask Logging about it.

We are going to internally keep track of patterns that are super slow and could be made better, and we should do more in terms of looking at accounts that have unacceptably high levels of Patterns failing. But customers don't need to see this -- pattern matching is a "best effort" process, it's OK if we can't match against the whole model.