### PR TITLE
Issue-4115 : Clarify docs to update timestamp in api JSON

### DIFF
--- a/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
@@ -28,8 +28,8 @@ Follow this example to send your first metric data points to New Relic:
 1. Get the [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key) for the account you want to report data to.
 2. Insert the license key into the following JSON, and then send the JSON to our [endpoint](#api-endpoint).
 3. Update the `timestamp` with a valid epoch timestamp.
-
-   This example creates a single metric data point for a metric named `memory.heap`, but you can create additional attributes or data points by specifying [metric types](#supported-metric-types) or adding [optional `common` blocks](#optional-map-attributes).
+fix(Metric API): Remove unnecessary indentation
+This example creates a single metric data point for a metric named `memory.heap`, but you can create additional attributes or data points by specifying [metric types](#supported-metric-types) or adding [optional `common` blocks](#optional-map-attributes).
 
    ```
    curl -vvv -k -H "Content-Type: application/json" \

--- a/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
@@ -27,6 +27,7 @@ Follow this example to send your first metric data points to New Relic:
 
 1. Get the [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key) for the account you want to report data to.
 2. Insert the license key into the following JSON, and then send the JSON to our [endpoint](#api-endpoint).
+3. Update the `timestamp` with a valid epoch timestamp.
 
    This example creates a single metric data point for a metric named `memory.heap`, but you can create additional attributes or data points by specifying [metric types](#supported-metric-types) or adding [optional `common` blocks](#optional-map-attributes).
 


### PR DESCRIPTION
This adds a step reminding users to update the timestamp when sending metric API payloads.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
[Customer got tripped up](https://github.com/newrelic/docs-website/issues/4115) when using the metric api for the first time. This PR sets out to make that experience better.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
N/A
* If your issue relates to an existing GitHub issue, please link to it.
https://github.com/newrelic/docs-website/issues/4115