### PR TITLE
Add trace observer region list

### DIFF
--- a/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
@@ -32,13 +32,15 @@ To create a new trace observer if you're using New Relic APM agents or third-par
 
 1. Go to [one.newrelic.com](https://one.newrelic.com) and click **Apps**, and then under **Your apps**, click **New Relic Edge**.
 2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled.
-3. If no trace observers are already present, click **New trace observer** to add one, fill out the information, and click **Create**.
+3. If no trace observers are already present, click **New trace observer** to add one, fill out the information, and click **Create**. Note that we offer the following regions:
 
-    <Callout variant="important">
-    We offer two options for the EU region:
-      * eu-west-1: Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
-      * eu-central-1: Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports in EU data centers.
-    </Callout>
+    * eu-central-1 (EU): Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports in EU data centers.
+    * us-east-1 (US)
+    * us-west-2 (US)
+    * eu-west-1 (US): Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
+    * ap-southeast-1 (US)
+    * ap-southeast-2 (US)
+    * us-east-2 (US, FedRAMP)
 
 4. Under the **Endpoints** dropdown, copy the endpoint value under **For other integrations** and have it ready. This value is referenced in our code examples as <var>YOUR_TRACE_OBSERVER_URL</var>. This is used to test the [trace observer](#sample-payload), as well as to configure our [telemetry integrations](/docs/distributed-tracing/enable-configure/quick-start) and for sending data via the [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api/).
 
@@ -175,13 +177,15 @@ If you haven't already set up a trace observer, complete the following:
 
 1. Go to [one.newrelic.com](https://one.newrelic.com) and click **Apps**, and then under **Your apps**, click **New Relic Edge**.
 2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled.
-3. If no trace observers are already present, click **New trace observer** to add one, fill out the information, and click **Create**.
+3. If no trace observers are already present, click **New trace observer** to add one, fill out the information, and click **Create**. Note that we offer the following regions:
 
-    <Callout variant="important">
-    We offer two options for the EU region:
-      * eu-west-1: Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
-      * eu-central-1: Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports in EU data centers.
-    </Callout>
+    * eu-central-1 (EU): Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports in EU data centers.
+    * us-east-1 (US)
+    * us-west-2 (US)
+    * eu-west-1 (US): Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
+    * ap-southeast-1 (US)
+    * ap-southeast-2 (US)
+    * us-east-2 (US, FedRAMP)
 
 4. Under the **Endpoints** dropdown, copy the endpoint value under **For other integrations** and have it ready. This value is referenced in our code examples as <var>YOUR_TRACE_OBSERVER_URL</var>. This is used to test the [trace observer](#sample-payload).
 

--- a/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
@@ -64,7 +64,7 @@ To create a new trace observer if you're using New Relic APM agents or third-par
        1. Get the [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key) for the account you want to report data to and have it ready.
        2. Copy the following `curl` request into a text editor:
 
-          ```
+          ```bash
           curl -i -H "Content-Type: application/json" \
             -H "Api-Key: <var>$YOUR_LICENSE_KEY</var>" \
             -H 'Data-Format: newrelic' \
@@ -207,7 +207,7 @@ If you haven't already set up a trace observer, complete the following:
        1. Get the [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key) for the account you want to report data to and have it ready.
        2. Copy the following `curl` request into a text editor:
 
-          ```
+          ```bash
           curl -i -H "Content-Type: application/json" \
             -H "Api-Key: <var>$YOUR_LICENSE_KEY</var>" \
             -H 'Data-Format: newrelic' \

--- a/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
@@ -34,13 +34,13 @@ To create a new trace observer if you're using New Relic APM agents or third-par
 2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled.
 3. If no trace observers are already present, click **New trace observer** to add one, fill out the information, and click **Create**. Note that we offer the following regions:
 
-    * eu-central-1 (EU): Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports in EU data centers.
-    * us-east-1 (US)
-    * us-west-2 (US)
-    * eu-west-1 (US): Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
-    * ap-southeast-1 (US)
-    * ap-southeast-2 (US)
-    * us-east-2 (US, FedRAMP)
+    * **eu-central-1 (EU):** Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports in EU data centers.
+    * **us-east-1 (US)**
+    * **us-west-2 (US)**
+    * **eu-west-1 (US):** Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
+    * **ap-southeast-1 (US)**
+    * **ap-southeast-2 (US)**
+    * **us-east-2 (US, FedRAMP)**
 
 4. Under the **Endpoints** dropdown, copy the endpoint value under **For other integrations** and have it ready. This value is referenced in our code examples as <var>YOUR_TRACE_OBSERVER_URL</var>. This is used to test the [trace observer](#sample-payload), as well as to configure our [telemetry integrations](/docs/distributed-tracing/enable-configure/quick-start) and for sending data via the [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api/).
 
@@ -179,13 +179,13 @@ If you haven't already set up a trace observer, complete the following:
 2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled.
 3. If no trace observers are already present, click **New trace observer** to add one, fill out the information, and click **Create**. Note that we offer the following regions:
 
-    * eu-central-1 (EU): Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports in EU data centers.
-    * us-east-1 (US)
-    * us-west-2 (US)
-    * eu-west-1 (US): Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
-    * ap-southeast-1 (US)
-    * ap-southeast-2 (US)
-    * us-east-2 (US, FedRAMP)
+    * **eu-central-1 (EU):** Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports in EU data centers.
+    * **us-east-1 (US)**
+    * **us-west-2 (US)**
+    * **eu-west-1 (US):** Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
+    * **ap-southeast-1 (US)**
+    * **ap-southeast-2 (US)**
+    * **us-east-2 (US, FedRAMP)**
 
 4. Under the **Endpoints** dropdown, copy the endpoint value under **For other integrations** and have it ready. This value is referenced in our code examples as <var>YOUR_TRACE_OBSERVER_URL</var>. This is used to test the [trace observer](#sample-payload).
 

--- a/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
@@ -34,9 +34,9 @@ To create a new trace observer if you're using New Relic APM agents or third-par
 2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled.
 3. If no trace observers are already present, click **New trace observer** to add one, fill out the information, and click **Create**. Note that we offer the following regions:
 
-    * **eu-central-1 (EU):** Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports in EU data centers.
     * **us-east-1 (US)**
     * **us-west-2 (US)**
+    * **eu-central-1 (EU):** Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports in EU data centers.
     * **eu-west-1 (US):** Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
     * **ap-southeast-1 (US)**
     * **ap-southeast-2 (US)**
@@ -179,9 +179,9 @@ If you haven't already set up a trace observer, complete the following:
 2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled.
 3. If no trace observers are already present, click **New trace observer** to add one, fill out the information, and click **Create**. Note that we offer the following regions:
 
-    * **eu-central-1 (EU):** Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports in EU data centers.
     * **us-east-1 (US)**
     * **us-west-2 (US)**
+    * **eu-central-1 (EU):** Select this region if you are collecting data from EU requests and you have an EU-based New Relic account that reports in EU data centers.
     * **eu-west-1 (US):** Select this region if you are collecting data from EU requests and you have a US-based New Relic account that reports in US data centers.
     * **ap-southeast-1 (US)**
     * **ap-southeast-2 (US)**


### PR DESCRIPTION
We've never had a list of trace observer region, so this PR adds the list in two places in the trace observer doc:

* In the APM/OTEL section
* In the browser, mobile, and lambda section

This will take some work to maintain, but I think it's easier for readers to find the information right when they need it.

REVIEWER: 

This just needs confirmation that it is readable. I don't need a review of the who document.