### PR TITLE
feat(infra-agent): added how to troubleshoot with log traces

### DIFF
--- a/src/content/docs/infrastructure/new-relic-infrastructure/troubleshooting/incorrect-data-reported.mdx
+++ b/src/content/docs/infrastructure/new-relic-infrastructure/troubleshooting/incorrect-data-reported.mdx
@@ -1,0 +1,88 @@
+---
+title: Incorrect data reported
+type: troubleshooting
+tags:
+  - Infrastructure
+  - Infrastructure monitoring troubleshooting
+  - Troubleshoot infrastructure
+redirects:
+  - /docs/infrastructure/new-relic-infrastructure/troubleshooting/wrong-data-reported
+---
+
+## Problem [#problem]
+
+The agent is working, but the [infrastructure monitoring UI](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-compute-page-measure-resource-usage) shows unexpected data for some of the events, metrics or attributes collected from the Infrastructure Agent.
+
+## Troubleshooting [#troubleshooting]
+
+The Infrastructure Agent supports trace-level logging that can be enabled on-demand to help troubleshooting complex scenarios.
+The following trace flags can be configured in order to print all events and metrics send to Telemetry Data Platform. 
+This setting generates a lot of data very quickly, we recommend only enabling it for troubleshooting purposes.
+
+1. Edit the [newrelic-infra.yml](/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#config-file) configuration file and add required flags. For example:
+
+   ```
+   verbose: 1
+   log_file: /path/myfile.log
+   trace: 
+     # v3.submission enables detailed logging for events, examples: SystemSample, NetworkSample, etc.
+     - v3.submission
+     # dm.submission 
+     - dm.submission
+   ```
+2. Use [your init system](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status#init-system) to restart the agent service:
+
+   <CollapserGroup>
+     <Collapser
+       id="systemd-verify-status"
+       title="Restart the agent with SystemD"
+     >
+       Use SystemD commands with CentOS 7, Debian 8, RHEL 7, and Ubuntu 15.04 or higher:
+
+       ```
+       sudo systemctl restart newrelic-infra
+       ```
+     </Collapser>
+
+     <Collapser
+       id="systemv-verify-status"
+       title="Restart the agent with System V"
+     >
+       Use System V commands with Debian 7:
+
+       ```
+       sudo /etc/init.d/newrelic-infra restart
+       ```
+     </Collapser>
+
+     <Collapser
+       id="upstart-verify-status"
+       title="Restart the agent with Upstart"
+     >
+       Use Upstart commands with Amazon Linux, CentOS 6, RHEL 6, and Ubuntu 14.10 or lower:
+
+       ```
+       sudo initctl restart newrelic-infra
+       ```
+     </Collapser>
+
+     <Collapser
+       id="windows-verify-status"
+       title="Restart the agent in Windows"
+     >
+       ```
+       net stop newrelic-infra
+       net start newrelic-infra
+       ```
+     </Collapser>
+   </CollapserGroup>
+
+3. Identify the new trace log lines to confirm the data being sent to Telemetry Data Platform
+
+Log example when v3.submission is enabled:
+```
+time="2021-12-28T09:27:28Z" level=debug msg="Sending events to metrics-ingest." component=MetricsIngestSender key=... numEvents=3 postCount=1 timestamps="[2021-01-01 09:27:28 +0000 UTC]"
+time="2021-12-28T09:27:28Z" level=debug msg="Preparing metrics post." component=MetricsIngestSender postCount=1
+time="2021-12-28T09:27:28Z" level=trace msg="[{\"EntityID\":111,\"IsAgent\":true,\"Events\":[{\"eventType\":\"SystemSample\",\"timestamp\":1640683648,\"entityKey\":\"...\",\"cpuPercent\":0.2004008016032026, ...}]" feature=v3.submission
+time="2021-12-28T09:27:29Z" level=debug msg="Metrics post succeeded." component=MetricsIngestSender postCount=1
+```

--- a/src/content/docs/infrastructure/new-relic-infrastructure/troubleshooting/incorrect-data-reported.mdx
+++ b/src/content/docs/infrastructure/new-relic-infrastructure/troubleshooting/incorrect-data-reported.mdx
@@ -11,75 +11,74 @@ redirects:
 
 ## Problem [#problem]
 
-The agent is working, but the [infrastructure monitoring UI](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-compute-page-measure-resource-usage) shows unexpected data for some of the events, metrics or attributes collected from the Infrastructure Agent.
+The agent is working, but the [infrastructure monitoring UI](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-compute-page-measure-resource-usage) shows unexpected data for some of the events, metrics or attributes collected from the infrastructure agent.
 
 ## Troubleshooting [#troubleshooting]
 
-The Infrastructure Agent supports trace-level logging that can be enabled on-demand to help troubleshooting complex scenarios.
-The following trace flags can be configured in order to print all events and metrics send to Telemetry Data Platform. 
-This setting generates a lot of data very quickly, we recommend only enabling it for troubleshooting purposes.
+Infrastructure supports trace-level logging that can be enabled on-demand to help troubleshooting complex scenarios. The following trace flags can be configured in order to print all events and metrics send to Telemetry Data Platform. This setting generates a lot of data very quickly, we recommend only enabling it for troubleshooting purposes.
 
 1. Edit the [newrelic-infra.yml](/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#config-file) configuration file and add required flags. For example:
 
-   ```
-   verbose: 1
-   log_file: /path/myfile.log
-   trace: 
-     # v3.submission enables detailed logging for events, examples: SystemSample, NetworkSample, etc.
-     - v3.submission
-     # dm.submission 
-     - dm.submission
-   ```
+  ```
+  verbose: 1
+  log_file: /path/myfile.log
+  trace: 
+    # v3.submission enables detailed logging for events, examples: SystemSample, NetworkSample, etc.
+    - v3.submission
+    # dm.submission 
+    - dm.submission
+  ```
 2. Use [your init system](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status#init-system) to restart the agent service:
 
-   <CollapserGroup>
-     <Collapser
-       id="systemd-verify-status"
-       title="Restart the agent with SystemD"
-     >
-       Use SystemD commands with CentOS 7, Debian 8, RHEL 7, and Ubuntu 15.04 or higher:
+  <CollapserGroup>
+    <Collapser
+      id="systemd-verify-status"
+      title="Restart the agent with SystemD"
+    >
+      Use SystemD commands with CentOS 7, Debian 8, RHEL 7, and Ubuntu 15.04 or higher:
 
-       ```
-       sudo systemctl restart newrelic-infra
-       ```
-     </Collapser>
+      ```
+      sudo systemctl restart newrelic-infra
+      ```
+    </Collapser>
 
-     <Collapser
-       id="systemv-verify-status"
-       title="Restart the agent with System V"
-     >
-       Use System V commands with Debian 7:
+    <Collapser
+      id="systemv-verify-status"
+      title="Restart the agent with System V"
+    >
+      Use System V commands with Debian 7:
 
-       ```
-       sudo /etc/init.d/newrelic-infra restart
-       ```
-     </Collapser>
+      ```
+      sudo /etc/init.d/newrelic-infra restart
+      ```
+    </Collapser>
 
-     <Collapser
-       id="upstart-verify-status"
-       title="Restart the agent with Upstart"
-     >
-       Use Upstart commands with Amazon Linux, CentOS 6, RHEL 6, and Ubuntu 14.10 or lower:
+    <Collapser
+      id="upstart-verify-status"
+      title="Restart the agent with Upstart"
+    >
+      Use Upstart commands with Amazon Linux, CentOS 6, RHEL 6, and Ubuntu 14.10, or lower:
 
-       ```
-       sudo initctl restart newrelic-infra
-       ```
-     </Collapser>
+      ```
+      sudo initctl restart newrelic-infra
+      ```
+    </Collapser>
 
-     <Collapser
-       id="windows-verify-status"
-       title="Restart the agent in Windows"
-     >
-       ```
-       net stop newrelic-infra
-       net start newrelic-infra
-       ```
-     </Collapser>
-   </CollapserGroup>
+    <Collapser
+      id="windows-verify-status"
+      title="Restart the agent in Windows"
+    >
+      ```
+      net stop newrelic-infra
+      net start newrelic-infra
+      ```
+    </Collapser>
+  </CollapserGroup>
 
-3. Identify the new trace log lines to confirm the data being sent to Telemetry Data Platform
+3. Identify the new trace log lines to confirm the data being sent to the Telemetry Data Platform.
 
 Log example when v3.submission is enabled:
+
 ```
 time="2021-12-28T09:27:28Z" level=debug msg="Sending events to metrics-ingest." component=MetricsIngestSender key=... numEvents=3 postCount=1 timestamps="[2021-01-01 09:27:28 +0000 UTC]"
 time="2021-12-28T09:27:28Z" level=debug msg="Preparing metrics post." component=MetricsIngestSender postCount=1

--- a/src/nav/infrastructure.yml
+++ b/src/nav/infrastructure.yml
@@ -750,6 +750,8 @@ pages:
             path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/incorrect-host-name-reported
           - title: Time gaps with missing data
             path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/time-gaps-missing-data
+          - title: Incorrect data reported  
+            path: /docs/infrastructure/new-relic-infrastructure/troubleshooting/incorrect-data-reported
       - title: Troubleshoot logs
         path: /docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs
         pages:


### PR DESCRIPTION
## Give us some context

* Adding a troubleshooting page explaining how to enable log traces in the Infrastructure Agent to print all events and metrics being sent to Telemetry Data Platform (Infrastructure endpoints). This is relevant for complex troubleshooting scenarios when there's discrepancy between expected data and what's shown in the UI. 