### PR TITLE
feat: add Korean translation functionality

### DIFF
--- a/scripts/actions/__tests__/add-files-to-translation-queue.test.js
+++ b/scripts/actions/__tests__/add-files-to-translation-queue.test.js
@@ -6,7 +6,7 @@ const { getLocalizedFileData } = require('../add-files-to-translation-queue');
 const MOCK_CONSTANTS = {
   LOCALE_IDS: {
     jp: 'ja-JP',
-    ko: 'ko-KR',
+    kr: 'ko-KR',
   },
 };
 

--- a/scripts/actions/__tests__/add-files-to-translation-queue.test.js
+++ b/scripts/actions/__tests__/add-files-to-translation-queue.test.js
@@ -6,7 +6,7 @@ const { getLocalizedFileData } = require('../add-files-to-translation-queue');
 const MOCK_CONSTANTS = {
   LOCALE_IDS: {
     jp: 'ja-JP',
-    kr: 'ko-KR',
+    ko: 'ko-KR',
   },
 };
 
@@ -61,6 +61,7 @@ describe('add-files-to-translation-queue tests', () => {
       const toBeTranslated = getLocalizedFileData(file);
       expect(toBeTranslated).toEqual([
         { filename: '/content/bar.mdx', locale: 'ja-JP', project_id: 'HT_ID' },
+        { filename: '/content/bar.mdx', locale: 'ko-KR', project_id: 'MT_ID' },
       ]);
     });
 
@@ -72,6 +73,7 @@ describe('add-files-to-translation-queue tests', () => {
 
       expect(toBeTranslated).toEqual([
         { filename: '/content/bar.mdx', locale: 'ja-JP', project_id: 'MT_ID' },
+        { filename: '/content/bar.mdx', locale: 'ko-KR', project_id: 'MT_ID' },
       ]);
     });
 

--- a/scripts/actions/__tests__/check-job-progress.test.js
+++ b/scripts/actions/__tests__/check-job-progress.test.js
@@ -91,12 +91,21 @@ describe('check-jobs-progress tests', () => {
 
       await updateTranslationRecords([slugStatus]);
 
-      expect(updateTranslations.mock.calls.length).toBe(1);
+      expect(updateTranslations.mock.calls.length).toBe(2);
       expect(updateTranslations.mock.calls[0][0]).toStrictEqual({
         slug: 'failure.txt',
         status: 'IN_PROGRESS',
+        locale: 'ja-JP',
       });
       expect(updateTranslations.mock.calls[0][1]).toStrictEqual({
+        status: 'COMPLETED',
+      });
+      expect(updateTranslations.mock.calls[1][0]).toStrictEqual({
+        slug: 'failure.txt',
+        status: 'IN_PROGRESS',
+        locale: 'ko-KR',
+      });
+      expect(updateTranslations.mock.calls[1][1]).toStrictEqual({
         status: 'COMPLETED',
       });
     });
@@ -108,12 +117,21 @@ describe('check-jobs-progress tests', () => {
 
       await updateTranslationRecords([slugStatus]);
 
-      expect(updateTranslations.mock.calls.length).toBe(1);
+      expect(updateTranslations.mock.calls.length).toBe(2);
       expect(updateTranslations.mock.calls[0][0]).toStrictEqual({
         slug: 'success.txt',
         status: 'IN_PROGRESS',
+        locale: 'ja-JP',
       });
       expect(updateTranslations.mock.calls[0][1]).toStrictEqual({
+        status: 'COMPLETED',
+      });
+      expect(updateTranslations.mock.calls[1][0]).toStrictEqual({
+        slug: 'success.txt',
+        status: 'IN_PROGRESS',
+        locale: 'ko-KR',
+      });
+      expect(updateTranslations.mock.calls[1][1]).toStrictEqual({
         status: 'COMPLETED',
       });
     });
