### PR TITLE
docs: clean up code block

### DIFF
--- a/src/content/docs/distributed-tracing/trace-api/report-new-relic-format-traces-trace-api.mdx
+++ b/src/content/docs/distributed-tracing/trace-api/report-new-relic-format-traces-trace-api.mdx
@@ -35,45 +35,45 @@ The following explains how to send a standard (non-[Infinite Tracing](/docs/unde
 1. Get a [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key) for the account you want to report data to.
 2. Insert that key into the following JSON and then send the JSON to our endpoint. Note: if you have a EU New Relic account, use the [EU endpoint](/docs/understand-dependencies/distributed-tracing/trace-api/trace-api-general-requirements-limits#requirements) instead.
 
-   ```
-   curl -i -H 'Content-Type: application/json' \
-       -H 'Api-Key: <var>$YOUR_LICENSE_KEY</var>' \
-       -H 'Data-Format: newrelic' \
-       -H 'Data-Format-Version: 1' \
-       -X POST \
-       -d '[
-             {
-                 "common": {
-                 "attributes": {
-                     "service.name": "Test Service A",
-                     "host": "host123.example.com"
-                     }
-                 },
-                 "spans": [
-                 {
-                     "trace.id": "123456",
-                     "id": "ABC",
-                     "attributes": {
-                     "duration.ms": 12.53,
-                         "name": "/home"
-                     }
-                 },
-                 {
-                     "trace.id": "123456",
-                     "id": "DEF",
-                     "attributes": {
-                  	  	"error.message": "Invalid credentials",
-                       "service.name": "Test Service A",
-                       "host": "host456.example.com",
-                       "duration.ms": 2.97,
-                       "name": "/auth",
-                       "parent.id": "ABC"
-                     }
-                 }
-                 ]
-             }
-           ]' 'https://trace-api.newrelic.com/trace/v1'
-   ```
+    ```bash
+    curl -i -H 'Content-Type: application/json' \
+        -H 'Api-Key: YOUR_LICENSE_KEY' \
+        -H 'Data-Format: newrelic' \
+        -H 'Data-Format-Version: 1' \
+        -X POST \
+        -d '[
+                {
+                    "common": {
+                        "attributes": {
+                            "service.name": "Test Service A",
+                            "host": "host123.example.com"
+                        }
+                    },
+                    "spans": [
+                        {
+                            "trace.id": "123456",
+                            "id": "ABC",
+                            "attributes": {
+                                "duration.ms": 12.53,
+                                "name": "/home"
+                            }
+                        },
+                        {
+                            "trace.id": "123456",
+                            "id": "DEF",
+                            "attributes": {
+                                "error.message": "Invalid credentials",
+                                "service.name": "Test Service A",
+                                "host": "host456.example.com",
+                                "duration.ms": 2.97,
+                                "name": "/auth",
+                                "parent.id": "ABC"
+                            }
+                        }
+                    ]
+                }
+            ]' 'https://trace-api.newrelic.com/trace/v1'
+    ```
 
    <Callout variant="tip">
      If you're sending more than one `POST`, change the `trace.id` to a unique value. Sending the same payload or span `id` multiple times for the same `trace.id` may result in fragmented traces in the UI.
@@ -435,7 +435,7 @@ Requirements and guidelines for trace JSON using the `newrelic` format:
 
 In the following example `POST`, there are two spans, both of which have the trace.id `12345` and the custom attribute `host: host123.example.com`. The first span has no `parent.id`, so that is the root of the trace; the second span's `parent.id` points to the ID of the first.
 
-```
+```json
 [
   {
     "common": {


### PR DESCRIPTION
The curl codeblock was indented a little wonky, since I was here I added the language identifiers to the examples as well

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.