### PR TITLE
fix(synth api tests): remove insert key, add Nerdgraph

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests.mdx
@@ -109,48 +109,63 @@ Here's an example of using a SSL option or `agentOptions`:
 
 To make a GET request, use the [`$http.get`](https://github.com/request/request#requestget) method to submit your request. Define your [request options](#request-options), make your request using `$http.get`, then [validate](#validating) the response to ensure your endpoint is returning the correct results.
 
-<CollapserGroup>
-  <Collapser
-    id="get-insights-example"
-    title="Insights GET example"
-  >
-    This example queries the Insights API by using GET:
-
-    ```
-    //Define your authentication credentials
-    var myAccountID = '{YOUR_ACCOUNT_ID}';
-    var myQueryKey = '{YOUR_QUERY_KEY}';
-    var options = {
-        //Define endpoint URI
-        uri: 'https://insights-api.newrelic.com/v1/accounts/'+myAccountID+'/query?nrql=SELECT%20average(duration)%20FROM%20Transaction',
-        //Define query key and expected data type.
-        headers: {
-        'X-Query-Key': myQueryKey,
-        'Accept': 'application/json'
-    }
-    };
-
-    //Define expected results using callback function.
-    function callback (err, response, body){
-    //Log JSON results from endpoint to Synthetics console.
-     console.log(JSON.parse(body)); 
-     console.log('done with script');
-    }
-
-    //Make GET request, passing in options and callback.
-    $http.get(<var>options,callback</var>);
-    ```
-  </Collapser>
-</CollapserGroup>
-
 ## Send a POST request [#post]
 
 To make a POST request, use the [`$http.post`](https://github.com/request/request#requestpost) method to submit your request. Define your [request options](#request-options), make your request using `$http.post`, then [validate](#validating) the response to ensure your endpoint is returning the correct results.
 
 <CollapserGroup>
+ <Collapser
+    id="get-nerdgraph-example"
+    title="NerdGraph example"
+  >
+    This example queries our [NerdGraph API](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph):
+
+    ```
+// Define your authentication credentials
+const myAccountId = '{YOUR_ACCOUNT_ID}';
+const myAPIKey = '{YOUR_LICENSE_KEY}';
+
+const options = {
+  // Define endpoint URI, https://api.eu.newrelic.com/graphql for EU accounts
+  uri: 'https://api.newrelic.com/graphql',
+  headers: {
+    'API-key': myLicenseKey,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    query: `
+      query getNrqlResults($accountId: Int!, $nrql: Nrql!) {
+        actor {
+          account(id: $accountId) {
+            nrql(query: $nrql) {
+              results
+            }
+          }
+        }
+      }
+    `,
+    variables: {
+      accountId: Number(myAccountId),
+      nrql: 'SELECT average(duration) FROM Transaction',
+    },
+  }),
+};
+
+// Define expected results using callback function
+function callback(err, response, body) {
+  // Log JSON results from endpoint to Synthetics console
+  console.log(JSON.parse(body));
+  console.log('Script execution completed');
+}
+
+// Make POST request, passing in options and callback
+$http.post(options, callback);
+    ```
+  </Collapser>
+
   <Collapser
     id="post-insights-example"
-    title="Custom event POST example"
+    title="Event API POST example"
   >
     This example POSTs a custom event containing static integers to the [Event API](/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events):
 


### PR DESCRIPTION
This was related to DOC-7619, removal of Insights insert key refs. In the synth API test docs, we had an Insights Query API example. Removed that and added a nerdgraph example. 