### PR TITLE
Added callout note for .net infinite tracing.

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -2864,6 +2864,10 @@ Distributed tracing reports span events. Span event reporting is enabled by defa
   Infinite Tracing requires [.NET Agent version 8.30](/docs/release-notes/agent-release-notes/net-release-notes) or higher.
 </Callout>
 
+<Callout variant="important">
+  Infinite Tracing spans can be limited by the [`transactionTracer.maxSegments`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#tracer-maxSegments) setting.
+</Callout>
+
 To turn on [Infinite Tracing](https://newrelic.com/products/edge-infinite-tracing), enable distributed tracing and add the additional settings below
 
 ```

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -2860,15 +2860,7 @@ Distributed tracing reports span events. Span event reporting is enabled by defa
 
 [Infinite Tracing](https://newrelic.com/products/edge-infinite-tracing) extends the distributed tracing service by employing a trace observer that is external to the agent. It observes 100% of your application traces across various services and provides actionable data so you can solve issues faster.
 
-<Callout variant="important">
-  Infinite Tracing requires [.NET Agent version 8.30](/docs/release-notes/agent-release-notes/net-release-notes) or higher.
-</Callout>
-
-<Callout variant="important">
-  Infinite Tracing spans can be limited by the [`transactionTracer.maxSegments`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#tracer-maxSegments) setting.
-</Callout>
-
-To turn on [Infinite Tracing](https://newrelic.com/products/edge-infinite-tracing), enable distributed tracing and add the additional settings below
+To turn on [Infinite Tracing](https://newrelic.com/products/edge-infinite-tracing), make sure you have [.NET agent version 8.30 or higher](/docs/release-notes/agent-release-notes/net-release-notes), and enable distributed tracing. Then add the following additional settings:
 
 ```
 <configuration . . . >
@@ -2878,6 +2870,10 @@ To turn on [Infinite Tracing](https://newrelic.com/products/edge-infinite-tracin
    </infiniteTracing>
 </configuration>
 ```
+
+<Callout variant="important">
+  Infinite Tracing spans can be limited by the [`transactionTracer.maxSegments`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#tracer-maxSegments) setting.
+</Callout>
 
 The `infiniteTracing` element supports the following elements:
 


### PR DESCRIPTION
Added important callout to the .Net Agent Infinite Tracing configuration section about how spans might get limited.