### PR TITLE
style(npm): Tweak indents for manual setup

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -215,10 +215,10 @@ Our NPM container supports all major versions of SNMP (v1, v2c, and v3). Additio
 
 3. Edit the `snmp-base.yaml` file and define the `discovery.cidrs` and `discovery.default_communities` attributes to appropriate values for your network.
 
-<Callout variant="tip">
-  It's recommended to set `discovery.add_mibs: true` to automate the addition of
-  all discovered MIBs into the `global.mibs_enabled` attribute
-</Callout>
+  <Callout variant="tip">
+    It's recommended to set `discovery.add_mibs: true` to automate the addition of
+    all discovered MIBs into the `global.mibs_enabled` attribute
+  </Callout>
 
 4. Launch a short-lived container to execute discovery by running
   ```shell
@@ -231,14 +231,14 @@ Our NPM container supports all major versions of SNMP (v1, v2c, and v3). Additio
       -snmp_discovery=true
   ```
 
-After the discovery run finishes, you should see an output similar to the following:
+  After the discovery run finishes, you should see an output similar to the following:
 
-```shell
->[Info] KTranslate Adding 3 new snmp devices to the config, 0 replaced from 3
-# In this example, the discovery run found 3 new SNMP devices.
-```
+  ```shell
+  >[Info] KTranslate Adding 3 new snmp devices to the config, 0 replaced from 3
+  # In this example, the discovery run found 3 new SNMP devices.
+  ```
 
-The discovered devices are listed in the `snmp-base.yaml` file's `devices.{}` section. By default, only the `IF-MIB` mib is polled. You can manually add other mibs to the `global.mibs_enabled` attribute if you did not set `discovery.add_mibs: true` before running the discovery.
+  The discovered devices are listed in the `snmp-base.yaml` file's `devices.{}` section. By default, only the `IF-MIB` mib is polled. You can manually add other mibs to the `global.mibs_enabled` attribute if you did not set `discovery.add_mibs: true` before running the discovery.
 
 5. Run `ktranslate` to poll target devices by running:
   ```shell

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -171,7 +171,7 @@ Our NPM container supports all major versions of SNMP (v1, v2c, and v3). Additio
 </table>
 
 <Callout variant="tip">
-  We recommend using read-only community strings/authentication with SNMP
+  We recommend using read-only community strings/authentication with SNMP.
 </Callout>
 
 ## Set up SNMP data monitoring in New Relic One [#setup-snmp-monitoring]
@@ -216,8 +216,7 @@ Our NPM container supports all major versions of SNMP (v1, v2c, and v3). Additio
 3. Edit the `snmp-base.yaml` file and define the `discovery.cidrs` and `discovery.default_communities` attributes to appropriate values for your network.
 
   <Callout variant="tip">
-    It's recommended to set `discovery.add_mibs: true` to automate the addition of
-    all discovered MIBs into the `global.mibs_enabled` attribute
+    We recommend to set `discovery.add_mibs: true` to automate the addition of all discovered MIBs into the `global.mibs_enabled` attribute.
   </Callout>
 
 4. Launch a short-lived container to execute discovery by running
@@ -237,7 +236,7 @@ Our NPM container supports all major versions of SNMP (v1, v2c, and v3). Additio
   >[Info] KTranslate Adding 3 new snmp devices to the config, 0 replaced from 3
   # In this example, the discovery run found 3 new SNMP devices.
   ```
-
+  
   The discovered devices are listed in the `snmp-base.yaml` file's `devices.{}` section. By default, only the `IF-MIB` mib is polled. You can manually add other mibs to the `global.mibs_enabled` attribute if you did not set `discovery.add_mibs: true` before running the discovery.
 
 5. Run `ktranslate` to poll target devices by running:


### PR DESCRIPTION
Fix a few indents to improve manual setup appearance

Link to doc on preview build: https://docswebsitedevelop-austinschaeferpatch348271.gtsb.io/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring