### PR TITLE
Revert "Revert "Core user type What's New post""

### DIFF
--- a/src/content/whats-new/2022/01/whats-new-01-12-core-user-type.md
+++ b/src/content/whats-new/2022/01/whats-new-01-12-core-user-type.md
@@ -1,0 +1,40 @@
+---
+title: 'Introducing our new core user type' 
+summary: 'Unlock telemetry data access for even more developers in your org' 
+releaseDate: '2022-01-12' 
+isFeatured: true
+learnMoreLink: 'https://newrelic.com/blog/nerdlog/core-user-usage-pricing' 
+---
+
+Observability is better together. Our new core user type enables more developers than ever to understand code performance better, collaborate and prioritize work directly from their IDE, and access relevant error details including stack traces, logs, alerts, and more.
+
+**New core users enable developers to:** 
+* Optimize code performance and feature planning with access to telemetry data from production and pre-production environments directly in their IDE via the [New Relic CodeStream integration](https://newrelic.com/codestream). 
+* Collaborate with DevOps, site reliability engineers (SREs), and ops engineers with a direct path from [error tracking](https://newrelic.com/platform/errors-inbox) in New Relic One to the relevant code block directly in their IDE.
+* Detect patterns and outliers in [log data](https://one.newrelic.com/launcher/logger.log-launcher?platform[accountId]=3386328&platform[timeRange][duration]=1800000&platform[$isFallbackTimeRange]=true&state=18f8ab72-f351-81d7-8b9d-d0a44b5b94a3) to resolve issues and improve code performance. 
+* Build and run [custom applications](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/build-new-relic-one/build-custom-new-relic-one-application) in New Relic One to surface performance insights, optimize cloud costs, and more. 
+* Onboard new developers with observability best practices and shared baselines for metrics.
+
+## Preview period: Try core user capabilities today
+
+All existing basic users currently have free access to core user capabilities through Feb. 28, 2022, as part of a preview period. After the preview period, only full platform or core users can access the New Relic CodeStream integration, errors inbox, New Relic One custom apps, and advanced log management features.
+
+**To start viewing error tracking and other telemetry data directly within your IDE,** follow the [instructions](https://newrelic.com/codestream) to set up the New Relic CodeStream integration.
+
+**To enable errors inbox** for your account, follow these steps: 
+* From [one.newrelic.com](one.newrelic.com), select errors inbox from the top nav.
+* If this is your first time accessing [errors inbox](https://one.newrelic.com/launcher/errors-inbox.launcher?platform[accountId]=3386328&platform[timeRange][duration]=86400000&platform[$isFallbackTimeRange]=true&state=49e6d628-79ac-7022-1689-a6a6b7673f54), you will be prompted to select a workload in the top left.
+* If you have no workloads set up, you'll be prompted to create one before you can use errors inbox.
+* Once you select your workload, your inbox should populate with error groups.
+
+## Explore core user capabilities in this walkthrough 
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/04JP0ky_hjI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+## Unlock core users in your account
+To start adding core users, visit the plan management UI (click the top right account dropdown and click **Manage your plan**) and enable core users by accepting the new terms. Note that some accounts may need to talk with their account team to unlock core users. If you can't access that UI, it may be because you don't have the right permissions (for example: users on the New Relic One user model require the [**Billing user role**](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#roles), which is assigned to the **Admin** group). 
+
+
+
+
+


### PR DESCRIPTION
The core users release 'What's new?' post was merged to develop and then reverted, and this is a reversion to restore the post. 

Any tagged reviewers can ignore this; this doesn't need review. 