### PR TITLE
fix(CodeStream): Add redirect for top-level codestream path

### DIFF
--- a/src/content/docs/codestream/start-here/what-is-codestream.mdx
+++ b/src/content/docs/codestream/start-here/what-is-codestream.mdx
@@ -1,6 +1,8 @@
 ---
 title: Intro to New Relic CodeStream
 description: "New Relic CodeStream is the code collaboration tool built for remote teams."
+redirects:
+  - /docs/codestream
 ---
 
 New Relic CodeStream is a developer collaboration platform that enables your development team to discuss and review code in a natural and contextual way. CodeStream not only makes your discussions easier, by allowing them to happen in context in your IDE, but it also preserves the institutional knowledge that is currently being lost in Slack channels and emails.


### PR DESCRIPTION
It seemed important to add this redirect.