### PR TITLE
chore: minor wording fix for codestream request-feedback page.

### DIFF
--- a/src/content/docs/codestream/how-use-codestream/request-feedback.mdx
+++ b/src/content/docs/codestream/how-use-codestream/request-feedback.mdx
@@ -3,7 +3,7 @@ title: Request feedback on CodeStream
 metaDescription: "How to review and request feedback from your teammates, as well as how to make direct code changes."
 ---
 
-New Relic CodeStream's feedback requests are powerful enough to use for traditional end-of-cycle code reviews, but at the same time they're so easy and flexible that you can use them throughout the development process to get quick feedback on work-in-progress. You can even use feedback requests for uncommitted your changes.
+New Relic CodeStream's feedback requests are powerful enough to use for traditional end-of-cycle code reviews, but at the same time they're so easy and flexible that you can use them throughout the development process to get quick feedback on work-in-progress. You can even use feedback requests for your uncommitted changes.
 
 Traditional code review happens at the end of the development cycle, when you’re looking to get the changes merged. Not only are end-of-cycle code reviews much more burdensome on your teammates, but you run the risk of identifying issues so late in the game that you end up having to decide between blowing up your schedule or taking on technical debt.
 
@@ -17,7 +17,7 @@ To request feedback at any time, regardless of the current state of your work, c
 
 ![A screenshot showing how to request feedback](/images/RequestFeedback.png "Request feedback")
 
-With a single click you can name the feedback request based on the last commit message, the branch name, or, if you [started work by selecting a ticket](/docs/codestream/how-use-codestream/start-work/), the ticket title. CodeStream assumes that you are requesting feedback on changes in the repository/branch of the file you've currently selected in your editor. If you have multiple repositories open in your IDE, you can change this via the repository dropdown at the very top of the feedback request form. 
+With a single click you can name the feedback request based on the last commit message, the branch name, or, if you [started work by selecting a ticket](/docs/codestream/how-use-codestream/start-work/), the ticket title. CodeStream assumes that you are requesting feedback on changes in the repository/branch of the file you've currently selected in your editor. If you have multiple repositories open in your IDE, you can change this via the repository dropdown at the very top of the feedback request form.
 
 Depending on your organization's settings, CodeStream may suggest specific reviewers. Based on the commit history of the code being changed, the suggestions may even include someone that isn't yet on your CodeStream team. In that case, they'd be notified by email. Hover over a reviewer’s name to see more details or to remove them. If multiple reviewers are assigned you may also have the option to determine whether any of them can approve the review or if each one has to approve it individually.
 
@@ -42,7 +42,7 @@ The four categories are:
 * Local commits
 * Pushed commits
 
-Commits are listed in descending order across the **Local Commits** and **Pushed Commits** sections. If you uncheck the box for a commit, it will automatically uncheck the boxes for all of its preceding commits. In other words, the commits included in the feedback request must be consecutive. Only your commits are checked by default, but you can include any of them in your review. 
+Commits are listed in descending order across the **Local Commits** and **Pushed Commits** sections. If you uncheck the box for a commit, it will automatically uncheck the boxes for all of its preceding commits. In other words, the commits included in the feedback request must be consecutive. Only your commits are checked by default, but you can include any of them in your review.
 
 <Callout variant="tip">
 Make sure the email address in your git configuration matches your CodeStream email address. Or set up a [blame map](/docs/codestream/how-use-codestream/my-organization/#blame-map) to map your git email address to you CodeStream email address.
@@ -50,7 +50,7 @@ Make sure the email address in your git configuration matches your CodeStream em
 
 Optionally, you can share your feedback request out to either Slack or Microsoft Teams.
 
-When you submit your feedback request, your teammates will be notified via the activity feed, with anyone assigned as a reviewer being @mentioned so that they’ll also receive an email notification. 
+When you submit your feedback request, your teammates will be notified via the activity feed, with anyone assigned as a reviewer being @mentioned so that they’ll also receive an email notification.
 
 ## Provide feedback [#provide-feedback]
 
@@ -76,7 +76,7 @@ If you want to comment on the actual changes, select some code from the right si
 
 Since you have the full file context, you aren’t limited to commenting on just the lines of code that were changed. For example, you might notice another part of the file that needs work as well or that you simply want to reference.
 
-Whether it’s a general comment or a comment on code, you can mark it as a change request to let the developer know that it’s required before you’ll approve the changes. 
+Whether it’s a general comment or a comment on code, you can mark it as a change request to let the developer know that it’s required before you’ll approve the changes.
 
 While you're providing feedback, you can even comment on files that aren't part of the changeset and they'll get added as a reply to the review. This is helpful to be able to point your teammate to another location in the codebase that might need improving.
 
@@ -106,7 +106,7 @@ By default, when the reviewer goes back into the feedback request, they’ll be 
 
 ![A screenshot showing review checkpoints](/images/ReviewCheckpoints.png "Review checkpoints")
 
-The feedback review process can continue across as many updates as needed to get to the final approval of your changes. Once the feedback request has been approved, you can [create a pull request](/docs/codestream/how-use-codestream/pull-requests) from within CodeStream to get your code merged. 
+The feedback review process can continue across as many updates as needed to get to the final approval of your changes. Once the feedback request has been approved, you can [create a pull request](/docs/codestream/how-use-codestream/pull-requests) from within CodeStream to get your code merged.
 
 <Callout variant="tip">
 The feedback request can't be amended or reopened once a pull request has been created.


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Before:

> You can even use feedback requests for uncommitted your changes.

After:

> You can even use feedback requests for your uncommitted changes.


Also looks like VS Code trimmed the extra whitespace which is inconsequential. 

