### PR TITLE
docs: add multi-location synthetic alert conditions to API documentation

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
@@ -93,8 +93,8 @@ Our REST API (v2) allows you to configure settings for alerts. The [API Explorer
         * [Notification channels](#channels)
         * Conditions for [APM, browser, and mobile](#conditions-list) ([Some limitations apply.](#excluded))
         * Conditions for [external services](#ext-conditions-list)
-        * Conditions for [Synthetic monitoring](#synthetics-conditions)
-        * Conditions for [Multi-location Synthetic monitoring](#multilocation-synthetics-conditions)
+        * Conditions for [synthetic monitoring](#synthetics-conditions)
+        * Conditions for [Multi-location synthetic monitoring](#multilocation-synthetics-conditions)
         * Conditions for NRQL ([Some limitations apply.](#excluded))
         * [Events](#events)
         * [Violations](#violations)
@@ -1010,16 +1010,16 @@ These API functions include links to the API Explorer, where you can create, upd
   </Collapser>
 </CollapserGroup>
 
-## Conditions for Synthetic monitoring [#synthetics-conditions]
+## Conditions for synthetic monitoring [#synthetics-conditions]
 
-These API functions include links to the API Explorer, where you can create, update, delete, or list [conditions](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions) for your alert policies. The API calls can be used with Synthetic monitoring.
+These API functions include links to the API Explorer, where you can create, update, delete, or list [conditions](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions) for your alert policies. The API calls can be used with synthetic monitoring.
 
 <CollapserGroup>
   <Collapser
     id="synthetics-conditions-create"
     title="Synthetics: Create conditions for policies"
   >
-    To add conditions to policies for Synthetic monitoring, include these values in the API call:
+    To add conditions to policies for synthetic monitoring, include these values in the API call:
 
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * The `policy_id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_policies/list) **Alerts Policies > GET > List**)
@@ -1050,11 +1050,11 @@ These API functions include links to the API Explorer, where you can create, upd
     id="synthetics-conditions-update"
     title="Synthetic monitoring: Update conditions for policies"
   >
-    To update policy conditions for Synthetic monitoring, include these values in the API call:
+    To update policy conditions for synthetic monitoring, include these values in the API call:
 
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * The condition `id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_synthetics_conditions/list) **Alerts Synthetics Conditions > GET > List**)
-    * The required `synthetics_condition` values in the API call (described in the API Explorer page to [create alert conditions for Synthetics](https://rpm.newrelic.com/api/explore/alerts_synthetics_conditions/create) and in the [Alerts conditions API glossary](/docs/alerts/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names))
+    * The required `synthetics_condition` values in the API call (described in the API Explorer page to [create alert conditions for synthetics](https://rpm.newrelic.com/api/explore/alerts_synthetics_conditions/create) and in the [Alerts conditions API glossary](/docs/alerts/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names))
 
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_synthetics_conditions/update) **Alerts Synthetics Conditions > PUT > Update**
@@ -1079,7 +1079,7 @@ These API functions include links to the API Explorer, where you can create, upd
     id="synthetics-conditions-delete"
     title="Synthetic monitoring: Delete conditions from policies"
   >
-    To delete policy conditions for Synthetic monitoring, include these values in the API call:
+    To delete policy conditions for synthetic monitoring, include these values in the API call:
 
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * The `condition_id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_synthetics_conditions/list) **Alerts Synthetics Conditions > GET > List**)
@@ -1097,7 +1097,7 @@ These API functions include links to the API Explorer, where you can create, upd
     id="synthetics-conditions-list"
     title="Synthetic monitoring: List existing conditions for policies"
   >
-    To view a list of existing policy conditions for Synthetic monitoring, use your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key) or [REST API key](/docs/apis/rest-api-v2/requirements/rest-api-key), and the associated [`policy_id`](#policies-list) in the API call.
+    To view a list of existing policy conditions for synthetic monitoring, use your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key) or [REST API key](/docs/apis/rest-api-v2/requirements/rest-api-key), and the associated [`policy_id`](#policies-list) in the API call.
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_synthetics_conditions/list) **Alerts Synthetics Conditions > GET > List**
 
@@ -1109,16 +1109,16 @@ These API functions include links to the API Explorer, where you can create, upd
   </Collapser>
 </CollapserGroup>
 
-## Multi-location conditions for Synthetic monitoring [#multilocation-synthetics-conditions]
+## Multi-location conditions for synthetic monitoring [#multilocation-synthetics-conditions]
 
-These API functions include links to the API Explorer, where you can create, update, delete, or list [conditions](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions) for your alert policies. The API calls can be used for multi-location conditions with Synthetic monitoring. Before creating or updating a condition, read the [rules for multi-location alert conditions](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/multi-location-synthetic-monitoring-alert-conditions/#rules).
+These API functions include links to the API Explorer, where you can create, update, delete, or list [conditions](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions) for your alert policies. The API calls can be used for multi-location conditions with synthetic monitoring. Before creating or updating a condition, read the [rules for multi-location alert conditions](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/multi-location-synthetic-monitoring-alert-conditions/#rules).
 
 <CollapserGroup>
   <Collapser
     id="multilocation-synthetics-conditions-create"
-    title="Multi-location Synthetics: Create conditions for policies"
+    title="Multi-location synthetics: Create conditions for policies"
   >
-    To add conditions to policies for multi-location Synthetic monitoring, include these values in the API call:
+    To add conditions to policies for multi-location synthetic monitoring, include these values in the API call:
 
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * The `policy_id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_policies/list) **Alerts Policies > GET > List**)
@@ -1157,9 +1157,9 @@ These API functions include links to the API Explorer, where you can create, upd
 
   <Collapser
     id="multilocation-synthetics-conditions-update"
-    title="Multi-location Synthetics: Update conditions for policies"
+    title="Multi-location synthetics: Update conditions for policies"
   >
-    To update policy conditions for multi-location Synthetic monitoring, include these values in the API call:
+    To update policy conditions for multi-location synthetic monitoring, include these values in the API call:
 
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * The condition `id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/list) **Alerts Location Failure Conditions > GET > List**)
@@ -1196,9 +1196,9 @@ These API functions include links to the API Explorer, where you can create, upd
 
   <Collapser
     id="multilocation-synthetics-conditions-delete"
-    title="Multi-location Synthetics: Delete conditions for policies"
+    title="Multi-location synthetics: Delete conditions for policies"
   >
-    To delete policy conditions for multi-location Synthetic monitoring, include these values in the API call:
+    To delete policy conditions for multi-location synthetic monitoring, include these values in the API call:
 
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * The `condition_id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/list) **Alerts Location Failure Conditions > GET > List**)
@@ -1214,9 +1214,9 @@ These API functions include links to the API Explorer, where you can create, upd
 
   <Collapser
     id="multilocation-synthetics-conditions-list"
-    title="Multi-location Synthetics: List existing conditions for policies"
+    title="Multi-location synthetics: List existing conditions for policies"
   >
-    To view a list of existing policy conditions for multi-location Synthetic monitoring, use your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key) or [REST API key](/docs/apis/rest-api-v2/requirements/rest-api-key), and the associated [`policy_id`](#policies-list) in the API call.
+    To view a list of existing policy conditions for multi-location synthetic monitoring, use your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key) or [REST API key](/docs/apis/rest-api-v2/requirements/rest-api-key), and the associated [`policy_id`](#policies-list) in the API call.
 
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/list) **Alerts Location Failure Conditions > GET > List**

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
@@ -93,7 +93,8 @@ Our REST API (v2) allows you to configure settings for alerts. The [API Explorer
         * [Notification channels](#channels-list)
         * Conditions for [APM, browser, and mobile](#conditions-list) ([Some limitations apply.](#excluded))
         * Conditions for [external services](#ext-conditions-list)
-        * Conditions for [Synthetic monitoring](#)
+        * Conditions for [Synthetic monitoring](#synthetics-conditions)
+        * Conditions for [Multi-location Synthetic monitoring](#multilocation-synthetics-conditions)
         * Conditions for NRQL ([Some limitations apply.](#excluded))
         * [Events](#events)
         * [Violations](#violations)
@@ -1087,6 +1088,122 @@ These API functions include links to the API Explorer, where you can create, upd
 
     ```
     curl -X GET 'https://api.newrelic.com/v2/alerts_synthetics_conditions.json' \
+         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+         -d 'policy_id=<var>$POLICY_ID</var>'
+    ```
+  </Collapser>
+</CollapserGroup>
+
+## Multi-location Conditions for Synthetic monitoring [#multilocation-synthetics-conditions]
+
+These API functions include links to the API Explorer, where you can create, update, delete, or list [conditions](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions) for your alert policies. The API calls can be used for multi-location conditions with Synthetic monitoring. Before creating or updating a condition, read the [rules for multi-location alert conditions](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/multi-location-synthetic-monitoring-alert-conditions/#rules).
+
+<CollapserGroup>
+  <Collapser
+    id="multilocation-synthetics-conditions-create"
+    title="Multi-location Synthetics: Create conditions for policies"
+  >
+    To add conditions to policies for Multi-location Synthetic monitoring, include these values in the API call:
+
+    * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
+    * The `policy_id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_policies/list) **Alerts Policies > GET > List**)
+    * The required `location_failure_condition` values in the API call (described in the API Explorer page and in the [Alerts conditions API glossary](/docs/alerts/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names))
+
+    [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/create) **Alerts Location Failure Conditions > POST > Create**
+
+    ```
+    curl -X POST 'https://api.newrelic.com/v2/alerts_location_failure_conditions/policies/<var>$POLICY_ID</var>.json' \
+         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+         -H 'Content-Type: application/json' \
+         -d \
+    '{
+      "location_failure_condition": {
+        "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#name">name</a>": "string",
+        "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#runbook_url">runbook_url</a>": "string",
+        "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#enabled">enabled</a>": boolean,
+        "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#entities">entities</a>":
+        [
+            "string"
+        ],
+        "terms": [
+            {
+                "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#priority">priority</a>": "string",
+                "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#threshold">threshold</a>": integer,
+            }
+        ],
+        "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#violation_time_limit_seconds">violation_time_limit_seconds</a>": integer
+      }
+    }'
+    ```
+
+    The JSON response returns a condition `id`, which you will need to update or delete the condition. You can also view the condition `id` from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/list) **Alerts Location Failure Conditions > GET > List**.
+  </Collapser>
+
+  <Collapser
+    id="multilocation-synthetics-conditions-update"
+    title="Multi-location Synthetics: Update conditions for policies"
+  >
+    To update policy conditions for Multi-location Synthetic monitoring, include these values in the API call
+
+    * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
+    * The condition `id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/list) **Alerts Location Failure Conditions > GET > List**)
+    * The required `location_failure_condition` values in the API call (described in the API Explorer page and in the [Alerts conditions API glossary](/docs/alerts/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names))
+
+    [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/update) **Alerts Location Failure Conditions > PUT > Update**
+
+    ```
+    curl -X PUT 'https://api.newrelic.com/v2/alerts_location_failure_conditions/<var>$CONDITION_ID</var>.json' \
+         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+         -H 'Content-Type: application/json' \
+         -d \
+    '{
+      "location_failure_condition": {
+        "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#name">name</a>": "string",
+        "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#runbook_url">runbook_url</a>": "string",
+        "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#enabled">enabled</a>": boolean,
+        "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#entities">entities</a>":
+        [
+            "string"
+        ],
+        "terms": [
+            {
+                "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#priority">priority</a>": "string",
+                "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#threshold">threshold</a>": integer,
+            }
+        ],
+        "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#violation_time_limit_seconds">violation_time_limit_seconds</a>": integer
+      }
+    }'
+    ```
+  </Collapser>
+
+  <Collapser
+    id="multilocation-synthetics-conditions-delete"
+    title="Multi-location Synthetics: Delete conditions for policies"
+  >
+    To delete policy conditions for Multi-location Synthetic monitoring, include these values in the API call:
+
+    * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
+    * The `condition_id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/list) **Alerts Location Failure Conditions > GET > List**)
+
+    [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/delete) **Alerts Location Failure Conditions > DELETE > Delete**
+
+    ```
+    curl -X DELETE 'https://api.newrelic.com/v2/alerts_location_failure_conditions/<var>$CONDITION_ID</var>.json' \
+         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
+    ```
+  </Collapser>
+
+  <Collapser
+    id="multilocation-synthetics-conditions-list"
+    title="Multi-location Synthetics: List existing conditions for policies"
+  >
+    To view a list of existing policy conditions for Multi-location Synthetic monitoring, use your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key) or [REST API key](/docs/apis/rest-api-v2/requirements/rest-api-key), and the associated [`policy_id`](#policies-list) in the API call.
+
+    [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/list) **Alerts Location Failure Conditions > GET > List**
+
+    ```
+    curl -X GET 'https://api.newrelic.com/v2/alerts_location_failure_conditions.json' \
          -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
          -d 'policy_id=<var>$POLICY_ID</var>'
     ```

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
@@ -90,7 +90,7 @@ Our REST API (v2) allows you to configure settings for alerts. The [API Explorer
         List output will be [paginated](/docs/apis/rest-api-v2/requirements/pagination-api-output). Available functions include:
 
         * [Alert policies](#policies-list)
-        * [Notification channels](#channels-list)
+        * [Notification channels](#channels)
         * Conditions for [APM, browser, and mobile](#conditions-list) ([Some limitations apply.](#excluded))
         * Conditions for [external services](#ext-conditions-list)
         * Conditions for [Synthetic monitoring](#synthetics-conditions)
@@ -292,6 +292,7 @@ These API functions include links to the API Explorer, where you can create, del
     * Optional policy `name` filter
     * Optional [pagination](/docs/apis/rest-api-v2/requirements/pagination-api-output) value
 
+
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_policies/list) **Alerts Policies > GET > List**
 
     ```
@@ -319,6 +320,7 @@ These API functions include links to the API Explorer, where you can create, del
     * New channel's name
     * [Type of channel](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/notification-channels-controlling-where-send-alerts#channel-types)
     * Configuration values
+
 
     The API Explorer shows the format for required configuration values for each type of notification channel.
 
@@ -547,6 +549,7 @@ These API functions include links to the API Explorer, where you can create, del
     * A `policy_id` value (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_policy/list) **Alerts Policies > GET > List**)
     * One or more `channel_id` values in an array, separated by commas or a new line (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_channels/list) **Alerts Channels > GET > List**)
 
+
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_policy_channels/update) **Alerts Policy Channels > PUT > Update**
 
     ```
@@ -567,6 +570,7 @@ These API functions include links to the API Explorer, where you can create, del
 
     * The `policy_id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_policy/list) **Alerts Policies > GET > List**)
     * The `channel_id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_channels/list) **Alerts Channels > GET > List**)
+
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_policy_channels/delete) **Alerts Policy Channels > DELETE > Delete**
 
@@ -606,6 +610,7 @@ These API functions include links to the API Explorer, where you can create, upd
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * The `policy_id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_policies/list) **Alerts Policies > GET > List**)
     * The required `condition` values in the API call (described in the API Explorer page and in the [Alerts conditions API glossary](/docs/alerts/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names))
+
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_conditions/create) **Alerts Conditions > POST > Create**
 
@@ -657,6 +662,7 @@ These API functions include links to the API Explorer, where you can create, upd
     * The condition's `id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_condition/list) **Alerts Conditions > GET > List**)
     * The required `condition` values in the API call (described in the API Explorer page and in the [Alerts conditions API glossary](/docs/alerts/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names))
 
+
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_conditions/update) **Alerts Conditions > PUT > Update**
 
     ```
@@ -704,6 +710,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * The `condition_id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_conditions/list) **Alerts Conditions > GET > List**)
+
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_conditions/update) **Alerts Conditions > DELETE > Delete**
 
@@ -807,6 +814,7 @@ These API functions include links to the API Explorer, where you can create, upd
     * The condition's `id` (available from [API Explorer: <Icon name="fe-external-link"/>](https://rpm.newrelic.com/api/explore/alerts_nrql_conditions/list "Link opens in a new window.") **Alerts Nrql Conditions > GET > List**)
     * The required `condition` values in the API call (described in the API Explorer page and in the [Alerts conditions API glossary](/docs/alerts/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names))
 
+
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_nrql_conditions/update) **Alerts Nrql Conditions > PUT > Update**
 
     ```
@@ -845,6 +853,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * The condition's `id` (available from [API Explorer: <Icon name="fe-external-link"/>](https://rpm.newrelic.com/api/explore/alerts_nrql_conditions/list "Link opens in a new window.") **Alerts Nrql Conditions > GET > List**)
+
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_nrql_conditions/delete) **Alerts Nrql Conditions > DELETE > Delete**
 
@@ -888,6 +897,7 @@ These API functions include links to the API Explorer, where you can create, upd
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * The `policy_id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_policies/list) **Alerts Policies > GET > List**)
     * The required `external_service_condition` values in the API call (described in the API Explorer page and in the [Alerts conditions API glossary](/docs/alerts/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names))
+
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_external_service_conditions/create) **Alerts External Service Conditions > POST > Create**
 
@@ -933,6 +943,7 @@ These API functions include links to the API Explorer, where you can create, upd
     * The external service condition's `id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_external_service_conditions/list) **Alerts External Service Conditions > GET > List**)
     * The required `external_service_condition` values in the API call (described in the API Explorer page and in the [Alerts conditions API glossary](/docs/alerts/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names))
 
+
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_external_service_conditions/update) **Alerts External Service Conditions > PUT > Update**
 
     ```
@@ -974,6 +985,7 @@ These API functions include links to the API Explorer, where you can create, upd
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * The `condition_id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_conditions/list) **Alerts External Service Conditions > GET > List**)
 
