### PR TITLE
Fixed typo for helm chart name

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/link-your-applications/link-your-applications-kubernetes.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/link-your-applications/link-your-applications-kubernetes.mdx
@@ -139,7 +139,7 @@ You can limit the injection of metadata only to specific namespaces by using lab
 To enable this feature, edit nri-bundle Helm `values.yaml` file:
 
 ```
-nri-metadata-injector:
+nri-metadata-injection:
   injectOnlyLabeledNamespaces: true
 ```
 
@@ -157,7 +157,7 @@ helm upgrade --install newrelic newrelic/nri-bundle \
 --set infrastructure.enabled=true \
 --set prometheus.enabled=true \
 --set webhook.enabled=<mark>true</mark> \
---set <mark>nri-metadata-injector.injectOnlyLabeledNamespaces=true</mark> \
+--set <mark>nri-metadata-injection.injectOnlyLabeledNamespaces=true</mark> \
 --set kubeEvents.enabled=true \
 --set logging.enabled=true
 ```
@@ -175,7 +175,7 @@ To use custom certificates you need to disable the automatic installation of cer
 To disable the installation for certificates just modify nri-bundle Helm `values.yaml` like this:
 
 ```
-nri-metadata-injector:
+nri-metadata-injection:
   customTLSCertificate: true
 ```
 
@@ -193,7 +193,7 @@ helm upgrade --install newrelic newrelic/nri-bundle \
 --set infrastructure.enabled=true \
 --set prometheus.enabled=true \
 --set webhook.enabled=<mark>true</mark> \
---set <mark>nri-metadata-injector.customTLSCertificate=true</mark> \
+--set <mark>nri-metadata-injection.customTLSCertificate=true</mark> \
 --set kubeEvents.enabled=true \
 --set logging.enabled=true
 ```


### PR DESCRIPTION
`nri-metadata-injector` changed to `nri-metadata-injection`

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Typo in docs.  `nri-metadata-injector` should be `nri-metadata-injection`.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.