### PR TITLE
fix(Docs): Added missing redirects from taxonomy-redirect.json

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/overview.mdx
+++ b/src/content/docs/alerts-applied-intelligence/overview.mdx
@@ -20,6 +20,8 @@ redirects:
   - /docs/alerts/new-relic-alerts-0
   - /docs/alerts
   - /docs/alerts-applied-intelligence/new-relic-alerts
+  - /docs/alerts/new-relic-alerts/getting-started
+  - /docs/alerts-applied-intelligence
 ---
 
 <LandingPageHero>

--- a/src/content/docs/apis/rest-api-v2/get-started/introduction-new-relic-rest-api-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/get-started/introduction-new-relic-rest-api-v2.mdx
@@ -19,6 +19,8 @@ redirects:
   - /docs/apis/rest-api-v2/plugin-examples-v2/get-list-plugins-v2
   - /docs/apis/rest-api-v2/plugin-examples-v2/list-multiple-plugin-componemts-v2
   - /docs/apis/rest-api-v2/plugin-examples-v2/listing-metrics-plugin-components-v2
+  - /docs/apm/apis/server-examples-v2
+  - /docs/apis/rest-api-v2
 ---
 
 [New Relic's REST APIs](/docs/apis/getting-started/introduction-new-relic-apis) let you retrieve data from, and push data to New Relic tools, and include configuration and delete capabilities. You can also use the [API Explorer](/docs/apis/rest-api-v2/api-explorer-v2/getting-started-new-relics-api-explorer) to understand the data available to you via the REST API, to obtain curl commands, and to see JSON responses.

--- a/src/content/docs/apm/agents/c-sdk/get-started/introduction-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/get-started/introduction-c-sdk.mdx
@@ -35,6 +35,8 @@ redirects:
   - /docs/introduction-c-sdk
   - /node/34346
   - /docs/agents/open-source-licensed-agents/open-source-licensed-agents/new-relic-c-sdk
+  - /docs/agents/c-sdk
+  - /docs/apm/agents/c-sdk
 ---
 
 The C SDK is designed to support the often complex, multi-threaded nature of C/C++ applications. You can gain a new level of visibility to help you identify and solve performance issues. You can also collect and analyze data to help you improve the customer experience and make data-driven business decisions.

--- a/src/content/docs/apm/agents/go-agent/get-started/introduction-new-relic-go.mdx
+++ b/src/content/docs/apm/agents/go-agent/get-started/introduction-new-relic-go.mdx
@@ -12,6 +12,8 @@ redirects:
   - /docs/agents/new-relic-go
   - /agents/new-relic-go
   - /docs/agents/go-agent/get-started/new-relic-go
+  - /docs/agents/go-agent
+  - /docs/apm/agents/go-agent
 ---
 
 New Relic for Go monitors your Go language applications and microservices to help you identify and solve performance issues. You can also use your data to improve your customers' experience and make data-driven business decisions.

--- a/src/content/docs/apm/agents/java-agent/getting-started/introduction-new-relic-java.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/introduction-new-relic-java.mdx
@@ -12,6 +12,9 @@ redirects:
   - /docs/java/new-relic-for-java
   - /docs/java/java-agent-installation
   - /docs/agents/java-agent/getting-started/new-relic-java
+  - /docs/agents/java-agent
+  - /docs/java-agent
+  - /docs/apm/agents/java-agent
 ---
 
 With New Relic's Java agent, you can track everything from performance issues to tiny errors within your code. Every minute the agent posts [metric timeslice and event data](/docs/data-analysis/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data) to the New Relic user interface, where the owner of that data can sign in and use the data to see how their website is performing.

--- a/src/content/docs/apm/agents/net-agent/getting-started/introduction-new-relic-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/introduction-new-relic-net.mdx
@@ -13,6 +13,8 @@ redirects:
   - /docs/dotnet/AgentDocumentation
   - /docs/dotnet/new-relic-for-net
   - /docs/agents/net-agent/getting-started/new-relic-net
+  - /docs/agents/net-agent
+  - /docs/apm/agents/net-agent
 ---
 
 With our .NET agent for application performance monitoring, you can:

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs.mdx
@@ -12,6 +12,8 @@ redirects:
   - /docs/nodejs/new-relic-for-nodejs
   - /docs/agents/nodejs-agent/getting-started/new-relic-nodejs
   - /docs/agents/node-agent
+  - /docs/agents/nodejs-agent/table-of-contents
+  - /docs/apm/agents/nodejs-agent
 ---
 
 Pinpoint and solve issues down to the line of code with Node.js monitoring from New Relic. With features like [service maps](/docs/data-analysis/service-maps/get-started/introduction-service-maps) and [error analytics](/docs/apm/applications-menu/error-analytics/error-analytics-explore-events-behind-errors), our Node.js agent helps you get the full picture of your app environment.

--- a/src/content/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php.mdx
@@ -17,6 +17,8 @@ redirects:
   - /docs/agents/php-agent/getting-started/new-relic-php
   - /docs/agents/php
   - /docs/apm/agents/php-agent/getting-started
+  - /docs/agents/php-agent
+  - /docs/apm/agents/php-agent
 ---
 
 Our PHP agent monitors your application to help you [identify and solve performance issues](#monitor-performance). You can also extend the agent's performance monitoring to [collect and analyze business data](#business-data) to help you improve the customer experience and make data-driven business decisions.

--- a/src/content/docs/apm/agents/python-agent/getting-started/introduction-new-relic-python.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/introduction-new-relic-python.mdx
@@ -12,6 +12,8 @@ redirects:
   - /docs/python/new-relic-for-python
   - /docs/agents/python-agent/getting-started/new-relic-python
   - /docs/agents/docs/agents/python-agent/getting-started/introduction-new-relic-python
+  - /docs/agents/python
+  - /docs/apm/agents/python-agent
 ---
 
 Our Python agent monitors your Python application to help you identify and solve [performance issues](#monitor-performance). You can also extend your performance monitoring to collect and analyze [business data](#business-data) to help you improve the customer experience and make data-driven business decisions. With flexible options for [custom instrumentation and APIs](/docs/agents/python-agent/custom-instrumentation/python-custom-instrumentation), The Python agent offers multiple building blocks to customize the data you need from your app.

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/introduction-new-relic-ruby.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/introduction-new-relic-ruby.mdx
@@ -15,6 +15,8 @@ redirects:
   - /docs/ruby/new-relic-for-ruby
   - /docs/agents/ruby-agent/getting-started/new-relic-ruby
   - /docs/agents/ruby-agent/getting-started
+  - /docs/agents/ruby-agent
+  - /docs/apm/agents/ruby-agent
 ---
 
 The New Relic Ruby agent monitors your applications to help you [identify and solve performance issues](#monitor-performance). You can also extend the agent's performance monitoring to [collect and analyze business data](#business-data) to help you improve the customer experience and make data-driven business decisions.

--- a/src/content/docs/apm/new-relic-apm/getting-started/introduction-apm.mdx
+++ b/src/content/docs/apm/new-relic-apm/getting-started/introduction-apm.mdx
@@ -13,6 +13,7 @@ redirects:
   - /docs/integrations/intro-integrations/get-started/apm
   - /docs/apm/agents
   - /docs/apm/new-relic-apm/getting-started
+  - /docs/apm
 ---
 
 Application performance monitoring (APM) is exactly what it sounds like: monitoring of your web or non-web application's performance. APM supports apps for several programming languages, including [Go](/docs/agents/go-agent/get-started/introduction-new-relic-go), [Java](/docs/agents/java-agent/getting-started/introduction-new-relic-java), [.NET](/docs/agents/net-agent/getting-started/introduction-new-relic-net), [Node.js](/docs/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs), [PHP](/docs/agents/php-agent/getting-started/introduction-new-relic-php), [Python](/docs/agents/python-agent/getting-started/introduction-new-relic-python), and [Ruby](/docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby), as well as a [C SDK](/docs/agents/c-sdk/get-started/introduction-c-sdk).

--- a/src/content/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring.mdx
+++ b/src/content/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring.mdx
@@ -14,6 +14,7 @@ redirects:
   - /docs/browser/new-relic-browser/getting-started/introduction-new-relic-browser
   - /docs/browser/new-relic-browser/getting-started/introduction-browser-monitoring
   - /docs/browser/browser-monitoring
+  - /docs/browser
 ---
 
 Your end-user experience depends on your entire technology stack. You need to quickly understand what's causing a customer complaint or issue.

--- a/src/content/docs/data-apis/get-started/nrdb-horsepower-under-hood.mdx
+++ b/src/content/docs/data-apis/get-started/nrdb-horsepower-under-hood.mdx
@@ -18,6 +18,9 @@ redirects:
   - /docs/telemetry-data-platform/ingest-manage-data/get-started/get-know-telemetry-data-platform 
   - /docs/telemetry-data-platform/get-started/get-know-telemetry-data-platform/
   - /docs/telemetry-data-platform/get-started/nrdb-horsepower-under-hood
+  - /docs/data-ingest-apis
+  - /docs/telemetry-data-platform
+  - /docs/data-apis
 ---
 If you’ve been reading our documentation, chances are you’ve already learned a bit about New Relic and the many tools and capabilities we offer.
 

--- a/src/content/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring.mdx
@@ -37,6 +37,7 @@ redirects:
   - /docs/infrastructure/new-relic-infrastructure/get-started/introduction-new-relic-infrastructure
   - /docs/infrastructure/new-relic-infrastructure/get-started/get-started-infrastructure-monitoring
   - /infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring
+  - /docs/infrastructure
 ---
 
 import amazonlinux from './images/amazonlinux.png'

--- a/src/content/docs/licenses/overview.mdx
+++ b/src/content/docs/licenses/overview.mdx
@@ -6,6 +6,7 @@ tags:
 metaDescription: Licenses landing page
 redirects:
   - /docs/licenses/license-information/general-usage-licenses
+  - /docs/licenses
 ---
 
 <LandingPageHero>

--- a/src/content/docs/logs/get-started/get-started-log-management.mdx
+++ b/src/content/docs/logs/get-started/get-started-log-management.mdx
@@ -17,6 +17,7 @@ redirects:
   - /docs/logs/log-management
   - /docs/logs/log-management/get-started
   - /docs/logs/log-management/get-started/get-started-log-management
+  - /docs/logs
 ---
 
 As applications move towards the cloud, microservices architecture is becoming more dispersed, making the ability to monitor logs essential. New Relic offers a fast, scalable log management platform so you can connect your logs with the rest of your telemetry and infrastructure data in a single place. See how it works with this video (approx. 2 minutes).

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring.mdx
@@ -47,6 +47,9 @@ redirects:
   - /docs/mobile-monitoring/new-relic-mobile-react-native/troubleshooting/troubleshoot-react-native-known-issues
   - /docs/mobile-monitoring/new-relic-mobile-react-native/install-configure/update-mobile-react-native-agent
   - /taxonomy/term/10236
+  - /docs/mobile-extensible-agent-toc
+  - /docs/mobile-react-native-agent-toc
+  - /docs/mobile-monitoring
 ---
 
 New Relic's mobile monitoring capabilities help you gain deeper visibility into how to analyze your [Android](/docs/mobile-monitoring/new-relic-mobile-android/get-started/introduction-new-relic-mobile-android) and [iOS](/docs/mobile-monitoring/new-relic-mobile-ios/get-started/introduction-new-relic-mobile-ios) application performance and troubleshoot crashes. You can also examine HTTP and other network performance for unexpected lag, which will in turn help you collaborate more efficiently with your backend teams.

--- a/src/content/docs/new-relic-solutions/overview.mdx
+++ b/src/content/docs/new-relic-solutions/overview.mdx
@@ -8,6 +8,7 @@ redirects:
   - /docs/solutions-best-practices-landing-page
   - /docs/new-relic-solutions/new-relic-solutions/measure-devops-success/guide-measuring-devops-success/
   - /docs/using-new-relic/welcome-new-relic/measure-devops-success/guide-measuring-devops-success
+  - /docs/new-relic-solutions
 ---
 
 <LandingPageHero>

--- a/src/content/docs/security/overview.mdx
+++ b/src/content/docs/security/overview.mdx
@@ -5,6 +5,7 @@ tags:
   - Security
 redirects:
   - /docs/security-landing-page
+  - /docs/security
 ---
 
 <LandingPageHero>

--- a/src/content/docs/serverless-function-monitoring/overview.mdx
+++ b/src/content/docs/serverless-function-monitoring/overview.mdx
@@ -1,6 +1,9 @@
 ---
 title: Serverless monitoring
 type: landingPage
+redirects:
+  - /docs/full-stack-observability/monitor-everything/observability-solutions/serverless-monitoring
+  - /docs/serverless-function-monitoring
 ---
 
 <LandingPageHero>

--- a/src/data/external-redirects.json
+++ b/src/data/external-redirects.json
@@ -45,5 +45,75 @@
     "paths": [
       "/docs/new-relic-one/use-new-relic-one/build-new-relic-one/discover-manage-applications-new-relic-one-catalog"
     ]
-  }
+  },
+  {
+    "url": "https://developer.newrelic.com/instant-observability/?search=&category=application-monitoring",
+    "paths": [
+      "/docs/agents"
+    ]
+  },
+  {
+    "url": "https://developer.newrelic.com/instant-observability/?search=linux",
+    "paths": [
+      "/docs/infrastructure/config-management-tools/installation",
+      "/docs/servers/new-relic-servers-linux/installation-configuration",
+      "/docs/infrastructure/install-configure-infrastructure/linux-installation",
+      "/docs/install-configure-infrastructure/linux-installation",
+      "/docs/infrastructure/install-configure-manage-infrastructure/linux-installation",
+      "/docs/infrastructure/install-configure-manage-infrastructure-agent/linux-installation",
+      "/docs/infrastructure/install-infrastructure-agent/linux-installation"
+    ]
+  },
+  {
+    "url": "https://developer.newrelic.com/instant-observability/?search=java",
+    "paths": [
+      "/docs/agents/java-agent/additional-installation",
+      "/docs/apm/agents/java-agent/additional-installation"
+    ]
+  },
+  {
+    "url": "https://developer.newrelic.com/instant-observability/?category=infrastructure-and-os",
+    "paths": [
+      "/docs/infrastructure/integrations/types-integrations/open-source-host-integration",
+      "/docs/infrastructure/new-relic-infrastructure/integrations/open-source-host-integrations",
+      "/docs/integrations/new-relic-integrations/host-integrations/host-integrations-list",
+      "/docs/infrastructure-integrations/host-integrations/host-integrations-list",
+      "/docs/integrations/host-integrations/host-integrations-list",
+      "/docs/integrations/host-integrations/open-source-host-integrations-list",
+      "/docs/infrastructure/host-integrations/host-integrations-list"
+    ]
+  },
+  {
+    "url": "https://developer.newrelic.com/instant-observability/?search=&filter=documentation",
+    "paths": [
+      "/docs/infrastructure/new-relic-infrastructure/getting-started/infrastructure-integrations",
+      "/docs/kubernetes-integration",
+      "/docs/infrastructure-integrations",
+      "/docs/more-integrations"
+    ]
+  },
+  {
+    "url": "https://developer.newrelic.com/instant-observability/?search=aws",
+    "paths": [
+      "/docs/infrastructure/amazon-integrations/aws-integrations-list"
+    ]
+  },
+  {
+    "url": "https://developer.newrelic.com/instant-observability/?search=azure",
+    "paths": [
+      "/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list"
+    ]
+  },
+  {
+    "url": "https://developer.newrelic.com/instant-observability",
+    "paths": [
+      "/docs/integrations"
+    ]
+  },
+  {
+    "url": "https://developer.newrelic.com/instant-observability/?search=gcp",
+    "paths": [
+      "/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list"
+    ]
+  }                
 ]


### PR DESCRIPTION
Because taxonomy-redirects.json was deleted, there were some auto-index and landing page redirects that needed to be added elsewhere.