### PR TITLE
fix: Correct directions to match command

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking.mdx
@@ -176,13 +176,13 @@ The `newrelic-lambda` CLI adds your New Relic license key as a secret in [AWS Se
 
     AWS CLI example:
 
-    Be sure to replace `YOUR_LICENSE_KEY` with the license key you found above.
+    Be sure to replace `YOUR_LICENSE_KEY` and `YOUR_ACCOUNT_ID` with the license key and account ID you found above.
 
     ```
       aws cloudformation create-stack --stack-name NewRelicLicenseKeySecret 
         --template-body file://license-key-secret.yaml 
-        --parameters 'ParameterKey=LicenseKey,ParameterValue=LICENSE_KEY' 
-        'ParameterKey=NrAccountId,ParameterValue=ACCOUNT_ID'
+        --parameters 'ParameterKey=LicenseKey,ParameterValue=YOUR_LICENSE_KEY' 
+        'ParameterKey=NrAccountId,ParameterValue=YOUR_ACCOUNT_ID'
     ```
   
     See also our [legacy docs on how to manually instrument your account](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy/). 


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?

Directions stated replace `YOUR_LICENSE_KEY` and command had `LICENSE_KEY` - changed the latter to match the directions and for uniformity, changed `ACCOUNT_ID` to match the same pattern. 

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

Double checked with the lambda team here https://newrelic.slack.com/archives/CJGUKK42D/p1642526497107600 

Thank you! 
