### PR TITLE
Adding i18n info to style guide

### DIFF
--- a/src/content/docs/accounts/accounts-billing/general-account-settings/default-time-zone-setting.mdx
+++ b/src/content/docs/accounts/accounts-billing/general-account-settings/default-time-zone-setting.mdx
@@ -29,7 +29,7 @@ To change your default time zone for your New Relic account:
 
 ## Exceptions [#exceptions]
 
-Users managed via [automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) (AUM) can't change their time zone in the UI. That must be configured in your identity provider.   
+Users managed via [automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) can't change their time zone in the UI. That must be configured in your identity provider.   
 
 Some New Relic features do not rely on the **User preferences** time zone settings. The following use Coordinated Universal Time (UTC) and aren't affected by user preferences:
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more.mdx
@@ -22,7 +22,7 @@ Requirements to configure these settings:
 * These features are for managing users on the [New Relic One user model](/docs/accounts/accounts-billing/new-relic-one-pricing-users/users-roles). For users on our original user model, see [Original account management](/docs/accounts/original-accounts-billing).
 * Configuring these settings requires [Pro or Enterprise edition](https://newrelic.com/pricing). 
 * To edit these settings, you must be in a group with the [**Authentication domain manager** role](/docs/accounts/accounts-billing/new-relic-one-pricing-users/users-roles#standard-roles).
-* [SCIM provisioning](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign), also known as automated user management (AUM), requires Enterprise edition.
+* [SCIM provisioning](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign), also known as automated user management requires Pro or Enterprise edition.
 * SAML SSO requires Pro or Enterprise edition. SAML support includes:
   * [Active Directory Federation Services (ADFS)](http://technet.microsoft.com/en-us/library/hh831502.aspx "Link opens in a new window")
   * [Auth0](https://marketplace.auth0.com/integrations/new-relic-sso)
@@ -61,7 +61,7 @@ If you have existing domains, they'll be on the left. Note that most organizatio
 
 To create a new domain from the authentication domain UI page, click **Create new**. For more about the configuration options, keep reading.
 
-## Source of users: Manual versus SCIM (AUM) [#source-users]
+## Source of users: Manual versus SCIM [#source-users]
 
 <Callout variant="tip">
   For an introduction to our SAML SSO and SCIM offerings, please read [Get started with SSO and SCIM](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-saml-scim). 
@@ -70,7 +70,7 @@ To create a new domain from the authentication domain UI page, click **Create ne
 From the [authentication domain UI](#ui), you can set one of two options for how users are added to New Relic:
 
 * **Manual:** This means that your users are added manually to New Relic from the [**User management** UI](/docs/accounts/accounts-billing/new-relic-one-user-management/add-manage-users-groups-roles/#where). 
-* **SCIM:** Our automated user management (AUM) feature allows you to use SCIM provisioning to import and manage users from your identity provider. 
+* **SCIM:** Our automated user management feature allows you to use SCIM provisioning to import and manage users from your identity provider. 
 
 Notes on these settings: 
   * You can't toggle **Source of users**. This means if you want to change this for an authentication domain that's already been set up, you'll need to create a new one.  

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-saml-scim.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-saml-scim.mdx
@@ -9,8 +9,8 @@ For setting up automatic controls over how your New Relic users are added to New
 
 * **SAML SSO**: this allows your users to use a single sign-on (SSO) identity provider service to log in to New Relic, as opposed to using the default email + password. 
     * Requirements: [Pro or Enterprise edition](https://newrelic.com/pricing). 
-* **SCIM provisioning**, also referred to as automated user management (AUM): SCIM provisioning allows organizations to use their identity provider service to automate how their users are added to and updated in New Relic. By definition, SCIM provisioning requires use of SAML SSO, but SAML SSO doesn't require SCIM. 
-    * Requirements: [Enterprise edition](https://newrelic.com/pricing), and organization must be on the New Relic One user model (more on that below). 
+* **SCIM provisioning**, also referred to as automated user management: SCIM provisioning allows organizations to use their identity provider service to automate how their users are added to and updated in New Relic. By definition, SCIM provisioning requires use of SAML SSO, but SAML SSO doesn't require SCIM. 
+    * Requirements: [Pro or Enterprise edition](https://newrelic.com/pricing), and organization must be on the New Relic One user model (more on that below). 
 
 Before enabling these, it's important to understand another major factor that affects these features: which user model your organization is on. In 2020, we released a new and improved user model, called the New Relic One user model. At first mainly new customers made use of this model, but now it’s available to some of our older customers via a [user migration procedure](/docs/accounts/original-accounts-billing/original-users-roles/user-migration/). Over time, all users will be migrated to this model. 
 

--- a/src/content/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign.mdx
@@ -1,5 +1,5 @@
 ---
-title: Introduction to automated user management (AUM) and single-sign on (SSO)
+title: Introduction to automated user management and single-sign on (SSO)
 tags:
   - Accounts
   - Accounts and billing
@@ -35,11 +35,11 @@ Requirements and recommendations:
 * Supports SCIM 2.0 standard.
 * [User model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model#user-models)-related requirements:
   * This feature requires you to be on our [New Relic One user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model#user-models) and creates users on that model. If you're on our [original user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model#user-models) (or otherwise can't seem to implement this feature), talk to your New Relic account representative.
-  * Configuring AUM requires that a user have the [**Authentication domain manager** and the **Organization manager** role](/docs/accounts/accounts-billing/new-relic-one-user-management/new-relic-one-user-model-understand-user-structure/#standard-roles) (users in the [default group **Admin**](/docs/accounts/accounts-billing/new-relic-one-user-management/new-relic-one-user-model-understand-user-structure/#groups) have these).
+  * Configuration requires that a user have the [**Authentication domain manager** and the **Organization manager** role](/docs/accounts/accounts-billing/new-relic-one-user-management/new-relic-one-user-model-understand-user-structure/#standard-roles) (users in the [default group **Admin**](/docs/accounts/accounts-billing/new-relic-one-user-management/new-relic-one-user-model-understand-user-structure/#groups) have these).
 * There are three identity providers that have a New Relic app: Azure AD, Okta, and OneLogin. For other identity providers, you can use our [SCIM API](/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management).
 * Before enabling this, it helps to first set up [user groups](/docs/accounts/accounts/automated-user-management/roles-permissions-automated-user-management) in your identity provider service and think about which New Relic roles and accounts those groups will have access to. 
 
-## Set up automated user management (AUM) [#how-to]
+## Set up automated user management [#how-to]
 
 For an explanation of how your identity provider groups map over to New Relic groups, see [Group and role mapping](/docs/accounts/accounts/automated-user-management/roles-permissions-automated-user-management).
 

--- a/src/content/docs/accounts/accounts/automated-user-management/azure-ad-scimsso-application-configuration.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/azure-ad-scimsso-application-configuration.mdx
@@ -10,7 +10,7 @@ redirects:
   - /docs/azure-scimsso-application-configuration
 ---
 
-Our [automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) (AUM) allows allows you to import and configure your New Relic users from your identity provider via SCIM. This guide provides Azure AD-specific details on how to configure the New Relic Azure AD SCIM/SSO application.
+Our [automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) allows allows you to import and configure your New Relic users from your identity provider via SCIM. This guide provides Azure AD-specific details on how to configure the New Relic Azure AD SCIM/SSO application.
 
 ## Requirements
 

--- a/src/content/docs/accounts/accounts/automated-user-management/okta-scimsso-application-configuration.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/okta-scimsso-application-configuration.mdx
@@ -9,11 +9,11 @@ redirects:
   - /docs/okta-scimsso-application-configuration
 ---
 
-Our [automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) (AUM) allows allows you to import and configure your New Relic users from your identity provider via SCIM. This guide provides Okta specific details on how to configure the New Relic Okta SCIM/SSO application.
+Our [automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) allows allows you to import and configure your New Relic users from your identity provider via SCIM. This guide provides Okta specific details on how to configure the New Relic Okta SCIM/SSO application.
 
 ## Requirements
 
-Before using this guide, read our [AUM requirements](/docs/assign-users-automated-provisioning-allow-single-sign#requirements).
+Before using this guide, read the [automated user management requirements](/docs/assign-users-automated-provisioning-allow-single-sign#requirements).
 
 Note that these instructions require going back and forth between your identity provider and New Relic. 
 

--- a/src/content/docs/accounts/accounts/automated-user-management/onelogin-scimsso-application-configuration.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/onelogin-scimsso-application-configuration.mdx
@@ -11,11 +11,11 @@ redirects:
   - /docs/onelogin-scimsso-application-configuration
 ---
 
-Our [automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) (AUM) allows allows you to import and configure your New Relic users from your identity provider via SCIM. This guide provides OneLogin-specific details on how to configure the New Relic OneLogin SCIM/SSO application.
+Our [automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) allows allows you to import and configure your New Relic users from your identity provider via SCIM. This guide provides OneLogin-specific details on how to configure the New Relic OneLogin SCIM/SSO application.
 
 ## Requirements
 
-Before using this guide, read our [AUM requirements](/docs/assign-users-automated-provisioning-allow-single-sign#requirements).
+Before using this guide, read the [automated user management requirements](/docs/assign-users-automated-provisioning-allow-single-sign#requirements).
 
 Note that these instructions require going back and forth between your identity provider and New Relic. 
 

--- a/src/content/docs/accounts/accounts/automated-user-management/roles-permissions-automated-user-management.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/roles-permissions-automated-user-management.mdx
@@ -4,12 +4,12 @@ tags:
   - Accounts
   - Accounts and billing
   - Automated user management
-metaDescription: 'For New Relic automated user management (AUM), an example of how identity provider groups map over to New Relic access grants.'
+metaDescription: 'For New Relic automated user management, an example of how identity provider groups map over to New Relic access grants.'
 redirects:
   - /docs/roles-permissions-automated-user-management
 ---
 
-With [automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) (AUM), your users and groups in your identity provider (like OneLogin or Okta) are synchronized with New Relic.
+With [automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign), your users and groups in your identity provider (like OneLogin or Okta) are synchronized with New Relic.
 
 ## How groups work [#group-example]
 

--- a/src/content/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management.mdx
@@ -10,7 +10,7 @@ redirects:
   - /docs/scim-support-automated-user-management
 ---
 
-If you want to implement New Relic's automated user management (AUM) and import your users from an identity provider, first read [Introduction to AUM](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) to learn about supported identity providers and when you'd want to use our SCIM API, documented below.
+If you want to implement New Relic's automated user management and import your users from an identity provider, first read [Introduction to automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) to learn about supported identity providers and when you'd want to use our SCIM API, documented below.
 
 ## Requirements 
 

--- a/src/content/docs/accounts/original-accounts-billing/original-users-roles/user-migration.mdx
+++ b/src/content/docs/accounts/original-accounts-billing/original-users-roles/user-migration.mdx
@@ -94,8 +94,8 @@ Tips:
 
 You may choose a) a guided setup that allows more configuration options, or b) an automatic setup with fewer steps. Some notes on the automatic setup:
 
-* It won't transition SSO or [AUM-implemented SCIM configurations](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign). Instead, users will be provisioned manually and will log in manually with their username and password. 
-* It provides all users with access to all accounts. If you use SSO or AUM today or require some accounts to be inaccessible by certain user groups, don't use the automatic option.
+* It won't transition SSO or [SCIM configurations](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign). Instead, users will be provisioned manually and will log in manually with their username and password. 
+* It provides all users with access to all accounts. If you use SSO or SCIM provisioning today or require some accounts to be inaccessible by certain user groups, don't use the automatic option.
 
 ## Step 3: Name your organization [#page3]
 

--- a/src/content/docs/release-notes/org-user-mgmt-release-notes/org-users-21-11-01.mdx
+++ b/src/content/docs/release-notes/org-user-mgmt-release-notes/org-users-21-11-01.mdx
@@ -4,8 +4,8 @@ releaseDate: '2021-11-01'
 version: '211101'
 ---
 
-## Automated user management (AUM) now available for Pro edition 
+## Automated user management now available for Pro edition 
 
-New Relic's [automated user management (AUM)](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) feature is now available to organizations with New Relic's [Pro edition](https://newrelic.com/pricing). Previously this was available only to organizations with Enterprise edition. 
+New Relic's [automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) feature is now available to organizations with New Relic's [Pro edition](https://newrelic.com/pricing). Previously this was available only to organizations with Enterprise edition. 
 
-AUM allows you to use SCIM provisioning to import, update, and deactivate your New Relic users from an identity provider, like Azure AD, Okta, or OneLogin. You can also manage attributes about your users, including user type and time zone, via your identity provider.
+Automated user management allows you to use SCIM provisioning to import, update, and deactivate your New Relic users from an identity provider, like Azure AD, Okta, or OneLogin. You can also manage attributes about your users, including user type and time zone, via your identity provider.

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/create-edit-content.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/create-edit-content.mdx
@@ -58,7 +58,7 @@ If you're making larger changes like adding a whole new doc or editing many exis
 
 ## Delete pages [#delete-doc]
 
-If you are comfortable with deleting the page yourself, go for it. If not, ask us by:
+If you are comfortable with deleting the page yourself, go for it. Note that if a doc is marked for translation, we should also delete it in the `i18n` folder. To request us to delete something:
 
 1. [File an issue in the docs-website repo](https://github.com/newrelic/docs-website/issues/new/choose), or contact the @hero in the #documentation channel if you're a New Relic employee.
 2. We'll take a look at your issue and help out.

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/understand-edit-docs-site-structure.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/understand-edit-docs-site-structure.mdx
@@ -6,34 +6,36 @@ redirects:
   - /docs/style-guide/processes-procedures/understand-edit-docs-site-structure 
 ---
 
-This doc contains information and procedures pertaining to the structure of the docs site, including: the nav files, the sidebar, docs category (index) views, and more. 
+This doc contains information and procedures pertaining to the structure of the docs site, including: the nav files, the sidebar, the folder/file structure, and more. 
 
-For brief instructions for common use cases, see [Procedures](#procedures), but if you're doing larger docs site projects, it's highly recommended you understand the [terms](#terms) and [general concepts](#understand) of how the docs site structure works. 
+For brief instructions for common use cases, see [Procedures](#procedures), but if you're doing larger docs site projects, it's recommended you understand the [general concepts](#understand) beforehand. 
 
 ## Terms [#terms]
 When talking about the docs site structure, sometimes people use different words for the same things. Below is a list of terms that can help us communicate about the docs site structure: 
 
-* **Nav files**: In the github docs site, there are yaml files under the `nav` folder that are used to determine the docs site structure that we display. This structure is exposed in the docs site left sidebar and when you view docs category views (also known as auto-index pages, like [this one](/docs/style-guide/writing-strategies)). 
-* **Folder**: In this context, "folders" refers to the actual docs site folder structure (those folders and files in the `content` section). Referring to "folders" can be a helpful way to differentiate between the actual folder structure and the displayed structure that's set using the nav files. 
-* **Sidebar**: On public-facing docs, the sidebar is what is visible on the left hand side, showing the structure of that category of docs. The sidebar and index view are both determined by the structure set in the nav file. 
-* **Category** or **sub-category**: we use these words a bit interchangeably to refer to specific areas of the docs site. 
-* **Auto-index pages** (mostly deprecated): This is the more technical way to refer to a category view of docs (for example, [this view](/docs/style-guide/writing-strategies)). While these views are still functional, we should no longer link to them from the docs, hence why these views are considered deprecated.
+* **Doc files**: All the docs are represented by .mdx files, also known as markdown files. 
+* **Nav files**: The nav files are what govern the displayed structure of the docs site, as exposed in the docs site left sidebar. The nav files are yaml files located in the `nav` directory. 
+* **Folder**: In this context, "folders" refers to the actual docs site folder structure (those folders and files in the `content` directory). Referring to "folders" can be a helpful way to differentiate between the actual folder structure and the displayed structure that's set using the nav files. 
+* **Sidebar**: On public-facing docs, the sidebar is what is visible on the left hand side, showing the structure of that category of docs. The sidebar structure is determined by the structure set in the nav file. 
+* **Category** or **sub-category**: we use these words fairly interchangeably to refer to specific areas of the docs site. For example, we might refer to the "Accounts" category, or the "Manage data" category. 
+* **Auto-index pages** (deprecated): This refers to a previous implementation where users could load views of the docs in a specific category (for example, by clicking a category heading in the sidebar). We no longer support this implementation. 
 
 ## Understand how the docs site structure works [#understand]
 
-This section will explain some of the logic behind how the docs site structure is determined and how the structure we display to the public relates to the actual docs folder structure. 
+This section will explain some of the logic behind how the docs site structure is determined and how the structure we display to the public relates to the actual folder structure. 
 
 ### How is the displayed structure related to the actual folders? [#folders-vs-categories]
 
-The actual docs folder structure (the folders and mdx files in the `content` folder) is entirely separate from the docs site structure in the sidebar. The displayed structure of the docs site is determined solely by the nav files (the yaml-format files in the `nav` folder). 
+The actual docs folder structure (the folders and mdx files in the `content` folder) is entirely separate from the docs site structure in the sidebar. The displayed structure seen in the sidebar is determined solely by the nav files (the yaml-format files in the `nav` folder). 
 
-It's important to understand the above point. The divergence of the docs folder structure and the displayed docs site structure is necessary: we need a way to control the displayed site structure, which is used for the sidebar and auto-index pages, without requiring us to keep the folder structure and folder names and doc file names completely parallel and matching. Because these two things are so separate, it means we have some fairly complex behind-the-scenes logic to get them to work together. And this means that there can be fairly unintuitive aspects of how that logic works. 
+It's important to understand the above point. The divergence of the docs folder structure and the displayed docs site structure is necessary: we need a way to control the structure displayed in the sidebar without requiring us to keep the folder structure and folder names and doc file names completely equivalent. Because these two things are separate, this can mean that there can be some unintuitive aspects of how that logic works. 
 
 We do have [procedures for common use cases](#procedures), but it will help you a lot to understand the specifics below of how the displayed structure is generated.
 
 ### What determines a doc's URL? [#doc-url]
 
 Where a doc file (`mdx` file) is located in the `content` folder, and the associated folder and file names, are the only factors that govern that doc's URL. 
+
 For example, consider the following doc file `automated-user-provisioning-single-sign.mdx`: 
 
 ![Example of a doc file in the folder structure](./images/example-doc-in-folder.png "Doc file in its folder")
@@ -46,38 +48,26 @@ docs.newrelic.com/docs/accounts/accounts/automated-user-management/automated-use
 
 This has important implications, including: 
 
-* When you move a doc from one folder to another, its URL changes, and this means that you will have to add a redirect to that doc of its original URL. 
-* If you rename an mdx file name or a folder name, that changes its URL, so that means you would have to add a redirect to that doc for its original URL. 
+* When you move a doc from one folder to another, its URL changes. This means that when you move a doc file, you must add a redirect to that doc of its original URL. 
+* If you rename an mdx file name or a folder name, that changes its URL. This means you must add a redirect to that doc of its original URL. 
 
 ### What does a nav file do? [#nav-file-contents]
 
-The nav files are quite simple. A nav file controls these things: 
-
-* The docs structure (the various levels of docs) for that category of docs. 
-* The category headers, set by `title` (for example, `On-host integrations list`) and `path` (for example, `/docs/integrations/on-host-integrations`). 
-* The doc information, set by `title` (for example, `NGINX integration`) and `path` (the doc's URL).
+The nav files are quite simple. A nav file controls the displayed structure of docs you see in the sidebar. Currently there are multiple nav files, one for each major section of docs. For example, there's a nav file for "Accounts", which contains organization- and account-related settings. And there's a nav file for "Infrastructure monitoring."
 
 For more on nav file format, see [Nav file format](#nav-format)
 
-### Where is the docs site structure exposed? [#exposed] 
-
-The structure set in the nav files is exposed in two places: 
-
-* The left sidebar of a doc that shows the structure of that category. When a category header in the sidebar is clicked, it shows a view of that docs site category. 
-* Doc category views, also sometimes called [auto-index pages](#terms): for example, [this view](/docs/style-guide/quick-reference), which shows a particular section of docs. Note that while these still work, we no longer want to link to these views. 
-
-### What determines a doc's sidebar? [#doc-sidebar]
+### What governs how a sidebar displays? [#doc-sidebar]
 
 As stated above, the sidebar is just one way that the docs site structure (which is governed by the nav files) is exposed.
 
-When a doc is loaded, the docs site searches for that URL in the nav files. If it finds a match, it displays that nav file in the sidebar with that doc highlighted. 
+When a doc is loaded, the docs site searches for that URL across all the nav files. If it finds a match, it displays that nav file in the sidebar with that doc highlighted. 
 
-If it finds that doc in more than one nav file, it attempts to find the right nav file by choosing the nav that matches the top level category in the doc URL. For example, if a doc with the relative URL `/docs/accounts/accounts-billing/account-setup/create-your-new-relic-account` was in two nav files, the docs site code would search to see if one of the nav files has `docs/accounts` as its first `path` field. If it finds a match, it uses that nav file. 
+A doc's URL may exist in more than one nav file. Currently, it's a rule that a doc can only be located in one place across all nav files. But we still have some docs that exist in multiple nav files. For those cases, our site attempts to find the appropriate nav file by choosing the nav file that matches the top level category in the doc URL. For example, if a doc with the relative URL `/docs/accounts/accounts-billing/account-setup/create-your-new-relic-account` was in two nav files, the docs site code would search to see if one of the nav files has `docs/accounts` as its first `path` field. If it finds a match, it uses that nav file. 
 
 ## Nav file format [#nav-format]
 
 Below is a snippet of the [`agents.yml`](https://github.com/newrelic/docs-website/tree/develop/src/nav/agents.yml) nav file. Note that the file has indentation that corresponds to the level of the navigation hierarchy. When making changes or creating a new nav file, be sure to use the existing spacing format. 
-
 
 ```
 yml
@@ -160,16 +150,16 @@ path: /docs/style-guide
 
 ## Procedures [#procedures]
 
-Below are instructions for several common procedures. It may help you to review [the terms we use](#terms) before starting a procedure. 
+Below are instructions for several common procedures. If you're doing a larger docs project, we recommend familiarizing yourself with the general [docs site structure concepts](#understand). 
+
 Procedures include: 
 
+* [Overview of what a large docs site restructuring involves](#large-project)
 * [Add a new docs category](#add-category)
 * [Add a doc to sidebar/nav-file](#add-doc-to-nav)  
 * [Move docs between folders or categories](#move-docs)
 * [Move or delete folders](#move-delete-folders)
-* [Create a "dummy" category for docs that don’t live in that area](#dummy-category)
-* [Make a category heading clickable](#category-clickable)
-* [Troubleshoot messed up category views](#troubleshoot-category)
+* [Create dummy docs](#dummy-doc)
 
 
 ### Overview of steps for a large docs site restructure project [#large-project]
@@ -184,35 +174,30 @@ For some smaller docs site edits, you can sometimes simply edit the nav files an
 
 For more specific and granular procedures, keep reading. 
 
-### Add a new category [#add-category]
+### Add a new category of docs [#add-category]
 
-We'll explain two procedures: adding a subcategory of docs in an existing nav file, and adding an entirely new nav file. 
-
-#### Add a new nav file [#add-new-nav]
-
-Adding an entirely new nav file should be rare, and something we only do occasionally during large overhauls of site structure. 
-
-To add an entirely new nav file: 
-
-1. Copy an existing file nav file, or create a new nav file.
-2. Customize the new nav file with the categories and docs you want, using the structure of existing nav files as a template. For more on structure, see [nav format](#nav-format).
-   <Callout variant="tip">
-     You need at least one level of nesting inside the nav file. Without that, doc titles in the auto-generated category views will render as H2 headings. For example, `src/content/level-one/level-two/doc` will work,
-     but `src/content/level-one/doc` will produce strange formatting.
-   </Callout>{' '}
+We'll explain two procedures: adding a sub-category of docs in an existing nav file, and adding an entirely new nav file: 
 
 #### Add a new category to a nav file [#add-nav-section]
 
 To add a new category to a nav file: 
 
 1. In an existing nav file, add a new category, represented by its `title`. 
-2. Add the docs you want in that section. 
-4. Ensure your new content matches the indenting of the surrounding nav file. 
+2. Add the docs you want in that section, emulating the format and indenting of other nav files.
 
 To learn more about how this works, see:
 
 * [How a doc's sidebar is determined](#doc-sidebar) 
 * [How a doc category view is determined](#category-view)
+
+#### Add a new nav file [#add-new-nav]
+
+Adding an entirely new nav file should be rare and something we only do occasionally during large overhauls of site structure. Adding new nav files should get sign-off from a docs site manager. 
+
+To add an entirely new nav file: 
+
+1. Copy an existing file nav file, or create a new nav file.
+2. Customize the new nav file with the categories and docs you want, using the standard nav file formatting and indenting. For more on structure, see [nav format](#nav-format).
 
 ### Add a doc to sidebar/nav-file [#add-doc-to-nav]
 
@@ -221,7 +206,7 @@ Once you [create a doc](/docs/style-guide/writing-guidelines/create-edit-content
 To add a doc to a nav file: 
 
 1. In the nav file location where you want to locate it, add the `title` (its short title displayed in the sidebar and category views) and the `path`, which is the doc's URL. 
-2. Ensure that you've emulated the indenting based on the surrounding nav file content or other nav files. 
+2. Ensure that you've emulated the standard nav file formatting and indenting. 
 
 ### Move docs to other categories [#move-docs]
 
@@ -237,42 +222,48 @@ Move a doc in the nav file when you want to change where it's visible in the sid
 To move a doc from one place to another in the nav file: 
 
 1. In the first nav file, copy the two rows representing that doc's entry (the `title` and `path` lines) and paste that content into the place you want it to live in the new nav file. 
-2. In the new nav file section, make sure that new content is aligned properly with the surrounding nav file content. See [Nav format](#nav-format) for more about nav file structure. 
+2. In the new nav file section, make sure the formatting and indenting match standard nav file structure. See [Nav format](#nav-format) for more about nav file structure. 
 
-#### Move docs between folders [#move-docs-between-folders]
+#### Move a doc between folders [#move-docs-between-folders]
 
 Note that moving docs between the folders should be relatively rare. The main reasons to do this are when the folder structure and nav file structure are becoming quite divergent, which can be bad for a couple reasons: 
 
 * Too much divergence can create user confusion (for example, when the elements of the folder-based URL are very different than the nav-file-based location) or sub-optimal search engine results. 
 * Too much divergence can make it harder for us to find and edit docs, so there can be value to keeping things fairly up to date and parallel. 
 
-When you move a doc between folders or rename a doc, that changes its URL. Similarly, if you rename a folder, that changes the URL of all docs in that area. 
+When you move a doc between folders or rename a doc, that changes its URL (for more on why, see [Understand structure](#understand)). Similarly, if you rename a folder, that changes the URL of all docs in that area. 
 
 To move a doc between folders: 
 
 1. Get the current URL of the doc you want to move and add that URL to its own list of redirects. Tips: 
-	* One way to do this in VSCode is to right click the file and click "Get relative path". 
-	* If you are moving many files, ask the team about ways to programmatically add redirects. 
-	* Remove the trailing slash. 
-2. Move the doc to the new folder. 
+	* One way to do this in VSCode is to right click the file name and click "Get relative path". 
+	* If you are moving many files, ask the team about our scripts for programmatically adding redirects to an entire doc directory. 
+	* Be sure that redirect URLs don't have a trailing slash. 
+2. Move the doc to its new folder location. 
 3. If that mdx file is present in the `i18n` directory (which it will be if it's marked for translation), make an equivalent move of that file in the `i18n` directory. 
 4. **Update nav files with the new URL**. Having the correct doc URL in the nav file, and not a redirect, is important. Note that a doc's URL may be in more than one nav file so searching the site for that URL can help. 
 
-### Move or delete a folder [#move-delete-folders]
+### Move or delete or rename a folder [#move-delete-folders]
 
-Sometimes when we are doing a larger restructuring project, we may want to move or delete the actual folders instead of simply editing the nav files. 
+Sometimes when we are doing a larger restructuring project, we may want to move or delete or rename the actual folders instead of simply editing the nav files. Instructions for this: 
 
-If you are moving an entire folder or multiple folders to another folder, docs and all: 
-
-1. Because moving a folder changes all the URLs of docs in that folder, you must first add redirects. You can do this manually ([described in step #1 here](#move-docs-between-folders)) or you can use a script we have for bulk adding redirects to all the mdx files in an entire directory. 
-2. Move the folder on your local disk to the new location (dragging and dropping via Finder, for example).
-3. If that folder is present in the `i18n` directory (which it will be if a doc in that folder has been marked for translation), make an equivalent edit in the `i18n` directory. 
+1. Because moving a folder or changing its name results in changing all the URLs of docs in that folder, you must first add redirects to the affected docs. You can do this manually ([described in step #1 here](#move-docs-between-folders)) or you can use a script the docs team has for bulk-adding redirects to all the docs in a directory. 
+2. Make the desired edit. For example, move the folder to the new location (dragging and dropping in the Finder window, for example), and/or rename the folder. 
+3. If the edited folder is present in the `i18n` directory (which it will be if a doc in that folder has been marked for translation), make an equivalent edit of that folder and its files in the `i18n` directory. Note: the `i18n` work is only necessary for movements or renaming of folders or files, **not** for editing of docs or nav file content.  
 
 For deleting folders, you'll want to essentially follow the same steps as above: adding redirects for the mdx files being moved or deleted, then moving or deleting the docs, and then deleting the empty folders.  
 
-### Create a "dummy" doc [#dummy-doc]
+### Change a doc's file name [#change-doc-file-name]
 
-We no longer want to have docs in multiple places in the nav files. If you want a doc to be referenced in more than one location in the nav files, instead attempt to find a relevant place within a doc where you want to reference it.  
+Changing an mdx file's name [results in its URL changing](#understand). Note that you can change a doc's displayed title in its front matter without changing the actual file name. Changing the file name can be useful. Instructions:
+
+1. Add a redirect to the doc whose file name you're changing. 
+2. Change the file's name.
+3. If that file is present in the `i18n` directory (which it will be if that doc has been marked for translation), make an equivalent edit of that file's name in the `i18n` directory. Note: the `i18n` work is only necessary for movements or renaming of folders or files, **not** for editing of docs or nav file content.  
+
+### Create "dummy" docs [#dummy-doc]
+
+We no longer want to have docs in multiple places in the nav files (although we still do have some docs that are like this). If you want a doc to be referenced in more than one location in the nav files, instead attempt to find a place within a doc where it makes sense to reference that doc.  
 
 
 

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/understand-edit-docs-site-structure.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/understand-edit-docs-site-structure.mdx
@@ -8,10 +8,9 @@ redirects:
 
 This doc contains information and procedures pertaining to the structure of the docs site, including: the nav files, the sidebar, docs category (index) views, and more. 
 
-For succinct instructions, see [Procedures](#procedures), but it is highly recommended you understand the general concepts of how the docs site structure works if you will be doing larger docs site projects. 
+For brief instructions for common use cases, see [Procedures](#procedures), but if you're doing larger docs site projects, it's highly recommended you understand the [terms](#terms) and [general concepts](#understand) of how the docs site structure works. 
 
 ## Terms [#terms]
-
 When talking about the docs site structure, sometimes people use different words for the same things. Below is a list of terms that can help us communicate about the docs site structure: 
 
 * **Nav files**: In the github docs site, there are yaml files under the `nav` folder that are used to determine the docs site structure that we display. This structure is exposed in the docs site left sidebar and when you view docs category views (also known as index views, like [this one](/docs/style-guide/quick-reference)). 
@@ -74,7 +73,7 @@ The structure set in the nav files is exposed in two places:
 
 ### What determines a doc's sidebar? [#doc-sidebar]
 
-As stated above, the sidebar is just one way that the docs site structure governed by the nav files is exposed.
+As stated above, the sidebar is just one way that the docs site structure (which is governed by the nav files) is exposed.
 
 When a doc is loaded, the docs site searches for that URL in the nav files. If it finds a match, it displays that nav file in the sidebar with that doc highlighted. 
 If it finds that doc in more than one nav file, it attempts to find the right nav file by choosing the nav that matches the top level category in the doc URL. For example, if a doc with a relative URL `/docs/accounts/accounts-billing/account-setup/create-your-new-relic-account` was in two nav files, the docs site code would search to see if one of the nav files has `docs/accounts` as its first `path` field. If it finds a match, it uses that nav file. 
@@ -121,10 +120,8 @@ title: Agents
 path: /docs/agents
 pages:
   - title: Manage APM agents
-    path: /docs/agents/manage-apm-agents
     pages:
       - title: Agent data
-        path: /docs/agents/manage-apm-agents/agent-data
         pages:
           - title: Real time streaming
             path: /docs/agents/manage-apm-agents/agent-data/real-time-streaming

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/understand-edit-docs-site-structure.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/understand-edit-docs-site-structure.mdx
@@ -1,5 +1,5 @@
 ---
-title: Understand and edit docs site structure (nav file, sidebar, categories)
+title: Understand and edit the docs site structure 
 redirects: 
   - /docs/style-guide/processes-procedures/include-a-doc-in-multiple-menus
   - /docs/style-guide/processes-procedures/update-left-navigation-pane
@@ -13,11 +13,11 @@ For brief instructions for common use cases, see [Procedures](#procedures), but 
 ## Terms [#terms]
 When talking about the docs site structure, sometimes people use different words for the same things. Below is a list of terms that can help us communicate about the docs site structure: 
 
-* **Nav files**: In the github docs site, there are yaml files under the `nav` folder that are used to determine the docs site structure that we display. This structure is exposed in the docs site left sidebar and when you view docs category views (also known as index views, like [this one](/docs/style-guide/quick-reference)). 
+* **Nav files**: In the github docs site, there are yaml files under the `nav` folder that are used to determine the docs site structure that we display. This structure is exposed in the docs site left sidebar and when you view docs category views (also known as auto-index pages, like [this one](/docs/style-guide/writing-strategies)). 
 * **Folder**: In this context, "folders" refers to the actual docs site folder structure (those folders and files in the `content` section). Referring to "folders" can be a helpful way to differentiate between the actual folder structure and the displayed structure that's set using the nav files. 
 * **Sidebar**: On public-facing docs, the sidebar is what is visible on the left hand side, showing the structure of that category of docs. The sidebar and index view are both determined by the structure set in the nav file. 
-* **Category** or **sub-category**: we use these words a bit interchangeably to refer to specific areas of the docs site. For example, [this view](/docs/using-new-relic/welcome-new-relic/get-started) shows a list of docs in a specific category, as does [this higher level category view](/docs/using-new-relic). In this doc, we'll often use the phrase "category view" to indicate a page load of a specific category of docs.  
-* **Auto-index pages**: This is another way, the more technical way, to refer to a category view of docs (for example, [this view](/docs/using-new-relic/welcome-new-relic/get-started)). "Auto-index page" and "category view" are used a bit interchangably in this doc, with "category view" being used as it's more informal and easy to parse. (Note that this use of "index" is a different use of "index" than the [authored index.mdx files](/docs/style-guide/article-templates/landing-page-template), which are used to display landing pages.)  
+* **Category** or **sub-category**: we use these words a bit interchangeably to refer to specific areas of the docs site. 
+* **Auto-index pages** (mostly deprecated): This is the more technical way to refer to a category view of docs (for example, [this view](/docs/style-guide/writing-strategies)). While these views are still functional, we should no longer link to them from the docs, hence why these views are considered deprecated.
 
 ## Understand how the docs site structure works [#understand]
 
@@ -57,11 +57,6 @@ The nav files are quite simple. A nav file controls these things:
 * The category headers, set by `title` (for example, `On-host integrations list`) and `path` (for example, `/docs/integrations/on-host-integrations`). 
 * The doc information, set by `title` (for example, `NGINX integration`) and `path` (the doc's URL).
 
-A category and a doc in a nav file have the same elements: a `title` and a `path. What separates a category from a doc is that: 
-
-* A category contains docs in the level below it. 
-* If a category has a `path` (which isn't required but should be present for most docs), the `path` points to a `content` docs folder that has at least one doc in it. 
-
 For more on nav file format, see [Nav file format](#nav-format)
 
 ### Where is the docs site structure exposed? [#exposed] 
@@ -69,45 +64,15 @@ For more on nav file format, see [Nav file format](#nav-format)
 The structure set in the nav files is exposed in two places: 
 
 * The left sidebar of a doc that shows the structure of that category. When a category header in the sidebar is clicked, it shows a view of that docs site category. 
-* Doc category views, also sometimes called [auto-index pages](#terms): for example, [this view](/docs/style-guide/quick-reference), which shows a particular section of docs. 
+* Doc category views, also sometimes called [auto-index pages](#terms): for example, [this view](/docs/style-guide/quick-reference), which shows a particular section of docs. Note that while these still work, we no longer want to link to these views. 
 
 ### What determines a doc's sidebar? [#doc-sidebar]
 
 As stated above, the sidebar is just one way that the docs site structure (which is governed by the nav files) is exposed.
 
 When a doc is loaded, the docs site searches for that URL in the nav files. If it finds a match, it displays that nav file in the sidebar with that doc highlighted. 
-If it finds that doc in more than one nav file, it attempts to find the right nav file by choosing the nav that matches the top level category in the doc URL. For example, if a doc with a relative URL `/docs/accounts/accounts-billing/account-setup/create-your-new-relic-account` was in two nav files, the docs site code would search to see if one of the nav files has `docs/accounts` as its first `path` field. If it finds a match, it uses that nav file. 
 
-For an example of a doc that is placed in two different nav files, for [this auto-index page](/docs/accounts/accounts-billing/general-account-settings) click the **Manage data** doc and see how, when it loads, it displays the sidebar for the nav file that better matches its URL. 
-
-### When you click a sidebar category, what determines how that auto-index page displays? [#category-view]
-
-When you click on a docs category header in the sidebar and an auto-index page loads ([like this one](/docs/apis/intro-apis)), what governs what is displayed there? Here is how this process works: 
-
-1. A category header in the sidebar has an associated URL, which is set in the nav file. In the example nav file snippet below, the `Get started` category view has a `path` set to `/docs/apis/intro-apis`. This is what governs the sidebar heading title of "Get started" and tells it the URL to use. 
-
-
-```
-  - title: APIs
-    path: /docs/apis
-    pages:
-      - title: Get started
-        path: /docs/apis/intro-apis
-        pages:
-          - title: New Relic APIs
-            path: /docs/apis/intro-apis/introduction-new-relic-apis
-          - title: API keys
-            path: /docs/apis/intro-apis/new-relic-api-keys
-```
-
-2. If the associated folder of that path has an `index` mdx file (representing a landing page, [like this one](/docs/agents/go-agent)), the docs site displays that landing page.
-
-3. If there is no landing page, we display the docs and structure contained in that section of the nav file. For example, [this view](/docs/accounts/original-accounts-billing) is based on the nav file section under that category header. For this to work correctly, the docs site verifies that that `path` matches an actual docs site folder that has at least one mdx file. Put another way: if we used a completely arbitrary URL path for a category's `path`, like `docs/random-category/random-category-2`, it would not work. To display a nav file, the `path` requires an existing folder with at least one doc in there. 
-
-Other aspects to consider:
-
-* **A `path` is not required.** A category header in the nav file does not require a `path`; that is just what tells it to create a link and a URL for that view. If a category in a nav file lacks a `path`, it won't have a link or associated URL for it (for an example, see the ["New Relic University" category in this section](/docs/using-new-relic)). Having a category without an associated link/URL can be an acceptable choice if you are creating a category of docs that don't reside in that section and you simply want to give a helpful category view in the sidebar. 
-* **Folder structure URLs aren't important.** Every folder in the docs site can be the basis for a URL, but we should only consider valuable the URLs we've chosen for inclusion in the nav files. For example, here's [a URL based on an actual folder containing one doc](/docs/accounts/accounts-billing/new-relic-one-pricing-users). But because there is no `path` in a nav file corresponding to that URL, it doesn't display anything. 
+If it finds that doc in more than one nav file, it attempts to find the right nav file by choosing the nav that matches the top level category in the doc URL. For example, if a doc with the relative URL `/docs/accounts/accounts-billing/account-setup/create-your-new-relic-account` was in two nav files, the docs site code would search to see if one of the nav files has `docs/accounts` as its first `path` field. If it finds a match, it uses that nav file. 
 
 ## Nav file format [#nav-format]
 
@@ -170,9 +135,7 @@ Here are important elements of the nav file:
       <td>`path`</td>
       <td>yes</td>
       <td>
-        <p>The URL path to the doc or the category view. Do not use trailing slashes.</p>
-        <p>For docs categories in the nav file, the `path` is required to create an index view. Without the `path`, a docs category won't be clickable as a link and won't display a view of those docs. [Learn more about index views.](#index-views) 
-        </p>
+        <p>The URL path to the doc. Each nav file's top level `title` also has a path. Do not use trailing slashes.</p>
       </td>
     </tr>
     <tr>
@@ -216,7 +179,8 @@ For some smaller docs site edits, you can sometimes simply edit the nav files an
 1. Plan out what the new nav file structure will look like, and plan out the work of moving docs files or creating new folders. It can help to write down the chunks of work a large project will entail. 
 2. Move the affected doc files to their new folder locations, making sure to add redirects. For more on that, see [Move docs between folders](#move-docs-between-folders). 
 3. Delete any empty folders. 
-4. Edit the nav files to reflect the new desired structure and point to the new doc URLs. If there are category header `path` URLs that are no longer needed, add those URLs as redirects to specific docs (preferred) or the taxonomy redirects file. 
+4. For any folder or file edits you do to the file structure itself (including file or folder renaming, moving files and folders, but **not** including editing of content or front matter within a doc or nav file), do the same edits to the folders and files in the `i18n` directory. Not all folders or files will be present in the i18n directory: it only populates an mdx file or an associated folder if that mdx file has been marked for translation. 
+5. Edit the nav files to reflect the new desired structure and point to the new doc URLs. 
 
 For more specific and granular procedures, keep reading. 
 
@@ -233,8 +197,7 @@ To add an entirely new nav file:
 1. Copy an existing file nav file, or create a new nav file.
 2. Customize the new nav file with the categories and docs you want, using the structure of existing nav files as a template. For more on structure, see [nav format](#nav-format).
    <Callout variant="tip">
-     You need at least one level of nesting inside the nav file. Without that, doc titles in the auto-generated category views will render as H2
-     headings. For example, `src/content/level-one/level-two/doc` will work,
+     You need at least one level of nesting inside the nav file. Without that, doc titles in the auto-generated category views will render as H2 headings. For example, `src/content/level-one/level-two/doc` will work,
      but `src/content/level-one/doc` will produce strange formatting.
    </Callout>{' '}
 
@@ -242,9 +205,8 @@ To add an entirely new nav file:
 
 To add a new category to a nav file: 
 
-1. In an existing nav file, add a new category, represented by its `title` and `path`. 
-2. If you're adding a `path` for that category (recommended), it must use the URL of an existing folder with at least one mdx file in it. 
-3. Add the docs you want in that section. 
+1. In an existing nav file, add a new category, represented by its `title`. 
+2. Add the docs you want in that section. 
 4. Ensure your new content matches the indenting of the surrounding nav file. 
 
 To learn more about how this works, see:
@@ -252,20 +214,14 @@ To learn more about how this works, see:
 * [How a doc's sidebar is determined](#doc-sidebar) 
 * [How a doc category view is determined](#category-view)
 
-If a category view isn't clickable, see [Make category view clickable](#category-clickable). 
-
 ### Add a doc to sidebar/nav-file [#add-doc-to-nav]
 
-Once you [create a doc](/docs/style-guide/writing-guidelines/create-edit-content/#creating-docs), you need to place it in one or more nav files. To do this: 
+Once you [create a doc](/docs/style-guide/writing-guidelines/create-edit-content/#creating-docs), you need to place it in a nav file. Do not place a doc in more than one nav file location: if you require a link to a doc from a different category, attempt to place that reference within a relevant doc section. 
+
+To add a doc to a nav file: 
 
 1. In the nav file location where you want to locate it, add the `title` (its short title displayed in the sidebar and category views) and the `path`, which is the doc's URL. 
 2. Ensure that you've emulated the indenting based on the surrounding nav file content or other nav files. 
-
-#### Add doc in multiple sidebar locations [#add-to-multiple-sidebars]
-
-To add a doc in more than one sidebar location, simply add that doc (its `title` and `path`) wherever you want it to be in the nav file. For more on how the sidebar is determined for docs in multiple nav files, see [Sidebar](#doc-sidebar).
-
-You can add a doc URL in multiple nav file locations. 
 
 ### Move docs to other categories [#move-docs]
 
@@ -285,10 +241,10 @@ To move a doc from one place to another in the nav file:
 
 #### Move docs between folders [#move-docs-between-folders]
 
-Note that moving docs between the folders should be relatively rare. The main reasons to do this are when the folder structure and nav file structure are becoming very different, which can be bad for a couple reasons: 
+Note that moving docs between the folders should be relatively rare. The main reasons to do this are when the folder structure and nav file structure are becoming quite divergent, which can be bad for a couple reasons: 
 
-* Too much divergence can create issues with category view displays or sidebar actions. 
-* Too much divergence can make finding and editing docs harder, so there can be value to keeping things fairly up to date and parallel. 
+* Too much divergence can create user confusion (for example, when the elements of the folder-based URL are very different than the nav-file-based location) or sub-optimal search engine results. 
+* Too much divergence can make it harder for us to find and edit docs, so there can be value to keeping things fairly up to date and parallel. 
 
 When you move a doc between folders or rename a doc, that changes its URL. Similarly, if you rename a folder, that changes the URL of all docs in that area. 
 
@@ -299,7 +255,8 @@ To move a doc between folders:
 	* If you are moving many files, ask the team about ways to programmatically add redirects. 
 	* Remove the trailing slash. 
 2. Move the doc to the new folder. 
-3. **Update nav files with the new URL**. This is easily overlooked but having the correct doc URL in the nav file, and not a redirect, is important. Note that a doc URL may be in more than one nav file so searching the site for that URL can help. 
+3. If that mdx file is present in the `i18n` directory (which it will be if it's marked for translation), make an equivalent move of that file in the `i18n` directory. 
+4. **Update nav files with the new URL**. Having the correct doc URL in the nav file, and not a redirect, is important. Note that a doc's URL may be in more than one nav file so searching the site for that URL can help. 
 
 ### Move or delete a folder [#move-delete-folders]
 
@@ -307,40 +264,16 @@ Sometimes when we are doing a larger restructuring project, we may want to move 
 
 If you are moving an entire folder or multiple folders to another folder, docs and all: 
 
-1. Move the folder on your local disk to the new location (in Finder, for example).
-2. Next, because that move changes all the URLs of the docs and categories, you'll need to add redirects: 
-  * For adding redirects for docs, see the [procedures for moving a doc between folders](#move-docs-between-folders). 
-  * For category redirects: 
-    1. For the section of the nav file affected by your folder editing, gather all the category URLs (`path` fields) that relate to the moved or deleted folders. **We don't need to redirect all folder-related URL paths**: we only need to redirect the nav file paths because those represent the paths that we actually link to in the docs (in other words: we aren't using folder-based URLs if they don't have a nav file `path`). 
-    2. Add those category `path` URLs as redirects in specific docs or, if that won't work, in the `taxonomy-redirects` file. We should aim to add category redirects in specific docs and the reason for this is that the `taxonomy-redirects` file is hard to use and because it's a better customer experience to land on a doc versus a category if possible. In most cases, you'll be able to find a fitting doc to redirect to but if only a category view makes sense, use the taxonomy redirects file. 
-3. For larger projects, this can be tough work, so you'll want to check out the build and make sure all the sidebar links and category headers are working as expected. 
+1. Because moving a folder changes all the URLs of docs in that folder, you must first add redirects. You can do this manually ([described in step #1 here](#move-docs-between-folders)) or you can use a script we have for bulk adding redirects to all the mdx files in an entire directory. 
+2. Move the folder on your local disk to the new location (dragging and dropping via Finder, for example).
+3. If that folder is present in the `i18n` directory (which it will be if a doc in that folder has been marked for translation), make an equivalent edit in the `i18n` directory. 
 
-For deleting folders, you'll want to essentially follow the same steps as above: either moving or deleting the docs in those folders first, gathering the affected category `path` URLs and adding them as redirects, adn then deleting the empty folders.  
+For deleting folders, you'll want to essentially follow the same steps as above: adding redirects for the mdx files being moved or deleted, then moving or deleting the docs, and then deleting the empty folders.  
 
-### Create a "dummy" sub-category of docs that don't live in that category [#dummy-category]
+### Create a "dummy" doc [#dummy-doc]
 
-Sometimes you want to create a category of docs that is there to help expose a related doc or set of docs. For example, in this view, we have added a category for 'New Relic University' even though that's not a doc that lives in that section; in this case, it's not even a doc on our site. 
+We no longer want to have docs in multiple places in the nav files. If you want a doc to be referenced in more than one location in the nav files, instead attempt to find a relevant place within a doc where you want to reference it.  
 
-![Non-clickable category header example](./images/non-clickable-category-example.png "Non-clickable category header example")
-
-In the example above, this 'New Relic University' category header is in regular text and not a link, and that's because it doesn't have a `path` set for it in the nav file. This also means that in the sidebar, this category header is not a clickable link and simply functions as a collapser/expander. This is acceptable if you don't mind it but below we explain how you can get a clickable category if you need it. 
-
-To create a so-called "dummy" category: 
-
-1. [Add the category structure](#add-nav-section) you want in the nav file. 
-2. If you're okay not having a clickable category header, your new category doesn't require a `path`. If you want a clickable category header, you will need to use or create a folder that matches the new category `path` and that has at least one mdx file in it ([details](#category-view)). 
-3. In the nav file, add the title and path information for the docs you want in that new category.
-4. Test your new category to ensure it is working correctly. 
-
-### Make a sidebar category heading clickable [#category-clickable] 
-
-If there's a sidebar category that's only acting as an expander/collapser and doesn't have a link, that's because it either a) doesn't have a `path` set in the nav file, or b) that `path` goes to a folder that doesn't have a doc in it. For more on this, see the [instructions regarding clickable headers in the "dummy" category section](#dummy-category).
-
-### Troubleshoot category views not working correctly [#troubleshoot-category]
-
-If a docs category view is not working correctly, review [how category views are formed](#category-view). If this does happen, get another opinion from another tech writer to make sure you're not missing something, as we should rarely have problems.  
-
-One reason that a category view might not work is specifically for `path` URLs that are also landing pages. In this case, if that `path` is used in more than one location in the same nav file, the docs site can be confused about which category view to use. We may fix this with a coding fix but in meantime: consider pointing to other URLs and not that path, so that there's only one use of that `path` per nav file. 
 
 
 


### PR DESCRIPTION
Adding info to our internal style guide explaining how, when you edit folder/file structures (e.g., moving folders/files, or renaming folders/files) you must do equivalent edits in the i18n directory. 