### PR TITLE
fix(logs): clarify roles/permissions

### DIFF
--- a/src/content/docs/logs/get-started/get-started-log-management.mdx
+++ b/src/content/docs/logs/get-started/get-started-log-management.mdx
@@ -45,6 +45,8 @@ Log management features include:
 
 Access to log management capabilities is restricted by user type. For more details, see [user type capabilities](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type#user-type-capabilities). 
 
+For users on our [New Relic One user model](/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models), some log functionality is governed by several [log-related capabilities](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#capabilities).  
+
 ## Bring in your logging data [#integrate-logs]
 
 To forward your log data to New Relic, you can:

--- a/src/content/docs/logs/ui-data/data-partitions.mdx
+++ b/src/content/docs/logs/ui-data/data-partitions.mdx
@@ -20,10 +20,10 @@ Data partitions also allow data to be mapped to an alternative, or â€œsecondaryâ
 
 ## Plan your partition [#plan]
 
-Before you start creating partitions, make sure you have the right permissions and a partition plan.
+Before you start creating partitions, make sure you have the [required permissions](/docs/logs/get-started/get-started-log-management#requirements) and a plan for how to implement the partitions.
 
 <Callout variant="important">
-Logs are routed to partitions during the ingestion process, before data is written to NRDB. Partition rules will not affect logs that were ingested before the rule was created.
+Logs are routed to partitions during the ingestion process, before data is written to NRDB. Partition rules won't affect logs that were ingested before the rule was created.
 </Callout>
 
 ### Sizing and organizing a partition [#size]


### PR DESCRIPTION
Did this due to issue https://github.com/newrelic/docs-website/issues/6592. Clarifying how roles/permissions work for logs and pointing to that requirements section from log partitions doc. 