### PR TITLE
add OR operator

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api.mdx
@@ -24,7 +24,7 @@ For example, You can generate static, snapshot versions of your New Relic dashbo
    ```
    {
     actor {
-       entitySearch(query: "parentId ='<var>YOUR_PAGE_GUID</var>'") {
+       entitySearch(query: "id ='<var>YOUR_PAGE_GUID</var>' OR parentId ='<var>YOUR_PAGE_GUID</var>'") {
          results {
            entities {
              guid


### PR DESCRIPTION
It would make more sense to get the list of GUIDs for dashboard pages with `isDashboardPage:true`, without the proposed change it will only work for getting the GUID's of a dashboard that has multiple nested pages, it will not load GUID's of single dashboard pages.

