### PR TITLE
docs: format code blocks, fix typos

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation.mdx
@@ -96,40 +96,40 @@ In order to create custom [web transactions](/docs/apm/transactions/intro-transa
   >
     This example instruments a `/websocket/ping` transaction, a `/websocket/update` transaction, and a `/websocket/new-message` transaction within `socket.io`. The `/ping` example is synchronous, while the `/new-message` and `/update` examples are asynchronous.
 
-    ```
-    var nr = require('newrelic')
-    var app = require('http').createServer()
-    var io = require('socket.io')(app)
+    ```js
+    var nr = require('newrelic');
+    var app = require('http').createServer();
+    var io = require('socket.io')(app);
 
-    io.on('connection', function (socket) {
-      socket.on('ping', function (data) {
+    io.on('connection', function(socket) {
+      socket.on('ping', function(data) {
         nr.startWebTransaction('/websocket/ping', function transactionHandler() {
           // Ended automatically after synchronously returning
-          socket.emit('pong')
-        })
-      })
-      socket.on('update', function (data) {
+          socket.emit('pong');
+        });
+      });
+      socket.on('update', function(data) {
         nr.startWebTransaction('/websocket/update', function transactionHandler() {
-          // Using API#getTransaction
-          var transaction = nr.getTransaction()
+          // Using API getTransaction
+          var transaction = nr.getTransaction();
           updateChatWindow(data, function transactionHandler() {
-            socket.emit('update-done')
-            transaction.end()
-          })
-        })
-      })
-      socket.on('new-message', function (data) {
+            socket.emit('update-done');
+            transaction.end();
+          });
+        });
+      });
+      socket.on('new-message', function(data) {
         nr.startWebTransaction('/websocket/new-message', function transactionHandler() {
           // Returning a promise
-          return new Promise(function (resolve, reject) {
-            addMessageToChat(data, function () {
-              socket.emit('message-received')
-              resolve()
-            })
-          })
-        })
-      })
-    })
+          return new Promise(function(resolve, reject) {
+            addMessageToChat(data, function() {
+              socket.emit('message-received');
+              resolve();
+            });
+          });
+        });
+      });
+    });
     ```
 
     This method only gives basic timing data for the transaction created. To create more intricate timing data and transaction naming for a particular framework, see the [Node.js API documentation](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#instrumentWebframework) and the [related tutorial on GitHub](http://newrelic.github.io/node-newrelic/docs/tutorial-Webframework-Simple.html).
@@ -200,35 +200,35 @@ To instrument background tasks, call [`startBackgroundTransaction`](/docs/agents
   >
     This example instruments `update:cache` within `setInterval`:
 
-    ```
-    var nr = require('newrelic')
-    var redis = require('redis').createClient()
+    ```js
+    var nr = require('newrelic');
+    var redis = require('redis').createClient();
 
-    // Using API#getTransaction to manage ending the transaction
-    setInterval(function () {
+    // Using API getTransaction to manage ending the transaction
+    setInterval(function() {
       nr.startBackgroundTransaction('update:cache', function transactionHandler() {
-        var newValue = someDataGenerator()
-        var transaction = nr.getTransaction()
- 
-        redis.set('some:cache:key', newValue, function () {
-          transaction.end()
-        })
-      })
-    }, 30000) // Every 30s
+        var newValue = someDataGenerator();
+        var transaction = nr.getTransaction();
+
+        redis.set('some:cache:key', newValue, function() {
+          transaction.end();
+        });
+      });
+    }, 30000); // Every 30s
 
     //Using a promise to manage ending the transaction
-    setInterval(function () {
+    setInterval(function() {
       nr.startBackgroundTransaction('flush:cache', function transactionHandler() {
         return new Promise(function(resolve, reject) {
           flushCache(redis, function afterFlush(err) {
             if (err) {
-              return reject(err)
+              return reject(err);
             }
-            resolve()
-          })
-        })
-      })
-    }, 60*60*1000)
+            resolve();
+          });
+        });
+      });
+    }, 60 * 60 * 1000);
     ```
   </Collapser>
 </CollapserGroup>
@@ -253,20 +253,20 @@ To do this, wrap your callbacks in custom tracers. Custom tracers create and col
   >
     This example tracks a single callback:
 
-    ```
+    ```js
     // Wrap the method in a segment.
     nr.startSegment('db:createObject', true, function(cb) {
       // This is recorded as the `db:createObject` segment.
-      db.createObject(cb)
+      db.createObject(cb);
     }, function(err, result) {
       // This is recorded as the callback to the `db:createObject` segment.
       if (util.handleError(err, res)) {
-        return
+        return;
       }
-      res.write(JSON.stringify(result.rows[0].id))
-      res.write('\n')
-      res.end()
-    })
+      res.write(JSON.stringify(result.rows[0].id));
+      res.write('\n');
+      res.end();
+    });
     ```
   </Collapser>
 
@@ -276,25 +276,25 @@ To do this, wrap your callbacks in custom tracers. Custom tracers create and col
   >
     This example tracks both `pg.connect` and `client.query`. This is because `client.query` is called by an asynchronous parent function (`pg.connect`). Otherwise, you would not get any data from `client.query`. This allows `startSegment()` to propagate the active transaction across those asynchronous boundaries.
 
-    ```
+    ```js
     nr.startSegment('pg:connect', true, function(cb) {
-      pg.connect(config.db_string, cb)
+      pg.connect(config.db_string, cb);
     }, function(err, client, done) {
       if (util.handleError(err, '500', res)) {
-        return done()
+        return done();
       }
 
       nr.startSegment('pg:query', true, function(cb) {
-        client.query('SELECT count(*) FROM test_count'), cb)
+        client.query('SELECT count(*) FROM test_count', cb);
       }, function(err, result) {
         if (util.handleError(err, '500', res)) {
-          return done()
+          return done();
         }
 
-        res.write(result.rows[0].count)
-        res.write('\n')
-      })
-    })
+        res.write(result.rows[0].count);
+        res.write('\n');
+      });
+    });
     ```
   </Collapser>
 
