### PR TITLE
Update theme and copyright year in global footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "^2.0.0-next.8",
     "@mdx-js/react": "^2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "^4.1.7",
+    "@newrelic/gatsby-theme-newrelic": "^4.1.8",
     "@splitsoftware/splitio-react": "^1.2.4",
     "babel-jest": "^26.3.0",
     "common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1979,10 +1979,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^4.1.7":
-  version "4.1.7"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-4.1.7.tgz#0397d08332efea7d52e43c74c7de7c7bdf6134d8"
-  integrity sha512-9Q23CtKs31dzr0ETjwq6+u8NLM3dSHV9W3vF2p9RVoKOVncg1uZNEnNlyudtLaDZQUNjVmOTQtqgdVeCDVzCDQ==
+"@newrelic/gatsby-theme-newrelic@^4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-4.1.8.tgz#d43698d87232cc029535b068f6e29ec37bfd8d83"
+  integrity sha512-wXKxPVnZC/KocBc9l+FLmxCacqyz6QSMyX2c5Y/ZD66cM95Y32dtD6ktklTLWXvx1NK9ywrDdjCdvY1lGNcqyQ==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
Updates the theme which brings in a change to dynamically render the copyright year in the footer

closes https://github.com/newrelic/gatsby-theme-newrelic/issues/625