### PR TITLE
feat(Browser API): removed note about admin api key

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-api.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-api.mdx
@@ -12,7 +12,7 @@ Browser monitoring supports the uploading of [source maps](/docs/new-relic-brows
 
 In order to upload source maps to browser via the API, you'll need this information:
 
-* A [user API key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key) (before November 20, 2020, the [Admin API key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#admin) was required; that will still work if already in place)
+* A [user API key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key)
 * The New Relic [application ID](/docs/browser/new-relic-browser/installation-configuration/copy-browser-monitoring-license-key-app-id) for the deployed app
 * The full [JavaScript file URL](#what-url)
 * Optionally, if the JavaScript URL doesn't automatically have release info appended to it, the [release name and ID](#release-id)


### PR DESCRIPTION
The admin API key is no longer necessary. 

This came in as a hero request in the documentation channel.