### PR TITLE
Update opentelemetry-quick-start.mdx

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start.mdx
@@ -175,7 +175,7 @@ service:
       processors: [batch]
       exporters: [otlp]
 ```
-2. Run the OpenTelemetry collector, making sure you replace <var>OTLP_ENDPOINT_HERE</var> with the appropriate [endpoint](#review-settings) and replace <var>YOUR_KEY_HERE</var> with your account's [license key](https://one.newrelic.com/launcher/api-keys-ui.launcher):
+2. Run the OpenTelemetry collector, making sure you replace <var>OTLP_ENDPOINT_HERE</var> with the appropriate [endpoint](#review-settings) as a `<hostname>:<port>` format without `http(s):` and replace <var>YOUR_KEY_HERE</var> with your account's [license key](https://one.newrelic.com/launcher/api-keys-ui.launcher):
 
 ```
 export OTEL_EXPORTER_OTLP_ENDPOINT=<var>OTLP_ENDPOINT_HERE</var>
@@ -186,9 +186,9 @@ docker run --rm \
   -e NEW_RELIC_LICENSE_KEY \
   -p 4317:4317 \
   -v "${PWD}/otel-config.yaml":/otel-config.yaml \
-  --config otel-config.yaml \
   --name otelcol \
-  otel/opentelemetry-collector
+  otel/opentelemetry-collector \
+  --config otel-config.yaml 
 ```
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start.mdx
@@ -175,7 +175,9 @@ service:
       processors: [batch]
       exporters: [otlp]
 ```
-2. Run the OpenTelemetry collector, making sure you replace <var>OTLP_ENDPOINT_HERE</var> with the appropriate [endpoint](#review-settings) as a `<hostname>:<port>` format without `http(s):` and replace <var>YOUR_KEY_HERE</var> with your account's [license key](https://one.newrelic.com/launcher/api-keys-ui.launcher):
+2. Run the OpenTelemetry collector after you make the following changes:
+   * Replace <var>OTLP_ENDPOINT_HERE</var> with the appropriate [endpoint](#review-settings), using the `<hostname>:<port>` format without `http(s)://` (for example, `otlp.nr-data.net:4317`).   
+   * Replace <var>YOUR_KEY_HERE</var> with your account's [license key](https://one.newrelic.com/launcher/api-keys-ui.launcher).
 
 ```
 export OTEL_EXPORTER_OTLP_ENDPOINT=<var>OTLP_ENDPOINT_HERE</var>


### PR DESCRIPTION


Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

- `--config` options should be placed after container image tag (otel/opentelemetry-collector).
- Note that OTLP endpoint should not contain protocol (https:) as discussed in https://github.com/open-telemetry/opentelemetry-collector/issues/2539#issuecomment-800351546