### PR TITLE
Docs metrics adapter correct AccountID value path and modify chart links

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/newrelic-metrics-adapter.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/newrelic-metrics-adapter.mdx
@@ -70,7 +70,7 @@ Please notice and adjust the following flags:
 
 ## Configuration [#configuration]
 
-You can configure multiple metrics in the metrics adapter and change some parameters to modify the behaviour of the metrics cache and filtering. To see the full list and descriptions of all parameters that can be modified, refer to the chart [README.md](https://github.com/newrelic/helm-charts/blob/master/charts/newrelic-k8s-metrics-adapter/README.md) and [values.yaml](https://github.com/newrelic/helm-charts/blob/master/charts/newrelic-k8s-metrics-adapter/values.yaml) files.
+You can configure multiple metrics in the metrics adapter and change some parameters to modify the behaviour of the metrics cache and filtering. To see the full list and descriptions of all parameters that can be modified, refer to the chart [README.md](https://github.com/newrelic/newrelic-k8s-metrics-adapter/blob/main/charts/newrelic-k8s-metrics-adapter/README.md) and [values.yaml](https://github.com/newrelic/newrelic-k8s-metrics-adapter/blob/main/charts/newrelic-k8s-metrics-adapter/values.yaml) files.
 
 ## How it works [#how-it-works]
 

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/newrelic-metrics-adapter.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/newrelic-metrics-adapter.mdx
@@ -58,7 +58,7 @@ Please notice and adjust the following flags:
 
 * `metrics-adapter.enabled`: Must be set to `true` so the metrics adapter chart is installed.
 * `newrelic-k8s-metrics-adapter.personalAPIKey`: Must be set to valid New Relic [Personal API key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#user-api-key).
-* `newrelic-k8s-metrics-adapter.accountID`: Must be set to valid New Relic account where metrics are going to be fetched from.
+* `newrelic-k8s-metrics-adapter.config.accountID`: Must be set to valid New Relic account where metrics are going to be fetched from.
 * `newrelic-k8s-metrics-adapter.config.externalMetrics.<var>external_metric_name</var>.<var>query</var>`: Adds a new external metric where:
   * `<var>external_metric_name</var>`: The metric name.
   * `<var>query</var>`: The base NRQL query that is used to get the value for the metric.


### PR DESCRIPTION
- We have moved the chart for the metrics adapter to its own repository.
- The nri-bundle installation keeps working as it was, but the links to the chart needed to be modified.
- We spotted also a wrong path for the accountID path.