### PR TITLE
chore: Update Ruby agent documentation to release version 8.3.0

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ignoring-specific-transactions.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ignoring-specific-transactions.mdx
@@ -18,7 +18,7 @@ redirects:
 New Relic for Ruby allows you to selectively disable instrumentation for particular requests within your Rails or Sinatra application.
 
 <Callout variant="important">
-  This documentation has not been tested with Rails 7+.
+  This procedure has not been tested with Rails version 7 or higher.
 </Callout>
 
 ## Blocking all instrumentation [#ignore]

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ignoring-specific-transactions.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ignoring-specific-transactions.mdx
@@ -17,6 +17,10 @@ redirects:
 
 New Relic for Ruby allows you to selectively disable instrumentation for particular requests within your Rails or Sinatra application.
 
+<Callout variant="important">
+  This documentation has not been tested with Rails 7+.
+</Callout>
+
 ## Blocking all instrumentation [#ignore]
 
 Call `newrelic_ignore` with no arguments from within a Rails controller or Sinatra application to prevent instrumentation of all requests serviced by that controller or application:
@@ -90,7 +94,7 @@ rules:
   ignore_url_regexes: ["secret", "^/admin"]
 ```
 
-This configuration will only prevent [Transaction events](/docs/telemetry-data-platform/understand-data/event-data/events-reported-apm/) that match the set pattern from reporting. Use any of the `newrelic_ignore*` family of methods if you would like to prevent all data, such as trace data, from reporting from a transaction. 
+This configuration will only prevent [Transaction events](/docs/telemetry-data-platform/understand-data/event-data/events-reported-apm/) that match the set pattern from reporting. Use any of the `newrelic_ignore*` family of methods if you would like to prevent all data, such as trace data, from reporting from a transaction.
 
 Note that regexes do not include any type of anchoring by default. The /secret/ regex will match 'newrelic.com/secret/login' and it will also match 'newrelic.com/users/secretpanda'. The anchored admin regex will match 'newrelic.com/admin/praetorians' but it will not match 'newrelic.com/users/totally-real-admin'.
 

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
@@ -66,7 +66,7 @@ end
 ## Tracing initializers
 
 <Callout variant="important">
-  This strategy does not work on Rails 7+.
+  This procedure does not work for Rails version 7 or higher.
 </Callout>
 
 For Rails, a common way to add instrumentation is to create an initializer and "monkey patch" the instrumentation directives.

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
@@ -65,6 +65,10 @@ end
 
 ## Tracing initializers
 
+<Callout variant="important">
+  This strategy does not work on Rails 7+.
+</Callout>
+
 For Rails, a common way to add instrumentation is to create an initializer and "monkey patch" the instrumentation directives.
 
 For example, to add a method tracer to `MyCache#get`:

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-metrics.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-metrics.mdx
@@ -4,7 +4,7 @@ tags:
   - Agents
   - Ruby agent
   - API guides
-metaDescription: 'For information about customizing New Relic''s Ruby agent API to collect additional metrics, start here.'
+metaDescription: "For information about customizing New Relic's Ruby agent API to collect additional metrics, start here."
 redirects:
   - /docs/agents/ruby-agent/api-guides/ruby-custom-metrics
   - /docs/ruby/ruby-custom-metric-collection
