### PR TITLE
docs: add another profiler to table

### DIFF
--- a/src/content/docs/apm/agents/net-agent/troubleshooting/profiler-conflicts.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/profiler-conflicts.mdx
@@ -139,6 +139,16 @@ Here are some commonly reported profiler conflicts. This is not an exhaustive li
   <tbody>
     <tr>
       <td>
+        APM Insight
+      </td>
+
+      <td>
+        989D151B-3F31-482E-926F-2E95D274BD36
+      </td>
+    </tr>
+    
+    <tr>
+      <td>
         App Dynamics
       </td>
 


### PR DESCRIPTION
I just had a ticket where APM Insight set the registry key to this value and I found more references to this key for APM Insight online:

https://www.manageengine.com/products/applications_manager/help/java-transaction-monitoring.html

 https://pitstop.manageengine.com/portal/en/kb/articles/unable-to-see-application-after-adding-apm-insight-net-agent-and-getting-failed-to-load-profiler-error-30-11-2020

https://www.site24x7.com/help/apm/dotnet-agent/install-dot-net-core-agent-via-nuget.html

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.