### PR TITLE
changes to machine translation for handling partial success, partial failure, batching

### DIFF
--- a/.github/workflows/check-translations-and-deserialize.yml
+++ b/.github/workflows/check-translations-and-deserialize.yml
@@ -60,6 +60,7 @@ jobs:
           echo "::set-output name=commit::true"
 
       - name: Create Pull Request
+        id: create-pr
         if: steps.fetch-deserialize.outputs.successfulTranslations != 0
         uses: peter-evans/create-pull-request@v3
         with:
@@ -75,13 +76,13 @@ jobs:
           team-reviewers: developer-enablement
 
       - name: Remove Completed Batches From Queue
-        if: steps.fetch-deserialize.outputs.successfulTranslations != 0
+        if: steps.fetch-deserialize.outputs.successfulTranslations != 0 && steps.create-pr.outcome == 'success'
         id: remove-batches
         run: |
           node ./scripts/actions/remove-completed-batch.js
 
       - name: Fail workflow if at least one translation failed
-        if: steps.fetch-deserialization.outputs.failedTranslations
+        if: steps.fetch-deserialization.outputs.failedTranslations > 0
         run: exit 1
 
   fetch-machine-translated-content:
@@ -130,6 +131,7 @@ jobs:
           echo "::set-output name=commit::true"
 
       - name: Create Pull Request
+        id: create-pr
         if: steps.fetch-deserialize.outputs.successfulTranslations != 0
         uses: peter-evans/create-pull-request@v3
         with:
@@ -145,11 +147,11 @@ jobs:
           team-reviewers: developer-enablement
 
       - name: Remove Completed Batches From Queue
-        if: steps.fetch-deserialize.outputs.successfulTranslations != 0
+        if: steps.fetch-deserialize.outputs.successfulTranslations != 0 && steps.create-pr.outcome == 'success'
         id: remove-batches
         run: |
           node ./scripts/actions/remove-completed-batch.js
 
       - name: Fail workflow if at least one translation failed
-        if: steps.fetch-deserialization.outputs.failedTranslations
+        if: steps.fetch-deserialization.outputs.failedTranslations > 0
         run: exit 1

--- a/.github/workflows/check-translations-and-deserialize.yml
+++ b/.github/workflows/check-translations-and-deserialize.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Commit changes
         id: commit-changes
-        if: steps.fetch-deserialize.outputs.batchesToDeserialize != 0
+        if: steps.fetch-deserialize.outputs.successfulTranslations != 0
         run: |
           git config --local user.email "${{ env.BOT_EMAIL }}"
           git config --local user.name "${{ env.BOT_NAME }}"
@@ -60,7 +60,7 @@ jobs:
           echo "::set-output name=commit::true"
 
       - name: Create Pull Request
-        if: steps.fetch-deserialize.outputs.batchesToDeserialize != 0
+        if: steps.fetch-deserialize.outputs.successfulTranslations != 0
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
@@ -75,10 +75,14 @@ jobs:
           team-reviewers: developer-enablement
 
       - name: Remove Completed Batches From Queue
-        if: steps.fetch-deserialize.outputs.batchesToDeserialize != 0
+        if: steps.fetch-deserialize.outputs.successfulTranslations != 0
         id: remove-batches
         run: |
           node ./scripts/actions/remove-completed-batch.js
+
+      - name: Fail workflow if at least one translation failed
+        if: steps.fetch-deserialization.outputs.failedTranslations
+        run: exit 1
 
   fetch-machine-translated-content:
     name: Fetch machine translated content
@@ -117,7 +121,7 @@ jobs:
 
       - name: Commit changes
         id: commit-changes
-        if: steps.fetch-deserialize.outputs.batchesToDeserialize != 0
+        if: steps.fetch-deserialize.outputs.successfulTranslations != 0
         run: |
           git config --local user.email "${{ env.BOT_EMAIL }}"
           git config --local user.name "${{ env.BOT_NAME }}"
@@ -126,7 +130,7 @@ jobs:
           echo "::set-output name=commit::true"
 
       - name: Create Pull Request
-        if: steps.fetch-deserialize.outputs.batchesToDeserialize != 0
+        if: steps.fetch-deserialize.outputs.successfulTranslations != 0
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
@@ -141,7 +145,11 @@ jobs:
           team-reviewers: developer-enablement
 
       - name: Remove Completed Batches From Queue
