### PR TITLE
Add dockerfile for local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.cache/
+node_modules/
+public/
+.dockerignore
+Dockerfile
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# This Dockerfile is a community contribution and is not maintained by the New Relic Docs team.
+# Use it at your own risk!
+#
+# docker build . -t docs-preview
+# docker run -ti --rm -p 8080:80 docs-preview
+# http://localhost:8080
+
+FROM node:16 as build
+
+WORKDIR /app
+
+# Pull dependencies
+ADD package.json yarn.lock .nvmrc /app/
+RUN yarn
+
+ADD . /app
+RUN yarn build
+
+FROM nginx
+COPY --from=build /app/public /usr/share/nginx/html
+RUN chmod 644 -R /usr/share/nginx/html &&\
+    find /usr/share/nginx/html -type d -execdir chmod 755 {} +


### PR DESCRIPTION
## Give us some context

Dependencies required to build docs locally are quite heavy and might clutter developer's machines. This Dockerfile yields a production-ready image based on `nginx` with the docs site built inside it.

Limitations:
- Docker image wil be big, around 3 GiB in size
- Dependencies will be cached, but intermediate builds unfortunately won't. This means that each build can take a long time, around `600s` in my local machine.

Developed while working on #5742 