### PR TITLE
fix(infra-agent): Debian 8 EOL reached

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -71,7 +71,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        Version 8 ("Jessie") or higher
+        Version 9 ("Stretch") or higher
       </td>
     </tr>
 


### PR DESCRIPTION
## Give us some context

* We cannot support OS beyond the manufacturer EOL. Debian 8 LTS ended Jun-30-2020.  