@@ -23,7 +23,7 @@ Custom metrics let you record arbitrary performance data via an API call (for ex
 </Callout>
 
 <Callout variant="important">
-  This documentation has not been tested with Rails 7+.
+  These procedures have not bee tested with Rails version 7 or higher.
 </Callout>
 
 ## Naming metrics [#metric_names]

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-metrics.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-metrics.mdx
@@ -22,6 +22,10 @@ Custom metrics let you record arbitrary performance data via an API call (for ex
   Collecting too many metrics can impact the performance of your application and your New Relic agent. To avoid data problems, keep the total number of unique custom metrics under 2000.
 </Callout>
 
+<Callout variant="important">
+  This documentation has not been tested with Rails 7+.
+</Callout>
+
 ## Naming metrics [#metric_names]
 
 Metric names identify specific data values tracked by New Relic. When using the New Relic Ruby agent's API to track custom metrics, it's important to consider your metric naming and how the values will aggregate.

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic.mdx
@@ -16,6 +16,10 @@ redirects:
 
 To send error data that you are handling in your own code to New Relic, use the Ruby agent API [`NewRelic::Agent.notice_error`](https://www.rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent#notice_error-instance_method) call within your error handler.
 
+<Callout variant="important">
+  This documentation has not been tested with Rails 7+.
+</Callout>
+
 ## Notify the New Relic Ruby agent of an error [#solution]
 
 This API call takes the exception and an optional options hash. Use this format:

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic.mdx
@@ -17,7 +17,7 @@ redirects:
 To send error data that you are handling in your own code to New Relic, use the Ruby agent API [`NewRelic::Agent.notice_error`](https://www.rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent#notice_error-instance_method) call within your error handler.
 
 <Callout variant="important">
-  This documentation has not been tested with Rails 7+.
+  These procedures have not been tested with Rails version 7 or higher.
 </Callout>
 
 ## Notify the New Relic Ruby agent of an error [#solution]

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -84,6 +84,7 @@ The New Relic Ruby agent does not support experimental versions. Ruby versions s
         * 2.6.x
         * 2.7.x
         * 3.0.x
+        * 3.1.x
       </td>
 
       <td>
@@ -298,6 +299,7 @@ The Ruby agent does not support experimental versions. Web frameworks supported 
         * 5.1.x
         * 5.2.x
         * 6.0.x
+        * 6.1.x
       </td>
 
       <td>

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -147,6 +147,8 @@ Web servers supported by the Ruby agent include:
       <td>
         * 2.0.x
         * 3.x.x
+        * 4.x.x
+        * 5.x.x
       </td>
 
       <td>
@@ -710,6 +712,7 @@ Background jobs supported by the New Relic Ruby agent include:
         * 5.0.x
         * 6.0.x
         * 6.1.x
+        * 6.2.x
       </td>
 
       <td>

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-820.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-820.mdx
@@ -1,6 +1,6 @@
 ---
 subject: Ruby agent
-releaseDate: '2021-11-19'
+releaseDate: '2021-11-29'
 version: 8.2.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.2.0.gem'
 ---

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-830.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-830.mdx
@@ -1,6 +1,6 @@
 ---
 subject: Ruby agent
-releaseDate: '2022-01-05'
+releaseDate: '2022-01-10'
 version: 8.3.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.3.0.gem'
 ---

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-830.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-830.mdx
@@ -1,0 +1,26 @@
+---
+subject: Ruby agent
+releaseDate: '2022-01-05'
+version: 8.3.0
+downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.3.0.gem'
+---
+
+
+  ## v8.3.0
+
+  * **Updated the agent to support Ruby 3.1.0**
+
+    Most of the changes involved updating the multiverse suite to exclude runs for older versions of instrumented gems that are not compatible with Ruby 3.1.0. In addition, Infinite Tracing testing was updated to accommodate `YAML::unsafe_load` for Psych 4 support.
+
+  * **Bugfix: Update AdaptiveSampler#sampled? algorithm**
+
+    One of the clauses in `AdaptiveSampler#sampled?` would always return false due to Integer division returning a result of zero. This method has been updated to use Float division instead, to exponentially back off the number of samples required. This may increase the number of traces collected for transactions. A huge thank you to @romul for bringing this to our attention and breaking down the problem!
+
+  * **Bugfix: Correctly encode ASCII-8BIT log messages**
+
+    The encoding update for the DecoratingLogger in v8.2.0 did not account for ASCII-8BIT encoded characters qualifying as `valid_encoding?`. Now, ASCII-8BIT characters will be encoded as UTF-8 and include replacement characters as needed. We're very grateful for @nikajukic's collaboration and submission of a test case to resolve this issue.
+
+
+## Support statement
+
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.6.0.349](https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-560349).


### PR DESCRIPTION
* Adds release notes for Ruby Agent 8.3.0
* Update release date for Ruby Agent 8.2.0
* Add warnings to documentation untested on Rails 7+