### PR TITLE
NerdGraph will not delete browser apps

### DIFF
--- a/src/content/docs/apm/new-relic-apm/maintenance/remove-applications-new-relic.mdx
+++ b/src/content/docs/apm/new-relic-apm/maintenance/remove-applications-new-relic.mdx
@@ -54,7 +54,6 @@ Before you can remove an application monitored by New Relic APM, browser monitor
     2. Restart the application server and wait up to ten minutes. Verify the color-coded [health status](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#health-status) for the app has turned to gray and is no longer reporting data.
     3. To remove the APM application from the UI (and any [associated apps in browser monitoring](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/#select-apm-app)), you have a few options:
        * **Delete the app from the UI.** Go to **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app/service) > Settings > Application**, and click the **Delete application** button. 
-       * **Use NerdGraph to delete an entity.** If you've done the above and are still seeing that app in the UI, you can [use NerdGraph to delete the relevant entities](/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial/#delete-entities). For how to find entity IDs, see [Entities](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#find).
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
There's an inconsistency a customer brought up this week in our documentation. A stated at the very bottom of this doc link here: https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial/, we do not mention browser entities, only APM-APPLICATION, EXT-SERVICE, and REF-REPOSITORY. 

I followed up with engineering to confirm here: https://newrelic.slack.com/archives/C28SEP2LR/p1642786630179500

It sounds like this ability may be coming soon to NerdGraph, see thread for context.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.