### PR TITLE
fix(NerdGraph): Use correct DashboardInput type

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/export-import-dashboards-using-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/export-import-dashboards-using-api.mdx
@@ -77,7 +77,7 @@ Example entity information in GraphiQL output:
 Use the following mutation to import the dashboard into another account:
 
 ```
-mutation create($dashboard: Input!) {
+mutation create($dashboard: DashboardInput!) {
   dashboardCreate(accountId: <mark>your_new_AccountID</mark>, dashboard: $dashboard) {
     entityResult {
       guid
@@ -92,7 +92,7 @@ mutation create($dashboard: Input!) {
 
 Follow these steps:
 
-1. In the **Query variables** section, name the entity `Dashboard` (since we declared the input variable as `$dashboard`).
+1. In the **Query variables** section, name the entity `dashboard` (since we declared the input variable as `$dashboard`).
 2. Copy and paste the [entity's output](#export) into the new account. It will be copied as an entity.
 3. Change `entity` to `dashboard`.
 


### PR DESCRIPTION
Also update the `dashboard` query variable to match the mutation.

## Give us some context

While working through this example to import a dashboard, I noticed that the type of the `$dashboard` variable declared in the mutation did not match the expected type in NerdGraph. I also noticed that the `dashboard` property in the query variables JSON needed to be updated to match the variable in the mutation.

Ideally, it would probably be good to update the corresponding screenshot as well, but I wasn't sure if y'all wanted to handle that yourselves. 🙂 