### PR TITLE
fix(Log management): LOGGING-6833: Grok types

### DIFF
--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -103,6 +103,96 @@ Here's an overview of how New Relic implements parsing of logs:
   </tbody>
 </table>
 
+## Grok
+
+Parsing patterns are specified using "Grok", an industry standard for parsing log messages. 
+
+Grok is a superset of Regular Expressions that adds built-in named patterns that can be used in place of literal complex regular expressions. For instance, instead of having to remember that an integer can be matched with the regular expression `(?:[+-]?(?:[0-9]+))`, you can just write `%{INT}` to use the Grok pattern `INT`, which represents the same regular expression. You can however still use a mix of regular expressions and Grok pattern names in your matching string.
+
+Grok patterns have the syntax:
+`%{PATTERN_NAME[:OPTIONAL_EXTRACTED_ATTRIBUTE_NAME[:OPTIONAL_TYPE]]}`
+- `PATTERN_NAME` is one of the patterns listed [here](https://grokdebug.herokuapp.com/patterns) (click 'grok-patterns' to see the most commonly-used patterns). The pattern name is just a user-friendly name representing a regular expression. They are exactly equal to the corresponding regular expression.
+- `OPTIONAL_EXTRACTED_ATTRIBUTE_NAME`, if provided, is the name of the attribute that will be added to your log message with the value matched by the pattern name. It is equivalent to using a named capture group using regular expressions. If this is not provided, then the parsing rule will just match a region of your string, but not extract an attribute with its value.
+- `OPTIONAL_TYPE` specifies the type of attribute value to extract. If it is omitted, values are extracted as strings. For instance, to extract the value `123` from `"File Size: 123"` as a number into attribute `file_size`, use `value: %{INT:file_size:int}`. Supported types are:
+ <table>
+  <thead>
+    <tr>
+      <th style={{ width: "100px" }}>
+        Type specified in Grok
+      </th>
+      <th>
+        Type stored in NRDB
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>boolean</code>
+      </td>
+      <td>
+        <code>boolean</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>byte</code><br/>
+        <code>short</code><br/>
+        <code>int</code><br/>
+        <code>integer</code><br/>
+      </td>
+      <td>
+         <code>integer</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+         <code>long</code>
+      </td>
+      <td>
+        <code>long</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>float</code>
+      </td>
+      <td>
+        <code>float</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>double</code>
+      </td>
+      <td>
+        <code>double</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>string</code> (default)<br/>
+        <code>text</code><br/>
+      </td>
+      <td>
+        <code>string</code>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>date</code><br/>
+        <code>datetime</code><br/>
+      </td>
+      <td>
+        ISO 8601 time as a <code>long</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+See [this blog post](https://newrelic.com/blog/how-to-relic/how-to-use-grok-log-parsing) for more details.
+
+
 ## Organizing by logtype [#logtype]
 
 New Relic's log ingestion pipeline can parse data by matching a log event to a rule that describes how the log should be parsed. There are two ways log events can be parsed:

--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -21,7 +21,7 @@ New Relic parses log data according to rules. This document describes how logs p
 
 You can also create, query, and manage your log parsing rules by using NerdGraph, our GraphQL API, at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql). For more information, see our [NerdGraph tutorial for parsing](/docs/apis/nerdgraph/examples/nerdgraph-log-parsing-rules-tutorial/).
 
-## Example [#parsing-defined]
+## Parsing example [#parsing-defined]
 
 A good example is a default NGINX access log containing unstructured text. It is useful for searching but not much else. Here's an example of a typical line:
 
@@ -103,25 +103,31 @@ Here's an overview of how New Relic implements parsing of logs:
   </tbody>
 </table>
 
-## Grok
+## Parse attributes using Grok [#grok]
 
-Parsing patterns are specified using "Grok", an industry standard for parsing log messages. 
+Parsing patterns are specified using Grok, an industry standard for parsing log messages. 
 
-Grok is a superset of Regular Expressions that adds built-in named patterns that can be used in place of literal complex regular expressions. For instance, instead of having to remember that an integer can be matched with the regular expression `(?:[+-]?(?:[0-9]+))`, you can just write `%{INT}` to use the Grok pattern `INT`, which represents the same regular expression. You can however still use a mix of regular expressions and Grok pattern names in your matching string.
+Grok is a superset of regular expressions that adds built-in named patterns to be used in place of literal complex regular expressions. For instance, instead of having to remember that an integer can be matched with the regular expression `(?:[+-]?(?:[0-9]+))`, you can just write `%{INT}` to use the Grok pattern `INT`, which represents the same regular expression. You can always use a mix of regular expressions and Grok pattern names in your matching string.
 
 Grok patterns have the syntax:
+
 `%{PATTERN_NAME[:OPTIONAL_EXTRACTED_ATTRIBUTE_NAME[:OPTIONAL_TYPE]]}`
-- `PATTERN_NAME` is one of the patterns listed [here](https://grokdebug.herokuapp.com/patterns) (click 'grok-patterns' to see the most commonly-used patterns). The pattern name is just a user-friendly name representing a regular expression. They are exactly equal to the corresponding regular expression.
-- `OPTIONAL_EXTRACTED_ATTRIBUTE_NAME`, if provided, is the name of the attribute that will be added to your log message with the value matched by the pattern name. It is equivalent to using a named capture group using regular expressions. If this is not provided, then the parsing rule will just match a region of your string, but not extract an attribute with its value.
-- `OPTIONAL_TYPE` specifies the type of attribute value to extract. If it is omitted, values are extracted as strings. For instance, to extract the value `123` from `"File Size: 123"` as a number into attribute `file_size`, use `value: %{INT:file_size:int}`. Supported types are:
- <table>
+
+Where:
+- `PATTERN_NAME` is one of the [Grok patterns](https://grokdebug.herokuapp.com/patterns). Click `grok-patterns` to see the most commonly-used patterns. The pattern name is just a user-friendly name representing a regular expression. They are exactly equal to the corresponding regular expression.
+- `OPTIONAL_EXTRACTED_ATTRIBUTE_NAME`, if provided, is the name of the attribute that will be added to your log message with the value matched by the pattern name. It's equivalent to using a named capture group using regular expressions. If this is not provided, then the parsing rule will just match a region of your string, but not extract an attribute with its value.
+- `OPTIONAL_TYPE` specifies the type of attribute value to extract. If omitted, values are extracted as strings. For instance, to extract the value `123` from `"File Size: 123"` as a number into attribute `file_size`, use `value: %{INT:file_size:int}`. 
+
+Supported types are:
+
+<table>
   <thead>
     <tr>
       <th style={{ width: "100px" }}>
         Type specified in Grok
       </th>
       <th>
-        Type stored in NRDB
+        Type stored in the New Relic database
       </th>
     </tr>
   </thead>
@@ -136,18 +142,18 @@ Grok patterns have the syntax:
     </tr>
     <tr>
       <td>
-        <code>byte</code><br/>
-        <code>short</code><br/>
-        <code>int</code><br/>
-        <code>integer</code><br/>
+        <code>byte</code>
+        <code>short</code>
+        <code>int</code>
+        <code>integer</code>
       </td>
       <td>
-         <code>integer</code>
+        <code>integer</code>
       </td>
     </tr>
     <tr>
       <td>
-         <code>long</code>
+        <code>long</code>
       </td>
       <td>
         <code>long</code>
@@ -171,8 +177,8 @@ Grok patterns have the syntax:
     </tr>
     <tr>
       <td>
-        <code>string</code> (default)<br/>
-        <code>text</code><br/>
+        <code>string</code> (default)
+        <code>text</code>
       </td>
       <td>
         <code>string</code>
@@ -180,8 +186,8 @@ Grok patterns have the syntax:
     </tr>
     <tr>
       <td>
-        <code>date</code><br/>
-        <code>datetime</code><br/>
+        <code>date</code>
+        <code>datetime</code>
       </td>
       <td>
         ISO 8601 time as a <code>long</code>
@@ -190,8 +196,7 @@ Grok patterns have the syntax:
   </tbody>
 </table>
 
-See [this blog post](https://newrelic.com/blog/how-to-relic/how-to-use-grok-log-parsing) for more details.
-
+See [our blog post](https://newrelic.com/blog/how-to-relic/how-to-use-grok-log-parsing) for more details.
 
 ## Organizing by logtype [#logtype]
 

--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -123,7 +123,7 @@ Supported types are:
 <table>  
   <thead>
     <tr>
-      <th style={{ width: "200px" }}>
+      <th style={{ width: "400px" }}>
         Type specified in Grok
       </th>
       <th>
@@ -135,63 +135,63 @@ Supported types are:
   <tbody>
     <tr>
       <td>
-        <code>boolean</code>
+        `boolean`
       </td>
       <td>
-        <code>boolean</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>byte</code>
-        <code>short</code>
-        <code>int</code>
-        <code>integer</code>
-      </td>
-      <td>
-        <code>integer</code>
+        `boolean`
       </td>
     </tr>
     <tr>
       <td>
-        <code>long</code>
+        `byte`
+        `short`
+        `int`
+        `integer`
       </td>
       <td>
-        <code>long</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>float</code>
-      </td>
-      <td>
-        <code>float</code>
+        `integer`
       </td>
     </tr>
     <tr>
       <td>
-        <code>double</code>
+        `long`
       </td>
       <td>
-        <code>double</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>string</code> (default)
-        <code>text</code>
-      </td>
-      <td>
-        <code>string</code>
+        `long`
       </td>
     </tr>
     <tr>
       <td>
-        <code>date</code>
-        <code>datetime</code>
+        `float`
       </td>
       <td>
-        ISO 8601 time as a <code>long</code>
+        `float`
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `double`
+      </td>
+      <td>
+        `double`
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `string` (default)
+        `text`
+      </td>
+      <td>
+        `string`
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `date`
+        `datetime`
+      </td>
+      <td>
+        ISO 8601 time as a `long`
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -120,10 +120,10 @@ Where:
 
 Supported types are:
 
-<table>
+<table>  
   <thead>
     <tr>
-      <th style={{ width: "100px" }}>
+      <th style={{ width: "200px" }}>
         Type specified in Grok
       </th>
       <th>
@@ -131,6 +131,7 @@ Supported types are:
       </th>
     </tr>
   </thead>
+
   <tbody>
     <tr>
       <td>


### PR DESCRIPTION
We support typed attributes being extracted using Grok, but documentation does not make that clear
