### PR TITLE
feat: Add metadata injection list of env vars in link-your-applications-kubernetes.mdx

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/link-your-applications/link-your-applications-kubernetes.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/link-your-applications/link-your-applications-kubernetes.mdx
@@ -15,6 +15,18 @@ You can surface Kubernetes metadata and [link it to your APM agents](/docs/integ
 
 You can quickly start monitoring Kubernetes clusters using our Auto-telemetry with Pixie integration, which doesn't require a language agent. Learn more about [Auto-telemetry with Pixie](/docs/full-stack-observability/observe-everything/get-started/get-started-auto-telemetry-pixie).
 
+The metadata injection product uses a `MutatingAdmissionWebhook` to add the following environment variables to pods:
+
+```
+NEW_RELIC_METADATA_KUBERNETES_CLUSTER_NAME
+NEW_RELIC_METADATA_KUBERNETES_NODE_NAME
+NEW_RELIC_METADATA_KUBERNETES_NAMESPACE_NAME
+NEW_RELIC_METADATA_KUBERNETES_DEPLOYMENT_NAME
+NEW_RELIC_METADATA_KUBERNETES_POD_NAME
+NEW_RELIC_METADATA_KUBERNETES_CONTAINER_NAME
+NEW_RELIC_METADATA_KUBERNETES_CONTAINER_IMAGE_NAME
+```
+
 <Callout variant="tip">
   Our Kubernetes metadata injection project is open source. Here's the [code to link APM and infrastructure data](https://github.com/newrelic/k8s-metadata-injection/) and the [code to automatically manage certificates](https://github.com/newrelic/k8s-webhook-cert-manager).
 </Callout>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

The list of environment variables that are required for the k8s-apm linkage is hidden at the bottom of the page as an example of what to look for. Also, the example is missing the deployment related env var because it creates a pod directly.
