### PR TITLE
fix (node agent): mentioned correct default value of allow_all_headers

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/attributes/nodejs-agent-attributes.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/attributes/nodejs-agent-attributes.mdx
@@ -148,7 +148,7 @@ Use the following configuration properties along with the [attribute rules](#att
     id="cfg-attributes-enabled"
     title="allow_all_headers"
   >
-    Enabled by default. Set this to `false` for the agent to only collect a subset of headers.
+    Disabled by default. Set this to `true` for the agent to only collect all headers, except those filtered by `exclude` rules.
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
This actually defaults to `false`, but we set it to `true` in the
recommended config file we tell our users to install. So in "most"
cases it is de facto `true`, but it's not actually technically `true`.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Fixes [#1080 of node-newrelic](https://github.com/newrelic/node-newrelic/issues/1080)