### PR TITLE
docs: indent curl block, add land identifier

### DIFF
--- a/src/content/docs/distributed-tracing/trace-api/report-zipkin-format-traces-trace-api.mdx
+++ b/src/content/docs/distributed-tracing/trace-api/report-zipkin-format-traces-trace-api.mdx
@@ -53,44 +53,44 @@ You'll be executing a curl request, below. Notes on this:
   * If you're using Infinite Tracing, use the [<var>YOUR_TRACE_OBSERVER_URL</var>](/docs/understand-dependencies/distributed-tracing/infinite-tracing/set-trace-observer#ui-endpoints) value in place of the standard endpoint.
   * If you want to send more than one post, change the trace ID to a different value. Sending the same payload or span `id` multiple times for the same `traceId` may result in fragmented traces in the UI.
 
-```
+```bash
 curl -i -H 'Content-Type: application/json' \
- -H 'Api-Key: <var>$NEW_RELIC_LICENSE_KEY</var>' \
- -H 'Data-Format: zipkin' \
- -H 'Data-Format-Version: 2' \
- -X POST \
- -d '[
+    -H 'Api-Key: NEW_RELIC_API_KEY' \
+    -H 'Data-Format: zipkin' \
+    -H 'Data-Format-Version: 2' \
+    -X POST \
+    -d '[
         {
-           "traceId": "test-zipkin-trace-id-1",
-           "id": "3e0f5885710776cd",
-           "kind": "CLIENT",
-           "name": "post",
-           "duration": 508068,
-           "localEndpoint": {
-               "serviceName": "service-1",
-               "ipv4": "127.0.0.1",
-               "port": 8080
-           },
-           "tags": {
-           }
-       },
-       {
-           "traceId": "test-zipkin-trace-id-1",
-           "parentId": "3e0f5885710776cd",
-           "id": "asdf9asdn123lkasdf",
-           "kind": "CLIENT",
-           "name": "service 2 span",
-           "duration": 2019,
-           "localEndpoint": {
-               "serviceName": "service-2",
-               "ipv4": "127.0.0.1",
-               "port": 8080
-           },
-           "tags": {
-"error.message": "Invalid credentials"
-           }
-       }
-   ]' '<var>https://trace-api.newrelic.com/trace/v1</var>'
+            "traceId": "test-zipkin-trace-id-1",
+            "id": "3e0f5885710776cd",
+            "kind": "CLIENT",
+            "name": "post",
+            "duration": 508068,
+            "localEndpoint": {
+                "serviceName": "service-1",
+                "ipv4": "127.0.0.1",
+                "port": 8080
+            },
+            "tags": {
+            }
+        },
+        {
+            "traceId": "test-zipkin-trace-id-1",
+            "parentId": "3e0f5885710776cd",
+            "id": "asdf9asdn123lkasdf",
+            "kind": "CLIENT",
+            "name": "service 2 span",
+            "duration": 2019,
+            "localEndpoint": {
+                "serviceName": "service-2",
+                "ipv4": "127.0.0.1",
+                "port": 8080
+            },
+            "tags": {
+                "error.message": "Invalid credentials"
+            }
+        }
+    ]' 'https://trace-api.newrelic.com/trace/v1'
 ```
 
 Within a minute, the trace should be available in [our distributed tracing UI](https://one.newrelic.com/launcher/distributed-tracing-nerdlets.distributed-tracing). To find it, run a query for the `trace.id`. In this example, it was `test-zipkin-trace-id-1`. Note that you search by the [transformed attribute](zipkin-transform) of `trace.id` (not `traceId`).
@@ -117,7 +117,7 @@ To report data from an existing Zipkin instrumentation, you'll point the Zipkin 
 
 Here's an example of what it might look like to create a Zipkin `OkHttpSender` in Java configured for the Trace API:
 
-```
+```java
 OkHttpSender.create("https://trace-api.newrelic.com/trace/v1?Api-Key=<var>NEW_RELIC_LICENSE_KEY</var>&Data-Format=zipkin&Data-Format-Version=2");
 ```
 


### PR DESCRIPTION
One line was not indented, so of course I went in and indented the whole thing more cleanly, and added identifiers to the curl command.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.