### PR TITLE
Use release branch for whats new ID commits

### DIFF
--- a/.github/workflows/update-whats-new-ids.yml
+++ b/.github/workflows/update-whats-new-ids.yml
@@ -19,8 +19,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
-          ref: develop
-          persist-credentials: false
+          fetch-depth: '0'
 
       - name: Setup node.js
         uses: actions/setup-node@v1
@@ -41,64 +40,11 @@ jobs:
           git add ./src/data/whats-new-ids.json
           git diff-index --quiet HEAD ./src/data/whats-new-ids.json || git commit -m 'chore(whats-new-ids): updated ids'
           echo "::set-output name=commit::true"
-
-      - name: Temporarily disable branch protection
-        id: disable-branch-protection
-        uses: actions/github-script@v1
-        with:
-          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
-          previews: luke-cage-preview
-          script: |
-            const result = await github.repos.updateBranchProtection({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              branch: 'develop',
-              required_status_checks: null,
-              restrictions: null,
-              enforce_admins: null,
-              required_pull_request_reviews: null
-            })
-            console.log("Result:", result)
-
-        # Push directly to the `develop` branch so we get the changes included in the release PR
+        # Push directly to the release branch so we get the changes included in the release PR
 
       - name: Push Commit
         if: steps.commit-changes.outputs.commit == 'true'
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
-          branch: develop
-
-      - name: Re-enable branch protection
-        id: enable-branch-protection
-        if: always()
-        uses: actions/github-script@v1
-        with:
-          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
-          previews: luke-cage-preview
-          script: |
-            const result = await github.repos.updateBranchProtection({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              branch: 'develop',
-              required_status_checks: {
-                strict: false,
-                contexts: [
-                  'Gatsby Build Service - docs-website-develop',
-                  'run linter',
-                  'run tests',
-                  'license/cla',
-                  'unpaired translations removed'
-                ]
-              },
-              restrictions: {
-                users: [],
-                teams: ['developer-enablement']
-              },
-              enforce_admins: null,
-              required_pull_request_reviews: {
-                dismiss_stale_reviews: true,
-                required_approving_review_count: 1
-              }
-            })
-            console.log("Result:", result)
+          branch: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/update-whats-new-ids.yml
+++ b/.github/workflows/update-whats-new-ids.yml
@@ -40,11 +40,50 @@ jobs:
           git add ./src/data/whats-new-ids.json
           git diff-index --quiet HEAD ./src/data/whats-new-ids.json || git commit -m 'chore(whats-new-ids): updated ids'
           echo "::set-output name=commit::true"
-        # Push directly to the release branch so we get the changes included in the release PR
+      - name: Temporarily disable branch protection
+        id: disable-branch-protection
+        uses: actions/github-script@v1
+        with:
+          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
+          previews: luke-cage-preview
+          script: |
+            const result = await github.repos.updateBranchProtection({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: context.payload.pull_request.head.ref,
+              required_status_checks: null,
+              restrictions: null,
+              enforce_admins: null,
+              required_pull_request_reviews: null
+            })
+            console.log("Result:", result)
+        # Push directly to the current release branch so we get the changes included in the release PR
 
       - name: Push Commit
         if: steps.commit-changes.outputs.commit == 'true'
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
-          branch: ${{ github.event.pull_request.head.ref }}
+          branch: ${{ github.head_ref }}
+
+      - name: Re-enable branch protection
+        id: enable-branch-protection
+        if: always()
+        uses: actions/github-script@v1
+        with:
+          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
+          previews: luke-cage-preview
+          script: |
+            const result = await github.repos.updateBranchProtection({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: context.payload.pull_request.head.ref,
+              enforce_admins: true,
+              required_status_checks: null,
+              restrictions: null,
+              required_pull_request_reviews: {
+                dismiss_stale_reviews: true,
+                required_approving_review_count: 1
+              }
+            })
+            console.log("Result:", result)


### PR DESCRIPTION
This updates the whats new ID generating workflow to commit new IDs to the branch PRing main instead of develop

closes https://github.com/newrelic/docs-website/issues/5927