### PR TITLE
chore: Adding lookout standalone experience to user type documentation

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -435,7 +435,17 @@ Here's a detailed comparison of capabilities by user type. For tips on why you'd
               name="fe-check"
             /></td>
         </tr>
-
+        <tr>
+          <td>
+           [Lookout](/docs/new-relic-one/core-concepts/new-relic-lookout-monitor-your-estate-glance) (Pro & Enterprise editions only)
+          </td>
+          <td style="text-align:center"></td>
+          <td></td>
+          <td style="text-align:center"><Icon
+              style={{color: '#328787'}}
+              name="fe-check"
+            /></td>
+        </tr>
 
       </tbody>
     </table>


### PR DESCRIPTION
## Give us some context

*Note - I am a New Relic employee. Please feel free to ping me on Slack if there are any ambiguities.*

* What problems does this PR solve?
  * Lookout's standalone experience is not currently included in the detailed capability comparison table. This PR aims to explicitly cite the user and account requirements for Lookout. Lookout standalone is only accessible to Full users belonging to a Pro or Enterprise account. It is otherwise accessible via Explorer as already called out in the document.
