### PR TITLE
Fix broken configuration link in trace observer doc

### DIFF
--- a/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
@@ -153,7 +153,7 @@ To set up a trace observer:
           </Callout>
      </Collapser>
    </CollapserGroup>
-6. (Optional) There are several ways to [configure Infinite Tracing](/docs/distributed-tracing/infinite-tracing). This configuration can wait until after you've completed the enable procedures.
+6. (Optional) Infinite Tracing offers several configuration options which you can look at after you've worked with this feature for a while. Bookmark the [first of these topics](/docs/distributed-tracing/infinite-tracing/infinite-tracing-configure-trace-observer-monitoring) as a reminder to review them later.
 7. This procedure is complete. Next, return to finish any remaining instructions for the tracing tool you started enabling:
 
    * [Language agents](/docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing#configure-agents)


### PR DESCRIPTION
The optional configuration step had a dead link in the trace observer setup. This will all get replaced shortly by a larger set of doc changes, but this is a short-term fix.

I am out of the office on 2/10/2022, but if this looks good, you can publish it for me.