### PR TITLE
fix(core user rules): clarifying apof downgrade rules

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing.mdx
@@ -65,7 +65,7 @@ The rules pertaining to how many times you can downgrade full platform users dif
     title="Pay-as-you-go: downgrade rules"
   >
 
-For the pay-as-you-go [usage plan](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing#usage-plans), there are no rules limiting downgrading of users but the [billing impacts](#user-count) may impact when you decide to upgrade or downgrade users. 
+For the [pay-as-you-go usage plan](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing#usage-plans), there are no rules limiting the downgrading of users but the [billing impacts](#user-count) may impact when you decide to upgrade or downgrade users. 
 </Collapser>
   <Collapser
     id="apof-downgrade"
@@ -74,15 +74,13 @@ For the pay-as-you-go [usage plan](/docs/accounts/accounts-billing/new-relic-one
 
 Before upgrading or downgrading a user, ensure you understand the [billing impacts](#user-count).
 
-For the [annual pool of funds plan](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing#usage-plans), we limit how many times a full platform user can be downgraded. There are no limitations on how many times you can downgrade a core user to a basic user.  
+For the [annual pool of funds plan](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing#usage-plans), we have rules regarding how many times a user can be downgraded from being a full platform user to a lower user type. (There are no rules regarding how often users change between core user and basic user.)
 
-On a month-by-month level (not within a month), a full platform user can only switch to a lower user type twice during one "contract year" (a year starting at your contract's starting point, or at the anniversary of that point). Once a full platform user has downgraded twice, if they switch back to be a full platform user in a later month, they are billed as a full platform user for the remaining months in that year. 
+During a New Relic organization's contract year (defined below), if a full platform user is changed to a lower user type and back to a full platform user twice, that user will be billed as a full platform user for the remainder of that contract year, regardless of user type adjustments. 
 
-Here's an example of how that works in practice: Let’s say your organization has a year-long contract that started March 1st. One of your full platform users downgrades to be a basic user for the month of May, then goes back to being a full platform user for the month of June, and then becomes a core user for the month of August. That user has reached the two-downgrades-per-contract-year limit. If that user then becomes a billable full platform user again for a subsequent calendar month in that remaining contract year, that user counts as a full platform user for the remaining months in that year, regardless of what their user type is changed to.
+A contract year is defined as a year starting at your contract's starting point, or at the anniversary of that point. If your organization started out on a different pricing plan and [switched to this version of pricing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/core-users-release#nr1core-optin), the user type downgrade rule will apply from when you opted in until the renewal of your subscription term or, if applicable, the annual anniversary date of your commitment term, whichever is earlier.
 
-Note that the downgrade limit doesn't apply within a month. A user can switch their user type as many times within a month as needed, and the highest user type that user is set as during that month is considered their [billable user type](#user-count) for that month. 
 
-If your organization started out on a different pricing plan and [switched to this pricing version](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/core-users-release#nr1core-optin), the two-times-per-year downgrade limit will apply from when you opted in until the renewal of your subscription term or, if applicable, the annual anniversary date of your commitment term, whichever is earlier. 
 </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
Pricing docs liaison work: it was realized what we had about downgrade rules for APOF core pricing needed clarification. 