### PR TITLE
Capping the Apache Httpclient version

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -378,7 +378,7 @@ The agent automatically instruments these frameworks and libraries:
       - Scala 2.12: 0.21 - 0.22.0-M8
       - Scala 2.13: 0.21 - 0.22.0-M8
     * HttpAsyncClient 4.1 to latest
-    * Apache Httpclient from 3.0 to latest
+    * Apache Httpclient from 3.0 to 4.5.x
     * java.net.HttpURLConnection
     * JMS and Spring-JMS 1.1 to latest
     * [Kafka Clients](/docs/agents/java-agent/instrumentation/use-kafka-message-queues) 0.10.0.0 to 2.8.1 (for metric and event data)


### PR DESCRIPTION
In response to confirmation that existing instrumentation does not work for the newer 5.x client version