### PR TITLE
Add new OpenTelemetry JVM UI details

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
@@ -274,16 +274,51 @@ Here's a typical workflow:
 
 You can choose several service instances to compare, based on summaries of key metrics: response time, throughput, error rate, garbage collection time, and memory usage. Then, you can compare all those instances' JVM metrics collected by OpenTelemetry instrumentation using timeseries charts to spot problems.
 
-When you drill into a specific JVM, the UI display charts driven by JVM metric data:
+Review these additional topics about using the JVMs page:
 
-  * JVM metrics follow the general [semantic conventions for runtime environment metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/runtime-environment-metrics.md#runtime-environment-specific-metrics---runtimeenvironment).
-  * The Java specific runtime metrics are not well documented. The [implementation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics) is effectively the documentation and may be subject to change.
-  * Note that memory usage and garbage collection time are presented as a percentage of available resources. For memory, it is used/committed, and for garbage collection (GC), time spent is GC/wall clock time.
+<CollapserGroup>
+  <Collapser
+    className="freq-link"
+    id="metric-details"
+    title="Runtime metric details"
+  >
+  When you drill into a specific JVM, the UI display charts driven by JVM metric data:
 
-For your data to appear in this section, make sure it has the following:
+    * JVM metrics follow the general [semantic conventions for runtime environment metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/runtime-environment-metrics.md#runtime-environment-specific-metrics---runtimeenvironment).
+    * The Java specific runtime metrics are not well documented. The [implementation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics) is effectively the documentation and may be subject to change.
+  </Collapser>
+  <Collapser
+    className="freq-link"
+    id="config-steps"
+    title="How to ensure your data appears"
+  >
+  For your data to appear in this section, make sure it has the following:
 
-  * Requires a unique `service.instance.id` attribute for rendering the list of JVMs
-  * `Service.instance.id` is an OpenTelemetry resource attribute
+    * A unique `service.instance.id` attribute for rendering the list of JVMs
+    * An OpenTelemetry resource attribute `Service.instance.id`.
+  </Collapser>
+  <Collapser
+    className="freq-link"
+    id="metric-types"
+    title="Gauges versus counters"
+  >
+  Starting in OpenTelemetry Java agent 1.10.0, JVM memory usage switched from being collected as an async gauge to an async up down counter. This has implications on the exported data. Gauges and counters export differently:
+  
+    * Async gauges export as OTLP gauges
+    * Async up down counters export as non-monotonic sums
+  
+
+
+  If you configure your SDK to export your metrics using delta aggregation temporality, that results in async up down counters exported as non-monotonic delta sums. New Relic is not able to perform any useful analysis of non-monotonic delta sum data.
+
+  The solution for now (until a better solution is sorted out in the OpenTelemetry metric specification) is to use the View API to indicate that async up down counters should be aggregated using last value aggregation instead of the default sum aggregation. This results in JVM memory usage being exported as gauge data, which is required for a useful experience in New Relic.
+
+  The way you configure the View API varies based on whether or not you’re using the OpenTelemetry Java agent:
+
+  * If you're not using the OpenTelemetry Java agent, review this simple [example](https://github.com/newrelic/newrelic-opentelemetry-examples/pull/89/files#diff-da355ef6d1092534a55829e95160ab8468884bdd521f9018feeaaa66aea6ac5bR82-R86) that shows how to register a view when configuring your `SdkMeterProvider`.
+  * If you're using the OpenTelemetry Java agent, you need to package up code to configure the `SdkMeterProvider` in what’s called an extension jar. The extension jar contains an implementation of a server provider interface that the agent loads and which contains programmatic configuration of the `SdkMeterProvider`’s views. This is demonstrated in the [`Customizer`](https://github.com/newrelic/newrelic-opentelemetry-examples/blob/main/java/agent-nr-config/config-extension/src/main/java/com/newrelic/otel/extension/Customizer.java#L28-L37) class of the [OpenTelemetry agent example](https://github.com/newrelic/newrelic-opentelemetry-examples/tree/main/java/agent-nr-config).
+  </Collapser>
+</CollapserGroup>
 
 ### Logs [#logs]
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
@@ -262,6 +262,14 @@ For more details, see [External services](/docs/apm/apm-ui-pages/monitoring/exte
 
 ### JVMs
 
+The JVMs page for services instrumented with OpenTelemetry allows you to identify which service instances have unusual or unhealthy performance patterns. You can compare the key service health and Java Virtual Machine (JVM) metrics, across any number of instances. With this data, you can:
+
+* Determine which instances need their JVM garbage collection or memory settings tuned for a better fit for their load.
+* Identify instances receiving an unbalanced amount of traffic.
+* Spot slow memory leaks.
+
+You can choose several service instances to compare, based on summaries of key metrics: response time, throughput, error rate, garbage collection time, and memory usage. Then, you can compare all those instances' JVM metrics collected by OpenTelemetry instrumentation using timeseries charts to spot problems.
+
 When you drill into a specific JVM, the UI display charts driven by JVM metric data:
 
   * JVM metrics follow the general [semantic conventions for runtime environment metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/runtime-environment-metrics.md#runtime-environment-specific-metrics---runtimeenvironment).

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
@@ -262,7 +262,9 @@ For more details, see [External services](/docs/apm/apm-ui-pages/monitoring/exte
 
 ### JVMs
 
-The JVMs page for services instrumented with OpenTelemetry allows you to identify which service instances have unusual or unhealthy performance patterns. You can compare the key service health and Java Virtual Machine (JVM) metrics across any number of instances. You can compare several JVMs across all of the health metrics and runtime metrics. Here's a typical workflow:
+The JVMs page for services instrumented with OpenTelemetry allows you to identify which service instances have unusual or unhealthy performance patterns. You can compare the key service health and Java Virtual Machine (JVM) metrics across any number of instances. 
+
+Here's a typical workflow:
 
 1. Find interesting JVMs using the table of summarized health metrics:
     * Sort to find outliers.

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
@@ -262,17 +262,16 @@ For more details, see [External services](/docs/apm/apm-ui-pages/monitoring/exte
 
 ### JVMs
 
-The JVMs page for services instrumented with OpenTelemetry allows you to identify which service instances have unusual or unhealthy performance patterns. You can compare the key service health and Java Virtual Machine (JVM) metrics across any number of instances. 
+The JVMs page for services instrumented with OpenTelemetry allows you to identify which service instances have unusual or unhealthy performance patterns. You can choose several service instances to compare, based on summaries of key metrics: response time, throughput, error rate, garbage collection time, and memory usage. Then, you can compare all those instances' JVM metrics collected by OpenTelemetry instrumentation using timeseries charts to spot problems.
 
 Here's a typical workflow:
 
-1. Find interesting JVMs using the table of summarized health metrics:
-    * Sort to find outliers.
+1. Click **JVMs**. 
+2. Find interesting JVMs using the table of summarized health metrics:
     * Use the filter bar to narrow down your search using tags.
-2. Select those interesting JVMs.
-3. Click to go to the second view, which displays the health and runtime metrics faceted by JVM.
-
-You can choose several service instances to compare, based on summaries of key metrics: response time, throughput, error rate, garbage collection time, and memory usage. Then, you can compare all those instances' JVM metrics collected by OpenTelemetry instrumentation using timeseries charts to spot problems.
+    * Sort to find outliers.
+3. Select those interesting JVMs.
+4. Click **Compare** to see a display of the health and runtime metrics faceted by JVM.
 
 Review these additional topics about using the JVMs page:
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
@@ -268,7 +268,7 @@ Here's a typical workflow:
 
 1. Click **JVMs**. 
 2. Find interesting JVMs using the table of summarized health metrics:
-    * Use the filter bar to narrow down your search using tags.
+    * Use the filter bar to narrow down your search.
     * Sort to find outliers.
 3. Select those interesting JVMs.
 4. Click **Compare** to see a display of the health and runtime metrics faceted by JVM.
@@ -312,7 +312,7 @@ Review these additional topics about using the JVMs page:
   The way you configure the View API varies based on whether or not you’re using the OpenTelemetry Java agent:
 
   * If you're not using the OpenTelemetry Java agent, review this simple [example](https://github.com/newrelic/newrelic-opentelemetry-examples/pull/89/files#diff-da355ef6d1092534a55829e95160ab8468884bdd521f9018feeaaa66aea6ac5bR82-R86) that shows how to register a view when configuring `SdkMeterProvider`.
-  * If you’re using the OpenTelemetry Java agent, you need to configure the View API in an [extension](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/agent-config.md#extensions). Extensions allow you to hook into the SDK configuration (among other things) and apply programmatic configuration that isn’t available by environment variable or system properties. This [example](https://github.com/newrelic/newrelic-opentelemetry-examples/tree/main/java/agent-nr-config) demonstrates how an extension can be used to [customize](https://github.com/newrelic/newrelic-opentelemetry-examples/blob/main/java/agent-nr-config/config-extension/src/main/java/com/newrelic/otel/extension/Customizer.java#L28-L37) the `SdkMeterProvider`’s views.
+  * If you’re using the OpenTelemetry Java agent, you need to configure the View API in an [extension](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/agent-config.md#extensions). Extensions allow you to hook into the SDK configuration (among other things) and apply programmatic configuration that isn’t available by environment variable or system properties. This [example](https://github.com/newrelic/newrelic-opentelemetry-examples/tree/main/java/agent-nr-config) demonstrates how you can use an extension to [customize](https://github.com/newrelic/newrelic-opentelemetry-examples/blob/main/java/agent-nr-config/config-extension/src/main/java/com/newrelic/otel/extension/Customizer.java#L28-L37) the `SdkMeterProvider`’s views.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
@@ -262,7 +262,7 @@ For more details, see [External services](/docs/apm/apm-ui-pages/monitoring/exte
 
 ### JVMs
 
-The JVMs page for services instrumented with OpenTelemetry allows you to identify which service instances have unusual or unhealthy performance patterns. You can compare the key service health and Java Virtual Machine (JVM) metrics, across any number of instances. You can compare several JVMs across all of the health metrics and runtime metrics. Here's a typical workflow:
+The JVMs page for services instrumented with OpenTelemetry allows you to identify which service instances have unusual or unhealthy performance patterns. You can compare the key service health and Java Virtual Machine (JVM) metrics across any number of instances. You can compare several JVMs across all of the health metrics and runtime metrics. Here's a typical workflow:
 
 1. Find interesting JVMs using the table of summarized health metrics:
     * Sort to find outliers.

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
@@ -262,18 +262,21 @@ For more details, see [External services](/docs/apm/apm-ui-pages/monitoring/exte
 
 ### JVMs
 
-The JVMs page for services instrumented with OpenTelemetry allows you to identify which service instances have unusual or unhealthy performance patterns. You can compare the key service health and Java Virtual Machine (JVM) metrics, across any number of instances. With this data, you can:
+The JVMs page for services instrumented with OpenTelemetry allows you to identify which service instances have unusual or unhealthy performance patterns. You can compare the key service health and Java Virtual Machine (JVM) metrics, across any number of instances. You can compare several JVMs across all of the health metrics and runtime metrics. Here's a typical workflow:
 
-* Determine which instances need their JVM garbage collection or memory settings tuned for a better fit for their load.
-* Identify instances receiving an unbalanced amount of traffic.
-* Spot slow memory leaks.
+1. Find interesting JVMs using the table of summarized health metrics:
+    * Sort to find outliers.
+    * Use the filter bar to narrow down your search using tags.
+2. Select those interesting JVMs.
+3. Click to go to the second view, which displays the health and runtime metrics faceted by JVM.
 
 You can choose several service instances to compare, based on summaries of key metrics: response time, throughput, error rate, garbage collection time, and memory usage. Then, you can compare all those instances' JVM metrics collected by OpenTelemetry instrumentation using timeseries charts to spot problems.
 
 When you drill into a specific JVM, the UI display charts driven by JVM metric data:
 
   * JVM metrics follow the general [semantic conventions for runtime environment metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/runtime-environment-metrics.md#runtime-environment-specific-metrics---runtimeenvironment).
-  * The Java specific runtime metrics are not well documented. The [implementation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics) is effectively the documentation and may be subject to change. 
+  * The Java specific runtime metrics are not well documented. The [implementation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics) is effectively the documentation and may be subject to change.
+  * Note that memory usage and garbage collection time are presented as a percentage of available resources. For memory, it is used/committed, and for garbage collection (GC), time spent is GC/wall clock time.
 
 For your data to appear in this section, make sure it has the following:
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-opentelemetry-data-new-relic.mdx
@@ -282,10 +282,7 @@ Review these additional topics about using the JVMs page:
     id="metric-details"
     title="Runtime metric details"
   >
-  When you drill into a specific JVM, the UI display charts driven by JVM metric data:
-
-    * JVM metrics follow the general [semantic conventions for runtime environment metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/runtime-environment-metrics.md#runtime-environment-specific-metrics---runtimeenvironment).
-    * The Java specific runtime metrics are not well documented. The [implementation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics) is effectively the documentation and may be subject to change.
+  When you drill into a specific JVM, the UI display charts driven by JVM metric data. The Java specific runtime metrics are not well documented. The [implementation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics) is effectively the documentation and may be subject to change.
   </Collapser>
   <Collapser
     className="freq-link"
@@ -294,8 +291,8 @@ Review these additional topics about using the JVMs page:
   >
   For your data to appear in this section, make sure it has the following:
 
-    * A unique `service.instance.id` attribute for rendering the list of JVMs
-    * An OpenTelemetry resource attribute `Service.instance.id`.
+    * A unique `service.instance.id` attribute for rendering the list of JVMs.
+    * An OpenTelemetry resource attribute `service.instance.id`.
   </Collapser>
   <Collapser
     className="freq-link"
@@ -305,18 +302,18 @@ Review these additional topics about using the JVMs page:
   Starting in OpenTelemetry Java agent 1.10.0, JVM memory usage switched from being collected as an async gauge to an async up down counter. This has implications on the exported data. Gauges and counters export differently:
   
     * Async gauges export as OTLP gauges
-    * Async up down counters export as non-monotonic sums
+    * Async up down counters export as OTLP non-monotonic sums
   
 
 
-  If you configure your SDK to export your metrics using delta aggregation temporality, that results in async up down counters exported as non-monotonic delta sums. New Relic is not able to perform any useful analysis of non-monotonic delta sum data.
+  If you configure your SDK to export your metrics using delta aggregation temporality (which is required for counter and histogram instruments to function with New Relic), that results in async up down counters exported as non-monotonic delta sums. New Relic is not able to perform any useful analysis of non-monotonic delta sum data.
 
-  The solution for now (until a better solution is sorted out in the OpenTelemetry metric specification) is to use the View API to indicate that async up down counters should be aggregated using last value aggregation instead of the default sum aggregation. This results in JVM memory usage being exported as gauge data, which is required for a useful experience in New Relic.
+  The solution for now (until a better solution is sorted out in the OpenTelemetry metric specification) is to use the View API to indicate that async up down counters should be aggregated using [last value aggregation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#last-value-aggregation) instead of the default sum aggregation. This results in JVM memory usage being exported as gauge data, which is required for a useful experience in New Relic.
 
   The way you configure the View API varies based on whether or not you’re using the OpenTelemetry Java agent:
 
-  * If you're not using the OpenTelemetry Java agent, review this simple [example](https://github.com/newrelic/newrelic-opentelemetry-examples/pull/89/files#diff-da355ef6d1092534a55829e95160ab8468884bdd521f9018feeaaa66aea6ac5bR82-R86) that shows how to register a view when configuring your `SdkMeterProvider`.
-  * If you're using the OpenTelemetry Java agent, you need to package up code to configure the `SdkMeterProvider` in what’s called an extension jar. The extension jar contains an implementation of a server provider interface that the agent loads and which contains programmatic configuration of the `SdkMeterProvider`’s views. This is demonstrated in the [`Customizer`](https://github.com/newrelic/newrelic-opentelemetry-examples/blob/main/java/agent-nr-config/config-extension/src/main/java/com/newrelic/otel/extension/Customizer.java#L28-L37) class of the [OpenTelemetry agent example](https://github.com/newrelic/newrelic-opentelemetry-examples/tree/main/java/agent-nr-config).
+  * If you're not using the OpenTelemetry Java agent, review this simple [example](https://github.com/newrelic/newrelic-opentelemetry-examples/pull/89/files#diff-da355ef6d1092534a55829e95160ab8468884bdd521f9018feeaaa66aea6ac5bR82-R86) that shows how to register a view when configuring `SdkMeterProvider`.
+  * If you’re using the OpenTelemetry Java agent, you need to configure the View API in an [extension](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/agent-config.md#extensions). Extensions allow you to hook into the SDK configuration (among other things) and apply programmatic configuration that isn’t available by environment variable or system properties. This [example](https://github.com/newrelic/newrelic-opentelemetry-examples/tree/main/java/agent-nr-config) demonstrates how an extension can be used to [customize](https://github.com/newrelic/newrelic-opentelemetry-examples/blob/main/java/agent-nr-config/config-extension/src/main/java/com/newrelic/otel/extension/Customizer.java#L28-L37) the `SdkMeterProvider`’s views.
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
This is work for Jira doc-7771. We have some new features on the OTEL JVM page.

Reviewer: Here's what I changed:

* Inserted new text to augment the existing text in the JVM page.
* I segmented some sub-tasks using new collapsers. See if those collapsers make sense.
* The final collapser has some detailed instructions. Is this clear?