### PR TITLE
chore(oma-datagov): 

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/dg-optimizing.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/dg-optimizing.mdx
@@ -250,6 +250,35 @@ Common database query setting changes include:
 
 More details can be found [here](docs/apm/transactions/transaction-traces/transaction-traces-database-queries-page/#settings).
 
+### Setting Event Limits
+
+Our APM agents and mobile agents have limits on how many events can be reported per harvest cycle. This is necessary because if there were no limit, a very large number of events being sent could have performance impacts on your application or on New Relic. When the limit is reached, the agents begin sampling events. Different agents have different limits, but the goal is to give a representative sample from across the harvest cycle.
+Events that are capped and subject to sampling include:
+
+- Transaction
+- TransactionError
+- Span (see Distributed tracing sampling)
+- Custom events reported via agent API (example: the .NET agent's RecordCustomEvent)
+- Mobile
+- MobileRequest
+- MobileCrash
+- MobileHandledException
+
+Most agents have configuration options for changing the limit on sampled transactions.  For example the Java agent uses [max_samples_stored](https://docs.newrelic.com/docs/agents/java-agent/configuration/java-agent-configuration-config-file#ae-max_samples_stored).  The default value for *max_samples_stored* is `2000` and the max is `10000`.  This value governs how many sampled events can be reported every 60 seconds from an agent instance.
+
+A full explanation of event sampling can be found [here](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/new-relic-event-limits-sampling/)
+
+
+When events are sampled you can compenstate fo this using the `EXTRAPOLATE` operator in NRQL.
+
+Before attempting to change how sampling occurs, please read these caveats and recommendations:
+
+- Reporting more events will result in the agent using more memory.
+- There will usually be a way for you to get the data you need without raising an agent's event-reporting limit.
+- The payload size limit is 1MB (10^6 bytes) (compressed), so the number of events may still be affected by that limit. To determine if events are being dropped, see the agent log for a 413 HTTP status message.
+
+
+
 ### Transaction traces
 
 <Callout variant='IMPORTANT' title='Growth Drivers'>

--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/dg-optimizing.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/dg-optimizing.mdx
@@ -252,32 +252,30 @@ More details can be found [here](docs/apm/transactions/transaction-traces/transa
 
 ### Setting Event Limits
 
-Our APM agents and mobile agents have limits on how many events can be reported per harvest cycle. This is necessary because if there were no limit, a very large number of events being sent could have performance impacts on your application or on New Relic. When the limit is reached, the agents begin sampling events. Different agents have different limits, but the goal is to give a representative sample from across the harvest cycle.
+Our APM and mobile agents have limits on how many events can be reported per harvest cycle. If there were no limit, a very large number of events being sent could impact the performance of your application or New Relic. When the limit is reached, the agents begin sampling events in order to give a representative sample of events across the harvest cycle. Different agents have different limits.
+
 Events that are capped and subject to sampling include:
 
-- Transaction
-- TransactionError
-- Span (see Distributed tracing sampling)
-- Custom events reported via agent API (example: the .NET agent's RecordCustomEvent)
-- Mobile
-- MobileRequest
-- MobileCrash
-- MobileHandledException
+* Custom events reported via agent API (for example, the .NET agent's `RecordCustomEvent`)
+* Mobile
+* MobileCrash
+* MobileHandledException
+* MobileRequest
+* Span (see Distributed tracing sampling)
+* Transaction
+* TransactionError
 
-Most agents have configuration options for changing the limit on sampled transactions.  For example the Java agent uses [max_samples_stored](https://docs.newrelic.com/docs/agents/java-agent/configuration/java-agent-configuration-config-file#ae-max_samples_stored).  The default value for *max_samples_stored* is `2000` and the max is `10000`.  This value governs how many sampled events can be reported every 60 seconds from an agent instance.
+Most agents have configuration options for changing the event limit on sampled transactions. For example the Java agent uses [max_samples_stored](https://docs.newrelic.com/docs/agents/java-agent/configuration/java-agent-configuration-config-file#ae-max_samples_stored). The default value for *max_samples_stored* is `2000` and the max is `10000`. This value governs how many sampled events can be reported every 60 seconds from an agent instance.
 
-A full explanation of event sampling can be found [here](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/new-relic-event-limits-sampling/)
+Here us a full explanation of [event sampling limits](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/new-relic-event-limits-sampling/)
 
-
-When events are sampled you can compenstate fo this using the `EXTRAPOLATE` operator in NRQL.
+You can compensate for sampled events via [NRQL's `EXTRAPOLATE` operator](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#extrapolate).
 
 Before attempting to change how sampling occurs, please read these caveats and recommendations:
 
-- Reporting more events will result in the agent using more memory.
-- There will usually be a way for you to get the data you need without raising an agent's event-reporting limit.
-- The payload size limit is 1MB (10^6 bytes) (compressed), so the number of events may still be affected by that limit. To determine if events are being dropped, see the agent log for a 413 HTTP status message.
-
-
+* The more events you report, the more memory your agent will use..
+* You can usually get the data you need without raising an agent's event-reporting limit.
+* The payload size limit is 1MB (10^6 bytes) (compressed), so the number of events may still be affected by that limit. To determine if events are being dropped, see the agent log for a`413 HTTP` status message.
 
 ### Transaction traces
 


### PR DESCRIPTION
## Give us some context

* Added explanation on APM events limits to optimization section
* Discussion with Nic Benders explained how this is used in New Relic's own monitoring practices use this to reduce volume.