### PR TITLE
chore: added Next.js to Node.js agent list of supported frameworks and included table row for logs enrichers

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -144,6 +144,7 @@ Errors resulting in unhandled rejections are not scoped to the transaction that 
 * [Hapi](https://www.npmjs.com/package/hapi)
 * [Koa](https://www.npmjs.com/package/koa) 2.0.0 or higher ([external module](https://github.com/newrelic/node-newrelic-koa) loaded with the agent)
 * [Fastify](https://www.npmjs.com/package/fastify)
+* [Next.js](https://www.npmjs.com/package/next) 12.0.9 or higher
 
 If you are using a supported framework with default routers, the Node.js agent can read these frameworks' route names as is. However, if you want more specific names than are provided by your framework, you may want to use one or more of the tools New Relic provides with the [Node.js transaction naming API](/docs/nodejs/nodejs-transaction-naming-api).
 
@@ -320,7 +321,7 @@ As a standard [security measure for data collection](/docs/accounts-partnerships
 
 ## Connect the agent to other New Relic features [#digital-intelligence-platform]
 
-The Node.js agent integrates with other features to give you observability across your entire stack: 
+The Node.js agent integrates with other features to give you observability across your entire stack:
 
 <table>
   <thead>

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs.mdx
@@ -79,6 +79,17 @@ After installing the Node.js agent, extend your instrumentation:
 
     <tr>
       <td>
+        Logs in Context
+      </td>
+
+      <td>
+        * To enrich [winston](https://github.com/winstonjs/winston) log data, use our [Winston Log Enricher](/docs/logs/logs-context/configure-logs-context-nodejs/#nodejs-winston).
+        * To enrich [pino](https://github.com/pinojs/pino) log data, use our [Pino Log Enricher](/docs/logs/logs-context/configure-logs-context-nodejs/#nodejs-pino).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         Traces
       </td>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers:
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
  * Adds Next.js to the list of supported frameworks for Node.js agent.
  * Adds a section in Node.js agent intro calling out our two log enrichers.
