### PR TITLE
fix(user type table): edit to alert/AI

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -167,19 +167,6 @@ Here's a detailed comparison of capabilities by user type. For tips on why you'd
 
      <tr>
           <td>
-            [Alerts](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts) and [applied intelligence](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence)<sup>1</sup>
-          </td>
-
-          <td style="text-align:center">Get notifications & resolve incidents</td>
-          <td style="text-align:center">Get notifications & resolve incidents</td>
-          <td style="text-align:center"><Icon
-              style={{color: '#328787'}}
-              name="fe-check"
-            /></td>
-        </tr>
-
-     <tr>
-          <td>
             [Log management](/docs/logs/get-started/get-started-log-management)<sup>1</sup>
           </td>
 
@@ -210,6 +197,19 @@ Here's a detailed comparison of capabilities by user type. For tips on why you'd
 
      <tr>
           <td>
+            [Alerts](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts) and [applied intelligence](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence)
+          </td>
+
+          <td style="text-align:center">Setup, notifications, and resolution<sup>1</sup></td>
+          <td style="text-align:center">Setup, notifications, and resolution<sup>1</sup></td>
+          <td style="text-align:center"><Icon
+              style={{color: '#328787'}}
+              name="fe-check"
+            /></td>
+        </tr>
+
+     <tr>
+          <td>
             [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts) with [Lookout](/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-lookout-monitor-your-estate-glance) and [Navigator](/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts/#view-navigator) 
           </td>
 
@@ -223,6 +223,7 @@ Here's a detailed comparison of capabilities by user type. For tips on why you'd
               name="fe-check"
             /></td>
         </tr>
+
 
      <tr>
           <td>
@@ -458,6 +459,30 @@ Here are more details about how user type impacts access to applied intelligence
       <tbody>
         <tr>
           <td>
+            Set up [alert conditions and policies](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/alerts-concepts-workflow)
+          </td>
+
+          <td style="text-align:center">
+            <Icon
+              style={{color: '#328787'}}
+              name="fe-check"
+            />
+          </td>
+          <td style="text-align:center">
+            <Icon
+              style={{color: '#328787'}}
+              name="fe-check"
+            />
+          </td>
+          <td style="text-align:center">
+            <Icon
+              style={{color: '#328787'}}
+              name="fe-check"
+            />
+          </td>
+        </tr>
+        <tr>
+          <td>
             Acknowledge and resolve issues
           </td>
 
@@ -483,7 +508,12 @@ Here are more details about how user type impacts access to applied intelligence
 
         <tr>
           <td>
-            Root cause analysis
+Access to higher-level [applied intelligence](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence) features, including: 
+* Root cause analysis            
+* Incident/anomaly analysis
+* Correlation assistant
+* Issue maps
+* Machine learning classification 
           </td>
           <td style="text-align:center">
           </td> 
@@ -495,72 +525,8 @@ Here are more details about how user type impacts access to applied intelligence
               name="fe-check"
             />
           </td>
-         
         </tr>
 
-        <tr>
-          <td>
-            Incident/anomaly analysis
-          </td>
-          <td style="text-align:center">
-          </td> 
-          <td style="text-align:center">
-          </td> 
-          <td style="text-align:center">
-            <Icon
-              style={{color: '#328787'}}
-              name="fe-check"
-            />
-          </td>
-
-        </tr>
-
-        <tr>
-          <td>
-            Correlation assistant
-          </td>
-          <td style="text-align:center">
-          </td> 
-          <td style="text-align:center">
-          </td> 
-          <td style="text-align:center">
-            <Icon
-              style={{color: '#328787'}}
-              name="fe-check"
-            />
-          </td>        
-        </tr>
-
-        <tr>
-          <td>
-            Issue maps
-          </td>
-          <td style="text-align:center">
-          </td> 
-          <td style="text-align:center">
-          </td> 
-          <td style="text-align:center">
-            <Icon
-              style={{color: '#328787'}}
-              name="fe-check"
-            />
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Machine learning classification
-          </td>
-          <td style="text-align:center">
-          </td> 
-          <td style="text-align:center">
-          </td> 
-          <td style="text-align:center">
-            <Icon
-              style={{color: '#328787'}}
-              name="fe-check"
-            />
-          </td>          
-        </tr>
       </tbody>
     </table>  
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -197,11 +197,11 @@ Here's a detailed comparison of capabilities by user type. For tips on why you'd
 
      <tr>
           <td>
-            [Alerts](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts) and [applied intelligence](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence)
+            [Alerts](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts) and [applied intelligence](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence)<sup>1</sup>
           </td>
 
-          <td style="text-align:center">Setup, notifications, and resolution<sup>1</sup></td>
-          <td style="text-align:center">Setup, notifications, and resolution<sup>1</sup></td>
+          <td style="text-align:center">Setup, get notifications, resolve incidents</td>
+          <td style="text-align:center">Setup, get notifications, resolve incidents</td>
           <td style="text-align:center"><Icon
               style={{color: '#328787'}}
               name="fe-check"
@@ -432,11 +432,24 @@ Here's a detailed comparison of capabilities by user type. For tips on why you'd
 <CollapserGroup>
 
   <Collapser
+    id="logs-capabilities"
+    title="Log management capabilities"
+  >
+<Callout variant="important">
+On January 12, 2022, basic users had some log management capabilities removed. Their current capabilities are described below. 
+</Callout>
+
+Log-related capabilities: 
+* **Basic users** can view and search the [log management UI](/docs/logs/get-started/get-started-log-management).
+* **Core users** and **full platform users** have access to all [log management UI features](/docs/logs/ui-data/use-logs-ui) and configuration capabilities, and can see [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents) for the UI experiences they have access to (for example, core users can see applicable log data in the errors inbox UI).
+
+</Collapser>  
+  <Collapser
     id="ai-capabilities"
-    title="Applied intelligence capabilities"
+    title="Alerts and applied intelligence capabilities"
   >
 
-Here are more details about how user type impacts access to applied intelligence features: 
+Here are more details about how user type impacts access to alerting and applied intelligence features: 
 
     <table>
       <thead>
@@ -530,21 +543,7 @@ Access to higher-level [applied intelligence](/docs/alerts-applied-intelligence/
       </tbody>
     </table>  
 
-</Collapser>  
-
-  <Collapser
-    id="logs-capabilities"
-    title="Log management capabilities"
-  >
-<Callout variant="important">
-On January 12, 2022, basic users had some log management capabilities removed. Their current capabilities are described below. 
-</Callout>
-
-Log-related capabilities: 
-* **Basic users** can view and search the [log management UI](/docs/logs/get-started/get-started-log-management).
-* **Core users** and **full platform users** have access to all [log management UI features](/docs/logs/ui-data/use-logs-ui) and configuration capabilities, and can see [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents) for the UI experiences they have access to (for example, core users can see applicable log data in the errors inbox UI).
-
-</Collapser>  
+</Collapser>    
 
 </CollapserGroup>
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -197,12 +197,20 @@ Here's a detailed comparison of capabilities by user type. For tips on why you'd
 
      <tr>
           <td>
-            [Alerts](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts) and [applied intelligence](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence)<sup>1</sup>
+            [Alerts](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts) and [applied intelligence](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence)
           </td>
 
-          <td style="text-align:center">Setup, get notifications, resolve incidents</td>
-          <td style="text-align:center">Setup, get notifications, resolve incidents</td>
           <td style="text-align:center"><Icon
+              style={{color: '#328787'}}
+              name="fe-check"
+            />
+            (not advanced features<sup>1</sup>)</td>
+          <td style="text-align:center"><Icon
+              style={{color: '#328787'}}
+              name="fe-check"
+            />
+            (not advanced features<sup>1</sup>)</td>          
+            <td style="text-align:center"><Icon
               style={{color: '#328787'}}
               name="fe-check"
             /></td>
@@ -472,7 +480,7 @@ Here are more details about how user type impacts access to alerting and applied
       <tbody>
         <tr>
           <td>
-            Set up [alert conditions and policies](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/alerts-concepts-workflow)
+            Set up [alert conditions](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/alerts-concepts-workflow), correlation decisions, and notifications 
           </td>
 
           <td style="text-align:center">


### PR DESCRIPTION
Work done: 
Made it more clear that basic users and core users have access to a lot of alerting & AI functionality. Clarified how it works in the footnote from the 'alerts and ai' entry in table. 