### PR TITLE
docs: format example code & add lang identifier

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -68,7 +68,7 @@ Define your configuration rules from the most specific to the most general. The 
 
   The retailer could create rules like this:
 
-  ```
+  ```js
   // newrelic.js
   exports.config={
     //other configuration
@@ -79,7 +79,7 @@ Define your configuration rules from the most specific to the most general. The 
         { pattern: "/user/customers/.*", name: "/user/customers/:customer" }
       ]
     }
-  }
+  };
   ```
 
   With these rules, the retailer would create three transaction names:
@@ -95,7 +95,7 @@ Define your configuration rules from the most specific to the most general. The 
 
 Make sure that loading the New Relic module is the first thing your application does, as it needs to bootstrap itself before the rest of your application loads:
 
-```
+```js
 var newrelic = require('newrelic');
 ```
 
@@ -110,7 +110,7 @@ Here is a summary of the Request API calls for New Relic's Node.js agent.
     id="transaction"
     title={<InlineCode>newrelic.setTransactionName(name)</InlineCode>}
   >
-    ```
+    ```js
     newrelic.setTransactionName(name)
     ```
 
@@ -123,9 +123,9 @@ Here is a summary of the Request API calls for New Relic's Node.js agent.
     id="controller"
     title={<InlineCode>newrelic.setControllerName(name, [action])</InlineCode>}
   >
-```    
-newrelic.setControllerName(name, [action])
-```
+    ```js
+    newrelic.setControllerName(name, [action])
+    ```
 
     Name the current request using a controller-style pattern, optionally including the current controller action. If the action is omitted, New Relic will include the HTTP method (GET, POST, etc.) as the action. The rules for when you can call `newrelic.setControllerName()` are the same as they are for `newrelic.setTransactionName()`, including the [request naming requirements](#requirements).
 
@@ -142,7 +142,7 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="instrument"
     title={<InlineCode>newrelic.instrument(moduleName, onRequire [, onError])</InlineCode>}
   >
-    ```
+    ```js
     newrelic.instrument(moduleName, onRequire [, onError])
     ```
 
@@ -163,7 +163,7 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="instrumentDatastore"
     title={<InlineCode>newrelic.instrumentDatastore(moduleName, onRequire [, onError])</InlineCode>}
   >
-    ```
+    ```js
     newrelic.instrumentDatastore(moduleName, onRequire [, onError])
     ```
 
@@ -176,23 +176,23 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="instrumentLoadedModule"
     title={<InlineCode>newrelic.instrumentLoadedModule(moduleName, moduleInstance)</InlineCode>}
   >
-    ```
+    ```js
     newrelic.instrumentLoadedModule(moduleName, moduleInstance)
     ```
 
     The `instrumentLoadedModule` method allows you to add stock instrumentation to specific modules in situations where it's impossible to have `require('newrelic');` as the first line of your app's main module.
 
-    ```
+    ```js
     // load the agent
-    const newrelic = require('newrelic')
+    const newrelic = require('newrelic');
 
     // module loaded before newrelic 
-    const expressModule = require('express')
+    const expressModule = require('express');
 
-    // instrument express _after_ the agent has been loaded
+    // instrument express after the agent has been loaded
     newrelic.instrumentLoadedModule(
-    'express', // the module's name, as a string
-    expressModule // the module instance
+      'express',    // the module's name, as a string
+      expressModule // the module instance
     );
     ```
 
@@ -205,7 +205,7 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="instrumentMessages"
     title={<InlineCode>newrelic.instrumentMessages(moduleName, onRequire \[, onError])</InlineCode>}
   >
-    ```
+    ```js
     newrelic.instrumentMessages(moduleName, onRequire [, onError])
     ```
 
@@ -218,7 +218,7 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="instrumentWebframework"
     title={<InlineCode>newrelic.instrumentWebframework(moduleName, onRequire [, onError])</InlineCode>}
   >
-    ```
+    ```js
     newrelic.instrumentWebframework(moduleName, onRequire [, onError])
     ```
 
@@ -231,7 +231,7 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="startWebTransaction"
     title={<InlineCode>newrelic.startWebTransaction(url, handle)</InlineCode>}
   >
-    ```
+    ```js
     newrelic.startWebTransaction(url, handle)
     ```
 
@@ -251,7 +251,7 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="startBackgroundTransaction"
     title={<InlineCode>newrelic.startBackgroundTransaction(name, [group], handle)</InlineCode>}
   >
