### PR TITLE
Specify condition when using per-signal env var

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start.mdx
@@ -62,7 +62,7 @@ To complete this third step, first familiarize yourself with some required New R
 Before you go to the external OTLP exporter documentation, consult the table below so you're ready to do the following:
 
 * Configure the OTLP exporter to add a header (```api-key```) whose value is the license key for the New Relic account you want to send data to.
-* Based on your integration, configure the endpoint where the exporter sends data to New Relic. Most users will want to use the US OTLP or EU OTLP endpoints.
+* Based on your integration, configure [the endpoint](#note-endpoints) where the exporter sends data to New Relic. Most users will want to use the US OTLP or EU OTLP endpoints.
 
 <table>
   <thead>
@@ -112,7 +112,8 @@ Before you go to the external OTLP exporter documentation, consult the table bel
       <td>Infinite Tracing<br/>(See [best practices](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts/#infinite-tracing)  for endpoint details</td>
       <td>✅</td>
       <td>❌</td>
-      <td>`https://{trace-bserver}:443`</td>
+      <td>`https://{trace-observer}`</td>
+      <td>`443`</td>
       <td>`api-key`</td>
       <td><a href="https://one.newrelic.com/launcher/api-keys-ui.launcher">License key</a></td>
       <td>✅</td>
@@ -129,6 +130,12 @@ In Node.js, the [opentelemetry-collector-exporter-grpc](https://www.npmjs.com/pa
 OTLP standards designate gRPC traffic to port `4317`, and HTTP traffic to port `4318`. The New Relic US FedRamp Native OTLP endpoint adheres to those specifications, as well as allowing gRPC traffic on port `443`. 
 
 However, non-FedRamp New Relic endpoints will accept both gRPC and HTTP traffic on any of the ports listed in the above chart.
+
+### A note about endpoints [#note-endpoints]
+
+Per the [OpenTelemetry spec](https://github.com/open-telemetry/opentelemetry-specification/blob/b7473b5de0f55f921f896948442ebb274f58b584/specification/protocol/exporter.md#endpoint-urls-for-otlphttp) on endpoint URLs for OTLP/HTTP: If you are sending HTTP traffic and using the non-per-signal environment variable (`OTEL_EXPORTER_OTLP_ENDPOINT`), you can simply set `OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net:{port}` and the exporter should append the appropriate path for the signal type (i.e., `v1/traces` or `v1/metrics`).
+
+If you are using a per-signal environment variable (i.e., `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and/or `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`), you are required to set it with the appropriate path. For example, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://otlp.nr-data.net:4318/v1/traces`. Not doing so will result in a 404. Note that this environment variable takes precedence over the non-per-signal one. 
 
 ### Complete the export configuration steps [#complete-configs]
 


### PR DESCRIPTION
- Adds new section called "A note about endpoints" that per Otel spec, when using a per-signal env var, it is required to set the endpoint URL ending in either `v1/traces` or `v1/metrics` (not doing so will result in a 404)
- Also fixes the Infinite Tracing row in the table
- Adds link to the new section in the config section above the table