### PR TITLE
fix(node agent): mention allow_all_headers is now also an envvar

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -235,6 +235,16 @@ This section defines the Node.js agent variables in the order they typically app
             `false`
           </td>
         </tr>
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_ALLOW_ALL_HEADERS`
+          </td>
+        </tr>
+
       </tbody>
     </table>
 


### PR DESCRIPTION
Using `allow_all_headers` as an envvar was introduced in [#1114 of node-newrelic](https://github.com/newrelic/node-newrelic/pull/1114).