+
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_external_service_conditions/delete) **Alerts External Service Conditions > DELETE > Delete**
 
     ```
@@ -1013,6 +1025,7 @@ These API functions include links to the API Explorer, where you can create, upd
     * The `policy_id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_policies/list) **Alerts Policies > GET > List**)
     * The required `synthetics_condition` values in the API call (described in the API Explorer page and in the [Alerts conditions API glossary](/docs/alerts/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names))
 
+
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_synthetics_conditions/create) **Alerts Synthetics Conditions > POST > Create**
 
     ```
@@ -1043,6 +1056,7 @@ These API functions include links to the API Explorer, where you can create, upd
     * The condition `id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_synthetics_conditions/list) **Alerts Synthetics Conditions > GET > List**)
     * The required `synthetics_condition` values in the API call (described in the API Explorer page to [create alert conditions for Synthetics](https://rpm.newrelic.com/api/explore/alerts_synthetics_conditions/create) and in the [Alerts conditions API glossary](/docs/alerts/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names))
 
+
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_synthetics_conditions/update) **Alerts Synthetics Conditions > PUT > Update**
 
     ```
@@ -1070,6 +1084,7 @@ These API functions include links to the API Explorer, where you can create, upd
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * The `condition_id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_synthetics_conditions/list) **Alerts Synthetics Conditions > GET > List**)
 
