### PR TITLE
Adding an example to Percentage function

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -1598,6 +1598,10 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
     Use the `percentage( )` function to return the percentage of a target data set that matches some condition.
 
     The first argument requires an [aggregator function](#functions) against the desired attribute. Use exactly two arguments (arguments after the first two will be ignored). If the attribute is not numeric, this function returns a value of 100%.
+    
+    ```
+    FROM Transaction SELECT percentage(count(*), WHERE error is true ) AS 'Error Percent' Where host LIKE '%west%' EXTRAPOLATE
+    ```
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
Just adding this NRQL to the percentage function
```
FROM Transaction SELECT percentage(count(*), WHERE error is true ) AS 'Error Percent' Where host LIKE '%west%' EXTRAPOLATE
```

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.