### PR TITLE
Update install-ecs-integration.mdx

### DIFF
--- a/src/content/docs/infrastructure/elastic-container-service-integration/installation/install-ecs-integration.mdx
+++ b/src/content/docs/infrastructure/elastic-container-service-integration/installation/install-ecs-integration.mdx
@@ -16,7 +16,7 @@ New Relic's ECS integration reports and displays performance data from your [Ama
 
 Before you install our ECS integration, we recommend reviewing the [requirements](/docs/introduction-amazon-ecs-integration#requirements). During the install process:
 
-* **For EC2 and EXTERNAL (ECS Anywhere) launch type:** The infrastructure agent (`newrelic-infra`) gets deployed onto an ECS cluster as a service using the [daemon scheduling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/scheduling_tasks.html) strategy. This deployment installs the infrastructure agent in all the container instances of the cluster. The infrastructure agent then monitors ECS and Docker containers.
+* **For EC2 and EXTERNAL (ECS Anywhere) launch type:** The infrastructure agent (`newrelic-infra`) gets deployed onto an ECS cluster as a service using the [daemon scheduling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/scheduling_tasks.html) strategy. This deployment installs the infrastructure agent in all the EC2 instances of the cluster. The infrastructure agent then monitors ECS and Docker containers.
 
 * **For AWS Fargate launch type:** The infrastructure agent (`newrelic-infra`) gets deployed as a sidecar in every task to monitor. The [AWS Fargate documentation](https://aws.amazon.com/blogs/compute/nginx-reverse-proxy-sidecar-container-on-amazon-ecs/) defines a sidecar as a way to move part of a service's core responsibility into a containerized module that is deployed alongside the core application.
 


### PR DESCRIPTION
From my understanding, the DAEMON service is for running the infra agent on each ECS EC2 instance.  Saying each "container" instance sounds like the sidecar method, however DAEMON is not one per container.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  
 Related doc - see how the cAdvisor open source monitoring is installed on ECS
-  https://digitalis.io/blog/technology/ecs-container-monitoring-using-cadvisor/
- Notice the sentence about the DAEMON service type
  
* If your issue relates to an existing GitHub issue, please link to it.