### PR TITLE
fix(Alerts and AI): Shortening title

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/overview.mdx
+++ b/src/content/docs/alerts-applied-intelligence/overview.mdx
@@ -70,7 +70,7 @@ Use the correlate features to define your data sources and to review and configu
 * **[Sources](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/get-started-incident-intelligence/#1-configure-sources)**: Manage the data input sources you've chosen to analyze and be notified about. You can add new sources or configure existing ones.
 * **[Decisions](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/change-applied-intelligence-correlation-logic-decisions/)**: Review your correlated incidents and make decisions on how to respond to them. You can also review, edit, and add decisions.
 
-## **Enrich and notify** your notifications with useful metadata [#enrich]
+## **Enrich and notify** with useful metadata [#enrich]
 
 Use the enrich and notify features to add additional metadata to your notifications, schedule when you don't want to be notified, and configure where your notifications get sent.
 

--- a/src/content/docs/alerts-applied-intelligence/overview.mdx
+++ b/src/content/docs/alerts-applied-intelligence/overview.mdx
@@ -24,11 +24,9 @@ redirects:
   - /docs/alerts-applied-intelligence
 ---
 
-Alerts and applied intelligence are a suite of tools and features that proactively notify you when things go wrong–even when they're starting to go wrong.
+Alerts and applied intelligence are a suite of tools and features that proactively notify you when things go wrong... right when they're starting to go wrong.
 
-Alerts lets you define the conditions in your system you want to be notified about, letting you focus on the things you care about most.
-
-Applied intelligence is a machine-learning engine that reduces alert noise, correlates incidents, automatically detects anomalies, and provides root cause analysis. Not only that, it enriches your notifications with metadata to give you greater context of what's happening when you are notified.
+Want to try Alerts & AI? Join us! It's free... forever!
 
 <ButtonGroup>
     <ButtonLink
@@ -39,7 +37,12 @@ Applied intelligence is a machine-learning engine that reduces alert noise, corr
     Sign up for free
     </ButtonLink>
 </ButtonGroup>
-    No credit card required. Already have an account? [Login](http://one.newrelic.com/).
+
+Already have an account? [Login](http://one.newrelic.com/).
+
+Alerts lets you define the conditions in your system you want to be notified about, letting you focus on the things you care about most.
+
+Applied intelligence is a machine-learning engine that reduces alert noise, correlates incidents, automatically detects anomalies, and provides root cause analysis. Not only that, it enriches your notifications with metadata to give you greater context of what's happening when you are notified.
 
 ![Screenshot of the Alerts and AI overview page](./images/alerts-ai-summary.png 'The alerts and applied intelligence overview page')
 


### PR DESCRIPTION
As requested in #5897.

After checking with @paperclypse, we're only addressing the first item in the issue. As for the second comment (In the Alerts (classic) section, the Events is separate from Incidents, and in the docs it looks like it's one UI section), it's meant to look like this.