### PR TITLE
fix(docs site): remove 'insights' mentions

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
@@ -134,42 +134,6 @@ If you have an EU region account, use the appropriate endpoints to access the fo
 
     <tr>
       <td>
-        [Dashboard API](/docs/insights/insights-api/manage-dashboards/insights-dashboard-api)
-      </td>
-
-      <td>
-        ```
-        rpm.<mark>eu</mark>.newrelic.com/api/explore/dashboards/list
-        ```
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [Insert API](/docs/insights/insights-data-sources/custom-data/insert-custom-events-insights-api)
-      </td>
-
-      <td>
-        ```
-        insights-collector.<mark>eu01</mark>.nr-data.net
-        ```
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [Insights Query API](/docs/insights/insights-api/get-data/query-insights-event-data-api)
-      </td>
-
-      <td>
-        ```
-        insights-api.<mark>eu</mark>.newrelic.com
-        ```
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         [Mobile apps](/docs/mobile-monitoring/new-relic-mobile/maintenance/viewing-your-application-token)
       </td>
 
@@ -265,6 +229,19 @@ If you have an EU region account, use the appropriate endpoints to access the fo
         ```
       </td>
     </tr>
+
+    <tr>
+      <td>
+        [Insights Query API](/docs/insights/insights-api/get-data/query-insights-event-data-api)
+      </td>
+
+      <td>
+        ```
+        insights-api.<mark>eu</mark>.newrelic.com
+        ```
+      </td>
+    </tr>
+
   </tbody>
 </table>
 

--- a/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
@@ -229,6 +229,17 @@ If you have an EU region account, use the appropriate endpoints to access the fo
         ```
       </td>
     </tr>
+    <tr>
+      <td>
+        [Event API](/docs/data-apis/ingest-apis/introduction-event-api)
+      </td>
+
+      <td>
+        ```
+        insights-collector.<mark>eu01</mark>.nr-data.net
+        ```
+      </td>
+    </tr>
 
     <tr>
       <td>

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/core-users-release.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/core-users-release.mdx
@@ -9,7 +9,7 @@ redirects:
   - /docs/accounts/pricing-billing/new-relic-one-pricing/new-relic-one-pricing-details
 ---
 
