### PR TITLE
Cloud: Moving uninstall instructions

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic.mdx
@@ -171,30 +171,46 @@ You can [disable any of your GCP integrations](/docs/infrastructure/new-relic-in
   <tbody>
     <tr>
       <td>
-        Disable a GCP service monitoring
+        Disable one or more GCP service integrations
       </td>
 
       <td>
-        To disconnect individual GCP services but keep the integration with New Relic for other GCP services in your Google account:
+        To disable services while keeping your GCP account linked to New Relic:
 
-        1. Go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure > GCP** and select **Manage services**.
-        2. From your GCP account page, make changes to the checkbox options for available services and select **Save changes**.
+        1. From **[one.newrelic.com](http://one.newrelic.com) > Infrastructure > GCP** **> Manage services**.
+        2. From your **Edit GCP account** page, clear the checkbox for each active service you want to disable.
+        3. Save your changes.
       </td>
     </tr>
 
     <tr>
       <td>
-        Unlink your project monitoring
+        Disable all GCP integrations and unlink your project monitoring
       </td>
 
       <td>
-        To uninstall all of your GCP services completely from New Relic Integrations, unlink your Google account:
+        To disconnect your GCP account completely from New Relic, you need to unlink your GCP account. This disables all New Relic integrations associated with that GCP account.
 
-        1. Go to [**one.newrelic.com**](https://one.newrelic.com) **> Infrastructure > GCP** and select **Manage services**.
-        2. From your GCP account page, select **Unlink account** and select **Save changes**.
+        If you registered the GCP project using a **User account**, follow these steps.
+
+        1. Go to **[one.newrelic.com](http://one.newrelic.com) > Infrastructure > GCP** **> Manage services**.
+        2. From your **Edit GCP account** page, select **Unlink this account**.
+        3. Save your changes.
+
+        If you registered the GCP project using a **Service account**, follow these steps. If you are deleting a custom role, be aware that this role may be used for other purposes besides New Relic access.
+
+        1. Sign in to New Relic and go to **Infrastructure > Integrations > Google Cloud Platform**.
+        2. For a standard (non-custom) user role, select **Manage Services** for the account you want to remove. Copy the value of **User** and save it.
+
+        OR
+
+        For a custom user role, go to **IAM > admin > Roles**, search for the role, select it, and select **DELETE**. You are now finished and can skip the remaining steps.
+        3. Standard (non-custom) user role: Sign in to [Google Cloud](https://console.cloud.google.com/) and select the correct project in the **Select a project** box.
+        4. From the navigation menu, select **IAM & admin > IAM**.
+        5. Search for and select the user value you saved, then select **REMOVE**.
       </td>
     </tr>
-
+    
     <tr>
       <td>
         Clean your GCP Projects after unlinking New Relic

--- a/src/content/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/uninstall-infrastructure-integrations.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/uninstall-infrastructure-integrations.mdx
@@ -10,7 +10,7 @@ redirects:
   - /docs/infrastructure/install-configure-infrastructure/update-or-uninstall/uninstall-integrations
 ---
 
-[Uninstalling the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/installation/uninstall-infrastructure-agent-or-integrations) does not directly affect any of your [infrastructure Integrations](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure): if you uninstall the agent, your integrations will remain. Similarly, if you [disable or uninstall your integrations](#uninstall-integrations), the infrastructure agent will remain.
+[Uninstalling the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/installation/uninstall-infrastructure-agent-or-integrations) does not directly affect any of your [infrastructure integrations](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure): If you uninstall the agent, your integrations will remain. Similarly, if you [disable or uninstall your integrations](#uninstall-integrations), the infrastructure agent will remain.
 
 To uninstall any of your integrations, follow the procedure corresponding to the type of integration.
 
@@ -139,68 +139,6 @@ To uninstall any of your integrations, follow the procedure corresponding to the
     </table>
   </Collapser>
 
-  <Collapser
-    id="uninstall-gcp"
-    title="Google Cloud Platform (GCP)"
-  >
-    <table>
-      <thead>
-        <tr>
-          <th style={{ width: "250px" }}>
-            **If you want to...**
-          </th>
-
-          <th>
-            **Do this**
-          </th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr>
-          <td id="disable-gcp-integrations">
-            Disable one or more GCP service integrations
-          </td>
-
-          <td>
-            To disable services while keeping your GCP account linked to New Relic:
-
-            1. From **[one.newrelic.com](http://one.newrelic.com) > Infrastructure > GCP** **> Manage services**.
-            2. From your **Edit GCP account** page, clear the checkbox for each active service you want to disable.
-            3. Save your changes.
-          </td>
-        </tr>
-
-        <tr>
-          <td id="unlink-gcp">
-            Disable all GCP integrations
-          </td>
-
-          <td>
-            To disconnect your GCP account completely from New Relic, you need to unlink your GCP account. This disables all New Relic integrations associated with that GCP account.
-
-            If you registered the GCP project using a **User account**, follow these steps.
-
-            1. Go to **[one.newrelic.com](http://one.newrelic.com) > Infrastructure > GCP** **> Manage services**.
-            2. From your **Edit GCP account** page, select **Unlink this account**.
-            3. Save your changes.
-
-            If you registered the GCP project using a **Service account**, follow these steps. If you are deleting a custom role, be aware that this role may be used for other purposes besides New Relic access.
-
-            1. Sign in to New Relic and go to **Infrastructure > Integrations > Google Cloud Platform**.
-            2. For a standard (non-custom) user role, select **Manage Services** for the account you want to remove. Copy the value of **User** and save it.
-
-               OR
-
-               For a custom user role, go to **IAM > admin > Roles**, search for the role, select it, and select **DELETE**. You are now finished and can skip the remaining steps.
-            3. Standard (non-custom) user role: Sign in to [Google Cloud](https://console.cloud.google.com/) and select the correct project in the **Select a project** box.
-            4. From the navigation menu, select **IAM & admin > IAM**.
-            5. Search for and select the user value you saved, then select **REMOVE**.
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </Collapser>
 </CollapserGroup>
 
 ## On-host integrations [#uninstall-on-host]


### PR DESCRIPTION
As requested by @josemore.

This commit removes GCP. 