### PR TITLE
Bringing back the browser availability SLI

### DIFF
--- a/src/content/docs/service-level-management/create-slm.mdx
+++ b/src/content/docs/service-level-management/create-slm.mdx
@@ -190,6 +190,30 @@ The following SLIs are based on Google's Browser Core Web Vitals.
 <CollapserGroup>
   <Collapser
     className="freq-link"
+    id="browser-availability"
+    title="Browser app availability"
+  >
+    It’s the proportion of page views that are served without errors.
+    **Valid events fields**
+  ```
+  FROM: PageView
+  WHERE: entityGuid = '{entityGuid}'
+  ```
+    
+    Where `{entityGuid}` is the service's GUID.
+    
+    **Bad events fields**
+      
+  ```
+  FROM: JavaScriptError
+  WHERE: entityGuid = '{entityGuid}' AND firstErrorInSession IS true
+  ```  
+  Where `{entityGuid}` is the browser app GUID.
+  
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
     id="browser-contentful-paint"
     title="Browser app largest contentful paint"
   >

--- a/src/content/docs/service-level-management/create-slm.mdx
+++ b/src/content/docs/service-level-management/create-slm.mdx
@@ -193,22 +193,25 @@ The following SLIs are based on Google's Browser Core Web Vitals.
     id="browser-availability"
     title="Browser app availability"
   >
-    It’s the proportion of page views that are served without errors.
+    It's the proportion of page views that are served without errors.
+    
     **Valid events fields**
-  ```
-  FROM: PageView
-  WHERE: entityGuid = '{entityGuid}'
-  ```
+    
+    ```
+    FROM: PageView
+    WHERE: entityGuid = '{entityGuid}'
+    ```
     
     Where `{entityGuid}` is the service's GUID.
     
     **Bad events fields**
       
-  ```
-  FROM: JavaScriptError
-  WHERE: entityGuid = '{entityGuid}' AND firstErrorInSession IS true
-  ```  
-  Where `{entityGuid}` is the browser app GUID.
+    ```
+    FROM: JavaScriptError
+    WHERE: entityGuid = '{entityGuid}' AND firstErrorInSession IS true
+    ```  
+  
+    Where `{entityGuid}` is the browser app GUID.
   
   </Collapser>
 


### PR DESCRIPTION
I'm bringing back the recommended SLI for browser availability. We're including a tweak on the condition, so we only count one error per session. Otherwise, the number of errors could be higher than the number of valid requests.