-    ```
+    ```js
     newrelic.startBackgroundTransaction(name, [group], handle)
     ```
 
@@ -272,7 +272,7 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="getTransaction"
     title={<InlineCode>newrelic.getTransaction()</InlineCode>}
   >
-    ```
+    ```js
     newrelic.getTransaction()
     ```
 
@@ -285,7 +285,7 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="endTransaction"
     title={<InlineCode>newrelic.endTransaction()</InlineCode>}
   >
-    ```
+    ```js
     newrelic.endTransaction()
     ```
 
@@ -296,7 +296,7 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="startSegment"
     title={<InlineCode>newrelic.startSegment(name, record, handler, callback)</InlineCode>}
   >
-    ```
+    ```js
     newrelic.startSegment(name, record, handler, callback)
     ```
 
@@ -320,7 +320,7 @@ Use these API calls to [record additional arbitrary metrics](/docs/agents/nodejs
     id="record_metric"
     title={<InlineCode>newrelic.recordMetric(name, value)</InlineCode>}
   >
-    ```
+    ```js
     newrelic.recordMetric(name, value)
     ```
 
@@ -334,7 +334,7 @@ Use these API calls to [record additional arbitrary metrics](/docs/agents/nodejs
     id="increment_metric"
     title={<InlineCode>newrelic.incrementMetric(name, [amount])</InlineCode>}
   >
-    ```
+    ```js
     newrelic.incrementMetric(name, [amount])
     ```
 
@@ -351,7 +351,7 @@ Use these API calls to record additional events:
     id="record_custom_event"
     title={<InlineCode>newrelic.recordCustomEvent(eventType, attributes)</InlineCode>}
   >
-    ```
+    ```js
     newrelic.recordCustomEvent(eventType, attributes)
     ```
 
@@ -367,13 +367,13 @@ Use these API calls to record additional events:
       >
         The following example demonstrates recording a custom event with multiple attributes.
 
-        ```
+        ```js
         const attributes = {
           attribute1: 'value1',
           attribute2: 2
-        }
+        };
 
-        newrelic.recordCustomEvent('MessagingEvent', attributes)
+        newrelic.recordCustomEvent('MessagingEvent', attributes);
         ```
       </Collapser>
     </CollapserGroup>
@@ -391,7 +391,7 @@ Use these methods to interact directly with the current transaction:
     id="transaction-handle-end"
     title={<InlineCode>transactionHandle.end([callback])</InlineCode>}
   >
-    ```
+    ```js
     transactionHandle.end([callback])
     ```
 
@@ -404,7 +404,7 @@ Use these methods to interact directly with the current transaction:
     id="transaction-handle-ignore"
     title={<InlineCode>transactionHandle.ignore()</InlineCode>}
   >
-    ```
+    ```js
     transactionHandle.ignore()
     ```
 
@@ -415,7 +415,7 @@ Use these methods to interact directly with the current transaction:
     id="transaction-handle-insertDistributedTraceHeaders"
     title={<InlineCode>transactionHandle.insertDistributedTraceHeaders(headers)</InlineCode>}
   >
-    ```
+    ```js
     transactionHandle.insertDistributedTraceHeaders(headers)
     ```
 
@@ -434,17 +434,17 @@ Use these methods to interact directly with the current transaction:
       >
         In the following example, by calling insertDistributedTraceHeaders with an empty object, the appropriate Distributed Trace headers and W3C Trace Context headers will be generated for the transaction.
 
-        ```
+        ```js
         // Call newrelic.getTransaction to retrieve a handle on the current transaction.
-        const transactionHandle = newrelic.getTransaction()
+        const transactionHandle = newrelic.getTransaction();
 
         // This could be a header object from an incoming request as well
-        const headersObject = {}
+        const headersObject = {};
         newrelic.startBackgroundTransaction('background task', function executeTransaction() {
-          const transaction = newrelic.getTransaction()
+          const transaction = newrelic.getTransaction();
           // generate the headers
-          transaction.insertDistributedTraceHeaders(headersObject)
-        })
+          transaction.insertDistributedTraceHeaders(headersObject);
+        });
         ```
       </Collapser>
     </CollapserGroup>
@@ -454,7 +454,7 @@ Use these methods to interact directly with the current transaction:
     id="transaction-handle-acceptDistributedTraceHeaders"
     title={<InlineCode>transactionHandle.acceptDistributedTraceHeaders(transportType, headers)</InlineCode>}
   >
-    ```
+    ```js
     transactionHandle.acceptDistributedTraceHeaders(transportType, headers)
     ```
 
@@ -487,19 +487,19 @@ Use these methods to interact directly with the current transaction:
       >
         The following example demonstrates adding distributed trace headers retrieved from a Kafka message. In this example, we assume that the incoming Kafka message has Distributed Trace headers inserted.
 
-        ```
+        ```js
         // incoming Kafka message headers
-        const headersObject = message.headers
+        const headersObject = message.headers;
 
         // Call newrelic.getTransaction to retrieve a handle on the current transaction.
-        const transactionHandle = newrelic.getTransaction()
+        const transactionHandle = newrelic.getTransaction();
 
         newrelic.startBackgroundTransaction('background task', function executeTransaction() {
-          const transaction = newrelic.getTransaction()
+          const transaction = newrelic.getTransaction();
 
           // accept the headers
-          transaction.acceptDistributedTraceHeaders('Kafka', headersObject)
-        })
+          transaction.acceptDistributedTraceHeaders('Kafka', headersObject);
+        });
         ```
       </Collapser>
     </CollapserGroup>
@@ -509,7 +509,7 @@ Use these methods to interact directly with the current transaction:
     id="transaction-handle-createDistributedTracePayload"
     title={<InlineCode>transactionHandle.createDistributedTracePayload()</InlineCode>}
   >
-    ```
+    ```js
     transactionHandle.createDistributedTracePayload()
     ```
 
@@ -538,16 +538,16 @@ Use these methods to interact directly with the current transaction:
           id="example-link-bg-txn"
           title="Link a nested background transaction"
         >
-          ```
+          ```js
           // Call newrelic.getTransaction to retrieve a handle on the current transaction.
-          var transactionHandle = newrelic.getTransaction()
-          var payload = transactionHandle.createDistributedTracePayload()
-          var jsonPayload = payload.text()
+          var transactionHandle = newrelic.getTransaction();
+          var payload = transactionHandle.createDistributedTracePayload();
+          var jsonPayload = payload.text();
           newrelic.startBackgroundTransaction('background task', function executeTransaction() {
-            var backgroundHandle = newrelic.getTransaction()
+            var backgroundHandle = newrelic.getTransaction();
             // Link the nested transaction by accepting the payload with the background transaction's handle
-            backgroundHandle.acceptDistributedTracePayload(jsonPayload)
-          })
+            backgroundHandle.acceptDistributedTracePayload(jsonPayload);
+          });
           ```
         </Collapser>
       </CollapserGroup>
@@ -558,12 +558,12 @@ Use these methods to interact directly with the current transaction:
           id="example-payload-outgoing-request"
           title="Place payload on an outgoing request"
         >
-          ```
+          ```js
           // Call newrelic.getTransaction to retrieve a handle on the current transaction.
-          var transactionHandle = newrelic.getTransaction()
-          var payload = transactionHandle.createDistributedTracePayload()
+          var transactionHandle = newrelic.getTransaction();
+          var payload = transactionHandle.createDistributedTracePayload();
           // Place the base64 encoded value on an outbound request header.
-          req.headers[myTracingHeader] = payload.httpSafe()
+          req.headers[myTracingHeader] = payload.httpSafe();
           ```
         </Collapser>
       </CollapserGroup>
@@ -573,7 +573,7 @@ Use these methods to interact directly with the current transaction:
     id="transaction-handle-acceptDistributedTracePayload"
     title={<InlineCode>transactionHandle.acceptDistributedTracePayload(payload)</InlineCode>}
   >
-    ```
+    ```js
     transactionHandle.acceptDistributedTracePayload(payload)
     ```
 
@@ -594,7 +594,7 @@ Use these methods to interact directly with the current transaction:
     id="transaction-handle-isSampled"
     title={<InlineCode>transactionHandle.isSampled()</InlineCode>}
   >
-    ```
+    ```js
     transactionHandle.isSampled()
     ```
 
@@ -611,7 +611,7 @@ New Relic's Node.js agent includes additional API calls.
     id="add-custom-attribute"
     title={<InlineCode>newrelic.addCustomAttribute(name, value)</InlineCode>}
   >
-    ```
+    ```js
     newrelic.addCustomAttribute(name, value)
     ```
 
@@ -622,7 +622,7 @@ New Relic's Node.js agent includes additional API calls.
         id="example-link-bg-txn"
         title="Add custom attribute"
       >
-        ```
+        ```js
         newrelic.addCustomAttribute('attribute1', 'value1')
         ```
       </Collapser>
@@ -637,7 +637,7 @@ New Relic's Node.js agent includes additional API calls.
     id="add-custom-attributes"
     title={<InlineCode>newrelic.addCustomAttributes(attributes)</InlineCode>}
   >
-    ```
+    ```js
     newrelic.addCustomAttributes(attributes)
     ```
 
@@ -648,13 +648,13 @@ New Relic's Node.js agent includes additional API calls.
         id="example-link-bg-txn"
         title="Adding custom attributes"
       >
-        ```
+        ```js
         const attributes = {
           attribute1: 'value1',
           attribute2: 2
-        }
+        };
 
