### PR TITLE
Update generating-logs-troubleshooting-php.mdx

### DIFF
--- a/src/content/docs/apm/agents/php-agent/troubleshooting/generating-logs-troubleshooting-php.mdx
+++ b/src/content/docs/apm/agents/php-agent/troubleshooting/generating-logs-troubleshooting-php.mdx
@@ -25,13 +25,13 @@ Monitoring your New Relic logs may help diagnose the problem. The New Relic PHP 
 1. Check both logs for content:
    * **[Default agent log location](/docs/php/php-agent-phpini-settings#inivar-logfile)**: `/var/log/newrelic/php_agent.log`
    * **[Default daemon log location](/docs/php/php-agent-phpini-settings#inivar-daemon-logfile)**: `/var/log/newrelic/newrelic-daemon.log`
-2. Set the log level for each to `verbosedebug` for more information:
-   * [Setting the agent **loglevel**](/docs/php/php-agent-phpini-settings#inivar-loglevel)
-   * [Setting the daemon **loglevel**](/docs/php/php-agent-phpini-settings#inivar-daemon-loglevel)
+2. Set the log level for the agent to `verbosedebug` and set the log level for the daemon to `debug`. For more information:
+   * [Setting the agent **loglevel** to **verbosedebug**](https://docs.newrelic.com/docs/apm/agents/php-agent/configuration/php-agent-configuration/#inivar-loglevel)
+   * [Setting the daemon **loglevel** to **debug**](https://docs.newrelic.com/docs/apm/agents/php-agent/configuration/php-agent-configuration/#inivar-daemon-loglevel)
 3. Restart your app.
-4. Collect 5 to 10 minutes of log time with your log level set to `verbosedebug`.
+4. Collect 5 to 10 minutes of log time with your log level set to the appropriate values.
 5. Examine your logs and use the information to diagnose the problem.
-6. When you are finished troubleshooting, reset the logs' levels. Do not keep them at `verbosedebug`.
+6. When you are finished troubleshooting, reset the logs' levels. Do not keep them at `verbosedebug` or `debug`.
 
 <Callout variant="caution">
   Watch the size of your log files. Depending on your application, they can grow very quickly.


### PR DESCRIPTION
verbosedebug is deprecated for the daemon specifically as noted [here](https://docs.newrelic.com/docs/apm/agents/php-agent/configuration/php-agent-configuration/#inivar-daemon-loglevel) and [here](https://github.com/newrelic/newrelic-php-agent/blob/3f93ee47f80703d46d8fccd53be7d6b80361a594/src/newrelic/log/log.go#L204). Updated docs to use debug, and fixed link to daemon log config.

verbosedebug is still valid for the agent log level.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.