### PR TITLE
[DOC-7631] Node.js Lamba logs

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs.mdx
@@ -32,7 +32,7 @@ To generate the detailed `trace` log file:
 4. After testing, change the `level` to a less verbose [logging level](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#log_level), such as `info` (default).
 5. Open and examine the generated log file.
 
-You cannot generate `trace` logs for Lambda. Read more on [Lambda monitoring](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring).
+If you're using Lambda, [learn how to set up logs](/docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda/#attach-logs).
 
 ## Examine log file [#logfile]
 

--- a/src/content/docs/apm/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs.mdx
@@ -13,7 +13,7 @@ redirects:
 Your New Relic [Node.js agent log](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#logging_config) captures errors at the default `info` level. However, when troubleshooting or debugging, generate a more verbose `trace` log to help find and investigate problems.
 
 <Callout variant="important">
-  The `trace` log setting is a highly verbose logging level. To reduce disk space consumption, return the `logging : {` section's `level` to its [original setting](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#logging_config) after testing.
+  The `trace` log setting is a highly verbose logging level. To reduce disk space consumption, return the `logging : {level}` section to its [original setting](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#logging_config) after testing.
 </Callout>
 
 ## Generate log files [#create]
@@ -31,6 +31,8 @@ To generate the detailed `trace` log file:
 3. Exercise your web application for about five minutes to generate sufficient logging data.
 4. After testing, change the `level` to a less verbose [logging level](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#log_level), such as `info` (default).
 5. Open and examine the generated log file.
+
+You cannot generate `trace` logs for Lambda. Read more on [Lambda monitoring](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring).
 
 ## Examine log file [#logfile]
 

--- a/src/content/docs/apm/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/troubleshooting/generate-trace-log-troubleshooting-nodejs.mdx
@@ -20,7 +20,7 @@ Your New Relic [Node.js agent log](/docs/apm/agents/nodejs-agent/installation-co
 
 To generate the detailed `trace` log file:
 
-1. Edit your `newrelic.js` file and change the `logging` section's `level` to `trace`, or if using environment variables, set the `NEW_RELIC_LOG_LEVEL` to `trace`.
+1. Edit your `newrelic.js` file and change the `logging` section's `level` to `trace`. If using environment variables (with Lambda, this is the most common way), set the `NEW_RELIC_LOG_LEVEL` to `trace`.
 
    ```js
    logging: {

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring.mdx
@@ -12,3 +12,5 @@ There are several steps to enabling Lambda monitoring:
 3. [Instrument an example function.](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-example)
 4. [Instrument your functions.](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own)
 5. [Optional: Set up alerts and custom events.](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/configure-serverless-monitoring-aws-lambda)
+
+See also [legacy manual instrumentation for Lambda](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy).

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
@@ -392,10 +392,12 @@ module.exports.handler = newrelic.setLambdaHandler((event, context, callback) =>
 9. Optional: To enable logging in serverless mode, set these environment variables:
     * Set `NEW_RELIC_LOG_ENABLED` to `true`.
     * Set `NEW_RELIC_LOG` to `stdout` for output to CloudWatch, or set to any writeable file location.
-    * The log level is set to `info` by default. See [other log levels](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#logging_config).
+    * `NEW_RELIC_LOG_LEVEL` is set to `info` by default, and it's only used when sending function logs in your Lamba. See [other log levels](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#logging_config).    
 10. Invoke the Lambda at least once. This creates a CloudWatch log group, which must be present for the next step to work.
 
 Our wrapper gathers data about the Lambda execution, generates a JSON message, and logs it to CloudWatch Logs. Next you'll [configure CloudWatch to send those logs to New Relic](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own/#manual-stream-logs).
+
+Read more on how to [send function logs with Lambda](https://github.com/newrelic/newrelic-lambda-extension/blob/c5c96bd8310156ce209ab55d5bc91fd084b3a8dd/config/config.go#L43).
 </Collapser>
 
 <Collapser

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
@@ -397,7 +397,7 @@ module.exports.handler = newrelic.setLambdaHandler((event, context, callback) =>
 
 Our wrapper gathers data about the Lambda execution, generates a JSON message, and logs it to CloudWatch Logs. Next you'll [configure CloudWatch to send those logs to New Relic](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own/#manual-stream-logs).
 
-Read more on how to [send function logs with Lambda](https://github.com/newrelic/newrelic-lambda-extension/blob/c5c96bd8310156ce209ab55d5bc91fd084b3a8dd/config/config.go#L43).
+Read more on how to [send function logs with Lambda](https://github.com/newrelic/newrelic-lambda-extension).
 </Collapser>
 
 <Collapser

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda.mdx
@@ -29,7 +29,7 @@ Besides these basic enablement problems, there are some additional problems that
 * You've completed the installation, integration, and instrumentation steps correctly, and your function is sending logs to CloudWatch but you're not seeing traces for specific dependencies (or any traces) in the UI. This may result from the order of layer merging (if you're using our Lambda layers) or from the order of import (if you're instrumenting manually):
 
   * If you're instrumenting with layers: make sure in your function configuration that the New Relic layer is merged before other layers (though if your function uses webpack, the New Relic layer should be merged after the webpack layer).
-  * If you're instrumenting a Node function manually, make sure that your function imports **newrelic** and **@newrelic/aws-sdk** before it imports any dependencies you expect to monitor.
+  * If you're instrumenting a Node function manually, make sure that [logging is enabled](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#logging_config), and that your function imports **newrelic** and **@newrelic/aws-sdk** before it imports any dependencies you expect to monitor.
 
 If none of these solutions help you, contact our [support team](https://support.newrelic.com/). The following information will help you when you talk to support technicians:
 

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda.mdx
@@ -29,7 +29,7 @@ Besides these basic enablement problems, there are some additional problems that
 * You've completed the installation, integration, and instrumentation steps correctly, and your function is sending logs to CloudWatch but you're not seeing traces for specific dependencies (or any traces) in the UI. This may result from the order of layer merging (if you're using our Lambda layers) or from the order of import (if you're instrumenting manually):
 
   * If you're instrumenting with layers: make sure in your function configuration that the New Relic layer is merged before other layers (though if your function uses webpack, the New Relic layer should be merged after the webpack layer).
-  * If you're instrumenting a Node function manually, make sure that [logging is enabled](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#logging_config), and that your function imports **newrelic** and **@newrelic/aws-sdk** before it imports any dependencies you expect to monitor.
+  * If you're instrumenting a Node function manually, make sure that [logging is enabled](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#logging_config), and that your function imports **newrelic** before it imports any dependencies you expect to monitor.
 
 If none of these solutions help you, contact our [support team](https://support.newrelic.com/). The following information will help you when you talk to support technicians:
 

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda.mdx
@@ -12,7 +12,7 @@ redirects:
 
 ## Problem
 
-You’re attempting to enable [serverless monitoring for AWS Lambda](/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/introduction-new-relic-monitoring-aws-lambda) and are having an issue or error.
+You're attempting to enable [serverless monitoring for AWS Lambda](/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/introduction-new-relic-monitoring-aws-lambda) and are having an issue or error.
 
 ## Solution
 


### PR DESCRIPTION
As reported in DOC-7631.

This commit adds exception for `trace` logs for Lambda.