-        if: steps.fetch-deserialize.outputs.batchesToDeserialize != 0
+        if: steps.fetch-deserialize.outputs.successfulTranslations != 0
         id: remove-batches
         run: |
           node ./scripts/actions/remove-completed-batch.js
+
+      - name: Fail workflow if at least one translation failed
+        if: steps.fetch-deserialization.outputs.failedTranslations
+        run: exit 1

--- a/scripts/actions/__tests__/fetch-and-deserialize.test.js
+++ b/scripts/actions/__tests__/fetch-and-deserialize.test.js
@@ -80,4 +80,23 @@ describe('createFileUriBatches', () => {
       expect(batches).toHaveLength(numberOfBatches);
     }
   );
+
+  it('splits batches with correct content', () => {
+    /**
+     * This tests that the resulting batches contain all and only the input array elements.
+     * How the batches are split doesn't really matter, just that if we recombined the batches it would equal the original input.
+     */
+
+    const input = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const batchSize = 2;
+
+    const batches = createFileUriBatches({ fileUris: input }, batchSize);
+
+    expect(
+      batches
+        .map((b) => b.fileUris)
+        .flat()
+        .sort()
+    ).toEqual(input.sort());
+  });
 });

--- a/scripts/actions/__tests__/fetch-and-deserialize.test.js
+++ b/scripts/actions/__tests__/fetch-and-deserialize.test.js
@@ -1,4 +1,7 @@
-import fetchAndDeserialize from '../fetch-and-deserialize';
+const {
+  writeFilesSync,
+  createFileUriBatches,
+} = require('../fetch-and-deserialize');
 const fse = require('fs-extra');
 const vfile = require('vfile');
 const { writeSync } = require('to-vfile');
