### PR TITLE
Firehose logs: clarification on the buffer size limitation and recommendation to use gzip

### DIFF
--- a/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
+++ b/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
@@ -35,8 +35,9 @@ To forward your logs from Kinesis Data Firehose to New Relic:
   **Note**: To send your logs to the EU, complete the remaining steps in this section, then proceed to the [configuration procedures for EU accounts](#configure-eu-stream).
 
 7. Paste your [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key) in the **API key** field.
-8. Set a buffer size of `1 MiB` under `Buffer hints/Buffer size`. Note that the `Buffer hints` section is folded by default. See [the buffer settings section](#buffer-settings) for a more thorough explanation.
-9. Configure and review the remaining metadata settings.
+8. Ensure that **Content encoding** is set to `GZIP`.
+9. Set a **buffer size** of `1 MiB` under `Buffer hints/Buffer size` (note that the `Buffer hints` section is folded by default). See [the buffer settings section](#buffer-settings) for a more thorough explanation.
+10. Configure and review the remaining metadata settings.
 
 
 Any optional key/value pairs you add in the AWS Management Console will result in attribute/value pairs you can use in New Relic.
@@ -78,9 +79,9 @@ When selecting our Kinesis Firehose integration for Logs in AWS, the wizard hide
 
 ![Firehose Buffer Hints](./images/firehose-buffer-hints.png "Firehose Buffer Hints")
 
-The default values are 5 MiB for `Buffer size`, and 60 seconds for `Buffer interval`. This means that Firehose accumulates logs until either they contain 5 MiB of data, or until 60 seconds have passed since the last time they were flushed to New Relic. **These default settings are not appropriate for New Relic**, we **strongly advise to use 1 MiB as the `Buffer size`**.
+The default values are 5 MiB for `Buffer size`, and 60 seconds for `Buffer interval`. This means that Firehose accumulates logs until either they contain 5 MiB of data, or until 60 seconds have passed since the last time they were flushed to New Relic. **These default settings are not appropriate for New Relic**, we **strongly advise to use 1 MiB as the `Buffer size` and activating GZIP body compression**.
 
-Why do we recommend this? New Relic accepts at most [payloads of 1 MiB](/docs/logs/log-api/introduction-log-api/#limits) for an individual HTTP request to its Logs API. If during a given 60 second accumulation period the size of the accumulated logs exceeds 1 MiB, we will reject those logs with a `413` HTTP error.
+Why do we recommend this? New Relic accepts at most [payloads of 1 MB](/docs/logs/log-api/introduction-log-api/#limits) (1.000.000 bytes) for an individual HTTP POST request to its Logs API. If during a given 60 second accumulation period the size of the accumulated logs exceeds 1 MB, we will reject those logs with a `413` HTTP error. Note that the delivery stream allows configuring, at a minimum, a buffer size of 1 MiB (1.048.576 bytes). Despite this value is slightly greater than the 1MB allowed by the New Relic Logs API, by using GZIP compression the resulting payload becomes smaller than the 1MB limit.
 
 ## What's next? [#what-next]
 


### PR DESCRIPTION
This PR adds a small explanation on the buffer size limitation and the need to use GZIP compression to avoid having log messages coming from Firehose rejected.