### PR TITLE
Rebrand XCFramework as iOS-tvOS-watchOS-XCFramework agent

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-compatibility-requirements.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-compatibility-requirements.mdx
@@ -135,7 +135,7 @@ Make sure your iOS app meets these requirements:
       </td>
 
       <td>
-        In order to use the latest XCFramework Agent, use CocoaPods version 1.10.1 or higher.
+        In order to use the latest iOS-tvOS-watchOS-XCFramework agent, use CocoaPods version 1.10.1 or higher.
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/release-notes/index.mdx
+++ b/src/content/docs/release-notes/index.mdx
@@ -49,9 +49,9 @@ To take full advantage of New Relic's latest features, enhancements, and importa
     to="/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes"
   />
   <TechTile
-    name="iOS agent"
+    name="iOS-tvOS-watchOS-XCFramework agent"
     icon="logo-apple-color"
-    to="/docs/release-notes/mobile-release-notes/ios-release-notes"
+    to="/docs/release-notes/mobile-release-notes/xcframework-release-notes"
   />
   <TechTile
     name="Java agent"
@@ -113,16 +113,6 @@ To take full advantage of New Relic's latest features, enhancements, and importa
     icon="logo-newrelic"
     to="/docs/release-notes/service-levels-release-notes"
   />  
-  <TechTile
-    name="tvOS agent"
-    icon="logo-apple-color"
-    to="/docs/release-notes/mobile-release-notes/tvos-release-notes"
-  />
-  <TechTile
-    name="XCFramework agent"
-    icon="logo-apple-color"
-    to="/docs/release-notes/mobile-release-notes/xcframework-release-notes"
-  />
   <TechTile
     name="Organization and user management"
     icon="logo-newrelic"

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/index.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 redirects:
   - /docs/releases/ios
   - /docs/mobile-monitoring/new-relic-mobile-ios/get-started/ios-release-notes

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-1300.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-1300.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2013-03-13'
 version: '1.300'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_1.300.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-1328.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-1328.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2013-04-22'
 version: '1.328'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_1.328.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-1342.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-1342.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2013-05-31'
 version: '1.342'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_1.342.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-1354.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-1354.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2013-06-28'
 version: '1.354'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_1.354.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-1376.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-1376.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2013-09-17'
 version: '1.376'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_1.376.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-1396.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-1396.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2013-11-22'
 version: '1.396'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_1.396.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3130.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3130.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2013-12-02'
 version: '3.130'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.130.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3154.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3154.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2013-12-16'
 version: '3.154'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.154.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3174.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3174.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-01-08'
 version: '3.174'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.174.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3184.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3184.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-01-21'
 version: '3.184'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.184.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3196.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3196.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-01-31'
 version: '3.196'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.196.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3252.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3252.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-02-26'
 version: '3.252'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.252.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3256.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3256.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-03-07'
 version: '3.256'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.256.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3257.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3257.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-03-11'
 version: '3.257'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.257.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3289.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3289.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-03-26'
 version: '3.289'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.289.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3311.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3311.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-05-05'
 version: '3.311'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.311.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3324.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3324.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-05-16'
 version: '3.324'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.324.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3343.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3343.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-06-16'
 version: '3.343'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.343.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3378.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3378.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-07-24'
 version: '3.378'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.378.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3380.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3380.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-08-05'
 version: '3.380'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.380.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3396.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3396.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-08-19'
 version: '3.396'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.396.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3398.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3398.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-08-27'
 version: '3.398'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.398.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3406-0.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3406-0.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-09-03'
 version: '3.406'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.406.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3412.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-3412.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-09-12'
 version: '3.412'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_3.412.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-4139.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-4139.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-11-21'
 version: '4.139'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_4.139.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-4152-0.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-4152-0.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-12-18'
 version: '4.152'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_4.152.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-4155.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-4155.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-01-08'
 version: '4.155'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_4.155.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-4174.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-4174.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-01-26'
 version: '4.174'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_4.174.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-4186.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-4186.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-01-29'
 version: '4.186'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_4.186.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-41861.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-41861.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-04-23'
 version: 4.186.1
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_4.186.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-483.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-483.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2014-10-08'
 version: '4.83'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_4.83.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-500.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-500.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-05-01'
 version: 5.0.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.0.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-501.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-501.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-05-01'
 version: 5.0.1
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.0.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-502.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-502.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-05-11'
 version: 5.0.2
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.0.2.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-503.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-503.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-05-15'
 version: 5.0.3
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.0.3.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-510.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-510.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-06-03'
 version: 5.1.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.1.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-512.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-512.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-06-30'
 version: 5.1.2
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.1.2.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-520.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-520.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-07-30'
 version: 5.2.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.2.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-521.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-521.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-08-17'
 version: 5.2.1
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.2.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-530.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-530.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-09-17'
 version: 5.3.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.3.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-531.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-531.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-10-13'
 version: 5.3.1
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.3.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-532.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-532.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-10-29'
 version: 5.3.2
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.3.2.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-1309.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-1309.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2013-03-29'
 version: '1.309'
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_1.309.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5100.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5100.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2017-01-23'
 version: 5.10.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.10.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5101.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5101.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2017-02-07'
 version: 5.10.1
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.10.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5110.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5110.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2017-02-27'
 version: 5.11.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.11.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5120.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5120.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2017-03-09'
 version: 5.12.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.12.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5122.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5122.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2017-03-29'
 version: 5.12.2
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.12.2.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5123.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5123.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2017-04-20'
 version: 5.12.3
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.12.3.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5130.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5130.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2017-05-11'
 version: 5.13.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.13.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5140.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5140.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2017-06-20'
 version: 5.14.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.14.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5141.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5141.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2017-07-11'
 version: 5.14.1
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.14.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5142.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5142.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2017-08-01'
 version: 5.14.2
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.14.2.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5150.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-5150.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2017-10-17'
 version: 5.15.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.15.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-522.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-522.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-09-01'
 version: 5.2.2
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.2.2.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-534.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-534.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2015-11-19'
 version: 5.3.4
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.3.4.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-535.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-535.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2016-01-07'
 version: 5.3.5
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.3.5.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-536.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-536.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2016-01-26'
 version: 5.3.6
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.3.6.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-540.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-540.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2016-03-04'
 version: 5.4.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.4.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-541.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-541.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2016-03-18'
 version: 5.4.1
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.4.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-550.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-550.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2016-05-03'
 version: 5.5.0
 ---

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-551.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-551.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2016-05-06'
 version: 5.5.1
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.5.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-552.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-552.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2016-05-23'
 version: 5.5.2
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.5.2.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-560.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-560.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2016-06-16'
 version: 5.6.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.6.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-570.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-570.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2016-07-29'
 version: 5.7.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.7.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-571.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-571.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2016-08-02'
 version: 5.7.1
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.7.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-580.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-580.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2016-09-02'
 version: 5.8.0
 ---

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-581.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-581.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2016-09-09'
 version: 5.8.1
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.8.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-582.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-582.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2016-09-22'
 version: 5.8.2
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.8.2.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-583.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-583.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2016-09-27'
 version: 5.8.3
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.8.3.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-590.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-590.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2017-01-10'
 version: 5.9.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.9.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-600.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-600.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2017-11-08'
 version: 6.0.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.0.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-610.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-610.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2017-12-14'
 version: 6.1.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.1.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-6100.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-6100.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2019-11-20'
 version: 6.10.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.10.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-611.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-611.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2018-02-09'
 version: 6.1.1
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.1.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-6110.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-6110.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2020-04-20'
 version: 6.11.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.11.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-6130.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-6130.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2020-07-21'
 version: 6.13.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.13.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-6140.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-6140.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2020-08-25'
 version: 6.14.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.14.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-620-0.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-620-0.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2018-03-06'
 version: 6.2.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.2.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-630.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-630.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2018-06-01'
 version: 6.3.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.3.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-632.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-632.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2018-09-12'
 version: 6.3.2
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.3.2.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-640.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-640.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2018-10-09'
 version: 6.4.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.4.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-641.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-641.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2018-10-30'
 version: 6.4.1
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.4.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-650.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-650.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2019-02-05'
 version: 6.5.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.5.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-660.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-660.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2019-03-14'
 version: 6.6.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.6.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-670.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-670.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2019-06-07'
 version: 6.7.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.7.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-680.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-680.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2019-09-13'
 version: 6.8.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.8.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-690.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-690.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2019-10-24'
 version: 6.9.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_6.9.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-700.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-700.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS agent
