### PR TITLE
k8s/changes: add an upgrade from v2 section

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/changes-since-v3.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/changes-since-v3.mdx
@@ -236,3 +236,55 @@ While not related to the integration configuration, the following miscellaneous 
  * `images.forwarder.*` to configure the infrastructure-agent forwarder.
  * `images.agent.*` to configure the image bundling the infrastructure-agent and on-host integrations.
  * `images.integration.*` to configure the image in charge of scraping k8s data.
+
+### Upgrade from v2 [#upgrade-from-v2]
+
+In order to upgrade from the Kubernetes integration version 2 (included in [nri-bundle chart](https://github.com/newrelic/helm-charts/tree/master/charts/nri-bundle) versions 3.x), we strongly encourage you to create a `values-newrelic.yaml` file with your desired License Key and configuration. If you had previously installed our chart from the CLI directly, for example using a command like the following:
+
+```
+helm install newrelic/nri-bundle \
+--set global.licenseKey=<New Relic License key> \
+--set global.cluster=<Cluster name> \
+--set infrastructure.enabled=true \
+--set prometheus.enabled=true \
+--set webhook.enabled=true \
+--set ksm.enabled=true \
+--set kubeEvents.enabled=true \
+--set logging.enabled=true
+```
+
+You can take the provided `--set` arguments and put them in a yaml file like the following:
+
+```yaml
+# values-newrelic.yaml
+global:
+  licenseKey: <New Relic License key>
+  cluster: <Cluster name>
+infrastructure:
+  enabled: true
+prometheus:
+  enabled: true
+webhook:
+  enabled: true
+ksm:
+  enabled: true
+kubeEvents:
+  enabled: true
+logging:
+  enabled: true
+```
+
+After doing this, and adapting any other setting you might have changed according to the [section above](#migration-guide), you can upgrade by running the following command:
+
+```shell
+helm upgrade newrelic newrelic/nri-bundle \
+--namespace newrelic --create-namespace \
+-f values-newrelic.yaml \
+--devel
+```
+
+The `--devel` flag will instruct helm to download the v3 version of the integration (version 4.x of the `nri-bundle` chart).
+
+<Callout variant="important">
+  The `--reuse-values` flag is not supported for upgrading from v2 to v3.
+</Callout>


### PR DESCRIPTION
## Give us some context

### What problems does this PR solve?

The page we dedicated to explain the changes for the new Kubernetes integration version did not have a section explicitly saying how to upgrade from v2. This PR adds this.

While this is slightly duplicated, as it is in fact the same command that can be found in the "install integration using helm" section, we thought it was worth adding it to encourage users to jump to action right away, rather than making them search _how_ to upgrade elsewhere.
