### PR TITLE
Clarify behavior with REST API and browser agent

### DIFF
--- a/src/content/docs/apis/rest-api-v2/get-started/introduction-new-relic-rest-api-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/get-started/introduction-new-relic-rest-api-v2.mdx
@@ -84,6 +84,6 @@ The <var>&lt;PAYLOAD></var> contains the query details, which define:
 See the following docs for example REST API use cases:
 
 * [APM examples](/docs/apis/rest-api-v2/application-examples-v2) (how to retrieve metric timeslice data from APM)
-* [Browser examples](/docs/apis/rest-api-v2/browser-examples-v2) (how to retrieve metric timeslice data from browser monitoring)
+* [Browser examples](/docs/apis/rest-api-v2/browser-examples-v2) (how to retrieve metric timeslice data from browser monitoring). To note, the REST API will only return the Lite agent script even though newly created browser apps (either via APM auto-inject or manual, copy/paste installs) are set to serve up Pro+SPA agent as the default.
 * [Infrastructure alert examples](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts)
 * [Alerts examples](/docs/alerts/new-relic-alerts/rest-api-alerts) (create alert conditions and configure notification channels, and more)


### PR DESCRIPTION
Is there a place in the REST API docs where we can make it more clear for browser apps? 

To note, the REST API will only return the Lite agent script even though newly created browser apps (either via APM auto-inject or manual, copy/paste installs) are set to serve up Pro+SPA agent as the default.



<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

Please see thread here for context: 
https://discuss.newrelic.com/t/feature-idea-generated-script-differs-when-comparing-ui-to-api-query/140964

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.