### PR TITLE
docs: clarified user types that have access to synthetics.

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring.mdx
@@ -163,7 +163,7 @@ Synthetic monitoring does not require any software except a [supported browser](
 
 ## Permissions
 
-By default, all users in your account can:
+By default, all [full platform users](docs/accounts/accounts-billing/new-relic-one-user-management/user-type/#user-type-comparison-table) in your account can:
 
 - [View synthetic monitoring pages](/docs/synthetics/new-relic-synthetics/dashboards).
 - [Add](/docs/synthetics/new-relic-synthetics/using-monitors/add-edit-monitors#adding-monitors), [edit](/docs/synthetics/new-relic-synthetics/using-monitors/add-edit-monitors#editing-monitors), and [delete](/docs/synthetics/new-relic-synthetics/using-monitors/add-edit-monitors#deleting-monitors) monitors.


### PR DESCRIPTION
Clarified user types that have access to synthetics and added a link to the user comparison table for more details.

## Give us some context

The existing documentation could cause confusion around which user types have access to synthetics. The update reflects that only full platform users will be able to access the synthetics UI.