### PR TITLE
Add custom metrics usage section to Python API guides.

### DIFF
--- a/src/content/docs/apm/agents/python-agent/python-agent-api/recordcustommetric-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/recordcustommetric-python-agent-api.mdx
@@ -50,7 +50,7 @@ This call records a single [custom metric](/docs/agents/manage-apm-agents/agent-
       <td>
         Required. Name of the metric.
 
-        There are no restrictions on naming formats, but we recommends you use a `Custom/` prefix for your custom metric names. This helps you differentiate custom metrics from default-monitored metrics in the our UI, and also helps you troubleshoot if necessary.
+        There are no restrictions on naming formats, but we recommend you use a `Custom/` prefix for your custom metric names. This helps you differentiate custom metrics from default-monitored metrics in the our UI, and also helps you troubleshoot if necessary.
       </td>
     </tr>
 
@@ -102,3 +102,7 @@ application = newrelic.agent.application()
 
 newrelic.agent.record_custom_metric('Custom/my_favorite_number', 42, application)
 ```
+
+## View and use custom metrics
+
+To view custom metrics, use the [data explorer](/docs/query-your-data/explore-query-data/data-explorer/introduction-data-explorer) to search and filter for custom metrics, create customizable charts, and add those charts to New Relic dashboards. You can use our [REST API](/docs/apis/rest-api-v2/requirements/new-relic-rest-api-v2-getting-started) to programmatically retrieve and use custom metric data outside of the UI. It is also possible to [create custom metric alert conditions](/docs/alerts/new-relic-alerts/configuring-alert-policies/define-custom-metrics-alert-condition) to notify you or your team when your custom metric exceeds specific values.

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/recordcustommetrics-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/recordcustommetrics-python-agent-api.mdx
@@ -90,3 +90,7 @@ def metrics():
 
 newrelic.agent.record_custom_metrics(metrics())
 ```
+
+## View and use custom metrics
+
+To view custom metrics, use the [data explorer](/docs/query-your-data/explore-query-data/data-explorer/introduction-data-explorer) to search and filter for custom metrics, create customizable charts, and add those charts to New Relic dashboards. You can use our [REST API](/docs/apis/rest-api-v2/requirements/new-relic-rest-api-v2-getting-started) to programmatically retrieve and use custom metric data outside of the UI. It is also possible to [create custom metric alert conditions](/docs/alerts/new-relic-alerts/configuring-alert-policies/define-custom-metrics-alert-condition) to notify you or your team when your custom metric exceeds specific values.


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
This PR adds a "View and use custom metrics" section to the Python agent `record_custom_metric` and `record_custom_metrics` API guides.