### PR TITLE
docs: add language identifiers

### DIFF
--- a/src/content/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net.mdx
@@ -38,23 +38,24 @@ Methods decorated with the `[Transaction]` attribute will only create a new tran
   >
     During the execution of this console application, `OuterMethod` will be called first and create a new transaction. The `InnerMethod` is called from within the transaction started by `OuterMethod`, so it will not create a new transaction. Instead, information about the execution of `InnerMethod` will be tracked as if the `[Trace]` attribute had been applied.
 
-    ```
-    static void Main(string[] args)
-    {
-        OuterMethod();
-    }
+```cs
+static void Main(string[] args)
+{
+    OuterMethod();
+}
 
-    [Transaction]
-    public void OuterMethod()
-    {
-        InnerMethod();
-    }
+[Transaction]
+public void OuterMethod()
+{
+    InnerMethod();
+}
 
-    [Transaction]
-    public void InnerMethod()
-    {
-    }
-    ```
+[Transaction]
+public void InnerMethod()
+{
+    // inner method code
+}
+```
   </Collapser>
 </CollapserGroup>
 
@@ -62,11 +63,11 @@ Methods decorated with the `[Transaction]` attribute will only create a new tran
 
 To start a non-web transaction (also known as a background request) with the `Transaction` attribute:
 
-```
+```cs
 [Transaction]
 public void Run()
 {
-  <var>// your background task</var>
+    // your background task
 }
 ```
 
@@ -79,14 +80,14 @@ To tell the agent to mark a non-web task as a web browser transaction, use eithe
 * Set the `Web` property of the `Transaction` attribute to `true`.
 * Set the transaction's URI with [`SetTransactionUri()`](/docs/agents/net-agent/net-agent-api).
 
-```
+```cs
 [Transaction(Web = true)]
 public void Run()
 {
-  var uri = new Uri("<var>http://www.mydomain.com/path</var>");
-  NewRelic.Api.Agent.NewRelic.SetTransactionUri(uri);
-  
-  <var>// your web task</var>
+    var uri = new Uri("<var>http://www.mydomain.com/path</var>");
+    NewRelic.Api.Agent.NewRelic.SetTransactionUri(uri);
+
+    // your web task
 }
 ```
 
@@ -98,11 +99,11 @@ For details about why to use either web or non-web, see [Classify as web or non-
 
 If your transaction traces show large blocks of un-instrumented time and you want to include additional methods within the trace, you can use the `Trace` attribute:
 
-```
+```cs
 [Trace]
 protected void MethodWithinTransaction()
 {
-  <var>// your app code</var>
+    // your app code
 }
 ```
 
@@ -147,7 +148,7 @@ The `Transaction` attribute supports the following properties:
 
     If `false` (default), the agent starts a non-web transaction when it reaches this `Transaction` attribute. For example:
 
-    ```
+    ```cs
     [Transaction(Web = true)]
     ```
   </Collapser>


### PR DESCRIPTION
I also made the indentation 4 spaces everywhere instead of a mix of 2 and 4. I also removed the unhelpful `<var>` stuff from codeblocks, I did that because it confuses the language syntax coloring where it's used.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.