### PR TITLE
.NET agent: Clarify custom error priority over configured ignored status codes

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1926,6 +1926,12 @@ The `errorCollector` element supports the following elements and attributes:
     </table>
 
     Lists specific HTTP error codes to not report to New Relic. You can use standard integral HTTP error codes, such as just 401, or you may use Microsoft full status codes with decimal points, such as 401.4 or 403.18. The status codes should be equal to or greater than 400.
+
+    <Callout variant="tip">
+      Custom errors reported with the agent's [`NoticeError()` API](/docs/agents/net-agent/net-agent-api/noticeerror-net-agent) are still reported to New Relic even if the associated transaction has an HTTP status code configured here.
+    </Callout>
+
+
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/net-agent/net-agent-api/noticeerror-net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/noticeerror-net-agent-api.mdx
@@ -43,6 +43,10 @@ If this method is invoked within a [transaction](/docs/accounts-partnerships/edu
   For an overview of error configuration in APM, see [Manage errors in APM](/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-mark-expected).
 </Callout>
 
+<Callout variant="tip">
+  Errors reported with this API are still sent to New Relic when they are reported within a transaction that results in an HTTP status code that is configured to be ignored by agent configuration, e.g. 404.
+</Callout>
+
 ## Parameters
 
 <table>


### PR DESCRIPTION
This PR adds some clarification regarding the expected behavior of custom error reporting with the `NoticeError()` API vs. agent configuration to ignore HTTP status code errors.  The API takes precedence; we had a support ticket with a customer who was expecting the opposite so hopefully this helps clear up the ambiguity.