### PR TITLE
chore: Update redis tutorial to use "replica"

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/link-apps-services/tutorial-monitor-redis-running-kubernetes.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/link-apps-services/tutorial-monitor-redis-running-kubernetes.mdx
@@ -34,7 +34,7 @@ If you'd like to first complete the [Kubernetes tutorial](https://kubernetes.io/
 
 ## Step 2: Enable monitoring of Redis instances [#monitor-redis]
 
-The PHP Guestbook application has three Redis instances: one master and two slave instances. Each instance is tagged with a label where `app=redis`. For this example, we're using our [Redis monitoring integration](/docs/integrations/host-integrations/host-integrations-list/redis-monitoring-integration). It can monitor both master and slave instances of Redis, so we don’t have to distinguish between them.
+The PHP Guestbook application has three Redis instances: one master and two replica instances. Each instance is tagged with a label where `app=redis`. For this example, we're using our [Redis monitoring integration](/docs/integrations/host-integrations/host-integrations-list/redis-monitoring-integration). It can monitor both master and replica instances of Redis, so we don’t have to distinguish between them.
 
 1. In the Kubernetes integration's YAML config file (`newrelic-infrastructure-k8s-latest.yaml`), you need to update the `nri-integration-cfg` section. From [the list of integration configs](/docs/monitor-service-running-kubernetes#integration-configs), get the Redis integration YAML and add it to the Kubernetes config. The Redis YAML is highlighted below.
 


### PR DESCRIPTION
Sounds like Redis is moving to using "replica" instead of "slave", see https://redis.io/commands/SLAVEOF

(This is Mary Ann from the Virtuoso team at NR, using my personal GH account.)

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

> * What problems does this PR solve?

Removes outdated and potentially offensive language.
