### PR TITLE
feat(Browser): Updated AjaxRequest event type to match latest feature release

### DIFF
--- a/src/data-dictionary/events/AjaxRequest/AjaxRequest.event-definition.md
+++ b/src/data-dictionary/events/AjaxRequest/AjaxRequest.event-definition.md
@@ -5,4 +5,4 @@ dataSources:
   - Browser agent
 ---
 
-An AjaxRequest event is created automatically when an Ajax request occurs during a BrowserInteraction event. The event attributes track geographic and browser info.
+AjaxRequest events occur for any Ajax request, including during a BrowserInteraction event. The event attribute tracks geographic and browser info. Use browser app settings to block specific requests.


### PR DESCRIPTION
Closes #5526.

I've updated the AjaxRequest entry in the data dictionary, @khickey-newrelic. 

Are there any other places where you think this should be updated?