### PR TITLE
Removing broken link in Python config doc

### DIFF
--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -881,7 +881,7 @@ These settings are available in the agent configuration file.
     Instead of setting the `proxy_scheme`, `proxy_host` and `proxy_port` settings, you can also set the `proxy_host` setting to a valid URI for the proxy. Include the scheme, host, and port; for example, `http://proxy-host:8000`. This also works if you set the details of the HTTP proxy with the `NEW_RELIC_PROXY_HOST` environment variable.
 
     <Callout variant="tip">
-      Python agent versions 2.0.0 or earlier do not provide the `proxy_scheme` setting, and the protocol scheme defaults to `http` or `https` depending whether [`ssl`](#ssl) is disabled or enabled. If you are upgrading from an older agent version and your config file doesn't include `proxy_scheme`, ensure you add the setting and set it appropriately. If you don't, the agent will continue to base the protocol scheme on the `ssl` setting for backwards compatibility. As proxies are usually only configured to accept proxy requests via the `http` protocol scheme, not setting `proxy_scheme` may result in a failure.
+      Python agent versions 2.0.0 or earlier do not provide the `proxy_scheme` setting, and the protocol scheme defaults to `http` or `https` depending whether `ssl` is disabled or enabled. If you are upgrading from an older agent version and your config file doesn't include `proxy_scheme`, ensure you add the setting and set it appropriately. If you don't, the agent will continue to base the protocol scheme on the `ssl` setting for backwards compatibility. As proxies are usually only configured to accept proxy requests via the `http` protocol scheme, not setting `proxy_scheme` may result in a failure.
     </Callout>
   </Collapser>
 


### PR DESCRIPTION
As reported in #5479. There's no replacement for the link, so I'm removing it.