### PR TITLE
Update get-started-incident-intelligence.mdx

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/get-started-incident-intelligence.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/get-started-incident-intelligence.mdx
@@ -15,16 +15,14 @@ redirects:
 As part of [Applied Intelligence](/docs/introduction-new-relic-ai), Incident Intelligence helps you correlate your incidents and reduce noise in your environment. It gives you an overview of all your incidents, their sources, and related events.
 
 If you haven't already, [sign up for a New Relic account](https://newrelic.com/signup) to get started.
- 
- <Callout variant="important">
-Please note, Pathways are depreacted and are replaced by Workflows.
-If you have have access to Pathways on your New Relice One left nav, don't hesitate to reach out to your New Relic account representative and ask to upgraded.
+
+<Callout variant="important">
+Pathways have been deprecated, and are replaced by [workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/).
+
+If you still have access to Pathways on New Relic One, reach out to your New Relic account representative and ask to be upgraded.
 </Callout>
 
-
 ## Set up Incident Intelligence [#get-started]
-
-
 
 To enable Incident Intelligence, follow these steps. Afterwards, issues should start to appear in your issue feed.
 
@@ -323,13 +321,10 @@ Adding anomalies as a source won't affect your current Proactive Detection confi
 
 ## 3. Configure destinations [#2-configure-destinations]
 
-Now that you've set up your sources, you can configure your destinations. These are the data outputs where you view your issues.
+Now that you've set up your sources, you can configure your destinations, which are the data outputs where you view your issues.
 
 To learn how to set up destinations and configure message templates, [check the documentation on notifications](/docs/alerts-applied-intelligence/notifications/destinations/).
-
   
 ## 4. Configure workflows [#3-configure-workflows]
 
-To learn how to set up workflows, [check the documentation on workflows](/docs/alerts-applied-intelligence/notifications/destinations/).[Workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows).
-  
- 
+To learn how to set up workflows, [check our workflows docs](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows). 

--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/get-started-incident-intelligence.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/get-started-incident-intelligence.mdx
@@ -15,15 +15,23 @@ redirects:
 As part of [Applied Intelligence](/docs/introduction-new-relic-ai), Incident Intelligence helps you correlate your incidents and reduce noise in your environment. It gives you an overview of all your incidents, their sources, and related events.
 
 If you haven't already, [sign up for a New Relic account](https://newrelic.com/signup) to get started.
+ 
+ <Callout variant="important">
+Please note, Pathways are depreacted and are replaced by Workflows.
+If you have have access to Pathways on your New Relice One left nav, don't hesitate to reach out to your New Relic account representative and ask to upgraded.
+</Callout>
+
 
 ## Set up Incident Intelligence [#get-started]
