### PR TITLE
kubernetes: clarify <1.16 deprecation message

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/deprecation-notice-v1.15andlower.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/deprecation-notice-v1.15andlower.mdx
@@ -4,16 +4,16 @@ subject: Kubernetes integration
 releaseDate: '2021-12-16'
 ---
  
-Effective Monday, 1 January 2022, Kubernetes integration v1.16 or lower will be deprecated. To avoid losing data, [upgrade to the latest version](https://docs.newrelic.com/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration#update). For more information, read this note or contact your account team.
+Effective Monday, 1 January 2022, Kubernetes integration drops support for Kubernetes v1.15 and lower. Kubernetes Integration v2.8.0 and above will only be compatible with Kubernetes versions 1.16 and above. For more information, read this note or contact your account team.
 
 ## Background [#bg]
 
-Enabling compatibility with the latest Kubernetes versions and adding new features to our Kubernetes offering avoid us being backward compatible with versions prior to v1.16.
+Enabling compatibility with the latest Kubernetes versions and adding new features to our Kubernetes offering prevents us from offering first-class support to versions prior to v1.16.
 
 ## What is happening? [#what-is-happening]
 
 * The latest Kubernetes version v1.22 has API incompatibilities with versions prior to v1.16.
-* A majority of major Kubernetes cloud providers have already deprecated these old versions.
+* A majority of major Kubernetes cloud providers have already deprecated v1.15 and below.
 
 ## What do you need to do? [#what-to-do]
 

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/deprecation-notice-v1.15andlower.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/deprecation-notice-v1.15andlower.mdx
@@ -3,8 +3,8 @@ title: 'Deprecation notice: Kubernetes'
 subject: Kubernetes integration
 releaseDate: '2021-12-16'
 ---
- 
-Effective Monday, 1 January 2022, Kubernetes integration drops support for Kubernetes v1.15 and lower. Kubernetes Integration v2.8.0 and above will only be compatible with Kubernetes versions 1.16 and above. For more information, read this note or contact your account team.
+
+Effective Monday, 1 January 2022, our Kubernetes integration drops support for Kubernetes v1.15 and lower. The Kubernetes integration v2.8.0 and higher will only be compatible with Kubernetes versions 1.16 and higher. For more information, read this note or contact your account team.
 
 ## Background [#bg]
 
@@ -13,13 +13,14 @@ Enabling compatibility with the latest Kubernetes versions and adding new featur
 ## What is happening? [#what-is-happening]
 
 * The latest Kubernetes version v1.22 has API incompatibilities with versions prior to v1.16.
-* A majority of major Kubernetes cloud providers have already deprecated v1.15 and below.
+* Most major Kubernetes cloud providers have already deprecated v1.15 and lower.
 
 ## What do you need to do? [#what-to-do]
 
-[Upgrade your Kubernetes clusters](https://docs.newrelic.com/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration#update) to a supported version.
+It's easy: [Upgrade your Kubernetes clusters](/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration#update) to a supported version.
 
 ## What happens if you don't make any changes to your account? [#account]
 
 The Kubernetes integration may continue to work with end-of-lifed versions. However, we can't guarantee the quality of the solution as new releases may cause some incompatibilities. 
-Support requests regarding these end-of-lifed versions won't be accepted.
+
+Note that support requests regarding these end-of-lifed versions won't be accepted.


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

## Give us some context

* What problems does this PR solve?
  * Previous notes stated that v1.16 was deprecated, which is not true.
  * Previous notes instructed to upgrade the integration rather than the cluster.
