### PR TITLE
Add documentation for new trace observer region in the EU.

### DIFF
--- a/src/content/docs/distributed-tracing/concepts/quick-start.mdx
+++ b/src/content/docs/distributed-tracing/concepts/quick-start.mdx
@@ -99,7 +99,7 @@ To set up distributed tracing, you'll complete three general steps:
       />
       <TechTile
         name="AWS Lambda Functions"
-        to="/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/"
+        to="/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/configure-serverless-monitoring-aws-lambda"
         icon={<img src={awslambdalogo} alt="AWS Lambda Functions"/>}
       />
       <TechTile

--- a/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
@@ -36,8 +36,8 @@ To create a new trace observer if you're using New Relic APM agents or third-par
 
     <Callout variant="important">
     We offer two options for the EU region:
-      * EU-Region-1: Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
-      * EU-Region-2: Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports to EU data centers.
+      * eu-west-1: Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
+      * eu-central-1: Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports in EU data centers.
     </Callout>
 
 4. Under the **Endpoints** dropdown, copy the endpoint value under **For other integrations** and have it ready. This value is referenced in our code examples as <var>YOUR_TRACE_OBSERVER_URL</var>. This is used to test the [trace observer](#sample-payload), as well as to configure our [telemetry integrations](/docs/distributed-tracing/enable-configure/quick-start) and for sending data via the [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api/).
@@ -179,8 +179,8 @@ If you haven't already set up a trace observer, complete the following:
 
     <Callout variant="important">
     We offer two options for the EU region:
-      * EU-Region-1: Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
-      * EU-Region-2: Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports to EU data centers.
+      * eu-west-1: Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
+      * eu-central-1: Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports in EU data centers.
     </Callout>
 
 4. Under the **Endpoints** dropdown, copy the endpoint value under **For other integrations** and have it ready. This value is referenced in our code examples as <var>YOUR_TRACE_OBSERVER_URL</var>. This is used to test the [trace observer](#sample-payload).

--- a/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
@@ -34,11 +34,11 @@ To create a new trace observer if you're using New Relic APM agents or third-par
 2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled.
 3. If no trace observers are already present, click **New trace observer** to add one, fill out the information, and click **Create**.
 
-   <Callout variant="important">
-     We offer two options for the EU region:
+    <Callout variant="important">
+    We offer two options for the EU region:
       * EU-Region-1: Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
       * EU-Region-2: Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports to EU data centers.
-   </Callout>
+    </Callout>
 
 4. Under the **Endpoints** dropdown, copy the endpoint value under **For other integrations** and have it ready. This value is referenced in our code examples as <var>YOUR_TRACE_OBSERVER_URL</var>. This is used to test the [trace observer](#sample-payload), as well as to configure our [telemetry integrations](/docs/distributed-tracing/enable-configure/quick-start) and for sending data via the [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api/).
 
@@ -177,9 +177,11 @@ If you haven't already set up a trace observer, complete the following:
 2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled.
 3. If no trace observers are already present, click **New trace observer** to add one, fill out the information, and click **Create**.
 
-   <Callout variant="important">
-     Note: If you select a trace observer in an EU region, you’ll still need a US-based New Relic account because data is reported to US data centers.
-   </Callout>
+    <Callout variant="important">
+    We offer two options for the EU region:
+      * EU-Region-1: Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
+      * EU-Region-2: Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports to EU data centers.
+    </Callout>
 
 4. Under the **Endpoints** dropdown, copy the endpoint value under **For other integrations** and have it ready. This value is referenced in our code examples as <var>YOUR_TRACE_OBSERVER_URL</var>. This is used to test the [trace observer](#sample-payload).
 

--- a/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
@@ -35,7 +35,9 @@ To create a new trace observer if you're using New Relic APM agents or third-par
 3. If no trace observers are already present, click **New trace observer** to add one, fill out the information, and click **Create**.
 
    <Callout variant="important">
-     Note: If you select a trace observer in an EU region, you’ll still need a US-based New Relic account because data is reported to US data centers.
+     We offer two options for the EU region:
+      * EU-Region-1: Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
+      * EU-Region-2: Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports to EU data centers.
    </Callout>
 
 4. Under the **Endpoints** dropdown, copy the endpoint value under **For other integrations** and have it ready. This value is referenced in our code examples as <var>YOUR_TRACE_OBSERVER_URL</var>. This is used to test the [trace observer](#sample-payload), as well as to configure our [telemetry integrations](/docs/distributed-tracing/enable-configure/quick-start) and for sending data via the [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api/).


### PR DESCRIPTION
This is a PR to introduce the new EU region and to differentiate it from the previous EU region that reports to the US data centers.

As a bonus, I changed the link from the Lambda tile in distributed tracing so it links directly to the page that discusses tracing with Lambda.