### PR TITLE
fix(node agent): clarify that proxy settings do not apply to Infinite Tracing

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -548,6 +548,9 @@ This section defines the Node.js agent variables in the order they typically app
     <Callout variant="important">
       The `proxy` config file setting overrides the other config file proxy settings (`proxy_host`, `proxy_port`, `proxy_user`, `proxy_pass`) if used. Similarly, the `NEW_RELIC_PROXY_URL` environment variable overrides the other environment variable proxy settings (`NEW_RELIC_PROXY_HOST`, `NEW_RELIC_PROXY_PORT`, `NEW_RELIC_PROXY_USER`, and `NEW_RELIC_PROXY_PASS`) if used.
     </Callout>
+    <Callout variant="tip">
+      Since Infinite Tracing uses gRPC over HTTP/2, these proxy settings will not apply. [See how to configure a proxy for Infinite Tracing.](/docs/distributed-tracing/infinite-tracing/infinite-tracing-configure-proxy-support/#node-php-python-ruby)
+    </Callout>
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -543,14 +543,10 @@ This section defines the Node.js agent variables in the order they typically app
       </tbody>
     </table>
 
-    A URL specifying the proxy server to connect to the Internet. For example, `proxy: 'http://user:pass@10.0.0.1:8000/'`.
+A URL specifying the proxy server to connect to the Internet. For example, `proxy: 'http://user:pass@10.0.0.1:8000/'`. Important considerations: 
+* The `proxy` config file setting overrides the other config file proxy settings (`proxy_host`, `proxy_port`, `proxy_user`, `proxy_pass`) if used. Similarly, the `NEW_RELIC_PROXY_URL` environment variable overrides the other environment variable proxy settings (`NEW_RELIC_PROXY_HOST`, `NEW_RELIC_PROXY_PORT`, `NEW_RELIC_PROXY_USER`, and `NEW_RELIC_PROXY_PASS`) if used.
+* If you're using [Infinite Tracing](/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing): [see how to configure a proxy for Infinite Tracing](/docs/distributed-tracing/infinite-tracing/infinite-tracing-configure-proxy-support/#node-php-python-ruby).
 
-    <Callout variant="important">
-      The `proxy` config file setting overrides the other config file proxy settings (`proxy_host`, `proxy_port`, `proxy_user`, `proxy_pass`) if used. Similarly, the `NEW_RELIC_PROXY_URL` environment variable overrides the other environment variable proxy settings (`NEW_RELIC_PROXY_HOST`, `NEW_RELIC_PROXY_PORT`, `NEW_RELIC_PROXY_USER`, and `NEW_RELIC_PROXY_PASS`) if used.
-    </Callout>
-    <Callout variant="tip">
-      Since Infinite Tracing uses gRPC over HTTP/2, these proxy settings will not apply. [See how to configure a proxy for Infinite Tracing.](/docs/distributed-tracing/infinite-tracing/infinite-tracing-configure-proxy-support/#node-php-python-ruby)
-    </Callout>
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
A client wanted to use the same proxy settings, but there's already a clear workaround for gRPC. This closes [#428 of
node-newrelic](https://github.com/newrelic/node-newrelic/issues/428).
