### PR TITLE
Licenses: fix broken links

### DIFF
--- a/src/content/docs/licenses/overview.mdx
+++ b/src/content/docs/licenses/overview.mdx
@@ -35,13 +35,13 @@ redirects:
   These licenses and terms relate to services that supplement the use of other
   New Relic products and services; for example, Expert Services and New Relic
   Diagnostics. [Learn
-  more.](/docs/licenses/license-information/special-services-licenses)
+  more.](/docs/licenses/license-information/special-services-licenses/data-collector-licenses)
 </LandingPageTile>
 
 {' '}
 <LandingPageTile title="Usage plans." icon="fe-user">
   These relate to New Relic One usage and pricing models. [Learn
-  more.](/docs/licenses/license-information/usage-plans)
+  more.](/docs/licenses/license-information/usage-plans/new-relic-one-usage-plan-descriptions)
 </LandingPageTile>
 
 {' '}
@@ -50,14 +50,14 @@ redirects:
   install them in your environment or receive custom software from Expert
   Services (whose services are under [separate
   terms](https://newrelic.com/termsandconditions/expert-services-terms)). [Learn
-  more.](/docs/licenses/license-information/distributed-licenses)
+  more.](/docs/licenses/license-information/distributed-licenses/add-end-user-license-agreement)
 </LandingPageTile>
 
 {' '}
 <LandingPageTile title="Referenced policies." icon="fe-external-link">
   These are policies referenced in your agreement with New Relic and relate to
   the New Relic products or services that you use. [Learn
-  more.](/docs/licenses/license-information/referenced-policies)
+  more.](/docs/licenses/license-information/referenced-policies/security-policy)
 </LandingPageTile>
 
   <LandingPageTile


### PR DESCRIPTION
The licenses doc had a few links to the old automatic index pages, I'm fixing them here.