### PR TITLE
Add attribute limits info

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts.mdx
@@ -75,6 +75,13 @@ All OpenTelemetry SDKs and Collectors provide a `BatchProcessor`, which batches 
 
 New Relic supports gzip compression for OTLP payloads transported via gRPC or HTTP. The maximum allowed payload size is 1MB (10^6 bytes). To maximize the amount of data you can send per request, we recommend enabling compression in all OTLP exporters. If there are other compression formats you'd like to see us support, please let us know in the [CNCF Slack channel](https://cloud-native.slack.com/archives/C024DRQ63UP).
 
+## Attribute lengths [#attribute-lengths]
+
+New Relic's limits on attributes apply to data from any source, including OTLP-sourced data. See [metric attribute limits](https://docs.newrelic.com/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes/) and [event attribute limits](https://docs.newrelic.com/docs/data-apis/ingest-apis/event-api/introduction-event-api/#limits) for other limits:
+
+* Length of attribute name: 255 characters
+* Length of attribute value: 4096 maximum character length
+
 ## Traces [#traces]
 
 Familiarize yourself with these trace topics to ensure your traces and spans appear in New Relic.


### PR DESCRIPTION
We have had a number of OpenTelemetry tickets where they experienced data being dropped due to exceeding our limits on attributes, but the numbers are not documented in the OTel section. This will make it clear that NR limits also apply to OTLP-sourced data, and include the exact numbers and links to the main limit docs for further perusal. 