### PR TITLE
fix(synthetics): add private locations reference

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring.mdx
@@ -157,7 +157,7 @@ Synthetic monitoring does not require any software except a [supported browser](
   To monitor a site behind your firewall, add the [synthetic monitoring public
   minion IP
   addresses](/docs/synthetics/new-relic-synthetics/using-monitors/synthetics-public-minion-ips)
-  to your allow list.
+  to your allow list or [create a private location](/docs/synthetics/synthetic-monitoring/private-locations/private-locations-overview-monitor-internal-sites-add-new-locations/).
 </Callout>
 
 ## Permissions


### PR DESCRIPTION
Added a link to private location details in the callout about monitoring sites behind your firewall.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
The current content implies that opening ports is the only option to monitor sites behind your firewall. This adds the private locations feature to the callout.