### PR TITLE
fix(AWS) how-to disable metric streams

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/uninstall-infrastructure-integrations.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/uninstall-infrastructure-integrations.mdx
@@ -39,7 +39,22 @@ To uninstall any of your integrations, follow the procedure corresponding to the
       <tbody>
         <tr>
           <td id="disable-aws-integrations">
-            Disable one or more AWS service integrations
+            Disable AWS CloudWatch metric streams integration
+          </td>
+
+          <td>
+            To disable AWS CloudWatch metric streams integration:
+
+            1. From AWS Console, remove all required resources that were created during AWS integration setup. These include: AWS CloudWatch stream, AWS Kinesis Data Firehose endpoint and the AWS S3 backup bucket. If you used the AWS CloudFormation template, then follow the steps to [delete a stack on the AWS CloudFormation console](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-delete-stack.html). 
+            2. Complete step 1 for each active AWS region where you connected the AWS CloudWatch metric stream. 
+            3. From **AWS Status Dashboard** in Infrastructure > AWS, make sure no new metric updates are being ingested in New Relic.
+            4. Complete the steps to [Disconnect the AWS account](#unlink-aws).
+          </td>
+        </tr>
+
+        <tr>
+          <td id="disable-aws-integrations">
+            Disable one or more AWS polling integrations
           </td>
 
           <td>
@@ -53,7 +68,7 @@ To uninstall any of your integrations, follow the procedure corresponding to the
 
         <tr>
           <td id="unlink-aws">
-            Disable all AWS integrations
+            Disconnect AWS account
           </td>
 
           <td>


### PR DESCRIPTION
## Give us some context

* Explanations to help customers disable AWS CloudWatch metric stream integration (requires changes on their AWS account). Feedback from support cases. 