### PR TITLE
Ruby agent release v8.5.0

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -837,7 +837,9 @@ The browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
       </tbody>
     </table>
 
-  If `true`, enables analytics event sampling.
+  <b>DEPRECATED</b> Please see: [transaction_events.enabled](docs/agents/ruby-agent/configuration/ruby-agent-configuration#transaction_events-enabled).
+
+If `true`, enables analytics event sampling.
   </Collapser>
 
   <Collapser id="analytics_events-max_samples_stored" title="analytics_events.max_samples_stored">
@@ -849,7 +851,9 @@ The browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
       </tbody>
     </table>
 
-  Defines the maximum number of request events reported from a single harvest.
+  <b>DEPRECATED</b> Please see: [transaction_events.max_samples_stored](docs/agents/ruby-agent/configuration/ruby-agent-configuration#transaction_events-max_samples_stored).   
+
+ Defines the maximum number of request events reported from a single harvest.
   </Collapser>
 
   <Collapser id="analytics_events-capture_attributes" title="analytics_events.capture_attributes">
@@ -2461,6 +2465,40 @@ If `true`, the agent won't install Grape instrumentation.
   </Collapser>
 
 </CollapserGroup>
+
+## Transaction Events
+
+
+
+<CollapserGroup>
+  
+  <Collapser id="transaction_events-enabled" title="transaction_events.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`(Dynamic)`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_EVENTS_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables transaction event sampling.
+  </Collapser>
+  
+  <Collapser id="transaction_events-max_samples_stored" title="transaction_events.max_samples_stored">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`(Dynamic)`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_EVENTS_MAX_SAMPLES_STORED`</td></tr>
+      </tbody>
+    </table>
+
+  Defines the maximum number of transaction events reported from a single harvest.
+  </Collapser>
+  
+</CollapserGroup>
+
+
 
 ## Utilization
 

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -60,6 +60,7 @@ The New Relic Ruby agent does not support experimental versions. Ruby versions s
         * 9.0.x
         * 9.1.x
         * 9.2.x
+        * 9.3.x
       </td>
 
       <td>

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-850.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-850.mdx
@@ -18,15 +18,49 @@ downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.5.0.gem'
 
   * **Added updated configuration options for transaction events and deprecated previous configs**
     This release deprecates and replaces the following configuration options:
-    | Deprecated      | Replacement |
-    | ----------- | ----------- |
-    | event_report_period.analytic_event_data | event_report_period.transaction_event_data |
-    | analytics_events.enabled | transaction_events.enabled        |
-    | analytics_events.max_samples_stored | transaction_events.max_samples_stored |
+    
+    <table>
+  <thead>
+    <tr>
+      <th>
+        Deprecated
+      </th>
+      <th>
+         Replacement
+      </th>
+    </tr>
+  </thead>
+    <tbody>
+    <tr>
+      <td>
+        event_report_period.analytic_event_data
+      </td>
+      <td>
+        event_report_period.transaction_event_data
+      </td>
+    </tr>
+    <tr>
+      <td>
+        analytics_events.enabled
+      </td>
+      <td>
+        transaction_events.enabled
+      </td>
+    </tr>
+    <tr>
+      <td>
+        analytics_events.max_samples_stored
+      </td>
+      <td>
+        transaction_events.max_samples_stored
+      </td>
+    </tr>
+    </tbody>
+</table>
 
   * **Eliminated warnings for redefined constants in ParameterFiltering**
 
-    Fixed the ParameterFiltering constant definitions so that they are not redefined on multiple reloads of the module. Thank you to @TonyArra for bringing this issue to our attention.
+    Fixed the `ParameterFiltering` constant definitions so that they are not redefined on multiple reloads of the module. Thank you to @TonyArra for bringing this issue to our attention.
 
   * **Docker for development**
 
@@ -39,7 +73,7 @@ downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.5.0.gem'
 
   * **CI: target JRuby 9.3.3.0**
 
-    Many thanks to @ahorek for [PR #919](https://github.com/newrelic/newrelic-ruby-agent/pull/919), [PR #921](https://github.com/newrelic/newrelic-ruby-agent/pull/921), and [PR #922](https://github.com/newrelic/newrelic-ruby-agent/pull/922) to keep us up to date on the JRuby side of things. The agent is now actively being tested against JRuby 9.3.3.0. NOTE that this release does not contain any non-CI related changes for JRuby. Old agent versions are still expected to work with newer JRubies and the newest agent version is still expected to work with older JRubies.
+    Many thanks to @ahorek for [PR #919](https://github.com/newrelic/newrelic-ruby-agent/pull/919), [PR #921](https://github.com/newrelic/newrelic-ruby-agent/pull/921), and [PR #922](https://github.com/newrelic/newrelic-ruby-agent/pull/922) to keep us up to date on the JRuby side of things. The agent is now actively being tested against JRuby 9.3.3.0. NOTE that this release does not contain any non-CI related changes for JRuby. Old agent versions are still expected to work with newer JRubies, and the newest agent version is still expected to work with older JRubies.
 
   * **CI: Update unit tests for Rails 7.0.2**
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-850.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-850.mdx
@@ -1,0 +1,49 @@
+---
+subject: Ruby agent
+releaseDate: '2022-02-24'
+version: 8.5.0
+downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.5.0.gem'
+---
+
+
+  ## v8.5.0
+
+  * **AWS: Support IMDSv2 by using a token with metadata API calls**
+
+    When querying AWS for instance metadata, include a token in the request headers. If an AWS user configures instances to require a token, the agent will now work. For instances that do not require the inclusion of a token, the agent will continue to work in that context as well.
+
+  * **Muffle anticipated stderr warnings for "hostname" calls**
+
+    When using the `hostname` binary to obtain hostname information, redirect STDERR to /dev/null. Thanks very much to @frenkel for raising this issue on behalf of OpenBSD users everywhere and for providing a solution with [PR #965](https://github.com/newrelic/newrelic-ruby-agent/pull/965)
+
+  * **Added updated configuration options for transaction events and deprecated previous configs**
+    This release deprecates and replaces the following configuration options:
+    | Deprecated      | Replacement |
+    | ----------- | ----------- |
+    | event_report_period.analytic_event_data | event_report_period.transaction_event_data |
+    | analytics_events.enabled | transaction_events.enabled        |
+    | analytics_events.max_samples_stored | transaction_events.max_samples_stored |
+
+  * **Bugfix: Rails 5 + Puma errors in rack "can't add a new key into hash during iteration"**
+
+    When using rails 5 with puma, the agent would intermittently cause rack to raise a `RuntimeError: can't add a new key into hash during iteration`. We have identified the source of the error in our instrumentation and corrected the behavior so it no longer interferes with rack. Thanks to @sasharevzin for bringing attention to this error and providing a reproduction of the issue for us to investigate.
+
+  * **Eliminated warnings for redefined constants in ParameterFiltering**
+
+    Fixed the ParameterFiltering constant definitions so that they are not redefined on multiple reloads of the module. Thank you to @TonyArra for bringing this issue to our attention.
+
+  * **CI: target JRuby 9.3.3.0**
+
+    Many thanks to @ahorek for [PR #919](https://github.com/newrelic/newrelic-ruby-agent/pull/919), [PR #921](https://github.com/newrelic/newrelic-ruby-agent/pull/921), and [PR #922](https://github.com/newrelic/newrelic-ruby-agent/pull/922) to keep us up to date on the JRuby side of things. The agent is now actively being tested against JRuby 9.3.3.0. NOTE that this release does not contain any non-CI related changes for JRuby. Old agent versions are still expected to work with newer JRubies and the newest agent version is still expected to work with older JRubies.
+
+  * **CI: Update unit tests for Rails 7.0.2**
+
+    Ensure that the 7.0.2 release of Rails is fully compatible with all relevant tests.
+
+  * **CI: Ubuntu 20.04 LTS**
+
+    To stay current and secure, our CI automation is now backed by version 20.04 of Ubuntu's long term support offering (previously 18.04).
+
+  * **Docker for development**
+
+    Docker and Docker Compose may now be used for local development and testing with the provided `Dockerfile` and `docker-compose.yml` files in the project root. See [DOCKER.md](DOCKER.md) for usage instructions.

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-850.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-850.mdx
@@ -14,7 +14,7 @@ downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.5.0.gem'
 
   * **Muffle anticipated stderr warnings for "hostname" calls**
 
-    When using the `hostname` binary to obtain hostname information, redirect STDERR to /dev/null. Thanks very much to @frenkel for raising this issue on behalf of OpenBSD users everywhere and for providing a solution with [PR #965](https://github.com/newrelic/newrelic-ruby-agent/pull/965)
+    When using the `hostname` binary to obtain hostname information, redirect STDERR to /dev/null. Thanks very much to @frenkel for raising this issue on behalf of OpenBSD users everywhere and for providing a solution with [PR #965](https://github.com/newrelic/newrelic-ruby-agent/pull/965).
 
   * **Added updated configuration options for transaction events and deprecated previous configs**
     This release deprecates and replaces the following configuration options:
@@ -24,13 +24,18 @@ downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.5.0.gem'
     | analytics_events.enabled | transaction_events.enabled        |
     | analytics_events.max_samples_stored | transaction_events.max_samples_stored |
 
-  * **Bugfix: Rails 5 + Puma errors in rack "can't add a new key into hash during iteration"**
-
-    When using rails 5 with puma, the agent would intermittently cause rack to raise a `RuntimeError: can't add a new key into hash during iteration`. We have identified the source of the error in our instrumentation and corrected the behavior so it no longer interferes with rack. Thanks to @sasharevzin for bringing attention to this error and providing a reproduction of the issue for us to investigate.
-
   * **Eliminated warnings for redefined constants in ParameterFiltering**
 
     Fixed the ParameterFiltering constant definitions so that they are not redefined on multiple reloads of the module. Thank you to @TonyArra for bringing this issue to our attention.
+
+  * **Docker for development**
+
+    Docker and Docker Compose may now be used for local development and testing with the provided `Dockerfile` and `docker-compose.yml` files in the project root. See [DOCKER.md](DOCKER.md) for usage instructions.
+
+
+  * **Bugfix: Rails 5 + Puma errors in rack "can't add a new key into hash during iteration"**
+
+    When using rails 5 with puma, the agent would intermittently cause rack to raise a `RuntimeError: can't add a new key into hash during iteration`. We have identified the source of the error in our instrumentation and corrected the behavior so it no longer interferes with rack. Thanks to @sasharevzin for bringing attention to this error and providing a reproduction of the issue for us to investigate.
 
   * **CI: target JRuby 9.3.3.0**
 
@@ -43,7 +48,3 @@ downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.5.0.gem'
   * **CI: Ubuntu 20.04 LTS**
 
     To stay current and secure, our CI automation is now backed by version 20.04 of Ubuntu's long term support offering (previously 18.04).
-
-  * **Docker for development**
-
-    Docker and Docker Compose may now be used for local development and testing with the provided `Dockerfile` and `docker-compose.yml` files in the project root. See [DOCKER.md](DOCKER.md) for usage instructions.


### PR DESCRIPTION
Updates for the Ruby agent v8.5.0 release

• Added new version specific release notes
• Updated the list of supported JRubies to include v9.3.x
• Denoted configuration parameter additions and deprecations