### PR TITLE
fix: missing capitalization use case

### DIFF
--- a/src/content/docs/style-guide/capitalization/product-capability-feature-usage.mdx
+++ b/src/content/docs/style-guide/capitalization/product-capability-feature-usage.mdx
@@ -377,7 +377,7 @@ Notes about features and capabilities:
             <td>errors inbox</td>
             <td>capability of New Relic One; our error tracking solution for triaging and resolving full-stack errors</td>
             <td>errors inbox</td>
-            <td>Do not use: Errors inbox, Errors inbox
+            <td>Do not use: Errors Inbox, Errors inbox
             </td>
         </tr>
 


### PR DESCRIPTION
It listed "Errors inbox" twice as what not to do. It should be "Errors Inbox" and "Errors inbox"

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.