### PR TITLE
fix(aws-stream): integrations not replaced

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
@@ -113,13 +113,15 @@ Please consider the following when migrating from poll-based integrations:
 
 The AWS CloudWatch Metric Streams integration focuses on CloudWatch metrics. As a result, the following integrations still need to be configured and enabled to get complete visibility from AWS services:
 
-* Polling integrations based on service APIs:
+Polling integrations based on service APIs:
+
 - AWS Billing
 - AWS CloudTrail
 - AWS Health
 - AWS Trusted Advisor
 - AWS X-Ray
 
-* Integrations based on CloudWatch Logs, [forwarded to New Relic via Lambda](/docs/logs/forward-logs/aws-lambda-sending-cloudwatch-logs):
+Integrations based on CloudWatch Logs, [forwarded to New Relic via Lambda](/docs/logs/forward-logs/aws-lambda-sending-cloudwatch-logs):
+
 - AWS RDS Enhanced
 - AWS VPC Flow Logs

--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
@@ -111,7 +111,7 @@ Please consider the following when migrating from poll-based integrations:
 
 ## Integrations not fully replaced by metric streams [#integrations-not-replaced-streams]
 
-The AWS CloudWatch Metric Streams integration focuses on CloudWatch metrics. As a result, the following integrations still need to be configured and enabled to get complete visibility from AWS services:
+The AWS CloudWatch Metric Streams integration focuses on CloudWatch metrics. As a result, the following integrations still need to be configured and enabled to get complete visibility from AWS services.
 
 Polling integrations based on service APIs:
 

--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
@@ -111,14 +111,15 @@ Please consider the following when migrating from poll-based integrations:
 
 ## Integrations not fully replaced by metric streams [#integrations-not-replaced-streams]
 
-The AWS CloudWatch Metric Streams integration focused on CloudWatch metrics. The following integrations still need to be configured and enabled to get complete visibility from AWS services:
-* Polling integrations based on services API:
+The AWS CloudWatch Metric Streams integration focuses on CloudWatch metrics. As a result, the following integrations still need to be configured and enabled to get complete visibility from AWS services:
+
+* Polling integrations based on service APIs:
 - AWS Billing
 - AWS CloudTrail
 - AWS Health
 - AWS Trusted Advisor
 - AWS X-Ray
 
-* Integrations based on CloudWatch Logs (forwarder to New Relic via Lambda):
+* Integrations based on CloudWatch Logs, [forwarded to New Relic via Lambda](/docs/logs/forward-logs/aws-lambda-sending-cloudwatch-logs):
 - AWS RDS Enhanced
 - AWS VPC Flow Logs

--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
@@ -111,11 +111,14 @@ Please consider the following when migrating from poll-based integrations:
 
 ## Integrations not fully replaced by metric streams [#integrations-not-replaced-streams]
 
-The AWS CloudWatch Metric Streams integration only collects CloudWatch metrics, resource metadata and custom tags. The following API polling integrations still need to be enabled to get complete visibility from AWS:
-
+The AWS CloudWatch Metric Streams integration focused on CloudWatch metrics. The following integrations still need to be configured and enabled to get complete visibility from AWS services:
+* Polling integrations based on services API:
 - AWS Billing
 - AWS CloudTrail
 - AWS Health
 - AWS Trusted Advisor
-- AWS VPC
 - AWS X-Ray
+
+* Integrations based on CloudWatch Logs (forwarder to New Relic via Lambda):
+- AWS RDS Enhanced
+- AWS VPC Flow Logs


### PR DESCRIPTION
## Give us some context
* Add RDS Enhanced to the list. 
* Clarifying there are other two types of integrations beyond metric streams.