### PR TITLE
fix(java compat): make 'not supported' more clear

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -30,7 +30,7 @@ Before you install the Java agent, ensure your system meets these requirements:
   >
       The Java agent is compatible with any JVM-based language, including: Java, Scala, Kotlin, and Clojure. For instrumentation support for language-specific features, see the [Automatically instrumented frameworks and libraries](#auto-instrumented) section below.
 
-      In order to continue to innovate and efficiently provide new capabilities to our customers, we'll occasionally need to drop engineering support and technical support for older JVM versions. In the table below, the column titled **Not supported** refers to this state. For the not-supported versions, you can continue using a version of the agent that is compatable with your older JVM version, but new features and fixes won't be included in those older agent versions. We recommend upgrading to a currently supported JVM version to take advantage of the latest agent releases. 
+      In order to continue to innovate and efficiently provide new capabilities to our customers, we'll occasionally need to drop engineering support and technical support for older JVM versions. In the table below, the column titled **No New Relic support** refers to agent versions that are in this state. For the not-supported versions, you can continue using a version of the agent that is compatable with your older JVM version, but new features and fixes won't be included in those older agent versions. We recommend upgrading to a currently supported JVM version to take advantage of the latest agent releases. 
 
     <table>
       <thead>

--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -28,12 +28,9 @@ Before you install the Java agent, ensure your system meets these requirements:
     id="jvm"
     title="JVM"
   >
-    <Callout variant="tip">
       The Java agent is compatible with any JVM-based language, including: Java, Scala, Kotlin, and Clojure. For instrumentation support for language-specific features, see the [Automatically instrumented frameworks and libraries](#auto-instrumented) section below.
 
-      In order to continue to innovate and efficiently provide new capabilities to our customers, we'll occasionally need to drop support for older JVM versions. When that happens, you can continue using a version of the agent that supports your older JVM version, but new features and fixes won't be included in those older agent versions. We recommend upgrading to a currently supported JVM version to take advantage of the latest agent releases. Please see the table of compatible agent versions to determine which JVM versions are compatible.
-    </Callout>
-
+      In order to continue to innovate and efficiently provide new capabilities to our customers, we'll occasionally need to drop engineering support and technical support for older JVM versions. In the table below, the column titled **Not supported** refers to this state. For the not-supported versions, you can continue using a version of the agent that is compatable with your older JVM version, but new features and fixes won't be included in those older agent versions. We recommend upgrading to a currently supported JVM version to take advantage of the latest agent releases. 
 
     <table>
       <thead>
@@ -42,12 +39,12 @@ Before you install the Java agent, ensure your system meets these requirements:
             Java version
           </th>
 
-          <th>
-            Compatible agent versions
+          <th style={{ width: "300px" }}>
+            Compatible Java agent versions
           </th>
           
           <th>
-            Not supported
+            No New Relic support (see above)
           </th>
 
         </tr>
@@ -60,7 +57,7 @@ Before you install the Java agent, ensure your system meets these requirements:
           </td>
 
           <td>
-            Agent v1.3.0 to v2.21.7
+            v1.3.0 to v2.21.7
           </td>
           
           <td>
@@ -75,7 +72,7 @@ Before you install the Java agent, ensure your system meets these requirements:
           </td>
 
           <td>
-            Agent v3.0.0 to v4.3.0
+            v3.0.0 to v4.3.0
           </td>
           
           <td>
@@ -89,7 +86,7 @@ Before you install the Java agent, ensure your system meets these requirements:
           </td>
 
           <td>
-            Agent v3.0.0 to v6.5.0, v6.5.2, and v6.5.3
+            v3.0.0 to v6.5.0, v6.5.2, and v6.5.3
           </td>
           
           <td>
@@ -103,7 +100,7 @@ Before you install the Java agent, ensure your system meets these requirements:
           </td>
 
           <td>
-            Agent v3.10.0 to current
+            v3.10.0 to current
           </td>
           
           <td>
@@ -117,7 +114,7 @@ Before you install the Java agent, ensure your system meets these requirements:
           </td>
 
           <td>
-            Agent v3.43.0 to current
+            v3.43.0 to current
           </td>
           
           <td>
@@ -131,7 +128,7 @@ Before you install the Java agent, ensure your system meets these requirements:
           </td>
 
           <td>
-            Agent v4.4.0 to current
+            v4.4.0 to current
           </td>
           
           <td>
@@ -145,7 +142,7 @@ Before you install the Java agent, ensure your system meets these requirements:
           </td>
 
           <td>
-            Agent v4.7.0 to current
+            v4.7.0 to current
           </td>
           
           <td>
@@ -159,7 +156,7 @@ Before you install the Java agent, ensure your system meets these requirements:
           </td>
 
           <td>
-            Agent v4.12.0 to current
+            v4.12.0 to current
           </td>
           
           <td>
@@ -173,7 +170,7 @@ Before you install the Java agent, ensure your system meets these requirements:
           </td>
 
           <td>
-            Agent v5.7.0 to current
+            v5.7.0 to current
           </td>
           
           <td>
@@ -187,7 +184,7 @@ Before you install the Java agent, ensure your system meets these requirements:
           </td>
 
           <td>
-            Agent v5.11.0 to current
+            v5.11.0 to current
           </td>
           
           <td>
@@ -201,7 +198,7 @@ Before you install the Java agent, ensure your system meets these requirements:
           </td>
 
           <td>
-            Agent v6.1.0 to current
+            v6.1.0 to current
           </td>
           
           <td>
@@ -215,7 +212,7 @@ Before you install the Java agent, ensure your system meets these requirements:
           </td>
 
           <td>
-            Agent v7.3.0 to current
+            v7.3.0 to current
           </td>
           
           <td>
@@ -229,7 +226,7 @@ Before you install the Java agent, ensure your system meets these requirements:
           </td>
 
           <td>
-            Agent v7.4.0 to current
+            v7.4.0 to current
           </td>
           
           <td>


### PR DESCRIPTION
Work based on https://github.com/newrelic/docs-website/issues/5624. Making the 'Not supported' aspect of the compatibility table more clear. 