### PR TITLE
Update heroku-log-forwarding.mdx

### DIFF
--- a/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
@@ -28,7 +28,7 @@ To enable our log management capabilities, start by creating a Heroku Syslog dra
 4. Run the following command and copy the Heroku Syslog [drain token](https://devcenter.heroku.com/articles/log-drains#drain-tokens) from the `token` attribute:
 
   ```
-  $ heroku drains -a <var>YOUR_APP_NAME</var>--json
+  $ heroku drains -a <var>YOUR_APP_NAME</var> --json
 
   ```
 


### PR DESCRIPTION
Add missing space in command to print Heroku drains in JSON format.

The existing command in docs will not run as it interprets the last part `--json` as part of the Heroku application name. Adding a space fixes this.