### PR TITLE
Clarify how to avoid rate limiting

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts.mdx
@@ -15,6 +15,7 @@ Here are some best practices based on how OpenTelemetry works with New Relic:
 * [Resources](#resources)
 * [Batching](#batching)
 * [Compression](#compression)
+* [Attribute lengths](#attribute-lengths)
 * [Traces](#traces)
 * [Metrics](#metrics)
 * [Logs](#logs)
@@ -37,7 +38,11 @@ The following suites of attributes are defined by the [OpenTelemetry resource se
 ## Batching [#batching]
 
 <Callout variant="caution">
-  Avoid getting rate limited! You should batch requests sent to the OTLP endpoint as described in this section.
+  Avoid getting rate limited! We recommend doing the following:
+  
+  * Batch requests sent to the OTLP endpoint as described in this section
+  * Explicitly enable [gzip compression](#compression) 
+  * Ensure your [attribute lengths](#attribute-lengths) don't exceed New Relic maximums
 </Callout>
 
 By default, the OpenTelemetry SDKs and Collector send one (1) data point per request. Using these defaults, it is likely your account will be rate limited.
@@ -81,6 +86,10 @@ New Relic's limits on attributes apply to data from any source, including OTLP-s
 
 * Length of attribute name: 255 characters
 * Length of attribute value: 4096 maximum character length
+
+If a span attribute is the offender, you can use [span limits environment variables](https://github.com/open-telemetry/opentelemetry-specification/blob/d6bcc0cb072d8d6f6ced856f1f23c451648a3caa/specification/sdk-environment-variables.md#span-limits-) to configure the maximum length(s). If a [resource attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/d6bcc0cb072d8d6f6ced856f1f23c451648a3caa/specification/sdk-environment-variables.md#general-sdk-configuration) is the offender, you can set `OTEL_RESOURCE_ATTRIBUTES=<offending-attribute>=unset` to override it.
+  
+Not all language SDKs support the span limits environment variables, so it depends on which language you are using. If your language does not support these, we recommend that you open a Github issue for it in the respective language SDK repo, so that the OpenTelemetry community can resolve it. 
 
 ## Traces [#traces]
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts.mdx
@@ -39,7 +39,7 @@ The following suites of attributes are defined by the [OpenTelemetry resource se
 
 <Callout variant="caution">
   To avoid getting rate limited, we recommend these practices:
-  
+
   * Batch requests sent to the OTLP endpoint as described in this section
   * Explicitly enable [gzip compression](#compression) 
   * Ensure your [attribute lengths](#attribute-lengths) don't exceed New Relic maximums
@@ -88,8 +88,8 @@ New Relic's limits on attributes apply to data from any source, including OTLP-s
 * Length of attribute value: 4096 maximum character length
 
 If a span attribute is the offender, you can use [span limits environment variables](https://github.com/open-telemetry/opentelemetry-specification/blob/d6bcc0cb072d8d6f6ced856f1f23c451648a3caa/specification/sdk-environment-variables.md#span-limits-) to configure the maximum length(s). If a [resource attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/d6bcc0cb072d8d6f6ced856f1f23c451648a3caa/specification/sdk-environment-variables.md#general-sdk-configuration) is the offender, you can set `OTEL_RESOURCE_ATTRIBUTES=<offending-attribute>=unset` to override it.
-  
-Not all language SDKs support the span limits environment variables, so it depends on which language you are using. If your language does not support these, we recommend that you open a Github issue for it in the respective language SDK repo, so that the OpenTelemetry community can resolve it. 
+
+Not all language SDKs support the span limits environment variables, so it depends on which language you are using. If your language doesn't support these, we recommend that you open a Github issue for it in the respective language SDK repo so that the OpenTelemetry community can resolve it.
 
 ## Traces [#traces]
 
@@ -184,7 +184,7 @@ OpenTelemetry [histograms](https://github.com/open-telemetry/opentelemetry-speci
   New Relic doesn't currently support cumulative histograms. Instead, convert your cumulative histograms to delta temporality.
 
   Before configuring your SDK to use delta temporality, see the [specification for the OTLP metric exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/ce50e4634efcba8da445cc23523243cb893905cb/specification/metrics/sdk_exporters/otlp.md#opentelemetry-metrics-exporter---otlp).
-  
+
   You can use this account query to determine if metrics are being dropped due to unsupported temporality:
 
 ```sql

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts.mdx
@@ -38,7 +38,7 @@ The following suites of attributes are defined by the [OpenTelemetry resource se
 ## Batching [#batching]
 
 <Callout variant="caution">
-  Avoid getting rate limited! We recommend doing the following:
+  To avoid getting rate limited, we recommend these practices:
   
   * Batch requests sent to the OTLP endpoint as described in this section
   * Explicitly enable [gzip compression](#compression) 


### PR DESCRIPTION
This PR makes it clearer the config settings we recommend to avoid getting rate limited. It also adds more information to the attributes section on how to set max attribute lengths using span limits env vars. Both have been common issues with our OpenTelemetry users. 