### PR TITLE
Clarifies permissions needed for monitor deletion

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors.mdx
@@ -155,7 +155,7 @@ You cannot change a monitor's [type](#setting-type) after the monitor is created
 
 ## Delete a monitor [#deleting-monitors]
 
-You must have [Admin Privileges](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/administration/user-roles-synthetic-monitoring/) in order to delete a Synthetics Monitor.
+You must have [Admin privileges](/docs/synthetics/synthetic-monitoring/administration/user-roles-synthetic-monitoring/) in order to delete a monitor.
 
 To delete a monitor:
 

--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors.mdx
@@ -155,6 +155,8 @@ You cannot change a monitor's [type](#setting-type) after the monitor is created
 
 ## Delete a monitor [#deleting-monitors]
 
+You must have [Admin Privileges](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/administration/user-roles-synthetic-monitoring/) in order to delete a Synthetics Monitor.
+
 To delete a monitor:
 
 1. From the **Monitors** tab in [**one.newrelic.com**](http://one.newrelic.com/) **> Synthetics**, select the monitor you want to edit.


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* **What problems does this PR solve?** The docs previously made it seem like anyone could delete a monitor. This makes it clear that only admins may do so.
* **Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.** Information obtained from these sources

- https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/administration/user-roles-synthetic-monitoring/
- https://discuss.newrelic.com/t/unable-to-delete-synthetics-monitor/74379

* **If your issue relates to an existing GitHub issue, please link to it.** N/A