+
+
 
 To enable Incident Intelligence, follow these steps. Afterwards, issues should start to appear in your issue feed.
 
 * [1. Configure your environment (one-time)](#1-configure-environment).
 * [2. Configure sources](#1-configure-sources).
 * [3. Configure destinations](#2-configure-destinations).
-* [4. Configure pathways](#3-configure-pathways).
+* [4. Configure workflows](#3-configure-workflows).
 
 ## 1. Configure your environment (one-time) [#1-configure-environment]
 
@@ -313,221 +321,15 @@ Adding anomalies as a source won't affect your current Proactive Detection confi
 
 </CollapserGroup>
 
-## 3. Configure destinations (ServiceNow and others) [#2-configure-destinations]
+## 3. Configure destinations [#2-configure-destinations]
 
-Now that you've set up your sources, you can configure your destinations. These are the data outputs where you view your incidents.
+Now that you've set up your sources, you can configure your destinations. These are the data outputs where you view your issues.
 
-###  Configure ServiceNow (example) [#configure-servicenow]
+To learn how to set up destinations and configure message templates, [check the documentation on notifications](/docs/alerts-applied-intelligence/notifications/destinations/).
 
-Using ServiceNow as a destination enables you to push valuable violation data into new ServiceNow incident tickets.
+  
+## 4. Configure workflows [#3-configure-workflows]
 
-<CollapserGroup>
-  <Collapser
-    id="servicenow-destination"
-    title="Send data to ServiceNow"
-  >
-    To configure Incident Intelligence to send data to ServiceNow:
-
-    1. Go to **[one.newrelic.com](https://one.newrelic.com)**, click **Alerts & AI**, in the left nav under **Incident Intelligence** click **Destinations**, then click **ServiceNow**.
-    2. **Required:** Enter a channel name. This is used internally in Applied Intelligence to identify the destination (for example, in Pathways).
-    3. **Required:** Enter your ServiceNow credentials:
-       1. Team domain (This must be unique. No two destinations can have the same domain).
-       2. Username
-       3. Password
-    4. Follow the two-way integration on screen instructions:
-       1. Open and download this [XML file](https://storage.cloud.google.com/newrelic-connect/workflows-proxy-production.xml).
-       2. In the ServiceNow sidebar menu, go to **System Definition > Business Rule**.
-       3. Click the menu icon in one of the column headers, select Import XML, and upload the XML file you downloaded.
-
-    The two way integration will allow the ServiceNow incident to be updated with changes to the Applied Intelligence issue.
-
-    Closing a ServiceNow incident will close its corresponding New Relic issue.
-
-    When a New Relic issue is resolved, the corresponding ServiceNow incident will be closed.
-
-    ## Custom notification message [#custom-message]
-
-    Applied Intelligence uses a templating framework called Jinja2 in the customization section interface. The Value field must be in [valid](https://cryptic-cliffs-32040.herokuapp.com/) Jinja syntax.
-
-    By default, the interface populates a set of default fields in ServiceNow.
-
-    When you add a custom field, enter the ServiceNow field name you want to use.
-    
-    When you want to skip a selected field in an issue update, add the `| skip_on_update` string at the end of the value you've selected.
-
-    <Callout variant="tip">
-      By default, ServiceNow adds `u_` to the beginning of its custom values. When mapping to ServiceNow attributes, use the Column name value.
-    </Callout>
-
-    ![ServiceNow Custom Field Example.png](./images/image-%281%29_0.png "ServiceNow Custom Field Example.png")
-
-    <figcaption>
-      Please note that the name needs to be lowercase separated by underscores.
-    </figcaption>
-
-    Go here to see the [custom notification message attribute descriptions](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/incident-intelligence-destination-examples#webhook-format).
-
-    Go here to see [Jinja2 Useful Syntax](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/incident-intelligence-destination-examples#jinja2-useful).
-  </Collapser>
-</CollapserGroup>
-
-### Other destinations [#other-destinations]
-
-You can set other destinations:
-
-<CollapserGroup>
-  <Collapser
-    id="pager-duty-destination"
-    title="Send data to PagerDuty"
-  >
-    <Callout title="EOL NOTICE">
-      As of October 2021, we've discontinued support for several capabilities with PagerDuty, including suggested responders, golden signals, and component enrichment. For more details, including how you can easily make this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/upcoming-changes-to-capabilities-and-support-across-node-agents-suggested-pagerduty-responders-golden-signals-and-components-incident-workflows-mobile-agent-cross-application-tracing-cat-and-kubernetes-instrumentation/164481).
-    </Callout>
-    
-    **Recommended**: Create a new PagerDuty service to use as a destination. Because PagerDuty services can also be used as sources, this can help you distinguish your data input from your output.
-
-    To create a PagerDuty destination:
-
-    1. Go to **[one.newrelic.com](https://one.newrelic.com)**, click **Alerts & AI**, in the left nav under **Incident Intelligence** click **Destinations**, then click **PagerDuty**.
-    2. Enter your [PagerDuty API key](https://support.pagerduty.com/docs/generating-api-keys).
-       * The key should be either a personal or general access key with write access. If it's created by a user, the user should be an admin. If you've configured a PagerDuty source with an API key, you can use the same key.
-    3. Select the PagerDuty services you want to connect to Applied Intelligence, and click **Connect**.
-
-    When you're ready, you can add policies for one or more PagerDuty destinations. You can also transfer the policies over from your existing services or leave them as sources if needed.
-
-    From the **Destinations > PagerDuty** page, you can also:
-
-    * Review the permissions for your services. Click **Authorize** when you're done.
-    * Add or delete existing services from the PagerDuty destination.
-    * Edit permissions for any service.
-
-    To configure your PagerDuty destinations, use the following settings:
-
-    <table>
-      <thead>
-        <tr>
-          <th style={{ width: "250px" }}>
-            Configuration setting
-          </th>
-
-          <th>
-            Description
-          </th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr>
-          <td>
-            Trigger new incidents
-          </td>
-
-          <td>
-            **Required**. Trigger correlated parent incidents so you can identify issues faster.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Edit incident titles
-          </td>
-
-          <td>
-            **Required**. Alter your incident titles to help you orient and understand issues.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Add new integrations
-          </td>
-
-          <td>
-            **Required**. Add integrations to enable incident creation for selected services.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Add webhook extensions
-          </td>
-
-          <td>
-            Add webhook extensions to sync user actions in PagerDuty to New Relic. This lets you update the correlated issue state.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Auto-resolve correlated incidents
-          </td>
-
-          <td>
-            When enabled, this will resolve and automatically close correlated parent/child incidents.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Select a user to take actions in PagerDuty
-          </td>
-
-          <td>
-            You need to select a user before you can enable deep integration with PagerDuty. Once you do, the user can:
-
-            * **Add notes to incidents (required)**: Incident notes are used to enrich incidents with context.
-            * **Acknowledge triggered incidents**: When enabled, Applied Intelligence will acknowledge and correlate newly triggered incidents in PagerDuty before you're notified.
-            * **Use the original escalation policy**: When enabled, the escalation policy of the source service will be applied to each incident.
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </Collapser>
-
-  <Collapser
-    id="webhook-destination"
-    title="Send data via webhook"
-  >
-    Incident Intelligence will send the event body in JSON format by HTTPS POST. The system expects the endpoint to return a successful HTTP code (`2xx`).
-
-    To configure Incident Intelligence to send data via webhook:
-
-    1. Go to **[one.newrelic.com](https://one.newrelic.com)**, click **Alerts & AI**, in the left nav under **Incident Intelligence** click **Destinations**, then click **Webhook**.
-    2. **Required:** Configure the unique `webhook key`, used in Applied Intelligence to refer to this webhook configuration and its specific settings.
-    3. **Required:** Configure the `destination endpoint` where the webhook payload will be sent.
-    4. Optional steps:
-       * Configure `custom headers`, which are `key:value` pairs of headers to be sent with the request. Example: `"Authentication" "Bearer" <bearer token>`
-       * Configure a `custom payload` template that can be used to map New Relic fields to match the destination tool's expected name and format.
-       * Configure `priority mapping` (critical, high, medium, or low), used to map New Relic's priorities to the priorities expected at the destination.
-
-<Callout variant="tip">  
-There’s a retry mechanism that is triggered a few times with exponential backoff for a couple of minutes once an error occurs. If we reach the retry limit, the Webhook will get auto-disabled.
-</Callout>
-
-</Collapser>
-
-</CollapserGroup>
-
-For examples of destination templates, webhook formats, and JSON schema, see the [Incident Intelligence destination examples](/docs/new-relic-one/use-new-relic-one/new-relic-ai/incident-intelligence-destination-examples).
-
-## 4. Configure pathways [#3-configure-pathways]
-
-To control when and where you want to receive notifications from your incidents, you can configure pathways.
-
-**To add a pathway:**
-
-1. Go to **[one.newrelic.com](https://one.newrelic.com)**, click **Alerts & AI**, in the left nav under **Incident Intelligence** click **Pathways**, then click **Add a pathway**.
-2. In the query builder box, select an attribute, such as `application/name`.
-   * This can be from the list of all attributes available in PagerDuty incidents and New Relic alerts violations, or you can add your own attributes.
-3. Select a logical operator. For example, `contains`.
-4. Enter a specific value to complete the logical expression.
-
-   * To include all issues created by your sources, select **Send everything**. (Use this if you only use one PagerDuty service to manage all incidents.)
-   * To build more complex logic, use the `AND/OR` operators.
-5. Select one or more of your [destinations](#2-configure-destinations).
-
-To edit or remove existing pathways, mouse over the pathway's name on the **Pathways** page.
-
-## What's next? [#next]
-
-Now that you've set up some sources and destinations for your incidents, read about [how to use Incident Intelligence](/docs/alerts-applied-intelligence/incident-intelligence/).
+To learn how to set up workflows, [check the documentation on workflows](/docs/alerts-applied-intelligence/notifications/destinations/).[Workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows).
+  
+ 


### PR DESCRIPTION
removed pathways and old IINT docs and replaced it by workflows and new destinations
add callout that states pathways are deprecated and if customers see them they should immediately ask to upgrade (please see if you can rephrase it better)

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.