### PR TITLE
chore: downgrade rehype-format to fix workflow send content error

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,5 +18,5 @@ module.exports = {
   setupFiles: ['<rootDir>/loadershim.js'],
   setupFilesAfterEnv: ['<rootDir>/setup-test-env.js'],
   testRegex: '(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$',
-  moduleFileExtensions: ['js', 'ts', 'tsx'],
+  moduleFileExtensions: ['js', 'ts', 'tsx', 'json'],
 };

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-spring": "9.1.2",
     "react-use": "^15.3.8",
     "react-use-measure": "^2.0.3",
-    "rehype-format": "^4.0.1",
+    "rehype-format": "^3.1.0",
     "rehype-parse": "^7.0.1",
     "rehype-raw": "^5.1.0",
     "rehype-remark": "^8.0.0",

--- a/scripts/actions/__tests__/__snapshots__/serialize-mdx.test.js.snap
+++ b/scripts/actions/__tests__/__snapshots__/serialize-mdx.test.js.snap
@@ -1,90 +1,424 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`kitchen sink 1`] = `
-"<div data-type=\\"frontmatter\\" data-value=\\"eyJ0aXRsZSI6IkVuYWJsZSBzZXJ2ZXJsZXNzIG1vbml0b3JpbmcgZm9yIEFXUyBMYW1iZGEiLCJjb250ZW50VHlwZSI6InBhZ2UiLCJ0ZW1wbGF0ZSI6ImJhc2ljRG9jIiwidG9waWNzIjpbXSwid2F0ZXJtYXJrIjoiQkVUQSIsInRyYW5zbGF0aW9uVHlwZSI6Imh1bWFuIn0=\\"><div data-key=\\"title\\">Enable serverless monitoring for AWS Lambda</div></div>
+"
+<div data-type=\\"frontmatter\\" data-value=\\"eyJ0aXRsZSI6IkVuYWJsZSBzZXJ2ZXJsZXNzIG1vbml0b3JpbmcgZm9yIEFXUyBMYW1iZGEiLCJjb250ZW50VHlwZSI6InBhZ2UiLCJ0ZW1wbGF0ZSI6ImJhc2ljRG9jIiwidG9waWNzIjpbXSwid2F0ZXJtYXJrIjoiQkVUQSIsInRyYW5zbGF0aW9uVHlwZSI6Imh1bWFuIn0=\\">
+  <div data-key=\\"title\\">Enable serverless monitoring for AWS Lambda</div>
+</div>
 <div data-type=\\"import\\" data-value=\\"aW1wb3J0IHsgTGluayB9IGZyb20gJ0BuZXdyZWxpYy9nYXRzYnktdGhlbWUtbmV3cmVsaWMn\\"></div>
 <p>New Relic defines a <a href=\\"/docs/apm/transactions/intro-transactions/transactions-new-relic-apm\\">web or non-web transaction</a> as one logical unit of work in a software application. Once you <a href=\\"/docs/instrument-transactions-c-agent\\">instrument a transaction</a>, you can also instrument errors in the transaction so you can monitor them in the New Relic UI. In order to use the C SDK to monitor errors, you must manually instrument your source code by adding the New Relic function <code>newrelic_notice_error()</code> to it.</p>
-<div data-type=\\"component\\" data-component=\\"Callout\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ2YXJpYW50IiwidmFsdWUiOiJ0aXAifV0=\\"><div data-type=\\"prop\\" data-prop=\\"children\\"><p>To include <var data-type=\\"component\\">function</var> calls in error traces, use GNU's <code>-rdynamic</code> linker flag to <a href=\\"/docs/install-c-agent-compile-link-your-code#compile\\">link your apps when compiling</a>. The <code>-rdynamic</code> linker flag gives you more meaningful error traces.</p></div></div>
-<h2 id=\\"in-page-toc\\">Contents </h2>
+<div data-type=\\"component\\" data-component=\\"Callout\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ2YXJpYW50IiwidmFsdWUiOiJ0aXAifV0=\\">
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <p>To include <var data-type=\\"component\\">function</var> calls in error traces, use GNU's <code>-rdynamic</code> linker flag to <a href=\\"/docs/install-c-agent-compile-link-your-code#compile\\">link your apps when compiling</a>. The <code>-rdynamic</code> linker flag gives you more meaningful error traces.</p>
+  </div>
+</div>
+<h2 id=\\"in-page-toc\\">Contents</h2>
 <p>For an index of <mark data-type=\\"component\\">documentation</mark> available during the private Beta, see the <a href=\\"https://docs.newrelic.com/docs/c-agent-table-contents\\">C SDK table of contents</a>.</p>
-<h2 id=\\"errors\\">Instrument errors in transactions </h2>
-<div data-type=\\"component\\" data-component=\\"Callout\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiQ29kZSJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ2YXJpYW50IiwidmFsdWUiOiJ0aXAifV0=\\"><div data-type=\\"prop\\" data-prop=\\"title\\">Code</div><div data-type=\\"prop\\" data-prop=\\"children\\"><p>To include function calls in error traces, use GNU's <code>-rdynamic</code> linker flag to <a href=\\"/docs/install-c-agent-compile-link-your-code#compile\\">link your apps when compiling</a>. The <code>-rdynamic</code> linker flag gives you more meaningful error traces.</p></div></div>
-<h2 id=\\"errors\\"><code>instrument_errors</code> </h2>
+<h2 id=\\"errors\\">Instrument errors in transactions</h2>
+<div data-type=\\"component\\" data-component=\\"Callout\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiQ29kZSJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ2YXJpYW50IiwidmFsdWUiOiJ0aXAifV0=\\">
+  <div data-type=\\"prop\\" data-prop=\\"title\\">Code</div>
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <p>To include function calls in error traces, use GNU's <code>-rdynamic</code> linker flag to <a href=\\"/docs/install-c-agent-compile-link-your-code#compile\\">link your apps when compiling</a>. The <code>-rdynamic</code> linker flag gives you more meaningful error traces.</p>
+  </div>
+</div>
+<h2 id=\\"errors\\"><code>instrument_errors</code></h2>
 <p>To instrument errors in transactions:</p>
 <ol>
-<li><a href=\\"/docs/instrument-transactions-c-agent#start-transaction\\">Start a transaction</a>.</li>
-<li>Record an with <a href=\\"https://source.datanerd.us/c-agent/c-agent/blob/master/examples/ex_notice_error.c\\"><code>newrelic_notice_error()</code></a>, supplying the required parameters.</li>
-<li><a href=\\"/docs/instrument-transactions-c-agent#end-transaction\\">End the transaction</a>.</li>
+  <li><a href=\\"/docs/instrument-transactions-c-agent#start-transaction\\">Start a transaction</a>.</li>
+  <li>Record an with <a href=\\"https://source.datanerd.us/c-agent/c-agent/blob/master/examples/ex_notice_error.c\\"><code>newrelic_notice_error()</code></a>, supplying the required parameters.</li>
+  <li><a href=\\"/docs/instrument-transactions-c-agent#end-transaction\\">End the transaction</a>.</li>
 </ol>
-<div data-type=\\"component\\" data-component=\\"ImageSizing\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ3aWR0aCIsInZhbHVlIjoiMzJweCJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJoZWlnaHQiLCJ2YWx1ZSI6IjMycHgifV0=\\"><div data-type=\\"prop\\" data-prop=\\"children\\"><p><img src=\\"./images/debian.png\\" alt=\\"debian.png\\"></p></div></div>
+<div data-type=\\"component\\" data-component=\\"ImageSizing\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ3aWR0aCIsInZhbHVlIjoiMzJweCJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJoZWlnaHQiLCJ2YWx1ZSI6IjMycHgifV0=\\">
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <p>
+      <img src=\\"./images/debian.png\\" alt=\\"debian.png\\">
+    </p>
+  </div>
+</div>
 <p>This is a test with an inline image <span data-type=\\"component\\" data-component=\\"ImageSizing\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ3aWR0aCIsInZhbHVlIjoiMzJweCJ9XQ==\\"><span data-type=\\"prop\\" data-prop=\\"children\\"><img src=\\"./images/image.png\\" alt=\\"image.png\\"></span></span></p>
-<table data-type=\\"component\\"><thead data-type=\\"component\\"><tr data-type=\\"component\\"><th data-type=\\"component\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJzdHlsZSIsInZhbHVlIjp7InR5cGUiOiJtZHhWYWx1ZUV4cHJlc3Npb24iLCJ2YWx1ZSI6Insgd2lkdGg6IFwiMjAwcHhcIiB9IiwicG9zaXRpb24iOnsic3RhcnQiOnsibGluZSI6NTEsImNvbHVtbiI6MTcsIm9mZnNldCI6MjE4MX0sImVuZCI6eyJsaW5lIjo1MSwiY29sdW1uIjozNywib2Zmc2V0IjoyMjAxfX19fV0=\\"><p><strong>If you want to...</strong></p></th><th data-type=\\"component\\"><p><strong>Do this...</strong></p></th></tr></thead><tbody data-type=\\"component\\"><tr data-type=\\"component\\"><td data-type=\\"component\\"><p>Run recent queries</p></td><td data-type=\\"component\\"><p>Select a recent query from the history list. The query will appear on the command line, where it can be edited.</p></td></tr><tr data-type=\\"component\\"><td data-type=\\"component\\"><p>Delete queries</p></td><td data-type=\\"component\\"><p>Mouse over a query in the history list so the delete <span data-type=\\"component\\" data-component=\\"Icon\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJmZS10cmFzaC0yIn1d\\"> </span> icon appears. The query history only retains the twenty most recent queries, so it can be useful to delete unwanted queries to make room for queries you like.</p></td></tr><tr data-type=\\"component\\"><td data-type=\\"component\\"><p>Favorite queries</p></td><td data-type=\\"component\\"><p>Mouse over a query in the history list and the favorite <span data-type=\\"component\\" data-component=\\"Icon\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJmZS1zdGFyIn1d\\"> </span> icon appears. Then, to view and use your favorite queries, select the <strong>Favorites</strong> tab.</p></td></tr></tbody></table>
+<table data-type=\\"component\\">
+  <thead data-type=\\"component\\">
+    <tr data-type=\\"component\\">
+      <th data-type=\\"component\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJzdHlsZSIsInZhbHVlIjp7InR5cGUiOiJtZHhWYWx1ZUV4cHJlc3Npb24iLCJ2YWx1ZSI6Insgd2lkdGg6IFwiMjAwcHhcIiB9IiwicG9zaXRpb24iOnsic3RhcnQiOnsibGluZSI6NTEsImNvbHVtbiI6MTcsIm9mZnNldCI6MjE4MX0sImVuZCI6eyJsaW5lIjo1MSwiY29sdW1uIjozNywib2Zmc2V0IjoyMjAxfX19fV0=\\">
+        <p><strong>If you want to...</strong></p>
+      </th>
+      <th data-type=\\"component\\">
+        <p><strong>Do this...</strong></p>
+      </th>
+    </tr>
+  </thead>
+  <tbody data-type=\\"component\\">
+    <tr data-type=\\"component\\">
+      <td data-type=\\"component\\">
+        <p>Run recent queries</p>
+      </td>
+      <td data-type=\\"component\\">
+        <p>Select a recent query from the history list. The query will appear on the command line, where it can be edited.</p>
+      </td>
+    </tr>
+    <tr data-type=\\"component\\">
+      <td data-type=\\"component\\">
+        <p>Delete queries</p>
+      </td>
+      <td data-type=\\"component\\">
+        <p>Mouse over a query in the history list so the delete <span data-type=\\"component\\" data-component=\\"Icon\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJmZS10cmFzaC0yIn1d\\"> </span> icon appears. The query history only retains the twenty most recent queries, so it can be useful to delete unwanted queries to make room for queries you like.</p>
+      </td>
+    </tr>
+    <tr data-type=\\"component\\">
+      <td data-type=\\"component\\">
+        <p>Favorite queries</p>
+      </td>
+      <td data-type=\\"component\\">
+        <p>Mouse over a query in the history list and the favorite <span data-type=\\"component\\" data-component=\\"Icon\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJmZS1zdGFyIn1d\\"> </span> icon appears. Then, to view and use your favorite queries, select the <strong>Favorites</strong> tab.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
 <pre data-type=\\"component\\" data-component=\\"CodeBlock\\" data-props=\\"eyJsYW5nIjoicHl0aG9uIiwibWV0YSI6ImNvcHlhYmxlPWZhbHNlIiwidmFsdWUiOiJAbmV3cmVsaWMuYWdlbnQubGFtYmRhX2hhbmRsZXIoKVxuZGVmIGhhbmRsZXIoZXZlbnQsIGNvbnRleHQpOlxuICAgIG5ld3JlbGljLmFnZW50LnJlY29yZF9jdXN0b21fZXZlbnQoJ0N1c3RvbUV2ZW50Jywgeydmb28nOiAnYmFyJ30pIiwicG9zaXRpb24iOnsic3RhcnQiOnsibGluZSI6OTQsImNvbHVtbiI6MSwib2Zmc2V0IjozMTYyfSwiZW5kIjp7ImxpbmUiOjk4LCJjb2x1bW4iOjQsIm9mZnNldCI6MzMyMn0sImluZGVudCI6WzEsMSwxLDFdfX0=\\"></pre>
-<div data-type=\\"component\\" data-component=\\"TechTileGrid\\"><div data-type=\\"prop\\" data-prop=\\"children\\"><div data-type=\\"component\\" data-component=\\"TechTile\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJpT1MifSx7InR5cGUiOiJtZHhBdHRyaWJ1dGUiLCJuYW1lIjoiaWNvbiIsInZhbHVlIjoibG9nby1hcHBsZSJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0byIsInZhbHVlIjoiL2FnZW50cy9pb3MtYWdlbnQifV0=\\"><div data-type=\\"prop\\" data-prop=\\"name\\">iOS</div></div><div data-type=\\"component\\" data-component=\\"TechTile\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJBbmRyb2lkIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6Imljb24iLCJ2YWx1ZSI6ImxvZ28tYW5kcm9pZCJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0byIsInZhbHVlIjoiL2FnZW50cy9hbmRyb2lkLWFnZW50In1d\\"><div data-type=\\"prop\\" data-prop=\\"name\\">Android</div></div><div data-type=\\"component\\" data-component=\\"TechTile\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJ0dk9TIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6Imljb24iLCJ2YWx1ZSI6ImxvZ28tYXBwbGUifSx7InR5cGUiOiJtZHhBdHRyaWJ1dGUiLCJuYW1lIjoidG8iLCJ2YWx1ZSI6Ii9hZ2VudHMvdHZvcy1hZ2VudCJ9XQ==\\"><div data-type=\\"prop\\" data-prop=\\"name\\">tvOS</div></div></div></div>
-<div data-type=\\"component\\" data-component=\\"CollapserGroup\\"><div data-type=\\"prop\\" data-prop=\\"children\\"><div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJpZCIsInZhbHVlIjoiZXZlbnRzLWFwaS1rZXkifSx7InR5cGUiOiJtZHhBdHRyaWJ1dGUiLCJuYW1lIjoidGl0bGUiLCJ2YWx1ZSI6IldoYXQgYWNjb3VudCBjaGFuZ2VzIGhhdmUgYmVlbiBtYWRlIHVzaW5nIGFuIEFQSSBrZXk/In1d\\"><div data-type=\\"prop\\" data-prop=\\"title\\">What account changes have been made using an API key?</div><div data-type=\\"prop\\" data-prop=\\"children\\"><p>To see detailed information about changes to the account that were made using an API key during a specific time frame, include <a href=\\"#actorType\\"><code>actorType = 'api_key'</code></a> in the query. For example:</p><pre data-type=\\"component\\" data-component=\\"CodeBlock\\" data-props=\\"eyJsYW5nIjpudWxsLCJtZXRhIjpudWxsLCJ2YWx1ZSI6IlNFTEVDVCBhY3Rpb25JZGVudGlmaWVyLCBkZXNjcmlwdGlvbiwgdGFyZ2V0VHlwZSwgdGFyZ2V0SWQsIGFjdG9yQVBJS2V5LCBhY3RvcklkLCBhY3RvckVtYWlsXG5GUk9NIE5yQXVkaXRFdmVudCBXSEVSRSBhY3RvclR5cGUgPSAnYXBpX2tleScgU0lOQ0UgMSB3ZWVrIGFnbyIsInBvc2l0aW9uIjp7InN0YXJ0Ijp7ImxpbmUiOjEyNywiY29sdW1uIjoxLCJvZmZzZXQiOjM5MzR9LCJlbmQiOnsibGluZSI6MTMxLCJjb2x1bW4iOjMsIm9mZnNldCI6NDExNn0sImluZGVudCI6WzEsMSwxLDFdfX0=\\"></pre></div></div><div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJpZCIsInZhbHVlIjoic3ludGgtdXNlciJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiU3ludGhldGljczogV2hhdCBtb25pdG9ycyB3ZXJlIGNyZWF0ZWQgYnkgYSBzcGVjaWZpYyB1c2VyPyJ9XQ==\\"><div data-type=\\"prop\\" data-prop=\\"title\\">Synthetics: What monitors were created by a specific user?</div><div data-type=\\"prop\\" data-prop=\\"children\\"><p>To query Synthetics monitor updates made by a specific user, include the <a href=\\"/attribute-dictionary/nrauditevent/actionidentifier\\"><code>actionIdentifier</code></a> and <a href=\\"/attribute-dictionary/nrauditevent/actoremail\\"><code>actorEmail</code></a> attribute in your query. For example:</p><pre data-type=\\"component\\" data-component=\\"CodeBlock\\" data-props=\\"eyJsYW5nIjpudWxsLCJtZXRhIjpudWxsLCJ2YWx1ZSI6IlNFTEVDVCBjb3VudCgqKSBGUk9NIE5yQXVkaXRFdmVudFxuV0hFUkUgYWN0aW9uSWRlbnRpZmllciA9ICdzeW50aGV0aWNzX21vbml0b3IudXBkYXRlX3NjcmlwdCdcbkZBQ0VUIGFjdG9yRW1haWwsIGFjdGlvbklkZW50aWZpZXIsIGRlc2NyaXB0aW9uXG5TSU5DRSAxIHdlZWsgYWdvIExJTUlUIDEwMDAiLCJwb3NpdGlvbiI6eyJzdGFydCI6eyJsaW5lIjoxMzksImNvbHVtbiI6MSwib2Zmc2V0Ijo0NDk0fSwiZW5kIjp7ImxpbmUiOjE0NSwiY29sdW1uIjozLCJvZmZzZXQiOjQ2OTh9LCJpbmRlbnQiOlsxLDEsMSwxLDEsMV19fQ==\\"></pre></div></div></div></div>
-<div data-type=\\"component\\" data-component=\\"CollapserGroup\\"><div data-type=\\"prop\\" data-prop=\\"children\\"><div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJpZCIsInZhbHVlIjoibGFjay1jcHUtY3JlZGl0LWJhbGFuY2UifSx7InR5cGUiOiJtZHhBdHRyaWJ1dGUiLCJuYW1lIjoidGl0bGUiLCJ2YWx1ZSI6IkxhY2sgb2YgQ1BVIENyZWRpdCBCYWxhbmNlIn1d\\"><div data-type=\\"prop\\" data-prop=\\"title\\">Lack of CPU Credit Balance</div><div data-type=\\"prop\\" data-prop=\\"children\\"><table data-type=\\"component\\"><tbody data-type=\\"component\\"><tr data-type=\\"component\\"><td data-type=\\"component\\"><p><strong>Condition name</strong></p></td><td data-type=\\"component\\"><p>Lack of CPU Credit Balance</p></td></tr><tr data-type=\\"component\\"><td data-type=\\"component\\"><p><strong>Cloud entity type</strong></p></td><td data-type=\\"component\\"><p>AWS RDS DB instance</p></td></tr><tr data-type=\\"component\\"><td data-type=\\"component\\"><p><strong>Description</strong></p></td><td data-type=\\"component\\"><p>The database instance is running out of CPU Credit Balance.</p></td></tr><tr data-type=\\"component\\"><td data-type=\\"component\\"><p><strong>Recommended action</strong></p></td><td data-type=\\"component\\"><p>You may need to reduce the load of the RDS instance, or use a larger RDS instance type.</p></td></tr><tr data-type=\\"component\\"><td data-type=\\"component\\"><p><strong>Reference</strong></p></td><td data-type=\\"component\\"><p>For more information, see <a href=\\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html\\">DB instance storage</a> or <a href=\\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-credits-baseline-concepts.html\\">CPU Credits and Baseline Performance for Burstable Performance Instances</a>.</p></td></tr></tbody></table></div></div></div></div>"
+<div data-type=\\"component\\" data-component=\\"TechTileGrid\\">
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <div data-type=\\"component\\" data-component=\\"TechTile\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJpT1MifSx7InR5cGUiOiJtZHhBdHRyaWJ1dGUiLCJuYW1lIjoiaWNvbiIsInZhbHVlIjoibG9nby1hcHBsZSJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0byIsInZhbHVlIjoiL2FnZW50cy9pb3MtYWdlbnQifV0=\\">
+      <div data-type=\\"prop\\" data-prop=\\"name\\">iOS</div>
+    </div>
+    <div data-type=\\"component\\" data-component=\\"TechTile\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJBbmRyb2lkIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6Imljb24iLCJ2YWx1ZSI6ImxvZ28tYW5kcm9pZCJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0byIsInZhbHVlIjoiL2FnZW50cy9hbmRyb2lkLWFnZW50In1d\\">
+      <div data-type=\\"prop\\" data-prop=\\"name\\">Android</div>
+    </div>
+    <div data-type=\\"component\\" data-component=\\"TechTile\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJ0dk9TIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6Imljb24iLCJ2YWx1ZSI6ImxvZ28tYXBwbGUifSx7InR5cGUiOiJtZHhBdHRyaWJ1dGUiLCJuYW1lIjoidG8iLCJ2YWx1ZSI6Ii9hZ2VudHMvdHZvcy1hZ2VudCJ9XQ==\\">
+      <div data-type=\\"prop\\" data-prop=\\"name\\">tvOS</div>
+    </div>
+  </div>
+</div>
+<div data-type=\\"component\\" data-component=\\"CollapserGroup\\">
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJpZCIsInZhbHVlIjoiZXZlbnRzLWFwaS1rZXkifSx7InR5cGUiOiJtZHhBdHRyaWJ1dGUiLCJuYW1lIjoidGl0bGUiLCJ2YWx1ZSI6IldoYXQgYWNjb3VudCBjaGFuZ2VzIGhhdmUgYmVlbiBtYWRlIHVzaW5nIGFuIEFQSSBrZXk/In1d\\">
+      <div data-type=\\"prop\\" data-prop=\\"title\\">What account changes have been made using an API key?</div>
+      <div data-type=\\"prop\\" data-prop=\\"children\\">
+        <p>To see detailed information about changes to the account that were made using an API key during a specific time frame, include <a href=\\"#actorType\\"><code>actorType = 'api_key'</code></a> in the query. For example:</p>
+        <pre data-type=\\"component\\" data-component=\\"CodeBlock\\" data-props=\\"eyJsYW5nIjpudWxsLCJtZXRhIjpudWxsLCJ2YWx1ZSI6IlNFTEVDVCBhY3Rpb25JZGVudGlmaWVyLCBkZXNjcmlwdGlvbiwgdGFyZ2V0VHlwZSwgdGFyZ2V0SWQsIGFjdG9yQVBJS2V5LCBhY3RvcklkLCBhY3RvckVtYWlsXG5GUk9NIE5yQXVkaXRFdmVudCBXSEVSRSBhY3RvclR5cGUgPSAnYXBpX2tleScgU0lOQ0UgMSB3ZWVrIGFnbyIsInBvc2l0aW9uIjp7InN0YXJ0Ijp7ImxpbmUiOjEyNywiY29sdW1uIjoxLCJvZmZzZXQiOjM5MzR9LCJlbmQiOnsibGluZSI6MTMxLCJjb2x1bW4iOjMsIm9mZnNldCI6NDExNn0sImluZGVudCI6WzEsMSwxLDFdfX0=\\"></pre>
+      </div>
+    </div>
+    <div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJpZCIsInZhbHVlIjoic3ludGgtdXNlciJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiU3ludGhldGljczogV2hhdCBtb25pdG9ycyB3ZXJlIGNyZWF0ZWQgYnkgYSBzcGVjaWZpYyB1c2VyPyJ9XQ==\\">
+      <div data-type=\\"prop\\" data-prop=\\"title\\">Synthetics: What monitors were created by a specific user?</div>
+      <div data-type=\\"prop\\" data-prop=\\"children\\">
+        <p>To query Synthetics monitor updates made by a specific user, include the <a href=\\"/attribute-dictionary/nrauditevent/actionidentifier\\"><code>actionIdentifier</code></a> and <a href=\\"/attribute-dictionary/nrauditevent/actoremail\\"><code>actorEmail</code></a> attribute in your query. For example:</p>
+        <pre data-type=\\"component\\" data-component=\\"CodeBlock\\" data-props=\\"eyJsYW5nIjpudWxsLCJtZXRhIjpudWxsLCJ2YWx1ZSI6IlNFTEVDVCBjb3VudCgqKSBGUk9NIE5yQXVkaXRFdmVudFxuV0hFUkUgYWN0aW9uSWRlbnRpZmllciA9ICdzeW50aGV0aWNzX21vbml0b3IudXBkYXRlX3NjcmlwdCdcbkZBQ0VUIGFjdG9yRW1haWwsIGFjdGlvbklkZW50aWZpZXIsIGRlc2NyaXB0aW9uXG5TSU5DRSAxIHdlZWsgYWdvIExJTUlUIDEwMDAiLCJwb3NpdGlvbiI6eyJzdGFydCI6eyJsaW5lIjoxMzksImNvbHVtbiI6MSwib2Zmc2V0Ijo0NDk0fSwiZW5kIjp7ImxpbmUiOjE0NSwiY29sdW1uIjozLCJvZmZzZXQiOjQ2OTh9LCJpbmRlbnQiOlsxLDEsMSwxLDEsMV19fQ==\\"></pre>
+      </div>
+    </div>
+  </div>
+</div>
+<div data-type=\\"component\\" data-component=\\"CollapserGroup\\">
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJpZCIsInZhbHVlIjoibGFjay1jcHUtY3JlZGl0LWJhbGFuY2UifSx7InR5cGUiOiJtZHhBdHRyaWJ1dGUiLCJuYW1lIjoidGl0bGUiLCJ2YWx1ZSI6IkxhY2sgb2YgQ1BVIENyZWRpdCBCYWxhbmNlIn1d\\">
+      <div data-type=\\"prop\\" data-prop=\\"title\\">Lack of CPU Credit Balance</div>
+      <div data-type=\\"prop\\" data-prop=\\"children\\">
+        <table data-type=\\"component\\">
+          <tbody data-type=\\"component\\">
+            <tr data-type=\\"component\\">
+              <td data-type=\\"component\\">
+                <p><strong>Condition name</strong></p>
+              </td>
+              <td data-type=\\"component\\">
+                <p>Lack of CPU Credit Balance</p>
+              </td>
+            </tr>
+            <tr data-type=\\"component\\">
+              <td data-type=\\"component\\">
+                <p><strong>Cloud entity type</strong></p>
+              </td>
+              <td data-type=\\"component\\">
+                <p>AWS RDS DB instance</p>
+              </td>
+            </tr>
+            <tr data-type=\\"component\\">
+              <td data-type=\\"component\\">
+                <p><strong>Description</strong></p>
+              </td>
+              <td data-type=\\"component\\">
+                <p>The database instance is running out of CPU Credit Balance.</p>
+              </td>
+            </tr>
+            <tr data-type=\\"component\\">
+              <td data-type=\\"component\\">
+                <p><strong>Recommended action</strong></p>
+              </td>
+              <td data-type=\\"component\\">
+                <p>You may need to reduce the load of the RDS instance, or use a larger RDS instance type.</p>
+              </td>
+            </tr>
+            <tr data-type=\\"component\\">
+              <td data-type=\\"component\\">
+                <p><strong>Reference</strong></p>
+              </td>
+              <td data-type=\\"component\\">
+                <p>For more information, see <a href=\\"https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html\\">DB instance storage</a> or <a href=\\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-credits-baseline-concepts.html\\">CPU Credits and Baseline Performance for Burstable Performance Instances</a>.</p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+"
 `;
 
