### PR TITLE
Logs API: updates about attribute types

### DIFF
--- a/src/content/docs/logs/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-api/introduction-log-api.mdx
@@ -124,7 +124,7 @@ Pass your license key by adding a custom HTTP header as described below:
       </td>
 
       <td>
-        A New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key). You can also [send this via query parameter](#query-parameters). 
+        A New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key). You can also [send this via query parameter](#query-parameters).
       </td>
     </tr>
 
@@ -228,11 +228,11 @@ You can send your JSON message using either a simplified or detailed set of attr
           </td>
 
           <td>
-            String
+            (any -- but String is recommended. See the [list of supported attribute types](#supported-types))
           </td>
 
           <td>
-            any string
+            any
           </td>
 
           <td>
@@ -268,17 +268,15 @@ You can send your JSON message using either a simplified or detailed set of attr
 
         <tr>
           <td>
-            `other_fields`
-
-            (must not contain white space)
+            Other fields
           </td>
 
           <td>
-            String
+            (any -- see the [list of supported attribute types](#supported-types))
           </td>
 
           <td>
-            any string
+            any
           </td>
 
           <td>
@@ -287,8 +285,6 @@ You can send your JSON message using either a simplified or detailed set of attr
 
           <td>
             These will become attributes of the log message.
-
-            Note: Log management does not support white space in attribute names.
           </td>
         </tr>
       </tbody>
@@ -377,6 +373,84 @@ You can send your JSON message using either a simplified or detailed set of attr
   </Collapser>
 </CollapserGroup>
 
+## Supported attribute types [#supported-types]
+
+Attributes may be of any of the following types:
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        Type in the JSON request
+      </th>
+      <th>
+        Type stored in the New Relic database
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `boolean`
+      </td>
+      <td>
+        `boolean`
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `integer`
+      </td>
+      <td>
+        `integer`
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `long`
+      </td>
+      <td>
+        `long`
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `float`
+      </td>
+      <td>
+        `float`
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `double`
+      </td>
+      <td>
+        `double`
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `string`
+      </td>
+      <td>
+        `string` (Note that if a string value is stringified JSON, it will be parsed and its fields
+         extracted as variables. See [JSON message attribute parsing](#message-attribute-parsin))
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Array
+      </td>
+      <td>
+        (unsupported)
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+
 ## Limits and restricted characters [#limits]
 
 <Callout variant="caution">
@@ -440,10 +514,6 @@ Exceeding rate limits affects how the Log API behaves. Follow these instructions
 ### Log payload format [#payload-format]
 
 We accept any valid JSON payload. The payload must encoded as **UTF-8**.
-
-<Callout variant="important">
-  Log management does not support white space in attribute names. For example, `{"Sample Attribute": "Value"}` would cause errors.
-</Callout>
 
 ## JSON message attributes [#attributes]
 
@@ -610,11 +680,11 @@ We accept any valid JSON payload. The payload must encoded as **UTF-8**.
           </td>
 
           <td>
-            String
+            (any -- but String is recommended. See the [list of supported attribute types](#supported-types))
           </td>
 
           <td>
-            (any string)
+            (any)
           </td>
 
           <td>
@@ -700,10 +770,6 @@ We accept any valid JSON payload. The payload must encoded as **UTF-8**.
 ## JSON message attribute parsing [#message-attribute-parsin]
 
 Our log management capabilities will parse any `message` attribute as JSON. The resulting JSON attributes in the parsed message will be added to the event. If the `message` attribute is not JSON, it is left as is.
-
-<Callout variant="important">
-  White space in an attribute name is not supported. For example, `{"Sample Attribute": "Value"}` would cause errors. Instead, use something like `{"Sample_Attribute":"Value"}`.
-</Callout>
 
 Here is an example `message` attribute:
 


### PR DESCRIPTION
- We support any value type for most attributes, updating text to reflect that
- Listing out supported value types
- Removing a now-obsolete restriction that attribute names not have space characters

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* Just something we noticed while investigating the data types we support