### PR TITLE
Add important callout for endpoints not listed

### DIFF
--- a/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
+++ b/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
@@ -11,7 +11,11 @@ redirects:
   - /docs/fedramp-endpoint-logs-metrics
 ---
 
-This document provides information on FedRAMP-compliant endpoints in New Relic. For more information about our security accreditation for the Federal Risk and Authorization Management Program (FedRAMP), see our [data encryption](/docs/security/new-relic-security/compliance/data-encryption) documentation. For further information on New Relic networks, domains, and ports see our [networking](/docs/using-new-relic/cross-product-functions/install-configure/networks) documentation.
+This document provides information on FedRAMP-compliant endpoints in New Relic. For more information about our security accreditation for the Federal Risk and Authorization Management Program (FedRAMP), see our [data encryption](/docs/security/new-relic-security/compliance/data-encryption) documentation. For further information on New Relic networks, domains, and ports see our [networking](/docs/using-new-relic/welcome-new-relic/get-started/networks) documentation.
+
+<Callout variant="important">
+ If a service's endpoint is not listed in this document and the service is not found in our list of [services not in scope](/docs/security/security-privacy/compliance/certificates-standards-regulations/fedramp-moderate), then the service's standard endpoint already meets FedRAMP compliance requirements as-is, without the need for a distinct FedRAMP endpoint.
+</Callout>
 
 ## Customer FedRAMP obligations [#obligations]
 


### PR DESCRIPTION
Confusion arises when customers see that:

- We have a list of non-compliant services where Synthetics is not listed.
- We have a list of compliant endpoints where Synthetics is also not listed.

This callout helps to clarify that this list of FedRAMP compliant endpoints is for services who's main endpoint is non-compliant. If a service's endpoint is not listed here and is not a non-compliant service, then it is compliant.

If this doc edit needs approval from New Relic Security, let's do that.