### PR TITLE
docs: format example code & add lang identifier

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -4,7 +4,7 @@ tags:
   - Agents
   - Nodejs agent
   - API guides
-metaDescription: 'How to use the Node.js API to name, rename, and ignore requests, and to read router names with New Relic''s Node.js agent.'
+metaDescription: "How to use the Node.js API to name, rename, and ignore requests, and to read router names with New Relic's Node.js agent."
 redirects:
   - /docs/agents/nodejs-agent/api-guides/nodejs-agent-api
   - /docs/nodejs/nodejs-transaction-naming-api

--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -1055,7 +1055,7 @@ Here are full examples of how rules are included in the configuration file:
   >
     If you are using **socket.io**, you will have a use case for ignoring rules right out of the box. To keep socket.io long-polling from dominating your response-time metrics and affecting the Apdex metrics for your application, add a rule such as:
 
-    ```
+    ```js
     // newrelic.js
       exports.config = {
         // other configuration


### PR DESCRIPTION
I missed the language identifier on one codeblock. this one will correct that after my previous PR is merged: https://github.com/newrelic/docs-website/pull/5410

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.