### PR TITLE
fix(api keys): adding note about capabilities

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
@@ -122,7 +122,7 @@ Our standard roles include:
       </td>
 
       <td>
-        Provides admin-level access to observability platform features but not organization-level and user management features. In other words, this role includes all New Relic capabilities with the exception of managing users (**Authentication domain manager** role), managing organization/account-structure settings (**Organization manager** role), and managing billing (**Billing user** role).
+        Provides admin-level access to observability platform features but not organization-level and user management features. In other words, this role includes all New Relic capabilities with the exception of managing users (**Authentication domain manager** role), managing organization/account-structure settings (**Organization manager** role), and managing billing (**Billing user** role). To better understand this role's capabilities, go to the **Organization and access** UI and view this role.
 
         Note: the **Standard user** role is essentially the **All product admin** role minus observability feature configuration capabilities. 
       </td>
@@ -138,7 +138,7 @@ Our standard roles include:
       </td>
 
       <td>
-        Provides access to observability platform features, but lacks permissions for configuring those features (for example, ability to configure [synthetic monitor secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests)) and lacks organization-level and user management permissions. 
+        Provides access to observability platform features, but lacks permissions for configuring those features (for example, ability to configure [synthetic monitor secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests)) and lacks organization-level and user management permissions. To better understand this role's capabilities, go to the **Organization and access** UI and view this role.
 
         Note: the **Standard user** role is essentially the **All product admin** role without that role's ability to configure platform features.  
       </td>
@@ -155,7 +155,7 @@ Our standard roles include:
       </td>
 
       <td>
-        Provides ability to manage subscriptions and billing setup, and read-only access to the rest of the platform. For organizations with multiple accounts, billing is aggregated in the primary (first-created) account, which is why assigning this role to that primary account grants billing permissions for the entire organization.
+        Provides ability to manage subscriptions and billing setup, and read-only access to the rest of the platform. For organizations with multiple accounts, billing is aggregated in the primary (first-created) account, which is why assigning this role to that primary account grants billing permissions for the entire organization. To better understand this role's capabilities, go to the **Organization and access** UI and view this role.
       </td>
     </tr>
 
@@ -169,7 +169,7 @@ Our standard roles include:
       </td>
 
       <td>
-        Provides the ability to manage [organization](/docs/accounts/accounts-billing/new-relic-one-pricing-users/new-relic-account-structure) settings, including organization structure, name, and preferences. Due to our recent switch to the [New Relic One user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-user-models), this role currently has few abilities but more will be added over time.
+        Provides the ability to manage [organization](/docs/accounts/accounts-billing/new-relic-one-pricing-users/new-relic-account-structure) settings, including organization structure, name, and preferences. Due to our recent switch to the [New Relic One user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-user-models), this role currently has few abilities but more will be added over time. Because this is an organization-scoped role, it has hidden capabilities that you cannot view in the **Roles** UI. 
         
         For how to grant this role, see [Add user management capability](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/#add-user-managers).
       </td>
@@ -185,7 +185,7 @@ Our standard roles include:
       </td>
 
       <td>
-        Provides the ability to view organization-level settings. For how to grant this role, see [Add user management capability](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/#add-user-managers).
+        Provides the ability to view organization-level settings. For how to grant this role, see [Add user management capability](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/#add-user-managers). Because this is an organization-scoped role, it has hidden capabilities that you cannot view in the **Roles** UI. 
       </td>
     </tr>
 
@@ -199,7 +199,7 @@ Our standard roles include:
       </td>
 
       <td>
-        Provides ability to add and manage users, and configure [authentication domains](/docs/accounts/accounts-billing/new-relic-one-user-management/configure-authentication-domains-sso) for users on the [New Relic One user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model#user-models). For how to grant this role, see [Add user management capability](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/#add-user-managers).
+        Provides ability to add and manage users, and configure [authentication domains](/docs/accounts/accounts-billing/new-relic-one-user-management/configure-authentication-domains-sso) for users on the [New Relic One user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model#user-models). For how to grant this role, see [Add user management capability](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/#add-user-managers). Because this is an organization-scoped role, it has hidden capabilities that you cannot view in the **Roles** UI. 
       </td>
     </tr>
 
@@ -213,7 +213,7 @@ Our standard roles include:
       </td>
 
       <td>
-        Provides the ability to view users in your organization and view the configuration of [authentication domains](/docs/accounts/accounts-billing/new-relic-one-user-management/configure-authentication-domains-sso). For how to grant this role, see [Add user management capability](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/#add-user-managers).
+        Provides the ability to view users in your organization and view the configuration of [authentication domains](/docs/accounts/accounts-billing/new-relic-one-user-management/configure-authentication-domains-sso). For how to grant this role, see [Add user management capability](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/#add-user-managers). Because this is an organization-scoped role, it has hidden capabilities that you cannot view in the **Roles** UI. 
       </td>
     </tr>
 
@@ -228,7 +228,7 @@ Our standard roles include:
       </td>
 
       <td>
-        Provides read-only access to the New Relic platform (except for [synthetic monitor secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests)).
+        Provides read-only access to the New Relic platform (except for [synthetic monitor secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests)). To better understand this role's capabilities, go to the **Organization and access** UI and view this role.
       </td>
     </tr>    
 
@@ -252,7 +252,7 @@ For more about how you'd assign roles to groups and create custom roles, see the
 
 ## Capabilities [#capabilities]
 
-A role, whether one of our [standard roles](#standard-roles) or a custom role, is a set of capabilities. To view roles and their associated capabilities, use the [**Organization and access** UI](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks#where).
+A role, whether one of our [standard roles](#standard-roles) or a custom role, is a set of capabilities. To learn what capabilities a role has, go to the [**Organization and access** UI](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks#where) and view a specific role. 
 
 ![New Relic user capabilities UI screenshot](./images/new-relic-user-capabilities-ui.png "New Relic user capabilities screenshot")
 <figcaption>

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -176,6 +176,8 @@ Our main key used for data ingest is called the license key. In the API keys UI 
 The license key is required for almost all New Relic data ingest. The exceptions are browser monitoring data (which uses a browser key) and mobile monitoring data (which uses a mobile app token). 
 
 The license key is a 40-character hexadecimal string associated with a New Relic account. When you first [sign up](/docs/subscriptions/creating-your-new-relic-account) for New Relic, an organization with a single account and its own license key are created. If more accounts are added, each account starts with its own license key. The license key originally created for an account cannot be deleted but you can create additional license keys that can be managed and deleted, and this is useful for implementing security-practices such as key rotation. If you need to delete an account's original license key, [contact support](https://support.newrelic.com).
+
+To restrict a user from being able to view or manage license keys, you can choose a role without those capabilities: [original user model](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model#add-on) | [New Relic One user model](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#capabilities). 
     
 </Collapser>
 


### PR DESCRIPTION
Adding note to API key 'license key' section about ability to restrict access to that api key. 

Also adding notes to roles/capabilities docs recommending checking out capabilities UI to better understand roles. 