### PR TITLE
chore(java-agent): update jedis supported version

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -406,7 +406,7 @@ The agent automatically instruments these frameworks and libraries:
     * HSQL 1.7.2.2 to latest
     * INet Oracle Driver (Oranxo) 3.06, 3.14
     * INet MERLIA 7.0.3, 8.04.03, and 8.06
-    * Jedis Redis driver 1.4.0 to 2.10.x, 3.0.0 to latest
+    * Jedis Redis driver 1.4.0 to 2.10.x, 3.0.0 to 3.8.x
     * jTDS 1.2 to latest
     * MariaDB 1.1.7 or higher
     * Microsoft SQL Server 1.2 to latest


### PR DESCRIPTION
## Give us some context
Jedis released version 4.0.0 a couple of weeks ago and our instrumentation does not apply to the new version.
So capping the supported version.