### PR TITLE
docs: add upper limit to maximumSamplesStored

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -2975,6 +2975,8 @@ The `spanEvents` element supports the following attributes:
 
     The maximum number of samples to store in memory at a time. This may be configured using the `NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED` environment variable as well.
     
+    We do not recommend configuring past 10k. The server will cap data at 10k per-minute.
+    
     <Callout variant="important">
       This configuration option is only available in the .NET Agent v9.0 or higher.
     </Callout>


### PR DESCRIPTION
This value can be any valid integer but the server won't handle over 10k. This note was taken from the config docs in node, the same rule applies here.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.