### PR TITLE
update information on CPM 3.0.62

### DIFF
--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-04.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-04.mdx
@@ -12,9 +12,9 @@ redirects:
 
 ## Summary
 
-New Relic released Containerized Private Minion (CPM) [version 3.0.58](/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3058/) on 2021-12-21 to address critical vulnerabilities CVE-2021-44228,CVE-2021-45046, and CVE-2021-45105 in the open source Apache Log4j framework. A malicious actor may be able to execute arbitrary code using log messages or log message parameters. 
+New Relic released Containerized Private Minion (CPM) [version 3.0.62](/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3062/) on 2022-03-07 to address critical vulnerabilities CVE-2021-44228, CVE-2021-44832, CVE-2021-45046, and CVE-2021-45105 in the open source Apache Log4j framework. A malicious actor may be able to execute arbitrary code using log messages or log message parameters. 
 
-New Relic also released Helm Charts version 1.0.46 on 2021-12-21 to address these vulnerabilities. Helm Charts version 1.0.46 contains the CPM version 3.0.58. 
+New Relic also released Helm Charts version 1.0.50 on 2022-03-07 to address these vulnerabilities. Helm Charts version 1.0.50 contains the CPM version 3.0.62.
 
 New Relic will update this Security Bulletin and our customer guidance as new information becomes available.
 
@@ -24,9 +24,9 @@ New Relic will update this Security Bulletin and our customer guidance as new in
 
 ## Affected software [#affected]
 
-Versions affected: All supported containerized private minion (CPM) versions prior to 3.0.58
+Versions affected: All supported containerized private minion (CPM) versions prior to 3.0.62
 
-Fixed version:  3.0.58, also available through Helm Charts version 1.0.46 
+Fixed version:  3.0.62, also available through Helm Charts version 1.0.50
 
 <table>
   <thead>
@@ -66,14 +66,22 @@ Fixed version:  3.0.58, also available through Helm Charts version 1.0.46
         2.17.0
       </td>
     </tr>
+    <tr>
+      <td>
+        3.0.62
+      </td>
+      <td>
+        2.17.1
+      </td>
+    </tr>
   </tbody>
 </table>
 
-If you use Helm Charts to update your CPM configurations, you will want to implement New Relic Helm Charts version 1.0.46. This will update your CPM to version 3.0.58.  
+If you use Helm Charts to update your CPM configurations, you will want to implement New Relic Helm Charts version 1.0.50. This will update your CPM to version 3.0.62.
 
 ## Action items [#action]
 
-To remediate CVE 2021-44228, CVE 2021-45046, and CVE 2021-45105 in the New Relic Containerized Private Minion, we recommend customers upgrade to version 3.0.58 as soon as possible. This version has been updated to use the remediated 2.17.0 version of the Apache Log4j framework. You may update your CPM through Helm Charts version 1.0.46.
+To remediate CVE 2021-44228, CVE-2021-44832, CVE 2021-45046, and CVE 2021-45105 in the New Relic Containerized Private Minion, we recommend customers upgrade to version 3.0.62 as soon as possible. This version has been updated to use the remediated 2.17.1 version of the Apache Log4j framework. You may update your CPM through Helm Charts version 1.0.50.
 
 This step will remediate your New Relic Containerized Private Minion (CPM) only. You may also need to update your New Relic Java agent. Please refer to [NR21-03](/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-03) for more information.
 
@@ -84,6 +92,7 @@ This step will remediate your New Relic Containerized Private Minion (CPM) only.
 A high level vulnerability was publicly disclosed for the log4j framework on 2021-12-09. An attacker is able to execute arbitrary code using log messages or log message parameters.
 
 * [CVE-2021-44228 CVSS 10.0](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228)
+* [CVE-2021-44832 CVSS 6.6](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832)
 * [CVE-2021-45046 CVSS 9.0](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046)
 * [CVE-2021-45105 CVSS 7.5](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105)
 * [Security guidance for New Relic customers related to Apache Log4j vulnerabilities](https://newrelic.com/blog/nerdlog/security-guidance-for-log4j)
@@ -96,16 +105,20 @@ A high level vulnerability was publicly disclosed for the log4j framework on 202
 <CollapserGroup>
   <Collapser
     id="357-update"
-    title="I've updated to CPM 3.0.55 already. Do I need to update to 3.0.58?"
+    title="I've updated to CPM 3.0.55 already. Do I need to update to 3.0.62?"
   >
 
-  Apache Foundation has disclosed additional vulnerabilities in log4j framework (CVE-2021-45046 and CVE-2021-45105) and advise that log4j v2.16.0 is not sufficient protection against exploitation. CPM 3.0.58 and later versions are the only CPM versions available with log4j 2.17.0. 
+  Apache Foundation has disclosed additional vulnerabilities in log4j framework (CVE-2021-44832, CVE-2021-45046 and CVE-2021-45105) and advise that log4j v2.16.0 is not sufficient protection against exploitation. CPM 3.0.62 and later versions are the only CPM versions available with log4j 2.17.1. 
 
 
   </Collapser>
 </CollapserGroup>
 
 ## Publication history [#history]
+
+* March 7, 2022: NR21-04 Major Revision:
+  * New fix version 3.0.62 available to address CVE-2021-44832.
+  * Addition of Helm Charts version 1.0.50 that contains the CPM 3.0.62 update.
 
 * December 22, 2021: NR21-04 Major Revision:
   * New fix version 3.0.58 available to address CVE-2021-44228, CVE-2021-45046, and CVE-2021-45105.


### PR DESCRIPTION
- included in Helm Charts version 1.0.50
- patches CVE-2021-44832 with log4j 2.17.1