### PR TITLE
Clarify behavior of SWA

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -735,6 +735,11 @@ You can use [sliding windows](/docs/query-your-data/nrql-new-relic-query-languag
 
 Once enabled, set the slide by duration to control how much overlap time your aggregated windows have. The slide by duration must be shorter than the aggregation windows duration, and must divide equally between them.
 
+<Callout variant="important">
+  Immediately after you create a new Sliding Windows alert condition or perform any action that can cause an [evaluation reset](#evaluation-resets), your condition will need time build up an "aggregated buffer" for the duration of the first aggregation window. During that time, no violations will trigger. Once that single aggregation window has passed, a complete "buffer" will have been built and the condition will function normally.
+</Callout>
+
+
 ### Streaming method [#streaming]
 
 Choose between [three streaming aggregation methods](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts/#aggregation-methods) to get the best evaluation results for your conditions.


### PR DESCRIPTION
When first created or immediately after a significant edit, SWA conditions will build up a picture of the aggregated data. No violations will open during this period. This takes as long as the first aggregation window, and after that point the condition behaves normally.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.