### PR TITLE
Added advice on creating charts with time functions.

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/nrql-group-results-across-time.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/nrql-group-results-across-time.mdx
@@ -162,4 +162,23 @@ SELECT count(*) FROM PageView SINCE 1 day ago FACET dateOf(account_created), mon
   >
     You can run NRQL queries to group your data in other ways, not just time. For additional examples, see the [NRQL `FACET` documentation](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions#sel-facet).
   </Collapser>
+  
+  <Collapser
+    id="timeseries-chart-examples"
+    title="Example of creating a chart by specifying TIMESERIES"
+  >
+    You need to be aware of UNTIL you add the TIMESERIES function and use the time function in a time series chart.
+The default value of UNTIL is NOW, so if you do not specify anything, the values of the time functions may be separated or combined.
+By specifying `UNTIL today`, you can create a chart that ends at 12:00 AM on the same day.
+
+    ```
+    SELECT count(*) FROM PageView TIMESERIES 1 day  WITH TIMEZONE '<localTimeZone>' SINCE 4 week ago UNTIL today
+    ```
+
+If you want to visualize data from `last month` instead of the past four weeks, you can use `since last month until this month`.
+
+    ```
+    SELECT count(*) FROM PageView TIMESERIES 1 day  WITH TIMEZONE '<localTimeZone>' since last month until this month
+    ```
+  </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
When charting a time function, if you don't specify "until", the StackBar chart may split time into concatenations.
I have described how to specify "today" or "this month" with until.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.