### PR TITLE
chore: adding data definitions for npm network flows

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-flow-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-flow-monitoring.mdx
@@ -252,3 +252,134 @@ When planning your strategy for collecting network flows at scale, New Relic rec
 7. [Visualize your network performance data in New Relic](/docs/network-performance-monitoring/monitoring-network-data/visualize-network-data).
   </Collapser>
 </CollapserGroup>
+
+## Find and use your metrics [#find-your-metrics]
+
+All network flow logs exported from the `ktranslate` container use the `KFlow` namespace, via the [New Relic Event API](/docs/telemetry-data-platform/ingest-apis/introduction-event-api). Currently, these are the default fields populated from this integration:
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>application</td>
+      <td>String</td>
+      <td>The class of program generating the traffic in this flow record. This is derived from the lowest numeric value from `l4_dst_port` and `l4_src_port`. Common examples include `http`, `ssh`, and `ftp`.</td>
+    </tr>
+    <tr>
+      <td>device_name</td>
+      <td>String</td>
+      <td>The display name of the sampling device for this flow record.</td>
+    </tr>
+    <tr>
+      <td>dst_addr</td>
+      <td>String</td>
+      <td>The target IP address for this flow record.</td>
+    </tr>
+    <tr>
+      <td>dst_as</td>
+      <td>Numeric</td>
+      <td>The target [Autonomous System Number](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) for this flow record.</td>
+    </tr>
+    <tr>
+      <td>dst_as_name</td>
+      <td>String</td>
+      <td>The target [Autonomous System Name](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) for this flow record.</td>
+    </tr>
+    <tr>
+      <td>dst_endpoint</td>
+      <td>String</td>
+      <td>The target `IP:Port` tuple for this flow record. This is a combination of `dst_addr` and `l4_dst_port`.</td>
+    </tr>
+    <tr>
+      <td>dst_geo</td>
+      <td>String</td>
+      <td>The target country for this flow record, if known.</td>
+    </tr>
+    <tr>
+      <td>in_bytes</td>
+      <td>Numeric</td>
+      <td>The number of bytes transferred for ingress flow records.</td>
+    </tr>
+    <tr>
+      <td>in_pkts</td>
+      <td>Numeric</td>
+      <td>The number of packets transferred for ingress flow records.</td>
+    </tr>
+    <tr>
+      <td>input_port</td>
+      <td>Numeric</td>
+      <td>`If_Index` value for the interface at the source of this flow record.</td>
+    </tr>
+    <tr>
+      <td>l4_dst_port</td>
+      <td>Numeric</td>
+      <td>The target port for this flow record.</td>
+    </tr>
+    <tr>
+      <td>l4_src_port</td>
+      <td>Numeric</td>
+      <td>The source port for this flow record.</td>
+    </tr>
+    <tr>
+      <td>output_port</td>
+      <td>Numeric</td>
+      <td>`If_Index` value for the interface at the destination of this flow record.</td>
+    </tr>
+    <tr>
+      <td>protocol</td>
+      <td>String</td>
+      <td>The display name of the protocol used in this flow record, derived from the [numeric IANA protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)</td>
+    </tr>
+    <tr>
+      <td>provider</td>
+      <td>String</td>
+      <td>This attribute is used to uniquely identify various sources of data from `ktranslate`. Network flow logs will always have the value of `kentik-flow-device`.</td>
+    </tr>
+    <tr>
+      <td>sample_rate</td>
+      <td>Numeric</td>
+      <td>Sampling rate applied by either the sampling device configuration, or the `sample_rate` argument in ktranslate.</td>
+    </tr>
+    <tr>
+      <td>src_addr</td>
+      <td>String</td>
+      <td>The source IP address for this flow record.</td>
+    </tr>
+    <tr>
+      <td>src_as</td>
+      <td>Numeric</td>
+      <td>The source [Autonomous System Number](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) for this flow record.</td>
+    </tr>
+    <tr>
+      <td>src_as_name</td>
+      <td>String</td>
+      <td>The source [Autonomous System Name](https://www.iana.org/assignments/as-numbers/as-numbers.xhtml) for this flow record.</td>
+    </tr>
+    <tr>
+      <td>src_endpoint</td>
+      <td>String</td>
+      <td>The source `IP:Port` tuple for this flow record. This is a combination of `src_addr` and `l4_src_port`.</td>
+    </tr>
+    <tr>
+      <td>src_geo</td>
+      <td>String</td>
+      <td>The source country for this flow record, if known.</td>
+    </tr>
+    <tr>
+      <td>tcp_flags</td>
+      <td>Numeric</td>
+      <td>TCP Flags in this flow record.</td>
+    </tr>
+    <tr>
+      <td>timestamp</td>
+      <td>Numeric</td>
+      <td>The time, in Unix seconds, when this flow record was received by the New Relic Event API.</td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
Adding definitions for the default fields collected in NPM Network flow telemetry.