### PR TITLE
fix(errors inbox): remove EU callout

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
@@ -43,7 +43,6 @@ New Relic offers almost all the same active products, features, support offering
 
 * [Infinite Tracing](/docs/understand-dependencies/distributed-tracing/infinite-tracing/introduction-infinite-tracing) is not available.
 * APM's [weekly performance reports](/docs/apm/reports/other-performance-analysis/weekly-performance-report) are not available.
-* [Errors inbox](/docs/apm/apm-ui-pages/errors-inbox/errors-inbox/) is not available.
 * [Log patterns](/docs/logs/log-management/ui-data/find-unusual-logs-log-patterns/#availability)
 * Deprecated products and features are not available.
 


### PR DESCRIPTION
Errors inbox is now available in the EU. This removes a reference saying it is not. 