@@ -304,29 +304,29 @@ To do this, wrap your callbacks in custom tracers. Custom tracers create and col
   >
     This example is the same as the callback one, but for interacting with a promise-based API. For promises, simply return the promise and call `then` after `startSegment` to continue your execution.
 
-    ```
+    ```js
     nr.startSegment('pg:connect', true, function() {
       // This `pg:connect` segment will time until the returned promise
       // either resolves or rejects.
-      return pg.connect(config.db_string)
+      return pg.connect(config.db_string);
     }).then(function(client) {
       // The transaction context is propagated into following promises.
       return nr.startSegment('pg:query', true, function() {
-        return client.query('SELECT count(*) FROM test_count'))
+        return client.query('SELECT count(*) FROM test_count');
       }).then(function(result) {
-        res.write(result.rows[0].count)
-        res.write('\n')
-        res.end()
+        res.write(result.rows[0].count);
+        res.write('\n');
+        res.end();
       }, function(err) {
         // Error from querying.
-        util.handleError(err, '500', res)
+        util.handleError(err, '500', res);
       }).finally(function() {
-        return client.release()
-      })
+        return client.release();
+      });
     }, function(err) {
       // Error from connecting.
-      util.handleError(err, '500', res)
-    })
+      util.handleError(err, '500', res);
+    });
     ```
   </Collapser>
 
@@ -336,32 +336,32 @@ To do this, wrap your callbacks in custom tracers. Custom tracers create and col
   >
     This example shows how to instrument code using `async`/`await` to control asynchronous work. This requires using Node 8 or higher, as well as the New Relic for Node.js agent v2.3.0 or higher.
 
-    ```
+    ```js
     try {
       const client = await nr.startSegment('pg:connect', true, async () => {
         // Async functions simply return promises, so this example is
         // very similar to the promise one.
-        return await pg.connect(config.db_string)
-      })
+        return await pg.connect(config.db_string);
+      });
 
       // The transaction context is propagated into the code following `await`.
       try {
         const result = await nr.startSegment('pg:query', true, async () => {
-          return await client.query('SELECT count(*) FROM test_count'))
-        })
+          return await client.query('SELECT count(*) FROM test_count');
+        });
 
-        res.write(result.rows[0].count)
-        res.write('\n')
-        res.end()
-      } catch(err) {
+        res.write(result.rows[0].count);
+        res.write('\n');
+        res.end();
+      } catch (err) {
         // Error from querying.
-        util.handleError(err, '500', res)
+        util.handleError(err, '500', res);
       } finally {
-        await client.release()
+        await client.release();
       }
-    } catch(err) {
+    } catch (err) {
       // Error from connecting.
-      util.handleError(err, '500', res)
+      util.handleError(err, '500', res);
     }
     ```
   </Collapser>
@@ -372,10 +372,10 @@ To do this, wrap your callbacks in custom tracers. Custom tracers create and col
   >
     This example shows how `startSegment` can be used to record a synchronous function that is responsible for assigning its return value to a variable.
 
-    ```
+    ```js
     var result = nr.startSegment('calculateTotal', true, function() {
-      return calculateTotal(outerVar1, outerVar2)
-    })
+      return calculateTotal(outerVar1, outerVar2);
+    });
     ```
 
     <Callout variant="important">

--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation.mdx
@@ -132,7 +132,7 @@ In order to create custom [web transactions](/docs/apm/transactions/intro-transa
     });
     ```
 
-    This method only gives basic timing data for the transaction created. To create more intricate timing data and transaction naming for a particular framework, see the [Node.js API documentation](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#instrumentWebframework) and the [related tutorial on GitHub](http://newrelic.github.io/node-newrelic/docs/tutorial-Webframework-Simple.html).
+    This method only gives basic timing data for the transaction created. To create more intricate timing data and transaction naming for a particular framework, see the [Node.js API docs](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#instrumentWebframework) and the [related tutorial on GitHub](http://newrelic.github.io/node-newrelic/docs/tutorial-Webframework-Simple.html).
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-metrics.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-metrics.mdx
@@ -41,7 +41,7 @@ The public API for recording metric data consists of two methods on `newrelic`:
 
 Here is an example that shows how you can use metrics to track currency flowing through a site:
 
-```
+```js
 app.post('/cart/checkout', function(req, res) {
   var total = computeCartTotal(req.user);
   newrelic.recordMetric('Cart/ChargeAmount', total);


### PR DESCRIPTION
I added semicolons and language identifiers to the code blocks.

Three code blocks had stray `)`s which were breaking them.

`API#getTransaction` seems like it was maybe supposed to be a link? But it didn't go anywhere so I altered it to just the method name

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.