### PR TITLE
fix(jmx): clarification about jmxterm not bundled

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/jmx-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/jmx-monitoring-integration.mdx
@@ -1000,7 +1000,7 @@ Troubleshooting tips:
     id="jmxterm"
     title="Troubleshooting via jmxterm"
   >
-    [JMXTerm](https://docs.cyclopsgroup.org/jmxterm) is a CLI interactive tool bundled within the package. Docs for JMXTerm can be found at our [nrjmx page](https://github.com/newrelic/nrjmx/#troubleshooting-via-jmxterm) in GitHub.
+    [JMXTerm](https://docs.cyclopsgroup.org/jmxterm) is a CLI interactive tool that can be used for troubleshooting. Documentation for JMXTerm can be found at our [nrjmx troubleshooting page](https://github.com/newrelic/nrjmx/blob/master/TROUBLESHOOT.md). As of nrjmx v1.7.0, JMXTerm is no longer bundled with nrjmx and needs to be downloaded independently. 
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
## Give us some context
* Updated JMXTerm troubleshooting section since it's no longer bundled with nrjmx. 