### PR TITLE
Update install-ecs-integration.mdx

### DIFF
--- a/src/content/docs/infrastructure/elastic-container-service-integration/installation/install-ecs-integration.mdx
+++ b/src/content/docs/infrastructure/elastic-container-service-integration/installation/install-ecs-integration.mdx
@@ -133,7 +133,7 @@ One [install option](#install-overview) is using our install script. To use the 
    AWS Fargate launch type:
 
    ```
-   ./newrelic-infra-ecs-installer.sh -fargate -c <var>YOUR_CLUSTER_NAME</var> -l <var>YOUR_LICENSE_KEY</var>
+   ./newrelic-infra-ecs-installer.sh -f -c <var>YOUR_CLUSTER_NAME</var> -l <var>YOUR_LICENSE_KEY</var>
    ```
 6. Additional steps for [Fargate launch type](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html) (not EC2 launch type):
    * Download the task definition example with the sidecar container to be deployed:


### PR DESCRIPTION
`-fargate` is not a valid arg from installer script, `-f` is:

```./newrelic-infra-ecs-installer.sh -fargate -c CLUSTERNAME -l NRAK-XXXX
./newrelic-infra-ecs-installer.sh: illegal option -- a
./newrelic-infra-ecs-installer.sh: illegal option -- r
./newrelic-infra-ecs-installer.sh: illegal option -- g
./newrelic-infra-ecs-installer.sh: illegal option -- a
./newrelic-infra-ecs-installer.sh: illegal option -- t
Installing the New Relic ECS integration...```