### PR TITLE
fix(style guide): add old var & mark detail

### DIFF
--- a/src/content/docs/style-guide/formatting/code-examples.mdx
+++ b/src/content/docs/style-guide/formatting/code-examples.mdx
@@ -177,7 +177,7 @@ Follow these guidelines when you use `<var>` tags:
 * Don't combine them with other punctuation to indicate variables (such as wrapping the text in angle brackets or curly braces).
 * Don't overuse them. For example, if you're showing a complete config file where the user is expected to customize many values, a `<var>` tag on each configurable value is overkill.
 
-A `<var>` tag would **not** be used for:
+Do **not** use a `<var>` tag for:
 
 * Example code: If the code is meant to be an example, to show the format of the code, and there is not an actual procedure the customer is following, var tags are not needed. A couple reasons for this: 1) The important part of showing an example config file is to show the overall structure of the file, 2) Usually the number of config options present in a file will vary based on whatever the customer wishes to use, so using `<var>` tags can actually be confusing as it implies that these values must be present. Examples:
   * [Example configuration file](/docs/integrations/host-integrations/host-integrations-list/oracledb-monitoring-integration#example-config) (or this [Java agent config template](/docs/agents/java-agent/configuration/java-agent-config-file-template)): if you are showing an example config file that isn't part of a procedure, you shouldn't use the `<var>` tag. 
@@ -200,7 +200,7 @@ Below are some general style recommendations for formatting user-specific `<var>
 * Bash variables for REST API code: Some `<var>` tagged code values on the docs site have the form $&#x7B;API_KEY}. This is a format used for variables in bash scripts, where users assign values to specific variable names and then call those variables later in the script by using the $VARIABLE_NAME. For more info, see this [explanation of bash variables](http://tldp.org/HOWTO/Bash-Prog-Intro-HOWTO-5.html).
 
   <Callout variant="important">
-    The bash variable style is currently used in the REST API docs and in some Synthetics docs and that's fine. But going forward we should use the general variable style (without the $ and `&lt;` >).
+    The bash variable style is currently used in the REST API docs, and in some Synthetics docs. However, going forward we should use the general variable style, without the $ and `&lt;` >.
   </Callout>
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/style-guide/formatting/code-examples.mdx
+++ b/src/content/docs/style-guide/formatting/code-examples.mdx
@@ -168,7 +168,7 @@ To format one or more lines of code, insert three backticks ( `` ``` `` ) above 
 
 ## Highlight user input with `<var>` [#var-tags]
 
-The `<var>` tag is used to highlight areas the user needs to customize the value in a code snippet.
+The `<var>` tag is used to highlight areas the user needs to customize the value in a code snippet. For example: you might use `<var>YOUR_ACCOUNT_ID</var>` to draw a user's attention to a place they'll need to input their account ID.
 
 Follow these guidelines when you use `<var>` tags:
 
@@ -177,28 +177,41 @@ Follow these guidelines when you use `<var>` tags:
 * Don't combine them with other punctuation to indicate variables (such as wrapping the text in angle brackets or curly braces).
 * Don't overuse them. For example, if you're showing a complete config file where the user is expected to customize many values, a `<var>` tag on each configurable value is overkill.
 
