### PR TITLE
Clarified authentication options

### DIFF
--- a/src/content/docs/logs/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-api/introduction-log-api.mdx
@@ -46,7 +46,7 @@ To send log data to your New Relic account via the Log API:
 1. Get your [New Relic license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).
 2. Review the [limits and restricted characters](#limits) for your JSON payload.
 3. Generate the JSON message using the required [headers](#json-headers) and [body](#json-body) fields.
-4. Ensure that your `Api-Key` or `License-Key` is included in your [headers](#json-headers) or [query parameters](#query-parameters). Refer to the [log JSON examples](#log-attribute-examples).
+4. Ensure that your `Api-Key` or `License-Key` is included in your [headers](#auth-headers) or [query parameters](#query-parameters). Refer to the [log JSON examples](#log-attribute-examples).
 5. Send your JSON message to the appropriate HTTP endpoint for your New Relic account in a `POST` request.
   * US: `https://log-api.newrelic.com/log/v1`
   * EU: `https://log-api.eu.newrelic.com/log/v1`
@@ -89,11 +89,38 @@ When creating your HTTP headers, use these guidelines:
       </td>
     </tr>
 
+  </tbody>
+</table>
+
+Gzipped JSON formatting is accepted. If sending compressed JSON, please include the `Content-Type: application/json` and `Content-Encoding: gzip` headers.
+
+## Authentication
+
+Your [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key) serves to authenticate your request to the Log API and determines the New Relic account where your submitted log message(s) will be written. It needs to to be passed as either an HTTP header or query string parameter.
+
+### Option 1: Authenticate using HTTP header [#auth-header]
+
+You can pass your license key by adding a custom HTTP header as described below:
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "200px" }}>
+        Header
+      </th>
+
+      <th>
+        Supported values
+      </th>
+    </tr>
+
+  </thead>
+
+  <tbody>
+
     <tr>
       <td>
         `Api-Key`
-
-        Required
       </td>
 
       <td>
@@ -104,11 +131,11 @@ When creating your HTTP headers, use these guidelines:
   </tbody>
 </table>
 
-Gzipped JSON formatting is accepted. If sending compressed JSON, please include the `Content-Type: application/json` and `Content-Encoding: gzip` headers.
+### Option 2: Authenticate using query string parameter ("headerless" authentication) [#query-parameters]
 
-## HTTP query parameters [#query-parameters]
+The license key can also be passed as a query string parameter in the URL. This can be useful when sending logs from cloud-based sources that don't allow custom HTTP request headers.
 
-The license key can also be passed as a query string parameter. This can be useful when sending logs from cloud-based sources that don't allow custom HTTP request headers.
+Example: `https://LOG_API_ENDPOINT/log/v1?Api-Key=YOUR_API_KEY_HERE`
 
 <table>
   <thead>
@@ -129,7 +156,7 @@ The license key can also be passed as a query string parameter. This can be usef
       </td>
 
       <td>
-        Your [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key). Use this key whenever you send a header.
+        Your [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key). You can also [send this via HTTP header](#auth-header).
       </td>
     </tr>
 
@@ -775,7 +802,7 @@ Log `POST` message example:
 POST /log/v1 HTTP/1.1
 Host: log-api.newrelic.com
 Content-Type: application/json
-X-License-Key: <var><YOUR_LICENSE_KEY></var>
+Api-Key: <var><YOUR_LICENSE_KEY></var>
 Accept: */*
 Content-Length: 319
 [{
@@ -907,7 +934,7 @@ Here's an example of a JSON POST request:
 POST /log/v1 HTTP/1.1
    Host: log-api.newrelic.com
    Content-Type: application/json
-   X-License-Key: <var><YOUR_LICENSE_KEY></var>
+   Api-Key: <var><YOUR_LICENSE_KEY></var>
    Accept: */*
    Content-Length: 133
    {

--- a/src/content/docs/logs/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-api/introduction-log-api.mdx
@@ -94,13 +94,13 @@ When creating your HTTP headers, use these guidelines:
 
 Gzipped JSON formatting is accepted. If sending compressed JSON, please include the `Content-Type: application/json` and `Content-Encoding: gzip` headers.
 
-## Authentication
+## Authentication [#authentication]
 
-Your [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key) serves to authenticate your request to the Log API and determines the New Relic account where your submitted log message(s) will be written. It needs to to be passed as either an HTTP header or query string parameter.
+Your [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key) serves to authenticate your request to the Log API, and determines the New Relic account where your submitted log message(s) will be written. It needs to be passed as either an HTTP header or a query string parameter.
 
 ### Option 1: Authenticate using HTTP header [#auth-header]
 
-You can pass your license key by adding a custom HTTP header as described below:
+Pass your license key by adding a custom HTTP header as described below:
 
 <table>
   <thead>
@@ -133,7 +133,7 @@ You can pass your license key by adding a custom HTTP header as described below:
 
 ### Option 2: Authenticate using query string parameter ("headerless" authentication) [#query-parameters]
 
-The license key can also be passed as a query string parameter in the URL. This can be useful when sending logs from cloud-based sources that don't allow custom HTTP request headers.
+The license key can also be passed as a query string parameter in the URL. This is useful when sending logs from cloud-based sources that don't allow custom HTTP request headers.
 
 Example: `https://LOG_API_ENDPOINT/log/v1?Api-Key=YOUR_API_KEY_HERE`
 


### PR DESCRIPTION
Authentication has been a source of confusion for users trying to directly utilise the Log API. Clarified the two available options and restructured slightly to make it clearer, as well as tidying up the examples.