### PR TITLE
docs: new-relic format to newrelic format

### DIFF
--- a/src/content/docs/distributed-tracing/trace-api/report-new-relic-format-traces-trace-api.mdx
+++ b/src/content/docs/distributed-tracing/trace-api/report-new-relic-format-traces-trace-api.mdx
@@ -12,13 +12,13 @@ redirects:
   - /docs/understand-dependencies/distributed-tracing/trace-api/report-new-relic-format-traces-trace-api
 ---
 
-If you want to create your own tracing implementation, you can use our [Trace API](/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api). This doc explains how to send traces in our general format, aka `new-relic` format. (To send Zipkin-format data, see [Zipkin](/docs/apm/distributed-tracing/trace-api/report-zipkin-format-traces-trace-api).)
+If you want to create your own tracing implementation, you can use our [Trace API](/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api). This doc explains how to send traces in our general format, aka `newrelic` format. (To send Zipkin-format data, see [Zipkin](/docs/apm/distributed-tracing/trace-api/report-zipkin-format-traces-trace-api).)
 
 ## Get started [#send-data-overview]
 
 Using our Trace API is as simple as:
 
-* Sending trace data in the expected format (in this case, our `new-relic` format).
+* Sending trace data in the expected format (in this case, our `newrelic` format).
 * Sending that data to the appropriate [endpoint](/docs/understand-dependencies/distributed-tracing/trace-api/trace-api-general-requirements-limits#requirements).
 
 Before using the Trace API, you should decide whether you want to use Infinite Tracing. To learn more about this, see [Intro to Infinite Tracing](/docs/understand-dependencies/distributed-tracing/infinite-tracing/introduction-infinite-tracing) and [Sampling considerations](/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api#sampling).


### PR DESCRIPTION
the data format does not contain a `-`, see example cURL commands:

```bash
...
    -H 'Data-Format: newrelic' \
```

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.