+
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_synthetics_conditions/delete) **Alerts Synthetics Conditions > DELETE > Delete**
 
     ```
@@ -1094,7 +1109,7 @@ These API functions include links to the API Explorer, where you can create, upd
   </Collapser>
 </CollapserGroup>
 
-## Multi-location Conditions for Synthetic monitoring [#multilocation-synthetics-conditions]
+## Multi-location conditions for Synthetic monitoring [#multilocation-synthetics-conditions]
 
 These API functions include links to the API Explorer, where you can create, update, delete, or list [conditions](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions) for your alert policies. The API calls can be used for multi-location conditions with Synthetic monitoring. Before creating or updating a condition, read the [rules for multi-location alert conditions](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/multi-location-synthetic-monitoring-alert-conditions/#rules).
 
@@ -1103,11 +1118,12 @@ These API functions include links to the API Explorer, where you can create, upd
     id="multilocation-synthetics-conditions-create"
     title="Multi-location Synthetics: Create conditions for policies"
   >
-    To add conditions to policies for Multi-location Synthetic monitoring, include these values in the API call:
+    To add conditions to policies for multi-location Synthetic monitoring, include these values in the API call:
 
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * The `policy_id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_policies/list) **Alerts Policies > GET > List**)
     * The required `location_failure_condition` values in the API call (described in the API Explorer page and in the [Alerts conditions API glossary](/docs/alerts/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names))
