### PR TITLE
Fix: Tracing api accepts gzip compression

### DIFF
--- a/src/content/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits.mdx
+++ b/src/content/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits.mdx
@@ -271,8 +271,26 @@ The following table shows the required request metadata for all trace data forma
         **Optional - Reserved for future use.** The value must be a valid `UUID4`. The value is expected to be unique for each request.
       </td>
     </tr>
+
+    <tr>
+      <td>
+        `Content-Type`
+
+        Required
+      </td>
+
+      <td>
+        * `application/json`
+        * `json`
+        * `application/gzip`
+        * `gzip`
+      </td>
+    </tr>
+
   </tbody>
 </table>
+
+Gzipped JSON formatting is accepted. If sending compressed JSON, please include the `Content-Type: application/json` and `Content-Encoding: gzip` headers.
 
 ## Response validation
 


### PR DESCRIPTION
The Tracing API supports gzipped compression. I copied the same lines outta the logs docs for consistency.