@@ -27,7 +30,7 @@ describe('writeFilesSync', () => {
 
   fse.existsSync.mockClear();
   fse.existsSync.mockReturnValue(true);
-  fetchAndDeserialize.writeFilesSync(testFiles);
+  writeFilesSync(testFiles);
 
   it('should call writeSync for each file', () => {
     expect(writeSync).toHaveBeenCalledTimes(testFiles.length);
@@ -35,16 +38,46 @@ describe('writeFilesSync', () => {
 
   it('should call copySync for each unique directory path', () => {
     expect(fse.copySync).toHaveBeenCalledTimes(2);
-    expect(fse.copySync).toHaveBeenNthCalledWith(1, 'src/content/docs/fake_path_1/images', 'src/i18n/content/jp/docs/fake_path_1/images', { overwrite: true });
-    expect(fse.copySync).toHaveBeenNthCalledWith(2, 'src/content/docs/fake_path_2/images', 'src/i18n/content/jp/docs/fake_path_2/images', { overwrite: true });
+    expect(fse.copySync).toHaveBeenNthCalledWith(
+      1,
+      'src/content/docs/fake_path_1/images',
+      'src/i18n/content/jp/docs/fake_path_1/images',
+      { overwrite: true }
+    );
+    expect(fse.copySync).toHaveBeenNthCalledWith(
+      2,
+      'src/content/docs/fake_path_2/images',
+      'src/i18n/content/jp/docs/fake_path_2/images',
+      { overwrite: true }
+    );
   });
 
   it('should not copy directories that dont have images', () => {
     fse.existsSync.mockClear();
     fse.existsSync.mockReturnValue(false);
     fse.copySync.mockClear();
-    fetchAndDeserialize.writeFilesSync(testFiles);
+    writeFilesSync(testFiles);
 
     expect(fse.copySync).toHaveBeenCalledTimes(0);
   });
+});
+
+describe('createFileUriBatches', () => {
+  it.each`
+    inputSize | batchSize | numberOfBatches
+    ${0}      | ${2}      | ${0}
+    ${1}      | ${2}      | ${1}
+    ${2}      | ${2}      | ${1}
+    ${11}     | ${3}      | ${4}
+  `(
+    "should create '$numberofBatches' when input size is '$inputSize' and batch size is '$batchSize'",
+    ({ inputSize, batchSize, numberOfBatches }) => {
+      const batches = createFileUriBatches(
+        { fileUris: Array(inputSize) },
+        batchSize
+      );
+
+      expect(batches).toHaveLength(numberOfBatches);
+    }
+  );
 });

--- a/scripts/actions/__tests__/send-and-update-translation-queue.test.js
+++ b/scripts/actions/__tests__/send-and-update-translation-queue.test.js
@@ -51,6 +51,15 @@ describe('send-and-update-translation-queue tests', () => {
             locale: 'ja-JP',
             status: 'IN_PROGRESS',
           },
+        ])
+        .calledWith({ status: 'ERRORED' })
+        .mockReturnValue([
+          {
+            id: 3,
+            slug: 'hello_world3.txt',
+            locale: 'ja-JP',
+            status: 'ERRORED',
+          },
         ]);
       fs.existsSync.mockReturnValue(true);
 
@@ -93,7 +102,53 @@ describe('send-and-update-translation-queue tests', () => {
             locale: 'ja-JP',
             status: 'IN_PROGRESS',
           },
-        ]);
+        ])
+        .calledWith({ status: 'ERRORED' })
+        .mockReturnValue([]);
+      fs.existsSync.mockReturnValue(true);
+
+      const translations = await getReadyToGoTranslationsForEachLocale();
+
+      expect(translations).toEqual({
+        'ja-JP': [
+          {
+            id: 3,
+            slug: 'hello_world2.txt',
+            locale: 'ja-JP',
+            status: 'PENDING',
+          },
+        ],
+      });
+    });
+
+    test('only returns pending translation if there is no matching errored translation', async () => {
+      when(getTranslations)
+        .calledWith({ status: 'PENDING' })
+        .mockReturnValue([
+          {
+            id: 1,
+            slug: 'hello_world.txt',
+            locale: 'ja-JP',
+            status: 'PENDING',
+          },
+          {
+            id: 3,
+            slug: 'hello_world2.txt',
+            locale: 'ja-JP',
+            status: 'PENDING',
+          },
+        ])
+        .calledWith({ status: 'ERRORED' })
+        .mockReturnValue([
+          {
+            id: 2,
+            slug: 'hello_world.txt',
+            locale: 'ja-JP',
+            status: 'ERRORED',
+          },
+        ])
+        .calledWith({ status: 'IN_PROGRESS' })
+        .mockReturnValue([]);
       fs.existsSync.mockReturnValue(true);
 
       const translations = await getReadyToGoTranslationsForEachLocale();
@@ -128,6 +183,8 @@ describe('send-and-update-translation-queue tests', () => {
           },
         ])
         .calledWith({ status: 'IN_PROGRESS' })
+        .mockReturnValue([])
+        .calledWith({ status: 'ERRORED' })
         .mockReturnValue([]);
 
       when(fs.existsSync)
@@ -175,7 +232,9 @@ describe('send-and-update-translation-queue tests', () => {
             locale: 'ja-JP',
             status: 'IN_PROGRESS',
           },
-        ]);
+        ])
+        .calledWith({ status: 'ERRORED' })
+        .mockReturnValue([]);
       fs.existsSync.mockReturnValue(false);
 
       await getReadyToGoTranslationsForEachLocale();

--- a/scripts/actions/check-job-progress.js
+++ b/scripts/actions/check-job-progress.js
@@ -7,7 +7,7 @@ const {
 } = require('./translation_workflow/database.js');
 
 const { vendorRequest } = require('./utils/vendor-request');
-const { batchedFetchAndDeserialize } = require('./fetch-and-deserialize');
+const { fetchAndDeserializeFiles } = require('./fetch-and-deserialize');
 const { configuration } = require('./configuration');
 
 const PROJECT_ID = configuration.TRANSLATION.VENDOR_PROJECT;
@@ -128,7 +128,9 @@ const main = async () => {
     );
 
     // download the newly translated files and deserialize them (into MDX)
-    await Promise.all(batchesToDeserialize.map(batchedFetchAndDeserialize));
+    const slugStatuses = await Promise.all(
+      batchesToDeserialize.flatMap(fetchAndDeserializeFiles)
+    );
     log('Content deserialized');
 
     // for (const batch of batchesToDeserialize) {

