### PR TITLE
fix(statsd): recommend latest instead of 2.0.0

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
@@ -45,7 +45,7 @@ docker run \
   -e NR_ACCOUNT_ID=<var>YOUR_ACCOUNT_ID</var> \
   -e NR_API_KEY=<var>NEW_RELIC_LICENSE_KEY</var> \
   -p 8125:8125/udp \
-  newrelic/nri-statsd:2.0.0
+  newrelic/nri-statsd:latest
 ```
 
 If your account is in the [EU data center region](/docs/using-new-relic/welcome-new-relic/get-started/introduction-eu-region-data-center), add this to the above command:
@@ -95,7 +95,7 @@ Here are examples of Kubernetes manifests for deployment and service objects:
         spec:
           containers:
           - name: newrelic-statsd
-            image: newrelic/nri-statsd:2.0.0
+            image: newrelic/nri-statsd:latest
             env:
             - name: NR_ACCOUNT_ID
               value: "<var>NEW_RELIC_ACCOUNT_ID</var>"
@@ -280,7 +280,7 @@ Here are some examples of customizing configuration by overwriting the default c
       ...
       -v ${PWD}/nri-statsd.toml:/etc/opt/newrelic/nri-statsd.toml \
       ...
-      newrelic/nri-statsd:2.0.0
+      newrelic/nri-statsd:latest
     ```
   </Collapser>
 
@@ -515,7 +515,7 @@ You can add tags to your data, which we save as [attributes](/docs/using-new-rel
       -e NR_API_KEY=<var>NEW_RELIC_LICENSE_KEY</var> \
     <mark>  -e TAGS="environment:production region:us" \ </mark>
       -p 8125:8125/udp \
-      newrelic/nri-statsd:2.0.0
+      newrelic/nri-statsd:latest
     ```
   </Collapser>
 


### PR DESCRIPTION
## Give us some context

* Updated docker image examples with "latest" tag instead of 2.0.0 to avoid updating docs for every release (2.1.0 is actually the latest now). 