### PR TITLE
style(api keys): Remove most anchor links, simlify some language

### DIFF
--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -164,7 +164,7 @@ You should treat your API keys securely, as you would passwords and other sensit
 
 ## Read more about our API keys [#key-details]
 
-To create or manage API keys, use the UI at [one.newrelic.com/launcher/api-keys-ui.api-keys-launcher](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher). For more details about each key, select one below: 
+To create or manage API keys, use the UI at [one.newrelic.com/launcher/api-keys-ui.api-keys-launcher](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher), or our [NerdGraph API](/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys). For more details, select a key: 
 
 <CollapserGroup>
   <Collapser
@@ -176,6 +176,7 @@ Our main key used for data ingest is called the license key. In the API keys UI 
 The license key is required for almost all New Relic data ingest. The exceptions are browser monitoring data (which uses a browser key) and mobile monitoring data (which uses a mobile app token). 
 
 The license key is a 40-character hexadecimal string associated with a New Relic account. When you first [sign up](/docs/subscriptions/creating-your-new-relic-account) for New Relic, an organization with a single account and its own license key are created. If more accounts are added, each account starts with its own license key. The license key originally created for an account cannot be deleted but you can create additional license keys that can be managed and deleted, and this is useful for implementing security-practices such as key rotation. If you need to delete an account's original license key, [contact support](https://support.newrelic.com).
+    
 </Collapser>
 
 

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -175,7 +175,7 @@ Our main key used for data ingest is called the license key. In the API keys UI 
 
 The license key is required for almost all New Relic data ingest. The exceptions are browser monitoring data (which uses a browser key) and mobile monitoring data (which uses a mobile app token). 
 
-The license key is a 40-character hexadecimal string associated with a New Relic account. When you first [sign up](/docs/subscriptions/creating-your-new-relic-account) for New Relic, that creates an organization with a single account, and that account has its own license key. If more accounts are added, each account starts with its own license key. The license key originally created for an account cannot be deleted but you can create additional license keys that can be managed and deleted, and this is useful for implementing security-practices such as key rotation. If you need to delete an account's original license key, [contact support](https://support.newrelic.com).
+The license key is a 40-character hexadecimal string associated with a New Relic account. When you first [sign up](/docs/subscriptions/creating-your-new-relic-account) for New Relic, an organization with a single account and its own license key are created. If more accounts are added, each account starts with its own license key. The license key originally created for an account cannot be deleted but you can create additional license keys that can be managed and deleted, and this is useful for implementing security-practices such as key rotation. If you need to delete an account's original license key, [contact support](https://support.newrelic.com).
 </Collapser>
 
 

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -47,7 +47,6 @@ Other ways to create and manage keys:
 * For a programmatic way to manage license keys, browser keys, and user keys: [use our NerdGraph API](/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys)
 * For user keys: [Use NerdGraph explorer to view and create](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer)
 
-
 ## Get to know our main API keys [#overview-keys]
 
 <table>
@@ -163,9 +162,9 @@ You should treat your API keys securely, as you would passwords and other sensit
   * Instruct your team members to keep their user keys secure. 
   * When members leave your organization, even if they're [basic users](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type), remove them from New Relic. 
 
-## More API key details [#key-details]
+## Read more about our API keys [#key-details]
 
