### PR TITLE
Rename availability as success (publish 03-11-22)

### DIFF
--- a/src/content/docs/release-notes/service-levels-release-notes/service-levels-20220311.mdx
+++ b/src/content/docs/release-notes/service-levels-release-notes/service-levels-20220311.mdx
@@ -1,0 +1,11 @@
+---
+title: 'Renaming availability SLI as success'
+subject: Service levels
+releaseDate: '2022-03-11'
+---
+
+New Relic suggests some typical SLIs for APM services and browser applications. If you choose to create one of the suggested SLIs through the UI, New Relic will analyze the latest data available, and will calculate the baseline for your SLI and SLO parameters.
+
+One of the typical SLIs checks the proportion of requests that are served without errors. When we launched the service levels beta release we decided to name this SLI *availability*; but this term has generated some confusion because it is often interpreted as a service being up and running and able to receive requests. This is why we're renaming the suggested SLI as *success* from now on.
+
+The existing SLIs created through New Relic suggested flows won't be renamed.

--- a/src/content/docs/service-level-management/create-slm.mdx
+++ b/src/content/docs/service-level-management/create-slm.mdx
@@ -56,9 +56,9 @@ Based on `Transaction` events, these SLIs are the most common for request-driven
   <Collapser
     className="freq-link"
     id="service-availability"
-    title="Service availability"
+    title="Service success"
   >
-  Service availability is the ratio of the number of successful responses to the number of all requests. This effectively is an error rate, but you can filter it down, for example removing expected errors.
+  Service success is the ratio of the number of successful responses to the number of all requests. This effectively is an error rate, but you can filter it down, for example removing expected errors.
 
   **Valid events fields**
 
@@ -123,9 +123,9 @@ Based on OpenTelemetry spans, these SLIs are the most common for request-driven 
   <Collapser
     className="freq-link"
     id="service-availability"
-    title="Service availability"
+    title="Service success"
   >
-  Service availability is the ratio of the number of successful responses to the number of all requests. This effectively is an error rate, but you can filter it down, for example removing expected errors.
+  Service success is the ratio of the number of successful responses to the number of all requests. This effectively is an error rate, but you can filter it down, for example removing expected errors.
 
   **Valid events fields**
 
@@ -191,7 +191,7 @@ The following SLIs are based on Google's Browser Core Web Vitals.
   <Collapser
     className="freq-link"
     id="browser-availability"
-    title="Browser app availability"
+    title="Browser app success"
   >
     It's the proportion of page views that are served without errors.
     


### PR DESCRIPTION
The 'availability' term has generated some confusion because it usually refers to a service being up and running and able to receive requests. This is why we're renaming the suggested SLI as Success from now on.

I haven't changed the anchor id, to prevent breaking any existing links.

We'll publish a release note as well.

