### PR TITLE
Add .NET agent 9.6.1 release notes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9610.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9610.mdx
@@ -1,0 +1,33 @@
+---
+subject: .NET agent
+releaseDate: '2022-03-15'
+version: 9.6.1.0
+downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+---
+
+### Fixes
+* Fixes [application pool allow/deny listing bug](https://github.com/newrelic/newrelic-dotnet-agent/issues/1014) introduced in 9.5.0 ([#1015](https://github.com/newrelic/newrelic-dotnet-agent/pull/1015))
+
+### Checksums
+| File | SHA - 256  Hash |
+| ---| ---|
+| newrelic-agent-win-9.6.1.0-scriptable-installer.zip | 5C06B19B9D29D0F8E47170083EE5A9A1D7C576BC049E6C207AD69D069E09E6F6 |
+| newrelic-agent-win-x64-9.6.1.0.msi | 2AE3A0E647BD9A490B9D4F3B23817784B5FA70B5F949136E1637206118A978C9 |
+| newrelic-agent-win-x64-9.6.1.0.zip | 4D1053241C2F4849199750D598A473DB81687F0C6357582A4DA76C2E5DED82F5 |
+| newrelic-agent-win-x86-9.6.1.0.msi | 835A95F61A9097A05A9EDECADA4BD9E665FF0BFF71786B238EAC0263B8E039EE |
+| newrelic-agent-win-x86-9.6.1.0.zip | D84DE006542F1EDEAD1C07F6FD7BF9E82405A777A9BFC5A72FE679310EA5007B |
+| newrelic-netcore20-agent-9.6.1.0-1.x86_64.rpm | 50317ABECA590387AEC7A97D7C40AB42981E074C888647174C01B2B326BF30E3 |
+| newrelic-netcore20-agent-win-9.6.1.0-scriptable-installer.zip | 759ADF56231178A5285087277D4968018DB6889F13BE7C8473FE87CCD1ABCA62 |
+| newrelic-netcore20-agent-win-x64-9.6.1.0.zip | CC080FBF6C4B46171F994C40DC36937E85E78A3665927E5CC0DD768BD6F4F555 |
+| newrelic-netcore20-agent-win-x86-9.6.1.0.zip | 01FC9A6DA642257ABDD9666831D3F68B2EB8D50C74279878B73D6E8E221AFF51 |
+| newrelic-netcore20-agent_9.6.1.0_amd64.deb | 99D46257FBE232806C8D79AFD95FE9A95F6194C9A78B023C9743C84D3BCB5A16 |
+| newrelic-netcore20-agent_9.6.1.0_amd64.tar.gz | 2ABDB8AE794660CE360A0AE13C6D32A224E67E2F8BDED8283E9B41F2F808BE77 |
+| newrelic-netcore20-agent_9.6.1.0_arm64.deb | 9E422642220A1E164ADBA6C48269207B00CBDD5FBA3491BE26AF4B91EBC94137 |
+| newrelic-netcore20-agent_9.6.1.0_arm64.tar.gz | A5102EDAEFC11C90368809C929ED80AA609D448FF67FA544CD7E75E27FE34BB1 |
+
+### Support statement
+New Relic recommends that you update the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [.NET agent 8.26.630.0](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8266300).
+
+### Updating
+* Follow standard procedures to [update the .NET agent](/docs/agents/net-agent/installation-configuration/update-net-agent).
+* If you're using a particularly old agent, review the list of major changes and procedures for [updating legacy .NET agents](/docs/agents/net-agent/troubleshooting/upgrade-legacy-net-agents).


### PR DESCRIPTION
Add release notes for .NET agent 9.6.1.