### PR TITLE
fix(infra): fixing link, finessing some data wording

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-integrations/get-started/understand-use-data-infrastructure-integrations.mdx
+++ b/src/content/docs/infrastructure/infrastructure-integrations/get-started/understand-use-data-infrastructure-integrations.mdx
@@ -33,12 +33,10 @@ redirects:
   - /docs/infrastructure/integrations-sdk/understand-use-data/understand-use-integration-data
 ---
 
-New Relic infrastructure integrations are separated into two main categories:
+With our infrastructure integrations, you can monitor the performance of many popular services. Our infrastructure integrations are separated into two main categories:
 
 * [Cloud integrations](/docs/integrations/new-relic-integrations/getting-started/introduction-infrastructure-integrations#cloud): Integrations for cloud platform services, including AWS, Azure, and GCP.
 * [On-host integrations](/docs/integrations/new-relic-integrations/getting-started/introduction-infrastructure-integrations#on-host): "On-host" refers to core services integrations that you can install directly on a host. Examples: MySQL, NGINX, Kubernetes, Redis.
-
-With our infrastructure integrations, you can monitor the performance of popular services, including [AWS](/docs/integrations/amazon-integrations/get-started/introduction-aws-integrations/), [Azure](/docs/integrations/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations/), [Google Cloud Platform](/docs/integrations/google-cloud-platform-integrations/getting-started/introduction-google-cloud-platform-integrations), [Kubernetes](/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration), [Redis](/docs/integrations/host-integrations/host-integrations-list/redis-monitoring-integration), [MySQL](/docs/infrastructure/host-integrations/host-integrations-list/mySQL/mysql-integration), and more.
 
 Here are some tips on how to find, understand, and use data reported from infrastructure integrations.
 

--- a/src/content/docs/infrastructure/infrastructure-integrations/get-started/understand-use-data-infrastructure-integrations.mdx
+++ b/src/content/docs/infrastructure/infrastructure-integrations/get-started/understand-use-data-infrastructure-integrations.mdx
@@ -33,7 +33,12 @@ redirects:
   - /docs/infrastructure/integrations-sdk/understand-use-data/understand-use-integration-data
 ---
 
-With [New Relic infrastructure integrations](/docs/infrastructure/infrastructure-integrations/get-started/introduction-infrastructure-integrations), you can monitor the performance of popular services, including [AWS](/docs/integrations/amazon-integrations/get-started/introduction-aws-integrations/), [Azure](/docs/integrations/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations/), [Google Cloud Platform](/docs/integrations/google-cloud-platform-integrations/getting-started/introduction-google-cloud-platform-integrations), [Kubernetes](/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration), [Redis](/docs/integrations/host-integrations/host-integrations-list/redis-monitoring-integration), [MySQL](/docs/infrastructure/host-integrations/host-integrations-list/mySQL/mysql-integration), and more.
+New Relic infrastructure integrations are separated into two main categories:
+
+* [Cloud integrations](/docs/integrations/new-relic-integrations/getting-started/introduction-infrastructure-integrations#cloud): Integrations for cloud platform services, including AWS, Azure, and GCP.
+* [On-host integrations](/docs/integrations/new-relic-integrations/getting-started/introduction-infrastructure-integrations#on-host): "On-host" refers to core services integrations that you can install directly on a host. Examples: MySQL, NGINX, Kubernetes, Redis.
+
+With our infrastructure integrations, you can monitor the performance of popular services, including [AWS](/docs/integrations/amazon-integrations/get-started/introduction-aws-integrations/), [Azure](/docs/integrations/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations/), [Google Cloud Platform](/docs/integrations/google-cloud-platform-integrations/getting-started/introduction-google-cloud-platform-integrations), [Kubernetes](/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration), [Redis](/docs/integrations/host-integrations/host-integrations-list/redis-monitoring-integration), [MySQL](/docs/infrastructure/host-integrations/host-integrations-list/mySQL/mysql-integration), and more.
 
 Here are some tips on how to find, understand, and use data reported from infrastructure integrations.
 
@@ -47,20 +52,6 @@ Some recommendations for exploring:
 * Query data: You can run custom queries and charts of your integration data. For more information, see [Query New Relic data](/docs/using-new-relic/data/understand-data/query-new-relic-data).
 * Create alert conditions: See [Alert conditions](#alerts).
 * Learn more about what metrics and inventory data an integration reports: See an integration's documentation: [cloud integrations](/docs/integrations/new-relic-integrations/getting-started/introduction-infrastructure-integrations#cloud) and [on-host integrations](/docs/integrations/new-relic-integrations/getting-started/introduction-infrastructure-integrations).
-
-## Types of integration data [#overview]
-
-New Relic infrastructure integrations are separated into two main categories:
-
-* [Cloud integrations](/docs/integrations/new-relic-integrations/getting-started/introduction-infrastructure-integrations#cloud): Integrations for cloud platform services, including AWS, Azure, and GCP.
-* [On-host integrations](/docs/integrations/new-relic-integrations/getting-started/introduction-infrastructure-integrations#on-host): "On-host" refers to core services integrations that you can install directly on a host. Examples: MySQL, NGINX, Kubernetes, Redis.
-
-An infrastructure integration can generate four types of data:
-
-* **Metrics**: Numeric measurement data. Examples: message counts, error counts, and CPU used percentage. Metric data appears in an integration's charts. For details about what metrics are reported and how to query them, see the documentation for a specific integration. For details about data structure, see [Data types](/docs/using-new-relic/data/understand-data/new-relic-data-types#metric-event-attributes).
-* **Inventory**: Information about the state and configuration of a service or host. Examples of inventory data: configuration settings, the name of the host the service is on, the AWS region, the port being used. Inventory data appears in the [**Inventory** UI page](/docs/infrastructure/infrastructure-ui-pages/infra-ui-pages/infrastructure-inventory-page-search-your-entire-infrastructure). Inventory data also appears in integration dashboards. Changes to inventory data generates [event data](#event-data).
-* **Events**: Events represent important activity on a system. Examples of event data: an admin logging in; a package install or uninstall; a service starting; a table being created. Most events represent changes to inventory data.
-* **Attributes**: Some integrations will generate other non-metric attributes (key-value pairs) that can be [queried in New Relic](/docs/using-new-relic/data/understand-data/query-new-relic-data).
 
 ## Create alert conditions [#alerts]
 

--- a/src/content/docs/infrastructure/infrastructure-ui-pages/infrastructure-events-page-live-feed-every-config-change.mdx
+++ b/src/content/docs/infrastructure/infrastructure-ui-pages/infrastructure-events-page-live-feed-every-config-change.mdx
@@ -12,7 +12,11 @@ redirects:
   - /docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-events-page-live-feed-every-config-change
 ---
 
-The **Events** page is a live feed of important system and host activity, including inventory change events, configuration changes, and log analytics events. The event feed helps you understand correlations between these events and system performance. Search and filter through your events to decrease the mean time to detect and repair infrastructure issues.
+In New Relic's infastructure monitoring, the **Events** UI page is a live feed of important system and host activity, including inventory change events, configuration changes, and log analytics events. The event feed helps you understand correlations between these events and system performance. Search and filter through your events to decrease the mean time to detect and repair infrastructure issues.
+
+<Callout variant="tip">
+Note that this use of "event" is specific to infrastructure monitoring and a separate concept from our more general [event data type](/docs/data-apis/understand-data/new-relic-data-types/#event-data).
+</Callout>
 
 You can access the **Events** page by going to **[one.newrelic.com](http://one.newrelic.com) > Infrastructure > Events**.
 
@@ -169,4 +173,4 @@ With the **Events** page, you can easily search through your event log to quickl
 
 ## Chart data attributes [#attributes]
 
-For a technical explanation of the [attributes](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) used to populate the **Events** page, see [InfrastructureEvent attributes](/docs/infrastructure/new-relic-infrastructure/data-instrumentation/default-infrastructure-attributes-events#infrastructure-event-attributes).
+For an explanation of the [attributes](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) used to populate the **Events** page, see [InfrastructureEvent attributes](https://docs.newrelic.com/attribute-dictionary/?event=InfrastructureEvent).

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/linux-agent-running-modes.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/linux-agent-running-modes.mdx
@@ -86,7 +86,7 @@ The agent provides different metrics and inventory depending on the running mode
       </td>
 
       <td>
-        All of the documented [data and instrumentation values](/docs/infrastructure/new-relic-infrastructure/data-instrumentation).
+        All of the documented [data and instrumentation values](/docs/infrastructure/manage-your-data/data-instrumentation/default-infrastructure-monitoring-data).
       </td>
     </tr>
 


### PR DESCRIPTION
As part of fixing a broken link, I deleted some 'types of infrastructure data' wording that was a) in an 'infra integrations' doc but really was more general than just integrations, and b) basically incorrect and more confusing than it needed to be. 