### PR TITLE
Update minimum version of Log4J2

### DIFF
--- a/src/content/docs/logs/logs-context/java-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/java-configure-logs-context-all.mdx
@@ -319,7 +319,7 @@ To enable logs in context for APM apps monitored by Java:
   
   To configure logs in context for your Java app with with the Log4j 2.x extension:
   
-  1. Make sure you have the [Log4j 2.x](https://logging.apache.org/log4j/2.x/index.html) or [Logs4j 2 binding](https://logging.apache.org/log4j/2.x/log4j-slf4j-impl/) package installed and working on your application.
+  1. Make sure you have the [Log4j 2.13.2 or higher](https://logging.apache.org/log4j/2.x/index.html) or [Logs4j 2 binding](https://logging.apache.org/log4j/2.x/log4j-slf4j-impl/) package installed and working on your application.
   
   2. Make sure you have the New Relic Java agent version 5.6.0 or higher installed on your application, and that you have enabled the [JVM argument `-javaagent`](/docs/agents/java-agent/installation/include-java-agent-jvm-argument).
   


### PR DESCRIPTION
The Java Log Extension only works with Log4J2 2.13.2 or higher.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.