### PR TITLE
Update opentelemetry-concepts.mdx

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts.mdx
@@ -129,7 +129,7 @@ Check out this documentation about how to configure different types of sampling:
 
   1. Follow the steps in [Set up the trace observer](/docs/distributed-tracing/infinite-tracing/set-trace-observer/) to get the value for <var>YOUR_TRACE_OBSERVER_URL</var>.
   2. As you complete the steps in the [quick start guide](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start/#review-settings), use the value of <var>YOUR_TRACE_OBSERVER_URL</var> to configure your integration. `YOUR_TRACE_OBSERVER_URL` follows the form `https://{trace-observer}:443/trace/v1`. When setting the OTLP gRPC endpoint, strip off the `/trace/v1` suffix, resulting in a URL of the form `https://{trace-observer}:443`.
-  3. Since you want New Relic to analyze all your traces, make sure to verify that all applications involved in the trace have [configured](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md) the OpenTelemetry SDK with a sampler which allows tail-based sampling. The default the `parent_based_always_on` as well as the `always_on` samplers are good choices.
+  3. Since you want New Relic to analyze all your traces, make sure to verify that all applications involved in the trace have [configured](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md) the OpenTelemetry SDK with a sampler which allows tail-based sampling. The default `parentbased_always_on` as well as the `always_on` samplers are good choices.
 
 
   Note that only trace data can be sent to trace observer endpoints. Your application (or collector) will need to separately configure export strategies for OpenTelemetry metrics and logs.


### PR DESCRIPTION
This PR fixes the name of `parentbased_always_on` sampler. Existing docs reference `parent_based_always_on` which isn't found in the OTEL spec. This could affect users who are trying to configure their application.

See reference in OTEL spec: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.