### PR TITLE
chore: Adds Node.js agent v8.8.0 release notes.

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-8-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-8-0.mdx
@@ -1,0 +1,53 @@
+---
+subject: Node.js agent
+releaseDate: '2022-02-23'
+version: 8.8.0
+downloadLink: 'https://www.npmjs.com/package/newrelic'
+---
+
+## Notes
+
+* Updated AWS metadata capture to utilize IMDSv2.
+
+* Fixed link to discuss.newrelic.com in README
+
+* Updated minimum Node version warning to output current Node version from process.
+
+* Bumped `@newrelic/native-metrics` to ^7.1.1.
+
+* Added `Nextjs` to a framework constant within the webframework-shim.
+
+* Updated shim to pass active segment to inContext callback.
+
+* Bumped `@grpc/grpc-js` to ^1.5.5.
+
+* Bumped `@grpc/proto-loader` to ^0.6.9.
+
+* Bumped `@newrelic/superagent` to ^5.1.0.
+
+* Bumped `@newrelic/koa` to ^6.1.0.
+
+* Bumped `async` to ^3.2.3.
+
+* Resolved several npm audit warnings for dev deps.
+
+* Fixed Post Release workflow by properly configuring git credentials so it can push API docs to branch
+ * Added `set -e` in publish docs script to exit on possible failures
+ * Removed redundant `npm ci` in publish API docs script
+
+* Added ability to ignore certain PRs in `bin/pending-prs.js` report to slack
+
+* Updated README to include `@newrelic/pino-enricher` as an external module.
+
+* Fixed documentation in a sample of the Datastore Instrumentation for Node.js.
+
+* Added a new `mongo:5` container to `npm run sevices` to test mongodb driver >=4.2.0.
+
+* Fixed conditions in post release workflow to function when triggered via successful release and manual invoked.
+
+* Updated method for retrieving agent version from repository by using `cat package.json | jq .version`
+
+* Fixed minor formatting and spelling issues in `create-docs-pr.js`.
+
+* Fixed an issue with the docs PR script that assumed `\n` in the NEWS.md file when extract version and release date
+


### PR DESCRIPTION
chore: Adds Node.js agent v8.8.0 release notes.