### PR TITLE
feat: php docker page add extra callouts

### DIFF
--- a/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
+++ b/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
@@ -14,7 +14,7 @@ redirects:
 You can install the [PHP agent](/docs/agents/php-agent/getting-started/introduction-new-relic-php) on a Docker container or other container to monitor one or more of your PHP applications. This is supported for containers that meet [PHP agent requirements](/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements).
 
 <Callout variant="caution">
- The PHP Agent's daemon transmits data to New Relic periodically during the minute-long [harvest cycle](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/getting-started/glossary#harvest-cycle). If you are starting up and tearing down containers often, ensure that you leave the daemon container running long enough to transmit any remaining data.
+ The PHP Agent's daemon transmits data to New Relic periodically during the minute-long [harvest cycle](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/getting-started/glossary#harvest-cycle). If you're starting up and tearing down containers often, ensure that you leave the daemon container running long enough to transmit any remaining data.
 </Callout>
 
 ## Container options [#overview]
@@ -31,7 +31,7 @@ Requirements:
 * Meet [PHP agent requirements](/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements)
 * PHP agent version 9.2 or higher
 
-To see an example application, go to [New Relic's Explorers Hub](https://discuss.newrelic.com/t/relic-solution-php-agent-and-daemon-containers/84841). If using short-lived application containers, it is recommended to use a separate container for the PHP Agent's daemon.
+To see an example application, go to [New Relic's Explorers Hub](https://discuss.newrelic.com/t/relic-solution-php-agent-and-daemon-containers/84841). If you're using short-lived application containers, we recommend you use a separate container for the PHP Agent's daemon.
 
 <Callout variant="caution">
   Data transmitted from the agent to the daemon is **not** encrypted. The only exception to this is the [SQL obfuscation](/docs/agents/php-agent/configuration/php-agent-configuration#inivar-tt-sql) that happens before sending data to the daemon. If the agent and daemon are running on different hosts, we recommend that you use a private network connection between the agent and daemon.
@@ -63,7 +63,7 @@ To set up the PHP agent container for Docker:
 ## Install agent and daemon in the same container [#install-same-container]
 
 <Callout variant="caution">
-By default, the first transaction causes the agent to trigger a daemon start and an application connection initialization. However, for performance reasons, the agent does not wait for those operations to complete before it initializes the connection, which can result in the loss of the first few transactions after a container starts. To prevent this, set both `newrelic.daemon.start_timeout` and `newrelic.daemon.app_connect_timeout` entries in the `newrelic.ini` file to (recommended values)[https://discuss.newrelic.com/t/php-troubleshooting-framework-configuration/119980] of 5s and 15s respectively.
+By default, the first transaction causes the agent to trigger a daemon start and an application connection initialization. For performance reasons, the agent does not wait for those operations to complete before it initializes the connection. This can result in the loss of the first few transactions after a container starts. To prevent this loss, set both `newrelic.daemon.start_timeout` and `newrelic.daemon.app_connect_timeout` entries in the `newrelic.ini` file to our (recommended values)[https://discuss.newrelic.com/t/php-troubleshooting-framework-configuration/119980] of 5s and 15s respectively.
 </Callout>
 
 To set up the PHP agent and daemon in the same Docker container:
@@ -103,7 +103,7 @@ To set up the PHP agent and daemon in the same Docker container:
 </CollapserGroup>
 
 <Callout variant="info">
-  Additionally docker troubleshooting resources:
+  Here are some Docker troubleshooting resources:
   - https://discuss.newrelic.com/t/relic-solution-single-php-script-docker-containers/80386
   - https://discuss.newrelic.com/t/php-troubleshooting-framework-configuration/119980
 </Callout>

--- a/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
+++ b/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
@@ -13,6 +13,10 @@ redirects:
 
 You can install the [PHP agent](/docs/agents/php-agent/getting-started/introduction-new-relic-php) on a Docker container or other container to monitor one or more of your PHP applications. This is supported for containers that meet [PHP agent requirements](/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements).
 
+<Callout variant="caution">
+ The daemon only transmits data to Newrelic periodically, once every minute. If you are standing up and tearing down containers often, ensure that you leave the daemon container running for enough time to transmit any remaining data.
+</Callout>
+
 ## Container options [#overview]
 
 The PHP agent requires two components to work: the PHP agent (one for each application) and a [daemon](/docs/agents/php-agent/getting-started/new-relic-daemon-processes), which aggregates data sent from one or more agents and sends it to New Relic. For this reason, there are two options for enabling the PHP agent for container environments:
@@ -27,7 +31,7 @@ Requirements:
 * Meet [PHP agent requirements](/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements)
 * PHP agent version 9.2 or higher
 
-To see an example application, go to [New Relic's Explorers Hub](https://discuss.newrelic.com/t/relic-solution-php-agent-and-daemon-containers/84841).
+To see an example application, go to [New Relic's Explorers Hub](https://discuss.newrelic.com/t/relic-solution-php-agent-and-daemon-containers/84841). Using a separate container for the daemon is recommended if there will be short-lived application containers.
 
 <Callout variant="caution">
   Data transmitted from the agent to the daemon is **not** encrypted. The only exception to this is the [SQL obfuscation](/docs/agents/php-agent/configuration/php-agent-configuration#inivar-tt-sql) that happens before sending data to the daemon. If the agent and daemon are running on different hosts, we recommend that you use a private network connection between the agent and daemon.
@@ -58,12 +62,15 @@ To set up the PHP agent container for Docker:
 
 ## Install agent and daemon in the same container [#install-same-container]
 
+<Callout variant="caution">
+By default, the first transaction causes the agent to trigger a daemon start and an application connection initialization. However, for performance reasons, the agent does not wait for those operations to complete before it initializes the connection, which can result in the loss of the first few transactions after a container starts. To prevent this, set both `newrelic.daemon.start_timeout` and `newrelic.daemon.app_connect_timeout` entries in the `newrelic.ini` file to recommended values.
+</Callout>
+
 To set up the PHP agent and daemon in the same Docker container:
 
 1. Make sure a PHP installation is available in the container. For example: you might use a published Docker image like `php:7.1`.
 2. To install the agent, download the PHP agent package from New Relic's [tar file download site](/docs/agents/php-agent/installation/php-agent-installation-tar-file) and run the `newrelic-install` script with the `install` argument.
 3. Set the application name and [license key](/docs/accounts/install-new-relic/account-setup/license-key) via the `newrelic.license` and `newrelic.appname` entries in the `newrelic.ini` file.
-4. By default, the first transaction causes the agent to trigger a daemon start and an application connection initialization. However, for performance reasons, the agent does not wait for those operations to complete before it initializes the connection, which can result in the loss of the first few transactions after a container starts. To prevent this, set both `newrelic.daemon.start_timeout` and `newrelic.daemon.app_connect_timeout` entries in the `newrelic.ini` file to recommended values.
 
 <CollapserGroup>
   <Collapser
@@ -94,3 +101,9 @@ To set up the PHP agent and daemon in the same Docker container:
     * `YOUR_APPLICATION_NAME`: Replace with the your application name, in quotes.
   </Collapser>
 </CollapserGroup>
+
+<Callout variant="info">
+  Additionally docker troubleshooting resources:
+  - https://discuss.newrelic.com/t/relic-solution-single-php-script-docker-containers/80386
+  - https://discuss.newrelic.com/t/php-troubleshooting-framework-configuration/119980
+</Callout>

--- a/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
+++ b/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
@@ -14,7 +14,7 @@ redirects:
 You can install the [PHP agent](/docs/agents/php-agent/getting-started/introduction-new-relic-php) on a Docker container or other container to monitor one or more of your PHP applications. This is supported for containers that meet [PHP agent requirements](/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements).
 
 <Callout variant="caution">
- The daemon only transmits data to Newrelic periodically, once every minute. If you are standing up and tearing down containers often, ensure that you leave the daemon container running for enough time to transmit any remaining data.
+ The PHP Agent's daemon transmits data to New Relic periodically during the minute-long [harvest cycle](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/getting-started/glossary#harvest-cycle). If you are starting up and tearing down containers often, ensure that you leave the daemon container running long enough to transmit any remaining data.
 </Callout>
 
 ## Container options [#overview]
@@ -31,7 +31,7 @@ Requirements:
 * Meet [PHP agent requirements](/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements)
 * PHP agent version 9.2 or higher
 
-To see an example application, go to [New Relic's Explorers Hub](https://discuss.newrelic.com/t/relic-solution-php-agent-and-daemon-containers/84841). Using a separate container for the daemon is recommended if there will be short-lived application containers.
+To see an example application, go to [New Relic's Explorers Hub](https://discuss.newrelic.com/t/relic-solution-php-agent-and-daemon-containers/84841). If using short-lived application containers, it is recommended to use a separate container for the PHP Agent's daemon.
 
 <Callout variant="caution">
   Data transmitted from the agent to the daemon is **not** encrypted. The only exception to this is the [SQL obfuscation](/docs/agents/php-agent/configuration/php-agent-configuration#inivar-tt-sql) that happens before sending data to the daemon. If the agent and daemon are running on different hosts, we recommend that you use a private network connection between the agent and daemon.
@@ -63,7 +63,7 @@ To set up the PHP agent container for Docker:
 ## Install agent and daemon in the same container [#install-same-container]
 
 <Callout variant="caution">
-By default, the first transaction causes the agent to trigger a daemon start and an application connection initialization. However, for performance reasons, the agent does not wait for those operations to complete before it initializes the connection, which can result in the loss of the first few transactions after a container starts. To prevent this, set both `newrelic.daemon.start_timeout` and `newrelic.daemon.app_connect_timeout` entries in the `newrelic.ini` file to recommended values.
+By default, the first transaction causes the agent to trigger a daemon start and an application connection initialization. However, for performance reasons, the agent does not wait for those operations to complete before it initializes the connection, which can result in the loss of the first few transactions after a container starts. To prevent this, set both `newrelic.daemon.start_timeout` and `newrelic.daemon.app_connect_timeout` entries in the `newrelic.ini` file to (recommended values)[https://discuss.newrelic.com/t/php-troubleshooting-framework-configuration/119980] of 5s and 15s respectively.
 </Callout>
 
 To set up the PHP agent and daemon in the same Docker container:


### PR DESCRIPTION
Add more info to the php docker docs page. This consolidates some important information to a page where it will be easier to find.