### PR TITLE
Fix metrics from Rabbitmq integration

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/rabbitmq-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/rabbitmq-monitoring-integration.mdx
@@ -739,6 +739,16 @@ These attributes are attached to the `RabbitmqNodeSample` event type:
 
     <tr>
       <td>
+        `node.fileDescriptorsTotal`
+      </td>
+
+      <td>
+        The total count of file descriptors. In RabbitMQ this is seen as `fd_total`.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         `node.fileDescriptorsTotalUsed`
       </td>
 
@@ -754,6 +764,16 @@ These attributes are attached to the `RabbitmqNodeSample` event type:
 
       <td>
         Number of file descriptors used as sockets. In RabbitMQ this is seen as `sockets_used`.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `node.fileDescriptorsTotalSockets`
+      </td>
+
+      <td>
+        Total number of file descriptors available as sockets. In RabbitMQ this is seen as `sockets_total`.
       </td>
     </tr>
 
@@ -779,11 +799,31 @@ These attributes are attached to the `RabbitmqNodeSample` event type:
 
     <tr>
       <td>
-        `node.paritionsSeen`
+        `node.partitionsSeen`
       </td>
 
       <td>
         Number of network partitions seen per node. In RabbitMQ this is seen as `partitions`.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `node.processesTotal`
+      </td>
+
+      <td>
+        Erlang process limit. In RabbitMQ this is seen as `proc_total`.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `node.processesUsed`
+      </td>
+
+      <td>
+        Erlang processes used. In RabbitMQ this is seen as `proc_used`.
       </td>
     </tr>
 
@@ -826,106 +866,6 @@ These attributes are attached to the `RabbitmqExchangeSample` event type:
 
       <td>
         Number of bindings for a specific exchange.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `exchange.messagesDeliveredAcknowledged`
-      </td>
-
-      <td>
-        Count of messages delivered to clients and acknowledged per exchange.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `exchange.messagesDeliveredAcknowledgedPerSecond`
-      </td>
-
-      <td>
-        Rate of messages delivered to clients and acknowledged per exchange per second.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `exchange.messagesConfirmed`
-      </td>
-
-      <td>
-        Count of messages confirmed per exchange.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `exchange.messagesConfirmedPerSecond`
-      </td>
-
-      <td>
-        Rate of messages confirmed per exchange per second.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `exchange.messagesRedelivered`
-      </td>
-
-      <td>
-        Count of subset of messages in deliver_get which had the redelivered flag set per queue.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `exchange.messagesRedeliveredPerSecond`
-      </td>
-
-      <td>
-        Rate of subset of messages in deliver_get which had the redelivered flag set per queue per second.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `exchange.messagesReturnedUnroutable`
-      </td>
-
-      <td>
-        Count of messages returned to publisher as unroutable per exchange.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `exchange.messagesReturnedUnroutablePerSecond`
-      </td>
-
-      <td>
-        Rate of messages returned to publisher as unroutable per exchange per second.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `exchange.messagesPublished`
-      </td>
-
-      <td>
-        Count of messages published per exchange.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `exchange.messagesPublishedPerSecond`
-      </td>
-
-      <td>
-        Rate of messages published per exchange queue per second.
       </td>
     </tr>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

Removed these metrics where not being generated by the integration:
```
exchange.messagesDeliveredAcknowledged
exchange.messagesDeliveredAcknowledgedPerSecond
exchange.messagesConfirmed
exchange.messagesConfirmedPerSecond
exchange.messagesRedelivered
exchange.messagesRedeliveredPerSecond
exchange.messagesReturnedUnroutable
exchange.messagesReturnedUnroutablePerSecond
exchange.messagesPublished
exchange.messagesPublishedPerSecond
```

Added this metrics that were not documented:
```
node.fileDescriptorsTotal
node.processesTotal
node.processesUsed
node.fileDescriptorsTotalSockets
node.partitionsSeen
```

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

notice that git diff is not showing the changes in the best way 

* If your issue relates to an existing GitHub issue, please link to it.