### PR TITLE
k8s: replace `K8` with `K8s`

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
@@ -426,7 +426,7 @@ Log Record after enabling `lowDataMode`.
 ]
 ```
 
-### New Relic Pixie Integration
+### New Relic Pixie Integration [#nr-pixie-integration]
 
 If `lowDataMode` is enabled, the `newrelic-pixie` integration performs heavier sampling on Pixie spans and reduces the collection interval from 10 seconds to 15 seconds.
 

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Kubernetes integration
   - Installation
-metaDescription: How to install the K8 integration using Helm.
+metaDescription: How to install the K8s integration using Helm.
 redirects:
   - /docs/integrations/kubernetes-integration/installation/install-kubernetes-integration-using-helm
 ---

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-windows.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-windows.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Kubernetes integration
   - Installation
-metaDescription: How to install the K8 integration for Windows.
+metaDescription: How to install the K8s integration for Windows.
 redirects:
   - /docs/integrations/kubernetes-integration/installation/install-kubernetes-integration-windows
 ---

--- a/src/i18n/content/jp/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
+++ b/src/i18n/content/jp/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Kubernetes integration
   - Installation
-metaDescription: How to install the K8 integration using Helm.
+metaDescription: How to install the K8s integration using Helm.
 translationType: machine
 ---
 

--- a/src/i18n/content/jp/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-windows.mdx
+++ b/src/i18n/content/jp/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-windows.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Kubernetes integration
   - Installation
-metaDescription: How to install the K8 integration for Windows.
+metaDescription: How to install the K8s integration for Windows.
 translationType: machine
 ---
 


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
  - Replaces `K8` with `K8s` in page meta descriptions.

It was making link previews look bad.