### PR TITLE
docs: clean up codeblocks and add lang identifiers

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
@@ -52,12 +52,12 @@ On this page, you will learn how to manually instrument your lambda function. It
 
           1. Build the binary for execution on Linux. This produces a binary file called `main`. You can use:
 
-            ```
+            ```bash
             $ GOOS=linux go build -o main
             ```
           2. Zip the binary into a deployment package using:
 
-            ```
+            ```bash
             $ zip deployment.zip main
             ```
           3. Upload the zip file to AWS using either the AWS Lambda console or the AWS CLI. Name the handler `main` (to match the name given during the binary build).
@@ -98,8 +98,8 @@ On this page, you will learn how to manually instrument your lambda function. It
     To instrument your Java Lambda:
 
     1. In your project’s `build.gradle` file, include our OpenTracing AWS Lambda Tracer and the AWS Lambda OpenTracing SDK dependencies:
-
-      ```
+    
+      ```java
       dependencies {
           compile("com.newrelic.opentracing:java-aws-lambda:2.1.0")
           compile("com.newrelic.opentracing:newrelic-java-lambda:2.2.1")
@@ -142,39 +142,38 @@ On this page, you will learn how to manually instrument your lambda function. It
         Note: `NewRelic.OpenTracing.AmazonLambda.Tracer` depends on version 1.2.0+ of `Amazon.Lambda.APIGatewayEvent` NuGet package. If the environment already uses a lower version of `Amazon.Lambda.APIGatewayEvent`, the New Relic package may produce errors such as `System.MissingMethodException` .
     2. Import the NuGet package and OpenTracing utils:
 
-        ```
+        ```cs
         using OpenTracing.Util;
         using NewRelic.OpenTracing.AmazonLambda;
         ```
 
     3. Instrument your function, as shown in this example:
 
-```
+```cs
 public class Function
 {
+  static Function()
+  {
+    // Register The NewRelic Lambda Tracer Instance
+    GlobalTracer.Register(NewRelic.OpenTracing.AmazonLambda.LambdaTracer.Instance);
+  }
 
-static Function()
-{
-  // Register The NewRelic Lambda Tracer Instance
-  GlobalTracer.Register(NewRelic.OpenTracing.AmazonLambda.LambdaTracer.Instance);
-}
+  public object FunctionWrapper(ILambdaContext context)
+  {
+    // Instantiate NewRelic TracingWrapper and pass your FunctionHandler as
+    // an argument
+    return new TracingRequestHandler().LambdaWrapper(FunctionHandler, context);
+  }
 
-public object FunctionWrapper(ILambdaContext context)
-{
-  // Instantiate NewRelic TracingWrapper and pass your FunctionHandler as
-  // an argument
-  return new TracingRequestHandler().LambdaWrapper(FunctionHandler, context);
-}
-
-/// <summary>
-/// A simple function that takes a string and does a ToUpper
-/// </summary>
-/// <param name="input"></param>
-/// <param name="context"></param>
-/// <returns></returns>
-public object FunctionHandler(ILambdaContext context)
-{ ... }
-
+  /// <summary>
+  /// A simple function that takes a string and does a ToUpper
+  /// </summary>
+  /// <param name="input"></param>
+  /// <param name="context"></param>
+  /// <returns></returns>
+  public object FunctionHandler(ILambdaContext context)
+  { ... }
+  
 }
 ```
 
@@ -191,7 +190,8 @@ public object FunctionHandler(ILambdaContext context)
 id="net-handler-returns-task-example"
 title="Async handler function"
 >
-```
+
+```cs
 public async Task<int> FunctionHandlerAsync(ILambdaContext lambdaContext)
 {
   return await new TracingRequestHandler().LambdaWrapper(
@@ -200,8 +200,9 @@ public async Task<int> FunctionHandlerAsync(ILambdaContext lambdaContext)
 
 public async Task<APIGatewayProxyResponse> ActualFunctionHandlerAsync(ILambdaContext
 lambdaContext)
-{ // Function can make other async operations here
-...
+{ 
+  // Function can make other async operations here
+  ...
 }
 
 ```
@@ -211,30 +212,30 @@ lambdaContext)
 id="net-handler-inherit-apigatewayproxyfunction"
 title="Inheriting from APIGatewayProxyFunction"
 >
-```
-
+  
+```cs
 public class LambdaFunction : APIGatewayProxyFunction
 {
-static LambdaFunction()
-{
-// Register The NewRelic Lambda Tracer Instance
-OpenTracing.Util.GlobalTracer.Register(NewRelic.OpenTracing.AmazonLambda.LambdaTracer.Instance);
-}
+  static LambdaFunction()
+  {
+    // Register The NewRelic Lambda Tracer Instance
+    OpenTracing.Util.GlobalTracer.Register(NewRelic.OpenTracing.AmazonLambda.LambdaTracer.Instance);
+  }
 
-public override Task<APIGatewayProxyResponse> FunctionHandlerAsync(APIGatewayProxyRequest request, ILambdaContext lambdaContext)
-{
-Task<APIGatewayProxyResponse> task = new TracingRequestHandler().LambdaWrapper(ActualFunctionHandlerAsync, request, lambdaContext);
-return task;
-}
+  public override Task<APIGatewayProxyResponse> FunctionHandlerAsync(APIGatewayProxyRequest request, ILambdaContext lambdaContext)
+  {
+    Task<APIGatewayProxyResponse> task = new TracingRequestHandler().LambdaWrapper(ActualFunctionHandlerAsync, request, lambdaContext);
+    return task;
+  }
 
-public Task<APIGatewayProxyResponse> ActualFunctionHandlerAsync(APIGatewayProxyRequest request, ILambdaContext lambdaContext)
-{
-return base.FunctionHandlerAsync(request, lambdaContext);
+  public Task<APIGatewayProxyResponse> ActualFunctionHandlerAsync(APIGatewayProxyRequest request, ILambdaContext lambdaContext)
+  {
+    return base.FunctionHandlerAsync(request, lambdaContext);
+  }
 }
-}
-
 ```
-</Collapser>
+
+  </Collapser>
 </CollapserGroup>
     4. Optional for SQS and SNS: Starting in version 1.0 of our .NET Lambda Tracer, [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) support has been added for SQS and SNS. To enable distributed tracing for SQS or SNS you will need to complete the items in this step as well as setup the environment variables in the step that follows this one.
 
@@ -257,8 +258,8 @@ The SQS wrapper supports wrapping the following methods:
 
 Examples
 
-```
-
+```cs
+  
 // SQS Client
 AmazonSQSClient client = new AmazonSQSClient("<var>AWS_SECRET_ACCESS_KEY</var>", <var>AWS_REGION</var>);
 
@@ -297,8 +298,8 @@ The SNS wrapper supports wrapping the following methods:
 
 Examples
 
-```
-
+```cs
+  
 // SNS Client
 AmazonSimpleNotificationServiceClient client = new Amazon.SimpleNotificationService.AmazonSimpleNotificationServiceClient("<var>AWS_SECRET_ACCESS_KEY</var>", <var>AWS_REGION</var>);
 
@@ -313,10 +314,10 @@ PublishRequest publishRequest = new PublishRequest("<var>TOPIC_ARN</var>", "An S
 Task<PublishResponse> publishResponse = SNSWrapper.WrapRequest(client.PublishAsync, publishRequest);
 
 // String-based without subject
-Task<PublishResponse> ResponseOne = SNSWrapper.WrapRequest(client.PublishAsync, "<var>TOPIC_ARN</var>", "Another SNS Message");
+Task<PublishResponse> responseOne = SNSWrapper.WrapRequest(client.PublishAsync, "<var>TOPIC_ARN</var>", "Another SNS Message");
 
 // String-based with subject
-Task<PublishResponse> ResponseTwo = SNSWrapper.WrapRequest(client.PublishAsync, "<var>TOPIC_ARN</var>", "Yet Another SNS Message", "A Subject");
+Task<PublishResponse> responseTwo = SNSWrapper.WrapRequest(client.PublishAsync, "<var>TOPIC_ARN</var>", "Yet Another SNS Message", "A Subject");
 
 ```
 </Collapser>
@@ -338,21 +339,21 @@ To instrument your Node.js Lambda:
 
 1. Download our Node.js agent package and place it in the same directory as your function, ensuring the agent is installed as a dependency in the `node_modules` directory. Use the Node Package Manager:
 
-```
-
+```bash
+  
 npm install newrelic --save
 
 ```
 2. Install our AWS SDK module alongside the Node.js agent:
 
-```
+```bash
 
 npm install @newrelic/aws-sdk --save
 
 ```
 3. In your Lambda code, require the agent module and the AWS SDK at the top of the file, and wrap the handler function. For example:
 
-```
+```js
 
 const newrelic = require('newrelic');
 require('@newrelic/aws-sdk');
@@ -360,23 +361,20 @@ require('@newrelic/aws-sdk');
 // Other module loads go under the two require statements above
 
 module.exports.handler = newrelic.setLambdaHandler((event, context, callback) => {
-// This is your handler function code
-console.log('Lambda executed');
-callback();
+  // This is your handler function code
+  console.log('Lambda executed');
+  callback();
 });
 
 ```
 4. Optional: You can also add [custom events](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#custom-event) to your Lambda using the [`recordCustomEvent` API](/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#record_custom_event). For example:
 
-```
-
+```js
 module.exports.handler = newrelic.setLambdaHandler((event, context, callback) => {
-newrelic.recordCustomEvent(‘MyEventType’, {foo: ‘bar’});
-
-console.log('Lambda executed');
-callback();
+  newrelic.recordCustomEvent('MyEventType', { foo: 'bar' });
+  console.log('Lambda executed');
+  callback();
 });
-
 ```
 5. Zip your Lambda function and the Node.js agent folder together. Requirements and recommendations:
 
@@ -408,7 +406,7 @@ To instrument your Python Lambda:
 
 1. Download our Python agent package and place it in the same directory as your function. To do this, use pip:
 
-```
+```bash
 
 pip install -t . newrelic
 
@@ -419,7 +417,7 @@ pip install -t . newrelic
 </Callout>
 2. In your Lambda code, import the Python agent module and decorate the handler function using the New Relic decorator. **The New Relic package must be imported first in your code.** Here's an example:
 
-```
+```py
 
 import newrelic.agent
 newrelic.agent.initialize()
@@ -430,12 +428,12 @@ def handler(event, context):
 ```
 3. Optional: You can also add [custom events](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#custom-event) to your Lambda using the [`record_custom_event` API](/docs/agents/python-agent/python-agent-api/record_custom_event). Here's an example:
 
-```
+```py
 
 @newrelic.agent.lambda_handler()
 def handler(event, context):
 newrelic.agent.record_custom_event('CustomEvent', {'foo': 'bar'})
-…
+...
 
 ```
   4. Zip your `lambda_function.py` and `newrelic/` folder together using these guidelines:


### PR DESCRIPTION
The C# and Javascript code was messy and not indented properly. I made various minor syntactical improvements to better match best practices. I also added language identifiers to code blocks since I was here. I've spoken to Shawn and Zachary about this types of edits in the past.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.