-        newrelic.addCustomAttributes(attributes)
+        newrelic.addCustomAttributes(attributes);
         ```
       </Collapser>
     </CollapserGroup>
@@ -665,7 +665,7 @@ New Relic's Node.js agent includes additional API calls.
   </Collapser>
 
   <Collapser title={<InlineCode>newrelic.addCustomSpanAttribute(name, value)</InlineCode>}>
-    ```
+    ```js
     newrelic.addCustomSpanAttribute(name, value)
     ```
 
@@ -676,7 +676,7 @@ New Relic's Node.js agent includes additional API calls.
         id="example-link-bg-txn"
         title="Add custom span attribute"
       >
-        ```
+        ```js
         newrelic.addCustomSpanAttribute('attribute1', 'value')
         ```
       </Collapser>
@@ -692,7 +692,7 @@ New Relic's Node.js agent includes additional API calls.
   </Collapser>
 
   <Collapser title={<InlineCode>newrelic.addCustomSpanAttributes(attributes)</InlineCode>}>
-    ```
+    ```js
     newrelic.addCustomSpanAttributes(attributes)
     ```
 
@@ -703,13 +703,13 @@ New Relic's Node.js agent includes additional API calls.
         id="example-link-bg-txn"
         title="Add custom span attributes"
       >
