### PR TITLE
Add in recommendation to only use one tooling tech

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/introduction-opentelemetry-new-relic.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/introduction-opentelemetry-new-relic.mdx
@@ -139,7 +139,9 @@ As you consider OpenTelemetry, you may also be looking at New Relic APM agents t
 
 As you'd expect, there is a lot of overlap between features available from OpenTelemetry agents and SDKs versus those available from New Relic APM agents. This is especially true if you're interested in distributed tracing telemetry data. The choice you make depends on what you need.
 
-We recommend that you explore both New Relic and OpenTelemetry instrumentation or discuss this with us in our [CNCF Slack channel](https://cloud-native.slack.com/archives/C024DRQ63UP) to decide what works best for you. 
+We recommend that you explore both New Relic and OpenTelemetry instrumentation, and encourage you to come discuss this with us in our [CNCF Slack channel](https://cloud-native.slack.com/archives/C024DRQ63UP) to decide what works best for you. 
+
+We do recommend instrumenting any one service with only either OpenTelemetry or a New Relic APM agent, as both manipulate byte code and could lead to a variety of issues. If you have a distributed system where some services are instrumented with OpenTelemetry and others with a New Relic APM agent, you would be able to see traces across any interconnected services due to [W3C Trace Context](https://www.w3.org/TR/trace-context/) support in both. 
 
 ### OpenTelemetry: A work in progress [#emerging-standard]
 


### PR DESCRIPTION
* This doc is not clear in saying that only ONE tooling tech (either OTel or an APM agent) should be used, and does not say that using both in any one service can cause issues. 
* This is to help clear up custy confusion, we've had several asks about it now. 