### PR TITLE
Bump kafka supported versions to 3.0

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka-monitoring-integration.mdx
@@ -16,7 +16,7 @@ Read on to install the Kafka integration, and to see what data it collects. To m
 
 ## Compatibility and requirements [#req]
 
-Our integration is compatible with Kafka versions 2.6 or below.
+Our integration is compatible with Kafka versions 3.0 or below.
 
 Before installing the integration, make sure that you meet the following requirements:
 


### PR DESCRIPTION
- This PR updates the nri-kafka supported version to 3.0. This is thanks to the release of the last version of nri-kafka that supports it.