### PR TITLE
chore: adding new env var for NPM container

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -705,9 +705,9 @@ FROM KFlow SELECT count(*) FACET device_name WHERE instrumentation.name = 'netfl
 
 To support monitoring of devices where performance statistics are not accessible or available, or in simple cases where basic round-trip time (RTT) monitoring is required, you can either set the `global.response_time` or `devices.<deviceName>.ping_only` attributes to `true`. 
 
-This feature uses the [go-ping](https://pkg.go.dev/github.com/sparrc/go-ping) package to send unprivileged UDP packets to devices in order to collect the average, min, max, and stddev round-trip time (RTT) as well as packet loss % for the endpoint based on sending 1 packet/sec from `ktranslate` to the device IP address. You can enable the use of privileged ICMP packets by setting the `KENTIK_PING_PRIV=true` environment variable during Docker runtime.
+This feature uses the [go-ping](https://pkg.go.dev/github.com/sparrc/go-ping) package to send unprivileged UDP packets to devices in order to collect the average, min, max, and stddev round-trip time (RTT). This package also shows packet loss percentage for the endpoint based on sending one packet/sec from `ktranslate` to the device IP address. You can enable the use of privileged ICMP packets by setting the `KENTIK_PING_PRIV=true` environment variable during Docker runtime.
 
-Setting the `global.response_time` attribute to `true` will add RTT monitoring on top of existing SNMP polling. `devices.<deviceName>.ping_only: true` will allow you to monitor devices with only the UDP|ICMP packets for RTT and no SNMP polling.
+Setting the `global.response_time` attribute to `true` will add RTT monitoring on top of existing SNMP polling. To monitor devices with only the UDP|ICMP packets for RTT and no SNMP polling, use `devices.<deviceName>.ping_only: true`.
 
 In New Relic One, you can see the results of this polling by investigating the following metrics:
 

--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -705,9 +705,9 @@ FROM KFlow SELECT count(*) FACET device_name WHERE instrumentation.name = 'netfl
 
 To support monitoring of devices where performance statistics are not accessible or available, or in simple cases where basic round-trip time (RTT) monitoring is required, you can either set the `global.response_time` or `devices.<deviceName>.ping_only` attributes to `true`. 
 
-This feature uses the [go-ping](https://pkg.go.dev/github.com/sparrc/go-ping) package to send unprivileged UDP packets to devices in order to collect the average, min, and max RTT for the endpoint based on sending 1 packet/sec from `ktranslate` to the device IP address.
+This feature uses the [go-ping](https://pkg.go.dev/github.com/sparrc/go-ping) package to send unprivileged UDP packets to devices in order to collect the average, min, max, and stddev round-trip time (RTT) as well as packet loss % for the endpoint based on sending 1 packet/sec from `ktranslate` to the device IP address. You can enable the use of privileged ICMP packets by setting the `KENTIK_PING_PRIV=true` environment variable during Docker runtime.
 
-Setting the `global.response_time` attribute to `true` will add RTT monitoring on top of existing SNMP polling. `devices.<deviceName>.ping_only: true` will allow you to monitor devices with only the UDP packets for RTT and no SNMP polling.
+Setting the `global.response_time` attribute to `true` will add RTT monitoring on top of existing SNMP polling. `devices.<deviceName>.ping_only: true` will allow you to monitor devices with only the UDP|ICMP packets for RTT and no SNMP polling.
 
 In New Relic One, you can see the results of this polling by investigating the following metrics:
 

--- a/src/content/docs/network-performance-monitoring/advanced/ktranslate-container-management.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/ktranslate-container-management.mdx
@@ -377,5 +377,17 @@ Below are the various options available during Docker runtime for the **ktransla
         Environment variable that can be used during Docker runtime to setup **ktranslate's** SNMPv3 configuration to use AWS Secrets Manager. Specifies the AWS Region to send requests to for commands requested using this profile.
       </td>
     </tr>
+    <tr>
+      <td>
+        `KENTIK_PING_PRIV`
+      </td>
+      <td>
+        Environment Variable
+      </td>
+      <td></td>
+      <td>
+        Environment variable that can be used during Docker runtime to setup **ktranslate's** `response_time` | `ping_only` configuration to use privileged mode for ICMP packets instead of the default UDP packets used in unprivileged mode.
+      </td>
+    </tr>
     </tbody>
 </table>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2643,10 +2643,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-5.0.0.tgz#db8e5663a9c7d6d77791211d6f0dca32219808eb"
-  integrity sha512-1eoSLKc3Fza8mKvXcIUtgTzZfAMixppCm2Rv3dOq+1YNNE8lFN/gK+hOgNK6PZ2e1c2ExMNjOfK6LwMsOPVLsQ==
+"@newrelic/gatsby-theme-newrelic@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-5.0.1.tgz#6961b0887c3e42c5c41169e05aef38162277a5f0"
+  integrity sha512-KOBDhdPs4AorYBFTVLSV0roD4jIKWcVagVQmLAFTxWNDguepvtKaMkSP1k72c2I2H6Pl9fJKE5xalrgqcfZiGw==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
adding notes for new environment monitor option on ktranslate container that supports round-trip time (RTT) monitoring