### PR TITLE
Update apm-config-nerdgraph.mdx to hoist guid to root level on update mutation.

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/apm-config-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/apm-config-nerdgraph.mdx
@@ -39,7 +39,7 @@ query ExampleReadQuery {
 Here's an example of disabling [server-side configuration](/docs/apm/agents/manage-apm-agents/configuration/server-side-agent-configuration). Note that `settings` uses an array, which may be helpful if you want to update multiple entities. 
 
 ```
-mutation ExampleUpdateQuery(settings: [{ guid: "ZjY1ODgxfEFQTXxBUFBYSUNBVElPTnz0ODEwMTY3NzZ", apmConfig: { useServerSideConfig: false }}] )
+mutation ExampleUpdateQuery(guid: "ZjY1ODgxfEFQTXxBUFBYSUNBVElPTnz0ODEwMTY3NzZ", settings: [{ apmConfig: { useServerSideConfig: false }}] )
   {
     apmSettings {
       apmConfig {

--- a/src/content/docs/apis/nerdgraph/examples/apm-config-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/apm-config-nerdgraph.mdx
@@ -39,7 +39,7 @@ query ExampleReadQuery {
 Here's an example of disabling [server-side configuration](/docs/apm/agents/manage-apm-agents/configuration/server-side-agent-configuration). Note that `settings` uses an array, which may be helpful if you want to update multiple entities. 
 
 ```
-mutation ExampleUpdateQuery(guid: "ZjY1ODgxfEFQTXxBUFBYSUNBVElPTnz0ODEwMTY3NzZ", settings: [{ apmConfig: { useServerSideConfig: false }}] )
+mutation ExampleUpdateQuery(guid: "ZjY1ODgxfEFQTXxBUFBYSUNBVElPTnz0ODEwMTY3NzZ", settings: { apmConfig: { useServerSideConfig: false }} )
   {
     apmSettings {
       apmConfig {


### PR DESCRIPTION
This is apparently related to a change that's coming out now with NerdGraph and effects are restrained just to this doc. - @zuluecho9 