### PR TITLE
[i18n] Fix erroneous slash in path used in database where clauses

### DIFF
--- a/scripts/actions/fetch-and-deserialize.js
+++ b/scripts/actions/fetch-and-deserialize.js
@@ -177,7 +177,7 @@ const deserializeHtmlToMdx = (locale) => {
    * @returns {Promise<SlugStatus>}
    */
   return async ({ path: contentPath, html }) => {
-    const completePath = path.join('src/content/docs', contentPath, '.mdx');
+    const completePath = `${path.join('src/content/docs', contentPath)}.mdx`;
 
     try {
       const localePath = path.join(

--- a/scripts/actions/utils/docs-content-tools/i18n-exclusions.yml
+++ b/scripts/actions/utils/docs-content-tools/i18n-exclusions.yml
@@ -11,3 +11,5 @@ excludePath:
     - src/content/docs/security/security-privacy/compliance
     - scripts/actions/__tests__/kitchen-sink.mdx
     - src/content/docs/infrastructure/manage-your-data/data-instrumentation/host-integrations-metrics.mdx
+excludeType:
+  ja-JP:


### PR DESCRIPTION
## Description

Fixes an issue where in the `deserializeHtmlToMdx()` the `completePath` had a trailing slash before `.mdx` like so:

```
src/content/docs/path/to/file/.mdx
```

That path won't match with that file's `slug` value in database:
```
src/content/docs/path/to/file.mdx
```

That `completePath` is returned by that method in the `slug` field to do other stuff, including updating the DB. It wasn't matching on `slug` and thus not updating the database and thus was returning an empty array that caused the error.

This also re-adds empty `excludeType` to MT exclusions YAML file because i noticed a warning in the console when trying to use that field in determining if a file should be queued up for MT.

## Related issues / PRs
Closes https://github.com/newrelic/docs-website/issues/5842