### PR TITLE
Revert "Use release branch for whats new ID commits"

### DIFF
--- a/.github/workflows/update-whats-new-ids.yml
+++ b/.github/workflows/update-whats-new-ids.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
-          fetch-depth: '0'
+          ref: develop
+          persist-credentials: false
 
       - name: Setup node.js
         uses: actions/setup-node@v1
@@ -40,6 +41,7 @@ jobs:
           git add ./src/data/whats-new-ids.json
           git diff-index --quiet HEAD ./src/data/whats-new-ids.json || git commit -m 'chore(whats-new-ids): updated ids'
           echo "::set-output name=commit::true"
+
       - name: Temporarily disable branch protection
         id: disable-branch-protection
         uses: actions/github-script@v1
@@ -50,21 +52,22 @@ jobs:
             const result = await github.repos.updateBranchProtection({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              branch: context.payload.pull_request.head.ref,
+              branch: 'develop',
               required_status_checks: null,
               restrictions: null,
               enforce_admins: null,
               required_pull_request_reviews: null
             })
             console.log("Result:", result)
-        # Push directly to the current release branch so we get the changes included in the release PR
+
+        # Push directly to the `develop` branch so we get the changes included in the release PR
 
       - name: Push Commit
         if: steps.commit-changes.outputs.commit == 'true'
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
-          branch: ${{ github.head_ref }}
+          branch: develop
 
       - name: Re-enable branch protection
         id: enable-branch-protection
@@ -77,10 +80,22 @@ jobs:
             const result = await github.repos.updateBranchProtection({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              branch: context.payload.pull_request.head.ref,
-              enforce_admins: true,
-              required_status_checks: null,
-              restrictions: null,
+              branch: 'develop',
+              required_status_checks: {
+                strict: false,
+                contexts: [
+                  'Gatsby Build Service - docs-website-develop',
+                  'run linter',
+                  'run tests',
+                  'license/cla',
+                  'unpaired translations removed'
+                ]
+              },
+              restrictions: {
+                users: [],
+                teams: ['developer-enablement']
+              },
+              enforce_admins: null,
               required_pull_request_reviews: {
                 dismiss_stale_reviews: true,
                 required_approving_review_count: 1


### PR DESCRIPTION
Reverts newrelic/docs-website#5948

we have an odd merge commit getting added by this action. we're not sure if it's causing stalled builds yet but i'm going to revert this for now. whats new IDs will go back to being committed to develop