+subject: iOS agent (archived)
 releaseDate: '2020-09-11'
 version: 7.0.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.0.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/index.mdx
@@ -1,4 +1,4 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 ---
 

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5121.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5121.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2017-03-10'
 version: 5.12.1
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_5.12.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5130.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5130.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2017-05-11'
 version: 5.13.0
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_5.13.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5140.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5140.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2017-06-20'
 version: 5.14.0
 downloadLink: 'http://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_5.14.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5141-0.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5141-0.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2017-07-11'
 version: 5.14.1
 downloadLink: 'http://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_5.14.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5150.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-5150.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2017-10-17'
 version: 5.15.0
 downloadLink: 'http://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_5.15.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-560.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-560.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2016-06-17'
 version: 5.6.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_iOS_Agent_5.6.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-570.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-570.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2016-07-29'
 version: 5.7.0
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_5.7.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-571.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-571.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2016-08-02'
 version: 5.7.1
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_5.7.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-580.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-580.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2016-09-02'
 version: 5.8.0
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_5.8.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-582-0.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-582-0.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2016-09-22'
 version: 5.8.2
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_5.8.2.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-600.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-600.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2017-11-08'
 version: 6.0.0
 downloadLink: 'http://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.0.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-610.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-610.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2017-12-14'
 version: 6.1.0
 downloadLink: 'http://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.1.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6100.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6100.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2019-11-20'
 version: 6.10.0
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.10.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6110.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6110.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2020-04-20'
 version: 6.11.0
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.11.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6120.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6120.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2020-07-13'
 version: 6.12.0
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.12.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6130.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6130.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2020-07-21'
 version: 6.13.0
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.13.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6140.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-6140.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2020-08-25'
 version: 6.14.0
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.14.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-620.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-620.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2018-03-01'
 version: 6.2.0
 downloadLink: 'http://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.2.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-630.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-630.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2018-06-01'
 version: 6.3.0
 downloadLink: 'http://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.3.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-631.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-631.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2018-06-14'
 version: 6.3.1
 downloadLink: 'http://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.3.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-632.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-632.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2018-09-12'
 version: 6.3.2
 downloadLink: 'http://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.3.2.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-640.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-640.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2018-10-09'
 version: 6.4.0
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.4.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-641.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-641.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2018-10-30'
 version: 6.4.1
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.4.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-650.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-650.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2019-02-05'
 version: 6.5.0
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.5.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-660.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-660.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2019-03-14'
 version: 6.6.0
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.6.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-670.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-670.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2019-06-07'
 version: 6.7.0
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.7.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-680.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-680.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2019-09-13'
 version: 6.8.0
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.8.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-690.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-690.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2019-10-25'
 version: 6.9.0
 downloadLink: 'https://download.newrelic.com/tvos_agent/NewRelic_tvOS_Agent_6.9.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-700.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/tvos-release-notes/tvos-agent-700.mdx
