### PR TITLE
docs: remove stray `,` from codeblock

### DIFF
--- a/src/content/docs/apm/agents/go-agent/instrumentation/instrument-go-segments.mdx
+++ b/src/content/docs/apm/agents/go-agent/instrumentation/instrument-go-segments.mdx
@@ -25,7 +25,7 @@ Once you instrument a [transaction](/docs/agents/go-agent/get-started/instrument
 
 To instrument an arbitrary block of code as a segment, use the following pattern, and include [`txn`](/docs/agents/go-agent/get-started/instrument-go-transactions) as the variable name set for the transaction:
 
-```
+```go
 segment := newrelic.Segment{}
 segment.Name = "<var>mySegmentName</var>"
 segment.StartTime = txn.StartSegmentNow()
@@ -35,7 +35,7 @@ segment.End()
 
 `StartSegment` is a convenient helper. It creates a segment and starts it:
 
-```
+```go
 segment := txn.StartSegment("<var>mySegmentName</var>")
 // ... code you want to time here ...
 segment.End()
@@ -47,7 +47,7 @@ Instrumenting a function as a segment is essentially the same as instrumenting a
 
 To instrument a function as a segment, add the following code at the start of the function, and include [`txn`](/docs/agents/go-agent/get-started/instrument-go-transactions) as the variable name set for the transaction:
 
-```
+```go
 defer txn.StartSegment("<var>mySegmentName</var>").End()
 ```
 
@@ -57,7 +57,7 @@ Segments can be nested. The segment being ended must be the most recently starte
 
 Here's an example of a segment starting and ending inside another segment:
 
-```
+```go
 s1 := txn.StartSegment("<var>outerSegment</var>")
 s2 := txn.StartSegment("<var>innerSegment</var>")
 // s2 must end before s1
@@ -67,10 +67,10 @@ s1.End()
 
 A zero value segment may safely be ended. Therefore, the following code is safe even if the conditional fails:
 
-```
+```go
 var s newrelic.Segment
 if recordSegment {
-    s.StartTime = txn.StartSegmentNow(),
+    s.StartTime = txn.StartSegmentNow()
 }
 // ... code you wish to time here ...
 s.End()
@@ -137,7 +137,7 @@ If you are using a MySQL, PostgreSQL, or SQLite database driver, the easiest way
 
     To use one of these integrations, first replace the driver with our integration version:
 
-    ```
+    ```go
     import (
     	// import our integration package in place of "github.com/go-sql-driver/mysql"
     	_ "github.com/newrelic/go-agent/v3/integrations/nrmysql"
@@ -151,7 +151,7 @@ If you are using a MySQL, PostgreSQL, or SQLite database driver, the easiest way
 
     Second, use the `ExecContext`, `QueryContext`, and `QueryRowContext` methods of [sql.DB](https://golang.org/pkg/database/sql/#DB), [sql.Conn](https://golang.org/pkg/database/sql/#Conn), [sql.Tx](https://golang.org/pkg/database/sql/#Tx), and [sql.Stmt](https://golang.org/pkg/database/sql/#Stmt) and provide a transaction-containing context. Calls to `Exec`, `Query`, and `QueryRow` do not get instrumented.
 
-    ```
+    ```go
     ctx := newrelic.NewContext(context.Background(), txn)
     row := db.QueryRowContext(ctx, "SELECT count(*) from tables")
     ```
@@ -169,7 +169,7 @@ If you are using a MySQL, PostgreSQL, or SQLite database driver, the easiest way
   >
     Just like basic segments, datastore segments begin when the `StartTime` field is populated and finish when the `End` method is called. To instrument a datastore segment, place the following at the beginning of the function you want to monitor:
 
-    ```
+    ```go
     s := newrelic.DatastoreSegment{
         Product: newrelic.DatastoreMySQL,
         Collection: "users",
@@ -195,7 +195,7 @@ If you are using a MySQL, PostgreSQL, or SQLite database driver, the easiest way
 
     When instrumenting a datastore call that spans an entire function call, you can use the defer statement to simplify instrumentation:
 
-    ```
+    ```go
     s := newrelic.DatastoreSegment{
         StartTime: txn.StartSegmentNow(),
         Product: newrelic.DatastoreMySQL,
@@ -228,7 +228,7 @@ There are two ways to instrument external segments:
   >
     **Recommendation:** Use the `StartExternalSegment` helper, since New Relic uses it to trace activity between your applications using [cross application tracing](/docs/agents/go-agent/features/cross-application-tracing-go).
 
-    ```
+    ```go
     func external(txn *newrelic.Transaction, req *http.Request) (*http.Response, error) {
         s := newrelic.StartExternalSegment(txn, req)
         response, err := http.DefaultClient.Do(req)
@@ -247,7 +247,7 @@ There are two ways to instrument external segments:
 
     Here is an example of `NewRoundTripper` instrumentation:
 
-    ```
+    ```go
     client := &http.Client{}
     client.Transport = newrelic.NewRoundTripper(client.Transport)
 
@@ -272,7 +272,7 @@ There is only one way to instrument message producer segments:
   >
     Just like basic segments, message producer segments begin when the `StartTime` field is populated, and finish when the `End` method is called. To instrument a message producer segment, place the following at the beginning of the function you want to monitor:
 
-    ```
+    ```go
     s := newrelic.MessageProducerSegment{
         Library:              "RabbitMQ",
         DestinationType:      newrelic.MessageExchange,
@@ -288,7 +288,7 @@ There is only one way to instrument message producer segments:
 
     When instrumenting a message producer call that spans an entire function call, you can use the defer statement to simplify instrumentation:
 
-    ```
+    ```go
     s := newrelic.MessageProducerSegment{
         StartTime:            txn.StartSegmentNow(),
         Library:              "RabbitMQ",


### PR DESCRIPTION
The `if` had a stray comma at the end of a line I removed, I also added language identifiers for go.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.