### PR TITLE
Improve .NET agent install instructions for Linux

### DIFF
--- a/src/content/docs/apm/agents/net-agent/installation/install-net-agent-linux.mdx
+++ b/src/content/docs/apm/agents/net-agent/installation/install-net-agent-linux.mdx
@@ -54,10 +54,10 @@ To install the .NET agent on a Linux system with a package manager:
        id="clamshell_debian_ubuntu_mint_aptget"
        title="Install with apt (Debian, Linux Mint, or Ubuntu)"
      >
-       1. Configure the New Relic apt repository by adding `deb http://apt.newrelic.com/debian/ newrelic non-free` to `/etc/apt/sources.list.d/newrelic.list`:
+       1. Configure the New Relic apt repository by adding `deb https://apt.newrelic.com/debian/ newrelic non-free` to `/etc/apt/sources.list.d/newrelic.list`:
 
           ```
-          echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
+          echo 'deb https://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
           ```
        2. Enable New Relic's GPG key to allow apt to find New Relic packages. To avoid possible errors about public keys, run this command as root:
 
@@ -80,7 +80,7 @@ To install the .NET agent on a Linux system with a package manager:
        id="clamshell_debian_ubuntu_mint_dpkg"
        title="Install with dpkg (Debian, Linux Mint, or Ubuntu)"
      >
-       1. Go to **[download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release/)**, and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-netcore20-agent` package.
+       1. Go to **[download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release/)**, and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-netcore20-agent` .deb package.
        2. Download the package with `wget`, replacing `https://LINK_TO_PACKAGE` with the full URL of the package:
 
           ```
@@ -94,38 +94,51 @@ To install the .NET agent on a Linux system with a package manager:
      </Collapser>
 
      <Collapser
-       id="clamshell_centos_rhel_oracle"
-       title="Install with rpm or yum (CentOS, Oracle Linux, or RHEL)"
+       id="clamshell_centos_rhel_oracle_yum"
+       title="Install with yum (CentOS, Oracle Linux, or RHEL)"
      >
       <Callout variant="important">
         New Relic does not currently offer Linux rpm packages for ARM64, instead [leverage the tarball to install](#clamshell_tarball) on these platforms.
       </Callout>
 
-       1. Configure the New Relic rpm repository:
+       1. Configure the New Relic yum repository:
 
           ```
-          sudo rpm -Uvh http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm
           cat << REPO | sudo tee "/etc/yum.repos.d/newrelic-netcore20-agent.repo"
           [newrelic-netcore20-agent-repo]
           name=New Relic .NET Core packages for Enterprise Linux
-          baseurl=http://yum.newrelic.com/pub/newrelic/el7/\$basearch
+          baseurl=https://yum.newrelic.com/pub/newrelic/el7/\$basearch
           enabled=1
           gpgcheck=1
           gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic
           REPO
           ```
+       2. Install the agent:
+
+          ```
+          sudo yum install newrelic-netcore20-agent
+          ```
+     </Collapser>
+
+     <Collapser
+       id="clamshell_centos_rhel_oracle_rpm"
+       title="Install with rpm (CentOS, Oracle Linux, or RHEL)"
+     >
+      <Callout variant="important">
+        New Relic does not currently offer Linux rpm packages for ARM64, instead [leverage the tarball to install](#clamshell_tarball) on these platforms.
+      </Callout>
+
+       1. Go to **[download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release/)**, and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-netcore20-agent` .rpm package.
+       2. Download the package with `wget`, replacing `https://LINK_TO_PACKAGE` with the full URL of the package:
+
+          ```
+          wget -L https://<var>LINK_TO_PACKAGE</var>
+          ```
        2. Install the agent, replacing `VERSION` with the current version:
 
-          * Install with rpm:
-
-            ```
-            sudo rpm -i newrelic-netcore20-agent_<var>VERSION</var>.x86_64.rpm
-            ```
-          * Install with yum:
-
-            ```
-            sudo yum install newrelic-netcore20-agent
-            ```
+          ```
+          sudo rpm -i newrelic-netcore20-agent_<var>VERSION</var>.x86_64.rpm
+          ```
      </Collapser>
 
      <Collapser

--- a/src/content/docs/apm/agents/net-agent/installation/install-net-agent-linux.mdx
+++ b/src/content/docs/apm/agents/net-agent/installation/install-net-agent-linux.mdx
@@ -98,7 +98,7 @@ To install the .NET agent on a Linux system with a package manager:
        title="Install with yum (CentOS, Oracle Linux, or RHEL)"
      >
       <Callout variant="important">
-        New Relic does not currently offer Linux rpm packages for ARM64, instead [leverage the tarball to install](#clamshell_tarball) on these platforms.
+        New Relic does not currently offer Linux rpm packages for ARM64. Instead, [leverage the tarball to install](#clamshell_tarball) on these platforms.
       </Callout>
 
        1. Configure the New Relic yum repository:

--- a/src/content/docs/apm/agents/net-agent/installation/install-net-agent-linux.mdx
+++ b/src/content/docs/apm/agents/net-agent/installation/install-net-agent-linux.mdx
@@ -125,10 +125,10 @@ To install the .NET agent on a Linux system with a package manager:
        title="Install with rpm (CentOS, Oracle Linux, or RHEL)"
      >
       <Callout variant="important">
-        New Relic does not currently offer Linux rpm packages for ARM64, instead [leverage the tarball to install](#clamshell_tarball) on these platforms.
+        New Relic does not currently offer Linux rpm packages for ARM64. Instead, [leverage the tarball to install](#clamshell_tarball) on these platforms.
       </Callout>
 
-       1. Go to **[download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release/)**, and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-netcore20-agent` .rpm package.
+       1. Go to [download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release/), and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-netcore20-agent` .rpm package.
        2. Download the package with `wget`, replacing `https://LINK_TO_PACKAGE` with the full URL of the package:
 
           ```


### PR DESCRIPTION
Two main changes to the .NET agent install instructions for Linux:

1. Switch to specifying `https://` URLs for the APT and YUM package manager configuration options instead of unsecure `http://` URLS.
2. Clarify the yum/rpm install instructions for rpm-based Linux distros (e.g. RHEL, Centos, etc.).  You can install using the package manager (YUM, which requires configuring the YUM repository) or with RPM (which requires downloading the .rpm file directly from the downloads site).  This mirrors the APT/DPKG (.deb) distinction that already exists for Debian-base distros (e.g. Ubuntu).

I hope I got the formatting right, please fix it if I didn't.