### PR TITLE
Chore: Add release notes for .NET Agent v9.6.0.0

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9600.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9600.mdx
@@ -1,0 +1,34 @@
+---
+subject: .NET agent
+releaseDate: '2022-02-24'
+version: 9.6.0.0
+downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+---
+
+### New Features
+* Adds new supportability metrics to track agent endpoint data usage. New metrics will be reported under the Supportability/DotNET/Collector namespace. ([#899](https://github.com/newrelic/newrelic-dotnet-agent/pull/899))
+* Uses IMDSv2 instead of IMDSv1 to gather utilization details for AWS hosted instances. [965](https://github.com/newrelic/newrelic-dotnet-agent/pull/965)
+
+### Checksums
+| File | SHA - 256  Hash |
+| ---| ---|
+| newrelic-agent-win-9.6.0.0-scriptable-installer.zip | 3D65ED0B10977CD13EFD8A4CC24B7F06B0B6B60E784830A09B4384EE6F5AD9BD |
+| newrelic-agent-win-x64-9.6.0.0.msi | 3C514C6C2C27DD33EBBFE84469333CC812045B42626619AA5BE3519FCEC17EAB |
+| newrelic-agent-win-x64-9.6.0.0.zip | 7CCC53713245555D52F910F368621DDC83F133A1A21F29FD917E2C515283B521 |
+| newrelic-agent-win-x86-9.6.0.0.msi | A2E015DB73832DB818CB1E184890ED62B97FAF39EB75A45458881CB36AD1DEE3 |
+| newrelic-agent-win-x86-9.6.0.0.zip | B962DC612C98F41F3AE63855119967246C7104CC65865F183F35E63CFF6AC36E |
+| newrelic-netcore20-agent-9.6.0.0-1.x86_64.rpm | 1578AA7CEC1B4AB798F0359F404F1AED2720BEA4EA20A491F54A5E6FE14D0AAA |
+| newrelic-netcore20-agent-win-9.6.0.0-scriptable-installer.zip | E61D552478F5808677DAAD10460B4C77C822157097BD4625E6CDBB9A20E65B53 |
+| newrelic-netcore20-agent-win-x64-9.6.0.0.zip | 25A5854FA85C7BCC33C9D6613B4FF2271ABAAE303C3361AA18AD37B41E59E193 |
+| newrelic-netcore20-agent-win-x86-9.6.0.0.zip | 2D839B98BDB0DE52D5F4BBAD2FF3DCE066492A4A21E81B49FE23397E9C22CCB9 |
+| newrelic-netcore20-agent_9.6.0.0_amd64.deb | 53B716293BBE577940514ED088A456FD41498A1351464C00E4697B94EA867AE6 |
+| newrelic-netcore20-agent_9.6.0.0_amd64.tar.gz | 18C66A4EF8023D83375A4F450A064892B5189A1BEEDBF393D2EB7E874F92CA96 |
+| newrelic-netcore20-agent_9.6.0.0_arm64.deb | C8826C78CEE2BF0B0C2F73AB65FC06BE74DE931EFDDD0A162A5BF907589852E5 |
+| newrelic-netcore20-agent_9.6.0.0_arm64.tar.gz | C8DDFD3DA29496DC760028C915E43FE54E46ACD10B213BB2F55F83DA82309431 |
+
+### Support statement
+New Relic recommends that you update the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [.NET agent 8.24.244.0](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8242440).
+
+### Updating
+* Follow standard procedures to [update the .NET agent](/docs/agents/net-agent/installation-configuration/update-net-agent).
+* If you're using a particularly old agent, review the list of major changes and procedures for [updating legacy .NET agents](/docs/agents/net-agent/troubleshooting/upgrade-legacy-net-agents).


### PR DESCRIPTION
## Give us some context

* Adds new release notes for .NET Agent v9.6.0.0.