### PR TITLE
chore(oma-datagov): Added two missing drop rule examples

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/dg-optimizing.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/dg-optimizing.mdx
@@ -1312,6 +1312,80 @@ mutation {
 
 </Collapser>
 <Collapser
+  id="drop-specific-attributes"
+  title="Drop Specific Attributes"
+>
+One powerful thing about drop rules is that we can configure a rule that drops specific attributes but maintains the rest of the data intact.  This can be done to remove private data from NRDB, but can also be used to drop excessively large attributes.  Examples of very large fields are things like stack traces or large chunks of JSON in log records.
+For these kinds of drop rules set the *action* field to `DROP_ATTRIBUTES` instead of `DROP_DATA`
+
+```
+mutation {
+    nrqlDropRulesCreate(accountId: YOUR_ACCOUNT_ID, rules: [
+        {
+            action: DROP_ATTRIBUTES
+            nrql: "SELECT stack_trace, json_data FROM Log where appName='myApp'"
+            description: "Drops large fields from logs for myApp"
+        }
+    ])
+    {
+        successes { id }
+        failures {
+            submitted { nrql }
+            error { reason description }
+        }
+    }
+}
+```
+
+</Collapser>
+<Collapser
+  id="drop-random-sample-of-events"
+  title="Drop Random Sample of Events"
+>
+
+<Callout variant="caution">
+This approach needs to be used carefully in situations where there are no other alternatives.  It can alter statistical inferrences made from your data.  However for events with massive sample size you may be okay with only a portion of the data as long as you understand the consequences.
+</Callout>
+In this example we will take advantage of the relative distribution of certain trace ids to approximate random sampling.  We can use the `rlike` operator to check for the leading values of a Span's `trace.id` attribute.
+
+
+The following example could drop about 25% of spans.
+
+```
+SELECT * FROM Span WHERE trace.id rlike r'^[0-3].*' and appName = 'myApp'
+```
+
+Useful expressions include:
+
+* `^0.*` approximates 6.25%
+* `^[0-1].*` approximates 12.5%
+* `^[0-2].*` approximates 18.75%
+* `^[0-3].*` approximates 25.0%
+
+
+Example of a full mutation:
+
+```
+mutation {
+    nrqlDropRulesCreate(accountId: YOUR_ACCOUNT_ID, rules: [
+        {
+            action: DROP_ATTRIBUTES
+            nrql: "SELECT * FROM Span WHERE trace.id rlike r'^[0-3].*' and appName = 'myApp'"
+            description: "Drops approximately 25% of spans for myApp"
+        }
+    ])
+    {
+        successes { id }
+        failures {
+            submitted { nrql }
+            error { reason description }
+        }
+    }
+}
+```
+
+</Collapser>
+<Collapser
   id="other-events-and-metrics"
   title="Other events and metrics"
 >


### PR DESCRIPTION
## Give us some context

* Added two missing examples of drop rule types that are important for data optimization.