### PR TITLE
Add a note that the endpoints are region-specific

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start.mdx
@@ -62,7 +62,7 @@ To complete this third step, first familiarize yourself with some required New R
 Before you go to the external OTLP exporter documentation, consult the table below so you're ready to do the following:
 
 * Configure the OTLP exporter to add a header (```api-key```) whose value is the license key for the New Relic account you want to send data to.
-* Based on your integration, configure [the endpoint](#note-endpoints) where the exporter sends data to New Relic. Most users will want to use the US OTLP or EU OTLP endpoints.
+* Based on your integration, configure [the endpoint](#note-endpoints) where the exporter sends data to New Relic. The endpoints are region-specific, so use the one according to where your account is based (e.g., use the EU endpoint if your account is based in Europe). 
 
 <table>
   <thead>

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start.mdx
@@ -62,7 +62,7 @@ To complete this third step, first familiarize yourself with some required New R
 Before you go to the external OTLP exporter documentation, consult the table below so you're ready to do the following:
 
 * Configure the OTLP exporter to add a header (```api-key```) whose value is the license key for the New Relic account you want to send data to.
-* Based on your integration, configure [the endpoint](#note-endpoints) where the exporter sends data to New Relic. The endpoints are region-specific, so use the one according to where your account is based (e.g., use the EU endpoint if your account is based in Europe). 
+* Based on your integration, configure the [endpoint](#note-endpoints) where the exporter sends data to New Relic. The endpoints are region-specific, so use the one according to where your account is based. For example, use the EU endpoint if your account is based in Europe. 
 
 <table>
   <thead>


### PR DESCRIPTION
* We had a custy use the wrong endpoint for where their account is based, as it doesn't specify in the doc to use the endpoint for where your account is based, and were unable to see data in NR1. 