### PR TITLE
docs: application contains name attribute, not applications

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1450,7 +1450,7 @@ The `instrumentation` element is a child of the `configuration` element. By defa
 
 ### Applications element (instrumentation) [#application-instrumentation]
 
-The `applications` element is a child of the `instrumentation` element. The applications element specifies which non-web apps to instrument. It contains a `name` attribute.
+The `applications` element is a child of the `instrumentation` element. The `applications` element supports `application` child elements which specify which non-web apps to instrument. The `application` element contains a `name` attribute.
 
 <Callout variant="important">
   This is not the same as the [`application` (configuration)](#application-configuration) element, which is a [child of the `configuration`](#application) element.


### PR DESCRIPTION
The xml example was pretty clear, but I specified in the text that the `name` attribute belonged to an unmentioned `application` element, not the parent `applications` element. It's `instrumentation.applications.application.name`.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.