### PR TITLE
External services fast-follow changes

### DIFF
--- a/src/content/docs/apm/apm-ui-pages/monitoring/external-services/external-services-intro.mdx
+++ b/src/content/docs/apm/apm-ui-pages/monitoring/external-services/external-services-intro.mdx
@@ -30,19 +30,6 @@ To use the external services feature, you need a New Relic account with an insta
 ![Screenshot showing the opening map for external services](./images/intro-example.png "Screenshot showing the opening map for external services")
 <figcaption>The thickness of the lines represents the throughput from your service to the upstream or downstream services. When you select a specific service, you will see the various endpoints making calls between the two services.</figcaption>
 
-## Relationship to classic external services [#classic-external-services]
-
-While you can still reach classic external services by using the UI toggle, the main external services UI is populated by data from distributed tracing. It still provides transaction data similar to classic external services, but here are some key things you need to know about the expanded external services: 
-
-  * **Dependency:** To use the external services feature, you need to enable distributed tracing on services that make calls to each other. 
-  * **Compatibility:** Distributed tracing is not backwards compatible with cross application tracing, so if you currently rely on classic external services, please note that you will only have visibility into calls between services using the same protocol. 
-  * **Data:** Unlike classic external services, the transaction-level detail of distributed tracing is based on sampling instead of metrics. This sampled data links into distributed tracing, which can give you deeper insights into what’s driving the performance of the transactions. 
-
-
-<Callout variant="tip">
-The external services feature does not support browser and mobile data.
-</Callout>
-
 ## When would you use external services? [#when-to-use]
 
 The external services feature is a tool you can use by itself to tune or troubleshoot a specific service. You can also use it as a starting point for additional troubleshooting with distributed tracing. 
@@ -58,6 +45,19 @@ Then, you can use distributed tracing to drill into more detail:
 
   1. Drill into distributed tracing and see in the trace that the calls in this transaction are doing something odd.
   2. Jump to that transaction on service B and see that it got slow after a deploy.
+
+## Relationship to classic external services [#classic-external-services]
+
+While you can still reach classic external services by using the UI toggle, the main external services UI is populated by data from distributed tracing. It still provides transaction data similar to classic external services, but here are some key things you need to know about the expanded external services: 
+
+  * **Dependency:** To use the external services feature, you need to enable distributed tracing on services that make calls to each other. 
+  * **Compatibility:** Distributed tracing is not backwards compatible with cross application tracing, so if you currently rely on classic external services, please note that you will only have visibility into calls between services using the same protocol. 
+  * **Data:** Unlike classic external services, the transaction-level detail of distributed tracing is based on sampling instead of metrics. This sampled data links into distributed tracing, which can give you deeper insights into what’s driving the performance of the transactions. 
+
+
+<Callout variant="tip">
+The external services feature does not support browser and mobile data.
+</Callout>
 
 ## What's next? [#next]
 

--- a/src/content/docs/data-apis/manage-data/view-system-limits.mdx
+++ b/src/content/docs/data-apis/manage-data/view-system-limits.mdx
@@ -220,7 +220,7 @@ The following table includes general max limits that apply across all New Relic 
       </td>
 
       <td>
-        Dependent on agreement. Max limit: 2M.
+        Max limit: 2M.
       </td>
     </tr>
 

--- a/src/content/docs/distributed-tracing/concepts/distributed-tracing-planning-guide.mdx
+++ b/src/content/docs/distributed-tracing/concepts/distributed-tracing-planning-guide.mdx
@@ -30,15 +30,6 @@ We may provide backward compatibility with some or all of the affected features 
 
 <CollapserGroup>
   <Collapser
-    id="external-details"
-    title="External services page has less detail"
-  >
-    When distributed tracing is enabled for an application, external calls do not have internal transaction details at **[one.newrelic.com](https://one.newrelic.com) > APM > (select an app) > Monitor > External services > (select external service)**.
-
-    To find that information, you would instead go to the **Distributed tracing** UI page, find the external call URLs, and see what their child spans are.
-  </Collapser>
-
-  <Collapser
     id="txn-trace-changes"
     title="Transaction trace UI displays service URLs, not transaction links"
   >


### PR DESCRIPTION
Reviewer, could you look at the following changes?

* In the introduction, I switched two sections around to highlight when you would use the feature.
* In the distributed tracing planning guide, I removed a collapser that had a warning that used to apply when you would enable DT. This is no longer applicable.
* In the limits topic, I removed an out of date comment about limit agreements for DT (per SME).
