### PR TITLE
Logging TCP endpoint available in EU

### DIFF
--- a/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
@@ -15,10 +15,6 @@ Forwarding your Heroku logs to New Relic will give you enhanced log management c
 
 ## Create a Heroku Syslog drain [#create-syslog-drain]
 
-<Callout variant="important">
-Currently, our Heroku Syslog endpoint only supports accounts in our [US data center](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers).
-</Callout>
-
 To enable our log management capabilities, start by creating a Heroku Syslog drain.
 
 1. Make sure your New Relic user account has the [Admin role](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model/#roles) assigned to it.

--- a/src/content/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic.mdx
+++ b/src/content/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic.mdx
@@ -19,10 +19,6 @@ To forward logs to New Relic using a syslog client, you need:
 * A valid [New Relic license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key) for the account you want to send logs to
 * Some minor changes to the syslog client's configuration, as explained in this document
 
-<Callout variant="important">
-  Currently, our syslog endpoint only supports accounts in our [US data center](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers).
-</Callout>
-
 ## Configure rsyslog [#rsyslog]
 
 To forward logs to New Relic with `rsyslog`:


### PR DESCRIPTION
Next week the EU TCP Logging endpoints are going live. These are the two references I could find in the docs indicating they were US-only.