### PR TITLE
chore: remove check for modified translations

### DIFF
--- a/scripts/actions/check-for-outdated-translations.js
+++ b/scripts/actions/check-for-outdated-translations.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const frontmatter = require('@github-docs/frontmatter');
 
 const { fetchPaginatedGHResults } = require('./utils/github-api-helpers');
 const checkArgs = require('./utils/check-args');
@@ -29,20 +28,6 @@ const checkOutdatedTranslations = async (url) => {
     ? files.filter((file) => path.extname(file.filename) === '.mdx')
     : [];
 
-  const mdxFilesContent = mdxFiles
-    .filter((file) => file.status !== 'removed')
-    .reduce((files, file) => {
-      const contents = fs.readFileSync(path.join(process.cwd(), file.filename));
-      const { data } = frontmatter(contents);
-      return [
-        ...files,
-        {
-          path: file.filename,
-          locales: data.translate || [],
-        },
-      ];
-    }, []);
-
   const removedMdxFileNames = mdxFiles
     .filter((f) => f.status === 'removed')
     .map(prop('filename'));
@@ -50,15 +35,6 @@ const checkOutdatedTranslations = async (url) => {
   const renamedMdxFileNames = mdxFiles
     .filter((f) => f.status === 'renamed')
     .map(prop('previous_filename'));
-
-  // if a locale was removed from the translate frontmatter, we want to remove the translated version of that file.
-
-  const modifiedFiles = mdxFilesContent.flatMap((file) => {
-    const unsetLocales = ADDITIONAL_LOCALES.filter(
-      (l) => !file.locales.includes(l)
-    );
-    return doI18nFilesExist(file.path, unsetLocales);
-  });
 
   const removedFiles = removedMdxFileNames.flatMap((name) =>
     doI18nFilesExist(name, ADDITIONAL_LOCALES)
@@ -68,11 +44,7 @@ const checkOutdatedTranslations = async (url) => {
     doI18nFilesExist(name, ADDITIONAL_LOCALES)
   );
 
-  const orphanedI18nFiles = [
-    ...modifiedFiles,
-    ...removedFiles,
-    ...renamedFiles,
-  ];
+  const orphanedI18nFiles = [...removedFiles, ...renamedFiles];
 
   if (orphanedI18nFiles.length > 0) {
     orphanedI18nFiles.forEach((f) =>

--- a/scripts/actions/check-for-outdated-translations.js
+++ b/scripts/actions/check-for-outdated-translations.js
@@ -1,10 +1,13 @@
 const fs = require('fs');
 const path = require('path');
+const frontmatter = require('@github-docs/frontmatter');
 
 const { fetchPaginatedGHResults } = require('./utils/github-api-helpers');
 const checkArgs = require('./utils/check-args');
 const { prop } = require('../utils/functional');
-const { ADDITIONAL_LOCALES } = require('../utils/constants');
+const { LOCALE_IDS } = require('./utils/constants');
+
+const ADDITIONAL_LOCALES = Object.keys(LOCALE_IDS);
 
 const doI18nFilesExist = (fileName, locales) => {
   const i18nPrefix = path.join(process.cwd(), 'src/i18n/content');
@@ -28,6 +31,20 @@ const checkOutdatedTranslations = async (url) => {
     ? files.filter((file) => path.extname(file.filename) === '.mdx')
     : [];
 
+  const mdxFilesContent = mdxFiles
+    .filter((file) => file.status !== 'removed')
+    .reduce((files, file) => {
+      const contents = fs.readFileSync(path.join(process.cwd(), file.filename));
+      const { data } = frontmatter(contents);
+      return [
+        ...files,
+        {
+          path: file.filename,
+          locales: data.translate || [],
+        },
+      ];
+    }, []);
+
   const removedMdxFileNames = mdxFiles
     .filter((f) => f.status === 'removed')
     .map(prop('filename'));
@@ -35,6 +52,15 @@ const checkOutdatedTranslations = async (url) => {
   const renamedMdxFileNames = mdxFiles
     .filter((f) => f.status === 'renamed')
     .map(prop('previous_filename'));
+
+  // if a locale was removed from the translate frontmatter, we want to remove the translated version of that file.
+
+  const modifiedFiles = mdxFilesContent.flatMap((file) => {
+    const unsetLocales = ADDITIONAL_LOCALES.filter(
+      (l) => !file.locales.includes(l)
+    );
+    return doI18nFilesExist(file.path, unsetLocales);
+  });
 
   const removedFiles = removedMdxFileNames.flatMap((name) =>
     doI18nFilesExist(name, ADDITIONAL_LOCALES)
@@ -44,7 +70,11 @@ const checkOutdatedTranslations = async (url) => {
     doI18nFilesExist(name, ADDITIONAL_LOCALES)
   );
 
-  const orphanedI18nFiles = [...removedFiles, ...renamedFiles];
+  const orphanedI18nFiles = [
+    ...modifiedFiles,
+    ...removedFiles,
+    ...renamedFiles,
+  ];
 
   if (orphanedI18nFiles.length > 0) {
     orphanedI18nFiles.forEach((f) =>

--- a/scripts/actions/check-for-outdated-translations.js
+++ b/scripts/actions/check-for-outdated-translations.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const frontmatter = require('@github-docs/frontmatter');
 
 const { fetchPaginatedGHResults } = require('./utils/github-api-helpers');
 const checkArgs = require('./utils/check-args');
@@ -31,20 +30,6 @@ const checkOutdatedTranslations = async (url) => {
     ? files.filter((file) => path.extname(file.filename) === '.mdx')
     : [];
 
-  const mdxFilesContent = mdxFiles
-    .filter((file) => file.status !== 'removed')
-    .reduce((files, file) => {
-      const contents = fs.readFileSync(path.join(process.cwd(), file.filename));
-      const { data } = frontmatter(contents);
-      return [
-        ...files,
-        {
-          path: file.filename,
-          locales: data.translate || [],
-        },
-      ];
-    }, []);
-
   const removedMdxFileNames = mdxFiles
     .filter((f) => f.status === 'removed')
     .map(prop('filename'));
@@ -52,15 +37,6 @@ const checkOutdatedTranslations = async (url) => {
   const renamedMdxFileNames = mdxFiles
     .filter((f) => f.status === 'renamed')
     .map(prop('previous_filename'));
-
-  // if a locale was removed from the translate frontmatter, we want to remove the translated version of that file.
-
-  const modifiedFiles = mdxFilesContent.flatMap((file) => {
-    const unsetLocales = ADDITIONAL_LOCALES.filter(
-      (l) => !file.locales.includes(l)
-    );
-    return doI18nFilesExist(file.path, unsetLocales);
-  });
 
   const removedFiles = removedMdxFileNames.flatMap((name) =>
     doI18nFilesExist(name, ADDITIONAL_LOCALES)
@@ -70,11 +46,7 @@ const checkOutdatedTranslations = async (url) => {
     doI18nFilesExist(name, ADDITIONAL_LOCALES)
   );
 
-  const orphanedI18nFiles = [
-    ...modifiedFiles,
-    ...removedFiles,
-    ...renamedFiles,
-  ];
+  const orphanedI18nFiles = [...removedFiles, ...renamedFiles];
 
   if (orphanedI18nFiles.length > 0) {
     orphanedI18nFiles.forEach((f) =>

--- a/scripts/utils/constants.js
+++ b/scripts/utils/constants.js
@@ -9,8 +9,6 @@ module.exports = {
   DATA_DIR: 'src/data',
   JP_DIR: 'src/i18n/content/jp',
 
-  ADDITIONAL_LOCALES: ['jp'],
-
   INSTRUCTIONS: {
     ADD: 'ADD',
     MOVE: 'MOVE',


### PR DESCRIPTION
We can just remove the check for `modifiedFiles` here.

The script takes the english path of the file and checks if there is a corresponding locale file, in any of the specified locales

## removedFiles
If an english file is removed we also want to make sure any locale versions are removed, so we flag that

## renamedFiles
This is essentially deleting a file and recreating it in a different location, so we want to check any locale versions that match the original location are deleted/moved/renamed

## modifiedFiles

This is currently checking to see if the `translate` frontmatter has been removed. This is also essentially the same as deleting the file because we want to flag the locale file(s) to be removed too.

However, now we don't need to. If a file has `translate: jp` it will be `Human Translated` in japanese and `Machine Translated for everything else. If you remove `translate: jp` it just means you want this to be MT instead of HT, so you essentially don't need to touch any current HT locale files because they are going to be MT and replaced in the next run anyway.

*We also had 2 places were we were declaring locale id constants so I modified that slightly*