-exports[`serialize Icon inline with text to HTML 1`] = `"<p>This is some text with a star <span data-type=\\"component\\" data-component=\\"Icon\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJmZS1zdGFyIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6InNpemUiLCJ2YWx1ZSI6IjFyZW0ifV0=\\"> </span> and some more text after it</p>"`;
+exports[`serialize Icon inline with text to HTML 1`] = `
+"
+<p>This is some text with a star <span data-type=\\"component\\" data-component=\\"Icon\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJmZS1zdGFyIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6InNpemUiLCJ2YWx1ZSI6IjFyZW0ifV0=\\"> </span> and some more text after it</p>
+"
+`;
 
-exports[`serializes Button to html 1`] = `"<div data-type=\\"component\\" data-component=\\"Button\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ2YXJpYW50IiwidmFsdWUiOiJub3JtYWwifV0=\\"><div data-type=\\"prop\\" data-prop=\\"children\\"><p>View all C SDK docs</p></div></div>"`;
+exports[`serializes Button to html 1`] = `
+"
+<div data-type=\\"component\\" data-component=\\"Button\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ2YXJpYW50IiwidmFsdWUiOiJub3JtYWwifV0=\\">
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <p>View all C SDK docs</p>
+  </div>
+</div>
+"
+`;
 
-exports[`serializes ButtonLink to html 1`] = `"<div data-type=\\"component\\" data-component=\\"ButtonLink\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0byIsInZhbHVlIjoiL2RvY3MvYWdlbnRzL3J1Ynktc2RrIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6InZhcmlhbnQiLCJ2YWx1ZSI6Im5vcm1hbCJ9XQ==\\"><div data-type=\\"prop\\" data-prop=\\"children\\"><p>View all C SDK docs</p></div></div>"`;
+exports[`serializes ButtonLink to html 1`] = `
+"
+<div data-type=\\"component\\" data-component=\\"ButtonLink\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0byIsInZhbHVlIjoiL2RvY3MvYWdlbnRzL3J1Ynktc2RrIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6InZhcmlhbnQiLCJ2YWx1ZSI6Im5vcm1hbCJ9XQ==\\">
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <p>View all C SDK docs</p>
+  </div>
+</div>
+"
+`;
 
