### PR TITLE
Update Ubuntu release names to match the official

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -236,25 +236,25 @@ To install infrastructure in Linux, follow these instructions:
        title={<><img src={ubuntuIcon} title="ubuntu icon" alt="ubuntu icon" style={{ height: '32px', width: '32px', verticalAlign: 'middle' }}/> Ubuntu</>}
      >
 
-       **Ubuntu 16 ("Xenial")**
+       **Ubuntu 16.04 LTS (Xenial Xerus)**
 
        ```
        printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt xenial main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
-       **Ubuntu 18 ("Bionic")**
+       **Ubuntu 18.04 LTS (Bionic Beaver)**
 
        ```
        printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt bionic main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
-       **Ubuntu 20 ("Focal")**
+       **Ubuntu 20.04 LTS (Focal Fossa)**
 
        ```
        printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt focal main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
-       **Ubuntu 20.10 ("Groovy")**
+       **Ubuntu 20.10 ("Groovy Gorilla")**
 
        ```
        printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt groovy main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -254,13 +254,13 @@ To install infrastructure in Linux, follow these instructions:
        printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt focal main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
-       **Ubuntu 20.10 ("Groovy Gorilla")**
+       **Ubuntu 20.10 (Groovy Gorilla)**
 
        ```
        printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt groovy main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
-       **Ubuntu 21.04 ("Hirsute Hippo")**
+       **Ubuntu 21.04 (Hirsute Hippo)**
 
        ```
        printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt hirsute main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list


### PR DESCRIPTION
A proposition to update the ubuntu releases to match the ones on the official site for release cycles https://ubuntu.com/about/release-cycle
The reason behind this is because as someone knew to ubuntu and using ubuntu, I am familiar with the official releases. I thought that since it confused me at first, looking at the NR docs, it may confuse others also. 

If there is a particular reason why the names are as they are on the docs please let me know. :) 

I am unsure if having the quotes is better or not. If you want them I can put them back in :) So it is consistent with the rest of the documentation. What is the reason behind the quotations? 

Thank you!

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
It allows the New Relic docs to be in sync with the official Ubuntu release names and versions as they are on the Ubuntu website and as people are familiar with. 
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.