### PR TITLE
fix: remove `ul` elements in favor of markdown

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -118,9 +118,9 @@ For any installation, you will need your New Relic [license key](/docs/subscript
         * CentOS 8
 
         <Callout variant="important">
-        ARM64 is only supported with:
-        * PHP 8.0 and with New Relic PHP Agent 9.18.1 or later.
-        * PHP 8.1 and with New Relic PHP Agent 9.19.0 or later.
+          ARM64 is only supported with:
+          * PHP 8.0 and with New Relic PHP Agent 9.18.1 or later.
+          * PHP 8.1 and with New Relic PHP Agent 9.19.0 or later.
         </Callout>
 
         For more information on ARM64 support, please see [the ARM64 installation info](/docs/apm/agents/php-agent/installation/php-agent-installation-arm64).

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -22,20 +22,21 @@ New Relic supports PHP versions 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, and 8.1.
 <Callout variant="important">
   Compatibility note: When PHP 8.0 or 8.1 detects an observability extension, like the New Relic agent, PHP disables Just-In-Time compilation.
 
-  Support for PHP 8.1 does not include Fibers.
+Support for PHP 8.1 does not include Fibers.
+
 </Callout>
 
-* We recommend using a [supported release](http://php.net/supported-versions.php) of PHP, especially 7.4, 8.0, and 8.1.
-* PHP 5.1 support was deprecated in release 4.0 of the agent, and removed in release 4.5.
-* PHP 5.2 support was deprecated in release 6.8 of the agent, and removed in release 7.0.
-* PHP 5.3 and PHP 5.4 support was deprecated in release [9.15](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293) of the agent, and removed in release [9.17](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9170300/).
-* 32-bit support for PHP versions 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4 was deprecated in release [9.19](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9190309).
-* Release [9.19](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9190309) is the last release to support ZTS builds. In the future, ZTS builds may not be provided and support may be completely pulled from the codebase.
+- We recommend using a [supported release](http://php.net/supported-versions.php) of PHP, especially 7.4, 8.0, and 8.1.
+- PHP 5.1 support was deprecated in release 4.0 of the agent, and removed in release 4.5.
+- PHP 5.2 support was deprecated in release 6.8 of the agent, and removed in release 7.0.
+- PHP 5.3 and PHP 5.4 support was deprecated in release [9.15](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293) of the agent, and removed in release [9.17](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9170300/).
+- 32-bit support for PHP versions 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4 was deprecated in release [9.19](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9190309).
+- Release [9.19](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9190309) is the last release to support ZTS builds. In the future, ZTS builds may not be provided and support may be completely pulled from the codebase.
 
 ## Permissions [#permissions]
 
-* Installation: Root access [is required](/docs/agents/php-agent/troubleshooting/determing-permissions-requirements) for most installations.
-* Running: Root access [is not required](/docs/agents/php-agent/troubleshooting/determing-permissions-requirements).
+- Installation: Root access [is required](/docs/agents/php-agent/troubleshooting/determing-permissions-requirements) for most installations.
+- Running: Root access [is not required](/docs/agents/php-agent/troubleshooting/determing-permissions-requirements).
 
 ## License key [#license_key]
 
@@ -43,8 +44,8 @@ For any installation, you will need your New Relic [license key](/docs/subscript
 
 ## Processor type [#processor]
 
-* Intel (and compatible) platforms
-* ARM64
+- Intel (and compatible) platforms
+- ARM64
 
 ## Operating systems [#operating-systems]
 
@@ -63,6 +64,7 @@ For any installation, you will need your New Relic [license key](/docs/subscript
         **Supported by New Relic's PHP agent**
       </th>
     </tr>
+
   </thead>
 
   <tbody>
@@ -80,7 +82,7 @@ For any installation, you will need your New Relic [license key](/docs/subscript
 
         * AWS Linux 2
         * Red Hat Enterprise Linux (RHEL) 6 or higher
-        
+
          <Callout variant="important">
             As of March 2022, we deprecated support for Red Hat Enterprise Linux (RHEL) 6. For more information, see our [PHP agent release notes v9.20.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9200310).  It will no longer be supported starting June, 2022.
           </Callout>
@@ -94,7 +96,7 @@ For any installation, you will need your New Relic [license key](/docs/subscript
          <Callout variant="important">
             As of March 2022, we deprecated support for Centos 6. For more information, see our [PHP agent release notes v9.20.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9200310).  It will no longer be supported starting June, 2022.
           </Callout>
-        
+
           <Callout variant="important">
             As of January 2021, we discontinued support for CentOS 5. For more information, see our [PHP agent release notes v9.15.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293) and our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-across-browser-php-python-mobile-and-android-agents/123951).
           </Callout>
@@ -116,14 +118,13 @@ For any installation, you will need your New Relic [license key](/docs/subscript
         * CentOS 8
 
         <Callout variant="important">
-        ARM64 is only supported with:<br/>
-          <ul>
-	          <li>PHP 8.0 and with New Relic PHP Agent 9.18.1 or later.</li>
-            <li> PHP 8.1 and with New Relic PHP Agent 9.19.0 or later.</li>
-          </ul>
+        ARM64 is only supported with:
+        * PHP 8.0 and with New Relic PHP Agent 9.18.1 or later.
+        * PHP 8.1 and with New Relic PHP Agent 9.19.0 or later.
         </Callout>
 
         For more information on ARM64 support, please see [the ARM64 installation info](/docs/apm/agents/php-agent/installation/php-agent-installation-arm64).
+
   </td>
 </tr>
 
@@ -160,8 +161,8 @@ For any installation, you will need your New Relic [license key](/docs/subscript
 
 ## Web servers [#webserver]
 
-* Apache 2.2 or 2.4 via `mod_php`
-* Any web server that supports FastCGI using PHP-FPM
+- Apache 2.2 or 2.4 via `mod_php`
+- Any web server that supports FastCGI using PHP-FPM
 
 ## Frameworks
 
@@ -255,20 +256,17 @@ Supported PHP frameworks include:
         Zend Framework 1.x, 2.x, and 3.x
       </td>
     </tr>
+
   </tbody>
 </table>
 
-<Callout variant="important">
-  Joomla 3.x is not supported on PHP 8.x
-</Callout>
+<Callout variant="important">Joomla 3.x is not supported on PHP 8.x</Callout>
 
 <Callout variant="important">
-  As of PHP agent version 9.17, the following frameworks or framework versions are no longer supported and may be removed from future agent builds:
-  * Cake PHP 1.x
-  * Joomla 1.5, 1.6, and 2.x
-  * Kohana
-  * Silex 1.x and 2.x
-  * Symfony 1.x and 2.x
+  As of PHP agent version 9.17, the following frameworks or framework versions
+  are no longer supported and may be removed from future agent builds: * Cake
+  PHP 1.x * Joomla 1.5, 1.6, and 2.x * Kohana * Silex 1.x and 2.x * Symfony 1.x
+  and 2.x
 </Callout>
 
 The PHP agent's list of frameworks continues to grow. Even if the framework you are using is not listed here, the PHP agent may be able to provide you with useful information about your app.
@@ -371,6 +369,7 @@ Supported databases and libraries:
         Sybase
       </td>
     </tr>
+
   </tbody>
 </table>
 
@@ -399,6 +398,7 @@ New Relic's PHP agent [version 6.8 or higher](/docs/release-notes/agent-release-
         Minimum agent version
       </th>
     </tr>
+
   </thead>
 
   <tbody>
@@ -513,20 +513,21 @@ New Relic's PHP agent [version 6.8 or higher](/docs/release-notes/agent-release-
         7.1
       </td>
     </tr>
+
   </tbody>
 </table>
 
 To disable collection of host information, use either of these options:
 
-* Set `newrelic.datastore_tracer.instance_reporting.enabled` to `false` in the `newrelic.ini`.
-* Omit the database name with `newrelic.datastore_tracer.database_name_reporting.enabled = false`.
+- Set `newrelic.datastore_tracer.instance_reporting.enabled` to `false` in the `newrelic.ini`.
+- Omit the database name with `newrelic.datastore_tracer.database_name_reporting.enabled = false`.
 
 To request instance-level information from datastores currently not listed for your New Relic agent, get support at [support.newrelic.com](https://support.newrelic.com).
 
 ## Message queuing [#queuing]
 
-* HTTP
-* Laravel Queuing, available as an experimental feature in the [PHP Agent 6.6.0.169 release](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-660169), enabled by default since [PHP Agent 8.0.0.204](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-800204).
+- HTTP
+- Laravel Queuing, available as an experimental feature in the [PHP Agent 6.6.0.169 release](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-660169), enabled by default since [PHP Agent 8.0.0.204](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-800204).
 
 ## Security requirements [#security]
 
@@ -547,6 +548,7 @@ The PHP agent integrates with other New Relic features to give you end-to-end vi
         Integration
       </th>
     </tr>
+
   </thead>
 
   <tbody>
@@ -589,5 +591,6 @@ The PHP agent integrates with other New Relic features to give you end-to-end vi
         [Synthetic transaction traces](/docs/synthetics/new-relic-synthetics/using-monitors/collect-synthetic-transaction-traces) connect requests from synthetic monitors to the underlying APM transaction.
       </td>
     </tr>
+
   </tbody>
 </table>


### PR DESCRIPTION
## Description

Removes `ul` and `li` html tags in favor of markdown to fix this serialization error when sending file for translation.

https://github.com/newrelic/docs-website/runs/5547110228?check_suite_focus=true