-exports[`serializes Callouts with title to html 1`] = `"<div data-type=\\"component\\" data-component=\\"Callout\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiTGlmZSB0aXBzICMxIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6InZhcmlhbnQiLCJ2YWx1ZSI6InRpcCJ9XQ==\\"><div data-type=\\"prop\\" data-prop=\\"title\\">Life tips #1</div><div data-type=\\"prop\\" data-prop=\\"children\\"><p>Don't walk down that dark alleyway</p></div></div>"`;
+exports[`serializes Callouts with title to html 1`] = `
+"
+<div data-type=\\"component\\" data-component=\\"Callout\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiTGlmZSB0aXBzICMxIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6InZhcmlhbnQiLCJ2YWx1ZSI6InRpcCJ9XQ==\\">
+  <div data-type=\\"prop\\" data-prop=\\"title\\">Life tips #1</div>
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <p>Don't walk down that dark alleyway</p>
+  </div>
+</div>
+"
+`;
 
-exports[`serializes Callouts without title to html 1`] = `"<div data-type=\\"component\\" data-component=\\"Callout\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ2YXJpYW50IiwidmFsdWUiOiJ0aXAifV0=\\"><div data-type=\\"prop\\" data-prop=\\"children\\"><p>Always tip your waiter</p></div></div>"`;
+exports[`serializes Callouts without title to html 1`] = `
+"
+<div data-type=\\"component\\" data-component=\\"Callout\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ2YXJpYW50IiwidmFsdWUiOiJ0aXAifV0=\\">
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <p>Always tip your waiter</p>
+  </div>
+</div>
+"
+`;
 
