### PR TITLE
Add clarifying callout for the background task usage for Python Agent

### DIFF
--- a/src/content/docs/apm/agents/python-agent/python-agent-api/backgroundtask-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/backgroundtask-python-agent-api.mdx
@@ -24,6 +24,10 @@ Used to instrument a background task or other non-web transaction.
 
 This Python decorator can be used to instrument background tasks or other [non-web transactions](/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions). This is typically used to instrument non-web activity like worker processes, job-based systems, and standalone scripts. Transactions marked as background tasks are displayed as non-web transactions in the APM UI and separated from web transactions.
 
+<Callout variant="imporant">
+To create a function trace for a given function within a background task, [function_trace()](/docs/apm/agents/python-agent/python-agent-api/functiontrace-python-agent-api) will need to be used if the function is not instrumented already.
+</Callout>
+
 If a function using the background task decorator is called within the context of a web transaction, then the web transaction is marked as a background task. The measurement of the time taken begins when the original web transaction starts.
 
 If you cannot use the decorator, one of these call formats may be more useful:

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/backgroundtask-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/backgroundtask-python-agent-api.mdx
@@ -25,7 +25,7 @@ Used to instrument a background task or other non-web transaction.
 This Python decorator can be used to instrument background tasks or other [non-web transactions](/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions). This is typically used to instrument non-web activity like worker processes, job-based systems, and standalone scripts. Transactions marked as background tasks are displayed as non-web transactions in the APM UI and separated from web transactions.
 
 <Callout variant="imporant">
-To create a function trace for a given function within a background task, [function_trace()](/docs/apm/agents/python-agent/python-agent-api/functiontrace-python-agent-api) will need to be used if the function is not instrumented already.
+If a function isn't already instrumented, use [function_trace()](/docs/apm/agents/python-agent/python-agent-api/functiontrace-python-agent-api) to create a function trace for that function within a background task.
 </Callout>
 
 If a function using the background task decorator is called within the context of a web transaction, then the web transaction is marked as a background task. The measurement of the time taken begins when the original web transaction starts.


### PR DESCRIPTION
This adds a sentence to the Python Agent's Background Task API to clarify the usage of the background task usage.