### PR TITLE
Ruby agent v8.4.0

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -302,6 +302,7 @@ The Ruby agent does not support experimental versions. Web frameworks supported 
         * 5.2.x
         * 6.0.x
         * 6.1.x
+        * 7.0.x
       </td>
 
       <td>

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-840.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-840.mdx
@@ -1,0 +1,30 @@
+---
+subject: Ruby agent
+releaseDate: '2022-01-25'
+version: 8.4.0
+downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.4.0.gem'
+---
+
+
+  ## v8.4.0
+
+  * **Provide basic support for Rails 7.0**
+
+  This release includes Rails 7.0 as a tested Rails version. Updates build upon the agent's current Rails instrumentation and do not include additional instrumentation for new features.
+
+  * **Improve the performance of NewRelic::Agent::GuidGenerator#generate_guid**
+
+  This method is called by many basic operations within the agent including transactions, datastore segments, and external request segments. Thank you, @jdelstrother for contributing this performance improvement!
+
+  * **Documentation: Development environment prep instructions**
+
+  The multiverse collection of test suites requires a variety of data handling software (MySQL, Redis, memcached, etc.) to be available on the machine running the tests. The [project documentation](test/multiverse/README.md) has been updated to outline the relevant software packages, and a `Brewfile` file has been added to automate software installation with Homebrew.
+
+  * **Bugfix: Add ControllerInstrumentation::Shims to Sinatra framework**
+
+    When the agent is disabled by setting the configuration settings `enabled`, `agent_enabled`, and/or `monitor_mode` to false, the agent loads shims for public controller instrumentation methods. These shims were missing for the Sinatra framework, causing applications to crash if the agent was disabled. Thank you, @NC-piercej for bringing this to our attention!
+
+
+## Support statement
+
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.7.0.350](https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-570350).


### PR DESCRIPTION
Updates for Ruby agent v8.4.0 release

* Added new version specific CHANGELOG info
* Listed Rails 7.x as a supported framework