### PR TITLE
fix(docker): remove reference to old CentOS image

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/docker-container-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/docker-container-infrastructure-monitoring.mdx
@@ -332,11 +332,9 @@ Once the infrastructure agent is running in a Docker container, it can collect t
 
 ## Containerized agent image [#view]
 
-The containerized agent image is built from an Alpine base image. A CentOS base image is also available.
+The containerized agent image is built from an Alpine base image.
 
-Alpine is used as the base image since version 0.0.55. This is the one pointed by `latest` tag.
-
-Earlier versions used CentOS 7 as base image. In order to keep using that legacy image, some backports may be included there. To fetch the latest CentOS 7 based image, point to the `latest-centos` tag.
+Alpine is used as the base image since version 0.0.55. This is the one pointed by `latest` tag. Earlier versions used CentOS 7 as base image. 
 
 ## Check the source code [#source-code]
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* The image base on CentOS is not offered anymore (this was migrated long time ago).
* Removing references to old image. 