--- a/scripts/actions/check-job-progress.js
+++ b/scripts/actions/check-job-progress.js
@@ -7,7 +7,7 @@ const {
 } = require('./translation_workflow/database.js');
 
 const { vendorRequest } = require('./utils/vendor-request');
-const { fetchAndDeserialize } = require('./fetch-and-deserialize');
+const { batchedFetchAndDeserialize } = require('./fetch-and-deserialize');
 const { configuration } = require('./configuration');
 
 const PROJECT_ID = configuration.TRANSLATION.VENDOR_PROJECT;
@@ -128,31 +128,31 @@ const main = async () => {
     );
 
     // download the newly translated files and deserialize them (into MDX)
-    await Promise.all(batchesToDeserialize.map(fetchAndDeserialize));
+    await Promise.all(batchesToDeserialize.map(batchedFetchAndDeserialize));
     log('Content deserialized');
 
-    for (const batch of batchesToDeserialize) {
-      const records = await getTranslationsJobsRecords({
-        job_id: batch.jobId,
-      });
+    // for (const batch of batchesToDeserialize) {
+    //   const records = await getTranslationsJobsRecords({
+    //     job_id: batch.jobId,
+    //   });
 
-      await Promise.all(
-        records.map(async (record) => {
-          const update = await updateTranslation(record.translation_id, {
-            status: 'COMPLETED',
-          });
-          return update;
-        })
-      );
-    }
+    //   await Promise.all(
+    //     records.map(async (record) => {
+    //       const update = await updateTranslation(record.translation_id, {
+    //         status: 'COMPLETED',
+    //       });
+    //       return update;
+    //     })
+    //   );
+    // }
 
-    const completedJobs = await Promise.all(
-      batchesToDeserialize.map((batch) => {
-        return updateJob(batch.jobId, { status: 'COMPLETED' });
-      })
-    );
+    // const completedJobs = await Promise.all(
+    //   batchesToDeserialize.map((batch) => {
+    //     return updateJob(batch.jobId, { status: 'COMPLETED' });
+    //   })
+    // );
 
-    log(`Jobs completed: ${JSON.stringify(completedJobs)}`);
+    // log(`Jobs completed: ${JSON.stringify(completedJobs)}`);
 
     // get a list of batches that we're still waiting on from our vendor
     const remainingBatches = batchStatuses
@@ -180,11 +180,11 @@ const main = async () => {
       )
     );
 
