### PR TITLE
fix(orgs/accounts): ability to export list of users

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
@@ -74,7 +74,7 @@ Before changing your users’ user type, we recommend you understand:
 
 To change the user type of one or more users: 
 
-1. On the [**User management** page](#find), click the checkboxes for the users whose user type you want to edit. 
+1. From the [**User management** UI](#where), click the checkboxes for the users whose user type you want to edit. 
 2. Once you start selecting users, an option will appear for **Edit type**. 
 
 You can also edit the user type and group of a specific user by clicking on that user. 
@@ -84,6 +84,17 @@ You can also edit the user type and group of a specific user by clicking on that
 To manage how users upgrade their user type, see the [authentication domain settings](/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more/#user-upgrade).
 
   </Collapser>
+
+    <Collapser
+    id="export-users"
+    title="Export a spreadsheet of users"
+  >
+To export a list of all users and their details (names, email addresses, current user type, groups, user ID): From the [**User management** UI](#where), click the download icon beside the **Add user** button. There's an option for downloading a list of all users in that authentication domain. 
+
+Alternatively, to export a subset of users, first select the users you want to export, and then hit the download button.   
+
+  </Collapser>
+
 
   <Collapser
     id="access-grants"

--- a/src/content/docs/release-notes/org-user-mgmt-release-notes/org-users-22-01-13.mdx
+++ b/src/content/docs/release-notes/org-user-mgmt-release-notes/org-users-22-01-13.mdx
@@ -1,0 +1,9 @@
+---
+subject: Organization and user management
+releaseDate: '2022-01-12'
+version: '220112'
+---
+
+We released the ability to export user data from the **User management** UI. The data is exportable via TSV. Exportable columns include users’ names, email addresses, current user type, groups, and user ID. Admins can choose to export all users or select a subset of users.
+
+For more details, see [Export user list](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks).


### PR DESCRIPTION
Work done: 
* Add a release note about the ability to export a spreadsheet of users and user details 
* Added to 'common UI tasks' doc