### PR TITLE
Fix broken API link in left navigation

### DIFF
--- a/src/nav/synthetics.yml
+++ b/src/nav/synthetics.yml
@@ -104,7 +104,7 @@ pages:
   - title: Synthetics API
     pages:
       - title: Synthetics REST API
-        path: /docs/synthetics/new-relic-synthetics/synthetics-api/synthetics-rest-api
+        path: /docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api
   - title: Troubleshooting
     pages:
       - title: 'Simple, scripted, or scripted API (non-ping) errors'


### PR DESCRIPTION
The link to the Synthetics API was broken in the left navigation. Evidently, the Synthetics API was moved to APIs, so the new navigation link point to this location: https://docs.newrelic.com/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api/

This is from GitHub issue #5609.