### PR TITLE
fix(apm/php-agent) Announce RHEL 5 EoSL in system requirements

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -79,7 +79,12 @@ For any installation, you will need your New Relic [license key](/docs/subscript
           </Callout>
 
         * AWS Linux 2
-        * Red Hat Enterprise Linux (RHEL) 5 or higher
+        * Red Hat Enterprise Linux (RHEL) 6 or higher
+
+          <Callout variant="important">
+            As of January 2021, we're discontinuing support for Red Hat Enterprise Linux (RHEL) 5. For more information, see our [PHP agent release notes v9.15.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293) and our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-across-browser-php-python-mobile-and-android-agents/123951).
+          </Callout>
+
         * CentOS 6 or higher
 
           <Callout variant="important">

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -82,13 +82,13 @@ For any installation, you will need your New Relic [license key](/docs/subscript
         * Red Hat Enterprise Linux (RHEL) 6 or higher
 
           <Callout variant="important">
-            As of January 2021, we're discontinuing support for Red Hat Enterprise Linux (RHEL) 5. For more information, see our [PHP agent release notes v9.15.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293) and our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-across-browser-php-python-mobile-and-android-agents/123951).
+            As of January 2021, we discontinued support for Red Hat Enterprise Linux (RHEL) 5. For more information, see our [PHP agent release notes v9.15.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293) and our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-across-browser-php-python-mobile-and-android-agents/123951).
           </Callout>
 
         * CentOS 6 or higher
 
           <Callout variant="important">
-            As of January 2021, we're discontinuing support for CentOS 5. For more information, see our [PHP agent release notes v9.15.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293) and our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-across-browser-php-python-mobile-and-android-agents/123951).
+            As of January 2021, we discontinued support for CentOS 5. For more information, see our [PHP agent release notes v9.15.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293) and our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-across-browser-php-python-mobile-and-android-agents/123951).
           </Callout>
 
         * Debian 7.0 ("wheezy") or higher


### PR DESCRIPTION
## PHP agent compatibility and requirements update

When CentOS 5 End of Service Life (EoSL) was announced, the same announcement should be made about Red Hat Enterprise Linux (RHEL) 5. This PR fixes this inconsistency.