+
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/create) **Alerts Location Failure Conditions > POST > Create**
 
@@ -1143,11 +1159,12 @@ These API functions include links to the API Explorer, where you can create, upd
     id="multilocation-synthetics-conditions-update"
     title="Multi-location Synthetics: Update conditions for policies"
   >
-    To update policy conditions for Multi-location Synthetic monitoring, include these values in the API call
+    To update policy conditions for multi-location Synthetic monitoring, include these values in the API call:
 
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * The condition `id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/list) **Alerts Location Failure Conditions > GET > List**)
     * The required `location_failure_condition` values in the API call (described in the API Explorer page and in the [Alerts conditions API glossary](/docs/alerts/new-relic-alerts/rest-api-alerts/alerts-conditions-api-field-names))
+
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/update) **Alerts Location Failure Conditions > PUT > Update**
 
@@ -1181,10 +1198,11 @@ These API functions include links to the API Explorer, where you can create, upd
     id="multilocation-synthetics-conditions-delete"
     title="Multi-location Synthetics: Delete conditions for policies"
   >
-    To delete policy conditions for Multi-location Synthetic monitoring, include these values in the API call:
+    To delete policy conditions for multi-location Synthetic monitoring, include these values in the API call:
 
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * The `condition_id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/list) **Alerts Location Failure Conditions > GET > List**)
+
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/delete) **Alerts Location Failure Conditions > DELETE > Delete**
 
