### PR TITLE
Documenting additional env vars

### DIFF
--- a/src/content/docs/logs/forward-logs/aws-lambda-sending-cloudwatch-logs.mdx
+++ b/src/content/docs/logs/forward-logs/aws-lambda-sending-cloudwatch-logs.mdx
@@ -88,6 +88,22 @@ Complete the following:
         Each tag is composed of a colon-delimited key and value. Multiple key-value pairs are semicolon-delimited; for example, `env:prod;team:myTeam`.
       </td>
     </tr>
+    <tr>
+      <td>
+        `NR_LAMBDA_LOG_GROUP_PREFIX`
+      </td>
+      <td>
+        If you've configured your Lambda log group to use a different path than `/aws/lambda`, you can specify it with this variable. **Optional.**
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `NR_VPC_LOG_GROUP_PREFIX`
+      </td>
+      <td>
+        If you've configured your VPC log group to use a different path than `/aws/vpc/flow-log`, you can specify it with this variable. **Optional.**
+      </td>
+    </tr>
     </tbody>
 </table>
 


### PR DESCRIPTION
Adding notes on NR_LAMBDA_LOG_GROUP_PREFIX and NR_VPC_LOG_GROUP_PREFIX. These optional environment variable options were added to our aws-log-ingestion/newrelic-log-ingestion Lambda function, but were previously documented only in the ReadMe.
