### PR TITLE
SINCE, UNTIL, and LIMIT not supported

### DIFF
--- a/src/content/docs/data-apis/manage-data/drop-data-using-nerdgraph.mdx
+++ b/src/content/docs/data-apis/manage-data/drop-data-using-nerdgraph.mdx
@@ -82,7 +82,9 @@ There are two ways to drop data:
 
 ## NRQL restrictions [#restrictions]
 
-Not all NRQL clauses make sense for generating drop rules. You can provide a [`WHERE`](/docs/query-data/nrql-new-relic-query-language/getting-started/nrql-syntax-clauses-functions#sel-where) clause to select data with specific attributes. Other features such as `TIMESERIES`, `COMPARE WITH`, `FACET`, and other clauses cannot be used.
+Not all NRQL clauses make sense for generating drop rules. You can provide a [`WHERE`](/docs/query-data/nrql-new-relic-query-language/getting-started/nrql-syntax-clauses-functions#sel-where) clause to select data with specific attributes. Other features such as `LIMIT`, `TIMESERIES`, `COMPARE WITH`, `FACET`, and other clauses cannot be used.
+
+`SINCE` and `UNTIL` are not supported in drop rules. If you have time-specific rules (say, drop everything until a time in the future), use `WHERE timestamp < (epoch milliseconds in the future)`. You also can't use `SINCE` to drop historical data: NRQL drop rules only apply to data reported after the drop rule was created. If you need to delete data that has already been reported, contact your New Relic representative.
 
 The two action types have these restrictions:
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

Attempting to prevent customer confusion. These keywords were never supported. However, New Relic didn't prevent users from supplying them. The data demonstrates confusion on how this feature works. We are updating the documentation now and we will prevent these rules from being created in the future.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.