### PR TITLE
Ruby agent v8.5.0

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -60,6 +60,7 @@ The New Relic Ruby agent does not support experimental versions. Ruby versions s
         * 9.0.x
         * 9.1.x
         * 9.2.x
+        * 9.3.x
       </td>
 
       <td>

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-850.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-850.mdx
@@ -1,0 +1,49 @@
+---
+subject: Ruby agent
+releaseDate: '2022-02-24'
+version: 8.5.0
+downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.5.0.gem'
+---
+
+
+  ## v8.5.0
+
+  * **AWS: Support IMDSv2 by using a token with metadata API calls**
+
+    When querying AWS for instance metadata, include a token in the request headers. If an AWS user configures instances to require a token, the agent will now work. For instances that do not require the inclusion of a token, the agent will continue to work in that context as well.
+
+  * **Muffle anticipated stderr warnings for "hostname" calls**
+
+    When using the `hostname` binary to obtain hostname information, redirect STDERR to /dev/null. Thanks very much to @frenkel for raising this issue on behalf of OpenBSD users everywhere and for providing a solution with [PR #965](https://github.com/newrelic/newrelic-ruby-agent/pull/965)
+
+  * **Added updated configuration options for transaction events and deprecated previous configs**
+    This release deprecates and replaces the following configuration options:
+    | Deprecated      | Replacement |
+    | ----------- | ----------- |
+    | event_report_period.analytic_event_data | event_report_period.transaction_event_data |
+    | analytics_events.enabled | transaction_events.enabled        |
+    | analytics_events.max_samples_stored | transaction_events.max_samples_stored |
+
+  * **Bugfix: Rails 5 + Puma errors in rack "can't add a new key into hash during iteration"**
+
+    When using rails 5 with puma, the agent would intermittently cause rack to raise a `RuntimeError: can't add a new key into hash during iteration`. We have identified the source of the error in our instrumentation and corrected the behavior so it no longer interferes with rack. Thanks to @sasharevzin for bringing attention to this error and providing a reproduction of the issue for us to investigate.
+
+  * **Eliminated warnings for redefined constants in ParameterFiltering**
+
+    Fixed the ParameterFiltering constant definitions so that they are not redefined on multiple reloads of the module. Thank you to @TonyArra for bringing this issue to our attention.
+
+  * **CI: target JRuby 9.3.3.0**
+
+    Many thanks to @ahorek for [PR #919](https://github.com/newrelic/newrelic-ruby-agent/pull/919), [PR #921](https://github.com/newrelic/newrelic-ruby-agent/pull/921), and [PR #922](https://github.com/newrelic/newrelic-ruby-agent/pull/922) to keep us up to date on the JRuby side of things. The agent is now actively being tested against JRuby 9.3.3.0. NOTE that this release does not contain any non-CI related changes for JRuby. Old agent versions are still expected to work with newer JRubies and the newest agent version is still expected to work with older JRubies.
+
+  * **CI: Update unit tests for Rails 7.0.2**
+
+    Ensure that the 7.0.2 release of Rails is fully compatible with all relevant tests.
+
+  * **CI: Ubuntu 20.04 LTS**
+
+    To stay current and secure, our CI automation is now backed by version 20.04 of Ubuntu's long term support offering (previously 18.04).
+
+  * **Docker for development**
+
+    Docker and Docker Compose may now be used for local development and testing with the provided `Dockerfile` and `docker-compose.yml` files in the project root. See [DOCKER.md](DOCKER.md) for usage instructions.


### PR DESCRIPTION
Updates for the Ruby agent v8.5.0 release

* Added new version specific release notes
* Updated the list of supported JRubies to include v9.3.x