-        ```
+        ```js
         const attributes = {
           attribute1: 'value1',
           attribute2: 'value2'
-        }
+        };
 
-        newrelic.addCustomSpanAttributes(attributes)
+        newrelic.addCustomSpanAttributes(attributes);
         ```
       </Collapser>
     </CollapserGroup>
@@ -727,7 +727,7 @@ New Relic's Node.js agent includes additional API calls.
     id="browserTimingHeader"
     title={<InlineCode>newrelic.getBrowserTimingHeader()</InlineCode>}
   >
-    ```
+    ```js
     newrelic.getBrowserTimingHeader()
     ```
 
@@ -738,7 +738,7 @@ New Relic's Node.js agent includes additional API calls.
     id="ignore"
     title={<InlineCode>newrelic.setIgnoreTransaction(ignored)</InlineCode>}
   >
-    ```
+    ```js
     newrelic.setIgnoreTransaction(ignored)
     ```
 
@@ -757,7 +757,7 @@ New Relic's Node.js agent includes additional API calls.
     id="noticeError"
     title={<InlineCode>newrelic.noticeError(error, [customParameters])</InlineCode>}
   >
-    ```
+    ```js
     newrelic.noticeError(error, [customParameters])
     ```
 
@@ -772,7 +772,7 @@ New Relic's Node.js agent includes additional API calls.
     id="shutdown"
     title={<InlineCode>newrelic.shutdown([options], callback)</InlineCode>}
   >
-    ```
+    ```js
     newrelic.shutdown([options], callback)
     ```
 
@@ -811,10 +811,10 @@ New Relic's Node.js agent includes additional API calls.
     
     **Example:**
 
-    ```
+    ```js
     newrelic.shutdown({collectPendingData: true, timeout: 10000}, (error) => {
-        process.exit()
-      })
+      process.exit();
+    });
     ```
   </Collapser>
 
@@ -822,7 +822,7 @@ New Relic's Node.js agent includes additional API calls.
     id="getLinkingMetadata"
     title={<InlineCode>newrelic.getLinkingMetadata()</InlineCode>}
   >
-    ```
+    ```js
     newrelic.getLinkingMetadata()
     ```
 
@@ -835,7 +835,7 @@ New Relic's Node.js agent includes additional API calls.
     id="getTraceMetadata"
     title={<InlineCode>newrelic.getTraceMetadata()</InlineCode>}
   >
-    ```
+    ```js
     newrelic.getTraceMetadata()
     ```
 
@@ -865,7 +865,7 @@ Here is the structure for rules in New Relic's Node.js agent.
 
     This can also be set with the environment variable `NEW_RELIC_NAMING_RULES`, with multiple rules passed in as a list of comma-delimited JSON object literals:
 
