### PR TITLE
docs: add lang identifiers, clean up syntax and indentation

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/noticeerror-net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/noticeerror-net-agent-api.mdx
@@ -15,7 +15,7 @@ redirects:
 
 ## Syntax
 
-```
+```cs
 NewRelic.Api.Agent.NewRelic.NoticeError(exception $exception[, IDictionary $attributes])
 NewRelic.Api.Agent.NewRelic.NoticeError(string $error_message, IDictionary $attributes)
 NewRelic.Api.Agent.NewRelic.NoticeError(string $error_message, IDictionary $attributes, bool $is_expected)
@@ -33,7 +33,7 @@ Compatible with all app types.
 
 Notice an error and report it to New Relic along with optional custom attributes. For each transaction, the agent only retains the exception and attributes from the first call to `NoticeError()`. You can pass an actual exception, or pass a string to capture an arbitrary error message.
 
-If this method is invoked within a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction), the agent reports the exception within the parent transaction. If it is invoked outside of a transaction, the agent creates an [error trace](/docs/apm/applications-menu/events/view-apm-error-analytics) and categorizes the error in the New Relic UI as a **NewRelic.Api.Agent.NoticeError API Call**. If invoked outside of a transaction, the `NoticeError` call will not contribute to the error rate of an application.
+If this method is invoked within a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction), the agent reports the exception within the parent transaction. If it is invoked outside of a transaction, the agent creates an [error trace](/docs/apm/applications-menu/events/view-apm-error-analytics) and categorizes the error in the New Relic UI as a **NewRelic.Api.Agent.NoticeError API Call**. If invoked outside of a transaction, the `NoticeError()` call will not contribute to the error rate of an application.
 
 <Callout variant="tip">
   The agent adds the attributes only to the traced error, and does not send them to New Relic. To add custom attributes, see [`AddCustomParameter()`](/docs/agents/net-agent/net-agent-api/addcustomparameter-net-agent).
@@ -65,7 +65,7 @@ If this method is invoked within a [transaction](/docs/accounts-partnerships/edu
   <tbody>
     <tr>
       <td colSpan={2}>
-        ```
+        ```cs
         NewRelic.Api.Agent.NewRelic.NoticeError(exception $exception[, IDictionary $attributes])
         ```
       </td>
@@ -97,7 +97,7 @@ If this method is invoked within a [transaction](/docs/accounts-partnerships/edu
 
     <tr>
       <td colSpan={2}>
-        ```
+        ```cs
         NewRelic.Api.Agent.NewRelic.NoticeError(string $error_message, IDictionary $attributes)
         ```
       </td>
@@ -129,7 +129,7 @@ If this method is invoked within a [transaction](/docs/accounts-partnerships/edu
 
     <tr>
       <td colSpan={2}>
-        ```
+        ```cs
         NewRelic.Api.Agent.NewRelic.NoticeError(string $error_message, IDictionary $attributes, bool $is_expected)
         ```
       </td>
@@ -177,10 +177,10 @@ If this method is invoked within a [transaction](/docs/accounts-partnerships/edu
 
 ### Pass an exception without custom attributes [#exception-no-attributes]
 
-```
+```cs
 try
 {
-  var ImNotABool = "43";
+  string ImNotABool = "43";
   bool.Parse(ImNotABool);
 }
 catch (Exception ex)
@@ -191,10 +191,10 @@ catch (Exception ex)
 
 ### Pass an exception with custom attributes [#exception-yes-attributes]
 
-```
+```cs
 try
 {
-  var ImNotABool = "43";
+  string ImNotABool = "43";
   bool.Parse(ImNotABool);
 }
 catch (Exception ex)
@@ -206,13 +206,13 @@ catch (Exception ex)
 
 ### Pass an error message string with custom attributes [#string-yes-attributes]
 
-```
+```cs
 try
 {
-  var ImNotABool = "43";
+  string ImNotABool = "43";
   bool.Parse(ImNotABool);
 }
-catch (Exception)
+catch (Exception ex)
 {
   var errorAttributes = new Dictionary<string, string>{{"foo", "bar"},{"baz", "luhr"}};
   NewRelic.Api.Agent.NewRelic.NoticeError("String error message", errorAttributes);
@@ -221,28 +221,28 @@ catch (Exception)
 
 ### Pass an error message string without custom attributes [#string-no-attributes]
 
-```
+```cs
 try
 {
- var ImNotABool = "43";
- bool.Parse(ImNotABool);
+  string ImNotABool = "43";
+  bool.Parse(ImNotABool);
 }
-catch (Exception)
+catch (Exception ex)
 {
- NewRelic.Api.Agent.NewRelic.NoticeError("String error message", null);
+  NewRelic.Api.Agent.NewRelic.NoticeError("String error message", null);
 }
 ```
 
 ### Pass an error message string and mark it as expected [#string-no-attributes]
 
-```
+```cs
 try
 {
- var ImNotABool = "43";
- bool.Parse(ImNotABool);
+  string ImNotABool = "43";
+  bool.Parse(ImNotABool);
 }
-catch (Exception)
+catch (Exception ex)
 {
- NewRelic.Api.Agent.NewRelic.NoticeError("String error message", null, true);
+  NewRelic.Api.Agent.NewRelic.NoticeError("String error message", null, true);
 }
 ```


### PR DESCRIPTION
Some indentation was off, changed `var` to `string` which is preferred in strongly typed C# and added C# land identifiers for syntax highlighting.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.