### PR TITLE
fix: quick updates to fix bugs, suboptimal-ness of workflow

### DIFF
--- a/scripts/actions/check-job-progress.js
+++ b/scripts/actions/check-job-progress.js
@@ -120,14 +120,6 @@ const main = async () => {
       (batch) => batch && batch.done
     );
 
-    const completedJobs = await Promise.all(
-      batchesToDeserialize.map((batch) => {
-        return updateJob(batch.jobId, { status: 'COMPLETED' });
-      })
-    );
-
-    log(`Jobs completed: ${JSON.stringify(completedJobs)}`);
-
     log(`${batchesToDeserialize.length} batches ready to be deserialized`);
     log(`batchUids: ${batchesToDeserialize.map(prop('batchUid')).join(', ')}`);
 
@@ -153,6 +145,14 @@ const main = async () => {
         })
       );
     }
+
+    const completedJobs = await Promise.all(
+      batchesToDeserialize.map((batch) => {
+        return updateJob(batch.jobId, { status: 'COMPLETED' });
+      })
+    );
+
+    log(`Jobs completed: ${JSON.stringify(completedJobs)}`);
 
     // get a list of batches that we're still waiting on from our vendor
     const remainingBatches = batchStatuses

--- a/scripts/actions/remove-completed-batch.js
+++ b/scripts/actions/remove-completed-batch.js
@@ -6,18 +6,20 @@ const {
 } = require('./translation_workflow/database.js');
 const { getAccessToken, vendorRequest } = require('./utils/vendor-request');
 const fetch = require('node-fetch');
+const { configuration } = require('./configuration');
 
-const PROJECT_ID = process.env.TRANSLATION_VENDOR_PROJECT;
+const PROJECT_ID = configuration.TRANSLATION.VENDOR_PROJECT;
 const DOCS_SITE_URL = 'https://docs.newrelic.com';
 
 /**
  * Updates the "being translated" queue with the batches that are not done.
+ * @param {string} projectId - identifier of project to cleanup associated state
  * @returns {Promise}
  */
-const setInProgressToDone = async () => {
+const setInProgressToDone = async (projectId) => {
   const [completedJobs, completedTranslations] = await Promise.all([
-    getJobs({ status: 'COMPLETED' }),
-    getTranslations({ status: 'COMPLETED' }),
+    getJobs({ status: 'COMPLETED', project_id: projectId }),
+    getTranslations({ status: 'COMPLETED', project_id: projectId }),
   ]);
 
   const deserializedFileUris = completedTranslations.map(
@@ -107,4 +109,4 @@ const removePageContext = async (fileUris) => {
   }, 'SUCCESS');
 };
 
-setInProgressToDone();
+setInProgressToDone(PROJECT_ID);


### PR DESCRIPTION
## Summary

On route to tackling #5485 I noticed a couple other awkward things that I thought should be fixed immediately. 

### Problems
Problems I observed were:
1. jobs are being marked as completed too early.
2. the remove/cleanup script is cleaning up state for ALL completed operations, when it should be limited to its specific project (machine or human).

### Fixes
1. I've moved marking a job as completed to after the files have been deserialized, and the translations are marked as completed.
2. I've updated the cleanup script to only cleanup completed state for the specific project of the run.