### PR TITLE
User type capabilities: clarify log mgmt capabilities

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -187,7 +187,8 @@ Here's a detailed comparison of capabilities by user type. For tips on why you'd
           <td style="text-align:center"><Icon
               style={{color: '#328787'}}
               name="fe-check"
-            /></td>
+            />
+            </td>
           <td style="text-align:center"><Icon
               style={{color: '#328787'}}
               name="fe-check"
@@ -584,7 +585,10 @@ Here are more details about how user type impacts access to applied intelligence
 On January 12, 2022, basic users had some log management capabilities removed. Their current capabilities are described below. 
 </Callout>
 
-Basic users can only view and search the [log management UI](/docs/logs/get-started/get-started-log-management). They don't have access to the more advanced log management features, such as [patterns](/docs/logs/ui-data/find-unusual-logs-log-patterns), [live tail](/docs/logs/troubleshooting/view-log-messages-real-time-live-tail), [parsing](/docs/logs/ui-data/parsing), and [data partitions](/docs/logs/ui-data/data-partitions).  
+Log-related capabilities: 
+* Basic users: can only view and search the [log management UI](/docs/logs/get-started/get-started-log-management). They don't have access to the more advanced log management features described below. 
+* Core users: have access to log management UI features, but not log data management and configuration capabilities or [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents).
+* Full platform users: Have access to all log management features, including [patterns](/docs/logs/ui-data/find-unusual-logs-log-patterns), parsing](/docs/logs/ui-data/parsing), [data partitions](/docs/logs/ui-data/data-partitions), and [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents). 
 
 </Collapser>  
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -577,7 +577,7 @@ On January 12, 2022, basic users had some log management capabilities removed. T
 Log-related capabilities: 
 * Basic users: can only view and search the [log management UI](/docs/logs/get-started/get-started-log-management). They don't have access to the more advanced log management features described below. 
 * Core users: have access to log management UI features, but not log data management and configuration. They have access to [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents) for any UI experiences they can access (for example, errors inbox).
-* Full platform users: Have access to all log management features, including [patterns](/docs/logs/ui-data/find-unusual-logs-log-patterns), parsing](/docs/logs/ui-data/parsing), [data partitions](/docs/logs/ui-data/data-partitions), and [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents). 
+* Full platform users: Have access to all log management features, including [patterns](/docs/logs/ui-data/find-unusual-logs-log-patterns), [parsing](/docs/logs/ui-data/parsing), [data partitions](/docs/logs/ui-data/data-partitions), and [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents). 
 
 </Collapser>  
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -575,9 +575,9 @@ On January 12, 2022, basic users had some log management capabilities removed. T
 </Callout>
 
 Log-related capabilities: 
-* **Basic users** can only view and search the [log management UI](/docs/logs/get-started/get-started-log-management). They don't have access to the more advanced log management features described below. 
-* **Core users** have access to log management UI features, but not log data management and configuration. They have access to [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents) for any UI experiences they can access (for example, errors inbox).
-* **Full platform users** have access to all log management features, including [patterns](/docs/logs/ui-data/find-unusual-logs-log-patterns), [parsing](/docs/logs/ui-data/parsing), [data partitions](/docs/logs/ui-data/data-partitions), and [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents). 
+* **Basic users** can view and search the [log management UI](/docs/logs/get-started/get-started-log-management).
+* **Core users** can see and use all log management UI features, but can't configure log data. They can use [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents) for any UI they have access to (for example, errors inbox).
+* **Full platform users** can use all log management features, including configuring log data. 
 
 </Collapser>  
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -575,9 +575,9 @@ On January 12, 2022, basic users had some log management capabilities removed. T
 </Callout>
 
 Log-related capabilities: 
-* Basic users: can only view and search the [log management UI](/docs/logs/get-started/get-started-log-management). They don't have access to the more advanced log management features described below. 
-* Core users: have access to log management UI features, but not log data management and configuration. They have access to [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents) for any UI experiences they can access (for example, errors inbox).
-* Full platform users: Have access to all log management features, including [patterns](/docs/logs/ui-data/find-unusual-logs-log-patterns), [parsing](/docs/logs/ui-data/parsing), [data partitions](/docs/logs/ui-data/data-partitions), and [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents). 
+* **Basic users** can only view and search the [log management UI](/docs/logs/get-started/get-started-log-management). They don't have access to the more advanced log management features described below. 
+* **Core users** have access to log management UI features, but not log data management and configuration. They have access to [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents) for any UI experiences they can access (for example, errors inbox).
+* **Full platform users** have access to all log management features, including [patterns](/docs/logs/ui-data/find-unusual-logs-log-patterns), [parsing](/docs/logs/ui-data/parsing), [data partitions](/docs/logs/ui-data/data-partitions), and [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents). 
 
 </Collapser>  
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -346,17 +346,6 @@ Here's a detailed comparison of capabilities by user type. For tips on why you'd
         </tr>
      <tr>
           <td>
-            [Logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents)
-          </td>
-          <td style="text-align:center"></td>
-          <td></td>
-          <td style="text-align:center"><Icon
-              style={{color: '#328787'}}
-              name="fe-check"
-            /></td>
-        </tr>
-     <tr>
-          <td>
             [Network performance monitoring](/docs/network-performance-monitoring/get-started/npm-introduction) (NPM)
           </td>
           <td style="text-align:center"></td>
@@ -587,7 +576,7 @@ On January 12, 2022, basic users had some log management capabilities removed. T
 
 Log-related capabilities: 
 * Basic users: can only view and search the [log management UI](/docs/logs/get-started/get-started-log-management). They don't have access to the more advanced log management features described below. 
-* Core users: have access to log management UI features, but not log data management and configuration capabilities or [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents).
+* Core users: have access to log management UI features, but not log data management and configuration. They have access to [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents) for any UI experiences they can access (for example, errors inbox).
 * Full platform users: Have access to all log management features, including [patterns](/docs/logs/ui-data/find-unusual-logs-log-patterns), parsing](/docs/logs/ui-data/parsing), [data partitions](/docs/logs/ui-data/data-partitions), and [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents). 
 
 </Collapser>  


### PR DESCRIPTION
User mgmt liaison work: clarifying log mgmt capabilities with improved footnote. Also removed separate 'logs in context' entry as having two logs entries was confusing IMO. 