### PR TITLE
Correct Android link to distributed tracing

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags.mdx
@@ -242,7 +242,7 @@ All settings, including the call to invoke the agent, are called in the `onCreat
     >
         Enable or disable the adding of distributed tracing headers to network requests.
         
-        Refer to [How New Relic distributed tracing works](docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works/#no-sampling) for more information on distributed tracing in mobile apps.
+        Refer to [How New Relic distributed tracing works](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works#browser-spans) for more information on distributed tracing in mobile apps.
 
       <table>
         <tbody>


### PR DESCRIPTION
This broken link was found by an internal contributor. 