### PR TITLE
chore: deal with errored translations

### DIFF
--- a/scripts/actions/__tests__/check-job-progress.test.js
+++ b/scripts/actions/__tests__/check-job-progress.test.js
@@ -8,6 +8,7 @@ const {
   aggregateStatuses,
   updateTranslationRecords,
   updateJobRecords,
+  logErroredStatuses,
 } = require('../check-job-progress');
 
 jest.mock('../translation_workflow/database');
@@ -83,21 +84,14 @@ describe('check-jobs-progress tests', () => {
   });
 
   describe('updateTranslationRecords', () => {
-    test('updates translation record to ERRORED for failed slug', async () => {
+    test('does not update translation record for failed slug', async () => {
       updateTranslations.mockReturnValue([{ id: 0 }]);
 
       const slugStatus = { ok: false, slug: 'failure.txt' };
 
       await updateTranslationRecords([slugStatus]);
 
-      expect(updateTranslations.mock.calls.length).toBe(1);
-      expect(updateTranslations.mock.calls[0][0]).toStrictEqual({
-        slug: 'failure.txt',
-        status: 'IN_PROGRESS',
-      });
-      expect(updateTranslations.mock.calls[0][1]).toStrictEqual({
-        status: 'ERRORED',
-      });
+      expect(updateTranslations.mock.calls.length).toBe(0);
     });
 
     test('updates translation record to COMPLETED for successful slug', async () => {
@@ -121,13 +115,62 @@ describe('check-jobs-progress tests', () => {
       updateTranslations.mockReturnValue([{ id: 0 }]);
       const slugStatuses = [
         { ok: true, slug: 'fake_slug.txt' },
-        { ok: false, slug: 'fake_slug_2.txt' },
+        { ok: true, slug: 'fake_slug_2.txt' },
         { ok: true, slug: 'fake_slug_3.txt' },
       ];
 
       await updateTranslationRecords(slugStatuses);
 
       expect(updateTranslations.mock.calls.length).toBe(3);
+    });
+
+    test('logs errored translations to the console', async () => {
+      console.log = jest.fn();
+      const erroredStatuses = [{ ok: false, slug: 'fake_slug.txt' }];
+
+      logErroredStatuses(erroredStatuses);
+
+      expect(console.log).toHaveBeenCalledWith(
+        '    [!]Translation errored: fake_slug.txt'
+      );
+    });
+
+    test('logs multiple errored translations', async () => {
+      console.log = jest.fn();
+      const erroredStatuses = [
+        { ok: false, slug: 'fake_slug.txt' },
+        { ok: false, slug: 'fake_slug_2.txt' },
+        { ok: false, slug: 'fake_slug_3.txt' },
+      ];
+
+      logErroredStatuses(erroredStatuses);
+
+      expect(console.log).toHaveBeenCalledWith(
+        '    [!]Translation errored: fake_slug.txt'
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        '    [!]Translation errored: fake_slug_2.txt'
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        '    [!]Translation errored: fake_slug_3.txt'
+      );
+    });
+
+    test('logs when an ok translation is passed in errored array', async () => {
+      console.log = jest.fn();
+      const erroredStatuses = [
+        { ok: false, slug: 'fake_slug.txt' },
+        { ok: true, slug: 'fake_slug_2.txt' },
+      ];
+
+      logErroredStatuses(erroredStatuses);
+
+      expect(console.log).toHaveBeenCalledWith(
+        '    [!]Translation errored: fake_slug.txt'
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        '    [!]The translation fake_slug_2.txt is ok and should be set to COMPLETED'
+      );
     });
   });
 

--- a/scripts/actions/__tests__/send-and-update-translation-queue.test.js
+++ b/scripts/actions/__tests__/send-and-update-translation-queue.test.js
@@ -243,6 +243,45 @@ describe('send-and-update-translation-queue tests', () => {
       expect(deleteTranslation.mock.calls[0][0]).toBe(1);
       expect(deleteTranslation.mock.calls[1][0]).toBe(3);
     });
+
+    test('deletes translations with an ERRORED status', async () => {
+      console.log = jest.fn();
+      when(getTranslations)
+        .calledWith({ status: 'PENDING' })
+        .mockReturnValue([
+          {
+            id: 1,
+            slug: 'hello_world.txt',
+            locale: 'ja-JP',
+            status: 'PENDING',
+          },
+          {
+            id: 3,
+            slug: 'hello_world2.txt',
+            locale: 'ja-JP',
+            status: 'PENDING',
+          },
+        ])
+        .calledWith({ status: 'IN_PROGRESS' })
+        .mockReturnValue([])
+        .calledWith({ status: 'ERRORED' })
+        .mockReturnValue([
+          {
+            id: 2,
+            slug: 'hello_world3.txt',
+            locale: 'ja-JP',
+            status: 'ERRORED',
+          },
+        ]);
+      fs.existsSync.mockReturnValue(true);
+
+      await getReadyToGoTranslationsForEachLocale();
+      expect(console.log).toHaveBeenCalledWith(
+        'Database record for -- 2 -- deleted'
+      );
+      expect(deleteTranslation.mock.calls.length).toBe(1);
+      expect(deleteTranslation.mock.calls[0][0]).toBe(2);
+    });
   });
 
   describe('createJobs', () => {

--- a/scripts/actions/send-and-update-translation-queue.js
+++ b/scripts/actions/send-and-update-translation-queue.js
@@ -34,7 +34,7 @@ const getReadyToGoTranslationsForEachLocale = async () => {
    *
    * 3. The file (slug) that is associated with the translation record still exists.
    */
-  const translationsToDelete = [];
+  const translationsToDelete = [...erroredTranslations];
 
   const readyToGoTranslations = pendingTranslations
     .filter(
@@ -76,7 +76,7 @@ const getReadyToGoTranslationsForEachLocale = async () => {
     })
   );
 
-  let translationsPerLocale = {};
+  const translationsPerLocale = {};
   for (const translation of readyToGoTranslations) {
     translationsPerLocale[translation.locale] = [
       ...(translationsPerLocale[translation.locale] || []),


### PR DESCRIPTION
This update deals with translations that have an `ERRORED` status in the DB:

 - No longer updates the translations status to `COMPLETED`
 - Logs all `ERRORED` status translations to the console
 - Only updates statuses for `ok` translations
 - Includes tests

Also updated the `send-an-update-translation-queue` file to:
 - Delete translations that have an `ERRORED` status from the DB
 - Includes tests