### PR TITLE
fix(azure): note about 2-years secret expiration

### DIFF
--- a/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations.mdx
@@ -76,7 +76,7 @@ To register your app in Azure:
 To create a client secret associated with your application:
 
 1. In Azure, under the application you've just created, select **Certificates & secrets**.
-2. Under **Client secrets**, click on **New client secret** and then on **Add**.
+2. Under **Client secrets**, click on **New client secret** and then on **Add**. Choose the secret expiration date which can be up to 2 years. Once the secret expires, follow the steps to [update the application details](#update-app).
 3. Copy the value of **Client Secret** and save it for later use.
 
 ## Step 4: Provide permissions to services [#read-permissions]
@@ -107,7 +107,7 @@ To add your Azure app to New Relic:
 
 ## Update application details and rotate client secrets [#update-app]
 
-It's possible to update the application's name and authentication credentials using the Infrastructure UI or the [Cloud Integrations API](/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial/) at any time. 
+It will be required to update the application's authentication credentials using the Infrastructure UI or the [Cloud Integrations API](/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial/) once the client secret expires (maximum expiration date available in Azure is 2 years). 
 
 Follow these steps to rotate the Azure client secret in the Infratructure UI:
 1. Go to [**one.newrelic.com**](http://one.newrelic.com) **> Infrastructure > Azure** and click on **Manage Services** on the Azure account you wish to edit.


### PR DESCRIPTION
## Give us some context

* Azure application client secrets can now only be defined with an expiration of 2-years (previously, the "Never" option was available and recommended). Updated with a note explaining how to rotate the secret in the UI or API. 