### PR TITLE
feat(UXP): Added sharing permalink user-facing domain

### DIFF
--- a/src/content/docs/using-new-relic/welcome-new-relic/get-started/networks.mdx
+++ b/src/content/docs/using-new-relic/welcome-new-relic/get-started/networks.mdx
@@ -14,7 +14,7 @@ redirects:
   - /docs/using-new-relic/cross-product-functions/install-configure/networks
 ---
 
-**This list is current. Networks, IPs, domains, ports, and endpoints last updated September 28, 2021.**
+**This list is current. Networks, IPs, domains, ports, and endpoints last updated January 6, 2022.**
 
 This is a list of the networks, IP addresses, domains, ports, and endpoints used by API clients or agents to communicate with New Relic. [TLS is required for all domains.](#tls)
 
@@ -164,6 +164,14 @@ If your organization uses a firewall that restricts outbound traffic, follow the
       </td>
       <td>
         OpenTelemetry and Pixie
+      </td>
+    </tr>
+        <tr>
+      <td>
+        onenr.io
+      </td>
+      <td>
+        New Relic One sharing permalinks
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Closes #5522

`onenr.io` is the user-facing domain used for sharing permalinks from New Relic One.