### PR TITLE
docs: remove duplicate $ from bash

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
@@ -53,12 +53,12 @@ On this page, you will learn how to manually instrument your lambda function. It
           1. Build the binary for execution on Linux. This produces a binary file called `main`. You can use:
 
             ```bash
-            $ GOOS=linux go build -o main
+            GOOS=linux go build -o main
             ```
           2. Zip the binary into a deployment package using:
 
             ```bash
-            $ zip deployment.zip main
+            zip deployment.zip main
             ```
           3. Upload the zip file to AWS using either the AWS Lambda console or the AWS CLI. Name the handler `main` (to match the name given during the binary build).
         </Collapser>


### PR DESCRIPTION
I added `bash` to these code blocks yesterday without realizing that they would now automatically add a `$` to the beginning of the lines of code. Since we were doing that directly in this markdown it was rendering as `$ $ zip deployment.zip main` instead of `$ zip deployment.zip main`. 

<img width="850" alt="image" src="https://user-images.githubusercontent.com/48165493/147693559-8297bbb6-1af7-425c-8d33-43a1b9b6ef4d.png">


<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.