### PR TITLE
docs: update links, correct code indentation

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs.mdx
@@ -10,10 +10,10 @@ redirects:
   - /docs/agents/nodejs-agent/troubleshooting/generate-logs-troubleshooting-nodejs
 ---
 
-Your New Relic [Node.js agent log](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#logging_config) captures errors at the default `info` level. However, when troubleshooting or debugging, generate a more verbose `trace` log to help find and investigate problems.
+Your New Relic [Node.js agent log](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#logging_config) captures errors at the default `info` level. However, when troubleshooting or debugging, generate a more verbose `trace` log to help find and investigate problems.
 
 <Callout variant="important">
-  The `trace` log setting is a highly verbose logging level. To reduce disk space consumption, return the `logging : {` section's `level` to its [original setting](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#logging_config) after testing.
+  The `trace` log setting is a highly verbose logging level. To reduce disk space consumption, return the `logging : {` section's `level` to its [original setting](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#logging_config) after testing.
 </Callout>
 
 ## Generate log files [#create]
@@ -22,19 +22,19 @@ To generate the detailed `trace` log file:
 
 1. Edit your `newrelic.js` file and change the `logging` section's `level` to `trace`.
 
-   ```
+   ```js
    logging: {
-       level: 'trace'
-     }
+     level: 'trace'
+   }
    ```
 2. Restart Node.
 3. Exercise your web application for about five minutes to generate sufficient logging data.
-4. After testing, change the `level` to a less verbose [logging level](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#log_level), such as `info` (default).
+4. After testing, change the `level` to a less verbose [logging level](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#log_level), such as `info` (default).
 5. Open and examine the generated log file.
 
 ## Examine log file [#logfile]
 
-By default, the Node.js agent [stores the log file](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#log) in the current working directory as `newrelic_agent.log`. If the log file or folder are not visible:
+By default, the Node.js agent [stores the log file](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#log) in the current working directory as `newrelic_agent.log`. If the log file or folder are not visible:
 
 1. Check whether you have set the logging path to `stdout` or `stderr`.
 2. Verify that the current working directory is the same as the directory where you expect the log file to be located.


### PR DESCRIPTION
The 4 links I updated weren't going to the correct `#path` location, just redirecting to the page.
The indentation was off on the js example. I also added the `js` identifier to the codeblock for highlighting, Shawn and Zachary are aware of that change.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.