### PR TITLE
fix helm chart link

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
@@ -394,7 +394,7 @@ To start the CPM, follow the applicable Docker or Kubernetes instructions.
        * If you are copying the charts for the first time:
 
          ```
-         helm repo add <var>YOUR_REPO_NAME</var> https://helm-charts.newrelic.com/charts
+         helm repo add <var>YOUR_REPO_NAME</var> https://helm-charts.newrelic.com
          ```
        * If you previously copied the Helm charts from the New Relic Helm repo, then get the latest:
 


### PR DESCRIPTION
The /charts path redirects to our old chart, but that is no longer maintained.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.