### PR TITLE
Remove reference to lambda

### DIFF
--- a/src/content/docs/codestream/how-use-codestream/pull-requests.mdx
+++ b/src/content/docs/codestream/how-use-codestream/pull-requests.mdx
@@ -289,17 +289,3 @@ To review a pull request:
 ![A screenshot showing a conversation in a request](/images/PRConversation-GH.png "pull request conversation")
 
 3. View the changes, add comments, and submit a review.
-
-## Leverage pull request comments [#pr-comments]
-
-Once the pull request has been approved and the code has been merged, that's usually the end of life for any comments in that pull request. Although there's often useful information in those comments that may have long-term value, they're rarely seen again. CodeStream gives those comments a second life by displaying them alongside the blocks of code that they refer to. 
-
-![A screenshot showing where comments appear](/images/PRComment-Gutter1.png "pull request comment gutter")
-
-To have pull request comments displayed as annotations in your codemarks, as well as in the **Codemarks** section of the CodeStream pane, click the gear icon in that section and check **Show comments from pull requests**. When you first check that box, if you haven't already authenticated with your code-hosting service, you'll be prompted to do so.
-
-Comments from merged PRs appear next to the blocks of code they refer to. Comments from open PRs will also be included if you are on a relevant branch. For example, if the open PR is a request to merge the feature/some-name branch into main, you'll see comments from that PR if you've checked out either feature/some-name or main, but not when you're on any other branch.
-
-As the code evolves, the location of each comment is automatically updated so that it remains linked to the block of code it refers to.
-
-PR comments for a given file are updated roughly every 30 minutes, so new comments may not appear right away. You can force an update by restarting your IDE.

--- a/src/content/docs/codestream/start-here/codestream-new-relic.mdx
+++ b/src/content/docs/codestream/start-here/codestream-new-relic.mdx
@@ -59,7 +59,7 @@ In order to view stack trace errors in your IDE, CodeStream needs to know what r
 
 ## Associate repositories with errors [#repo-url]
 
-Once you've started monitoring for APM, mobile, browser, or Lambda, you should create repository entities and associate them with entities for all of your services. In order to create a repository entity you'll need to provide the repository's remote URL. For example, the remote URL can be in either the SSH or HTTPS format:
+Once you've started monitoring for APM, mobile, or browser, you should create repository entities and associate them with entities for all of your services. In order to create a repository entity you'll need to provide the repository's remote URL. For example, the remote URL can be in either the SSH or HTTPS format:
 
 * `git@github.com:newrelic/beta-docs-site.git`
 * `https://github.com/newrelic/beta-docs-site.git`

--- a/src/content/docs/codestream/troubleshooting/git-issues.mdx
+++ b/src/content/docs/codestream/troubleshooting/git-issues.mdx
@@ -8,7 +8,7 @@ Git-related warnings.
 
 ## Repo isn’t managed by Git or Git can't be found [#not-found]
 
-While technically not a requirement, key elements of Code Stream’s functi onal ity depend on your repository being managed by Git or a Git-hosting service likeGitHub. If you’re not using Git, CodeStream won't be able to connect thecomments and issues you create to the appropriate blocks of code in your sourcefiles. This means that comments and issues will appear in the activity feed andin search results, but they won't appear in the codemarkssection when your teammates are viewing the source file.
+While technically not a requirement, key elements of Code Stream’s functionality depend on your repository being managed by Git or a Git-hosting service like GitHub. If you’re not using Git, CodeStream won't be able to connect the comments and issues you create to the appropriate blocks of code in your source files. This means that comments and issues will appear in the activity feed and in search results, but they won't appear in the codemarks section when your teammates are viewing the source file.
 
 This error could also mean that Git isn’t in your PATH. If so, please add it to your PATH and then restart your IDE.
 


### PR DESCRIPTION
We don't actually support open-in-IDE for lambda errors, so removed that reference. Also removed extraneous spaces in git-issues article.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>