### PR TITLE
Clarify when PMM review is necessary and add PMM to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@ yarn.lock @newrelic/developer-enablement
 
 # Whats new files (pings individual project marketing managers)
 
-/src/content/whats-new/ @ishanmkh @jkinmonth @alexiskjones @molson10 @daynaslord
+/src/content/whats-new/ @ishanmkh @jkinmonth @alexiskjones @B1XR11L729w583adTl5899556EJ5322a @daynaslord

--- a/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
@@ -22,7 +22,7 @@ A high-altitude view of the `What's new` process looks like this:
 
 Each day, the hero is responsible for checking the status of `What’s new` posts. The daily hero takes ownership of the post (reviewing, posting, and confirming that posts make it to docs site and product UI). When the post comes in, only assign it to yourself if you're going to see it through from start to finish. Otherwise, you can just monitor it as it goes through the workflow.
 
-Before you start your writing review, make sure it was reviewed by a product marketing manager if the post was from outside that department. For example, if a developer or product manager submits a post, it should be reviewed first by a product marketing manager (anyone listed in the [CODEOWNERS file](.github/CODEOWNERS). After a product marketing manager reviews the post and passes it to the hero, make sure you complete the steps in the sections below.
+Before you start your writing review, make sure it was reviewed by a product marketing manager if the post was from outside that department. For example, if a developer or product manager submits a post, it should be reviewed first by a product marketing manager (anyone listed in the [CODEOWNERS file](.github/CODEOWNERS)). After a product marketing manager reviews the post and passes it to the hero, make sure you complete the steps in the sections below.
 
 ### Manage GitHub board [#the-board]
 

--- a/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
@@ -22,7 +22,7 @@ A high-altitude view of the `What's new` process looks like this:
 
 Each day, the hero is responsible for checking the status of `What’s new` posts. The daily hero takes ownership of the post (reviewing, posting, and confirming that posts make it to docs site and product UI). When the post comes in, only assign it to yourself if you're going to see it through from start to finish. Otherwise, you can just monitor it as it goes through the workflow.
 
-Before you start your writing review, most posts need to be reviewed by a product marketing manager listed in [CODEOWNERS](.github/CODEOWNERS), unless the post came directly from one of those managers. After a product marketing manager reviews the post and passes it to the hero, make sure you complete the steps in the sections below.
+Before you start your writing review, make sure that posts submitted by anyone outside of product marketing management gets reviewed by a product marketing manager listed in [CODEOWNERS](.github/CODEOWNERS). For example, if a product manager submits a post, this should be reviewed first by a product marketing manager. After a product marketing manager reviews the post and passes it to the hero, make sure you complete the steps in the sections below.
 
 ### Manage GitHub board [#the-board]
 

--- a/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
@@ -22,7 +22,7 @@ A high-altitude view of the `What's new` process looks like this:
 
 Each day, the hero is responsible for checking the status of `What’s new` posts. The daily hero takes ownership of the post (reviewing, posting, and confirming that posts make it to docs site and product UI). When the post comes in, only assign it to yourself if you're going to see it through from start to finish. Otherwise, you can just monitor it as it goes through the workflow.
 
-Before you start your writing review, make sure that posts submitted by anyone outside of product marketing management gets reviewed by a product marketing manager listed in [CODEOWNERS](.github/CODEOWNERS). For example, if a product manager submits a post, this should be reviewed first by a product marketing manager. After a product marketing manager reviews the post and passes it to the hero, make sure you complete the steps in the sections below.
+Before you start your writing review, make sure it was reviewed by a product marketing manager if the post was from outside that department. For example, if a developer or product manager submits a post, it should be reviewed first by a product marketing manager (anyone listed in the [CODEOWNERS file](.github/CODEOWNERS). After a product marketing manager reviews the post and passes it to the hero, make sure you complete the steps in the sections below.
 
 ### Manage GitHub board [#the-board]
 


### PR DESCRIPTION
It turns out that PMMs who submit "What's new" posts don't need a review from a fellow PMM.

I also replaced on PMM with another in the CODEOWNERS list of reviewers.