### PR TITLE
docs: fix default value for infra agent Storage sample rate

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -4495,7 +4495,7 @@ If you are having problems with proxy configuration, see [Proxy troubleshooting]
           </td>
 
           <td>
-            `5`
+            `20`
           </td>
 
           <td>


### PR DESCRIPTION
The default `metrics_storage_sample_rate` value is 20