### PR TITLE
fix(license keys): clarify you can add them

### DIFF
--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -69,25 +69,26 @@ Here are keys used for querying New Relic data or configuration of features:
 
 ## License key [#ingest-license-key]
 
-Our primary key used for data ingest is called the license key, also referenced in the UI and [NerdGraph API](/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys) as `ingest - license`. The license key is a 40-character hexadecimal string associated with a New Relic account. Each account in a [New Relic organization](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure) has its own license key. When you first [sign up](/docs/subscriptions/creating-your-new-relic-account) for New Relic, that creates an organization with a single account, and that account has its own license key. If more accounts are added, each account will have its own license key. 
+Our primary key used for data ingest is called the license key, also referenced in the UI and [NerdGraph API](/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys) as `ingest - license`. 
+
+The license key is a 40-character hexadecimal string associated with a New Relic account. Each account in a [New Relic organization](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure) has at least one license key. When you first [sign up](/docs/subscriptions/creating-your-new-relic-account) for New Relic, that creates an organization with a single account, and that account has its own license key. If more accounts are added, each account will have its own license key. An account's original license key cannot be deleted but you can create additional license keys that can be managed and deleted. 
 
 The types of data ingest the license key is used for include: 
 
-* APM agent data
-* Infrastructure agent data
-* Data sent via our core data ingest APIs ([Metric API](/docs/telemetry-data-platform/ingest-manage-data/ingest-apis/introduction-metric-api), [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api), [Event API](/docs/telemetry-data-platform/ingest-manage-data/ingest-apis/introduction-event-api), [Log API](/docs/logs/log-management/log-api/introduction-log-api)), and the SDKs and integrations that use those APIs
+* APM agent data.
+* Infrastructure agent data.
+* Data sent via our core data ingest APIs ([Metric API](/docs/telemetry-data-platform/ingest-manage-data/ingest-apis/introduction-metric-api), [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api), [Event API](/docs/telemetry-data-platform/ingest-manage-data/ingest-apis/introduction-event-api), [Log API](/docs/logs/log-management/log-api/introduction-log-api)), and the SDKs and integrations that use those APIs.
 
-The license key is used for all data ingest except for browser monitoring data (which uses a [browser key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-browser-key)) and mobile monitoring data (which uses a [mobile app token](/docs/mobile-monitoring/new-relic-mobile/maintenance/viewing-your-application-token/)). 
+The license key is used for almost all New Relic data ingest. The main exceptions are browser monitoring data (which uses a [browser key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-browser-key)) and mobile monitoring data (which uses a [mobile app token](/docs/mobile-monitoring/new-relic-mobile/maintenance/viewing-your-application-token/)). 
 
-Because the license key is used for data ingest, we recommend you treat your license key securely, like you would a password. This ensures no unwanted data is sent to your New Relic account. If your license key falls into the wrong hands, an attacker could send fake data to your account, which could trigger false alerts and contaminate your data so that detecting actual issues is more difficult. If you believe a license key has been exposed and has led to unwanted data, work with our [Support team](/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/). 
+Because the license key is used for data ingest, we recommend you treat your license keys securely, like you would a password. This ensures no unwanted data is sent to your New Relic account. If a license key falls into the wrong hands, it would allow someone to send data to your account, which could trigger false alerts and contaminate your data so that detecting actual issues is more difficult. If you believe a license key has been exposed and has led to unwanted data, work with our [Support team](/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/). 
 
-### View and manage license key [#manage-license-key]
+### Create and manage license keys [#manage-license-key]
 
-To manage the license key: From the [account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown), click **API keys** (get [a direct link to the API keys page](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher)). 
+To add, delete, and manage license keys: From the [account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown), click **API keys** (get [a direct link to the API keys page](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher)). You can also [create and manage keys with our NerdGraph API](/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-personal-api-keys).
 
