### PR TITLE
docs: fix bash command

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -875,7 +875,7 @@ The `proxy` element supports the following attributes:
     For additional security, the .NET Agent supports the use of an obfuscated proxy password with the passwordObfuscated attribute. The obfuscated proxy password is generated using the following [New Relic CLI](https://github.com/newrelic/newrelic-cli) command:
 
     ```bash
-    newrelic agent config obfuscate --key <var>OBSCURING_KEY</var> --value "<var>CLEAR_TEXT_PROXY_PASSWORD</var>"
+    newrelic agent config obfuscate --key OBSCURING_KEY --value "PLAIN_TEXT_PROXY_PASSWORD"
     ```
 
     <Callout variant="important">


### PR DESCRIPTION
the `<var>...</var>` in the bash command was being displayed as part of the command

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.