@@ -128,7 +146,7 @@ describe('check-jobs-progress tests', () => {
 
       await updateTranslationRecords(slugStatuses);
 
-      expect(updateTranslations.mock.calls.length).toBe(3);
+      expect(updateTranslations.mock.calls.length).toBe(6);
     });
 
     test('logs errored translations to the console', async () => {

--- a/scripts/actions/__tests__/check-job-progress.test.js
+++ b/scripts/actions/__tests__/check-job-progress.test.js
@@ -87,25 +87,17 @@ describe('check-jobs-progress tests', () => {
     test('updates translation record to COMPLETED for failed slug', async () => {
       updateTranslations.mockReturnValue([{ id: 0 }]);
 
-      const slugStatus = { ok: false, slug: 'failure.txt' };
+      const slugStatus = { ok: false, slug: 'failure.txt', locale: 'ja-JP' };
 
       await updateTranslationRecords([slugStatus]);
 
-      expect(updateTranslations.mock.calls.length).toBe(2);
+      expect(updateTranslations.mock.calls.length).toBe(1);
       expect(updateTranslations.mock.calls[0][0]).toStrictEqual({
         slug: 'failure.txt',
         status: 'IN_PROGRESS',
         locale: 'ja-JP',
       });
       expect(updateTranslations.mock.calls[0][1]).toStrictEqual({
-        status: 'COMPLETED',
-      });
-      expect(updateTranslations.mock.calls[1][0]).toStrictEqual({
-        slug: 'failure.txt',
-        status: 'IN_PROGRESS',
-        locale: 'ko-KR',
-      });
-      expect(updateTranslations.mock.calls[1][1]).toStrictEqual({
         status: 'COMPLETED',
       });
     });
@@ -113,11 +105,11 @@ describe('check-jobs-progress tests', () => {
     test('updates translation record to COMPLETED for successful slug', async () => {
       updateTranslations.mockReturnValue([{ id: 0 }]);
 
-      const slugStatus = { ok: true, slug: 'success.txt' };
+      const slugStatus = { ok: true, slug: 'success.txt', locale: 'ja-JP' };
 
       await updateTranslationRecords([slugStatus]);
 
-      expect(updateTranslations.mock.calls.length).toBe(2);
+      expect(updateTranslations.mock.calls.length).toBe(1);
       expect(updateTranslations.mock.calls[0][0]).toStrictEqual({
         slug: 'success.txt',
         status: 'IN_PROGRESS',
@@ -126,27 +118,43 @@ describe('check-jobs-progress tests', () => {
       expect(updateTranslations.mock.calls[0][1]).toStrictEqual({
         status: 'COMPLETED',
       });
+    });
+
+    test('updates multiple records', async () => {
+      updateTranslations.mockReturnValue([{ id: 0 }]);
+      const slugStatuses = [
+        { ok: true, slug: 'fake_slug.txt', locale: 'ja-JP' },
+        { ok: false, slug: 'fake_slug_2.txt', locale: 'ko-KR' },
+        { ok: true, slug: 'fake_slug_3.txt', locale: 'ko-KR' },
+      ];
+
+      await updateTranslationRecords(slugStatuses);
+
+      expect(updateTranslations.mock.calls.length).toBe(3);
+      expect(updateTranslations.mock.calls[0][0]).toStrictEqual({
+        slug: 'fake_slug.txt',
+        status: 'IN_PROGRESS',
+        locale: 'ja-JP',
+      });
+      expect(updateTranslations.mock.calls[0][1]).toStrictEqual({
+        status: 'COMPLETED',
+      });
       expect(updateTranslations.mock.calls[1][0]).toStrictEqual({
-        slug: 'success.txt',
+        slug: 'fake_slug_2.txt',
         status: 'IN_PROGRESS',
         locale: 'ko-KR',
       });
       expect(updateTranslations.mock.calls[1][1]).toStrictEqual({
         status: 'COMPLETED',
       });
-    });
-
-    test('updates multiple records', async () => {
-      updateTranslations.mockReturnValue([{ id: 0 }]);
-      const slugStatuses = [
-        { ok: true, slug: 'fake_slug.txt' },
-        { ok: false, slug: 'fake_slug_2.txt' },
-        { ok: true, slug: 'fake_slug_3.txt' },
-      ];
-
-      await updateTranslationRecords(slugStatuses);
-
-      expect(updateTranslations.mock.calls.length).toBe(6);
+      expect(updateTranslations.mock.calls[2][0]).toStrictEqual({
+        slug: 'fake_slug_3.txt',
+        status: 'IN_PROGRESS',
+        locale: 'ko-KR',
+      });
+      expect(updateTranslations.mock.calls[2][1]).toStrictEqual({
+        status: 'COMPLETED',
+      });
     });
 
     test('logs errored translations to the console', async () => {

--- a/scripts/actions/check-job-progress.js
+++ b/scripts/actions/check-job-progress.js
@@ -10,6 +10,7 @@ const {
 const { vendorRequest } = require('./utils/vendor-request');
 const { fetchAndDeserializeFiles } = require('./fetch-and-deserialize');
 const { configuration } = require('./configuration');
+const { LOCALE_IDS } = require('./utils/constants.js');
 
 const PROJECT_ID = configuration.TRANSLATION.VENDOR_PROJECT;
 
@@ -175,14 +176,15 @@ const updateTranslationRecords = async (slugStatuses) => {
 
   await Promise.all(
     slugStatuses.map(async ({ slug }) => {
-      const records = await updateTranslations(
-        { slug, status: StatusEnum.IN_PROGRESS },
-        { status: StatusEnum.COMPLETED }
-      );
-
-      console.log(
-        `Translation ${records[0].id} marked as ${StatusEnum.COMPLETED}`
-      );
+      Object.values(LOCALE_IDS).forEach(async (localeId) => {
+        const records = await updateTranslations(
+          { slug, status: StatusEnum.IN_PROGRESS, locale: localeId },
+          { status: StatusEnum.COMPLETED }
+        );
+        console.log(
+          `Translation ${records[0].id} for ${localeId} marked as ${StatusEnum.COMPLETED}`
+        );
+      });
     })
   );
 };

--- a/scripts/actions/check-job-progress.js
+++ b/scripts/actions/check-job-progress.js
@@ -10,7 +10,6 @@ const {
 const { vendorRequest } = require('./utils/vendor-request');
 const { fetchAndDeserializeFiles } = require('./fetch-and-deserialize');
 const { configuration } = require('./configuration');
-const { LOCALE_IDS } = require('./utils/constants.js');
 
 const PROJECT_ID = configuration.TRANSLATION.VENDOR_PROJECT;
 
@@ -48,6 +47,7 @@ const prop = (key) => (x) => x[key];
  * @property {boolean} SlugStatus[].ok - Boolean flag signaling if translation deserialized. If it did, we can treat this translation as having completed.
  * @property {string} SlugStatus[].slug - Slug representing file path translated.
  * @property {string} SlugStatus[].jobId - Job id translation is associated with.
+ * @property {string} SlugStatus[].locale - Locale ID translation is translated to.
  */
 
 /**
@@ -175,16 +175,15 @@ const updateTranslationRecords = async (slugStatuses) => {
   // TODO: need to update this when we implement multiple locales. This only works for one locale.
 
   await Promise.all(
-    slugStatuses.map(async ({ slug }) => {
-      Object.values(LOCALE_IDS).forEach(async (localeId) => {
-        const records = await updateTranslations(
-          { slug, status: StatusEnum.IN_PROGRESS, locale: localeId },
-          { status: StatusEnum.COMPLETED }
-        );
-        console.log(
-          `Translation ${records[0].id} for ${localeId} marked as ${StatusEnum.COMPLETED}`
-        );
-      });
+    slugStatuses.map(async ({ locale, slug }) => {
+      const records = await updateTranslations(
+        { slug, status: StatusEnum.IN_PROGRESS, locale },
+        { status: StatusEnum.COMPLETED }
+      );
+
+      console.log(
+        `Translation ${records[0].id} marked as ${StatusEnum.COMPLETED}`
+      );
     })
   );
 };

--- a/scripts/actions/fetch-and-deserialize.js
+++ b/scripts/actions/fetch-and-deserialize.js
@@ -198,12 +198,13 @@ const deserializeHtmlToMdx = (locale) => {
       return {
         ok: true,
         slug: completePath,
+        locale,
       };
     } catch (ex) {
       console.log(`Failed to deserialize: ${contentPath}`);
       console.log(ex);
 
-      return { ok: false, slug: completePath };
+      return { ok: false, slug: completePath, locale };
     }
   };
 };

--- a/scripts/actions/fetch-and-deserialize.js
+++ b/scripts/actions/fetch-and-deserialize.js
@@ -10,10 +10,7 @@ const fetch = require('node-fetch');
 const deserializedHtml = require('./deserialize-html');
 const createDirectories = require('../utils/migrate/create-directories');
 const { getAccessToken } = require('./utils/vendor-request');
-
-const localesMap = {
-  'ja-JP': 'jp',
-};
+const { LOCALE_IDS } = require('./utils/constants');
 
 const projectId = process.env.TRANSLATION_VENDOR_PROJECT;
 
@@ -178,10 +175,13 @@ const deserializeHtmlToMdx = (locale) => {
    */
   return async ({ path: contentPath, html }) => {
     const completePath = `${path.join('src/content/docs', contentPath)}.mdx`;
+    const localeKey = Object.keys(LOCALE_IDS).find(
+      (key) => LOCALE_IDS[key] === locale
+    );
 
     try {
       const localePath = path.join(
-        `src/i18n/content/${localesMap[locale]}/docs/`,
+        `src/i18n/content/${localeKey}/docs/`,
         contentPath
       );
       const mdx = await deserializedHtml(html);

--- a/scripts/actions/translation_workflow/testing/migrations/20211201221649-test.js
+++ b/scripts/actions/translation_workflow/testing/migrations/20211201221649-test.js
@@ -150,6 +150,9 @@ module.exports = {
       {
         locale: 'ja-JP',
       },
+      {
+        locale: 'ko-KR',
+      },
     ]);
   },
 

--- a/scripts/actions/utils/constants.js
+++ b/scripts/actions/utils/constants.js
@@ -1,5 +1,7 @@
+// This should be in the format {localeKey: locale} across scripts
 const LOCALE_IDS = {
   jp: 'ja-JP',
+  ko: 'ko-KR',
 };
 
 const EXCLUSIONS_FILE =

--- a/scripts/actions/utils/constants.js
+++ b/scripts/actions/utils/constants.js
@@ -1,7 +1,7 @@
 // This should be in the format {localeKey: locale} across scripts
 const LOCALE_IDS = {
   jp: 'ja-JP',
-  ko: 'ko-KR',
+  kr: 'ko-KR',
 };
 
 const EXCLUSIONS_FILE =

--- a/scripts/actions/utils/vendor-request.js
+++ b/scripts/actions/utils/vendor-request.js
@@ -6,17 +6,11 @@ const path = require('path');
 const serializeMDX = require('../serialize-mdx');
 const FormData = require('form-data');
 const NodeCache = require('node-cache');
+const { LOCALE_IDS } = require('./constants');
 
 const cache = new NodeCache({ stdTTL: 60 * 4, checkperiod: 2 });
 const PROJECT_ID = process.env.TRANSLATION_VENDOR_PROJECT;
 const DOCS_SITE_URL = 'https://docs.newrelic.com';
-
-// NOTE: the vendor requires the locales in a different format
-// We should consider this into the Gatsby config for each locale.
-const LOCALE_IDS = {
-  jp: 'ja-JP',
-  'ja-JP': 'jp',
-};
 
 const MAX_RETRY = 5;
 const POLL_INTERVAL = 1500;
@@ -145,7 +139,7 @@ const vendorRequest = async ({
 const sendPageContext = async (fileUri, accessToken) => {
   const filepath = fileUri.replace(`src/content/`, '');
   const slug = filepath.replace(`.mdx`, '');
-  const contextUrl = new URL(slug, DOCS_SITE_URL); //need to change this once we migrate to docs-newrelic-com
+  const contextUrl = new URL(slug, DOCS_SITE_URL);
 
   const res = await fetch(contextUrl.href);
   const html = await res.text();
@@ -198,7 +192,11 @@ const uploadFile = (locale, batchUid) => async (translation) => {
     html,
   };
 
-  const filename = `${Buffer.from(LOCALE_IDS[locale] + page.file).toString(
+  const localeKey = Object.keys(LOCALE_IDS).find(
+    (key) => LOCALE_IDS[key] === locale
+  );
+
+  const filename = `${Buffer.from(localeKey + page.file).toString(
     'base64'
   )}.html`;
   const filepath = path.join(process.cwd(), filename);


### PR DESCRIPTION
 - Combines all declarations of `locale ids` into a constant located in [src/scripts/actions/utils/constants.js](https://github.com/newrelic/docs-website/blob/develop/scripts/actions/utils/constants.js) in format `{localeKey: locale}` e.g. `{ko: 'ko-KR'}`
     - This is to keep the `localeKey` and `locale` variable usage consistent across all scripts, as we need each of them for different purposes
 - [scripts/actions/check-job-progress.js](https://github.com/newrelic/docs-website/compare/feature/korean-translations?expand=1#diff-c1c3066f6308eccb7a065b31959adc9c3b2937f72889b25bdb64d4519a7abd6c) now accounts for multiple languages when marking translations as __COMPLETED__ 
 - Updates tests to account for new Korean language
 - Update the migration script so that the Test DB `locales` table includes `ko-KR`