### PR TITLE
docs(servicelevels): Fix typo in service levels release notes

### DIFF
--- a/src/content/docs/release-notes/service-levels-release-notes/service-levels-20220225.mdx
+++ b/src/content/docs/release-notes/service-levels-release-notes/service-levels-20220225.mdx
@@ -36,7 +36,7 @@ New Relic will execute an **automatic migration** to adapt the existing SLIs and
 
 * Those SLIs that had more than one SLO with the same target and different periods (for example, 99.0% for 7 days and 99% for 28 days) will keep just one SLO with the same target, adopting the longest period.
 * Those SLIs that had different SLO targets will be split into different SLIs. 
-* The very few SLIs that didn't have any SLO configured will be assigned an SLO with a 99.0% target for a period of 7 days.
+* The very few SLIs that didn't have any SLO configured will be assigned an SLO with a 95.0% target for a period of 7 days.
 * SLIs with one SLO won't be modified.
 
 Any charts that you've added to a dashboard will continue to work. 


### PR DESCRIPTION
Fix typo in the service levels release note "service-levels-20220225".