### PR TITLE
fix: add redirects for defunct landing pages

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring.mdx
@@ -6,12 +6,13 @@ tags:
   - Getting started
 translate:
   - jp
-metaDescription: 'New Relic''s synthetic monitoring capabilities give you automated, scriptable tools to monitor your websites, critical business transactions, and API endpoints.'
+metaDescription: "New Relic's synthetic monitoring capabilities give you automated, scriptable tools to monitor your websites, critical business transactions, and API endpoints."
 redirects:
   - /docs/new-relic-only/new-relic-synthetics/getting-started/new-relic-synthetics
   - /docs/synthetics/new-relic-synthetics/getting-started/new-relic-synthetics
   - /docs/synthetics/new-relic-synthetics/getting-started/introduction-new-relic-synthetics
   - /docs/synthetics/synthetic-monitoring/getting-started/get-started-new-relic-synthetic-monitoring
+  - /docs/synthetics
 ---
 
 Synthetic monitoring is a suite of automated, scriptable tools to monitor your websites, critical business transactions, and API endpoints. You can simulate user traffic to proactively detect and resolve outages and poor performance of critical endpoints before your customers notice.
@@ -20,11 +21,11 @@ Synthetic monitoring is a suite of automated, scriptable tools to monitor your w
 
 With synthetic monitoring, you can:
 
-* Get the context of failures by connecting the availability and performance of endpoints to the underlying applications and infrastructure.
-* Easily diagnose if an issue stems from the network or AWS location, a slow third party resource, or the health of backend services or infrastructure.
-* Add synthetic monitoring into build automation and CI/CD pipelines to automatically track performance and check functionality for each deployment.
-* Expand your monitoring further with real, Selenium-powered [scripted browsers](/docs/synthetics/new-relic-synthetics/scripting-monitors/writing-synthetic-scripts), which test login procedures, searches, and other critical business transactions.
-* Monitor your API endpoints with [API tests](/docs/synthetics/new-relic-synthetics/scripting-monitors/writing-api-tests).
+- Get the context of failures by connecting the availability and performance of endpoints to the underlying applications and infrastructure.
+- Easily diagnose if an issue stems from the network or AWS location, a slow third party resource, or the health of backend services or infrastructure.
+- Add synthetic monitoring into build automation and CI/CD pipelines to automatically track performance and check functionality for each deployment.
+- Expand your monitoring further with real, Selenium-powered [scripted browsers](/docs/synthetics/new-relic-synthetics/scripting-monitors/writing-synthetic-scripts), which test login procedures, searches, and other critical business transactions.
+- Monitor your API endpoints with [API tests](/docs/synthetics/new-relic-synthetics/scripting-monitors/writing-api-tests).
 
 Ready to get started? If you don't already have one, [sign up for a New Relic account](https://newrelic.com/signup). It's free, forever!
 
@@ -61,6 +62,7 @@ Synthetic monitoring includes the following features:
         Description
       </th>
     </tr>
+
   </thead>
 
   <tbody>
@@ -139,6 +141,7 @@ Synthetic monitoring includes the following features:
         * [Alert notifications](/docs/apis/synthetics-rest-api/alert-examples/manage-synthetics-alert-notifications-rest-api)
       </td>
     </tr>
+
   </tbody>
 </table>
 
@@ -151,14 +154,17 @@ The data from synthetic monitoring is test data, representing typical interactio
 Synthetic monitoring does not require any software except a [supported browser](/docs/apm/new-relic-apm/getting-started/supported-browsers).
 
 <Callout variant="important">
-  To monitor a site behind your firewall, add the [synthetic monitoring public minion IP addresses](/docs/synthetics/new-relic-synthetics/using-monitors/synthetics-public-minion-ips) to your allow list.
+  To monitor a site behind your firewall, add the [synthetic monitoring public
+  minion IP
+  addresses](/docs/synthetics/new-relic-synthetics/using-monitors/synthetics-public-minion-ips)
+  to your allow list.
 </Callout>
 
 ## Permissions
 
 By default, all users in your account can:
 
-* [View synthetic monitoring pages](/docs/synthetics/new-relic-synthetics/dashboards).
-* [Add](/docs/synthetics/new-relic-synthetics/using-monitors/add-edit-monitors#adding-monitors), [edit](/docs/synthetics/new-relic-synthetics/using-monitors/add-edit-monitors#editing-monitors), and [delete](/docs/synthetics/new-relic-synthetics/using-monitors/add-edit-monitors#deleting-monitors) monitors.
+- [View synthetic monitoring pages](/docs/synthetics/new-relic-synthetics/dashboards).
+- [Add](/docs/synthetics/new-relic-synthetics/using-monitors/add-edit-monitors#adding-monitors), [edit](/docs/synthetics/new-relic-synthetics/using-monitors/add-edit-monitors#editing-monitors), and [delete](/docs/synthetics/new-relic-synthetics/using-monitors/add-edit-monitors#deleting-monitors) monitors.
 
 For more fine-grained control, you can [enable the optional permissions system](/docs/synthetics/new-relic-synthetics/administration/synthetics-permissions-user-groups). The permissions system allows you to manage the level of access for users to view and edit within synthetic monitoring (for example, monitors and [private locations](/docs/synthetics/new-relic-synthetics/private-locations/private-locations-overview-monitor-internal-sites-add-new-locations)).

--- a/src/i18n/content/jp/docs/alerts-applied-intelligence/overview.mdx
+++ b/src/i18n/content/jp/docs/alerts-applied-intelligence/overview.mdx
@@ -3,6 +3,8 @@ title: アラートとインテリジェンスの応用
 type: landingPage
 tags:
   - Alerts and Applied Intelligence
+redirects:
+  - /docs/alerts-applied-intelligence
 ---
 
 New Relic アラートと Applied Intelligence は、New Relicの運用可能性を解き放つ、柔軟かつ一元化された通知システムです。Alertsではアラートポリシーとアラート条件の管理を単一ツールで行えるため、最も関心の高いメトリックスに集中できるようになります。


### PR DESCRIPTION
## Description

Adds redirect for defunct synthetics landing page that a user discovered.

https://docs.newrelic.com/docs/synthetics/

Best doc seems to be the get started intro doc:

https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring/