### PR TITLE
fix(user type): clarifying deviating signals

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -225,7 +225,9 @@ Here's a detailed comparison of capabilities by user type. For tips on why you'd
           <td style="text-align:center"><Icon
               style={{color: '#328787'}}
               name="fe-check"
-            /></td>
+            />
+            (except [deviating signals](/docs/new-relic-one/core-concepts/new-relic-lookout-monitor-your-estate-glance/#signals))
+            </td>
           <td style="text-align:center"><Icon
               style={{color: '#328787'}}
               name="fe-check"
@@ -333,7 +335,7 @@ Here's a detailed comparison of capabilities by user type. For tips on why you'd
 
      <tr>
           <td>
-            [Distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing/)
+            [Distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing)
           </td>
           <td style="text-align:center"></td>
           <td></td>

--- a/src/content/docs/new-relic-one/core-concepts/new-relic-lookout-monitor-your-estate-glance.mdx
+++ b/src/content/docs/new-relic-one/core-concepts/new-relic-lookout-monitor-your-estate-glance.mdx
@@ -97,6 +97,8 @@ To analyze an application or facet, click a circle, table row, or abnormal golde
 
 There’s also an indication of whether the selected evaluation time period would be abnormal or not in reference to other comparison time windows, such as the same time yesterday or the same time last week. This allows you to quickly see if the abnormal behavior is odd in general, or just based on the comparison time window.
 
+
+
 ### Performance tab [#performance]
 
 The default tab shows charts for other key performance indicators for the selected application or facet. The charts compare the two time windows being analyzed. You can click their titles to rerun the analysis, focusing on the selected key performance indicator.


### PR DESCRIPTION
Adding small clarification to the Explorer entry in the user type table to say that core users don't have access to deviating signals