### PR TITLE
Update branch committed to by whats new ID workflow

### DIFF
--- a/.github/workflows/update-whats-new-ids.yml
+++ b/.github/workflows/update-whats-new-ids.yml
@@ -19,8 +19,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
-          ref: develop
-          persist-credentials: false
+          ref: ${{github.head_ref}}
 
       - name: Setup node.js
         uses: actions/setup-node@v1
@@ -52,7 +51,7 @@ jobs:
             const result = await github.repos.updateBranchProtection({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              branch: 'develop',
+              branch: context.payload.pull_request.head.ref,
               required_status_checks: null,
               restrictions: null,
               enforce_admins: null,
@@ -60,14 +59,14 @@ jobs:
             })
             console.log("Result:", result)
 
-        # Push directly to the `develop` branch so we get the changes included in the release PR
+        # Push directly to the current release branch so we get the changes included in the release PR
 
       - name: Push Commit
         if: steps.commit-changes.outputs.commit == 'true'
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
-          branch: develop
+          branch: ${{ github.head_ref }}
 
       - name: Re-enable branch protection
         id: enable-branch-protection
@@ -80,22 +79,10 @@ jobs:
             const result = await github.repos.updateBranchProtection({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              branch: 'develop',
-              required_status_checks: {
-                strict: false,
-                contexts: [
-                  'Gatsby Build Service - docs-website-develop',
-                  'run linter',
-                  'run tests',
-                  'license/cla',
-                  'unpaired translations removed'
-                ]
-              },
-              restrictions: {
-                users: [],
-                teams: ['developer-enablement']
-              },
-              enforce_admins: null,
+              branch: context.payload.pull_request.head.ref,
+              enforce_admins: true,
+              required_status_checks: null,
+              restrictions: null,
               required_pull_request_reviews: {
                 dismiss_stale_reviews: true,
                 required_approving_review_count: 1


### PR DESCRIPTION
This is a take 2 to solve our whats new ID commit issue. Currently the workflow commits to develop but we'd like the IDs committed to the release branch. The previous attempt was adding an odd merge commit but this iteration specifies the checkout branch as the head and appears to have solved the issue in tests


## Related PRs
- https://github.com/newrelic/docs-website/pull/5948
- https://github.com/newrelic/docs-website/pull/6034