### PR TITLE
Update upload-source-maps-api.mdx

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-api.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-api.mdx
@@ -16,7 +16,7 @@ In order to upload source maps to browser via the API, you'll need this informat
 * The New Relic [application ID](/docs/browser/new-relic-browser/installation-configuration/copy-browser-monitoring-license-key-app-id) for the deployed app
 * The full [JavaScript file URL](#what-url)
 * Optionally, if the JavaScript URL doesn't automatically have release info appended to it, the [release name and ID](#release-id)
-NOTE: Only one source map can be uploaded/published per API request.
+
 <CollapserGroup>
   <Collapser
     id="what-url"
@@ -59,6 +59,7 @@ NOTE: Only one source map can be uploaded/published per API request.
 
     * You can upload a maximum of 1000 source maps per minute.
     * You can upload a maximum of 15,000 source maps per day.
+    * Only one source map can be uploaded or published per API request.
 
     Source map files can be a maximum of 50Mb in size.
   </Collapser>

--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-api.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-api.mdx
@@ -16,7 +16,7 @@ In order to upload source maps to browser via the API, you'll need this informat
 * The New Relic [application ID](/docs/browser/new-relic-browser/installation-configuration/copy-browser-monitoring-license-key-app-id) for the deployed app
 * The full [JavaScript file URL](#what-url)
 * Optionally, if the JavaScript URL doesn't automatically have release info appended to it, the [release name and ID](#release-id)
-
+NOTE: Only one source map can be uploaded/published per API request.
 <CollapserGroup>
   <Collapser
     id="what-url"


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?  Explicitly let the customers know only one source map can via published at a time.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.: After reading over and over the docs is not clear if a user can upload multiple source maps per API call or if it's is scoped to one map at a time. I asked engineering and they have confirmed only one map is supported per call. Thread [here](https://newrelic.slack.com/archives/C28SEP2LR/p1642091627081900)

* If your issue relates to an existing GitHub issue, please link to it.  N/A