### PR TITLE
Incorrect Link to Advanced Configurations

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/elasticsearch/elasticsearch-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/elasticsearch/elasticsearch-integration.mdx
@@ -25,7 +25,7 @@ To install the Elasticsearch monitoring integration, run through the following s
 1. [Configure the integration](#config).
 2. [Install and activate the integration](#install).
 3. [Find and use data](#find-and-use).
-4. Optionally, see [the advanced configuration settings](https://beta-docs.newrelic.com/docs/integrations/mySQL/mysql-advanced-config).
+4. Optionally, see [the advanced configuration settings](https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/elasticsearch/elasticsearch-advanced-config).
 
 ## Compatibility and requirements [#req]
 


### PR DESCRIPTION
Link was pointing to beta.docs and for MySQL. Updated to proper Elasticsearch Advanced Configuration page (non-beta).

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.