### PR TITLE
Updated K8s helm uninstall

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
@@ -348,7 +348,7 @@ The default settings for these parameters and others can be found in the [newrel
 To uninstall the Kubernetes integration using Helm, run the following command. Replace `some-manifest-file.yml` with your specific filename.
 
 ```
-helm --uninstall newrelic newrelic/nri-bundle
+helm uninstall newrelic -n newrelic
 if kubectl then :
 kubectl delete -f some-manifest-file.yml
 ```


### PR DESCRIPTION
Updated the helm uninstall command syntax. Prior, the command pointed to the chart and not the release so it would not run if somebody copied/pasted it as is.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.