### PR TITLE
Add documentation to upgrade/downgrade Fluent Bit and support disclaimer

### DIFF
--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -60,10 +60,10 @@ Here is an example of logs for your host's UI. You can see logs in context of ev
 
 To use the log forwarder of the infrastructure agent, make sure you meet the following requirements:
 
-- Infrastructure Agent version 1.11.4 or higher
-- [Fluent Bit](https://fluentbit.io/). The Infrastructure Agent already installs the latest version for you, refer to [this section](#install-fb-version) to update/downgrade it to a particular version.
-- OpenSSL library 1.1.0 or higher is required by Infrastructure agent starting from 1.16.4.
-- Built-in support for ARM64 architecture on Linux systems (in example, AWS Graviton architecture) added in Infrastructure agent [1.26.0](https://github.com/newrelic/infrastructure-agent/releases/tag/1.20.6).
+- Infrastructure agent version 1.11.4 or higher.
+- [Fluent Bit](https://fluentbit.io/). The infrastructure agent already installs the latest version for you, refer to [this section](#install-fb-version) to update/downgrade it to a specfic version.
+- OpenSSL library 1.1.0 or higher is required by the infrastructure agent starting from version 1.16.4.
+- Built-in support for ARM64 architecture on Linux systems (for example, AWS Graviton architecture) added in infrastructure agent [1.26.0](https://github.com/newrelic/infrastructure-agent/releases/tag/1.20.6).
 
 <Callout variant="important">
 The log forwarding feature is not supported with the [Docker container for infrastructure monitoring agents](/docs/infrastructure/install-infrastructure-agent/linux-installation/docker-container-infrastructure-monitoring/).
@@ -605,11 +605,11 @@ The runtime file does not define a [`[SERVICE]` section](https://docs.fluentbit.
 `parsers_file:` path to an existing Fluent Bit parsers file. The following parser names are reserved: `rfc3164`, `rfc3164-local` and `rfc5424`.
 
     <Callout variant="important">
-    The Infrastructure Agent allows forwarding logs for the most common use cases by defining simple log forwarding configurations in the YAML files within the `logging.d/` directory, as described in this document. These files are internally translated into Fluent Bit configuration files with the correct format and sane configuration defaults. New Relic provides official support for these configuration options, since we ensure that the generated configuration files are correct and operative.
+    The infrastructure agent allows forwarding logs for the most common use cases by defining simple log forwarding configurations in the YAML files in the `logging.d/` directory, as described in this document. These files are internally translated into Fluent Bit configuration files with the correct format and sane configuration defaults. New Relic provides official support for these configuration options, since we ensure that the generated configuration files are correct and operative.
 
     Nevertheless, for those use cases not covered by our supported configuration options, we provide the possibility to use an externally-generated Fluent Bit configuration and parsers file using the `fluentbit`, `config_file` and `parsers_file` options.
 
-    Note that we cannot guarantee the correct operation of the log forwarded in this case, given that the provided configurations are completely arbitrary and are not being generated/validated by the Infrastructure Agent. Therefore, New Relic does not provide official support for the external configurations specified via these options.
+    Note that we cannot guarantee the correct operation of the log forwarded in this case, given that the provided configurations are completely arbitrary, and are not being generated/validated by the agent. Therefore, New Relic does not provide official support for the external configurations specified via these options.
     </Callout>
 
   </Collapser>
@@ -971,9 +971,9 @@ If you encounter problems with configuring your log forwarder, try these trouble
     title="Install a particular Fluent Bit version (Linux)"
   >
 
-  Prior to version [1.19.0](https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1190) (and [1.20.3](https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1203) for SLES 12.5), the Linux Infrastructure Agent came bundled with a Fluent Bit binary. Starting at this version, Fluent Bit is now included as as a separate `recommended` package dependency.
+  Prior to version [1.19.0](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1190) (or version [1.20.3](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1203) for SLES 12.5), the Linux infrastructure agent came bundled with a Fluent Bit binary. Starting in this version, Fluent Bit is now included as as a separate `recommended` package dependency.
 
-  This means that you can install, update or downgrade Fluent Bit separately from the Infrastructure Agent. We have included several Fluent Bit packages in the same repository where the Infrastructure Agent lives for your convenience, so you do not need to install any additional repository to upgrade Fluent Bit.
+  This means that you can install, update, or downgrade Fluent Bit separately from the agent. For your convenience, we have included several Fluent Bit packages in the same repository where the infrastructure lives, so you don't need to install any additional repositories to upgrade Fluent Bit.
 
   Note that the agent automatically installs Fluent Bit when you first install it, using the latest available version. After the first installation, you can upgrade Fluent Bit as you would normally do with any Linux package.
 

--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -60,9 +60,10 @@ Here is an example of logs for your host's UI. You can see logs in context of ev
 
 To use the log forwarder of the infrastructure agent, make sure you meet the following requirements:
 
-- Infrastructure agent version 1.11.4 or higher
+- Infrastructure Agent version 1.11.4 or higher
+- [Fluent Bit](https://fluentbit.io/). The Infrastructure Agent already installs the latest version for you, refer to [this section](#install-fb-version) to update/downgrade it to a particular version.
 - OpenSSL library 1.1.0 or higher is required by Infrastructure agent starting from 1.16.4.
-- Built-in support for ARM64 architecture on Linux systems (in example, AWS Graviton architecture) added in Infrastructure agent [1.26.0](https://github.com/newrelic/infrastructure-agent/releases/tag/1.20.6). 
+- Built-in support for ARM64 architecture on Linux systems (in example, AWS Graviton architecture) added in Infrastructure agent [1.26.0](https://github.com/newrelic/infrastructure-agent/releases/tag/1.20.6).
 
 <Callout variant="important">
 The log forwarding feature is not supported with the [Docker container for infrastructure monitoring agents](/docs/infrastructure/install-infrastructure-agent/linux-installation/docker-container-infrastructure-monitoring/).
@@ -295,7 +296,7 @@ logs:
 ```
 
   </Collapser>
-  
+
   <Collapser
     id="syslog"
     title="syslog"
@@ -498,7 +499,7 @@ The infrastructure agent automatically inserts log attributes for your convenien
 
       <td>
         Always inserted.
-        
+
         The infrastructure agent inserts the [Entity GUID](/attribute-dictionary/span/entityguid) assigned by New Relic to identify the host where it's running. It is available in the `entity.guids` field.
 
         Note: If the captured logs belong to an application instrumented using APM, the `entity.guids` field contains both the entity GUID of infrastructure, as well as the GUID of APM, separated by a pipe ( | ) delimiter.
@@ -512,7 +513,7 @@ The infrastructure agent automatically inserts log attributes for your convenien
 
       <td>
         Always inserted.
-        
+
         The underlying [Fluent Bit input plugin type](https://docs.fluentbit.io/manual/pipeline/inputs) used to capture the logs. Currently its values are `tail`, `systemd`, `winlog`, `syslog`, and `tcp`.
       </td>
     </tr>
@@ -524,7 +525,7 @@ The infrastructure agent automatically inserts log attributes for your convenien
 
       <td>
         Inserted when sing the `file` input type.
-        
+
         Absolute file path of the file being monitored.
       </td>
     </tr>
@@ -602,6 +603,14 @@ The runtime file does not define a [`[SERVICE]` section](https://docs.fluentbit.
 `config_file:` path to an existing Fluent Bit configuration file. Note that any overlapping source results in duplicate messages in New Relic Logs.
 
 `parsers_file:` path to an existing Fluent Bit parsers file. The following parser names are reserved: `rfc3164`, `rfc3164-local` and `rfc5424`.
+
+    <Callout variant="important">
+    The Infrastructure Agent allows forwarding logs for the most common use cases by defining simple log forwarding configurations in the YAML files within the `logging.d/` directory, as described in this document. These files are internally translated into Fluent Bit configuration files with the correct format and sane configuration defaults. New Relic provides official support for these configuration options, since we ensure that the generated configuration files are correct and operative.
+
+    Nevertheless, for those use cases not covered by our supported configuration options, we provide the possibility to use an externally-generated Fluent Bit configuration and parsers file using the `fluentbit`, `config_file` and `parsers_file` options.
+
+    Note that we cannot guarantee the correct operation of the log forwarded in this case, given that the provided configurations are completely arbitrary and are not being generated/validated by the Infrastructure Agent. Therefore, New Relic does not provide official support for the external configurations specified via these options.
+    </Callout>
 
   </Collapser>
 </CollapserGroup>
@@ -771,7 +780,7 @@ If you encounter problems with configuring your log forwarder, try these trouble
     title="No data appears when capturing via a Syslog socket"
   >
   The log forwarding feature requires that the agent has permission to read the data sources. When running the infrastructure agent in [privileged or non-privileged modes](/docs/infrastructure/install-configure-infrastructure/linux-installation/linux-agent-running-modes):
-  
+
   * If you're using Unix domain socket files, make sure that the `nri-agent` user can access these files (please refer to the previous section) and that they have read and write permissions (`666`) so that other users than `nri-agent` can write to them.
   * If you're using IP sockets, ensure that the port that you are using is not a system reserved one (like port `80`, for example).
 
@@ -835,7 +844,7 @@ If you encounter problems with configuring your log forwarder, try these trouble
   5. [Restart the agent](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status) to load the new settings.
 
   This configuration sets up the agent in troubleshooting mode, but the log forwarder (based on [Fluent Bit](https://fluentbit.io/)) will continue in a non-verbose mode.
-  
+
   Sometimes you can have issues with the log forwarder itself. For example, there may be problems accessing a specific channel when shipping Windows log events or when accessing a particular log file. In these situations, you can also enable the verbose mode for the log forwarder:
 
   1. Set `verbose` to a value other than `0`.
@@ -914,18 +923,18 @@ If you encounter problems with configuring your log forwarder, try these trouble
   * `The user limit on the total number of inotify watches was reached or the kernel failed to allocate a needed resource`
 
   The operating system defines a maximum amount of allocatable file descriptors (typically 1024 by default), and a maximum amount of allocatable inotify watches (typically 8192 by default). Any process attempting to go above these limits will fail, returning one of the errors above.
-  
+
   The underlying technology we use to forward logs, [Fluent Bit](https://fluentbit.io/), opens one file descriptor and sets an inotify watch for each file you configure to be forwarded. Moreover, at the time of writing this section, Fluent Bit uses an extra set of 32 file descriptors for its normal operation, with another extra file descriptor when it shuts down. Therefore, **to capture a large amount of files you need to ensure that both the file descriptor and inotify watch limits are slightly greater than the amount of log files you wish to tail**.
-  
+
   The following instructions summarize how to increase these limits if you want to tail 10,000 log files. Also, it assumes the infrastructure agent is installed in `root` [running mode](/docs/infrastructure/install-infrastructure-agent/linux-installation/linux-agent-running-modes/), and therefore must be run using the `root` user.
-  
+
   1. Check which is the current hard limit for the amount of file descriptors per process. Typically, this limit should be quite high and should not need to be modified.
 
   ```
   ulimit -Hn
   ```
 
-  2. Add the following line to `/etc/security/limits.conf`. We specified a limit of `10100` here instead of just `10000` to allow Fluent Bit to allocate the extra file descriptors it may need to work. 
+  2. Add the following line to `/etc/security/limits.conf`. We specified a limit of `10100` here instead of just `10000` to allow Fluent Bit to allocate the extra file descriptors it may need to work.
 
   ```
   root    soft    nofile  10100  # replace root by nri-agent for non-root (privileged and unprivileged) installations
@@ -944,7 +953,7 @@ If you encounter problems with configuring your log forwarder, try these trouble
   ```
 
   5. Restart your system.
-  
+
   6. Ensure that the new limits have been enforced by running:
 
   ```
@@ -954,7 +963,48 @@ If you encounter problems with configuring your log forwarder, try these trouble
 
   [Learn more on how to increase open file limits](https://tecadmin.net/increase-open-files-limit-ubuntu/), or on [how to increase the inotify watches](https://dev.to/rubiin/ubuntu-increase-inotify-watcher-file-watch-limit-kf4).
 
-  </Collapser>  
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="install-fb-version"
+    title="Install a particular Fluent Bit version (Linux)"
+  >
+
+  Prior to version [1.19.0](https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1190) (and [1.20.3](https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1203) for SLES 12.5), the Linux Infrastructure Agent came bundled with a Fluent Bit binary. Starting at this version, Fluent Bit is now included as as a separate `recommended` package dependency.
+
+  This means that you can install, update or downgrade Fluent Bit separately from the Infrastructure Agent. We have included several Fluent Bit packages in the same repository where the Infrastructure Agent lives for your convenience, so you do not need to install any additional repository to upgrade Fluent Bit.
+
+  Note that the agent automatically installs Fluent Bit when you first install it, using the latest available version. After the first installation, you can upgrade Fluent Bit as you would normally do with any Linux package.
+
+  You can list the available Fluent Bit versions by running:
+
+  RPM:
+  ```
+  sudo yum check-update
+  yum list td-agent-bit --showduplicates
+  ```
+
+  DEB:
+  ```
+  sudo apt update
+  apt-cache showpkg td-agent-bit
+  ```
+
+  To upgrade to a particular Fluent Bit version, just run (in the following examples, version `1.8.12` is used):
+
+  RPM:
+  ```
+  # Remove command only required when downgrading to a previous version
+  sudo yum remove td-agent-bit
+  sudo yum install td-agent-bit-1.8.12-1
+  ```
+
+  DEB:
+  ```
+  sudo apt install td-agent-bit=1.8.12
+  ```
+  </Collapser>
 
 </CollapserGroup>
 


### PR DESCRIPTION
# Description

Many of the support requests that the Logging team receives are related to the Infrastructure Agent's log forwarder. The log forwarder, based on Fluent Bit, allows the customer to define a totally customizable external configuration file, which is out of the scope of the support provided by New Relic. In this PR we include a PR informing of this, as well as instructions of how to upgrade/downgrade Fluent Bit to a particular version.