-exports[`serializes Collapser with JSX title to html 1`] = `"<div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjp7InR5cGUiOiJtZHhWYWx1ZUV4cHJlc3Npb24iLCJ2YWx1ZSI6Ijw+PElubGluZUNvZGU+YWdlbnQucmVwb3J0X2N1c3RvbV9hdHRyaWJ1dGU8L0lubGluZUNvZGU+IEFQSTwvPiIsInBvc2l0aW9uIjp7InN0YXJ0Ijp7ImxpbmUiOjMsImNvbHVtbiI6OSwib2Zmc2V0IjoyMH0sImVuZCI6eyJsaW5lIjozLCJjb2x1bW4iOjc0LCJvZmZzZXQiOjg1fX19fV0=\\"><div data-type=\\"prop\\" data-prop=\\"title\\"><div data-type=\\"component\\" data-component=\\"React.Fragment\\"><div data-type=\\"prop\\" data-prop=\\"children\\"><code data-type=\\"component\\" data-component=\\"InlineCode\\">agent.report_custom_attribute</code> API</div></div></div><div data-type=\\"prop\\" data-prop=\\"children\\"><p>Some API docs about <code>agent.report_custom_attribute</code></p></div></div>"`;
+exports[`serializes Collapser with JSX title to html 1`] = `
+"
+<div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjp7InR5cGUiOiJtZHhWYWx1ZUV4cHJlc3Npb24iLCJ2YWx1ZSI6Ijw+PElubGluZUNvZGU+YWdlbnQucmVwb3J0X2N1c3RvbV9hdHRyaWJ1dGU8L0lubGluZUNvZGU+IEFQSTwvPiIsInBvc2l0aW9uIjp7InN0YXJ0Ijp7ImxpbmUiOjMsImNvbHVtbiI6OSwib2Zmc2V0IjoyMH0sImVuZCI6eyJsaW5lIjozLCJjb2x1bW4iOjc0LCJvZmZzZXQiOjg1fX19fV0=\\">
+  <div data-type=\\"prop\\" data-prop=\\"title\\">
+    <div data-type=\\"component\\" data-component=\\"React.Fragment\\">
+      <div data-type=\\"prop\\" data-prop=\\"children\\"><code data-type=\\"component\\" data-component=\\"InlineCode\\">agent.report_custom_attribute</code> API</div>
+    </div>
+  </div>
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <p>Some API docs about <code>agent.report_custom_attribute</code></p>
+  </div>
+</div>
+"
+`;
 
