### PR TITLE
docs: fix link to Optional Vars & +lang indentifiers

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -183,7 +183,7 @@ If your system has previously used monitoring services (non-New Relic), you may 
 
 For specific install instructions, see the [.NET agent install documentation](/docs/agents/net-agent/installation/new-relic-net-agent-install-introduction).
 
-## Optional environment variables [#environment-variables]
+## Optional environment variables [#optional-environment-variables]
 
 Some configuration options in New Relic's .NET agent can be set via environment variables as an alternative to setting them in a config file. Below is a list of environment variables recognized by the .NET agent with example values.
 
@@ -223,7 +223,7 @@ Use these options to setup and configure your agent via the newrelic.config file
 
 The root element of the configuration document is a `configuration` element.
 
-```
+```xml
 <configuration xmlns="urn:newrelic-config"
   agentEnabled="true"
   maxStackTraceLines="50"
@@ -331,7 +331,7 @@ The `configuration` element supports the following attributes:
 
 The first child of the `configuration` element is a `service` element. The service element configures the agent's connection to the New Relic service.
 
-```
+```xml
 <service licenseKey="<var>YOUR_LICENSE_KEY</var>"
   sendEnvironmentInfo="true"
   syncStartup="false"
@@ -626,7 +626,7 @@ The `service` element supports the following attributes:
 
 The `obscuringKey` element is an optional child of the `service` element. The .NET Agent uses this value to deobfuscate supported configuration values. For example, when an [obfuscated proxy password](#) is supplied, it will be deobfuscated using this key.
 
-```
+```xml
 <service licenseKey="<var>YOUR_LICENSE_KEY</var>">
     <obscuringKey><var>OBSCURING_KEY</var></obscuringKey>
 </service>
@@ -642,7 +642,7 @@ The obscuring key may also be configured by setting the `NEW_RELIC_CONFIG_OBSCUR
 
 The `proxy` element is an optional child of the `service` element. The `proxy` element is used when the agent communicates to the New Relic back-end service via a proxy.
 
-```
+```xml
 <service licenseKey="<var>YOUR_LICENSE_KEY</var>">
  <proxy
    host="<var>hostname</var>"
@@ -874,7 +874,7 @@ The `proxy` element supports the following attributes:
 
     For additional security, the .NET Agent supports the use of an obfuscated proxy password with the passwordObfuscated attribute. The obfuscated proxy password is generated using the following [New Relic CLI](https://github.com/newrelic/newrelic-cli) command:
 
-    ```
+    ```bash
     newrelic agent config obfuscate --key <var>OBSCURING_KEY</var> --value "<var>CLEAR_TEXT_PROXY_PASSWORD</var>"
     ```
 
@@ -888,7 +888,7 @@ The `proxy` element supports the following attributes:
 
 The `log` element is a child of the `configuration` element. The `log` element configures New Relic's logging . The agent generates its own log file to keep its logging information separate from your application's logs.
 
-```
+```xml
 <log level="info"
   auditLog="false"
   console="false"
@@ -1112,7 +1112,7 @@ The `application` element is a child of the `configuration` element. This requir
 
     You can also assign [up to three names](/docs/agents/manage-apm-agents/app-naming/use-multiple-names-app) to your app. The first name is the primary name. For example:
 
-    ```
+    ```xml
     <application>
       <name><var>MY APPLICATION PRIMARY</var></name>
       <name><var>SECOND APP NAME</var></name>
@@ -1169,7 +1169,7 @@ The `application` element is a child of the `configuration` element. This requir
 
 The `dataTransmission` element is a child of the `configuration` element. This element affects how data is sent to New Relic and can be used if you have specific data transmission requirements.
 
-```
+```xml
 <dataTransmission
   putForDataSend="false"
   compressedContentEncoding="deflate"/>
@@ -1225,7 +1225,7 @@ To set a display name, choose one of the following options. The environment vari
   >
     Set the `displayName` attribute in the `processHost` element in `newrelic.config`. The `processHost` element is a child of the `configuration` element.
 
-    ```
+    ```xml
     <configuration . . . >
        <processHost displayName="<var>CUSTOM_NAME</var>" />
     </configuration>
@@ -1456,7 +1456,7 @@ The `applications` element is a child of the `instrumentation` element. The appl
   This is not the same as the [`application` (configuration)](#application-configuration) element, which is a [child of the `configuration`](#application) element.
 </Callout>
 
-```
+```xml
 <instrumentation>
   <applications>
     <application name="<var>MyService1.exe</var>" />
@@ -1472,7 +1472,7 @@ An attribute is a key/value pair that determines the properties of an event or t
 
 In this example, the agent excludes all attributes whose key begins with **myApiKey** (**myApiKey.bar**, **myApiKey.value**), but collects the custom attribute **myApiKey.foo**.
 
-```
+```xml
 <attributes enabled="true">
   <exclude><var>myApiKey.*</var></exclude>
   <include><var>myApiKey.foo</var></include>
@@ -1607,7 +1607,7 @@ The `applicationPools` element is a child of the `configuration` element. The `a
 
 Here is an example of disabling instrumentation for specific application pools:
 
-```
+```xml
 <applicationPools>
   <applicationPool name="<var>Foo</var>" instrument="false"/>
   <applicationPool name="<var>Bar</var>" instrument="false"/>
@@ -1616,7 +1616,7 @@ Here is an example of disabling instrumentation for specific application pools:
 
 Here is an example of disabling instrumentation for all application pools currently executing on the server and enabling instrumentation for specific application pools:
 
-```
+```xml
 <applicationPools>
   <defaultBehavior instrument="false"/>
   <applicationPool name="<var>Foo</var>" instrument="true"/>
@@ -1672,7 +1672,7 @@ The `applicationPools` element supports the following elements:
 
 The `crossApplicationTracer` element is a child of the `configuration` element. `crossApplicationTracer` links transaction traces across applications. When linked in a service-oriented architecture, all instrumented applications that communicate with each other via HTTP will now "link" transaction traces with the applications that they call and the applications they are called by. [Cross application tracing](/docs/traces/cross-application-traces) makes it easier to understand the performance relationship between services and applications.
 
-```
+```xml
 <crossApplicationTracer enabled="true"/>
 ```
 
@@ -1715,7 +1715,7 @@ The `crossApplicationTracer` element supports the following attribute:
 
 The `errorCollector` element is a child of the `configuration` element. `errorCollector` configures error collection, which captures information about uncaught exceptions and sends them to New Relic.
 
-```
+```xml
 <errorCollector enabled="true" captureEvents="true" maxEventSamplesStored="100">
   <ignoreClasses>
     <errorClass><var>System.IO.FileNotFoundException</var></errorClass>
@@ -1998,7 +1998,7 @@ The `highSecurity` element is a child of the `configuration` element. To enable 
 
     Enable or disable high security mode. Example:
 
-    ```
+    ```xml
     <highSecurity enabled="true"/>
     ```
   </Collapser>
@@ -2039,7 +2039,7 @@ The `stripExceptionMessages` element is a child of the `configuration` element. 
 
     Enable or disable strip exception messages. Example:
 
-    ```
+    ```xml
     <stripExceptionMessages enabled="true"/>
     ```
   </Collapser>
@@ -2049,7 +2049,7 @@ The `stripExceptionMessages` element is a child of the `configuration` element. 
 
 The `transactionEvents` element is a child of the `configuration` element. Use `transactionEvents` to configure transaction events.
 
-```
+```xml
 <transactionEvents enabled="true"
   maximumSamplesStored="10000">
  <attributes enabled="true">
@@ -2150,7 +2150,7 @@ The `transactionEvents` element supports the following attributes:
 
 The `customEvents` element is a child of the `configuration` element. Use `customEvents` to configure [custom events](/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-new-relic-apm-agents#net-att).
 
-```
+```xml
 <customEvents enabled="true" maximumSamplesStored="10000"/>
 ```
 
@@ -2230,7 +2230,7 @@ The `CustomEvents` element supports the following attributes:
 
 The `customParameters` element is a child of the `configuration` element. Use `customParameters` to configure [custom parameters](/docs/insights/insights-data-sources/custom-data/add-custom-attributes-apm-data).
 
-```
+```xml
 <customParameters enabled="true" />
 ```
 
@@ -2275,7 +2275,7 @@ The `labels` element is a child of the `configuration` element.
 
 This sets [tag](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor) names and values. The list is a semicolon delimited list of colon-separated name and value pairs. You can also use with the `NEW_RELIC_LABELS` environment variable. Example:
 
-```
+```xml
 <labels><var>foo</var>:<var>bar</var>;<var>zip</var>:<var>zap</var></labels>
 ```
 
@@ -2283,7 +2283,7 @@ This sets [tag](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-
 
 The `browserMonitoring` element is a child of the `configuration` element. `browserMonitoring` configures browser monitoring in your .NET application. Browser gives you insight your end users' performance experience. This is accomplished by measuring the time it takes for your users' browsers to download and render your webpages by injecting a small amount of JavaScript code into the header and footer of each page.
 
-```
+```xml
 // If you use both the Exclude and Attribute elements
 // the Exclude element must be listed first.
 <browserMonitoring autoInstrument="true">
@@ -2347,7 +2347,7 @@ The `browserMonitoring` element supports the following attributes:
   >
     Use this sub-element to prevent the browser agent from being injected in specific pages. The element is used as follows:
 
-    ```
+    ```xml
     <requestPathsExcluded>
       <path regex="url-regex-1"/>
       <path regex="url-regex-2"/>
@@ -2368,7 +2368,7 @@ The `browserMonitoring` element supports the following attributes:
 
 The `slowSql` element is a child of the `configuration` element. `slowSql` configures capturing information about slow query executions, and captures and obfuscates explain plans for these queries.
 
-```
+```xml
 <slowSql enabled="true"/>
 ```
 
@@ -2411,7 +2411,7 @@ The `slowSql` element supports the following attribute:
 
 The `transactionTracer` element is a child of the `configuration` element. `transactionTracer` configures [transaction traces](/docs/traces/transaction-traces). Included in the trace is the exact call sequence of the transactions, including any query statements issued.
 
-```
+```xml
 <transactionTracer enabled="true"
     transactionThreshold="apdex_f"
     recordSql="obfuscated"
@@ -2707,7 +2707,7 @@ The `transactionTracer` element supports the following attributes:
 
 The `datastoreTracer` element is a child of the `configuration` element.
 
-```
+```xml
 <datastoreTracer>
   <instanceReporting enabled="true"  />
   <databaseNameReporting enabled="true" />
@@ -2749,7 +2749,7 @@ The `datastoreTracer` element supports the following sub-elements:
 
 The `distributedTracing` element is a child of the `configuration` element.
 
-```
+```xml
 <distributedTracing enabled="false"
    excludeNewrelicHeader="false"/>
 ```
@@ -2843,7 +2843,7 @@ Distributed tracing reports span events. Span event reporting is enabled by defa
   >
     Set the `<spanEvents>` element to `false` to disable via the newrelic.config file. This element is a child of the `<configuration>` element.
 
-    ```
+    ```xml
     <configuration . . . >
        <spanEvents enabled="false" />
     </configuration>
@@ -2868,7 +2868,7 @@ Distributed tracing reports span events. Span event reporting is enabled by defa
 
 To turn on [Infinite Tracing](https://newrelic.com/products/edge-infinite-tracing), make sure you have [.NET agent version 8.30 or higher](/docs/release-notes/agent-release-notes/net-release-notes), and enable distributed tracing. Then add the following additional settings:
 
-```
+```xml
 <configuration . . . >
    <distributedTracing enabled="true" />
    <infiniteTracing>
@@ -2902,7 +2902,7 @@ The `infiniteTracing` element supports the following elements:
 
 The `spanEvents` element is a child of the `configuration` element. Use `spanEvents` to configure span events.
 
-```
+```xml
 <spanEvents enabled="true">
  <attributes enabled="true">
     <exclude><var>myApiKey.*</var></exclude>
@@ -3035,7 +3035,7 @@ request.headers.user-agent
 
     Enable or disable HTTP request headers capture. Example:
 
-    ```
+    ```xml
 	  <allowAllHeaders enabled="true" />
     <attributes enabled="true">
        <include>request.headers.*</include>
@@ -3047,7 +3047,7 @@ request.headers.user-agent
 <Callout variant="important">
   The `allowAllHeaders` setting is only available in the .NET Agent version 8.40.0+. When using `allowAllHeaders` to capture attributes, the captured request header attributes are still being controlled by the root level and destination level [attributes](/docs/agents/net-agent/configuration/net-agent-configuration/#agent-attributes) settings. Without setting the `request.header.*` in the `include` list under the `attributes` element (see the following), the .NET Agent still filters out all header attributes. The default `newrelic.config` is set to include the `request.header.*`.
 
-  ```
+  ```xml
   <allowAllHeaders enabled="true" />
   <attributes enabled="true">
     <include>request.headers.*</include>
@@ -3057,7 +3057,7 @@ request.headers.user-agent
 
   The default `newrelic.config` is also set to explicitly exclude the following HTTP request headers to prevent the .NET Agent collecting unwanted data.
 
-  ```
+  ```xml
   <attributes enabled="true">
     <exclude>request.headers.cookie</exclude>
     <exclude>request.headers.authorization</exclude>
@@ -3076,7 +3076,7 @@ For ASP.NET and .NET Framework console apps you can also configure the following
     id="app-cfg-agent-enabled"
     title="Enable and disable the agent"
   >
-    ```
+    ```xml
     <appSettings>
        <add key = "NewRelic.AgentEnabled" value="false" />
     </appSettings>
@@ -3093,7 +3093,7 @@ For ASP.NET and .NET Framework console apps you can also configure the following
   >
     For more information, see [Name your .NET application](/docs/agents/net-agent/installation-configuration/name-your-net-application).
 
-    ```
+    ```xml
     <appSettings>
        <add key = "NewRelic.AppName" value ="Descriptive Name" />
     </appSettings>
@@ -3104,7 +3104,7 @@ For ASP.NET and .NET Framework console apps you can also configure the following
     id="app-cfg-license-key"
     title="License key"
   >
-    ```
+    ```xml
     <appSettings>
        <add key = "NewRelic.LicenseKey" value ="XXXXXXXX" />
     </appSettings>
@@ -3117,7 +3117,7 @@ For ASP.NET and .NET Framework console apps you can also configure the following
   >
     Designates an alternative location for the config file outside of the local root of the app or global config location. The location entered must be an absolute path.
 
-    ```
+    ```xml
     <appSettings>
        <add key = "NewRelic.ConfigFile" value="C:\Path-to-alternate-config-dir\newrelic.config" />
     </appSettings>
@@ -3140,7 +3140,7 @@ For .NET Core apps, you can configure the following settings in `appsettings.jso
     id="appsettings-json-agent-enabled"
     title="Enable and disable the agent"
   >
-    ```
+    ```json
     {
        "NewRelic.AgentEnabled":"false"
     }
@@ -3157,7 +3157,7 @@ For .NET Core apps, you can configure the following settings in `appsettings.jso
   >
     For more information, see [Name your .NET application](/docs/agents/net-agent/installation-configuration/name-your-net-application).
 
-    ```
+    ```json
     {
        "NewRelic.AppName": "Descriptive Name"
     }
@@ -3168,7 +3168,7 @@ For .NET Core apps, you can configure the following settings in `appsettings.jso
     id="appsettings-json-application-license-key"
     title="License key"
   >
-    ```
+    ```json
     {
        "NewRelic.LicenseKey": "XXXXXXXX"
     }
@@ -3181,7 +3181,7 @@ For .NET Core apps, you can configure the following settings in `appsettings.jso
   >
     Designates an alternative location for the config file outside of the local root of the app or global config location. The location entered must be an absolute path.
 
-    ```
+    ```json
     {
        "NewRelic.ConfigFile": "C:\\Path-to-alternate-config-dir\\newrelic.config"
     }

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -120,7 +120,7 @@ Here are details about the configuration methods shown in the diagram, and their
 
 ## Required environment variables [#environment-variables]
 
-New Relic's .NET agent relies on environment variables to tell the .NET Common Language Runtime (CLR) to attach New Relic to your processes. Some [.NET agent install procedures](/docs/agents/net-agent/installation/new-relic-net-agent-install-introduction) (like the MSI installer) will automatically set these variables for you; some procedures will require you to manually set them.
+Our .NET agent relies on environment variables to tell the .NET Common Language Runtime (CLR) to attach New Relic to your processes. Some [.NET agent install procedures](/docs/agents/net-agent/installation/new-relic-net-agent-install-introduction) (like the MSI installer) will automatically set these variables for you; some procedures will require you to manually set them.
 
 <Callout variant="caution">
   Security recommendation: You should consider what users can set system environment variables. You should also secure the accounts under which your applications execute to prevent user environment variables overriding system environment variables
@@ -177,7 +177,7 @@ If your system has previously used monitoring services (non-New Relic), you may 
     id="profiler-conflicts"
     title="Profiler conflict explanation"
   >
-    New Relic’s .NET agents rely on environment variables to tell the .NET Common Language Runtime (CLR) to load New Relic into your processes. The install-related environment variables are Microsoft variables, not New Relic variables. They can be used by other .NET profilers, and only one profiler can be attached to a process at a time. For this reason, if you have used previous application monitoring products, you may have [profiler conflicts](/docs/agents/net-agent/troubleshooting/profiler-conflicts).
+    New Relic's .NET agents rely on environment variables to tell the .NET Common Language Runtime (CLR) to load New Relic into your processes. The install-related environment variables are Microsoft variables, not New Relic variables. They can be used by other .NET profilers, and only one profiler can be attached to a process at a time. For this reason, if you have used previous application monitoring products, you may have [profiler conflicts](/docs/agents/net-agent/troubleshooting/profiler-conflicts).
   </Collapser>
 </CollapserGroup>
 
@@ -204,11 +204,11 @@ NEWRELIC_LOG_DIRECTORY=<var>path\to\a\directory</var> (Insert a directory where 
 NEWRELIC_LOG_LEVEL=<var>off|error|warn|info|debug|finest|all<var>
 ```
 
-If you're using New Relic APM and CodeStream, see [how to associate repositories](/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags](/docs/codestream/start-here/codestream-new-relic/#buildsha) with errors inbox.
+If you're using APM and CodeStream, see [how to associate repositories](/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags](/docs/codestream/start-here/codestream-new-relic/#buildsha) with errors inbox.
 
 ## Setup options, newrelic.config [#setup]
 
-Use these options to setup and configure your agent via the newrelic.config file. The New Relic .NET agent supports the following categories of setup options:
+Use these options to setup and configure your agent via the newrelic.config file. The .NET agent supports the following categories of setup options:
 
 * [Configuration element](#configuration)
 * [Service element](#service)


### PR DESCRIPTION
* What problems does this PR solve?

Optional Vars section link went to the section above it.