### PR TITLE
Update the log4j security security bulletin to reference newer versions of the agent

### DIFF
--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-03.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-03.mdx
@@ -10,13 +10,13 @@ metaDescription: 'Apache Log4j CVE-2021-44228, Security Bulletin NR21-03 (Java)'
 
 **Versions affected:** All agent versions between (a) 4.12.0 and 6.5.1; and (b) 7.0.0 and 7.4.1
 
-**Fix versions:** 6.5.2, 6.5.3, 7.4.2, and 7.4.3
+**Fix versions:** 6.5.2, 6.5.3, 6.5.4, 7.4.2, 7.4.3 and 7.5.0
 
 **Vulnerability identifier:** NR21-03
 
-We have determined that the new vulnerability identified (CVE-2021-44832) does NOT affect New Relic's Java Agent, unless an additional attack vector would allow write permissions to the host system. In light of this finding, we have determined that no new Agent releases are needed to specifically mitigate this issue. Nonetheless, as part of its next planned release in January, the New Relic Java Agent will use the latest Apache version of log4j (currently version 2.17.1, which patches CVE-2021-44832).
+We have determined that the new vulnerability identified (CVE-2021-44832) does NOT affect New Relic's Java Agent, unless an additional attack vector would allow write permissions to the host system. Nonetheless, newer versions of the New Relic Java Agent will use the latest Apache versions of log4j (currently versions 2.17.1 (Java 8) and 2.12.4 (Java 7), which patches CVE-2021-44832).
 
-We have also determined that New Relic's Java Agent is NOT vulnerable to either CVE-2021-45046 or CVE-2021-45105. This is because the agent's use of log4j sits behind a wrapper interface that does not use or support Thread Context Map input data, a required aspect of the vulnerability. However, we recommend updating to at least the 6.5.2 or 7.4.2 release to ensure comprehensive protection against CVE-2021-44228.
+We have also determined that New Relic's Java Agent is NOT vulnerable to either CVE-2021-45046 or CVE-2021-45105. This is because the agent's use of log4j sits behind a wrapper interface that does not use or support Thread Context Map input data, a required aspect of the vulnerability. However, we recommend updating to *at least* the 6.5.2 or 7.4.2 release to ensure comprehensive protection against CVE-2021-44228.
 
 As new versions of log4j become available, we will continue to release new versions of the agent.
 
@@ -58,6 +58,14 @@ As new versions of log4j become available, we will continue to release new versi
     </tr>
     <tr>
       <td>
+        6.5.4
+      </td>
+      <td>
+        2.12.4
+      </td>
+    </tr>
+    <tr>
+      <td>
         7.4.1
       </td>
       <td>
@@ -78,6 +86,14 @@ As new versions of log4j become available, we will continue to release new versi
       </td>
       <td>
         2.17.0
+      </td>
+    </tr>
+    <tr>
+      <td>
+        7.5.0+
+      </td>
+      <td>
+        2.17.1
       </td>
     </tr>
     </tbody>
@@ -166,13 +182,16 @@ The above step will remediate your New Relic Java agent only. You may also need 
     title="I've updated to 6.5.1 or 7.4.1 already, do I need to update again?"
   >
 
-  If you have already upgraded to agent versions 6.5.1 or 7.4.1, we recommend also disabling agent logging, as the fix for CVE-2021-44228 was incomplete in log4j v2.15.0. We recommend updating to at least the Java Agent 6.5.2 or 7.4.2 release to ensure comprehensive protection against this critical vulnerability.  While we have released newer Java Agents with log4j 2.17.0, we have determined that updating to 6.5.3 or 7.4.3 is not critical as New Relic's Java Agent is not susceptible to either CVE-2021-45046 or CVE-2021-45105. 
+  If you have already upgraded to agent versions 6.5.1 or 7.4.1, we recommend also disabling agent logging, as the fix for CVE-2021-44228 was incomplete in log4j v2.15.0. We recommend updating to at least the Java Agent 6.5.2 or 7.4.2 release to ensure comprehensive protection against this critical vulnerability.  While we have released newer Java Agents with log4j 2.17.1 (Java 8) and 2.12.4 (Java 7), we have determined that updating to 6.5.3+ or 7.4.3+ is not critical as New Relic's Java Agent is not susceptible to either CVE-2021-45046 or CVE-2021-45105. 
 
   </Collapser>
 
 </CollapserGroup>
 
 ## Publication history [#pub-history]
+
+* March 3, 2022: NR21-03 Revision:
+  * Updated references to Java agent versions 6.5.4 & 7.5.0
 
 * December 29, 2021: NR21-03 Revision:
   * Updated to reflect agent findings on CVE-2021-44832


### PR DESCRIPTION
Included references to 6.5.4 and 7.5.0+ versions of the Java agent. Please WAIT until we confirm that 6.5.4 has been published (will be later on 3/3) before these changes go live