### PR TITLE
chore: adding notes based on new ktranslate logs available

### DIFF
--- a/src/content/docs/network-performance-monitoring/troubleshooting/snmp-polling-missing-metrics.mdx
+++ b/src/content/docs/network-performance-monitoring/troubleshooting/snmp-polling-missing-metrics.mdx
@@ -75,7 +75,31 @@ You should always pull the latest image for your container before making changes
 
 ### Verify ktranslate is polling the device as expected [#verify-ktranslate-polling]
 
-If the previous test passes, you should run a single SNMP poll against your device to see exactly what **ktranslate** receives from the request, using the supplied configuration.
+If the previous test passes, you should check your account for `Warn`-severity errors that signify **ktranslate** having issues collecting certain metrics from your device.
+
+Logs UI:
+
+```shell
+collector.name:"ktranslate" message:"*OID failed to return results*"
+```
+
+NRQL:
+
+```sql
+FROM Log SELECT * WHERE `collector.name` = 'ktranslate' AND `message` LIKE '%OID failed to return results%'
+```
+
+Expected Results:
+
+```
+KTranslate>cisco-7513 OID failed to return results, Metric Name: ipIfStatsHCInOctets, Profile: cisco-asr
+```
+
+<Callout variant="tip">
+In this example, you can see that the target device, `cisco-7513` is not returning metrics for the `ipIfStatsHCInOctets` OID, which is found in the `cisco-asr` SNMP profile.
+</Callout>
+
+Next, you should run a single SNMP poll against your device to see exactly what **ktranslate** receives from the request, using the supplied configuration.
 
 To do this, you can run **ktranslate** as a short-lived container, utilizing the `-snmp_poll_now` flag to target your device based on its name in the `snmp-base.yaml` configuration file. For example:
 


### PR DESCRIPTION
updating one of the NPM troubleshooting docs to add notes about new logs that are available from the **ktranslate** container. 