-You can't manage or delete the original license key that was created when an account was initially created. For that, [contact New Relic support](https://support.newrelic.com/).
+Note that you can't delete an account's original license key that was generated upon account creation. For that, [contact New Relic support](https://support.newrelic.com/). 
 
-You can also [create additional license keys and manage them with our NerdGraph API](/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-personal-api-keys).
 
 ## User key [#user-api-key]
 

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -52,19 +52,25 @@ Our keys can be broken down into two categories:
 
 ### Keys for data ingest [#ingest-keys]
 
-There are many ways to [get data into New Relic](/docs/telemetry-data-platform/get-started/introduction-new-relic-data-ingest-apis-sdks). Here are the API keys used for data ingest: 
+There are [many ways to get data into New Relic](https://developer.newrelic.com/instant-observability). Here are the API keys used for data ingest: 
 
 * [License key](#ingest-license-key): our primary ingest key, used for APM ingest, infrastructure monitoring ingest, and our [ingest APIs](/docs/data-apis/ingest-apis) and the integrations that use them. 
 * [Browser key](#ingest-browser-key): used for browser monitoring ingest.
 * [Mobile app token](/docs/mobile-monitoring/new-relic-mobile/maintenance/viewing-your-application-token/): used for mobile monitoring ingest. 
 * [Insights insert key](#insights-insert-key): an older key that has been mostly deprecated, it has the same functionality as the license key. **We recommend using the license key instead.**
 
+#### Recommendations for managing ingest keys [#ingest-recommendations]
+
+Some recommendations for managing data ingest keys: 
+* **Keep them safe.** Because these keys are used for data ingest, we recommend you treat ingest keys securely, like you would a password. This ensures no unwanted data is sent to your New Relic account. If a data ingest key falls into the wrong hands, it would allow someone to send data to your account, which could trigger false alerts and contaminate your data so that detecting actual issues is more difficult. If you believe a data ingest key has been exposed and has generated unwanted data, work with our [Support team](/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/). 
+* **Make additional keys.** When setting up monitoring solutions that require a data ingest key, we recommend creating a new key, if possible. The original data ingest key for an account or app cannot be deleted or edited, so in order to give you greater management control (for example, deleting a key if exposed), we recommend creating new ones and using those.
+
 ### Keys for querying and configuration [#query-config-keys]
 
 Here are keys used for querying New Relic data or configuration of features: 
 
 * [User key](#user-api-key), also known as a "personal API key": used for [NerdGraph](/docs/apis/graphql-api/getting-started/introduction-new-relic-graphql-api) (our GraphQL API) and for accessing [REST API](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2) endpoints. 
-* [REST API key](#rest-api-key): used for the [REST API](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2) but **we instead recommend using the user key** because it has fewer restrictions.
+* [REST API key](#rest-api-key): used for the [REST API](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2) but **we instead recommend using the user key** because it has fewer restrictions. 
 * [Insights query key](#insights-query-key): used with the Insights query API for querying New Relic data. **We recommend using NerdGraph instead of this API**.  
 
 ## License key [#ingest-license-key]
@@ -81,9 +87,9 @@ The types of data ingest the license key is used for include:
 
 The license key is used for almost all New Relic data ingest. The main exceptions are browser monitoring data (which uses a [browser key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-browser-key)) and mobile monitoring data (which uses a [mobile app token](/docs/mobile-monitoring/new-relic-mobile/maintenance/viewing-your-application-token/)). 
 
-Because the license key is used for data ingest, we recommend you treat your license keys securely, like you would a password. This ensures no unwanted data is sent to your New Relic account. If a license key falls into the wrong hands, it would allow someone to send data to your account, which could trigger false alerts and contaminate your data so that detecting actual issues is more difficult. If you believe a license key has been exposed and has led to unwanted data, work with our [Support team](/docs/using-new-relic/welcome-new-relic/get-started/find-help-use-support-portal/). 
-
 ### Create and manage license keys [#manage-license-key]
+
+For tips on best practices for key management, see [Ingest key recommendations](#ingest-recommendations).
 
 To add, delete, and manage license keys: From the [account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown), click **API keys** (get [a direct link to the API keys page](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher)). You can also [create and manage keys with our NerdGraph API](/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-personal-api-keys).
 
@@ -102,6 +108,8 @@ To manage this key via API, see [Manage keys with NerdGraph](/docs/apis/nerdgrap
 ## Browser key [#ingest-browser-key]
 
 One of the New Relic API keys that are used for data ingest is the browser key. The browser key allows the ingestion of data from New Relic [browser monitoring](/docs/browser/new-relic-browser/getting-started/introduction-browser-monitoring).
+
+For tips on best practices for key management, see [Ingest key recommendations](#ingest-recommendations).
 
 To view and manage this key: From the [account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown), click **API keys** ([here's a direct link to the API keys page](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher)). 
 

--- a/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
@@ -15,6 +15,7 @@ redirects:
   - /docs/apis/graphql-api/get-started/introduction-new-relic-graphql-api
   - /docs/apis/graphql-api/get-started/introduction-new-relic-nerdgraph
   - /docs/apis/nerdgraph
+  - /docs/apis/graphql-api
 ---
 
 NerdGraph is our GraphQL-format API that lets you query New Relic data and configure some New Relic features. After you [sign up for a free New Relic account](https://newrelic.com/signup) and [install](/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic/) any of our monitoring services, you can get started with NerdGraph.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/maintenance/viewing-your-application-token.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/maintenance/viewing-your-application-token.mdx
@@ -1,15 +1,15 @@
 ---
-title: Application token for New Relic mobile monitoring
+title: New Relic mobile monitoring application token
 tags:
   - Mobile monitoring
   - New Relic Mobile
   - Maintenance
-metaDescription: 'For New Relic mobile monitoring: how to find application token (aka the mobile license key).'
+metaDescription: 'For New Relic mobile monitoring: how to find the app token (aka the mobile data ingest key).'
 redirects:
   - /docs/mobile-apps/viewing-your-application-token
 ---
 
-New Relic's mobile monitoring automatically assigns a unique, 40-character hexadecimal string to each mobile app you monitor, for both the US and EU datacenter. This application token is similar to a New Relic license key and is required to authenticate your app's data.
+One of our [data ingest keys](/docs/apis/intro-apis/new-relic-api-keys) is our mobile monitoring application token. For each mobile app you monitor, we automatically assign a unique, 40-character hexadecimal string to that app, for both the US and EU datacenter. This token is required to authenticate your app's data.
 
 To view your application token:
 


### PR DESCRIPTION
As part of DOC-7619, an attempt to make it more clear that you can create additional license keys. 