-exports[`serializes Collapser with plain text title to html 1`] = `"<div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiQ29sbGFwc2UgbWUgeW8ifV0=\\"><div data-type=\\"prop\\" data-prop=\\"title\\">Collapse me yo</div><div data-type=\\"prop\\" data-prop=\\"children\\"><p>These tests are hard to write docs for</p></div></div>"`;
+exports[`serializes Collapser with plain text title to html 1`] = `
+"
+<div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiQ29sbGFwc2UgbWUgeW8ifV0=\\">
+  <div data-type=\\"prop\\" data-prop=\\"title\\">Collapse me yo</div>
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <p>These tests are hard to write docs for</p>
+  </div>
+</div>
+"
+`;
 
-exports[`serializes CollapserGroup to html 1`] = `"<div data-type=\\"component\\" data-component=\\"CollapserGroup\\"><div data-type=\\"prop\\" data-prop=\\"children\\"><div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiRWFzeSBwZWFzeSJ9XQ==\\"><div data-type=\\"prop\\" data-prop=\\"title\\">Easy peasy</div><div data-type=\\"prop\\" data-prop=\\"children\\"><p>Par-cheesy</p></div></div></div></div>"`;
+exports[`serializes CollapserGroup to html 1`] = `
+"
+<div data-type=\\"component\\" data-component=\\"CollapserGroup\\">
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiRWFzeSBwZWFzeSJ9XQ==\\">
+      <div data-type=\\"prop\\" data-prop=\\"title\\">Easy peasy</div>
+      <div data-type=\\"prop\\" data-prop=\\"children\\">
+        <p>Par-cheesy</p>
+      </div>
+    </div>
+  </div>
+</div>
+"
+`;
 
-exports[`serializes DoNotTranslate to html 1`] = `"<div data-type=\\"component\\" data-component=\\"DoNotTranslate\\" class=\\"notranslate\\"><h1>Not all who wander are lost...</h1><p>Testing this line too</p></div>"`;
+exports[`serializes DoNotTranslate to html 1`] = `
+"
+<div data-type=\\"component\\" data-component=\\"DoNotTranslate\\" class=\\"notranslate\\">
+  <h1>Not all who wander are lost...</h1>
+  <p>Testing this line too</p>
+</div>
+"
+`;
 
-exports[`serializes DoNotTranslate to html inline 1`] = `"<p>This is an <span data-type=\\"component\\" data-component=\\"DoNotTranslate\\" class=\\"notranslate\\">MDX</span> file</p>"`;
+exports[`serializes DoNotTranslate to html inline 1`] = `
+"
+<p>This is an <span data-type=\\"component\\" data-component=\\"DoNotTranslate\\" class=\\"notranslate\\">MDX</span> file</p>
+"
+`;
 
-exports[`serializes DoNotTranslate wrapping a Collapser 1`] = `"<div data-type=\\"component\\" data-component=\\"DoNotTranslate\\" class=\\"notranslate\\"><div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiQ29sbGFwc2UgbWUgeW8ifV0=\\"><div data-type=\\"prop\\" data-prop=\\"title\\">Collapse me yo</div><div data-type=\\"prop\\" data-prop=\\"children\\"><p>These tests are hard to write docs for</p></div></div></div>"`;
+exports[`serializes DoNotTranslate wrapping a Collapser 1`] = `
+"
+<div data-type=\\"component\\" data-component=\\"DoNotTranslate\\" class=\\"notranslate\\">
+  <div data-type=\\"component\\" data-component=\\"Collapser\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiQ29sbGFwc2UgbWUgeW8ifV0=\\">
+    <div data-type=\\"prop\\" data-prop=\\"title\\">Collapse me yo</div>
+    <div data-type=\\"prop\\" data-prop=\\"children\\">
+      <p>These tests are hard to write docs for</p>
+    </div>
+  </div>
+</div>
+"
+`;
 
-exports[`serializes ExternalLink to html 1`] = `"<div data-type=\\"component\\" data-component=\\"ExternalLink\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJocmVmIiwidmFsdWUiOiJodHRwczovL2RldmVsb3Blci5uZXdyZWxpYy5jb20ifV0=\\"><div data-type=\\"prop\\" data-prop=\\"children\\"><p>Go to developer site</p></div></div>"`;
+exports[`serializes ExternalLink to html 1`] = `
+"
+<div data-type=\\"component\\" data-component=\\"ExternalLink\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJocmVmIiwidmFsdWUiOiJodHRwczovL2RldmVsb3Blci5uZXdyZWxpYy5jb20ifV0=\\">
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <p>Go to developer site</p>
+  </div>
+</div>
+"
+`;
 
-exports[`serializes Icon to html 1`] = `"<div data-type=\\"component\\" data-component=\\"Icon\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJmZS1leHRlcm5hbC1saW5rIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6InNpemUiLCJ2YWx1ZSI6IjFyZW0ifV0=\\"> </div>"`;
+exports[`serializes Icon to html 1`] = `
+"
+<div data-type=\\"component\\" data-component=\\"Icon\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJmZS1leHRlcm5hbC1saW5rIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6InNpemUiLCJ2YWx1ZSI6IjFyZW0ifV0=\\"> </div>
+"
+`;
 
