### PR TITLE
[ESA-415] Document nerdgraph entitySearch limit

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
@@ -53,7 +53,7 @@ Besides `domainType`, other common entity attributes are:
 You can filter by any of the above attributes. Additionally, you can use [tags](/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial/#add-tags) for filtering too. 
 
 <Callout variant="caution">
-  You cannot filter by custom, root-level entity properties. Custom properties are only retrieved as part of the entity’s metadata in the actual search response. To filter by a custom field, transform it into an entity tag.
+  You cannot filter by custom, root-level entity properties. Custom properties are only retrieved as part of the entity's metadata in the actual search response. To filter by a custom field, transform it into an entity tag.
 </Callout>
 
 You can craft a query in one of two ways:
@@ -64,7 +64,7 @@ You can craft a query in one of two ways:
 To use NerdGraph to query one or more entities, you can search by attribute or GUID.
 
 <Callout variant="tip">
-  NerdGraph sets a limit to the total number of entities that can be returned in one query, it is actually 200. If you need to retrieve all entities for a query, you can use cursor pagination as explained in examples.
+  NerdGraph sets the total number of entities that can be returned in one query to 200. If you need to retrieve all entities for a query, use cursor pagination as explained in the examples.
 </Callout>
 
 In addition to [the examples below](#graphql-examples), we highly recommend exploring the API using the [NerdGraph GraphiQL explorer](https://api.newrelic.com/graphiql), and benefiting from its inline documentation.
@@ -455,7 +455,7 @@ Entities in NerdGraph rely on [GraphQL interfaces](/docs/apis/graphql-api/gettin
   >
     The NerdGraph GraphiQL explorer paginates results from an entity search. 
 
-    * If your search criteria yields more than the API limit: 200 entities in a single response, and you want to view the rest of the results, you can request `nextCursor` in your initial request, and use its value in another query to retrieve the following "page" of results.
+    * If your search criteria yields more than the API limit of 200 entities in a single response, and you want to view the rest of the results, you can request `nextCursor` in your initial request, and use its value in another query to retrieve the following "page" of results.
     * If there are no more results, `nextCursor` will be null.
 
     ```

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
@@ -63,6 +63,10 @@ You can craft a query in one of two ways:
 
 To use NerdGraph to query one or more entities, you can search by attribute or GUID.
 
+<Callout variant="tip">
+  NerdGraph sets a limit to the total number of entities that can be returned in one query, it is actually 200. If you need to retrieve all entities for a query, you can use cursor pagination as explained in examples.
+</Callout>
+
 In addition to [the examples below](#graphql-examples), we highly recommend exploring the API using the [NerdGraph GraphiQL explorer](https://api.newrelic.com/graphiql), and benefiting from its inline documentation.
 
 ### Search with `queryBuilder` [#search-querybuilder]
@@ -449,9 +453,9 @@ Entities in NerdGraph rely on [GraphQL interfaces](/docs/apis/graphql-api/gettin
     id="get-nextcursor"
     title="Get the nextCursor for paginated search results"
   >
-    The NerdGraph GraphiQL explorer paginates results from an entity search.
+    The NerdGraph GraphiQL explorer paginates results from an entity search. 
 
-    * If your search criteria yields more than the API limit and you want to view the rest of the results, you can request `nextCursor` in your initial request, and use its value in another query to retrieve the following "page" of results.
+    * If your search criteria yields more than the API limit: 200 entities in a single response, and you want to view the rest of the results, you can request `nextCursor` in your initial request, and use its value in another query to retrieve the following "page" of results.
     * If there are no more results, `nextCursor` will be null.
 
     ```


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Currently customers are not aware sometimes there is an actual limit in the number of entities returned by API and how to paginate through results.