### PR TITLE
Added callout about attributes config param

### DIFF
--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -518,7 +518,7 @@ The following configuration parameters are not required but are still recommende
 List of custom attributes specified as key-value pairs that can be used to send additional data with the logs which you can then query. The `attributes` configuration parameter can be used with any log source.
     
 <Callout variant="important">
-  The `attributes` configuration parameter does not add custom attributes to logs forwarded via external Fluent Bit configuration (i.e. using the `fluentbit` configuration parameter). In this scenario, you should refer to the `record_modifier` option in the [Fluent Bit documentation](https://docs.fluentbit.io/manual/).
+  The `attributes` configuration parameter does not add custom attributes to logs forwarded via external Fluent Bit configuration (for example, using the `fluentbit` configuration parameter). In this scenario, you should refer to the `record_modifier` option in the [Fluent Bit documentation](https://docs.fluentbit.io/manual/).
 </Callout>
 
 One common use of the `attributes` configuration parameter is to specify the `logtype` attribute. This attribute allows leveraging one of the [built-in parsing rules](https://docs.newrelic.com/docs/logs/log-management/ui-data/parsing/#built-in-rules) supported by New Relic Logs.

--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -516,6 +516,10 @@ The following configuration parameters are not required but are still recommende
     >
 
 List of custom attributes specified as key-value pairs that can be used to send additional data with the logs which you can then query. The `attributes` configuration parameter can be used with any log source.
+    
+<Callout variant="important">
+  The `attributes` configuration parameter does not add custom attributes to logs forwarded via external Fluent Bit configuration (i.e. using the `fluentbit` configuration parameter). In this scenario, you should refer to the `record_modifier` option in the [Fluent Bit documentation](https://docs.fluentbit.io/manual/).
+</Callout>
 
 One common use of the `attributes` configuration parameter is to specify the `logtype` attribute. This attribute allows leveraging one of the [built-in parsing rules](https://docs.newrelic.com/docs/logs/log-management/ui-data/parsing/#built-in-rules) supported by New Relic Logs.
 


### PR DESCRIPTION
Attributes config param doesn't take effect when an external Fluent Bit configuration file is specified. Added callout explaining this.