### PR TITLE
Update find-help-use-support-portal.mdx

### DIFF
--- a/src/content/docs/new-relic-solutions/solve-common-issues/find-help-use-support-portal.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/find-help-use-support-portal.mdx
@@ -89,7 +89,7 @@ If you can't find an answer in the documentation, you can file an issue to ask u
 
 ## File a case in the platform or support portal [#file-ticket]
 
-If none of the above methods worked, click the **?** icon on the top right menu, or go to [support.newrelic.com](https://support.newrelic.com/home). The support portal gives you access to unified search across all of New Relic's help resources. If you can't find what you're looking for, and your subscription level includes technical support, [file a support ticket](https://support.newrelic.com/tickets).
+If none of the above methods worked, click the **?** icon on the top right menu, or go to [support.newrelic.com](https://support.newrelic.com). The support portal gives you access to unified search across all of New Relic's help resources. If you can't find what you're looking for, and your subscription level includes technical support, [file a support ticket](https://support.newrelic.com/s/inbox).
 
 <Callout variant="important">
   Support for beta or limited release features may not be available.


### PR DESCRIPTION
The links https://support.newrelic.com/home and https://support.newrelic.com/tickets were returning 404's. Updating them to the new URLs.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

Two links were leading to 404 errors. The links are https://support.newrelic.com/home and https://support.newrelic.com/tickets.


* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

I updated the links to the new URLs.

https://support.newrelic.com/home = https://support.newrelic.com
https://support.newrelic.com/tickets = https://support.newrelic.com/s/inbox

* If your issue relates to an existing GitHub issue, please link to it.