@@ -1,5 +1,5 @@
 ---
-subject: tvOS agent
+subject: tvOS agent (archived)
 releaseDate: '2020-09-11'
 version: 7.0.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.0.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/index.mdx
@@ -1,4 +1,4 @@
 ---
-subject: iOS-XCFramework agent
+subject: iOS-tvOS-watchOS-XCFramework agent
 ---
 

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/index.mdx
@@ -1,4 +1,4 @@
 ---
-subject: XCFramework agent
+subject: iOS-XCFramework agent
 ---
 

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-700.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-700.mdx
@@ -1,5 +1,5 @@
 ---
-subject: XCFramework agent
+subject: iOS-XCFramework agent
 releaseDate: '2020-09-09'
 version: 7.0.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.0.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-700.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-700.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS-XCFramework agent
+subject: iOS-tvOS-watchOS-XCFramework agent
 releaseDate: '2020-09-09'
 version: 7.0.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.0.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-710.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-710.mdx
@@ -1,5 +1,5 @@
 ---
-subject: XCFramework agent
+subject: iOS-XCFramework agent
 releaseDate: '2020-10-15'
 version: 7.1.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.1.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-710.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-710.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS-XCFramework agent
+subject: iOS-tvOS-watchOS-XCFramework agent
 releaseDate: '2020-10-15'
 version: 7.1.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.1.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-720.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-720.mdx
