### PR TITLE
feat(alerts): remove deprecated "sum of" field for nrql alert conditions

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -38,7 +38,7 @@ To create a NRQL alert condition for a policy:
 * Click **Add a condition**.
 * Under **Select a product** click **NRQL**, and then click **Next, define thresholds**.
 
-Note that editing an existing condition can result in [resetting its evaluation](#evaluation-resets). 
+Note that editing an existing condition can result in [resetting its evaluation](#evaluation-resets).
 
 ## Create a condition from a chart [#create-chart]
 
@@ -178,8 +178,8 @@ Some elements of NRQL used in charts don’t make sense in the streaming context
         `SINCE` and `UNTIL`
       </td>
       <td>
-        Example:  
-        
+        Example:
+
         ```
         SELECT percentile(largestContentfulPaint, 75) FROM PageViewTiming WHERE (appId = 837807) SINCE yesterday
         ```
@@ -255,7 +255,7 @@ Some elements of NRQL used in charts don’t make sense in the streaming context
       <td>
         The `SLIDE BY` clause supports a feature known as sliding windows. With sliding windows, `SLIDE BY` data is gathered into "windows" of time that overlap with each other. These windows can help to smooth out line graphs with a lot of variation in cases where the rolling aggregate (such as a rolling mean) is more important than aggregates from narrow windows of time.
 
-        You can enable sliding windows in the UI. When creating or editing a condition, go to **Fine-tune advanced signal settings** > **Data aggregation settings** > **Use sliding window aggregation**. 
+        You can enable sliding windows in the UI. When creating or editing a condition, go to **Fine-tune advanced signal settings** > **Data aggregation settings** > **Use sliding window aggregation**.
       </td>
     </tr>
         <tr>
@@ -365,17 +365,17 @@ Let's say this is your alert condition query:
 SELECT count(*) FROM SyntheticCheck WHERE monitorName = 'My Cool Monitor' AND result = 'FAILURE'
 ```
 If there are no failures for the aggregation window:
-1. The system will execute the `FROM` clause by grabbing all `SyntheticCheck` events on your account. 
-2. Then it will execute the `WHERE` clause to filter through those events by looking only for the ones that match the monitor name and result specified. 
-3. If there are still events left to scan through after completing the `FROM` and `WHERE` operations, the `SELECT` clause will be executed. If there are no remaining events, the `SELECT` clause will not be executed. 
+1. The system will execute the `FROM` clause by grabbing all `SyntheticCheck` events on your account.
+2. Then it will execute the `WHERE` clause to filter through those events by looking only for the ones that match the monitor name and result specified.
+3. If there are still events left to scan through after completing the `FROM` and `WHERE` operations, the `SELECT` clause will be executed. If there are no remaining events, the `SELECT` clause will not be executed.
 
-This means that aggregators like `count()` and `uniqueCount()` will never return a zero value. When there is a count of 0, the `SELECT` clause is ignored and no data is returned, resulting in a value of `NULL`. 
+This means that aggregators like `count()` and `uniqueCount()` will never return a zero value. When there is a count of 0, the `SELECT` clause is ignored and no data is returned, resulting in a value of `NULL`.
 
 ### Example: zero value returned [#example-zero]
 
-If you have a data source delivering legitimate numeric zeroes, the query will return zero values and not null values. 
+If you have a data source delivering legitimate numeric zeroes, the query will return zero values and not null values.
 
-Let's say this is your alert condition query, and that `MyCoolEvent` is an attribute that can sometimes return a zero value. 
+Let's say this is your alert condition query, and that `MyCoolEvent` is an attribute that can sometimes return a zero value.
 
 ```
 SELECT average(MyCoolAttribute) FROM MyCoolEvent
@@ -494,13 +494,13 @@ Here are some tips for creating and using a NRQL condition:
 
       <td>
         NRQL conditions evaluate data based on how it's aggregated, using aggregation windows from 30 seconds to 120 minutes, in increments of 15 seconds. For best results, we recommend using the event flow or event timer aggregation methods.
-        
+
         For the cadence aggregation method, the implicit `SINCE ... UNTIL` clause specifying which minute to evaluate is controlled by your [**delay/timer**](#time) setting. Since very recent data may be incomplete, you may want to query data from 3 minutes ago or longer, especially for:
 
         * Applications that run on multiple hosts.
         * `SyntheticCheck` data: Timeouts can take 3 minutes, so 5 minutes or more is recommended.
 
-        Also, if a query will generate intermittent data, consider using the [`sum of query results`](#sum) option.
+        Also, if a query will generate intermittent data, consider using the advanced signal [`slide by`](#sliding-window-aggregation) option.
       </td>
     </tr>
 
@@ -555,7 +555,7 @@ Here are some tips for creating and using a NRQL condition:
       </td>
 
       <td>
-        In order for a NRQL alert condition [health status display](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/view-entity-health-status-find-entities-without-alert-conditions) to function properly, use a FACET clause to scope each signal to a single entity (for example, `FACET hostname` or `FACET appname`). 
+        In order for a NRQL alert condition [health status display](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/view-entity-health-status-find-entities-without-alert-conditions) to function properly, use a FACET clause to scope each signal to a single entity (for example, `FACET hostname` or `FACET appname`).
       </td>
     </tr>
 
@@ -577,7 +577,7 @@ Here are some tips for creating and using a NRQL condition:
 ## Condition edits can reset condition evaluation [#evaluation-resets]
 
 When you edit NRQL alert conditions in some specific ways (detailed below), their evaluations are reset, meaning that any evaluation up until that point is lost, and the evaluation starts over from that point. The two ways this will affect you are:
-* For "for at least x minutes" thresholds: because the evaluation window has been reset, there will be a delay of at least x minutes before any violations can be reported. 
+* For "for at least x minutes" thresholds: because the evaluation window has been reset, there will be a delay of at least x minutes before any violations can be reported.
 * For [baseline conditions](#threshold-types): the condition starts over again and all baseline learning is lost.
 
 The following actions cause an evaluation reset for NRQL conditions:
@@ -647,16 +647,6 @@ When you create a NRQL alert, you can choose from different types of conditions:
   </tbody>
 </table>
 
-## Sum of query results (limited or intermittent data) [#sum]
-
-<Callout variant="important">
-  Available only for static (basic) condition types.
-</Callout>
-
-If a query returns intermittent or limited data, it may be difficult to set a meaningful threshold. Missing or limited data will sometimes generate false positives or false negatives. You can use loss of signal, aggregation duration, and gap filling settings to minimize these false notifications.
-
-To avoid this problem when using the static threshold type, you can set the selector to **sum of query results**. This lets you set the alert on an aggregated sum instead of a value from a single harvest cycle. Up to two hours of one-minute data checks can be aggregated. The duration you select determines the width of the rolling sum and the preview chart will update accordingly.
-
 ## Set the loss of signal threshold [#signal-loss]
 
 Loss of signal occurs when no data matches the NRQL condition over a specific period of time. You can set your loss of signal threshold duration and also what happens when the threshold is crossed.
@@ -691,7 +681,7 @@ To create a NRQL alert configured with loss of signal detection in the UI:
 2. Write a [NRQL query](/docs/alerts/new-relic-alerts/defining-conditions/create-alert-conditions-nrql-queries#syntax) that returns the values you want to alert on.
 3. For **Threshold type**, select **Static** or **Baseline**.
 4. Click **+ Add lost signal threshold**, then set the signal expiration duration time in minutes or seconds in the **Signal is lost after** field.
-5. Choose what you want to happen when the signal is lost. You can check one or both of **Close all current open violations** and **Open new "lost signal" violation**. These control how loss of signal violations will be handled for the condition. 
+5. Choose what you want to happen when the signal is lost. You can check one or both of **Close all current open violations** and **Open new "lost signal" violation**. These control how loss of signal violations will be handled for the condition.
 6. Make sure you name your condition before you save it.
 
 Violations open due to loss of signal close when


### PR DESCRIPTION
## Give us some context

We are deprecating the sum of value function field for nrql alert conditions.  [See announcement.](https://discuss.newrelic.com/t/end-of-life-for-sum-of-query-results-thresholds/176182)  So we'd like to remove the related documentation.  If users want to configure a similar option, they should use `slide by` in the advanced signal section instead.

* What problems does this PR solve? 
https://newrelic.atlassian.net/browse/AINTER-8207 

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
<img width="2542" alt="Screen Shot 2022-03-01 at 9 53 40 AM" src="https://user-images.githubusercontent.com/26093145/156238488-00419991-3c5b-4846-999c-e034b135953a.png">

https://discuss.newrelic.com/t/end-of-life-for-sum-of-query-results-thresholds/176182

* If your issue relates to an existing GitHub issue, please link to it.