@@ -1198,7 +1216,8 @@ These API functions include links to the API Explorer, where you can create, upd
     id="multilocation-synthetics-conditions-list"
     title="Multi-location Synthetics: List existing conditions for policies"
   >
-    To view a list of existing policy conditions for Multi-location Synthetic monitoring, use your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key) or [REST API key](/docs/apis/rest-api-v2/requirements/rest-api-key), and the associated [`policy_id`](#policies-list) in the API call.
+    To view a list of existing policy conditions for multi-location Synthetic monitoring, use your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key) or [REST API key](/docs/apis/rest-api-v2/requirements/rest-api-key), and the associated [`policy_id`](#policies-list) in the API call.
+
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/list) **Alerts Location Failure Conditions > GET > List**
 
@@ -1229,6 +1248,7 @@ These API functions include links to the API Explorer, where you can view inform
     * Other optional values to use as filters (described in the [API Explorer page](https://rpm.newrelic.com/api/explore/alerts_events/list)) that depend on the type of product (browser monitoring, mobile monitoring, etc.), entity (as apps or key transactions for APM, synthetic monitoring, etc.), and type of event (notification, deployment, instrumentation, etc.)
     * An optional [pagination](/docs/apis/rest-api-v2/requirements/pagination-api-output) value
 
+
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_events/list) **Alerts Events > GET > List**
 
     ```
@@ -1246,6 +1266,7 @@ These API functions include links to the API Explorer, where you can view inform
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key) or [REST API key](/docs/apis/rest-api-v2/requirements/rest-api-key)
     * An optional flag to show only those violations that are currently open
     * An optional [pagination](/docs/apis/rest-api-v2/requirements/pagination-api-output) value
+
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_violations/list) **Alerts Violations > GET > List**
 
@@ -1269,6 +1290,7 @@ These API functions include links to the API Explorer, where you can view inform
     * An optional flag to show only those incidents that are currently open
     * An optional flag to exclude violation data from response
     * An optional [pagination](/docs/apis/rest-api-v2/requirements/pagination-api-output) value
+
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_incidents/list) **Alerts Incidents > GET > List**
 
@@ -1304,6 +1326,7 @@ These API functions include links to the API Explorer, where you can view inform
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * An incident ID
 
+
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_incidents/acknowledge) **Alerts Incidents > PUT > Acknowledge**
 
     ```
@@ -1321,6 +1344,7 @@ These API functions include links to the API Explorer, where you can view inform
 
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
     * An incident ID
+
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_incidents/close) **Alerts Incidents > PUT > Close**
 
@@ -1356,6 +1380,7 @@ These API functions include links to the API Explorer, where you can list, add a
       * MobileApplication
       * KeyTransaction
 
+
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_entity_conditions/list) **Alerts Entity Conditions > GET > list**
 
     ```
@@ -1380,6 +1405,7 @@ These API functions include links to the API Explorer, where you can list, add a
       * BrowserApplication
       * MobileApplication
       * KeyTransaction
+
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_entity_conditions/add) **Alerts Entity Conditions > PUT > Add**
 
@@ -1406,6 +1432,7 @@ These API functions include links to the API Explorer, where you can list, add a
       * BrowserApplication
       * MobileApplication
       * KeyTransaction
+
 
     [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_entity_conditions/remove) **Alerts Entity Conditions > DELETE > Remove**
 


### PR DESCRIPTION
Added a section for multi-location Synthetic monitoring conditions per issue https://github.com/newrelic/docs-website/issues/3009

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Adds multi-location Synthetic monitor alert condition examples which previously required finding usage examples in the API explorer. This also fixes a broken link in Available data and functions via API to the synthetics-conditions section header.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.
https://github.com/newrelic/docs-website/issues/3009