### PR TITLE
docs: add to step 1 option to use env vars

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs.mdx
@@ -20,7 +20,7 @@ Your New Relic [Node.js agent log](/docs/apm/agents/nodejs-agent/installation-co
 
 To generate the detailed `trace` log file:
 
-1. Edit your `newrelic.js` file and change the `logging` section's `level` to `trace`.
+1. Edit your `newrelic.js` file and change the `logging` section's `level` to `trace`, or if using environment variables, set the `NEW_RELIC_LOG_LEVEL` to `trace`.
 
    ```js
    logging: {


### PR DESCRIPTION
You can set the logging level to `trace` with an env var or in the newrelic.js. Some users do not use the newrelic.js for config so these steps will not work for them.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.