### PR TITLE
Remove license reference to unused 3rd-party lib

### DIFF
--- a/src/content/docs/licenses/product-or-service-licenses/new-relic-mobile/ios-sdk-new-relic-mobile-licenses.mdx
+++ b/src/content/docs/licenses/product-or-service-licenses/new-relic-mobile/ios-sdk-new-relic-mobile-licenses.mdx
@@ -51,16 +51,6 @@ We love open-source software, and use the following in the iOS SDK for mobile mo
 
     <tr>
       <td>
-        [mod-pbxproj](https://github.com/kronenthaler/mod-pbxproj/blob/master/license.txt)
-      </td>
-
-      <td>
-        [BSD-3](https://github.com/kronenthaler/mod-pbxproj)
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         [PLCrashReporter](https://www.plcrashreporter.org/)
       </td>
 


### PR DESCRIPTION
3rd-party component `mod-pdxproj` doesn't appear to be used anymore. Remove its reference from the [iOS docs license page](https://docs.newrelic.com/docs/licenses/product-or-service-licenses/new-relic-mobile/ios-sdk-new-relic-mobile-licenses).

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.