### PR TITLE
docs: Update K8s 1.21+ callout

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
@@ -245,7 +245,7 @@ To host CPMs, your system must meet the minimum requirements for the chosen syst
           <td>
             We recommend that your Kubernetes cluster supports [Kubernetes v1.15](https://kubernetes.io/blog/2019/06/19/kubernetes-1-15-release-announcement/).
             <Callout variant="caution">
-              We have identified a compatibility issue with Kubernetes v1.21+. A workaround is available by disabling the `BoundServiceAccountTokenVolume` feature gate on the cluster.
+              For Kubernetes v1.21 or newer, use minion release [v3.0.61](https://docs.newrelic.com/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3061) or newer.
             </Callout>
           </td>
         </tr>


### PR DESCRIPTION
Update K8s 1.21+ callout to point to the 3.0.61 release of the minion or newer.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Compatibility issues with K8s 1.21+ have been resolved. The documentation should be updated to point users to an appropriate version of the containerized private minion (CPM).