-    console.log(
-      `::set-output name=deserializedFileUris::${deserializedFileUris.join(
-        ','
-      )}`
-    );
+    // console.log(
+    //   `::set-output name=deserializedFileUris::${deserializedFileUris.join(
+    //     ','
+    //   )}`
+    // );
 
     process.exit(0);
   } catch (error) {

--- a/scripts/actions/fetch-and-deserialize.js
+++ b/scripts/actions/fetch-and-deserialize.js
@@ -157,26 +157,34 @@ const deserializeHtmlToMdx = (locale) => {
    * @param {String} file.path - path of file w/o 'src/.../content/docs' prefix
    * @param {String} file.html - html content of file
    */
-  return async ({ path, html }) => {
+  return async ({ path: contentPath, html }) => {
+    const completePath = path.join('src/content/docs', contentPath, '.mdx');
+
     try {
-      const newPath = `src/i18n/content/${localesMap[locale]}/docs/${path}`;
+      const localePath = path.join(
+        `src/i18n/content/${localesMap[locale]}/docs/`,
+        contentPath
+      );
       const mdx = await deserializedHtml(html);
 
       const temp = vfile({
         contents: mdx,
-        path: newPath,
+        path: localePath,
         extname: '.mdx',
       });
 
       createDirectories([temp]);
       writeFilesSync([temp]);
 
-      return { ok: true, slug: `src/content/docs/${path}` };
+      return {
+        ok: true,
+        slug: completePath,
+      };
     } catch (ex) {
-      console.log(`Failed to deserialize: ${path}`);
+      console.log(`Failed to deserialize: ${contentPath}`);
       console.log(ex);
 
-      return { ok: false, slug: `src/content/docs/${path}` };
+      return { ok: false, slug: completePath };
     }
   };
 };

--- a/scripts/actions/fetch-and-deserialize.js
+++ b/scripts/actions/fetch-and-deserialize.js
@@ -74,6 +74,9 @@ const fetchTranslatedFilesZip = async (fileUris, locale) => {
 const fetchAndDeserialize = async ({ locale, fileUris }) => {
   const response = await fetchTranslatedFilesZip(fileUris, locale);
 
+  console.log(response.status);
+  console.log(JSON.stringify(response));
+
   const buffer = await response.buffer();
 
   const zip = new AdmZip(buffer);
@@ -88,28 +91,59 @@ const fetchAndDeserialize = async ({ locale, fileUris }) => {
     };
   });
 
-  const deserializedMdx = await Promise.all(
-    translatedHtml.map(async ({ path, html }) => {
-      console.log(`[*] Deserializing ${path}`);
-      return {
-        path: `src/i18n/content/${localesMap[locale]}/docs/${path}`,
-        mdx: await deserializedHtml(html),
-      };
-    })
-  );
+  try {
+    const deserializedMdx = await Promise.all(
+      translatedHtml.map(async ({ path, html }) => {
+        console.log(`[*] Deserializing ${path}`);
+        return {
+          path: `src/i18n/content/${localesMap[locale]}/docs/${path}`,
+          mdx: await deserializedHtml(html),
+        };
+      })
+    );
 
-  const files = deserializedMdx.map(
-    ({ path, mdx }) =>
-      vfile({
-        contents: mdx,
-        path,
-        extname: '.mdx',
-      }),
-    'utf-8'
-  );
+    const files = deserializedMdx.map(
+      ({ path, mdx }) =>
+        vfile({
+          contents: mdx,
+          path,
+          extname: '.mdx',
+        }),
+      'utf-8'
+    );
 
-  createDirectories(files);
-  writeFilesSync(files);
+    createDirectories(files);
+    writeFilesSync(files);
+  } catch (ex) {
+    console.log(ex);
+  }
 };
 
-module.exports = { writeFilesSync, fetchAndDeserialize };
+const batchedFetchAndDeserialize = async ({ locale, fileUris }) => {
+  const batchSizeLimit = 50;
+  let batchToSend = [];
+
+  for (let i = 0; i < fileUris.length; i++) {
+    batchToSend.push(fileUris[i]);
+
+    if (batchToSend.length === batchSizeLimit) {
+      // send the request, reset the count & array
+      console.log('Sending full batch');
+
+      await fetchAndDeserialize({ locale, fileUris: batchToSend });
+      batchToSend = [];
+    }
+  }
+
+  // cleanup the last batch
+  if (batchToSend.length != 0) {
+    console.log(`Sending last batch of size ${batchToSend.length}`);
+    await fetchAndDeserialize({ locale, fileUris: batchToSend });
+  }
+};
+
+module.exports = {
+  writeFilesSync,
+  fetchAndDeserialize,
+  batchedFetchAndDeserialize,
+};

--- a/scripts/actions/fetch-and-deserialize.js
+++ b/scripts/actions/fetch-and-deserialize.js
@@ -183,7 +183,9 @@ const deserializeHtmlToMdx = (locale) => {
 
 /**
  *
- * @param {*} param0
+ * @param {Object} input
+ * @param {String} input.locale - locale associated with fileUris
+ * @param {String[]} input.fileUris - list of file paths used for download & deserialization. This will be the complete singular list prior to batching.
  * @returns
  */
 const fetchAndDeserializeFiles = async ({ locale, fileUris }) => {

--- a/scripts/actions/fetch-and-deserialize.js
+++ b/scripts/actions/fetch-and-deserialize.js
@@ -67,8 +67,8 @@ const createFileUriBatches = ({ fileUris }) => {
 
     if (currentBatch.length === batchSizeLimit) {
       // send the request, reset the count & array
-      currentBatch = [];
       batches.push({ fileUris: currentBatch });
+      currentBatch = [];
     }
   }
 

--- a/scripts/actions/fetch-and-deserialize.js
+++ b/scripts/actions/fetch-and-deserialize.js
@@ -56,16 +56,16 @@ const writeFilesSync = (vfiles) => {
 /**
  * @param {Object} input
  * @param {String[]} input.fileUris
+ * @param {Number} batchSize - maximum batch size
  */
-const createFileUriBatches = ({ fileUris }) => {
-  const batchSizeLimit = 50;
+const createFileUriBatches = ({ fileUris }, batchSize = 50) => {
   let batches = [];
   let currentBatch = [];
 
   for (let i = 0; i < fileUris.length; i++) {
     currentBatch.push(fileUris[i]);
 
-    if (currentBatch.length === batchSizeLimit) {
+    if (currentBatch.length === batchSize) {
       // send the request, reset the count & array
       batches.push({ fileUris: currentBatch });
       currentBatch = [];
@@ -211,6 +211,7 @@ const fetchAndDeserializeFiles = async ({ locale, fileUris }) => {
 };
 
 module.exports = {
+  createFileUriBatches,
   writeFilesSync,
   fetchAndDeserializeFiles,
 };

--- a/scripts/actions/fetch-and-deserialize.js
+++ b/scripts/actions/fetch-and-deserialize.js
@@ -10,7 +10,6 @@ const fetch = require('node-fetch');
 const deserializedHtml = require('./deserialize-html');
 const createDirectories = require('../utils/migrate/create-directories');
 const { getAccessToken } = require('./utils/vendor-request');
-const { updateTranslations } = require('./translation_workflow/database');
 
 const localesMap = {
   'ja-JP': 'jp',
@@ -54,120 +53,162 @@ const writeFilesSync = (vfiles) => {
   });
 };
 
-const fetchTranslatedFilesZip = async (fileUris, locale) => {
-  const fileUriStr = fileUris.reduce((str, uri) => {
-    return str.concat(`&fileUris[]=${encodeURIComponent(uri)}`);
-  }, '');
-
-  const localeIdStr = `localeIds[]=${locale}`;
-
-  return fetch(
-    `https://api.smartling.com/files-api/v2/projects/${projectId}/files/zip?${localeIdStr}${fileUriStr}`,
-    {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${await getAccessToken()}`,
-      },
-    }
-  );
-};
-
-const fetchAndDeserialize = async ({ locale, fileUris }) => {
-  const response = await fetchTranslatedFilesZip(fileUris, locale);
-
-  if (response.status !== 200) {
-    console.log(
-      `Error encountered downloading files from vendor. Response code received: ${response.status}`
-    );
-    return;
-  }
-
-  const buffer = await response.buffer();
-
-  const zip = new AdmZip(buffer);
-  const zipEntries = zip.getEntries();
-
-  const translatedHtml = zipEntries.map((entry) => {
-    const filepath = entry.entryName.replace(`${locale}/src/content/docs`, '');
-    const slug = filepath.replace(`.mdx`, '');
-    return {
-      path: slug,
-      html: zip.readAsText(entry, 'utf8'),
-    };
-  });
-
-  await Promise.all(
-    translatedHtml.map(async ({ path, html }) => {
-      try {
-        const newPath = `src/i18n/content/${localesMap[locale]}/docs/${path}`;
-        const mdx = await deserializedHtml(html);
-
-        const temp = vfile({
-          contents: mdx,
-          path: newPath,
-          extname: '.mdx',
-        });
-
-        createDirectories([temp]);
-        writeFilesSync([temp]);
-
-        // TODO: update current record we are processing to have status='COMPLETED'
-        const translations = await updateTranslations(
-          { slug: `src/content/docs/${path}`, status: 'IN_PROGRESS' },
-          { status: 'COMPLETED' }
-        );
-
-        console.log(
-          `updated translation record ${translations[0].id} to 'COMPLETED'`
-        );
-      } catch (ex) {
-        console.log(`Failed to deserialize: ${path}`);
-        console.log(ex);
-
-        const translations = await updateTranslations(
-          { slug: `src/content/docs/${path}`, status: 'IN_PROGRESS' },
-          { status: 'ERRORED' }
-        );
-
-        console.log(
-          `updated translation record ${translations[0].id} to 'ERRORED'`
-        );
-      }
-    })
-  );
-};
-
-const batchedFetchAndDeserialize = async ({ locale, fileUris }) => {
+/**
+ * @param {Object} input
+ * @param {String[]} input.fileUris
+ */
+const createFileUriBatches = ({ fileUris }) => {
   const batchSizeLimit = 50;
-  let batchToSend = [];
+  let batches = [];
+  let currentBatch = [];
 
   for (let i = 0; i < fileUris.length; i++) {
-    batchToSend.push(fileUris[i]);
+    currentBatch.push(fileUris[i]);
 
-    if (batchToSend.length === batchSizeLimit) {
+    if (currentBatch.length === batchSizeLimit) {
       // send the request, reset the count & array
-      console.log('Sending full batch');
-
-      await fetchAndDeserialize({
-        locale,
-        fileUris: batchToSend,
-      });
-      batchToSend = [];
+      currentBatch = [];
+      batches.push({ fileUris: currentBatch });
     }
   }
 
   // cleanup the last batch
-  if (batchToSend.length != 0) {
-    console.log(`Sending last batch of size ${batchToSend.length}`);
-    await fetchAndDeserialize({
-      locale,
-      fileUris: batchToSend,
-    });
+  if (currentBatch.length != 0) {
+    batches.push({ fileUris: currentBatch });
   }
+
+  return batches; // [ [{ locale: ja-JP, fileUris: ['hello_world.txt']}], [...], ... ]
+};
+
+/**
+ * @param {String} locale
+ */
+const fetchTranslatedFilesZip = (locale) => {
+  /**
+   * @param {Object} input
+   * @param {String[]} input.fileUris
+   */
+  return async ({ fileUris }) => {
+    const fileUriStr = fileUris.reduce((str, uri) => {
+      return str.concat(`&fileUris[]=${encodeURIComponent(uri)}`);
+    }, '');
+
+    const localeIdStr = `localeIds[]=${locale}`;
+
+    const response = await fetch(
+      `https://api.smartling.com/files-api/v2/projects/${projectId}/files/zip?${localeIdStr}${fileUriStr}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${await getAccessToken()}`,
+        },
+      }
+    );
+
+    if (response.status !== 200) {
+      console.log(
+        `Error encountered downloading files from vendor. Response code received: ${response.status}`
+      );
+      console.log(
+        `The following files were not downloaded for ${locale}: ${JSON.stringify(
+          fileUris,
+          null,
+          4
+        )}`
+      );
+      return null;
+    }
+
+    const buffer = await response.buffer();
+    const zip = new AdmZip(buffer);
+
+    return zip;
+  };
+};
+
+/**
+ * @param {String} locale
+ */
+const extractFiles = (locale) => {
+  /**
+   * @param {AdmZip} zip - the downloaded zip containing batch of files.
+   */
+  return async (zip) => {
+    return zip.getEntries().map((entry) => {
+      const filepath = entry.entryName.replace(
+        `${locale}/src/content/docs`,
+        ''
+      );
+      const slug = filepath.replace(`.mdx`, '');
+      return {
+        path: slug,
+        html: zip.readAsText(entry, 'utf8'),
+      };
+    });
+  };
+};
+
+/**
+ * @param {String} locale
+ */
+const deserializeHtmlToMdx = (locale) => {
+  /**
+   * @param {object} file
+   * @param {String} file.path - path of file w/o 'src/.../content/docs' prefix
+   * @param {String} file.html - html content of file
+   */
+  return async ({ path, html }) => {
+    try {
+      const newPath = `src/i18n/content/${localesMap[locale]}/docs/${path}`;
+      const mdx = await deserializedHtml(html);
+
+      const temp = vfile({
+        contents: mdx,
+        path: newPath,
+        extname: '.mdx',
+      });
+
+      createDirectories([temp]);
+      writeFilesSync([temp]);
+
+      return { ok: true, slug: `src/content/docs/${path}` };
+    } catch (ex) {
+      console.log(`Failed to deserialize: ${path}`);
+      console.log(ex);
+
+      return { ok: false, slug: `src/content/docs/${path}` };
+    }
+  };
+};
+
+/**
+ *
+ * @param {*} param0
+ * @returns
+ */
+const fetchAndDeserializeFiles = async ({ locale, fileUris }) => {
+  const batches = createFileUriBatches({ fileUris });
+
+  console.log(`Created ${batches.length} batches of files.`);
+
+  const zips = (
+    await Promise.all(batches.map(fetchTranslatedFilesZip(locale)))
+  ).filter(Boolean);
+
+  console.log(`Downloaded ${zips.length} zips`);
+
+  const files = (await Promise.all(zips.map(extractFiles(locale)))).flat();
+
+  console.log(`Unzipped ${files.length} total files.`);
+
+  const slugStatuses = await Promise.all(
+    files.map(deserializeHtmlToMdx(locale))
+  );
+
+  return slugStatuses;
 };
 
 module.exports = {
   writeFilesSync,
-  fetchAndDeserialize,
-  batchedFetchAndDeserialize,
+  fetchAndDeserializeFiles,
 };

--- a/scripts/actions/translation_workflow/database.js
+++ b/scripts/actions/translation_workflow/database.js
@@ -118,6 +118,24 @@ const updateTranslation = async (translationId, updates) => {
 };
 
 /**
+ * Method to update existing translation record(s) matching `filter` criteria.
+ * @param {Partial<Translation>} filters - fields which filter translation(s) you want to be updated
+ * @param {Partial<Translation>} updates - fields to update and their updated values
+ * @example
+ * await updateTranslations({ id: 1 }, { status: 'IN_PROGRESS' }); // update record with id=1 to have a status='IN_PROGRESS'
+ * await updateTranslations({ slug: 'hello_world.txt', status: 'COMPLETED' }); // update all records where slug='hello_world.txt' to have status='COMPLETED'
+ * await updateTranslations({ slug: 'hello_world.txt', status: 'IN_PROGRESS' }, { status:'ERRORED' }); // update all records where slug='hello_world.txt' AND status='IN_PROGRESS' to have status='ERRORED'
+ * @returns updated translations
+ */
+const updateTranslations = async (filters, updates) => {
+  const [_, translations] = await Models.Translation.update(updates, {
+    where: { ...filters },
+    returning: true,
+  });
+  return translations;
+};
+
+/**
  * Method to get records from 'translations' table.
  * @param {Translation} filters - fields with values to match on
  * @example
@@ -199,6 +217,7 @@ module.exports = {
   getStatuses,
   addTranslation,
   updateTranslation,
+  updateTranslations,
   getTranslations,
   deleteTranslation,
   addTranslationsJobsRecord,

--- a/scripts/actions/translation_workflow/database.js
+++ b/scripts/actions/translation_workflow/database.js
@@ -208,6 +208,19 @@ const deleteTranslationsJobsRecords = async (jobId) => {
   });
 };
 
+/**
+ * Enum containing values from `Status` table.
+ * @example
+ * await updateTranslation(1, { status: StatusEnum.ERRORED }); // update translation with id=1 to have status='ERRORED'
+ */
+const StatusEnum = {
+  PENDING: 'PENDING',
+  IN_PROGRESS: 'IN_PROGRESS',
+  IN_REVIEW: 'IN_REVIEW',
+  COMPLETED: 'COMPLETED',
+  ERRORED: 'ERRORED',
+};
+
 module.exports = {
   addJob,
   updateJob,
@@ -223,4 +236,5 @@ module.exports = {
   addTranslationsJobsRecord,
   deleteTranslationsJobsRecords,
   getTranslationsJobsRecords,
+  StatusEnum,
 };


### PR DESCRIPTION
## Summary

Key changes:
* files are downloaded in batches of 50. previously this was limitless, and we were running into errors because of this.
  * the batching change fixes the original bug, but I also added in a response check & console log for if we run into responses that aren't HTTP 200s.
* partial success & failure is now possible in the `fetch-content` jobs.
  * files are deserialized individually, and errors are caught and console logged out.
  * translations that download & deserialize correctly will be marked as `COMPLETED` in the DB. these will be subsequently cleaned up in the removal step / script.
  * translations that do not deserialize / throw during deserialization are marked as `ERRORED`. for the moment, these require manual updates to the file and we should treat these as NOT replayable / resubmittable files until fixed.
  * jobs that have all their translations complete are marked as `COMPLETED`. if at least one translation errors, the job is marked as `ERRORED` and we will treat that functionally as completed with errors -- we won't touch this job again, and fixes will be submitted in subsequent jobs.
  * the GitHub workflow will submit a PR if at least one translation is successfully completed, AND will fail if at least one translation errors.
* now, translations that are marked as `ERRORED` will prevent subsequent uploads to our translation vendor (of that particular file, locale) until remedied.
* added in another database helper method for updating translations using any field as input. the existing method uses translation id.

## Links
Resolves: #5485