### PR TITLE
fix(Infrastructure): Removed broken installation tiles

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring.mdx
@@ -140,59 +140,7 @@ You can also see log messages related to your errors and traces directly in your
 
 Our open source infrastructure agent is a [lightweight](/docs/infrastructure/new-relic-infrastructure/getting-started/agent-performance-overhead) executable file that works in the background to collect data from your operating system. 
 
-If you don't want to use our [guided install](#quick), the simplest way to install the infrastructure agent is [with a package manager](/docs/infrastructure/install-configure-manage-infrastructure/linux-installation/install-infrastructure-linux-using-package-manager) (Linux) or with the [MSI installer](/docs/infrastructure/install-configure-manage-infrastructure/windows-installation/install-infrastructure-windows-server-using-msi-installer) (Windows). You can also use our installation assistants:
-
-<TechTileGrid>
-  <TechTile
-    name="Amazon Linux"
-    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything&state=17f97073-d0d5-7a83-28af-13e3115dc508"
-    icon={<img src={amazonlinux} alt="Amazon Linux"/>}
-  />
-
-  <TechTile
-    name="CentOS"
-    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything&state=e9e347c9-813c-abfd-1d33-2c1cb1326195"
-    icon={<img src={centos} alt="CentOS"/>}
-  />
-
-  <TechTile
-    name="Container (Docker)"
-    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything&state=38a2cea3-0472-0fe7-d9df-6a897777731d"
-    icon={<img src={dockerLogoCrop} alt="Docker"/>}
-  />
-
-  <TechTile
-    name="Debian"
-    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything&state=0d9d2431-ed10-c3aa-d815-d824923f05db"
-    icon={<img src={debian} alt="Debian"/>}
-  />
-
-  <TechTile
-    name="RHEL"
-    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything&state=c7061991-0944-1d6a-56e2-27f576d3cd43"
-    icon={<img src={redHatNew2} alt="Red Hat"/>}
-  />
-
-  <TechTile
-    name="SLES"
-    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything&state=bcf5d183-bbad-01e4-dd82-b8dca2274d82"
-    icon={<img src={suse} alt="SLES"/>}
-  />
-
-  <TechTile
-    name="Ubuntu"
-    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything&state=3255499e-7daa-e169-4154-1f5c24fd8043"
-    icon={<img src={ubuntu} alt="Ubuntu"/>}
-  />
-
-  <TechTile
-    name="Windows"
-    to="https://one.newrelic.com/nr1-core/tucson/plg-instrument-everything&state=a72d02fa-4e70-3f8d-641a-d208d6844939"
-    icon={<img src={windows} alt="Windows"/>}
-  />
-</TechTileGrid>
-
-To use the links above, you must be logged to your New Relic account.
+If you don't want to use our [guided install](#quick), the simplest way to install the infrastructure agent is [with a package manager](/docs/infrastructure/install-configure-manage-infrastructure/linux-installation/install-infrastructure-linux-using-package-manager) (Linux) or with the [MSI installer](/docs/infrastructure/install-configure-manage-infrastructure/windows-installation/install-infrastructure-windows-server-using-msi-installer) (Windows).
 
 If you don't have a New Relic account yet, or prefer to follow the procedure step-by-step, see our tutorials to install the agent for [Linux](/docs/infrastructure/install-configure-manage-infrastructure/linux-installation/install-infrastructure-linux-using-package-manager) \| [Windows](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-windows-server) \| [Elastic Beanstalk](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-agent-aws-elastic-beanstalk) \| [Ansible](/docs/infrastructure/new-relic-infrastructure/config-management-tools/configure-new-relic-infrastructure-using-ansible) \| [Chef](/docs/infrastructure/new-relic-infrastructure/config-management-tools/configure-new-relic-infrastructure-using-chef) \| [Puppet](/docs/infrastructure/new-relic-infrastructure/config-management-tools/configure-new-relic-infrastructure-puppet).
 


### PR DESCRIPTION
The installation tiles were pointing to pages in New Relic One that don't exist anymore.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>