### PR TITLE
Code owner changes and team reference update

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
 # .github directory & its subdirectories
-/.github/ @newrelic/developer-enablement
+/.github/ @newrelic/docs-engineering
 
 # all javascript files
-*.js @newrelic/developer-enablement
+*.js @newrelic/docs-engineering
 
-yarn.lock @newrelic/developer-enablement
+yarn.lock @newrelic/docs-engineering
 
 # Whats new files (pings individual project marketing managers)
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@ yarn.lock @newrelic/docs-engineering
 
 # Whats new files (pings individual project marketing managers)
 
-/src/content/whats-new/ @ishanmkh @jkinmonth @alexiskjones @B1XR11L729w583adTl5899556EJ5322a @daynaslord
+/src/content/whats-new/ @jkinmonth @alexiskjones @daynaslord

--- a/.github/workflows/check-translations-and-deserialize.yml
+++ b/.github/workflows/check-translations-and-deserialize.yml
@@ -73,7 +73,7 @@ jobs:
           base: develop
           delete-branch: true
           reviewers: jmiraNR
-          team-reviewers: developer-enablement
+          team-reviewers: docs-engineering
 
       - name: Remove Completed Batches From Queue
         if: steps.fetch-deserialize.outputs.successfulTranslations != 0 && steps.create-pr.outcome == 'success'
@@ -144,7 +144,7 @@ jobs:
           base: develop
           delete-branch: true
           reviewers: jmiraNR
-          team-reviewers: developer-enablement
+          team-reviewers: docs-engineering
 
       - name: Remove Completed Batches From Queue
         if: steps.fetch-deserialize.outputs.successfulTranslations != 0 && steps.create-pr.outcome == 'success'

--- a/.github/workflows/update-whats-new-ids.yml
+++ b/.github/workflows/update-whats-new-ids.yml
@@ -60,8 +60,8 @@ jobs:
             })
             console.log("Result:", result)
 
-        # Push directly to the `develop` branch so we get the changes included in the release PR
 
+        # Push directly to the `develop` branch so we get the changes included in the release PR
       - name: Push Commit
         if: steps.commit-changes.outputs.commit == 'true'
         uses: ad-m/github-push-action@v0.6.0
@@ -93,7 +93,7 @@ jobs:
               },
               restrictions: {
                 users: [],
-                teams: ['developer-enablement']
+                teams: ['docs-engineering']
               },
               enforce_admins: null,
               required_pull_request_reviews: {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@
     - [Unit tests](#unit-tests)
     - [Using multiple versions of Node](#using-multiple-versions-of-node)
     - [Cloning vs forking](#cloning-vs-forking)
+      - [Forks - GitHub Workflows / Actions](#forks---github-workflows--actions)
     - [Submitting a PR from a forked repo](#submitting-a-pr-from-a-forked-repo)
     - [Submitting a PR from a cloned repo](#submitting-a-pr-from-a-cloned-repo)
     - [Using the `develop` branch](#using-the-develop-branch)
@@ -79,15 +80,15 @@ which clearly explains the setup and configuration of NVM.
 
 ### Cloning vs forking
 
-To be able to [clone](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) this repository and contribute you will need to be given write access to the repository. This is reserved for New Relic Doc Writers. Contact the Developer Enablement team (#help-deven-websites Slack channel) if you need write access.
+To be able to [clone](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) this repository and contribute you will need to be given write access to the repository. This is reserved for New Relic Doc Writers. Contact the Docs Engineering team (#help-deven-websites Slack channel) if you need write access.
 
 To contribute without write access, you can [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the repository and contribute as needed. If you're planning to leave a fork open for a long time (for example, you're working on a complex set of changes to many docs), [sync your fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork) occasionally to avoid merge conflicts.
 
 #### Forks - GitHub Workflows / Actions
 
-This repository contains workflows that are not meant to be run on forks. If they do run, they will fail and generate alerts on every failed run. 
+This repository contains workflows that are not meant to be run on forks. If they do run, they will fail and generate alerts on every failed run.
 
-By default, a user should see a prompt like this after cloning the repo when looking at the actions tab: 
+By default, a user should see a prompt like this after cloning the repo when looking at the actions tab:
 
 ![Disabled GitHub Actions](src/images/workflows_disabled_by_default.png 'disabled-workflows-prompt')
 
@@ -173,8 +174,8 @@ As a reminder, here's the format for a single-line commit, but you are welcome t
 <type>(optional scope): <description>
 ```
 
-When choosing a type, you can pick from any of the standard types (feat, fix, style, test, or chore) or you can add your own. 
-**Note**: There is a `documentation` type, but please refrain from using it for general documentation changes since it is intended for changes to the repository's documentation (such as `README.md` and `CONTRIBUTING.md`) 
+When choosing a type, you can pick from any of the standard types (feat, fix, style, test, or chore) or you can add your own.
+**Note**: There is a `documentation` type, but please refrain from using it for general documentation changes since it is intended for changes to the repository's documentation (such as `README.md` and `CONTRIBUTING.md`)
 
 As far as scope, we recommend that you include this because it helps us identify relevant commits. For the docs project, the scope might refer to the part of the docs you are editing (for example, APM or errors inbox). If you are suggesting a code change to the docs site, insert the section of the codebase you worked on.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ which clearly explains the setup and configuration of NVM.
 
 ### Cloning vs forking
 
-To be able to [clone](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) this repository and contribute you will need to be given write access to the repository. This is reserved for New Relic Doc Writers. Contact the Docs Engineering team (#help-deven-websites Slack channel) if you need write access.
+To be able to [clone](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) this repository and contribute you will need to be given write access to the repository. This is reserved for New Relic Doc Writers. Contact the Docs Engineering team (#help-documentation Slack channel) if you need write access.
 
 To contribute without write access, you can [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the repository and contribute as needed. If you're planning to leave a fork open for a long time (for example, you're working on a complex set of changes to many docs), [sync your fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork) occasionally to avoid merge conflicts.
 


### PR DESCRIPTION
## Summary

### Github:
- Created new [Docs Engineering Team](https://github.com/orgs/newrelic/teams/docs-engineering/)
- Added team as Admin to [Docs Site](https://github.com/newrelic/docs-website)

### Repo
- Update `CODEOWNERS` file
- Remove references to `Developer Enablement` and updated to `Docs Engineering`

> Slightly blocked by #6566 to update the `CONTRIBUTING.md` with the correct slack channel