-exports[`serializes Icon to html 2`] = `"<div data-type=\\"component\\" data-component=\\"Icon\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJmZS1leHRlcm5hbC1saW5rIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6InNpemUiLCJ2YWx1ZSI6IjFyZW0ifV0=\\"> </div>"`;
+exports[`serializes Icon to html 2`] = `
+"
+<div data-type=\\"component\\" data-component=\\"Icon\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJmZS1leHRlcm5hbC1saW5rIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6InNpemUiLCJ2YWx1ZSI6IjFyZW0ifV0=\\"> </div>
+"
+`;
 
 exports[`serializes InlineCode to html 1`] = `"<code data-type=\\"component\\" data-component=\\"InlineCode\\">agent.report_custom_event()</code>"`;
 
 exports[`serializes LandingPageTile to html 1`] = `
-"<div data-type=\\"component\\" data-component=\\"LandingPageTile\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiR2V0IHN0YXJ0ZWQuIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6Imljb24iLCJ2YWx1ZSI6ImZlLWNoZWNrLXNxdWFyZSJ9XQ==\\"><div data-type=\\"prop\\" data-prop=\\"title\\">Get started.</div><div data-type=\\"prop\\" data-prop=\\"children\\"><ul>
-<li><a href=\\"/docs/apm/new-relic-apm/getting-started/introduction-new-relic-apm\\">Learn</a> about the wealth of APM data automatically available to you.</li>
-<li><a href=\\"/docs/agents/manage-apm-agents/installation/installing-agent\\">Install your APM language agent</a> from New Relic One, then start seeing actionable performance data in the <a href=\\"/docs/apm/apm-ui-pages\\">APM UI</a>.</li>
-<li>Monitor your own <a href=\\"/docs/apm/transactions/key-transactions/introduction-key-transactions\\">business-critical key transactions</a>.</li>
-</ul></div></div>"
+"
+<div data-type=\\"component\\" data-component=\\"LandingPageTile\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiR2V0IHN0YXJ0ZWQuIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6Imljb24iLCJ2YWx1ZSI6ImZlLWNoZWNrLXNxdWFyZSJ9XQ==\\">
+  <div data-type=\\"prop\\" data-prop=\\"title\\">Get started.</div>
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <ul>
+      <li><a href=\\"/docs/apm/new-relic-apm/getting-started/introduction-new-relic-apm\\">Learn</a> about the wealth of APM data automatically available to you.</li>
+      <li><a href=\\"/docs/agents/manage-apm-agents/installation/installing-agent\\">Install your APM language agent</a> from New Relic One, then start seeing actionable performance data in the <a href=\\"/docs/apm/apm-ui-pages\\">APM UI</a>.</li>
+      <li>Monitor your own <a href=\\"/docs/apm/transactions/key-transactions/introduction-key-transactions\\">business-critical key transactions</a>.</li>
+    </ul>
+  </div>
+</div>
+"
 `;
 
 exports[`serializes LandingPageTileGrid to html 1`] = `
-"<div data-type=\\"component\\" data-component=\\"LandingPageTileGrid\\"><div data-type=\\"prop\\" data-prop=\\"children\\"><div data-type=\\"component\\" data-component=\\"LandingPageTile\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiR2V0IHN0YXJ0ZWQuIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6Imljb24iLCJ2YWx1ZSI6ImZlLWNoZWNrLXNxdWFyZSJ9XQ==\\"><div data-type=\\"prop\\" data-prop=\\"title\\">Get started.</div><div data-type=\\"prop\\" data-prop=\\"children\\"><ul>
-<li><a href=\\"/docs/apm/new-relic-apm/getting-started/introduction-new-relic-apm\\">Learn</a> about the wealth of APM data automatically available to you.</li>
-<li><a href=\\"/docs/agents/manage-apm-agents/installation/installing-agent\\">Install your APM language agent</a> from New Relic One, then start seeing actionable performance data in the <a href=\\"/docs/apm/apm-ui-pages\\">APM UI</a>.</li>
-<li>Monitor your own <a href=\\"/docs/apm/transactions/key-transactions/introduction-key-transactions\\">business-critical key transactions</a>.</li>
-</ul></div></div></div></div>"
+"
+<div data-type=\\"component\\" data-component=\\"LandingPageTileGrid\\">
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <div data-type=\\"component\\" data-component=\\"LandingPageTile\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0aXRsZSIsInZhbHVlIjoiR2V0IHN0YXJ0ZWQuIn0seyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6Imljb24iLCJ2YWx1ZSI6ImZlLWNoZWNrLXNxdWFyZSJ9XQ==\\">
+      <div data-type=\\"prop\\" data-prop=\\"title\\">Get started.</div>
+      <div data-type=\\"prop\\" data-prop=\\"children\\">
+        <ul>
+          <li><a href=\\"/docs/apm/new-relic-apm/getting-started/introduction-new-relic-apm\\">Learn</a> about the wealth of APM data automatically available to you.</li>
+          <li><a href=\\"/docs/agents/manage-apm-agents/installation/installing-agent\\">Install your APM language agent</a> from New Relic One, then start seeing actionable performance data in the <a href=\\"/docs/apm/apm-ui-pages\\">APM UI</a>.</li>
+          <li>Monitor your own <a href=\\"/docs/apm/transactions/key-transactions/introduction-key-transactions\\">business-critical key transactions</a>.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+"
 `;
 
-exports[`serializes Link to html 1`] = `"<div data-type=\\"component\\" data-component=\\"Link\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0byIsInZhbHVlIjoiL2RvY3MvYWdlbnRzL3J1Ynktc2RrIn1d\\"><div data-type=\\"prop\\" data-prop=\\"children\\"><p>Check out our Ruby agent docs</p></div></div>"`;
+exports[`serializes Link to html 1`] = `
+"
+<div data-type=\\"component\\" data-component=\\"Link\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0byIsInZhbHVlIjoiL2RvY3MvYWdlbnRzL3J1Ynktc2RrIn1d\\">
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <p>Check out our Ruby agent docs</p>
+  </div>
+</div>
+"
+`;
 
-exports[`serializes Table to html 1`] = `"<table data-type=\\"component\\"><thead data-type=\\"component\\"><tr data-type=\\"component\\"><td data-type=\\"component\\"><p>Column A</p></td><td data-type=\\"component\\"><p>Column B</p></td></tr></thead><tbody data-type=\\"component\\"><tr data-type=\\"component\\"><td data-type=\\"component\\"><p>Data 1a</p></td><td data-type=\\"component\\"><p>Data 2a</p></td></tr><tr data-type=\\"component\\"><td data-type=\\"component\\"><p>Data 1b</p></td><td data-type=\\"component\\"><p>Data 2b</p></td></tr></tbody></table>"`;
+exports[`serializes Table to html 1`] = `
+"
+<table data-type=\\"component\\">
+  <thead data-type=\\"component\\">
+    <tr data-type=\\"component\\">
+      <td data-type=\\"component\\">
+        <p>Column A</p>
+      </td>
+      <td data-type=\\"component\\">
+        <p>Column B</p>
+      </td>
+    </tr>
+  </thead>
+  <tbody data-type=\\"component\\">
+    <tr data-type=\\"component\\">
+      <td data-type=\\"component\\">
+        <p>Data 1a</p>
+      </td>
+      <td data-type=\\"component\\">
+        <p>Data 2a</p>
+      </td>
+    </tr>
+    <tr data-type=\\"component\\">
+      <td data-type=\\"component\\">
+        <p>Data 1b</p>
+      </td>
+      <td data-type=\\"component\\">
+        <p>Data 2b</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+"
+`;
 
-exports[`serializes TechTileGrid to html 1`] = `"<div data-type=\\"component\\" data-component=\\"TechTileGrid\\"><div data-type=\\"prop\\" data-prop=\\"children\\"><div data-type=\\"component\\" data-component=\\"TechTile\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJpT1MifSx7InR5cGUiOiJtZHhBdHRyaWJ1dGUiLCJuYW1lIjoiaWNvbiIsInZhbHVlIjoibG9nby1hcHBsZSJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0byIsInZhbHVlIjoiL2FnZW50cy9pb3MtYWdlbnQifV0=\\"><div data-type=\\"prop\\" data-prop=\\"name\\">iOS</div></div></div></div>"`;
+exports[`serializes TechTileGrid to html 1`] = `
+"
+<div data-type=\\"component\\" data-component=\\"TechTileGrid\\">
+  <div data-type=\\"prop\\" data-prop=\\"children\\">
+    <div data-type=\\"component\\" data-component=\\"TechTile\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJuYW1lIiwidmFsdWUiOiJpT1MifSx7InR5cGUiOiJtZHhBdHRyaWJ1dGUiLCJuYW1lIjoiaWNvbiIsInZhbHVlIjoibG9nby1hcHBsZSJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0byIsInZhbHVlIjoiL2FnZW50cy9pb3MtYWdlbnQifV0=\\">
+      <div data-type=\\"prop\\" data-prop=\\"name\\">iOS</div>
+    </div>
+  </div>
+</div>
+"
+`;
 
