### PR TITLE
fix(Logs Kinesis Firehose): CF-10272

### DIFF
--- a/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
+++ b/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
@@ -35,7 +35,9 @@ To forward your logs from Kinesis Data Firehose to New Relic:
   **Note**: To send your logs to the EU, complete the remaining steps in this section, then proceed to the [configuration procedures for EU accounts](#configure-eu-stream).
 
 7. Paste your [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key) in the **API key** field.
-8. Configure and review the remaining settings.
+8. Configure and review the remaining metadata settings.
+
+Any optional key/value pairs you add in the AWS Management Console will result in attribute/value pairs you can use in New Relic.
 
 ## Configure your stream to send logs to EU accounts [#configure-eu-stream]
 


### PR DESCRIPTION
Added clarification that optional metadata settings in AWS = attribute/value pairs in New Relic