### PR TITLE
docs(ServiceLevel): SLO periods now include complete weeks

### DIFF
--- a/src/content/docs/release-notes/service-levels-release-notes/service-levels-20220127.mdx
+++ b/src/content/docs/release-notes/service-levels-release-notes/service-levels-20220127.mdx
@@ -24,4 +24,4 @@ We've added suggestions and validations for the NRQL queries on the setup flow, 
 
 SLO compliance results for rolling time windows are more consistent when they include complete weeks. This way, the calculation always includes the same amount of weekends, and any weekly seasonality doesn't impact the results depending on which day of the week you look at SLOs.
 
-Due to this fact, SLOs with a 30 days period are no longer supported, and any existing SLO previously configured with a 30 days period has been changed to 28 days.
+Due to this fact, SLOs with a 30-day period are no longer supported, and any existing SLO previously configured with a 30-day period has been changed to 28 days.

--- a/src/content/docs/release-notes/service-levels-release-notes/service-levels-20220127.mdx
+++ b/src/content/docs/release-notes/service-levels-release-notes/service-levels-20220127.mdx
@@ -17,3 +17,11 @@ You can learn more about our suggested service levels in [our docs](/docs/servic
 We've added suggestions and validations for the NRQL queries on the setup flow, so now it's easier to customize service level parameters and exceptions.
 
 ![Improved service level setup flow](./images/setup_flow.png "Improved service level setup flow")
+
+### Changes
+
+**SLO periods now only include complete weeks.**
+
+SLO compliance results for rolling time windows are more consistent when they include complete weeks. This way, the calculation always includes the same amount of weekends, and any weekly seasonality doesn't impact the results depending on which day of the week you look at SLOs.
+
+Due to this fact, SLOs with a 30 days period are no longer supported, and any existing SLO previously configured with a 30 days period has been changed to 28 days.

--- a/src/content/docs/service-level-management/faqs-slm.mdx
+++ b/src/content/docs/service-level-management/faqs-slm.mdx
@@ -128,3 +128,7 @@ Alternatively, you can find the SLI id and SLI attainment query through the Nerd
 ```
 
 Use the `entityGuid` of the entity that's associated with the SLI. On the query results, you’ll get the SLI id in the `serviceLevel.indicators.id` field.
+
+## Why do the SLO periods only include complete weeks? [#slo-periods-complete-weeks]
+
+SLO compliance results for rolling time windows are more consistent when they include complete weeks. This way, the calculation always includes the same amount of weekends, and any weekly seasonality doesn't impact the results depending on which day of the week you look at SLOs.


### PR DESCRIPTION
## Give us some context

Update the docs since now SLO periods in service levels only include complete weeks.

The changes include a new section in the release notes from the January 27 and a new question in the FAQs.