### PR TITLE
Remove auto-index/category docs views/URLs

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-structure/factors-affecting-access-features-data.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-structure/factors-affecting-access-features-data.mdx
@@ -37,10 +37,10 @@ If you think your user permissions are preventing you from accessing something, 
 
 ## Account access [#account-access]
 
-If you're having trouble finding an account, here are some causes and solutions: 
+If you're having trouble finding an account or an expected UI page in your account, it may be because you're in the wrong account. Some tips to troubleshoot this: 
 
-* If your organization has multiple accounts and you have access to those accounts, you will see an account switcher at the top left of most New Relic UI pages that will let you switch between accounts.
-* If you're logged into New Relic but can't find an account or its data, it may be for one of these reasons: 
+* If your organization has multiple accounts and you have access to those accounts, you'll see an account switcher at the top left of most New Relic UI pages that lets you switch between accounts.
+* If you're logged into New Relic but can't find an account or an expected UI page, it may be for one of these reasons: 
   * You may need to be added to that account. How you do this will depend on your user model: [Original user model](/docs/accounts/original-accounts-billing/original-users-roles/original-account-structure) \| [New Relic One user model](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure/#account-access). 
   * You may have more than one New Relic login associated with the same email address. If you think this may be the case, log out and log back in. When you input your email address, the login UI notes if you have multiple user records and gives you [an option for verifying your email to see all available accounts when you log in](/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems/#verify-email). Other details about multiple logins: 
     * To see all your available login options the next time you log in, select **Remember me** when logging in. 

--- a/src/content/docs/alerts-applied-intelligence/notifications/intro-notifications.mdx
+++ b/src/content/docs/alerts-applied-intelligence/notifications/intro-notifications.mdx
@@ -12,7 +12,7 @@ metaDescription: "Notifications are where you integrate your New Relic One data 
 <Callout title="Early access">
 The features described here are early access. You won't be able to use these features if you're not part of the early access program.
 
-For more information on related features, see our docs on [Alerts notification channels](/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts/), [Incident Intelligence destinations](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/incident-intelligence-destination-examples/), and [Proactive Detection notifications](/docs/alerts-applied-intelligence/applied-intelligence/proactive-detection/proactive-detection-applied-intelligence/#set-up).
+For more information on related features, see our docs on [Alerts notification channels](/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts), [Incident Intelligence destinations](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/incident-intelligence-destination-examples/), and [Proactive Detection notifications](/docs/alerts-applied-intelligence/applied-intelligence/proactive-detection/proactive-detection-applied-intelligence/#set-up).
 </Callout>
 
 Notifications are a consolidation of the different ways to send notification-events to third-party services, such as Slack, Jira, ServiceNow, and email. You can also use webhooks to send your data to any compatible third-party service.

--- a/src/content/docs/alerts-applied-intelligence/notifications/notification-integrations.mdx
+++ b/src/content/docs/alerts-applied-intelligence/notifications/notification-integrations.mdx
@@ -11,7 +11,7 @@ metaDescription: "Alerts and Applied Intelligence notification integrations are 
 <Callout title="Early access">
 The features described here are early access. You won't be able to use these features if you're not part of the early access program.
 
-For more information on related features, see our docs on [Alerts notification channels](/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts), [Incident Intelligence destinations](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/incident-intelligence-destination-examples/), and [Proactive Detection notifications](https://docs.newrelic.com/docs/alerts-applied-intelligence/applied-intelligence/proactive-detection/proactive-detection-applied-intelligence/#set-up).
+For more information on related features, see our docs on [Alerts notification channels](/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts), [Incident Intelligence destinations](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/incident-intelligence-destination-examples), and [Proactive Detection notifications](https://docs.newrelic.com/docs/alerts-applied-intelligence/applied-intelligence/proactive-detection/proactive-detection-applied-intelligence/#set-up).
 </Callout>
 
 Alerts and Applied Intelligence notification integrations are specific services and platforms you can use to send notifications from New Relic.

--- a/src/content/docs/alerts-applied-intelligence/notifications/notification-integrations.mdx
+++ b/src/content/docs/alerts-applied-intelligence/notifications/notification-integrations.mdx
@@ -11,7 +11,7 @@ metaDescription: "Alerts and Applied Intelligence notification integrations are 
 <Callout title="Early access">
 The features described here are early access. You won't be able to use these features if you're not part of the early access program.
 
-For more information on related features, see our docs on [Alerts notification channels](/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts/), [Incident Intelligence destinations](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/incident-intelligence-destination-examples/), and [Proactive Detection notifications](https://docs.newrelic.com/docs/alerts-applied-intelligence/applied-intelligence/proactive-detection/proactive-detection-applied-intelligence/#set-up).
+For more information on related features, see our docs on [Alerts notification channels](/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts), [Incident Intelligence destinations](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/incident-intelligence-destination-examples/), and [Proactive Detection notifications](https://docs.newrelic.com/docs/alerts-applied-intelligence/applied-intelligence/proactive-detection/proactive-detection-applied-intelligence/#set-up).
 </Callout>
 
 Alerts and Applied Intelligence notification integrations are specific services and platforms you can use to send notifications from New Relic.

--- a/src/content/docs/apm/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code.mdx
+++ b/src/content/docs/apm/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code.mdx
@@ -161,4 +161,4 @@ To view your app's performance with [APM](/docs/apm/new-relic-apm/getting-starte
 1. Generate some traffic for your app, then wait a few minutes for your app to send data to New Relic.
 2. Explore your app's data in the [APM UI](/docs/apm/applications-menu/monitoring/apm-overview-page).
 
-If no data appears within a few minutes, check your `c_sdk.log` and `newrelic-daemon.log` files for errors. If you still have problems, follow the [troubleshooting tips](/docs/no-data-appears-c).
+If no data appears within a few minutes, check your `c_sdk.log` and `newrelic-daemon.log` files for errors. If you still have problems, follow the [troubleshooting tips](/docs/apm/agents/c-sdk/troubleshooting/no-data-appears-c-sdk).

--- a/src/content/docs/apm/agents/c-sdk/install-configure/update-your-c-sdk-library.mdx
+++ b/src/content/docs/apm/agents/c-sdk/install-configure/update-your-c-sdk-library.mdx
@@ -25,4 +25,4 @@ To update your application's code library to the latest version of New Relic's C
 6. Redeploy your application to your production environment.
 7. Wait a few minutes for your application to send data to New Relic. Then, check your application's performance in [New Relic](/docs/apm/applications-menu/monitoring/apm-overview-page).
 
-If no data appears within a few minutes, follow the [troubleshooting tips](/docs/no-data-appears-c).
+If no data appears within a few minutes, follow the [troubleshooting tips](/docs/apm/agents/c-sdk/troubleshooting/no-data-appears-c-sdk).

--- a/src/content/docs/apm/agents/java-agent/getting-started/introduction-new-relic-java.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/introduction-new-relic-java.mdx
@@ -162,4 +162,4 @@ The agent receives basic information about your host environment, such as operat
 
 ## Troubleshooting procedures [#troubleshoot]
 
-If you encounter problems with the Java agent, see the [troubleshooting documentation](/docs/apm/agents/java-agent/troubleshooting).
+If you have problems, see [No data appears](/docs/apm/agents/java-agent/troubleshooting/no-data-appears-java) and other troubleshooting docs in that section. 

--- a/src/content/docs/apm/agents/java-agent/troubleshooting/gather-troubleshooting-information-java.mdx
+++ b/src/content/docs/apm/agents/java-agent/troubleshooting/gather-troubleshooting-information-java.mdx
@@ -12,7 +12,7 @@ redirects:
   - /docs/agents/java-agent/troubleshooting/providing-troubleshooting-information-java
 ---
 
-If none of the New Relic Java agent's [troubleshooting procedures](/docs/apm/agents/java-agent/troubleshooting) resolve the problem, use the [log files](#logfiles) to troubleshoot the issue. If you need further assistance, gather the following information for getting support at [support.newrelic.com](https://support.newrelic.com).
+If the Java agent's troubleshooting procedures (like [No data appears](/docs/apm/agents/java-agent/troubleshooting/no-data-appears-java) and other docs in that category) have not resolved your problem, use the [log files](#logfiles) to troubleshoot the issue. If you need further assistance, contact [support.newrelic.com](https://support.newrelic.com).
 
 <table>
   <thead>

--- a/src/content/docs/apm/agents/java-agent/troubleshooting/gather-troubleshooting-information-java.mdx
+++ b/src/content/docs/apm/agents/java-agent/troubleshooting/gather-troubleshooting-information-java.mdx
@@ -12,7 +12,7 @@ redirects:
   - /docs/agents/java-agent/troubleshooting/providing-troubleshooting-information-java
 ---
 
-If the Java agent's troubleshooting procedures (like [No data appears](/docs/apm/agents/java-agent/troubleshooting/no-data-appears-java) and other docs in that category) have not resolved your problem, use the [log files](#logfiles) to troubleshoot the issue. If you need further assistance, contact [support.newrelic.com](https://support.newrelic.com).
+If the Java agent's troubleshooting procedures (like [No data appears](/docs/apm/agents/java-agent/troubleshooting/no-data-appears-java) and other docs in that category) haven't resolved your problem, use the [log files](#logfiles) to troubleshoot the issue. If you need further assistance, contact [support.newrelic.com](https://support.newrelic.com).
 
 <table>
   <thead>

--- a/src/content/docs/apm/agents/net-agent/getting-started/introduction-new-relic-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/introduction-new-relic-net.mdx
@@ -82,7 +82,7 @@ When you are ready to install, use our launcher, or see the install instructions
   To stay up-to-date with new features and bug fixes, see the [.NET agent release notes](/docs/release-notes/agent-release-notes/net-release-notes).
 </Callout>
 
-After you install the agent and wait a few minutes for your app to generate traffic, data will appear in the [APM **Summary** page](/docs/apm/applications-menu/monitoring/apm-overview-page). If [no data appears](/docs/agents/net-agent/troubleshooting/no-data-appears-net), or if you encounter other problems, see New Relic's [.NET agent troubleshooting procedures](/docs/agents/net-agent/troubleshooting).
+After you install the agent and wait a few minutes for your app to generate traffic, data will appear in the [APM **Summary** page](/docs/apm/applications-menu/monitoring/apm-overview-page). If you have problems, see [No data appears](/docs/agents/net-agent/troubleshooting/no-data-appears-net) and the other troubleshooting docs in that section. 
 
 ![net_overview.png](./images/net_overview.png "net_overview.png")
 

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs.mdx
@@ -116,13 +116,13 @@ You can also bring your logs and application's data together to make troubleshoo
 
 ## Troubleshoot your installation [#troubleshooting]
 
-If you encounter issues with your Node.js agent, see our troubleshooting information:
+If you encounter issues with your Node.js agent, see our troubleshooting docs. Some of the most important troubleshooting docs in that section include:
 
 * [Large memory usage](/docs/agents/nodejs-agent/troubleshooting/troubleshooting-large-memory-usage-nodejs): If you've installed the Node.js agent and your memory usage has increased, check out these possible solutions.
 * [Troubleshooting your Node.js installation](/docs/agents/nodejs-agent/troubleshooting/troubleshooting-your-nodejs-installation): Try these steps if you don't see any data, cannot log files, or encounter other installation problems with the Node.js agent.
 * [Troubleshooting browser instrumentation](/docs/agents/nodejs-agent/troubleshooting/troubleshooting-page-load-timing-nodejs): If you encounter problems with browser data, see these additional tips for Node.js.
 
-You can also [view all troubleshooting docs](/docs/agents/net-agent/troubleshooting). If you need additional assistance, get support at [support.newrelic.com](https://support.newrelic.com).
+If you need additional assistance, get support at [support.newrelic.com](https://support.newrelic.com).
 
 ## Check the source code [#source-code]
 

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs.mdx
@@ -122,7 +122,7 @@ If you encounter issues with your Node.js agent, see our troubleshooting docs. S
 * [Troubleshooting your Node.js installation](/docs/agents/nodejs-agent/troubleshooting/troubleshooting-your-nodejs-installation): Try these steps if you don't see any data, cannot log files, or encounter other installation problems with the Node.js agent.
 * [Troubleshooting browser instrumentation](/docs/agents/nodejs-agent/troubleshooting/troubleshooting-page-load-timing-nodejs): If you encounter problems with browser data, see these additional tips for Node.js.
 
-If you need additional assistance, get support at [support.newrelic.com](https://support.newrelic.com).
+If you need more help, get support at [support.newrelic.com](https://support.newrelic.com).
 
 ## Check the source code [#source-code]
 

--- a/src/content/docs/apm/agents/php-agent/advanced-installation/use-newrelic-install-script-php.mdx
+++ b/src/content/docs/apm/agents/php-agent/advanced-installation/use-newrelic-install-script-php.mdx
@@ -190,7 +190,7 @@ This is useful if the daemon runs on a different host or in a different containe
 
 ## Troubleshoot your PHP installation [#troubleshoot]
 
-If there were problems with the installation process, or if [no data appears](/docs/agents/php-agent/troubleshooting/no-data-appears-php) in the UI, review the [PHP troubleshooting procedures](/docs/agents/php-agent/troubleshooting) before contacting New Relic for support. Be sure to attach your [archive file](#archive-file) to any bug report, as well as the output of the [`phpinfo()`](/docs/agents/php-agent/troubleshooting/submitting-troubleshooting-results-php) function produced by your web server.
+If there were problems with the installation process, review [No data appears](/docs/agents/php-agent/troubleshooting/no-data-appears-php) and other troubleshooting docs before contacting New Relic for support. Be sure to attach your [archive file](#archive-file) to any bug report, as well as the output of the [`phpinfo()`](/docs/agents/php-agent/troubleshooting/submitting-troubleshooting-results-php) function produced by your web server.
 
 ## Uninstall mode [#install-uninstall]
 

--- a/src/content/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php.mdx
@@ -146,7 +146,7 @@ After installing the agent, go further and extend the agent's instrumentation:
 
 ## Troubleshoot your installation [#troubleshoot]
 
-If you encounter issues with the PHP agent, see our [full list of troubleshooting documentation](/docs/agents/php-agent/troubleshooting). Common installation issues include:
+If you're having problems, see the PHP agent troubleshooting docs. Common issues include:
 
 * [No data appears (PHP)](/docs/agents/php-agent/troubleshooting/no-data-appears-php)
 * [Determining permissions requirements](/docs/agents/php-agent/troubleshooting/determining-permissions-requirements)

--- a/src/content/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php.mdx
@@ -146,7 +146,7 @@ After installing the agent, go further and extend the agent's instrumentation:
 
 ## Troubleshoot your installation [#troubleshoot]
 
-If you're having problems, see the PHP agent troubleshooting docs. Common issues include:
+If you're having problems, see the PHP agent troubleshooting docs. Some of the most important troubleshooting docs in that section include:
 
 * [No data appears (PHP)](/docs/agents/php-agent/troubleshooting/no-data-appears-php)
 * [Determining permissions requirements](/docs/agents/php-agent/troubleshooting/determining-permissions-requirements)

--- a/src/content/docs/apm/agents/php-agent/troubleshooting/submitting-troubleshooting-results-php.mdx
+++ b/src/content/docs/apm/agents/php-agent/troubleshooting/submitting-troubleshooting-results-php.mdx
@@ -18,7 +18,7 @@ You continue to have problems with installing the New Relic PHP agent.
 
 ## Solution
 
-If you continue to have problems with your New Relic PHP installation after following the [troubleshooting tips](/docs/agents/php-agent/troubleshooting), get support at [support.newrelic.com](https://support.newrelic.com "Link opens in a new window").
+If you continue to have problems with your New Relic PHP installation after following the [troubleshooting tips](/docs/apm/agents/php-agent/troubleshooting/no-data-appears-php), get support at [support.newrelic.com](https://support.newrelic.com).
 
 When working with a New Relic Technical Support engineer, provide the following information:
 

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/introduction-new-relic-ruby.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/introduction-new-relic-ruby.mdx
@@ -107,7 +107,7 @@ After installing the agent, go further and extend the agent's instrumentation:
 
 ## Troubleshooting [#tshoot]
 
-If you encounter issues with the Ruby agent, see our [full list of troubleshooting documentation](/docs/apm/agents/ruby-agent/troubleshooting). Common issues include:
+If you're having problems, see the Ruby agent troubleshooting docs. Common issues include:
 
 * [No data appears (Ruby)](/docs/agents/ruby-agent/troubleshooting/no-data-appears-ruby)
 * [Gems incompatible with the Ruby agent](/docs/agents/ruby-agent/troubleshooting/incompatible-gems)

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/migration-7x-guide.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/migration-7x-guide.mdx
@@ -72,7 +72,7 @@ instrumentation:
    The use case for this is when a newer version of the conflicting gem is released and it's known to no longer conflict with prepend strategy.
 </Callout>
 
-If you encounter stack level too deep errors, see our [troubleshooting guide](/docs/agents/ruby-agent/troubleshooting/systemstackerror-stack-level-too-deep/) on how to resolve these issues. After working through this troubleshooting guide, you can let us know about the prepend conflict you find by commenting on this [GitHub issue](https://github.com/newrelic/newrelic-ruby-agent/issues/731). We appreciate your feedback so we may detect and automatically fall back to method-chaining in such scenarios.
+If you encounter stack level too deep errors, see our [troubleshooting guide](/docs/agents/ruby-agent/troubleshooting/systemstackerror-stack-level-too-deep) on how to resolve these issues. After working through this troubleshooting guide, you can let us know about the prepend conflict you find by commenting on this [GitHub issue](https://github.com/newrelic/newrelic-ruby-agent/issues/731). We appreciate your feedback so we may detect and automatically fall back to method-chaining in such scenarios.
 
 ## Modernized auto-instrumentation strategy [#modernized-auto-instrumentation]
 

--- a/src/content/docs/distributed-tracing/troubleshooting/missing-trace-data.mdx
+++ b/src/content/docs/distributed-tracing/troubleshooting/missing-trace-data.mdx
@@ -299,3 +299,7 @@ Here are some causes and solutions when you have problems finding expected data 
     Questions about integrating with OpenTelemetry should be taken to the [Explorers Hub](https://discuss.newrelic.com).
   </Collapser>
 </CollapserGroup>
+
+## Other factors affecting access [#more-info]
+
+For more on factors that can affect your ability to access New Relic features, see [Factors affecting access](/docs/accounts/accounts-billing/general-account-settings/factors-affecting-access-features-data).

--- a/src/content/docs/infrastructure/infrastructure-integrations/get-started/introduction-infrastructure-integrations.mdx
+++ b/src/content/docs/infrastructure/infrastructure-integrations/get-started/introduction-infrastructure-integrations.mdx
@@ -71,7 +71,7 @@ Our cloud integrations collect data from cloud platform services and accounts. T
       <td>
         Connect your Microsoft Azure account to monitor and report data to New Relic.
 
-        See our [Azure integrations](/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/).
+        See our [Azure integrations](/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list).
       </td>
     </tr>
 
@@ -83,7 +83,7 @@ Our cloud integrations collect data from cloud platform services and accounts. T
       <td>
         Connect your Google Cloud Platform (GCP) account to monitor and report data to New Relic.
 
-        See our [GCP integrations](/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/).
+        See our [GCP integrations](/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list).
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/no-data-appears-infrastructure.mdx
+++ b/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/no-data-appears-infrastructure.mdx
@@ -177,3 +177,7 @@ If you are missing data from an integration, see troubleshooting procedures for:
 * [APM data missing from infrastructure monitoring](/docs/infrastructure/new-relic-infrastructure/troubleshooting/apm-data-missing-infrastructure)
 * [Amazon/AWS integrations](/docs/infrastructure/amazon-integrations/troubleshooting/no-data-appears-amazonaws-integrations)
 * [On-host integrations](/docs/infrastructure/on-host-integrations/troubleshooting/not-seeing-host-integration-data)
+
+## Other factors affecting access [#more-info]
+
+For more on factors that can affect your ability to access New Relic features, see [Factors affecting access](/docs/accounts/accounts-billing/general-account-settings/factors-affecting-access-features-data).

--- a/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations.mdx
@@ -20,7 +20,7 @@ The Azure integrations are not the same as [APM's .NET support for Azure](/docs/
 
 ## Requirements [#permissions]
 
-Check the docs for our [Azure integrations](/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list) for requirements for specific integrations.
+Check the docs of our [Azure integrations](/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list) for requirements for specific integrations.
 
 New Relic cannot obtain monitoring data from resources that are located in Azure Government or that were created through the [classic deployment model](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-deployment-model).
 

--- a/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations.mdx
@@ -20,7 +20,7 @@ The Azure integrations are not the same as [APM's .NET support for Azure](/docs/
 
 ## Requirements [#permissions]
 
-Check the [Azure integrations documentation](/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list) for requirements on individual integrations.
+Check the docs for our [Azure integrations](/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list) for requirements for specific integrations.
 
 New Relic cannot obtain monitoring data from resources that are located in Azure Government or that were created through the [classic deployment model](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-deployment-model).
 

--- a/src/content/docs/logs/logs-context/configure-logs-context-ruby.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-ruby.mdx
@@ -154,7 +154,7 @@ If you have configured your logging in `/config/application.rb` or in `/config/e
 
 ## Troubleshooting
 
-If you don't see log data in the UI, follow the [troubleshooting procedures](/docs/logs/log-management/troubleshooting/no-log-data-appears-ui/). Also, if you see JSON logs in your application's output, but your query does not return logs, check your [log forwarder](/docs/logs/new-relic-logs/enable-logs/enable-new-relic-logs).
+If you don't see log data in the UI, follow the [troubleshooting procedures](/docs/logs/log-management/troubleshooting/no-log-data-appears-ui). Also, if you see JSON logs in your application's output, but your query does not return logs, check your [log forwarder](/docs/logs/new-relic-logs/enable-logs/enable-new-relic-logs).
 
 If the logs from your application are not formatted in JSON with fields like `trace.id` and `span.id`, there may be a problem with your log forwarding extension. In this situation:
 

--- a/src/content/docs/logs/logs-context/java-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/java-configure-logs-context-all.mdx
@@ -565,7 +565,7 @@ To enable logs in context for APM apps monitored by Java:
 
 To verify that you have configured the log appender correctly, run your application, then check your [logs data in New Relic One](/docs/logs/log-management/ui-data/use-logs-ui/) using the query operator `has:span.id has:trace.id`.
 
-If everything is configured correctly and your data is being forwarded to New Relic with the enriched metadata, your logs should now be emitted as JSON and contain `trace.id` and `span.id` fields. If you don't see log data in the UI, follow the [troubleshooting procedures](/docs/logs/log-management/troubleshooting/no-log-data-appears-ui/).
+If everything is configured correctly and your data is being forwarded to New Relic with the enriched metadata, your logs should now be emitted as JSON and contain `trace.id` and `span.id` fields. If you don't see log data in the UI, follow the [troubleshooting procedures](/docs/logs/log-management/troubleshooting/no-log-data-appears-ui).
 
 ## What's next? [#whats-next]
 

--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -460,7 +460,7 @@ You can use our [Serilog](https://serilog.net/) extension to link to your log da
 
 To verify that you have configured the log appender correctly, run your application, then check your [logs data in New Relic One](/docs/logs/log-management/ui-data/use-logs-ui/) using the query operator `has:span.id has:trace.id`.
 
-If everything is configured correctly and your data is being forwarded to New Relic with the enriched metadata, your logs should now be emitted as JSON and contain `trace.id` and `span.id` fields. If you don't see log data in the UI, follow the [troubleshooting procedures](/docs/logs/log-management/troubleshooting/no-log-data-appears-ui/).
+If everything is configured correctly and your data is being forwarded to New Relic with the enriched metadata, your logs should now be emitted as JSON and contain `trace.id` and `span.id` fields. If you don't see log data in the UI, follow the [troubleshooting procedures](/docs/logs/log-management/troubleshooting/no-log-data-appears-ui).
 
 ## What's next? [#what-next]
 

--- a/src/content/docs/logs/troubleshooting/no-log-data-appears-ui.mdx
+++ b/src/content/docs/logs/troubleshooting/no-log-data-appears-ui.mdx
@@ -106,5 +106,5 @@ If no data appears after you send some log payloads and wait about five minutes,
 
 ## Other factors affecting access [#more-info]
 
-For more on factors that can affect your ability to access New Relic features, see [Factors affecting access](/docs/accounts/accounts-billing/general-account-settings/factors-affecting-access-features-data).
+Learn more about [factors affecting your access to New Relic](/docs/accounts/accounts-billing/general-account-settings/factors-affecting-access-features-data).
 

--- a/src/content/docs/logs/troubleshooting/no-log-data-appears-ui.mdx
+++ b/src/content/docs/logs/troubleshooting/no-log-data-appears-ui.mdx
@@ -103,3 +103,8 @@ If no data appears after you send some log payloads and wait about five minutes,
     </tr>
   </tbody>
 </table>
+
+## Other factors affecting access [#more-info]
+
+For more on factors that can affect your ability to access New Relic features, see [Factors affecting access](/docs/accounts/accounts-billing/general-account-settings/factors-affecting-access-features-data).
+

--- a/src/content/docs/mlops/integrations/aporia-mlops-integration.mdx
+++ b/src/content/docs/mlops/integrations/aporia-mlops-integration.mdx
@@ -57,8 +57,8 @@ Now that you’ve integrated New Relic and Aporia, you can monitor your data usi
 
 ![Set up notifications for Aporia.](./images/aporia2.png "Set up notifications for Aporia")
 
-5. **Get notified:** Once you've created an alerts condition, you can choose how you want to be notified. See our docs on [how to set up notification channels](/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts/).
+5. **Get notified:** Once you've created an alerts condition, you can choose how you want to be notified. See our docs on [how to set up notification channels](/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts).
         
-6. **Correlate your incidents:** In addition to notifications, you can use Incident Intelligence to correlate your incidents. See our docs on [how to correlate incidents using decisions](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/change-applied-intelligence-correlation-logic-decisions/).
+6. **Correlate your incidents:** In addition to notifications, you can use Incident Intelligence to correlate your incidents. See our docs on [how to correlate incidents using decisions](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/change-applied-intelligence-correlation-logic-decisions).
 
 ![Correlate your incidents for Aporia.](./images/aporia3.png "Correlate your incidents for Aporia")

--- a/src/content/docs/mlops/integrations/aws-sagemaker-mlops-integration.mdx
+++ b/src/content/docs/mlops/integrations/aws-sagemaker-mlops-integration.mdx
@@ -26,7 +26,7 @@ Start benefiting from New Relic [MLOps](/docs/alerts-applied-intelligence/mlops/
 </Callout>
 
 ### Manual option [#set-up-manual] 
-Follow our docs to set up [CloudWatch Metric Streams](/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream/).
+Follow our docs to set up [CloudWatch Metric Streams](/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream).
 
 ### Automated option [#set-up-automated] 
 

--- a/src/content/docs/new-relic-partnerships/partner-integration-guide/getting-started/support-resources-new-relic-partners.mdx
+++ b/src/content/docs/new-relic-partnerships/partner-integration-guide/getting-started/support-resources-new-relic-partners.mdx
@@ -11,7 +11,7 @@ redirects:
   - /docs/accounts-partnerships/partner-integration-guide/getting-started/support-resources-new-relic-partners
 ---
 
-This document is for [New Relic partners](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions). After you complete your partnership integration, you'll be introduced to your technical contacts at New Relic. Use these channels for non-urgent escalations.
+This document is for our [New Relic partners](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions). After you complete your partnership integration, you'll be introduced to your technical contacts at New Relic. Use these channels for non-urgent escalations.
 
 <Callout variant="tip">
   If you're not a New Relic partner, see New Relic's resources for [finding help or filing a support ticket](/docs/accounts-partnerships/education/getting-started-new-relic/finding-help).

--- a/src/content/docs/new-relic-partnerships/partner-integration-guide/getting-started/support-resources-new-relic-partners.mdx
+++ b/src/content/docs/new-relic-partnerships/partner-integration-guide/getting-started/support-resources-new-relic-partners.mdx
@@ -11,10 +11,10 @@ redirects:
   - /docs/accounts-partnerships/partner-integration-guide/getting-started/support-resources-new-relic-partners
 ---
 
-This document is for New Relic partners. After you complete your partnership integration, you will be introduced to your technical contacts at New Relic. Use these channels for non-urgent escalations.
+This document is for [New Relic partners](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions). After you complete your partnership integration, you'll be introduced to your technical contacts at New Relic. Use these channels for non-urgent escalations.
 
 <Callout variant="tip">
-  If you are not a New Relic partner, see New Relic's resources for [finding help or filing a support ticket](/docs/accounts-partnerships/education/getting-started-new-relic/finding-help).
+  If you're not a New Relic partner, see New Relic's resources for [finding help or filing a support ticket](/docs/accounts-partnerships/education/getting-started-new-relic/finding-help).
 </Callout>
 
 ## New Relic Support [#support]
@@ -25,43 +25,7 @@ To obtain support for partner accounts, create a ticket at [support.newrelic.com
 
 Documentation from [New Relic's docs site](https://docs.newrelic.com) is an important resource for your support group when providing Level 1 support to your New Relic subscribers. Posting these links on your support pages is an effective way to encourage self help and reduce your support efforts.
 
-Top level entry point for New Relic documentation: [docs.newrelic.com](https://docs.newrelic.com). From here you can select information about New Relic products and features by category.
-
-<Callout variant="tip">
-  The docs site includes a [Partnerships](/docs/accounts-partnerships/partnerships) category with information for New Relic partners and some partnership customers.
-</Callout>
-
-Here are the five most commonly consulted articles on the New Relic docs site. Providing easily found and direct links to these articles can provide many users with self-serve answers to their questions.
-
-* [Create your New Relic account](/docs/accounts-partnerships/accounts/account-setup/creating-your-new-relic-account)
-* [Name your application](/docs/apm/new-relic-apm/installation-configuration/naming-your-application)
-* [Configure the agent](/docs/apm/new-relic-apm/installation-configuration/configuring-agent)
-* [Not seeing data](/docs/apm/new-relic-apm/troubleshooting/not-seeing-data)
-* [Apdex: Measuring user satisfaction](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction)
-
-## Agent documentation [#agent-docs]
-
-Here are links to New Relic documentation categories organized by APM agent languages:
-
-* [Go](/docs/agents/go-agent)
-* [Java](/docs/agents/java-agent)
-* [.NET](/docs/agents/net-agent)
-* [Node.js](/docs/agents/nodejs-agent)
-* [PHP](/docs/agents/php-agent)
-* [Python](/docs/agents/python-agent)
-* [Ruby](/docs/agents/ruby-agent)
-
-## Agent release notes [#agent-releases]
-
-Here are links to New Relic release notes organized by agent languages:
-
-* [Go](/docs/release-notes/agent-release-notes/go-release-notes)
-* [Java](/docs/release-notes/agent-release-notes/java-release-notes)
-* [.NET](/docs/release-notes/agent-release-notes/net-release-notes)
-* [Node.js](/docs/release-notes/agent-release-notes/nodejs-release-notes)
-* [PHP](/docs/release-notes/agent-release-notes/php-release-notes)
-* [Python](/docs/release-notes/agent-release-notes/python-release-notes)
-* [Ruby](/docs/release-notes/agent-release-notes/ruby-release-notes)
+The entry point for New Relic docs: [docs.newrelic.com](https://docs.newrelic.com). 
 
 ## Online Technical Community [#community]
 

--- a/src/content/docs/new-relic-solutions/solve-common-issues/find-help-use-support-portal.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/find-help-use-support-portal.mdx
@@ -49,7 +49,7 @@ New Relic offers a variety of support options, including online help, a troubles
 
 ## Find answers in New Relic Docs and New Relic University [#find-answers]
 
-New Relic's [docs site](https://docs.newrelic.com/) contains helpful installation, configuration, and troubleshooting tips. From the [main page](http://docs.newrelic.com), select from frequently-used categories and topics, like [release notes](/docs/release-notes). Or, [search from any page](http://docs.newrelic.com/search).
+New Relic's [docs site](https://docs.newrelic.com) contains helpful installation, configuration, and troubleshooting tips. From the [main page](http://docs.newrelic.com), select from frequently-used categories and topics, like [release notes](/docs/release-notes). Or, [search from any page](http://docs.newrelic.com/search).
 
 For a library of additional videos, webinars, and other information about using New Relic features, visit [New Relic University](https://learn.newrelic.com/) and [newrelic.com/resources](https://newrelic.com/resources/videos).
 

--- a/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/not-seeing-data.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/not-seeing-data.mdx
@@ -87,6 +87,6 @@ Follow the troubleshooting procedures for your mobile app:
 * [iOS](/docs/mobile-monitoring/mobile-monitoring-installation/ios/no-data-appears-ios)
 * [Android](/docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/no-data-appears-android)
 
-### Other factors affecting access [#more-info]
+## Other factors affecting access [#more-info]
 
 For more on factors that can affect your ability to access New Relic features, see [Factors affecting access](/docs/accounts/accounts-billing/general-account-settings/factors-affecting-access-features-data).


### PR DESCRIPTION
DOC-7645. Attempts to remove as many references to auto-index/category URLs as possible. This was focused on troubleshooting docs but a few other things, too. 