### PR TITLE
fix: broken link to category page

### DIFF
--- a/src/content/docs/licenses/overview.mdx
+++ b/src/content/docs/licenses/overview.mdx
@@ -62,6 +62,6 @@ redirects:
     title="Third party attributions."
     icon="fe-folder"
   >
-     These are the licenses and attributions for third party and open source components that are distributed with specific New Relic products and services. [Learn more.](/docs/licenses/product-or-service-licenses)
+     These are the licenses and attributions for third party and open source components that are distributed with specific New Relic products and services. [Learn more.](/docs/licenses/product-or-service-licenses/new-relic-apm/new-relic-apm-licenses)
   </LandingPageTile>
 </LandingPageTileGrid>


### PR DESCRIPTION
Fixes a broken link due to turning off index pages.

Reviewer, please double check that the new link is the best place to send users to. There wasn't a perfect location, and this seemed the best one. 