### PR TITLE
chore: remove korean locale from constants

### DIFF
--- a/scripts/actions/__tests__/add-files-to-translation-queue.test.js
+++ b/scripts/actions/__tests__/add-files-to-translation-queue.test.js
@@ -6,7 +6,7 @@ const { getLocalizedFileData } = require('../add-files-to-translation-queue');
 const MOCK_CONSTANTS = {
   LOCALE_IDS: {
     jp: 'ja-JP',
-    kr: 'ko-KR',
+    // kr: 'ko-KR',
   },
 };
 
@@ -61,7 +61,7 @@ describe('add-files-to-translation-queue tests', () => {
       const toBeTranslated = getLocalizedFileData(file);
       expect(toBeTranslated).toEqual([
         { filename: '/content/bar.mdx', locale: 'ja-JP', project_id: 'HT_ID' },
-        { filename: '/content/bar.mdx', locale: 'ko-KR', project_id: 'MT_ID' },
+        // { filename: '/content/bar.mdx', locale: 'ko-KR', project_id: 'MT_ID' },
       ]);
     });
 
@@ -73,7 +73,7 @@ describe('add-files-to-translation-queue tests', () => {
 
       expect(toBeTranslated).toEqual([
         { filename: '/content/bar.mdx', locale: 'ja-JP', project_id: 'MT_ID' },
-        { filename: '/content/bar.mdx', locale: 'ko-KR', project_id: 'MT_ID' },
+        // { filename: '/content/bar.mdx', locale: 'ko-KR', project_id: 'MT_ID' },
       ]);
     });
 
@@ -105,18 +105,18 @@ describe('add-files-to-translation-queue tests', () => {
           locale: 'ja-JP',
           project_id: 'HT_ID',
         },
-        {
-          filename: '/content/bar.mdx',
-          locale: 'ko-KR',
-          project_id: 'MT_ID',
-        },
+        // {
+        //   filename: '/content/bar.mdx',
+        //   locale: 'ko-KR',
+        //   project_id: 'MT_ID',
+        // },
       ]);
     });
 
     test('Doesnt exclude any files from translation', async () => {
       const files = [
         { filename: 'included/path/content/bar.mdx', locale: 'ja-JP' },
-        { filename: 'included/path/content/foo.mdx', locale: 'ko-KR' },
+        // { filename: 'included/path/content/foo.mdx', locale: 'ko-KR' },
       ];
       setup();
       const { excludeFiles } = require('../add-files-to-translation-queue');
@@ -125,17 +125,17 @@ describe('add-files-to-translation-queue tests', () => {
 
       expect(includedFiles).toEqual([
         { filename: 'included/path/content/bar.mdx', locale: 'ja-JP' },
-        { filename: 'included/path/content/foo.mdx', locale: 'ko-KR' },
+        // { filename: 'included/path/content/foo.mdx', locale: 'ko-KR' },
       ]);
     });
 
     test('Excludes files under a set path', async () => {
       const files = [
-        {
-          filename: 'included/path/content/bar.mdx',
-          contentType: 'doc',
-          locale: 'ko-KR',
-        },
+        // {
+        //   filename: 'included/path/content/bar.mdx',
+        //   contentType: 'doc',
+        //   locale: 'ko-KR',
+        // },
         {
           filename: 'excluded/path/content/bar.mdx',
           contentType: 'doc',
@@ -148,21 +148,21 @@ describe('add-files-to-translation-queue tests', () => {
       const includedFiles = excludeFiles(files);
 
       expect(includedFiles).toEqual([
-        {
-          filename: 'included/path/content/bar.mdx',
-          contentType: 'doc',
-          locale: 'ko-KR',
-        },
+        // {
+        //   filename: 'included/path/content/bar.mdx',
+        //   contentType: 'doc',
+        //   locale: 'ko-KR',
+        // },
       ]);
     });
 
     test('Excludes specific file types', async () => {
       const files = [
-        {
-          filename: 'included/path/content/bar.mdx',
-          contentType: 'excludedType',
-          locale: 'ko-KR',
-        },
+        // {
+        //   filename: 'included/path/content/bar.mdx',
+        //   contentType: 'excludedType',
+        //   locale: 'ko-KR',
+        // },
         {
           filename: 'included/path/content/bar.mdx',
           contentType: 'doc',
@@ -185,11 +185,11 @@ describe('add-files-to-translation-queue tests', () => {
 
     test('Excludes files and file types under a set path', async () => {
       const files = [
-        {
-          filename: 'included/path/content/bar.mdx',
-          contentType: 'doc',
-          locale: 'ko-KR',
-        },
+        // {
+        //   filename: 'included/path/content/bar.mdx',
+        //   contentType: 'doc',
+        //   locale: 'ko-KR',
+        // },
         {
           filename: 'included/path/content/bar.mdx',
           contentType: 'excludedType',
@@ -207,11 +207,11 @@ describe('add-files-to-translation-queue tests', () => {
       const includedFiles = excludeFiles(files);
 
       expect(includedFiles).toEqual([
-        {
-          filename: 'included/path/content/bar.mdx',
-          contentType: 'doc',
-          locale: 'ko-KR',
-        },
+        // {
+        //   filename: 'included/path/content/bar.mdx',
+        //   contentType: 'doc',
+        //   locale: 'ko-KR',
+        // },
       ]);
     });
   });

--- a/scripts/actions/utils/constants.js
+++ b/scripts/actions/utils/constants.js
@@ -1,7 +1,7 @@
 // This should be in the format {localeKey: locale} across scripts
 const LOCALE_IDS = {
   jp: 'ja-JP',
-  kr: 'ko-KR',
+  // kr: 'ko-KR',
 };
 
 const EXCLUSIONS_FILE =


### PR DESCRIPTION
* temporarily removing korean locale from constants. This value being
set means that we've been queueing up korean translation requests &
sending them to the vendor, despite not being ready / intending to do
so.

we will re-set this value as part of https://github.com/newrelic/docs-website/pull/6367