-    ```
+    ```json
     NEW_RELIC_NAMING_RULES='{"pattern":"^t","name":"u"},{"pattern":"^u","name":"t"}'
     ```
 
@@ -909,7 +909,7 @@ Here is the structure for rules in New Relic's Node.js agent.
 
             When set to `true`, all matches of the pattern will be replaced. Otherwise, only the first match will be replaced. Using the `g` flag with regular expression literal will have the same effect. For example:
 
-            ```
+            ```bash
             pattern: '[0-9]+',
             replace_all: true
             ```
@@ -936,7 +936,7 @@ Here is the structure for rules in New Relic's Node.js agent.
 
     The Node.js agent comes with a command-line tool for testing naming rules. For more information, run the following command in terminal window in a directory where your app is installed:
 
-    ```
+    ```bash
     node node_modules/.bin/newrelic-naming-rules
     ```
 
@@ -949,15 +949,15 @@ Here is the structure for rules in New Relic's Node.js agent.
         id="naming-full-url"
         title="Match full URL"
       >
-        ```
+        ```bash
         pattern: "^/items/[0-9]+$",
         name: "/items/:id"
         ```
 
         will result in:
 
-        ```
-        /items/123  =>  /items/:id
+        ```bash
+        /items/123   =>  /items/:id
         /orders/123  =>  /orders/123   (not replaced since the rule is a full match)
         ```
       </Collapser>
@@ -966,16 +966,16 @@ Here is the structure for rules in New Relic's Node.js agent.
         id="first-match-url"
         title="Replace first match in URL"
       >
-        ```
+        ```bash
         pattern: "[0-9]+",
         name: ":id"
         ```
 
         will result in:
 
-        ```
-        /orders/123  =>  /orders/:id
-        /items/123  =>  /items/:id
+        ```bash
+        /orders/123            =>  /orders/:id
+        /items/123             =>  /items/:id
         /orders/123/items/123  =>  /orders/:id/items/123
         ```
       </Collapser>
@@ -984,7 +984,7 @@ Here is the structure for rules in New Relic's Node.js agent.
         id="replace-urls"
         title="Replace all matches in any URL"
       >
-        ```
+        ```bash
         pattern: "[0-9]+",
         name: ":id",
         replace_all: true
@@ -992,7 +992,7 @@ Here is the structure for rules in New Relic's Node.js agent.
 
         will result in:
 
-        ```
+        ```bash
         /orders/123/items/123  =>  /orders/:id/items/:id
         ```
       </Collapser>
@@ -1003,16 +1003,16 @@ Here is the structure for rules in New Relic's Node.js agent.
       >
         Using regular expression match group references:
 
-        ```
+        ```bash
         pattern: '^/(items|orders)/[0-9]+$',
         name: '/\\1/:id'
         ```
 
         will result in:
 
-        ```
+        ```bash
         /orders/123  =>  /orders/:id
-        /items/123  =>  /items/:id
+        /items/123   =>  /items/:id
         ```
       </Collapser>
     </CollapserGroup>
@@ -1024,7 +1024,7 @@ Here is the structure for rules in New Relic's Node.js agent.
   >
     This can also be set via the environment variable `NEW_RELIC_IGNORING_RULES`, with multiple rules passed in as a list of comma-delimited patterns. Currently there is no way to escape commas in patterns.
 
-    ```
+    ```bash
     NEW_RELIC_IGNORING_RULES='^/socket\.io/\*/xhr-polling,ignore_me'
     ```
   </Collapser>
@@ -1037,15 +1037,16 @@ Here are full examples of how rules are included in the configuration file:
     id="example-naming-rule"
     title="Naming rule example"
   >
-    ```
+    ```js
     // newrelic.js
-      exports.config = {
-        // other configuration
-        rules : {
-          name : [
-            { pattern: "/tables/name-here", name: "/name-hererule1" }
-          ]
-        }
+    exports.config = {
+      // other configuration
+      rules : {
+        name : [
+          { pattern: "/tables/name-here", name: "/name-hererule1" }
+        ]
+      }
+    };
     ```
   </Collapser>
 
@@ -1057,14 +1058,14 @@ Here are full examples of how rules are included in the configuration file:
 
     ```
     // newrelic.js
-      exports.config = {
-        // other configuration
-        rules : {
-          ignore : [
-            '^\/socket\.io\/.*\/xhr-polling'
-          ]
-        }
-      };
+    exports.config = {
+      // other configuration
+      rules : {
+        ignore : [
+          '^\/socket\.io\/.*\/xhr-polling'
+        ]
+      }
+    };
     ```
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
I added language identifiers to the code blocks for colorization, fixed some indentation, added missing semicolons and removed some markdown in code blocks where it couldn't display. No major changes, just visual cleanup and improvements.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.