-exports[`serializes Video to html 1`] = `"<div data-type=\\"component\\" data-component=\\"Video\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJpZCIsInZhbHVlIjoiYWJjZCJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0eXBlIiwidmFsdWUiOiJ3aXN0aWEifV0=\\"></div>"`;
+exports[`serializes Video to html 1`] = `
+"
+<div data-type=\\"component\\" data-component=\\"Video\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJpZCIsInZhbHVlIjoiYWJjZCJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0eXBlIiwidmFsdWUiOiJ3aXN0aWEifV0=\\"></div>
+"
+`;
 
-exports[`serializes Video with title to html 1`] = `"<div data-type=\\"component\\" data-component=\\"Video\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJpZCIsInZhbHVlIjoiYWJjZCJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0eXBlIiwidmFsdWUiOiJ3aXN0aWEifSx7InR5cGUiOiJtZHhBdHRyaWJ1dGUiLCJuYW1lIjoidGl0bGUiLCJ2YWx1ZSI6IlRoZSB2aWRlbyB0aXRsZSJ9XQ==\\"><div data-type=\\"prop\\" data-prop=\\"title\\">The video title</div></div>"`;
+exports[`serializes Video with title to html 1`] = `
+"
+<div data-type=\\"component\\" data-component=\\"Video\\" data-props=\\"W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJpZCIsInZhbHVlIjoiYWJjZCJ9LHsidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0eXBlIiwidmFsdWUiOiJ3aXN0aWEifSx7InR5cGUiOiJtZHhBdHRyaWJ1dGUiLCJuYW1lIjoidGl0bGUiLCJ2YWx1ZSI6IlRoZSB2aWRlbyB0aXRsZSJ9XQ==\\">
+  <div data-type=\\"prop\\" data-prop=\\"title\\">The video title</div>
+</div>
+"
+`;
 
 exports[`serializes mark to html 1`] = `"<mark data-type=\\"component\\"><p>PDF</p></mark>"`;
 
 exports[`serializes var to html 1`] = `"<var data-type=\\"component\\"><p>JAVA_AGENT_VERSION</p></var>"`;
 
-exports[`test <b> element serializes 1`] = `"<p>The Varnish Cache integration collects both metrics(<span data-type=\\"component\\" data-component=\\"b\\"><span data-type=\\"prop\\" data-prop=\\"children\\">M</span></span>) and inventory(<span data-type=\\"component\\" data-component=\\"b\\"><span data-type=\\"prop\\" data-prop=\\"children\\">I</span></span>) information.</p>"`;
+exports[`test <b> element serializes 1`] = `
+"
+<p>The Varnish Cache integration collects both metrics(<span data-type=\\"component\\" data-component=\\"b\\"><span data-type=\\"prop\\" data-prop=\\"children\\">M</span></span>) and inventory(<span data-type=\\"component\\" data-component=\\"b\\"><span data-type=\\"prop\\" data-prop=\\"children\\">I</span></span>) information.</p>
+"
+`;
 
