### PR TITLE
Added Automatic OHI Logging

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mySQL/mysql-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mySQL/mysql-integration.mdx
@@ -100,6 +100,7 @@ To install the MySQL integration, follow the instructions for your environment:
 
 4. Edit the `mysql-config.yml` configuration file with your favorite editor. Check out some [great configuration file examples.](#examples).
 5. Restart the infrastructure agent. See how to [restart the infrastructure agent in different Linux environments](/docs/infrastructure/install-infrastructure-agent/manage-your-agent/start-stop-restart-infrastructure-agent/#linux).
+6. Optionally, the MySQL error logs [can automatically be sent to New Relic](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent#on-host).
 
 ### Other environments [#other-env]
 

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mySQL/mysql-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mySQL/mysql-integration.mdx
@@ -100,7 +100,7 @@ To install the MySQL integration, follow the instructions for your environment:
 
 4. Edit the `mysql-config.yml` configuration file with your favorite editor. Check out some [great configuration file examples.](#examples).
 5. Restart the infrastructure agent. See how to [restart the infrastructure agent in different Linux environments](/docs/infrastructure/install-infrastructure-agent/manage-your-agent/start-stop-restart-infrastructure-agent/#linux).
-6. Optionally, the MySQL error logs [can automatically be sent to New Relic](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent#on-host).
+6. Optionally, the MySQL error logs [can automatically be sent to New Relic](/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent#on-host).
 
 ### Other environments [#other-env]
 

--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -606,6 +606,28 @@ The runtime file does not define a [`[SERVICE]` section](https://docs.fluentbit.
   </Collapser>
 </CollapserGroup>
 
+## Enable automatic on-host integration logs [#on-host]
+
+You can now enable automatic log parsing and shipment to New Relic for our most popular on-host integrations with one simple step. To enable this feature, the on-host-log.yml.example file needs to be renamed to on-host-log.yml. Once this is done the integration logs will automatically be parsed and sent to New Relic.
+Examples for supported on-host integrations are below. Note this option is currently only available for Linux hosts. 
+
+To enable the on-host integration log forwarding feature:
+
+  <Collapser
+    id="MySQL logs"
+    title="MySQL logs"
+    >
+
+Simply copy (or rename) the `mysql-log.yml.example` file to `mysql-log.yml` to enable automatic MySQL error log parsing and shipment to New Relic. No agent restart is required.
+
+**Example:**
+
+```
+sudo cp /etc/newrelic-infra/logging.d/mysql-log.yml.example /etc/newrelic-infra/logging.d/mysql-log.yml
+```
+
+  </Collapser>
+
 ### Sample configuration file [#running-modes]
 
 Here is an example of a `logging.d/` configuration file in YAML format. For more configuration examples, [see the infrastructure agent repository](https://github.com/newrelic/infrastructure-agent/tree/master/assets/examples/logging).


### PR DESCRIPTION
Added a section in the docs for a new option for users where they can automatically send OHI logs to NR by simply renaming an .example file. The mysql-log.yml.example file is already in the nri-mysql repo.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.