@@ -1,5 +1,5 @@
 ---
-subject: XCFramework agent
+subject: iOS-XCFramework agent
 releaseDate: '2020-11-19'
 version: 7.2.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.2.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-720.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-720.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS-XCFramework agent
+subject: iOS-tvOS-watchOS-XCFramework agent
 releaseDate: '2020-11-19'
 version: 7.2.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.2.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-721.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-721.mdx
@@ -1,5 +1,5 @@
 ---
-subject: XCFramework agent
+subject: iOS-XCFramework agent
 releaseDate: '2020-12-17'
 version: 7.2.1
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.2.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-721.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-721.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS-XCFramework agent
+subject: iOS-tvOS-watchOS-XCFramework agent
 releaseDate: '2020-12-17'
 version: 7.2.1
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.2.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-730.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-730.mdx
@@ -1,5 +1,5 @@
 ---
-subject: XCFramework agent
+subject: iOS-XCFramework agent
 releaseDate: '2021-03-31'
 version: 7.3.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.3.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-730.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-730.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS-XCFramework agent
+subject: iOS-tvOS-watchOS-XCFramework agent
 releaseDate: '2021-03-31'
 version: 7.3.0
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.3.0.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-731.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-731.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS-XCFramework agent
+subject: iOS-tvOS-watchOS-XCFramework agent
 releaseDate: '2021-04-30'
 version: 7.3.1
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.3.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-731.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-731.mdx
@@ -1,5 +1,5 @@
 ---
-subject: XCFramework agent
+subject: iOS-XCFramework agent
 releaseDate: '2021-04-30'
 version: 7.3.1
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.3.1.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-732.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-732.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS-XCFramework agent
+subject: iOS-tvOS-watchOS-XCFramework agent
 releaseDate: '2021-06-17'
 version: 7.3.2
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.3.2.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-732.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-732.mdx
@@ -1,5 +1,5 @@
 ---
-subject: XCFramework agent
+subject: iOS-XCFramework agent
 releaseDate: '2021-06-17'
 version: 7.3.2
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.3.2.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-733.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-733.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS-XCFramework agent
+subject: iOS-tvOS-watchOS-XCFramework agent
 releaseDate: '2021-08-23'
 version: 7.3.3
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.3.3.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-733.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-733.mdx
@@ -1,5 +1,5 @@
 ---
-subject: XCFramework agent
+subject: iOS-XCFramework agent
 releaseDate: '2021-08-23'
 version: 7.3.3
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.3.3.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-734.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-734.mdx
@@ -1,5 +1,5 @@
 ---
-subject: XCFramework agent
+subject: iOS-XCFramework agent
 releaseDate: '2021-11-18'
 version: 7.3.4
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.3.4.zip'

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-734.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-734.mdx
@@ -1,5 +1,5 @@
 ---
-subject: iOS-XCFramework agent
+subject: iOS-tvOS-watchOS-XCFramework agent
 releaseDate: '2021-11-18'
 version: 7.3.4
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.3.4.zip'


### PR DESCRIPTION
This is a PR to rebrand XCFramework agent as iOS-tvOS-watchOS-XCFramework agent.