### PR TITLE
Fix typo in link to metric normalization rules page

### DIFF
--- a/src/content/docs/data-apis/manage-data/drop-data-using-nerdgraph.mdx
+++ b/src/content/docs/data-apis/manage-data/drop-data-using-nerdgraph.mdx
@@ -25,7 +25,7 @@ Besides using NerdGraph, other ways to drop data include:
 
 * If you're using Prometheus remote write, see [Drop Prometheus remote write data](/docs/integrations/prometheus-integrations/install-configure/remote-write-drop-data/).
 * If you're reporting logs, you can [drop log data via the UI](/docs/logs/ui-data/drop-data-drop-filter-rules). 
-* If you want to drop APM metric timeslice data, you can use [metric normalization rules](/docs/new-relic-one/ui-data/metric-normalization-rules). 
+* If you want to drop APM metric timeslice data, you can use [metric normalization rules](/docs/new-relic-one/use-new-relic-one/ui-data/metric-normalization-rules). 
 
 ## Requirements [#requirements]
 


### PR DESCRIPTION
A recent change added that link, but it has a typo in the document path.