### PR TITLE
Query would not have worked and is not faceted

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -411,7 +411,7 @@ If, in the aggregation window being evaluated, there's at least one instance of 
     Without a `FACET`, the inner query produces a single result, giving the outer query nothing to aggregate. If you're using a nested query, make sure your inner query is faceted.
 
     ```
-    SELECT max(cpu) FROM (FROM Event SELECT min(cpuTime) as cpu) ​​​​​
+    SELECT max(cpu) FROM (FROM SystemSample SELECT min(cpuPercent) as 'cpu' FACET hostname) ​​​​​
     ```
   </Collapser>
 


### PR DESCRIPTION
Bad query example, since there was no actual FACET clause in the inner query. I edited it and also added quotes around the string value that must have quotes. I also used a real event type (SystemSample) for the example instead of a pretend one, as well as changing the attribute to match one on that event type.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.