### PR TITLE
Update supported kafka api versions

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
@@ -16,7 +16,7 @@ Read on to install the Kafka integration, and to see what data it collects. To m
 
 ## Compatibility and requirements [#req]
 
-Our integration is compatible with Kafka versions 0.8 or higher.
+Our integration is compatible with Kafka versions 2.6 or below.
 
 Before installing the integration, make sure that you meet the following requirements:
 


### PR DESCRIPTION
It was shown in https://newrelic.atlassian.net/browse/GTSE-12934 that we do not fully support kafka api version 2.8 yet and only support 2.6 and below. I updated our documentation accordingly until we can test on the newer version.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.