### PR TITLE
Clarify the Browser agent cookie behavior

### DIFF
--- a/src/content/docs/browser/browser-monitoring/page-load-timing-resources/cookie-collection-session-tracking.mdx
+++ b/src/content/docs/browser/browser-monitoring/page-load-timing-resources/cookie-collection-session-tracking.mdx
@@ -31,7 +31,7 @@ Session tracking will not work properly in these situations:
 
 ## Enable or disable cookie collection [#settings]
 
-At New Relic, we take data privacy seriously. By default, we do not retain any personal data collected by our browser agent, and you can control session tracking. To turn cookie collection on or off for your app:
+At New Relic, we take data privacy seriously. By default, we do not retain any personal data collected by our browser agent, and you can control session tracking.  If you want to enable or disable cookie storage on web browsers of visitors to your website:
 
 1. Go to **[one.newrelic.com](https://one.newrelic.com) > Browser > (select an app) > Settings > Application settings**.
-2. In your app's **Privacy** settings, toggle **Cookie collection**.
+2. In your app's **Privacy** settings, toggle **Cookie storage**.

--- a/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
+++ b/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
@@ -111,6 +111,10 @@ Instrumentation is compatible with every browser type, including Google Chrome, 
   </tbody>
 </table>
 
+<Callout variant="important">
+  When you use New Relic Browser with cookies, New Relic’s cookies are a third-party cookie on your site. New Relic’s third-party cookies may not store or work on certain web browsers used by your visitors. See the applicable browser’s websites for details about their compatibility with third-party cookies.
+</Callout>
+
 ## APM agents
 
 You can deploy the browser agent for apps monitored by APM, or you can deploy the browser agent for your standalone apps. For more information, see the [installation procedures](/docs/browser/new-relic-browser/getting-started/adding-apps-new-relic-browser).

--- a/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
+++ b/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
@@ -13,7 +13,7 @@ redirects:
 
 Browser monitoring includes [strict security measures](/docs/browser/new-relic-browser/performance-quality/security-new-relic-browser) to provide a robust, standalone product with browser monitoring features. Before you [install the browser agent](/docs/browser/new-relic-browser/getting-started/adding-apps-new-relic-browser), make sure your system meets these requirements.
 
-Want to try out our browser monitoring? [Create a New Relic account](https://newrelic.com/signup) for free! No credit card required.
+Want to try out our browser monitoring agent? [Create a New Relic account](https://newrelic.com/signup)... It's for free, forever! No credit card required.
 
 ## Basic requirements [#requirements]
 
@@ -33,7 +33,7 @@ Most typical browser applications meet these requirements. However, browser appl
 
 For more information, review the [instrumentation for browser monitoring](/docs/browser/new-relic-browser/page-load-timing-resources/instrumentation-browser-monitoring) documentation, and verify [end-user network access](/docs/browser/new-relic-browser/troubleshooting/troubleshooting-browser-monitoring-installation#manual_network_access).
 
-## Browser types
+## Browser types [#browser-types]
 
 Instrumentation is compatible with every browser type, including Google Chrome, Mozilla Firefox, Microsoft Internet Explorer and Edge, and Apple Safari. The user interface is compatible with [New Relic's supported browser versions](/docs/data-analysis/user-interface-functions/view-your-data/supported-browsers-new-relics-ui).
 
@@ -112,14 +112,14 @@ Instrumentation is compatible with every browser type, including Google Chrome, 
 </table>
 
 <Callout variant="important">
-  When you use New Relic Browser with cookies, New Relic’s cookies are a third-party cookie on your site. New Relic’s third-party cookies may not store or work on certain web browsers used by your visitors. See the applicable browser’s websites for details about their compatibility with third-party cookies.
+  When you use browser monitoring with cookies, New Relic's cookies are a third-party cookie on your site, and may not store or work on certain web browsers used by your visitors. See the applicable browser's websites for details about their compatibility with third-party cookies.
 </Callout>
 
-## APM agents
+## APM agents [#apm-agents]
 
 You can deploy the browser agent for apps monitored by APM, or you can deploy the browser agent for your standalone apps. For more information, see the [installation procedures](/docs/browser/new-relic-browser/getting-started/adding-apps-new-relic-browser).
 
-If you are deploying browser for an app using APM, make sure your agent supports browser monitoring:
+If you're deploying browser for an app using APM, make sure your agent supports browser monitoring:
 
 * [C SDK](/docs/release-notes/agent-release-notes/c-sdk-release-notes): Version 1.0.0 or higher
 * [Go](/docs/release-notes/agent-release-notes/go-release-notes): Version 2.5.0 or higher


### PR DESCRIPTION
In response to some customer feedback, this PR updates our description of how the cookies the Browser agent stores behave. It clarifies the behavior of cookies when multiple sites open on a user's browser have the Browser agent running. A corresponding change is being made in the UI to clarify this same behavior.