### PR TITLE
Move iOS information out of Android DT doc and into separate doc

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-and-dt.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-and-dt.mdx
@@ -45,4 +45,4 @@ Here are some tips for finding and querying data:
 
 ## Troubleshooting [#troubleshooting]
 
-If you don't see end-user spans, or are having other distributed tracing issues, see [Troubleshooting](/docs/apm/distributed-tracing/troubleshooting/troubleshooting-missing-trace-data#browser-data).
+If you don't see end-user spans, or are having other distributed tracing issues, see [Troubleshooting](/docs/apm/distributed-tracing/troubleshooting/troubleshooting-missing-trace-data).

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-and-dt.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-and-dt.mdx
@@ -16,7 +16,7 @@ Watch this short video (approx. 2:15 minutes) to learn how to:
 
 ## Requirements
 
-Here's what you need to use distributed tracing with New Relic mobile: Android agent version 6.0.0 or higher.
+We recommend the most current agent, but to use distributed tracing you need at least Android agent version 6.0.0.
 
 <Callout variant="tip">
 Infinite Tracing is not yet available for mobile monitoring.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-and-dt.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-and-dt.mdx
@@ -1,0 +1,49 @@
+---
+title: New Relic Android mobile monitoring with distributed tracing
+metaDescription: This page describes how to set up Android distributed tracing.
+redirects:
+
+  - /docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-mobile-and-dt
+---
+New Relic Android mobile monitoring agents support distributed tracing. This lets you see how your mobile app activity connects to related services.
+
+Watch this short video (approx. 2:15 minutes) to learn how to:
+
+* Find mobile distributed tracing data in New Relic.
+* Filter by standard and custom attributes.
+
+<Video id="tkAxeE5cT2Q" type="youtube" />
+
+## Requirements
+
+Here's what you need to use distributed tracing with New Relic mobile: Android agent version 6.0.0 or higher.
+
+<Callout variant="tip">
+Infinite Tracing is not yet available for mobile monitoring.
+</Callout>
+
+## How to set up distributed tracing
+
+For mobile agents that support this feature, it’s enabled by default. 
+
+If you prefer to turn off distributed tracing, see the following: [Android feature flag](/docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-agent-configuration-feature-flags/#dt)
+
+## Find data
+
+Mobile spans appear in any [New Relic distributed tracing UI](/docs/understand-dependencies/distributed-tracing/ui-data/additional-distributed-tracing-features-new-relic-one/) where those spans are part of a trace. 
+
+Here are some tips for finding and querying data:
+
+* You can find end-user-originating traces in any [New Relic One distributed tracing UI](/docs/understand-dependencies/distributed-tracing/ui-data/additional-distributed-tracing-features-new-relic-one).
+* In the distributed tracing UI, end-user spans are indicated with the ![New Relic distributed tracing browser span icon](./images/mobile-icon.png "distributed-tracing-browser-span-icon.png") icon.
+* To see a span's attributes, select [a span in the UI](/docs/apm/distributed-tracing/ui-data/understand-use-distributed-tracing-data#span-details).
+* Spans are reported as [Span data](/attribute-dictionary/?event=Span), and can be [queried in New Relic](/docs/using-new-relic/data/understand-data/query-new-relic-data).
+* Query tips:
+  * Query by browser app name by setting `mobileApp.name` to the browser app name.
+  * Query for traces containing at least one mobile app span with `mobileApp.name is not null`.
+  * Query for traces containing at least one back-end app with `appName is not null`.
+  * Query for traces containing both mobile and back-end spans by combining the two previous conditions.
+
+## Troubleshooting
+
+If you don't see end-user spans, or are having other distributed tracing issues, see [Troubleshooting](/docs/apm/distributed-tracing/troubleshooting/troubleshooting-missing-trace-data#browser-data).

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-and-dt.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-and-dt.mdx
@@ -2,7 +2,6 @@
 title: New Relic Android mobile monitoring with distributed tracing
 metaDescription: This page describes how to set up Android distributed tracing.
 redirects:
-
   - /docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-mobile-and-dt
 ---
 New Relic Android mobile monitoring agents support distributed tracing. This lets you see how your mobile app activity connects to related services.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-and-dt.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-and-dt.mdx
@@ -14,21 +14,21 @@ Watch this short video (approx. 2:15 minutes) to learn how to:
 
 <Video id="tkAxeE5cT2Q" type="youtube" />
 
-## Requirements
+## Requirements [#requirements]
 
-We recommend the most current agent, but to use distributed tracing you need at least Android agent version 6.0.0.
+To use distributed tracing, you need at least Android agent version 6.0.0. We recommend you use the most recent agent.
 
 <Callout variant="tip">
 Infinite Tracing is not yet available for mobile monitoring.
 </Callout>
 
-## How to set up distributed tracing
+## How to set up distributed tracing [#setup]
 
 For mobile agents that support this feature, it’s enabled by default. 
 
-If you prefer to turn off distributed tracing, see the following: [Android feature flag](/docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-agent-configuration-feature-flags/#dt)
+If you prefer to turn off distributed tracing, see [Android feature flag](/docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-agent-configuration-feature-flags/#dt).
 
-## Find data
+## Find data [#find-data]
 
 Mobile spans appear in any [New Relic distributed tracing UI](/docs/understand-dependencies/distributed-tracing/ui-data/additional-distributed-tracing-features-new-relic-one/) where those spans are part of a trace. 
 
@@ -44,6 +44,6 @@ Here are some tips for finding and querying data:
   * Query for traces containing at least one back-end app with `appName is not null`.
   * Query for traces containing both mobile and back-end spans by combining the two previous conditions.
 
-## Troubleshooting
+## Troubleshooting [#troubleshooting]
 
 If you don't see end-user spans, or are having other distributed tracing issues, see [Troubleshooting](/docs/apm/distributed-tracing/troubleshooting/troubleshooting-missing-trace-data#browser-data).

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-and-dt.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-and-dt.mdx
@@ -13,7 +13,7 @@ Watch this short video (approx. 2:15 minutes) to learn how to:
 
 ## Requirements
 
-Here's what you need to use distributed tracing with iOS: XCFramework agent version 7.3.0
+We recommend the most current agent, but to use distributed tracing, you need at least XCFramework agent version 7.3.0.
 
 <Callout variant="tip">
 Infinite Tracing is not yet available for mobile monitoring.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-and-dt.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-and-dt.mdx
@@ -43,4 +43,4 @@ Here are some tips for finding and querying data:
 
 ## Troubleshooting [#troubleshooting]
 
-If you don't see end-user spans, or are having other distributed tracing issues, see [Troubleshooting](/docs/apm/distributed-tracing/troubleshooting/troubleshooting-missing-trace-data#browser-data).
+If you don't see end-user spans, or are having other distributed tracing issues, see [Troubleshooting](/docs/apm/distributed-tracing/troubleshooting/troubleshooting-missing-trace-data).

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-and-dt.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-and-dt.mdx
@@ -11,21 +11,21 @@ Watch this short video (approx. 2:15 minutes) to learn how to:
 
 <Video id="tkAxeE5cT2Q" type="youtube" />
 
-## Requirements
+## Requirements [#requirements]
 
-We recommend the most current agent, but to use distributed tracing, you need at least XCFramework agent version 7.3.0.
+To use distributed tracing, you need at least XCFramework agent version 7.3.0. We recommend you use the most recent agent.
 
 <Callout variant="tip">
 Infinite Tracing is not yet available for mobile monitoring.
 </Callout>
 
-## How to set up distributed tracing
+## How to set up distributed tracing [#setup]
 
 For mobile agents that support this feature, it’s enabled by default. 
 
-If you prefer to turn off distributed tracing, see the following: [iOS feature flag](/docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-agent-configuration-feature-flags/#dt)
+If you prefer to turn off distributed tracing, see [iOS feature flag](/docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-agent-configuration-feature-flags/#dt).
 
-## Find data
+## Find data [#find-data]
 
 Mobile spans appear in any [New Relic distributed tracing UI](/docs/understand-dependencies/distributed-tracing/ui-data/additional-distributed-tracing-features-new-relic-one/) where those spans are part of a trace. 
 
@@ -41,6 +41,6 @@ Here are some tips for finding and querying data:
   * Query for traces containing at least one back-end app with `appName is not null`.
   * Query for traces containing both mobile and back-end spans by combining the two previous conditions.
 
-## Troubleshooting
+## Troubleshooting [#troubleshooting]
 
 If you don't see end-user spans, or are having other distributed tracing issues, see [Troubleshooting](/docs/apm/distributed-tracing/troubleshooting/troubleshooting-missing-trace-data#browser-data).

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-and-dt.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-and-dt.mdx
@@ -1,7 +1,8 @@
 ---
-title: New Relic mobile monitoring with distributed tracing
+title: New Relic iOS mobile monitoring with distributed tracing
+metaDescription: This page describes how to set up iOS distributed tracing.
 ---
-New Relic mobile monitoring agents support distributed tracing. This lets you see how your mobile app activity connects to related services.
+New Relic iOS mobile monitoring agents support distributed tracing. This lets you see how your mobile app activity connects to related services.
 
 Watch this short video (approx. 2:15 minutes) to learn how to:
 
@@ -12,10 +13,7 @@ Watch this short video (approx. 2:15 minutes) to learn how to:
 
 ## Requirements
 
-Here's what you need to use distributed tracing with New Relic mobile:
-
-    * Android agent version 6.0.0 or higher
-    * XCFramework agent version 7.3.0
+Here's what you need to use distributed tracing with iOS: XCFramework agent version 7.3.0
 
 <Callout variant="tip">
 Infinite Tracing is not yet available for mobile monitoring.
@@ -25,10 +23,7 @@ Infinite Tracing is not yet available for mobile monitoring.
 
 For mobile agents that support this feature, it’s enabled by default. 
 
-If you prefer to turn off distributed tracing, see the following:
-
-    * [Android feature flag](/docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-agent-configuration-feature-flags/#dt)
-    * [iOS feature flag](/docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-agent-configuration-feature-flags/#dt)
+If you prefer to turn off distributed tracing, see the following: [iOS feature flag](/docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-agent-configuration-feature-flags/#dt)
 
 ## Find data
 

--- a/src/nav/mobile.yml
+++ b/src/nav/mobile.yml
@@ -98,7 +98,7 @@ pages:
           - title: Compatibility and requirements
             path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements
           - title: Android distributed tracing
-            path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-mobile-and-dt
+            path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-and-dt
           - title: Android release notes
             path: /docs/mobile-monitoring/new-relic-mobile-android/get-started/android-release-notes
       - title: Install and configure
@@ -183,6 +183,8 @@ pages:
             path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/introduction-new-relic-mobile-ios
           - title: iOS compatibility and requirements
             path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-compatibility-requirements
+          - title: iOS distributed tracing
+            path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-and-dt
           - title: iOS release notes
             path: /docs/release-notes/mobile-release-notes/xcframework-release-notes/
       - title: Installation


### PR DESCRIPTION
For historical reasons, the Android doc about DT also contained the iOS information. Now, it is time to separate the two.

I did the following:

* Created a separate iOS distributed tracing page based on the original Android page. 
* I renamed the original Android page to clarify it and added a redirect.
* Removed references in each file so they only talk about Android or iOS.
* Added a navigation link for the iOS page.