### PR TITLE
Remove the availability SLI for browser apps

### DIFF
--- a/src/content/docs/service-level-management/create-slm.mdx
+++ b/src/content/docs/service-level-management/create-slm.mdx
@@ -187,7 +187,7 @@ Based on OpenTelemetry spans, these SLIs are the most common for request-driven 
 
 The following SLIs are based on Google’s Browser Core Web Vitals.
 
-<CollapserGroup>
+<!--- CollapserGroup>
   <Collapser
     className="freq-link"
     id="browser-availability"
@@ -213,7 +213,7 @@ The following SLIs are based on Google’s Browser Core Web Vitals.
 
   Where `{entityGuid}` is the browser app GUID.
   
-  </Collapser>
+  </Collapser --->
 
   <Collapser
     className="freq-link"

--- a/src/content/docs/service-level-management/create-slm.mdx
+++ b/src/content/docs/service-level-management/create-slm.mdx
@@ -187,34 +187,6 @@ Based on OpenTelemetry spans, these SLIs are the most common for request-driven 
 
 The following SLIs are based on Google's Browser Core Web Vitals.
 
-<!--- CollapserGroup>
-  <Collapser
-    className="freq-link"
-    id="browser-availability"
-    title="Browser app availability"
-  >
-    It’s the proportion of page views that are served without errors.
-
-    **Valid events fields**
-
-  ```
-  FROM: PageView
-  WHERE: entityGuid = '{entityGuid}'
-  ```
-    
-    Where `{entityGuid}` is the service's GUID.
-    
-    **Bad events fields**
-      
-  ```
-  FROM: JavaScriptError
-  WHERE: entityGuid = '{entityGuid}'
-  ```  
-
-  Where `{entityGuid}` is the browser app GUID.
-  
-  </Collapser --->
-
 <CollapserGroup>
   <Collapser
     className="freq-link"

--- a/src/content/docs/service-level-management/create-slm.mdx
+++ b/src/content/docs/service-level-management/create-slm.mdx
@@ -185,7 +185,7 @@ Based on OpenTelemetry spans, these SLIs are the most common for request-driven 
     
 ### SLIs for browser applications [#sli-browser]
 
-The following SLIs are based on Google’s Browser Core Web Vitals.
+The following SLIs are based on Google's Browser Core Web Vitals.
 
 <!--- CollapserGroup>
   <Collapser
@@ -215,6 +215,7 @@ The following SLIs are based on Google’s Browser Core Web Vitals.
   
   </Collapser --->
 
+<CollapserGroup>
   <Collapser
     className="freq-link"
     id="browser-contentful-paint"


### PR DESCRIPTION
We've noticed that the suggested queries for the Browser app availability service level are not working well. The reason is that one Page View event can generate more than one Javascript error event, therefore the number of bad events is not always a subset of valid events. Until we come up with a better option, we're removing this section (I'm commenting the content so we can reuse it quickly if needed).

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.