### PR TITLE
docs: specify datatype of customAttributes arg

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -203,7 +203,7 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
 
   <Collapser
     id="instrumentMessages"
-    title={<InlineCode>newrelic.instrumentMessages(moduleName, onRequire \[, onError])</InlineCode>}
+    title={<InlineCode>newrelic.instrumentMessages(moduleName, onRequire [, onError])</InlineCode>}
   >
     ```js
     newrelic.instrumentMessages(moduleName, onRequire [, onError])

--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -755,13 +755,15 @@ New Relic's Node.js agent includes additional API calls.
 
   <Collapser
     id="noticeError"
-    title={<InlineCode>newrelic.noticeError(error, [customParameters])</InlineCode>}
+    title={<InlineCode>newrelic.noticeError(error, [customAttributes])</InlineCode>}
   >
     ```js
-    newrelic.noticeError(error, [customParameters])
+    newrelic.noticeError(error, [customAttributes])
     ```
 
     Use this call if your app is doing its own error handling with domains or try/catch clauses, but you want all of the information about how many errors are coming out of the app to be centrally managed. Unlike other Node.js calls, this can be used outside of route handlers, but it will have additional context if called from within transaction scope.
+    
+    `customAttributes` is an optional object of any custom attributes to be displayed in the New Relic UI.
 
     <Callout variant="caution">
       Errors recorded using this method do not obey the [ignore_status_codes](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#error_ignore) configuration value.


### PR DESCRIPTION
Changed `customParameters` to `customAttributes` in `noticeError()`. In the [source code that parameter is named `customAttributes`](https://github.com/newrelic/node-newrelic/blob/556543726f350b7c72bd33db3f175b7b1aed4a45/api.js#L417), and `customParameter` is a slightly inaccurate term for the arg. I also added the blurb from the source code describing it's purpose and datatype.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.