### PR TITLE
Replace link to latest grpc exporter for Node.js

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start.mdx
@@ -103,7 +103,7 @@ If you have FedRamp compliance constraints, you will need to use `https://gov-ot
 </Callout>
 
 <Callout variant="important">
-In Node.js, the [opentelemetry-collector-grpc](https://www.npmjs.com/package/@opentelemetry/exporter-collector-grpc) library requires additional options to enable TLS.
+In Node.js, the [opentelemetry-collector-exporter-grpc](https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-grpc) library requires additional options to enable TLS.
 </Callout>
 
 ### Complete the export configuration steps [#complete-configs]


### PR DESCRIPTION
The previous grpc exporter for Node was deprecated.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.