+A `<var>` tag would **not** be used for:
+
+* Example code: If the code is meant to be an example, to show the format of the code, and there is not an actual procedure the customer is following, var tags are not needed. A couple reasons for this: 1) The important part of showing an example config file is to show the overall structure of the file, 2) Usually the number of config options present in a file will vary based on whatever the customer wishes to use, so using `<var>` tags can actually be confusing as it implies that these values must be present. Examples:
+  * [Example configuration file](/docs/integrations/host-integrations/host-integrations-list/oracledb-monitoring-integration#example-config) (or this [Java agent config template](/docs/agents/java-agent/configuration/java-agent-config-file-template)): if you are showing an example config file that isn't part of a procedure, you shouldn't use the `<var>` tag. 
+  * [Instrumentation procedure](/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-new-relic-monitoring-aws-lambda#java) (at bottom of the Java section): the var tag wouldn't be necessary because it's an example, not part of a procedure, and the main goal is seeing the general structure. Also, because it's an example of app code, the concept of user-specific values doesn't have much meaning, because the entire code will vary dependent on how the customer has written their code. (If anything, this would be a potential for using [`<mark>` format](#highlighting) to emphasize the New Relic functions.)
+* Response/output code: If the code is meant to show an expected return, and is not related to a procedure, then var tags shouldn't be used. Here's [a doc section](/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api#get-all-monitors) (the returned JSON) where var tags are not needed.
+
+For some use cases, [highlighting](#annotate-mark) may be a better choice than a `var` tag.
+
 <CollapserGroup>
   <Collapser
     id="var-tag-examples"
-    title="Examples of using the <var> tag"
+    title="Examples of `<var>` tag use"
   >
-  ```
-  echo "license_key: <var>YOUR_LICENSE_KEY</var>" | sudo tee -a /etc/newrelic-infra.yml
-  ```
-  
-  ```
-  <var>PATH/TO/SOMETHING.exe</var>
-  ```
-  
-  ```
-  msiexec.exe /qn /i <var>PATH\TO</var>\newrelic-infra.msi
-  ```
+Below are some general style recommendations for formatting user-specific `<var>` values. `<var>` tag formatting may vary based on language- or system-specific expectations, so be sure check the style used in the documentation section in question, and to ask relevant SMEs what they think of the style.
+
+* Account IDs and other IDs/#s: `<var>YOUR_ACCOUNT_ID</var>`, `<var>YOUR_API_KEY</var>`, etc. **This should be the general style used.**
+* URLs: [example.com](https://example.com), or maybe <var>`YOUR_URL`</var>
+* Paths: `<var>PATH/TO/SOMETHING.exe</var>` or maybe `<var>PATH_TO_FILE</var>`
+* Emails: [datanerd@example.com](mailto:datanerd@example.com) or maybe `<var>YOUR_EMAIL</var>`
+* Bash variables for REST API code: Some `<var>` tagged code values on the docs site have the form $&#x7B;API_KEY}. This is a format used for variables in bash scripts, where users assign values to specific variable names and then call those variables later in the script by using the $VARIABLE_NAME. For more info, see this [explanation of bash variables](http://tldp.org/HOWTO/Bash-Prog-Intro-HOWTO-5.html).
+
+  <Callout variant="important">
+    The bash variable style is currently used in the REST API docs and in some Synthetics docs and that's fine. But going forward we should use the general variable style (without the $ and `&lt;` >).
+  </Callout>
   </Collapser>
 </CollapserGroup>
 
-## Annotate code with `<mark>` [#annotate-mark]
+## Highlight a code section with `<mark>` [#annotate-mark]
 
-Use the `<mark>` tag to highlight areas of a code block that are particularly important. Most commonly, `<mark>` is used to highlight New Relic API methods in sample code that contains a lot of "other logic." They're also handy when you want to indicate a bit of code that will be referenced later in a procedure or doc. 
+Use the `<mark>` tag to highlight areas of a code block that are particularly important but not directly procedural-related. Most commonly, `<mark>` is used to highlight New Relic API methods in sample code that contains a lot of "other logic." They're also handy when you want to indicate a bit of code that will be referenced later in a procedure or doc. 
+
+ Here are two examples of highlighting:
+* Highlighting values in code response that are meant for later use: [Activate Azure integrations doc](/docs/infrastructure/microsoft-azure-integrations/getting-started/activate-azure-integrations#get-ids).
+* Highlighting the commands in a large code block example that are New Relic-specific commands, with explanations below: [Java API doc](/docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications#use-gettoken).
 
 When you use `<mark>`, you should usually follow the code block with a list of bullets that explain what each API call is doing and link to method syntax. 
 


### PR DESCRIPTION
Noticed that we had lost some old `<var>` and `<mark>` info during migration so added some of that to style guide doc. 