-Basic information about our keys are in the [API keys overview table](#overview-keys). For more details about each key, select one below: 
+To create or manage API keys, use the UI at [one.newrelic.com/launcher/api-keys-ui.api-keys-launcher](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher). For more details about each key, select one below: 
 
 <CollapserGroup>
   <Collapser
@@ -174,11 +173,9 @@ Basic information about our keys are in the [API keys overview table](#overview-
   >
 Our main key used for data ingest is called the license key. In the API keys UI and in [NerdGraph](/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys), this key is sometimes referenced as `ingest - license`. 
 
-The license key is required for almost all New Relic data ingest. The exceptions are browser monitoring data (which uses a [browser key](#overview-keys)) and mobile monitoring data (which uses a [mobile app token](#overview-keys)). 
+The license key is required for almost all New Relic data ingest. The exceptions are browser monitoring data (which uses a browser key) and mobile monitoring data (which uses a mobile app token). 
 
-The license key is a 40-character hexadecimal string associated with a New Relic account. When you first [sign up](/docs/subscriptions/creating-your-new-relic-account) for New Relic, that creates an organization with a single account, and that account has its own license key. If more accounts are added, each account starts with its own license key. The license key originally created for an account cannot be deleted but you can create additional license keys that can be managed and deleted, and this is useful for implementing [security policies](#security-practices) (for example, key rotation). If you need to delete an account's original license key, [contact support](https://support.newrelic.com).
-
-For security-related best practices, see [Best practices](#security-practices).
+The license key is a 40-character hexadecimal string associated with a New Relic account. When you first [sign up](/docs/subscriptions/creating-your-new-relic-account) for New Relic, that creates an organization with a single account, and that account has its own license key. If more accounts are added, each account starts with its own license key. The license key originally created for an account cannot be deleted but you can create additional license keys that can be managed and deleted, and this is useful for implementing security-practices such as key rotation. If you need to delete an account's original license key, [contact support](https://support.newrelic.com).
 </Collapser>
 
 
@@ -187,11 +184,9 @@ For security-related best practices, see [Best practices](#security-practices).
     title="Browser key"
   >
 
-One of the API keys used for data ingest is the browser key. The browser key is what allows the [browser monitoring agent](/docs/browser/new-relic-browser/getting-started/introduction-browser-monitoring) to report data to New Relic. 
+Browser monitoring uses a browser key to report data, rather than the license key. The browser key is used to associate data from the [browser monitoring agent](/docs/browser/new-relic-browser/getting-started/introduction-browser-monitoring) to your account. 
 
 You can't manage or delete the original browser key created when your account was created, but you can create new browser keys and delete those keys. For assistance deleting an account's first browser key, [contact support](https://support.newrelic.com).
-
-For security-related best practices, see [Best practices](#security-practices).
 
 </Collapser>
 
@@ -200,7 +195,7 @@ For security-related best practices, see [Best practices](#security-practices).
     title="Mobile app token"
   >
 
-See [Mobile app token](/docs/mobile-monitoring/new-relic-mobile/maintenance/viewing-your-application-token).
+Mobile monitoring uses a mobile app token to report data, rather than the license key. See [Mobile app token](/docs/mobile-monitoring/new-relic-mobile/maintenance/viewing-your-application-token) for more information.
 </Collapser>
 
   <Collapser
@@ -210,8 +205,6 @@ See [Mobile app token](/docs/mobile-monitoring/new-relic-mobile/maintenance/view
 New Relic user keys, sometimes referred to as "personal API keys," are required for using [NerdGraph](/docs/apis/intro-apis/introduction-new-relic-apis/#graphql) and our [REST API](/docs/apis/intro-apis/introduction-new-relic-apis/#rest-api). 
 
 A user key is tied to both a specific New Relic user and a specific account, and they cannot be transferred. The user key allows you to make queries for any accounts you've been granted access to, not just the specific account the key was associated with. If a New Relic user is deleted in New Relic, their user keys are also deactivated and won't work. 
-
-For security-related best practices, see [Best practices](#security-practices).
 
 </Collapser>
 
@@ -227,10 +220,10 @@ Besides our [main API keys explained above](#overview-keys), we have several oth
     title="Insights insert key (not recommended)"
   >
 <Callout variant="important">
-This key is still in use but we highly recommend using the [license key](#ingest-license-key), which can be used for the same things and more. 
+This key is still in use but we highly recommend using the license key, which can be used for the same things and more. 
 </Callout>
 
-One of our older New Relic API keys used for data ingest is the Insights insert key, also known as an insert key. Note that the [license key](#license-key) is used for the same functionality and more, which is why we recommend the license key over this key. 
+One of our older New Relic API keys used for data ingest is the Insights insert key, also known as an insert key. Note that the license key is used for the same functionality and more, which is why we recommend the license key over this key. 
 
 This key is used for the ingestion of data via our [Event API](/docs/insights/insights-data-sources/custom-data/insert-custom-events-insights-api), [Log API](/docs/enable-new-relic-logs-http-input), [Metric API](/docs/introduction-new-relic-metric-api), and [Trace API](/docs/apm/distributed-tracing/trace-api/introduction-new-relic-trace-api), or via the integrations that use those APIs.
 
@@ -256,24 +249,24 @@ To find and manage Insights query keys: From the [account dropdown](/docs/accoun
     id="admin-keys"
     title="Admin key (deprecated)"
   >
-  The admin key is one of our older, deprecated API keys. As of December 4, 2020, all existing admin keys have been migrated to be [user keys](#user-key).
+  The admin key is one of our older, deprecated API keys. As of December 4, 2020, all existing admin keys have been migrated to be user keys.
 
   If you were using admin keys, you don't need to do anything for those keys to remain active. They'll be automatically accessible via the API keys UI, labeled as user keys, and granted identical permissions. You can manage them as you would any user key via the same workflow.
 
-  All migrated admin keys will have a note that says “Migrated from an admin user key” in the key table.
+  All migrated admin keys will have a note that says **Migrated from an admin user key** in the key table.
 </Collapser>
   <Collapser
     id="rest-api-key"
     title="REST API key (not recommended)"
   >
 
-The REST API key is an older key for using our [REST API](/docs/apis/rest-api-v2/get-started/introduction-new-relic-rest-api-v2). **We now recommend using the [user key](#user-key) instead of the REST API key.** The user is user-specific as opposed to account-specific, which gives your organization more control over your team members' access. Also, we recommend using our newer API, [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph), instead of the REST API.  
+The REST API key is an older key for using our [REST API](/docs/apis/rest-api-v2/get-started/introduction-new-relic-rest-api-v2). **We now recommend using the user key instead of the REST API key.** The user is user-specific as opposed to account-specific, which gives your organization more control over your team members' access. Also, we recommend using our newer API, [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph), instead of the REST API.  
 
 Things to consider: 
 * Each New Relic account can have only **one** REST API key.
-* We recommend using a [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key) instead of the REST API key.
+* We recommend using a user key instead of the REST API key.
 * We recommend using [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) over the REST API, if possible.
-* Requires admin-level user permissions. If you don't have access to the REST API key or the REST API explorer, it might be due to lack of permissions. Talk to your New Relic account manager, or use a [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key) instead.  
+* Requires admin-level user permissions. If you don't have access to the REST API key or the REST API explorer, it might be due to lack of permissions. Talk to your New Relic account manager, or use a user key instead.  
 
 To find and manage REST API keys: From the [account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown), click **API keys** (get [a direct link to the API keys page](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher)). Then click **REST API key**. Before you configure or delete an API key, ensure you are doing so for the correct account.
 </Collapser>


### PR DESCRIPTION
Mostly minor changes:

- Removed most of the anchor links back and forth across the doc in favor of just references. I'm assuming a bit more linear reading here and I worry that the links send people in a circular pattern through the doc.
- Tweak a bit of copy on headings