### PR TITLE
fix inaccuracy

### DIFF
--- a/src/content/docs/accounts/accounts/saml-single-sign/saml-service-providers.mdx
+++ b/src/content/docs/accounts/accounts/saml-single-sign/saml-service-providers.mdx
@@ -214,7 +214,7 @@ To help ensure security and account for network time and clock skews, configure 
 
 To set up your SSO configuration for users on our [original user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-user-models):
 
-1. Read about an option to have [users bypass SAML SSO](#add-users-saml) if they use domains you own.
+1. Read about an option to have [users bypass email confirmation](#add-users-saml) if they use domains you own.
 2. Go to: **[account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown) > Account settings > Security and authentication > Single sign on**.
 3. From the **SAML Single Sign On** page, review your New Relic SAML service provider details.
 4. To upload your SAML identity provider certificate, select **Choose file**, then follow standard procedures to select and save the file.


### PR DESCRIPTION
In the Original User Model all users are either authenticated via Username/Password, or via SSO. There is no option for a portion of users to auth one way and another portion to auth the other. 

the doc contained reference to "Read about an option to have users bypass SAML SSO if they use domains you own."  there is no way to bypass SSO. What users are bypassing is the requirement to verify their email address. Hopefully this PR clarifies that. :)

