### PR TITLE
Mention metric normalization rules for dropping data

### DIFF
--- a/src/content/docs/data-apis/manage-data/drop-data-using-nerdgraph.mdx
+++ b/src/content/docs/data-apis/manage-data/drop-data-using-nerdgraph.mdx
@@ -25,6 +25,7 @@ Besides using NerdGraph, other ways to drop data include:
 
 * If you're using Prometheus remote write, see [Drop Prometheus remote write data](/docs/integrations/prometheus-integrations/install-configure/remote-write-drop-data/).
 * If you're reporting logs, you can [drop log data via the UI](/docs/logs/ui-data/drop-data-drop-filter-rules). 
+* If you want to drop APM metric timeslice data, you can use [metric normalization rules](/docs/new-relic-one/ui-data/metric-normalization-rules). 
 
 ## Requirements [#requirements]
 


### PR DESCRIPTION
The way to manage APM metric timeslice ingest is via metric normalization rules, not via NRQL drop rules.

Leave a pointer to the normalization rules docs in the overview page for dropping data using NerdGraph.