-On January 12, 2022, we released a version of [New Relic One pricing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing) that added a new user type: the **core user** ([learn benefits](#benefits)). 
+On January 12, 2022, we released a version of [New Relic One pricing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing) that added a new user type: the **core user** ([learn benefits](#benefits)).
 
 ## Who is this resource for? [#what-is-this]
 

--- a/src/content/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model.mdx
+++ b/src/content/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model.mdx
@@ -708,15 +708,12 @@ Admin and manager capabilities for Infrastructure include:
 
 ## Insights permissions
 
-Here is a summary of Admin and Add-on manager capabilities with [New Relic Insights](/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights). 
+Note that [New Relic Insights has been deprecated](/docs/glossary/glossary/#nr-insights).
 
-To allow a User or Restricted User to execute any of these functions, assign an Insights manager role. These functions include:
+To allow a User or Restricted User to execute any of these functions, assign an Insights manager role. The functions include the ability to create, view, modify, or delete:
 
-* Create, view, modify, or delete [Query API keys](/docs/insights/export-insights-data/export-api/query-insights-event-data-api) or [Insert API keys](/docs/insights/explore-data/custom-events/insert-custom-events-insights-api#register).
-
-<Callout variant="tip">
-  New Relic Insights includes permission levels to [share your Insights dashboards](/docs/insights/new-relic-insights/managing-dashboards-data/building-insights-dashboards#permissions) with others.
-</Callout>
+* [Query API keys](/docs/apis/intro-apis/new-relic-api-keys/#insights-query-key): Note that we now recommend using [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) and not the Insights query API. 
+* [Insert API keys](/docs/apis/intro-apis/new-relic-api-keys/#insights-insert-key): Note that we now recommend using the [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key) instead. 
 
 ## Mobile permissions
 

--- a/src/content/docs/accounts/original-accounts-billing/product-based-pricing/overview-data-retention-components.mdx
+++ b/src/content/docs/accounts/original-accounts-billing/product-based-pricing/overview-data-retention-components.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview of data retention (original pricing model)
+title: Data retention for original pricing model
 tags:
   - Accounts
   - Original accounts and billing

--- a/src/content/docs/accounts/original-accounts-billing/product-based-pricing/trial-lite-accounts-deprecated.mdx
+++ b/src/content/docs/accounts/original-accounts-billing/product-based-pricing/trial-lite-accounts-deprecated.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trial and Lite accounts
+title: "Trial and Lite accounts (original pricing model)"
 tags:
   - Accounts
   - Original accounts and billing

--- a/src/content/docs/apis/insights-apis/insights-dashboard-api.mdx
+++ b/src/content/docs/apis/insights-apis/insights-dashboard-api.mdx
@@ -1,10 +1,8 @@
 ---
 title: Insights Dashboard API
 tags:
-  - Insights
   - Event data sources
-  - Insights API
-metaDescription: 'Use New Relic''s Dashboard API with the API Explorer to list, create, read, update and delete new or existing dashboards.'
+metaDescription: "Use New Relic's Dashboard API with the API Explorer to list, create, read, update and delete new or existing dashboards."
 redirects:
   - /docs/insights-dashboard-api
   - /docs/insights/insights-api/manage-dashboards/insights-dashboard-api

--- a/src/content/docs/apis/insights-apis/insights-dashboard-api.mdx
+++ b/src/content/docs/apis/insights-apis/insights-dashboard-api.mdx
@@ -2,7 +2,7 @@
 title: Insights Dashboard API
 tags:
   - Event data sources
-metaDescription: "Use New Relic's Dashboard API with the API Explorer to list, create, read, update and delete new or existing dashboards."
+metaDescription: "New Relic's Dashboard API is now deprecated."
 redirects:
   - /docs/insights-dashboard-api
   - /docs/insights/insights-api/manage-dashboards/insights-dashboard-api

--- a/src/content/docs/apis/insights-apis/query-insights-event-data-api.mdx
+++ b/src/content/docs/apis/insights-apis/query-insights-event-data-api.mdx
@@ -1,12 +1,10 @@
 ---
 title: Insights query API
 tags:
-  - Insights
   - Event data sources
-  - Insights API
 translate:
   - jp
-metaDescription: Use the New Relic Insights API and a query key to make remote queries to the events database via a standard HTTPS request.
+metaDescription: The New Relic Insights API is largely deprecated.
 redirects:
   - /docs/rubicon/remote-queries
   - /docs/insights/remote-queries

--- a/src/content/docs/apis/insights-apis/query-insights-event-data-api.mdx
+++ b/src/content/docs/apis/insights-apis/query-insights-event-data-api.mdx
@@ -4,7 +4,7 @@ tags:
   - Event data sources
 translate:
   - jp
-metaDescription: The New Relic Insights API is largely deprecated.
+metaDescription: The New Relic Insights query API is largely deprecated.
 redirects:
   - /docs/rubicon/remote-queries
   - /docs/insights/remote-queries

--- a/src/content/docs/apis/intro-apis/introduction-new-relic-apis.mdx
+++ b/src/content/docs/apis/intro-apis/introduction-new-relic-apis.mdx
@@ -600,16 +600,6 @@ Insights-related APIs include:
           </td>
         </tr>
 
-        <tr>
-          <td>
-            Dashboard API
-          </td>
-
-          <td>
-          Use the [Dashboards API](/docs/query-your-data/explore-query-data/dashboards/dashboards-api).
-          </td>
-        </tr>
-
       </tbody>
     </table>
   </Collapser>

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -57,7 +57,7 @@ There are [many ways to get data into New Relic](https://developer.newrelic.com/
 * [License key](#ingest-license-key): our primary ingest key, used for APM ingest, infrastructure monitoring ingest, and our [ingest APIs](/docs/data-apis/ingest-apis) and the integrations that use them. 
 * [Browser key](#ingest-browser-key): used for browser monitoring ingest.
 * [Mobile app token](/docs/mobile-monitoring/new-relic-mobile/maintenance/viewing-your-application-token/): used for mobile monitoring ingest. 
-* [Insights insert key](#insights-insert-key): an older key that has been mostly deprecated, it has the same functionality as the license key. **We recommend using the license key instead.**
+* [Insights insert key](#insights-insert-key): an older key that has been mostly deprecated, it has the same functionality as the license key. **We recommend using the license key.**
 
 #### Recommendations for managing ingest keys [#ingest-recommendations]
 

--- a/src/content/docs/apis/nerdgraph/examples/create-widgets-dashboards-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/create-widgets-dashboards-api.mdx
@@ -14,10 +14,6 @@ redirects:
 
 With the New Relic dashboards API you can use [NerdGraph](https://api.newrelic.com/graphiql) to build your [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards). This document explains the different types of widgets you can add to your dashboards, and how to create and get them using the API.
 
-<Callout variant="tip">
-  If you're using the deprecated Insights Dashboard API, we have a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that helps you transition to using the new API.
-</Callout>
-
 ## Widget schema and types [#widget-schema]
 
 The widget GraphQL schema for query and mutation outputs looks like this:

--- a/src/content/docs/apis/rest-api-v2/get-started/admin-users-api-key-partnerships.mdx
+++ b/src/content/docs/apis/rest-api-v2/get-started/admin-users-api-key-partnerships.mdx
@@ -34,6 +34,5 @@ This partner-only authentication method will only work with the [New Relic REST 
 * [Deployment API](/docs/apm/new-relic-apm/maintenance/deployment-notifications#api)
 * [Infrastructure API for alerts](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts)
 * [Insights API](/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-insights-api)
-* [Insights Dashboard API](/docs/insights/insights-api/manage-dashboards/insights-dashboard-api)
 * [Partner API](/docs/accounts-partnerships/partnerships/partner-api/partner-api-reference)
 * [Synthetics API](/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api)

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/agent-attributes.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/agent-attributes.mdx
@@ -91,11 +91,11 @@ Collected attributes appear in these locations:
 
     <tr>
       <td>
-        [Insights page views](/docs/insights/insights-data-sources/default-events-attributes/browser-default-events-attributes-insights)
+        [Browser events](/docs/insights/insights-data-sources/default-events-attributes/browser-default-events-attributes-insights)
       </td>
 
       <td>
-        Browser page views will contain [attributes](/docs/insights/new-relic-insights/decorating-events/insights-attributes) collected during the transaction. However, attributes collected at the end of a transaction may not appear on `PageView` events. This destination is also called browser monitoring.
+        Browser monitoring events will contain [attributes](/docs/insights/new-relic-insights/decorating-events/insights-attributes) collected during the transaction. However, attributes collected at the end of a transaction may not appear on `PageView` events. This destination is also called browser monitoring.
       </td>
     </tr>
 

--- a/src/content/docs/apm/agents/manage-apm-agents/app-naming/use-multiple-names-app.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/app-naming/use-multiple-names-app.mdx
@@ -38,7 +38,7 @@ To avoid duplicate events, disable collection for each of the duplicate app name
 1. Go to **[one.newrelic.com](https://one.newrelic.com) or [one.eu.newrelic.com](https://one.eu.newrelic.com)  > More > Manage Insights Data**.
 2. Toggle data collection on/off for duplicate app names, then save.
 
-![Insights transaction events](./images/Insights-ToggleOnOff.png "Transaction events")
+![Transaction events](./images/Insights-ToggleOnOff.png "Transaction events")
 
 ## Roll up browser data [#browser-rollup]
 

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -2927,7 +2927,7 @@ Here are custom events settings available via the agent configuration file.
       </tbody>
     </table>
 
-    Allow recording of events to the Insights custom events API via [`record_custom_event()`](/docs/agents/python-agent/customization-extension/python-transaction-api#record_custom_event).
+    Allow recording of events to the Event API via [`record_custom_event()`](/docs/agents/python-agent/customization-extension/python-transaction-api#record_custom_event).
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/guide-using-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/guide-using-python-agent-api.mdx
@@ -264,7 +264,7 @@ Use these methods to create new event data and new metric data:
       </td>
 
       <td>
-        To add attributes to events for more detailed analysis in Insights or error analytics, use [`add_custom_parameter`](/docs/agents/python-agent/python-agent-api/add_custom_parameter).
+        To add attributes to events for more detailed querying or error analytics, use [`add_custom_parameter`](/docs/agents/python-agent/python-agent-api/add_custom_parameter).
       </td>
     </tr>
 

--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -785,7 +785,7 @@ For information on ignored and expected errors, [see this page on Error Analytic
       </tbody>
     </table>
 
-  Defines the maximum number of [TransactionError events](/docs/insights/new-relic-insights/decorating-events/error-event-default-attributes-insights) sent to Insights per harvest cycle.
+  Defines the maximum number of [TransactionError events](/docs/insights/new-relic-insights/decorating-events/error-event-default-attributes-insights) reported per harvest cycle.
   </Collapser>
 
 </CollapserGroup>
@@ -1248,12 +1248,12 @@ The browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
       </tbody>
     </table>
 
-  If `false`, custom attributes will not be sent on Insights events.
+  If `false`, custom attributes will not be sent on events.
   </Collapser>
 
 </CollapserGroup>
 
-## Custom Insights Events
+## Custom Events
 
 <CollapserGroup>
 
@@ -1266,7 +1266,7 @@ The browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
       </tbody>
     </table>
 
-  If `true`, the agent captures [New Relic Insights custom events](/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-new-relic-apm-agents).
+  If `true`, the agent captures [custom events](/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-new-relic-apm-agents).
   </Collapser>
 
   <Collapser id="custom_insights_events-max_samples_stored" title="custom_insights_events.max_samples_stored">
@@ -1278,7 +1278,7 @@ The browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
       </tbody>
     </table>
 
-  Specify a maximum number of custom Insights events to buffer in memory at a time.
+  Specify a maximum number of custom events to buffer in memory at a time.
   </Collapser>
 
 </CollapserGroup>

--- a/src/content/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'APM: Report custom events and attributes'
 tags:
-  - Insights
   - Event data sources
   - Custom events
 metaDescription: How to report APM custom events and attributes in New Relic.

--- a/src/content/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data.mdx
@@ -1,7 +1,6 @@
 ---
 title: Data requirements and limits for custom event data
 tags:
-  - Insights
   - Event data sources
   - Custom events
 translate:
@@ -66,9 +65,7 @@ When reporting custom events and attributes, follow these general requirements f
       </td>
 
       <td>
-        [Attribute](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute) values can be either a string or a numeric integer or float.
-
-        If your attribute values contain date information, define it as an unformatted Unix timestamp (in seconds or milliseconds) by using the [Insights data formatter](/docs/insights/use-insights-ui/manage-account-data/data-formatter-set-default-formats-numeric-values).
+        [Attribute](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute) values can be either a string or a numeric integer or float. For information about formatting date and time data, see [Custom date/time](/docs/query-your-data/explore-query-data/use-charts/use-your-charts/#custom-date-time).
       </td>
     </tr>
 
@@ -262,8 +259,8 @@ Avoid using the following reserved words as names for events and attributes. Oth
 
 ## Event type limits [#event-limits]
 
-The current limit for total number of `eventType` values is 250 per child account in a given 24-hour time period. If a user exceeds this limit, New Relic may filter or drop data. Event types include:
+The current limit for total number of `eventType` values is 250 per account (not per organization) in a given 24-hour time period. If an account exceeds this limit, New Relic may filter or drop data. Event types include:
 
-* Default events from New Relic agents
-* Custom events from New Relic agents
-* Custom events from Insights custom event inserter
+* Default events from New Relic agents and integrations
+* Custom events from agents or 
+* Custom events from Event API

--- a/src/content/docs/infrastructure/amazon-integrations/troubleshooting/aws-service-specific-api-rate-limiting.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/troubleshooting/aws-service-specific-api-rate-limiting.mdx
@@ -48,9 +48,9 @@ After enabling Amazon integrations with New Relic Infrastructure, you encounter 
     To review the API usage for New Relic Infrastructure integrations with Amazon AWS:
 
     1. Go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure > AWS > Account status dashboard**.
-    2. Review the New Relic Insights dashboard, which appears automatically.
+    2. Review the dashboard.
 
-    The Insights dashboard includes a chart with your account's Amazon AWS API call count for the last month as well as the CloudWatch API calls (per AWS resource) for the last day. This information is the API usage for New Relic only. It does not include other AWS API or CloudWatch usage that may occur.
+    The dashboard includes a chart with your account's Amazon AWS API call count for the last month as well as the CloudWatch API calls (per AWS resource) for the last day. This information is the API usage for New Relic only. It does not include other AWS API or CloudWatch usage that may occur.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/infrastructure/amazon-integrations/troubleshooting/cloudwatch-billing-increase.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/troubleshooting/cloudwatch-billing-increase.mdx
@@ -51,9 +51,9 @@ After setting up New Relic Infrastructure Amazon integrations, your usage of the
     To review the API usage for New Relic Infrastructure integrations with Amazon AWS:
 
     1. Go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure > AWS > Account status dashboard**.
-    2. Review the New Relic Insights dashboard, which appears automatically.
+    2. Review the dashboard.
 
-    The Insights dashboard includes a chart with your account's Amazon AWS API call count for the last month as well as the CloudWatch API calls (per AWS resource) for the last day. This information is the API usage for New Relic only. It does not include other AWS API or CloudWatch usage that may occur.
+    The dashboard includes a chart with your account's Amazon AWS API call count for the last month as well as the CloudWatch API calls (per AWS resource) for the last day. This information is the API usage for New Relic only. It does not include other AWS API or CloudWatch usage that may occur.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/infrastructure/amazon-integrations/troubleshooting/no-data-appears-aws-integrations.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/troubleshooting/no-data-appears-aws-integrations.mdx
@@ -14,7 +14,7 @@ redirects:
 
 ## Problem
 
-You installed the New Relic Infrastructure agent and then connected your Amazon account to it. After waiting a few minutes, you still do not see data for your Amazon Web Service (AWS) integrations in the New Relic Infrastructure UI or in New Relic Insights.
+You installed the New Relic Infrastructure agent and then connected your Amazon account to it. After waiting a few minutes, you still do not see data for your Amazon Web Service (AWS) integrations in the infrastructure monitoring UI or when querying for the data.
 
 ## Solution
 

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration.mdx
@@ -180,7 +180,7 @@ Query `GcpBigQueryDatasetSample` events in New Relic to view data for the follow
 
 ### GcpBigQueryTableSample [#table-sample]
 
-Query `GcpBigQueryTableSample` events in Insights to view data for the following metrics. Resolution is one data point per minute with a 6-hour delay.
+Query `GcpBigQueryTableSample` events to view data for the following metrics. Resolution is one data point per minute with a 6-hour delay.
 
 <dd>
   <table>

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-compute-engine-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-compute-engine-monitoring-integration.mdx
@@ -12,7 +12,7 @@ redirects:
 
 All New Relic Infrastructure accounts, regardless of [subscription level](https://newrelic.com/infrastructure/pricing), can use New Relic's Compute Engine integration to get a comprehensive, real-time view of their host's performance and status.
 
-[New Relic Infrastructure's integration](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) with [Google Compute Engine](https://cloud.google.com/compute/) reports metadata about instances (virtual machines) hosted on Google's infrastructure. You can monitor and alert on your GCP instances data from [New Relic Infrastructure](/docs/infrastructure), and you can create custom queries and chart dashboards in [New Relic Insights](/docs/insights).
+[New Relic Infrastructure's integration](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) with [Google Compute Engine](https://cloud.google.com/compute/) reports metadata about instances (virtual machines) hosted on Google's infrastructure. You can monitor and alert on your GCP instances data from [New Relic Infrastructure](/docs/infrastructure), and you can create custom queries and charts in New Relic.
 
 ## Activate integration [#activate]
 
@@ -142,7 +142,7 @@ After activating the integration and waiting a few minutes (based on the [pollin
 
 ## Inventory data [#inventory]
 
-[Inventory data](/docs/integrations/new-relic-integrations/getting-started/understand-use-data-infrastructure-integrations#overview) is information about the status or configuration of a service or host. You can examine inventory data in New Relic Infrastructure and in New Relic Insights.
+[Inventory data](/docs/integrations/new-relic-integrations/getting-started/understand-use-data-infrastructure-integrations#overview) is information about the status or configuration of a service or host. You can examine inventory data in our infrastructure monitoring UI or via querying in New Relic.
 
 The Google Compute Engine integration reports configuration information and labels for virtual machines and disks through the properties listed below.
 

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations.mdx
@@ -33,6 +33,6 @@ To view your GCP data: Go to [**one.newrelic.com**](http://one.newrelic.com) **>
 * Select the **Explore data** <Icon name="fe-database"/>
   icon to view GCP data.
 
-You can view and reuse the Insights NRQL queries both in the pre-configured dashboards and in the **Events explorer** dashboards. This allows you to tailor queries to your specific needs.
+You can view and reuse the NRQL queries both in the pre-configured dashboards and in the **Events explorer** dashboards. This allows you to tailor queries to your specific needs.
 
 Inventory, events, and dashboards for all services are available in New Relic.

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/f5-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/f5-monitoring-integration.mdx
@@ -415,7 +415,7 @@ Our default sample config file includes examples of labels. You can remove, modi
 
 To find your integration data, go to **[one.newrelic.com](https://one.newrelic.com) > Infrastructure > Third-party services** and select one of the F5 BIG-IP integration links.
 
-In [New Relic Insights](/docs/insights), F5 BIG-IP data is attached to the following Insights [event types](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#event):
+F5 BIG-IP data is attached to the following event types:
 
 - `F5BigIpSystemSample`
 - `F5BigIpVirtualServerSample`
@@ -683,7 +683,7 @@ These attributes can be found by querying the `F5BigIpSystemSample` event types.
 
 ### Virtual server sample metrics [#virtual-server-sample]
 
-These attributes can be found by querying the `F5BigIpVirtualServerSample` event types in Insights.
+These attributes can be found by querying the `F5BigIpVirtualServerSample` event type.
 
 <table>
   <thead>
@@ -975,7 +975,7 @@ These attributes can be found by querying the `F5BigIpVirtualServerSample` event
 
 ### Pool sample metrics [#pool-sample]
 
-These attributes can be found by querying the `F5BigIpPoolSample` event types in Insights.
+These attributes can be found by querying the `F5BigIpPoolSample` event type. 
 
 <table>
   <thead>
@@ -1224,7 +1224,7 @@ These attributes can be found by querying the `F5BigIpPoolSample` event types in
 
 ### Pool member sample metrics [#pool-member-sample]
 
-These attributes can be found by querying the `F5BigIpPoolMemberSample` event types in Insights.
+These attributes can be found by querying the `F5BigIpPoolMemberSample` event type.
 
 <table>
   <thead>
@@ -1393,7 +1393,7 @@ These attributes can be found by querying the `F5BigIpPoolMemberSample` event ty
 
 ### Node sample metrics [#node-sample]
 
-These attributes can be found by querying the `F5BigIpNodeSample` event types in Insights.
+These attributes can be found by querying the `F5BigIpNodeSample` event type. 
 
 <table>
   <thead>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/nagios-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/nagios-monitoring-integration.mdx
@@ -219,7 +219,7 @@ The `service_checks_config` yaml file contains the top-level array `service_chec
       </td>
 
       <td>
-        A collection of key: value pairs which help to identify and group service checks in Insights.
+        A collection of key: value pairs which help to identify and group service checks in New Relic.
       </td>
     </tr>
 
@@ -327,7 +327,7 @@ The Nagios integration collects the following metric data attributes.
 
 ### Nagios service check sample metrics [#nagios-service-check-sample]
 
-These attributes can be found by querying the `NagiosServiceCheckSample` event types in Insights.
+These attributes can be found by querying the `NagiosServiceCheckSample` event type.
 
 <table>
   <thead>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/varnish-cache-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/varnish-cache-monitoring-integration.mdx
@@ -296,7 +296,7 @@ For more about the general structure of on-host integration configuration, see [
 
 To find your integration data in Infrastructure, go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure > Third-party services** and select one of the Varnish Cache integration links.
 
-In New Relic, Varnish Cache data is attached to the following Insights [event type](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#event):
+In New Relic, Varnish Cache data is attached to the following event type:
 
 - `VarnishSample`
 - `VarnishLockSample`
@@ -1731,7 +1731,7 @@ These attributes can be found by querying the VarnishSample event types.
 
 ### Varnish lock sample metrics [#varnish-lock-sample]
 
-These attributes can be found by querying the `VarnishLockSample` event types in Insights.
+These attributes can be found by querying the `VarnishLockSample` event type.
 
 <table>
   <thead>
@@ -1875,7 +1875,7 @@ These attributes can be found by querying the `VarnishStorageSample` event type.
 
 ### Varnish mempool sample metrics [#varnish-mempool-sample]
 
-These attributes can be found by querying the `VarnishMempoolSample` event types in Insights.
+These attributes can be found by querying the `VarnishMempoolSample` event type.
 
 <table>
   <thead>

--- a/src/content/docs/infrastructure/host-integrations/infrastructure-integrations-sdk/specifications/host-integration-executable-file-json-specifications.mdx
+++ b/src/content/docs/infrastructure/host-integrations/infrastructure-integrations-sdk/specifications/host-integration-executable-file-json-specifications.mdx
@@ -460,7 +460,7 @@ Data values follow the executable file header. You can record three [data types]
 * [Inventory](#inventory)
 
 <Callout variant="important">
-  From the perspective of New Relic Dashboards, the infrastructure metrics and events are both classified as [event data types](/docs/data-analysis/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data#overview). To find both metrics and events, use the Insights [Event data explorer](/docs/insights/explore-data/data-explorer/event-explorer-query-chart-your-event-data), not the Metric data explorer.
+  From the perspective of New Relic dashboards, infrastructure metrics and events are both classified as [event data](/docs/data-apis/understand-data/new-relic-data-types/#event-data). 
 </Callout>
 
 <CollapserGroup>
@@ -474,7 +474,7 @@ Data values follow the executable file header. You can record three [data types]
     * Count of MySQL requests in a queue per second
     * Count of active connections to a specific system per minute
 
-    Besides associated metadata, a metric is essentially just a metric name and a numeric value. To view this data, use the New Relic Insights [Event data explorer](/docs/insights/explore-data/data-explorer/event-explorer-query-chart-your-event-data).
+    Besides associated metadata, a metric is essentially just a metric name and a numeric value. To learn more about this data, see [Event data](/docs/data-apis/understand-data/new-relic-data-types/#event-data).
 
     Here's an example of an entity's metric data JSON:
 
@@ -580,7 +580,7 @@ Data values follow the executable file header. You can record three [data types]
     * Starting up a specific service
     * Creating a new table
 
-    You can view this data in the [Infrastructure **Events** page](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-events-page-live-feed-every-config-change) and [Infrastructure events heatmap](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/events-heatmap-examine-patterns-time-range). You can also query the `InfrastructureEvent` event type in Insights.
+    You can view this data in the [Infrastructure **Events** page](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-events-page-live-feed-every-config-change) and [Infrastructure events heatmap](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/events-heatmap-examine-patterns-time-range). You can also query the `InfrastructureEvent` event type in New Relic.
 
     Here's an example of an integration's event data JSON payload, which follows the [header JSON](#exec-header), and field definitions.
 
@@ -653,7 +653,7 @@ Data values follow the executable file header. You can record three [data types]
     * System versions installed
     * Other system metadata
 
-    You can view this data in the [Infrastructure **Inventory** page](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-inventory-page-search-your-entire-infrastructure) and [Infrastructure events heatmap](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/events-heatmap-examine-patterns-time-range). You can also query data related to inventory changes in Insights.
+    You can view this data on the [**Inventory** page](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-inventory-page-search-your-entire-infrastructure) and [Infrastructure events heatmap](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/events-heatmap-examine-patterns-time-range). You can also query data related to inventory changes.
 
     The `inventory` data type is a hash of one or more JSON sub-objects containing:
 

--- a/src/content/docs/infrastructure/manage-your-data/data-instrumentation/default-infrastructure-monitoring-data.mdx
+++ b/src/content/docs/infrastructure/manage-your-data/data-instrumentation/default-infrastructure-monitoring-data.mdx
@@ -28,10 +28,6 @@ redirects:
   - /docs/infrastructure/manage-your-data
 ---
 
-<Callout variant="important">
-  As of April 12, 2021, we are upgrading Insights to an improved web and mobile experience! All of your Insights URLs will be redirected automatically to the corresponding [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards) in New Relic One. For more details about this migration and how you can easily plan for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-insights-upgrade-to-nr1-dashboards/127823).
-</Callout>
-
 New Relic's infrastructure monitoring agent collects and displays data using six primary [events](/docs/using-new-relic/data/understand-data/new-relic-data-types#event-data), each with associated [attributes](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) that represent assorted metrics and metadata.
 
 Understanding infrastructure data can help you:

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data.mdx
@@ -2499,7 +2499,7 @@ Query the `K8sControllerManagerSample` event to see Controller manager data. For
 
 ### Scheduler data
 
-Query the `K8sSchedulerSample` event in New Relic Insights to see Scheduler data. For more information, see [Configure control plane monitoring](http://docs.newrelic.com/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring):
+Query the `K8sSchedulerSample` event to see Scheduler data. For more information, see [Configure control plane monitoring](http://docs.newrelic.com/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring):
 
 <table>
   <thead>
@@ -2899,7 +2899,7 @@ Query the `K8sEtcdSample` [event](/docs/telemetry-data-platform/understand-data/
 
 ### Endpoint data
 
-Query the `K8sEndpointSample` event in New Relic Insights for endpoint data:
+Query the `K8sEndpointSample` event for endpoint data:
 
 <table>
   <thead>
@@ -3109,7 +3109,7 @@ Query the `K8sServiceSample` [event](/docs/telemetry-data-platform/understand-da
 
 ### Horizontal Pod Autoscaler data [#hpa-data]
 
-Query the `K8sHpaSample` event in New Relic Insights for Horizontal Pod Autoscaler data:
+Query the `K8sHpaSample` event for Horizontal Pod Autoscaler data:
 
 <table>
   <thead>

--- a/src/content/docs/licenses/product-or-service-licenses/new-relic-insights/new-relic-insights-licenses.mdx
+++ b/src/content/docs/licenses/product-or-service-licenses/new-relic-insights/new-relic-insights-licenses.mdx
@@ -3,11 +3,13 @@ title: New Relic Insights licenses
 tags:
   - Licenses
   - Product or service licenses
-  - New Relic Insights
 metaDescription: A list of third-party licenses we use in New Relic Insights.
 redirects:
   - /docs/licenses/new-relic-products/new-relic-insights/new-relic-insights-licenses
 ---
+
+
+New Relic Insights is a largely deprecated product, although it is still a product name for customers on our [original pricing model](/docs/accounts/original-accounts-billing/product-pricing/product-based-pricing). [Learn more about Insights.](/docs/glossary/glossary/#nr-insights)
 
 We love open-source software, and use the following in New Relic Insights. Thank you, open-source community, for making these fine tools! Some of these are listed under multiple software licenses, and in that case we have listed the license we've chosen to use.
 

--- a/src/content/docs/mobile-apps/tvos-app/introduction-apple-tv-app.mdx
+++ b/src/content/docs/mobile-apps/tvos-app/introduction-apple-tv-app.mdx
@@ -3,7 +3,6 @@ title: Introduction to Apple TV app
 tags:
   - Mobile apps
   - New Relic mobile apps
-  - Insights app
 metaDescription: Install the New Relic app for Apple TV (4th generation) to display your data on your kiosks or in your conference rooms.
 redirects:
   - /docs/mobile-apps/new-relic-mobile-apps/insights-app/insights-app-apple-tv

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/handled-exceptions-occurrences.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/handled-exceptions-occurrences.mdx
@@ -94,7 +94,7 @@ The **Occurrences** page shows details about the selected exception, including b
       </td>
 
       <td>
-        Use New Relic Insights to [query the data](/docs/insights/nrql-new-relic-query-language/using-nrql/query-page-create-edit-nrql-queries) or to [create dashboards](/docs/insights/use-insights-ui/manage-dashboards/create-edit-copy-insights-dashboards) that you can view or share.
+        Use New Relic to [query the data](/docs/insights/nrql-new-relic-query-language/using-nrql/query-page-create-edit-nrql-queries) or to [create dashboards](/docs/insights/use-insights-ui/manage-dashboards/create-edit-copy-insights-dashboards) that you can view or share.
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/transition-new-relic-one-insights.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/core-concepts/transition-new-relic-one-insights.mdx
@@ -12,10 +12,6 @@ redirects:
   - /docs/insights/use-insights-ui/getting-started/switch-new-relic-one-insights
 ---
 
-<Callout variant="important">
-  As of April 12, 2021, we're upgrading Insights to an improved web and mobile experience! All of your Insights URLs will be redirected automatically to the corresponding [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards) in New Relic One. For more details about this migration and how you can easily plan for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-insights-upgrade-to-nr1-dashboards/127823).
-</Callout>
-
 Released in 2014, New Relic Insights was our original way to create custom queries, charts, and dashboards. With [New Relic One](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one), we have modernized the experience for you to access, analyze, and visualize your data. New Relic One offers an improved charts and dashboards experience, and it provides a platform where we can more rapidly bring new innovations to you.
 
 This transition guide can help you understand:

--- a/src/content/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one.mdx
+++ b/src/content/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one.mdx
@@ -193,8 +193,6 @@ New Relic One [dashboards](/docs/introduction-new-relic-one-dashboards) let you 
 * [Send data](/docs/insights/insights-data-sources/custom-data/send-custom-data-insights) to your dashboards using our agents, integrations, and APIs.
 * Share dashboards or charts as a .pdf, or embed a chart in an external site.
 
-If you previously used New Relic Insights to create dashboards, they are [available as New Relic One dashboards](/docs/new-relic-one/use-new-relic-one/core-concepts/transition-new-relic-one-insights).
-
 ## Build on New Relic One [#build]
 
 If custom charts and dashboards don't solve your current challenge, we give you a framework for building React JavaScript applications that:

--- a/src/content/docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-guide.mdx
+++ b/src/content/docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-guide.mdx
@@ -36,7 +36,7 @@ This is enabled by default for new [browser agent installs](/docs/browser/browse
 
 If you’re also a [APM](https://newrelic.com/application-monitoring) customer, we recommend enabling [automatic instrumentation](/docs/browser/new-relic-browser/installation-configuration/add-apps-new-relic-browser) where possible, as this will automatically inject the browser monitoring JavaScript agent into your frontend for you. Not only will the browser agent remain automatically up to date with this approach, using these products together helps unify frontend to backend visibility.
 
-For example, you’d be able to link frontend AJAX calls to their corresponding backend transaction, and to align your frontend and backend data together in an Insights dashboard.
+For example, you’d be able to link frontend AJAX calls to their corresponding backend transaction, and to align your frontend and backend data together in a dashboard.
 
 <Callout variant="tip">
   Depending on your backend framework or CDN strategy, a copy/paste approach may be the better strategy. Just remember that it’ll require periodic updating.

--- a/src/content/docs/new-relic-solutions/best-practices-guides/full-stack-observability/mobile-monitoring-best-practices-guide.mdx
+++ b/src/content/docs/new-relic-solutions/best-practices-guides/full-stack-observability/mobile-monitoring-best-practices-guide.mdx
@@ -227,7 +227,7 @@ Create custom interactions and events to hone in on the most important signals, 
        recordCustomEvent(<myMobileTimers>, <spinnerOnScreenA>, {attributes})
        ```
     3. Track specific user actions or funnel steps in the app (like "add to cart"), and include the price as an attribute on that event.
-    4. Measure flows through the application by viewing the related funnel steps with custom events in Insights. For example, create a timer to track the start and end times of a subflow or an entire flow across multiple funnel steps to understand how long it took users to get through the process.
+    4. Measure flows through the application by viewing the related funnel steps with custom events. For example, create a timer to track the start and end times of a subflow or an entire flow across multiple funnel steps to understand how long it took users to get through the process.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/new-relic-solutions/new-relic-solutions/customer-experience-improvement-track-experience-indicators.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-solutions/customer-experience-improvement-track-experience-indicators.mdx
@@ -54,13 +54,13 @@ If you’ve completed the [Iterate and measure impact](/docs/iterate-measure-imp
 
 Using the attributes collected in Step 1, build dashboards to examine the impact of performance issues on your users. Additionally, to drive visibility across your teams, add dedicated widgets to the team dashboards you built in the [Establish team dashboards](/docs/establish-team-dashboards) .
 
-![Insights-catalyst-dashbaord-1.png](./images/Insights-catalyst-dashbaord-1.png "Insights-catalyst-dashbaord-1.png")
+![Catalyst-dashbaord-1.png](./images/Insights-catalyst-dashbaord-1.png "Catalyst-dashbaord-1.png")
 
 <figcaption>
   **[insights.newrelic.com](https://insights.newrelic.com) > Dashboards**
 </figcaption>
 
-For example, if you were collecting a custom `username` attribute, you could use [NRQL](/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) queries like these to create your widgets for your [New Relic Insights dashboard](/docs/insights/use-insights-ui/manage-dashboards/create-edit-copy-insights-dashboards):
+For example, if you were collecting a custom `username` attribute, you could use [NRQL](/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql) queries like these to create your widgets for your [dashboard](/docs/insights/use-insights-ui/manage-dashboards/create-edit-copy-insights-dashboards):
 
 * Number of errors by username:
 
@@ -98,6 +98,6 @@ Dashboards, data, and metrics that nobody looks at or knows about might as well 
 
 After you create your dashboards, use them to scope issues affecting particular customers or sets of customers. For example, the following widget shows which apps have errors for a particular user:
 
-![Insights-catalyst-user-errors.png](./images/Insights-catalyst-user-errors_0.png "Insights-catalyst-user-errors.png")
+![Catalyst-user-errors.png](./images/Insights-catalyst-user-errors_0.png "Catalyst-user-errors.png")
 
 Use attributes that track user and performance to set alerts on high priority users or customers. For example, you could include a [`WHERE` clause](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions#sel-where) in your NRQL queries to scope the results to a set of user IDs or customer IDs. Set alerts on any performance or business metric that is tied to these attributes.

--- a/src/content/docs/new-relic-solutions/new-relic-solutions/establish-objectives-baselines-define-team-slos.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-solutions/establish-objectives-baselines-define-team-slos.mdx
@@ -544,7 +544,7 @@ To close any remaining gaps in visibility for your SLIs, use custom instrumentat
 * Packaging XML-based custom instrumentation modules with deployed applications
 * Adding UI-based instrumentation without a code deploy
 
-In addition, you can add custom attributes to each transaction event that match application performance factors to critical business information. Then you can track those attributes in Insights dashboards. For more information, see the custom instrumentation documentation for your application:
+In addition, you can add custom attributes to each transaction event that match application performance factors to critical business information. Then you can track those attributes in dashboards. For more information, see the custom instrumentation documentation for your application:
 
 * [APM](/docs/agents/manage-apm-agents/agent-data/custom-instrumentation)
 * [Browser](/docs/insights/insights-data-sources/custom-data/insert-data-via-new-relic-browser)

--- a/src/content/docs/query-your-data/explore-query-data/browse-data/introduction-data-explorer.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/browse-data/introduction-data-explorer.mdx
@@ -49,10 +49,6 @@ With the data explorer you can:
 * Add your searches to a [dashboard](/docs/dashboards/new-relic-one-dashboards/get-started/introduction-new-relic-one-dashboards) in a click.
 * Understand how [NRQL](/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql) works: data explorer shows how queries are built while navigating the available data.
 
-<Callout variant="tip">
-  Want to switch to New Relic One from Insights? See [our transition guide](/docs/transition-new-relic-one-dashboards-insights).
-</Callout>
-
 ## Query your data [#explore-data]
 
 To access the data explorer, go to [one.newrelic.com](https://one.newrelic.com) and

--- a/src/content/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards.mdx
@@ -71,12 +71,6 @@ Use dashboards to:
 * Search your dashboards for attributes and metrics.  
 * [Send data](/docs/insights/insights-data-sources/custom-data/report-custom-event-data) to your dashboards using our APIs.
 
-## Transitioning from Insights [#dashboards-full-experience]
-
-Switching to using New Relic One dashboards from our deprecated Insights dashboards? See [our transition guide](/docs/transition-new-relic-one-dashboards-insights).
-
-If you're using the Insights Dashboard API, we have have a [migration guide](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/) that will help you transition to using the new API.
-
 ## Get started with dashboards [#get-started]
 
 To access dashboards, go to [one.newrelic.com](http://one.newrelic.com) and click on **Dashboards** on the top navigation menu.
@@ -174,8 +168,6 @@ Here you can carry out the following actions:
     Clicking the star icon next to a dashboard toggles on or off the favorites. When you favorite a dashboard, it’s grouped with other favorite dashboards at the top of the list, and appears on the New Relic One home page.
 
     To remove a dashboard from your favorites, select the star icon again.
-
-    New Relic One doesn’t retrieve [favorited dashboards from Insights](/docs/insights/use-insights-ui/manage-dashboards/view-organize-share-insights-dashboards#organize-dashboards). Learn how to make the [transition from Insights to New Relic One](/docs/transition-new-relic-one-dashboards-insights).
   </Collapser>
 
   <Collapser

--- a/src/content/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard.mdx
@@ -182,8 +182,6 @@ We offer other features to connect dashboards:
 * Use [facet filtering](/docs/dashboards/new-relic-one-dashboards/manage-your-dashboard/filter-new-relic-one-dashboards-facets) to create links that automatically link to and filter other dashboards.
 * Use the dashboard search to find similarly named dashboards. To take advantage of this, you can add team- or project-specific words/phrases to dashboard names.
 
-In New Relic Insights, this feature was called [data apps](/docs/insights/use-insights-ui/manage-dashboards/data-apps-build-collections-linked-dashboards). For more about switching from Insights to New Relic One, see our [transition guide](/docs/dashboards/new-relic-one-dashboards/get-started/transition-new-relic-one-dashboards-insights).
-
 ### Add and edit pages to a dashboard [#add-pages-edit]
 
 To add or edit a page in a dashboard:
@@ -246,10 +244,6 @@ To change the time range:
 
 * Select one of the available options from the dropdown menu (ranging from `Last 30 minutes` to `Last 7 days`).
 * Customize the time range with specific start and end timestamps using the custom menu.
-
-<Callout variant="important">
-  In dashboards, unlike Insights, the time zone is independent from your laptop's time. You can set the time zone you want to use in your **user preferences**, easily accessible from the custom menu in the time picker.
-</Callout>
 
 ## Export and share your data [#dash-export]
 

--- a/src/content/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder.mdx
@@ -26,11 +26,6 @@ redirects:
 
 With the query builder, you can run queries of your data to create custom charts and other visualizations. You can also build custom [dashboards](/docs/dashboards/manage-your-dashboard/manage-your-dashboard#dash-create-chart) containing multiple charts.
 
-
-<Callout variant="important">
-  Are you a New Relic Insights user? See [our transition guide](/docs/transition-new-relic-one-dashboards-insights).
-</Callout>
-
 ## Why it matters
 
 Modern business systems are a complex maze of data-generating elements. You need an easy, solid way to fetch, analyze, and visualize the never-ending stream of data flowing from your daily working activities.

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language.mdx
@@ -358,7 +358,7 @@ Basic rules include:
       </td>
 
       <td>
-        Insights does not support data type "coercion." For more information, see [Data type conversion](/docs/insights/nrql-new-relic-query-language/nrql-reference/nrql-syntax-components-functions#type-conversion).
+        We don't support data type "coercion." For more information, see [Data type conversion](/docs/insights/nrql-new-relic-query-language/nrql-reference/nrql-syntax-components-functions#type-conversion).
       </td>
     </tr>
 

--- a/src/content/docs/release-notes/agent-release-notes/c-sdk-release-notes/c-sdk-130.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/c-sdk-release-notes/c-sdk-130.mdx
@@ -9,7 +9,7 @@ downloadLink: 'https://github.com/newrelic/c-sdk/'
 
 * **Support for Real Time Streaming**
 
-  * Event data is now sent to New Relic every five seconds, instead of every minute. As a result, transaction, error, and custom events will now be available in New Relic One and Insights dashboards in near real time. For more information on how to view your events with a five-second refresh, see the [real time streaming documentation](/docs/agents/manage-apm-agents/agent-data/real-time-streaming).
+  * Event data is now sent to New Relic every five seconds, instead of every minute. As a result, transaction, error, and custom events will now be available in New Relic dashboards in near real time. For more information on how to view your events with a five-second refresh, see the [real time streaming documentation](/docs/agents/manage-apm-agents/agent-data/real-time-streaming).
   * Note that the overall limits on how many events can be sent per minute have not changed. Also, span events, metrics, and trace data is unaffected, and will still be sent every minute.
 
 ### Bug Fixes

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-28.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-28.mdx
@@ -11,7 +11,7 @@ downloadLink: 'https://github.com/newrelic/go-agent/tree/v2.8.0'
 
 * **Support for Real Time Streaming**
 
-  * Event data is now sent to New Relic every five seconds, instead of every minute. As a result, transaction, error, and custom events will now be available in New Relic One and Insights dashboards in near real time. For more information on how to view your events with a five-second refresh, see the [real time streaming documentation](/docs/agents/manage-apm-agents/agent-data/real-time-streaming).
+  * Event data is now sent to New Relic every five seconds, instead of every minute. As a result, transaction, error, and custom events will now be available in New Relic dashboards in near real time. For more information on how to view your events with a five-second refresh, see the [real time streaming documentation](/docs/agents/manage-apm-agents/agent-data/real-time-streaming).
   * Note that the overall limits on how many events can be sent per minute have not changed. Also, span events, metrics, and trace data is unaffected, and will still be sent every minute.
 * Introduce support for databases using [database/sql](https://golang.org/pkg/database/sql/). This new functionality allows you to instrument MySQL, PostgreSQL, and SQLite calls without manually creating [DatastoreSegment](https://godoc.org/github.com/newrelic/go-agent#DatastoreSegment)s.
 

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-3100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-3100.mdx
@@ -25,7 +25,7 @@ metaDescription: Release notes for Java Agent 3.10.0
   Prior to this version, JMX metrics could not be pulled by the agent with WebSphere when global security was enabled. This means custom JMX metrics in a yaml file and default JMX metrics displayed on the JVM Threads and Http Sessions tabs were not reported.
 * Servlet UserPrincipal name can be reported as an attribute
 
-  With this release, you can enable the capturing of the UserPrincipal name so that it is available in New Relic Insights and as a transaction trace attribute. To enable:
+  With this release, you can enable the capturing of the UserPrincipal name so that it is available in New Relic and as a transaction trace attribute. To enable:
 
   ```
   class_transformer:

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-340.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-340.mdx
@@ -24,4 +24,4 @@ version: 3.4.0
   New Relic's Java agent now handles firstCompletedOf to Futures correctly.
 * Additional functionality to API call addCustomParameter
 
-  New Relic's API call addCustomParameter will now add the custom parameters to New Relic Insights. For more information, see [http://newrelic.com/software-analytics](http://newrelic.com/software-analytics)
+  New Relic's API call addCustomParameter will now add the custom parameters to New Relic. For more information, see [http://newrelic.com/software-analytics](http://newrelic.com/software-analytics)

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-490.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-490.mdx
@@ -7,7 +7,7 @@ downloadLink: 'http://download.newrelic.com/newrelic/java-agent/newrelic-agent/4
 
 ### Improvements
 
-* The 'request.uri' attribute is now included in Transaction events and corresponding Transaction Error events. As a result this attribute can now be queried in Insights. It may be excluded via the exclude list in the [attributes stanza of the yaml config file](https://docs.newrelic.com/docs/agents/java-agent/attributes/enabling-disabling-attributes-java). It is also excluded when High Security Mode is enabled.
+* The 'request.uri' attribute is now included in Transaction events and corresponding Transaction Error events. As a result this attribute can now be queried in New Relic. It may be excluded via the exclude list in the [attributes stanza of the yaml config file](https://docs.newrelic.com/docs/agents/java-agent/attributes/enabling-disabling-attributes-java). It is also excluded when High Security Mode is enabled.
 * Distributed Tracing can now be enabled at the same time as [auto app naming](https://docs.newrelic.com/docs/agents/java-agent/configuration/automatic-application-naming). Each application created by this setting will share an event reservoir for Distributed Tracing.
 * Updates Akka HTTP instrumentation to support the newest version of Akka HTTP, 10.1.5 and above.
 

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-550.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-550.mdx
@@ -9,7 +9,7 @@ downloadLink: 'http://download.newrelic.com/newrelic/java-agent/newrelic-agent/5
 
 * **Support for Real Time Streaming**
 
-  * Event data is now sent to New Relic every five seconds, instead of every minute. As a result, transaction, error, and custom events will now be available in New Relic One and Insights dashboards in near real time. For more information on how to view your events with a five-second refresh, see the [real time streaming documentation](https://docs.newrelic.com/docs/agents/manage-apm-agents/agent-data/real-time-streaming).
+  * Event data is now sent to New Relic every five seconds, instead of every minute. As a result, transaction, error, and custom events will now be available in New Relic dashboards in near real time. For more information on how to view your events with a five-second refresh, see the [real time streaming documentation](https://docs.newrelic.com/docs/agents/manage-apm-agents/agent-data/real-time-streaming).
   * Note that the overall limits on how many events can be sent per minute have not changed. Also, span events, metrics, and trace data is unaffected, and will still be sent every minute.
 
 ### Improvements

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-260046.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-260046.mdx
@@ -16,7 +16,7 @@ For a list of known issues with the Python agent, see [Status of the Python agen
 
 ### New Feature
 
-* Custom Insights Events
+* Custom Events
 
 Prior to this release, the Python agent had the capability to record two types of Insights events automatically: `Transaction` and `TransactionError` events. In addition, custom attributes could be added to those events. Now, with the addition of the [`record_custom_event()`](/docs/agents/python-agent/customization-extension/python-transaction-api#record_custom_event) API, it is possible to define your own custom event types, enabling greater flexibility about what types of events you can view and query in Insights.
 

--- a/src/content/docs/style-guide/writing-docs/article-templates/agent-api-guide-template.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/agent-api-guide-template.mdx
@@ -96,7 +96,7 @@ Use these methods when you want to instrument a method within an existing transa
 
 ## Enhance the metadata of a transaction [#metadata]
 
-Sometimes, the code you are targeting is visible in the New Relic UI, but some details of the method are not useful. For example, the default name might not be helpful (perhaps it is causing a [metric grouping issue](/docs/agents/manage-apm-agents/troubleshooting/metric-grouping-issues#video)), or you want to add [custom attributes](/docs/agents/manage-apm-agents/agent-data/collect-custom-attributes) to your transactions so you can filter them in Insights.
+Sometimes, the code you are targeting is visible in the New Relic UI, but some details of the method are not useful. For example, the default name might not be helpful (perhaps it is causing a [metric grouping issue](/docs/agents/manage-apm-agents/troubleshooting/metric-grouping-issues#video)), or you want to add [custom attributes](/docs/agents/manage-apm-agents/agent-data/collect-custom-attributes) to your transactions so you can better filter them when querying.
 
 Use these methods when you want to change how New Relic instruments a transaction that’s already visible in the New Relic UI:
 
@@ -326,7 +326,7 @@ APM includes a number of ways to record arbitrary custom data. For an explanatio
   <tbody>
     <tr>
       <td>
-        Send data about an event so you can analyze it in New Relic Insights...
+        Send data about an event so you can analyze it when querying...
       </td>
 
       <td>
@@ -336,7 +336,7 @@ APM includes a number of ways to record arbitrary custom data. For an explanatio
 
     <tr>
       <td>
-        Tag your events with metadata to filter and facet them in Insights or error analytics...
+        Tag your events with metadata to filter/facet them when querying or when using error analytics...
       </td>
 
       <td>

--- a/src/content/docs/style-guide/writing-docs/article-templates/api-tutorial-template.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/api-tutorial-template.mdx
@@ -55,7 +55,7 @@ Methods and example code to implement step 3.
 
 ### Last step. Verify that the task was completed...
 
-Explain how a user would know they'd completed the task correctly. In particular, how would the user find the new change or data in the New Relic UI. What New Relic products and pages would the change be noticed on? If new data shows up in Insights, what event types can it be found under?
+Explain how a user would know they'd completed the task correctly. In particular, how would the user find the new change or data in the New Relic UI. What New Relic products and pages would the change be noticed on? If new data shows up in NRDB, what event types can it be found under?
 
 ## Optional: Do something else with the API [#another_do_something]
 

--- a/src/content/docs/synthetics/synthetic-monitoring/pages/synthetic-monitoring-aggregate-monitor-metrics.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/pages/synthetic-monitoring-aggregate-monitor-metrics.mdx
@@ -107,7 +107,7 @@ SLA reports support the following features:
 
 ## Generate SLA values [#generating_sla_in_insights]
 
-The values in the SLA report are generated from Insights queries against the available synthetic monitoring data. You can easily recreate these values and modify the queries to meet your needs.
+The values in the SLA report are generated from NRQL queries against the available synthetic monitoring data. You can easily recreate these values and modify the queries to meet your needs.
 
 This query returns the average duration, the apdex, and the uptime. Substitute your values for the <var>variables</var> highlighted and described below.
 

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
@@ -145,7 +145,7 @@ Along with npm modules, you can also use [Node.js modules](/docs/synthetics/new-
 
 ## Permanent data storage [#permanent-data-volume]
 
-CPM is a stateless application and does not preserve information from prior requests or sessions by default. However, you can preserve data between launches by enabling permanent data storage. For example, you can permanently set how the minion identifies itself (for example, `Minion_ID`), and use it to associate the data visible in Synthetics and Insights events with the exact minion that produced it.
+CPM is a stateless application and does not preserve information from prior requests or sessions by default. However, you can preserve data between launches by enabling permanent data storage. For example, you can permanently set how the minion identifies itself (for example, `Minion_ID`), and use it to associate that data with the exact minion that produced it.
 
 To set permanent data storage on Docker:
 

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-maintenance-monitoring.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-maintenance-monitoring.mdx
@@ -30,7 +30,7 @@ After [installing your containerized private minion (CPM)](/docs/install-contain
 Connecting to a running CPM using HTTP is the easiest way to check if it's healthy and working. The container exposes two ports: `8080` and `8180`. You can check the CPM with the following endpoints:
 
 * `:8080/status/check`: provides details about internal health checks that the minion performs. `HTTP 200` means the status is healthy.
-* `:8080/status`: provides details about a minion's status, which is the same data published in Insights as `SyntheticsPrivateMinion` event.
+* `:8080/status`: provides details about a minion's status, which is the same data published in a `SyntheticsPrivateMinion` event.
 * `:8180/`: provides JVM application admin endpoints. This is an advanced view of a minion's Java Development Kit (JDK) internal state.
 
 ## Check if your private location requires more minions [#more-minions]

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/monitor-private-locations.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/monitor-private-locations.mdx
@@ -1169,7 +1169,7 @@ After doubling the number of minions to handle the load, the alert recovers. For
 You can also check how a minion is operating by contacting it directly. You can use a set of HTTP endpoints exposed by the minion to determine what the application is doing. In order to access these endpoints, bind ports `8080` and `8180` to ports on the host. For example, for Docker, use `docker run -p 80:8080 -p 81:8180 ...`):
 
 * `:8080/status/check`: Details about internal health-checks the minion performs; HTTP 200 means "healthy."
-* `:8080/status`: Details about a minion's status; the same data is then [published to Insights as a `SyntheticsPrivateMinion` event](/docs/insights/insights-data-sources/default-events-attributes/synthetics-default-events-attributes-insights#syntheticprivateminion-table).
+* `:8080/status`: Details about a minion's status; the same data is then [reported as a `SyntheticsPrivateMinion` event](/docs/insights/insights-data-sources/default-events-attributes/synthetics-default-events-attributes-insights#syntheticprivateminion-table).
 * `:8180/`: JVM application admin endpoints; an advanced view of a minion's internal state.
 
 This approach is not as automated or flexible as the [`checksPending` example](#more-minions). However, if you have total network connectivity failure, this manual approach can help troubleshoot the situation.

--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/add-custom-attributes-synthetic-monitoring-data.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/add-custom-attributes-synthetic-monitoring-data.mdx
@@ -13,11 +13,7 @@ redirects:
   - /docs/insights/insights-data-sources/custom-data/add-custom-attributes-synthetics-events
 ---
 
-<Callout variant="important">
-  As of April 12, 2021, we are upgrading Insights to an improved web and mobile experience! All of your Insights URLs will be redirected automatically to the corresponding [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards) in New Relic One. For more details about this migration and how you can easily plan for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-insights-upgrade-to-nr1-dashboards/127823).
-</Callout>
-
-New Relic's `$util.insights` is a set of tools to set and manipulate [events](/docs/using-new-relic/data/understand-data/new-relic-data-types#event-data) reported from synthetic monitoring. The `$util.insights` toolset includes the word `insights` because Insights was historically how New Relic saved queryable [event data](/docs/using-new-relic/data/understand-data/new-relic-data-types#event-data).
+New Relic's `$util.insights` is a set of tools to set and manipulate [events](/docs/using-new-relic/data/understand-data/new-relic-data-types#event-data) reported from synthetic monitoring. 
 
 You can add custom data as custom attributes, with the prefix `custom`, to the `SyntheticCheck` [event](/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights#event-type). These attributes are in addition to the event's [default attributes](/docs/insights/new-relic-insights/decorating-events/synthetics-default-attributes-insights#syntheticcheck-table).
 

--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests.mdx
@@ -179,7 +179,7 @@ To make a POST request, use the [`$http.post`](https://github.com/request/reques
         console.log(response.statusCode + " status code")
         //Verify endpoint returns 200 (OK) response code.
         assert.ok(response.statusCode == 200, 'Expected 200 OK response');
-        //Parse JSON received from Insights into variable.
+        //Parse JSON into variable.
         var info = JSON.parse(body);
         //Verify that `info` contains element named `success` with a value of `true`.
         assert.ok(info.success == true, 'Expected True results in Response Body, result was ' + info.success);

--- a/src/content/docs/using-new-relic/welcome-new-relic/optimize-your-cloud-native-environment/establish-objectives-baselines-define-team-slos.mdx
+++ b/src/content/docs/using-new-relic/welcome-new-relic/optimize-your-cloud-native-environment/establish-objectives-baselines-define-team-slos.mdx
@@ -484,14 +484,13 @@ Use custom instrumentation to close any remaining visibility gaps visibility for
 * Packaging XML-based custom instrumentation modules with deployed applications
 * Adding UI-based instrumentation without a code deploy
 
-In addition, you can add custom attributes to each transaction event— matching application performance factors to critical business information, and then tracking those attributes in Insights dashboards.
+In addition, you can add custom attributes to each transaction event— matching application performance factors to critical business information, and then tracking those attributes in New Relic dashboards.
 
 For more information, see the custom instrumentation documentation for your application:
 
 * [APM](/docs/agents/manage-apm-agents/agent-data/custom-instrumentation)
 * [Browser](/docs/insights/insights-data-sources/custom-data/insert-data-via-new-relic-browser)
 * [Infrastructure](/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#conf-custom_attributes)
-* [Insights](/docs/insights/insights-data-sources/custom-data/send-custom-data-insights)
 * [Mobile](/docs/mobile-monitoring/new-relic-mobile/maintenance/add-custom-data-new-relic-mobile)
 * [Synthetics](/docs/synthetics/new-relic-synthetics/scripting-monitors/add-custom-attributes-new-relic-synthetics-data)
 
@@ -513,10 +512,10 @@ To query and view data from the SLIs you selected for baselining:
 2. Create dashboards that include [widgets](/docs/insights/use-insights-ui/manage-dashboards/chart-types) for SLI baseline data.
 3. Use these widgets and dashboards to establish team dashboards that you can [share](/docs/insights/use-insights-ui/manage-dashboards/view-organize-share-insights-dashboards) and use to conduct operations reviews.
 
-![Establish objectives: Insights](./images/catalyst-establish-objectives-2.png "Establish objectives: Insights")
+![Establish objectives](./images/catalyst-establish-objectives-2.png "Establish objectives")
 
 <figcaption>
   **[insights.newrelic.com](https://insights.newrelic.com) > (select a dashboard):** Query your SLI baseline data, create dashboards with widgets to visualize the data, then share with your team and stakeholders.
 </figcaption>
 
-The metrics you capture will become your application's baseline. Share your Insights dashboard with your application team and stakeholders to provide visibility into what is happening with your application and to monitor future performance.
+The metrics you capture will become your application's baseline. Share your dashboard with your application team and stakeholders to provide visibility into what is happening with your application and to monitor future performance.

--- a/src/nav/accounts.yml
+++ b/src/nav/accounts.yml
@@ -45,6 +45,8 @@ pages:
             path: /docs/accounts/original-accounts-billing/original-product-based-pricing/switch-new-models
           - title: Original pricing usage
             path: /docs/accounts/original-accounts-billing/original-product-based-pricing/introduction-new-relic-subscription-usage-data
+          - title: Data retention
+            path: /docs/accounts/original-accounts-billing/product-based-pricing/overview-data-retention-components
           - title: Trial and Lite accounts
             path: /docs/accounts/original-accounts-billing/product-based-pricing/trial-lite-accounts-deprecated
           - title: Set session timeouts


### PR DESCRIPTION
We noticed there were still quite a few 'Insights' references that shouldn't be there, so removed almost all bad ones (still some present I have questions out to teams about). 