-exports[`test <strong> element serializes 1`] = `"<p>The Varnish Cache integration collects both metrics(<span data-type=\\"component\\" data-component=\\"strong\\"><span data-type=\\"prop\\" data-prop=\\"children\\">M</span></span>) and inventory(<span data-type=\\"component\\" data-component=\\"strong\\"><span data-type=\\"prop\\" data-prop=\\"children\\">I</span></span>) information.</p>"`;
+exports[`test <strong> element serializes 1`] = `
+"
+<p>The Varnish Cache integration collects both metrics(<span data-type=\\"component\\" data-component=\\"strong\\"><span data-type=\\"prop\\" data-prop=\\"children\\">M</span></span>) and inventory(<span data-type=\\"component\\" data-component=\\"strong\\"><span data-type=\\"prop\\" data-prop=\\"children\\">I</span></span>) information.</p>
+"
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4628,11 +4628,6 @@ bail@^1.0.0:
   resolved "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz"
   integrity sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==
 
-bail@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
-  integrity sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
@@ -9316,13 +9311,6 @@ hast-util-embedded@^1.0.0:
   dependencies:
     hast-util-is-element "^1.1.0"
 
-hast-util-embedded@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/hast-util-embedded/-/hast-util-embedded-2.0.0.tgz#877f4261044854743fc2621f728930ca61c8376f"
-  integrity sha512-vEr54rDu2CheBM4nLkWbW8Rycf8HhkA/KsrDnlyKnvBTyhyO+vAG6twHnfUbiRGo56YeUBNCI4HFfHg3Wu+tig==
-  dependencies:
-    hast-util-is-element "^2.0.0"
-
 hast-util-from-dom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-3.0.0.tgz"
@@ -9348,11 +9336,6 @@ hast-util-has-property@^1.0.0, hast-util-has-property@^1.0.4:
   resolved "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-1.0.4.tgz"
   integrity sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg==
 
-hast-util-has-property@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/hast-util-has-property/-/hast-util-has-property-2.0.0.tgz#c15cd6180f3e535540739fcc9787bcffb5708cae"
-  integrity sha512-4Qf++8o5v14us4Muv3HRj+Er6wTNGA/N9uCaZMty4JWvyFKLdhULrv4KE1b65AthsSO9TXSZnjuxS8ecIyhb0w==
-
 hast-util-is-body-ok-link@^1.0.0:
   version "1.0.4"
   resolved "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-1.0.4.tgz"
@@ -9366,20 +9349,12 @@ hast-util-is-element@^1.0.0, hast-util-is-element@^1.1.0:
   resolved "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz"
   integrity sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ==
 
-hast-util-is-element@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-2.1.2.tgz#fc0b0dc7cef3895e839b8d66979d57b0338c68f3"
-  integrity sha512-thjnlGAnwP8ef/GSO1Q8BfVk2gundnc2peGQqEg2kUt/IqesiGg/5mSwN2fE7nLzy61pg88NG6xV+UrGOrx9EA==
-  dependencies:
-    "@types/hast" "^2.0.0"
-    "@types/unist" "^2.0.0"
-
 hast-util-parse-selector@^2.0.0:
   version "2.2.5"
   resolved "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz"
   integrity sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==
 
-hast-util-phrasing@^1.0.5:
+hast-util-phrasing@^1.0.0, hast-util-phrasing@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-1.0.5.tgz"
   integrity sha512-P3uxm+8bnwcfAS/XpGie9wMmQXAQqsYhgQQKRwmWH/V6chiq0lmTy8KjQRJmYjusdMtNKGCUksdILSZy1suSpQ==
@@ -9388,16 +9363,6 @@ hast-util-phrasing@^1.0.5:
     hast-util-has-property "^1.0.0"
     hast-util-is-body-ok-link "^1.0.0"
     hast-util-is-element "^1.0.0"
-
-hast-util-phrasing@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/hast-util-phrasing/-/hast-util-phrasing-2.0.0.tgz#36b526bbfd5a9e0a85bc7a96509fa591edabcd0c"
-  integrity sha512-4rFSiFpdmTtp4aAxki6obpEbVJ85fOEN8/A8bOByoCaqRDTtd1AKTw3P/cXgVm0/RDuaWj0tSd1pTb0Jw5QfdA==
-  dependencies:
-    hast-util-embedded "^2.0.0"
-    hast-util-has-property "^2.0.0"
-    hast-util-is-body-ok-link "^1.0.0"
-    hast-util-is-element "^2.0.0"
 
 hast-util-raw@6.0.0:
   version "6.0.0"
@@ -9539,11 +9504,6 @@ hast-util-whitespace@^1.0.0, hast-util-whitespace@^1.0.4:
   resolved "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz"
   integrity sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A==
 
-hast-util-whitespace@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-2.0.0.tgz#4fc1086467cc1ef5ba20673cb6b03cec3a970f1c"
-  integrity sha512-Pkw+xBHuV6xFeJprJe2BBEoDV+AvQySaz3pPDRUs5PNZEMQjpXJJueqrpcHIXxnWTcAGi/UOCgVShlkY6kLoqg==
-
 hastscript@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz"
@@ -9662,10 +9622,10 @@ html-void-elements@^1.0.0:
   resolved "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz"
   integrity sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==
 
-html-whitespace-sensitive-tag-names@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-2.0.0.tgz#80c7512c969de90c94279641068fafb5fa6da468"
-  integrity sha512-SQdIvTTtnHAx72xGUIUudvVOCjeWvV1U7rvSFnNGxTGRw3ZC7RES4Gw6dm1nMYD60TXvm6zjk/bWqgNc5pjQaw==
+html-whitespace-sensitive-tag-names@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-1.0.3.tgz#60325c5bd331048d14ced6bac419c89d76cc9dd8"
+  integrity sha512-GX1UguduCBEAEo1hjFxc2Bz04/sDq0ACNyT7LsuoDcPfXYI3nS0NRPp3dyazLJyVUMp3GPBB56i/0Zr6CqD2PQ==
 
 htmlparser2@6.0.0:
   version "6.0.0"
@@ -10406,11 +10366,6 @@ is-plain-obj@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
-
-is-plain-obj@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.0.0.tgz#06c0999fd7574edf5a906ba5644ad0feb3a84d22"
-  integrity sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw==
 
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -14854,22 +14809,21 @@ regjsparser@^0.7.0:
   dependencies:
     jsesc "~0.5.0"
 
-rehype-format@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/rehype-format/-/rehype-format-4.0.1.tgz#0d4ad47733699dd8e3fcd9f73d04f210246b39e1"
-  integrity sha512-HA92WeqFri00yiClrz54IIpM9no2DH9Mgy5aFmInNODoAYn+hN42a6oqJTIie2nj0HwFyV7JvOYx5YHBphN8mw==
+rehype-format@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/rehype-format/-/rehype-format-3.1.0.tgz#3ed1214b4b0047cb7817e6b3471f3515caebab26"
+  integrity sha512-XC88CLU83x6ocwHbDsqbK/y+qNxqWcSp7gZdYeJzUZPQH05ABFke3Zb+H53UGsRAUTB2W95/UMMtn/pM+UFiKQ==
   dependencies:
-    "@types/hast" "^2.0.0"
-    hast-util-embedded "^2.0.0"
-    hast-util-is-element "^2.0.0"
-    hast-util-phrasing "^2.0.0"
-    hast-util-whitespace "^2.0.0"
-    html-whitespace-sensitive-tag-names "^2.0.0"
-    rehype-minify-whitespace "^5.0.0"
-    unified "^10.0.0"
-    unist-util-visit-parents "^5.0.0"
+    hast-util-embedded "^1.0.0"
+    hast-util-is-element "^1.0.0"
+    hast-util-phrasing "^1.0.0"
+    hast-util-whitespace "^1.0.0"
+    html-whitespace-sensitive-tag-names "^1.0.0"
+    rehype-minify-whitespace "^4.0.0"
+    repeat-string "^1.0.0"
+    unist-util-visit-parents "^3.0.0"
 
-rehype-minify-whitespace@^4.0.3:
+rehype-minify-whitespace@^4.0.0, rehype-minify-whitespace@^4.0.3:
   version "4.0.5"
   resolved "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-4.0.5.tgz"
   integrity sha512-QC3Z+bZ5wbv+jGYQewpAAYhXhzuH/TVRx7z08rurBmh9AbG8Nu8oJnvs9LWj43Fd/C7UIhXoQ7Wddgt+ThWK5g==
@@ -14878,18 +14832,6 @@ rehype-minify-whitespace@^4.0.3:
     hast-util-is-element "^1.0.0"
     hast-util-whitespace "^1.0.4"
     unist-util-is "^4.0.0"
-
-rehype-minify-whitespace@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/rehype-minify-whitespace/-/rehype-minify-whitespace-5.0.0.tgz#f3eec0ac94e78adbb868133e64864343ba9fff1f"
-  integrity sha512-cUkQldYx8jpWM6FZmCkOF/+mev09+5NAtBzUFZgnfXsIoglxo3h6t3S3JbNouiaqIDE6vbpI+GQpOg0xD3Z7kg==
-  dependencies:
-    "@types/hast" "^2.0.0"
-    hast-util-embedded "^2.0.0"
-    hast-util-is-element "^2.0.0"
-    hast-util-whitespace "^2.0.0"
-    unified "^10.0.0"
-    unist-util-is "^5.0.0"
 
 rehype-parse@^7.0.1:
   version "7.0.1"
@@ -17074,11 +17016,6 @@ trough@^1.0.0:
   resolved "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
-trough@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/trough/-/trough-2.0.2.tgz#94a3aa9d5ce379fc561f6244905b3f36b7458d96"
-  integrity sha512-FnHq5sTMxC0sk957wHDzRnemFnNBvt/gSY99HzK8F7UP5WAbvP70yX5bd7CjEQkN+TjdxwI7g7lJ6podqrG2/w==
-
 "true-case-path@^2.2.1":
   version "2.2.1"
   resolved "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz"
@@ -17407,19 +17344,6 @@ unified@9.0.0:
     trough "^1.0.0"
     vfile "^4.0.0"
 
-unified@^10.0.0:
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-10.1.1.tgz#345e349e3ab353ab612878338eb9d57b4dea1d46"
-  integrity sha512-v4ky1+6BN9X3pQrOdkFIPWAaeDsHPE1svRDxq7YpTc2plkIqFMwukfqM+l0ewpP9EfwARlt9pPFAeWYhHm8X9w==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    bail "^2.0.0"
-    extend "^3.0.0"
-    is-buffer "^2.0.0"
-    is-plain-obj "^4.0.0"
-    trough "^2.0.0"
-    vfile "^5.0.0"
-
 unified@^7.0.0:
   version "7.1.0"
   resolved "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz"
@@ -17548,11 +17472,6 @@ unist-util-is@^4.0.2:
   resolved "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz"
   integrity sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ==
 
-unist-util-is@^5.0.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-5.1.1.tgz#e8aece0b102fa9bc097b0fef8f870c496d4a6236"
-  integrity sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==
-
 unist-util-map@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/unist-util-map/-/unist-util-map-1.0.5.tgz"
@@ -17672,14 +17591,6 @@ unist-util-visit-parents@^3.0.0, unist-util-visit-parents@^3.1.0, unist-util-vis
   dependencies:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
-
-unist-util-visit-parents@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz#44bbc5d25f2411e7dfc5cecff12de43296aa8521"
-  integrity sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    unist-util-is "^5.0.0"
 
 unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.3:
   version "2.0.3"
@@ -18065,14 +17976,6 @@ vfile-message@^2.0.0:
     "@types/unist" "^2.0.0"
     unist-util-stringify-position "^2.0.0"
 
-vfile-message@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-3.1.0.tgz#5437035aa43185ff4b9210d32fada6c640e59143"
-  integrity sha512-4QJbBk+DkPEhBXq3f260xSaWtjE4gPKOfulzfMFF8ZNwaPZieWsg3iVlcmF04+eebzpcpeXOOFMfrYzJHVYg+g==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    unist-util-stringify-position "^3.0.0"
-
 vfile-reporter@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-6.0.1.tgz"
@@ -18135,16 +18038,6 @@ vfile@^4.2.0:
     replace-ext "1.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
-
-vfile@^5.0.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/vfile/-/vfile-5.3.0.tgz#4990c78cb3157005590ee8c930b71cd7fa6a006e"
-  integrity sha512-Tj44nY/48OQvarrE4FAjUfrv7GZOYzPbl5OD65HxVKwLJKMPU7zmfV8cCgCnzKWnSfYG2f3pxu+ALqs7j22xQQ==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    is-buffer "^2.0.0"
-    unist-util-stringify-position "^3.0.0"
-    vfile-message "^3.0.0"
 
 vinyl-fs@^3.0.2:
   version "3.0.3"


### PR DESCRIPTION
## Description

Downgrades `rehype-format` back to 3.1.0 to keep using CommonJS `require()`'s.

Tested uploading via `scripts/actions/translation_workflow/testing/script.sh` and it completed successfully.

Not sure we're quite in a place to switch over to ESM.

## Related issues / PRs
Closes https://github.com/newrelic/docs-website/issues/5905