### PR TITLE
docs: remove <var>s appearing as plain text

### DIFF
--- a/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
@@ -23,7 +23,7 @@ Complete the trace observer setup up that fits your types of data sources (servi
 * [(Optional) Additional configuration for all service types](#follow-up-config)
 
 <Callout variant="tip">
-Do some of your requests communicate with services that are still using standard distributed tracing? To avoid [configuration conflicts](/docs/understand-dependencies/distributed-tracing/troubleshooting/infinite-tracing-trace-configuration-conflicts), you should ideally enable Infinite Tracing for all associated services.
+  Do some of your requests communicate with services that are still using standard distributed tracing? To avoid [configuration conflicts](/docs/understand-dependencies/distributed-tracing/troubleshooting/infinite-tracing-trace-configuration-conflicts), you should ideally enable Infinite Tracing for all associated services.
 </Callout>
 
 ## Services instrumented with APM agents and third-party telemetry tools [#apm-and-third-party]
@@ -42,9 +42,9 @@ To create a new trace observer if you're using New Relic APM agents or third-par
     * **ap-southeast-2 (US)**
     * **us-east-2 (US, FedRAMP)**
 
-4. Under the **Endpoints** dropdown, copy the endpoint value under **For other integrations** and have it ready. This value is referenced in our code examples as <var>YOUR_TRACE_OBSERVER_URL</var>. This is used to test the [trace observer](#sample-payload), as well as to configure our [telemetry integrations](/docs/distributed-tracing/enable-configure/quick-start) and for sending data via the [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api/).
+4. Under the **Endpoints** dropdown, copy the endpoint value under **For other integrations** and have it ready. This value is referenced in our code examples as `YOUR_TRACE_OBSERVER_URL`. This is used to test the [trace observer](#sample-payload), as well as to configure our [telemetry integrations](/docs/distributed-tracing/enable-configure/quick-start) and for sending data via the [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api/).
 
-5. If you are setting up an APM agent, you should also copy the endpoint value under **For language agents** and have it ready. This value is referenced in our code examples as <var>YOUR_TRACE_OBSERVER_HOST</var>. This is used for [configuring our language agents to send data to the trace observer](/docs/distributed-tracing/enable-configure/quick-start).
+5. If you are setting up an APM agent, you should also copy the endpoint value under **For language agents** and have it ready. This value is referenced in our code examples as `YOUR_TRACE_OBSERVER_HOST`. This is used for [configuring our language agents to send data to the trace observer](/docs/distributed-tracing/enable-configure/quick-start).
 
 6. (Optional) To verify the trace observer is working, we recommend sending a sample trace payload. If you're using our [Trace API](/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api) directly, this will help you learn how the API works.
 
@@ -65,45 +65,44 @@ To create a new trace observer if you're using New Relic APM agents or third-par
        2. Copy the following `curl` request into a text editor:
 
           ```bash
-          curl -i -H "Content-Type: application/json" \
-            -H "Api-Key: <var>$YOUR_LICENSE_KEY</var>" \
-            -H 'Data-Format: newrelic' \
-            -H 'Data-Format-Version: 1' \
-            -X POST \
-            -d '[
-                {
-                    "common": {
-                    "attributes": {
-                        "environment": "staging"
-                    }
-                    },
-                    "spans": [
-                    {
-                        "trace.id": "123456",
-                        "id": "ABC",
-                        "attributes": {
-                            "duration.ms": 12.53,
-                            "host": "host123.example.com",
-                            "name": "/home",
-                            "service.name": "Test Service A"
-                        }
-                    },
-                    {
-                        "trace.id": "123456",
-                        "id": "DEF",
-                        "attributes": {
-                            "duration.ms": 2.97,
-                            "host": "host456.example.com",
-                            "error.message": "Invalid credentials",
-                            "name": "/auth",
-                            "parent.id": "ABC",
-                            "service.name": "Test Service B"
-                        }
-                    }
-                    ]
-                }
-                ]' \
-          '<var>$YOUR_TRACE_OBSERVER_URL</var>'
+          curl -i -H 'Content-Type: application/json' \
+              -H 'Api-Key: YOUR_LICENSE_KEY' \
+              -H 'Data-Format: newrelic' \
+              -H 'Data-Format-Version: 1' \
+              -X POST \
+              -d '[
+                  {
+                      "common": {
+                          "attributes": {
+                              "environment": "staging"
+                          }
+                      },
+                      "spans": [
+                          {
+                              "trace.id": "123456",
+                              "id": "ABC",
+                              "attributes": {
+                                  "duration.ms": 12.53,
+                                  "host": "host123.example.com",
+                                  "name": "/home",
+                                  "service.name": "Test Service A"
+                              }
+                          },
+                          {
+                              "trace.id": "123456",
+                              "id": "DEF",
+                              "attributes": {
+                                  "error.message": "Invalid credentials",
+                                  "service.name": "Test Service B",
+                                  "host": "host456.example.com",
+                                  "duration.ms": 2.97,
+                                  "name": "/auth",
+                                  "parent.id": "ABC"
+                              }
+                          }
+                      ]
+                  }
+              ]' 'YOUR_TRACE_OBSERVER_URL'
           ```
        3. Insert your own values into the `curl` request:
 
@@ -124,19 +123,19 @@ To create a new trace observer if you're using New Relic APM agents or third-par
               <tr>
                 <td>
                   <var>
-                    $YOUR_LICENSE_KEY
+                    `YOUR_LICENSE_KEY`
                   </var>
                 </td>
 
                 <td>
-                  Replace this with your [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).
+                  Replace this with your ingest [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).
                 </td>
               </tr>
 
               <tr>
                 <td>
                   <var>
-                    $YOUR_TRACE_OBSERVER_URL
+                    `YOUR_TRACE_OBSERVER_URL`
                   </var>
                 </td>
 
@@ -149,7 +148,7 @@ To create a new trace observer if you're using New Relic APM agents or third-par
        4. Copy the curl request into a terminal and execute it.
        5. The test should return `HTTP/1.1 202 Accepted`, indicating success. If it does not, check the following common issues:
           * Confirm that you used the [**For other integrations** endpoint](#endpoints) value.
-          * Confirm you're using single quotes around <var>YOUR_TRACE_OBSERVER_URL</var>.
+          * Confirm you're using single quotes around `YOUR_TRACE_OBSERVER_URL`.
           * Check that you're using the correct API key.
        6. If your test returned `HTTP/1.1 202 Accepted`, go to the New Relic UI to see a query of the sample payload data using the span attribute `service.name = Test Service A` ([here's a link for that query](https://one.newrelic.com/launcher/distributed-tracing-nerdlets.distributed-tracing?launcher=eyJ0aW1lUmFuZ2UiOnsiYmVnaW5fdGltZSI6bnVsbCwiZW5kX3RpbWUiOm51bGwsImR1cmF0aW9uIjoxODAwMDAwfSwiJGlzRmFsbGJhY2tUaW1lUmFuZ2UiOnRydWV9&pane=eyJuZXJkbGV0SWQiOiJkaXN0cmlidXRlZC10cmFjaW5nLW5lcmRsZXRzLmRpc3RyaWJ1dGVkLXRyYWNpbmctbGF1bmNoZXIiLCJzb3J0SW5kZXgiOjAsInNvcnREaXJlY3Rpb24iOiJERVNDIiwicXVlcnkiOnsib3BlcmF0b3IiOiJBTkQiLCJpbmRleFF1ZXJ5Ijp7ImNvbmRpdGlvblR5cGUiOiJJTkRFWCIsIm9wZXJhdG9yIjoiQU5EIiwiY29uZGl0aW9ucyI6W119LCJzcGFuUXVlcnkiOnsib3BlcmF0b3IiOiJBTkQiLCJjb25kaXRpb25TZXRzIjpbeyJjb25kaXRpb25UeXBlIjoiU1BBTiIsIm9wZXJhdG9yIjoiQU5EIiwiY29uZGl0aW9ucyI6W3siYXR0ciI6InNlcnZpY2UubmFtZSIsIm9wZXJhdG9yIjoiRVEiLCJ2YWx1ZSI6IlRlc3QgU2VydmljZSBBIn1dfV19fX0=)). Because the sample payload contains an error attribute, the error sampler will mark it for keeping. If you modify the payload to remove the error attributes, the random sampler may not choose to keep this particular trace.
 
@@ -208,45 +207,44 @@ If you haven't already set up a trace observer, complete the following:
        2. Copy the following `curl` request into a text editor:
 
           ```bash
-          curl -i -H "Content-Type: application/json" \
-            -H "Api-Key: <var>$YOUR_LICENSE_KEY</var>" \
-            -H 'Data-Format: newrelic' \
-            -H 'Data-Format-Version: 1' \
-            -X POST \
-            -d '[
-                {
-                    "common": {
-                    "attributes": {
-                        "environment": "staging"
-                    }
-                    },
-                    "spans": [
-                    {
-                        "trace.id": "123456",
-                        "id": "ABC",
-                        "attributes": {
-                            "duration.ms": 12.53,
-                            "host": "host123.example.com",
-                            "name": "/home",
-                            "service.name": "Test Service A"
-                        }
-                    },
-                    {
-                        "trace.id": "123456",
-                        "id": "DEF",
-                        "attributes": {
-                            "duration.ms": 2.97,
-                            "host": "host456.example.com",
-                            "error.message": "Invalid credentials",
-                            "name": "/auth",
-                            "parent.id": "ABC",
-                            "service.name": "Test Service B"
-                        }
-                    }
-                    ]
-                }
-                ]' \
-          '<var>$YOUR_TRACE_OBSERVER_URL</var>'
+          curl -i -H 'Content-Type: application/json' \
+              -H 'Api-Key: YOUR_LICENSE_KEY' \
+              -H 'Data-Format: newrelic' \
+              -H 'Data-Format-Version: 1' \
+              -X POST \
+              -d '[
+                  {
+                      "common": {
+                          "attributes": {
+                              "environment": "staging"
+                          }
+                      },
+                      "spans": [
+                          {
+                              "trace.id": "123456",
+                              "id": "ABC",
+                              "attributes": {
+                                  "duration.ms": 12.53,
+                                  "host": "host123.example.com",
+                                  "name": "/home",
+                                  "service.name": "Test Service A"
+                              }
+                          },
+                          {
+                              "trace.id": "123456",
+                              "id": "DEF",
+                              "attributes": {
+                                  "error.message": "Invalid credentials",
+                                  "service.name": "Test Service B",
+                                  "host": "host456.example.com",
+                                  "duration.ms": 2.97,
+                                  "name": "/auth",
+                                  "parent.id": "ABC"
+                              }
+                          }
+                      ]
+                  }
+              ]' 'YOUR_TRACE_OBSERVER_URL'
           ```
        3. Insert your own values into the `curl` request:
 
@@ -267,7 +265,7 @@ If you haven't already set up a trace observer, complete the following:
               <tr>
                 <td>
                   <var>
-                    $YOUR_LICENSE_KEY
+                    `YOUR_LICENSE_KEY`
                   </var>
                 </td>
 
@@ -279,7 +277,7 @@ If you haven't already set up a trace observer, complete the following:
               <tr>
                 <td>
                   <var>
-                    $YOUR_TRACE_OBSERVER_URL
+                    `YOUR_TRACE_OBSERVER_URL`
                   </var>
                 </td>
 
@@ -292,7 +290,7 @@ If you haven't already set up a trace observer, complete the following:
        4. Copy the curl request into a terminal and execute it.
        5. The test should return `HTTP/1.1 202 Accepted`, indicating success. If it does not, check the following common issues:
           * Confirm that you used the [**For other integrations** endpoint](#endpoints) value.
-          * Confirm you're using single quotes around <var>YOUR_TRACE_OBSERVER_URL</var>.
+          * Confirm you're using single quotes around `YOUR_TRACE_OBSERVER_URL`.
           * Check that you're using the correct API key.
        6. If your test returned `HTTP/1.1 202 Accepted`, go to the New Relic UI to see a query of the sample payload data using the span attribute `service.name = Test Service A` ([here's a link for that query](https://one.newrelic.com/launcher/distributed-tracing-nerdlets.distributed-tracing?launcher=eyJ0aW1lUmFuZ2UiOnsiYmVnaW5fdGltZSI6bnVsbCwiZW5kX3RpbWUiOm51bGwsImR1cmF0aW9uIjoxODAwMDAwfSwiJGlzRmFsbGJhY2tUaW1lUmFuZ2UiOnRydWV9&pane=eyJuZXJkbGV0SWQiOiJkaXN0cmlidXRlZC10cmFjaW5nLW5lcmRsZXRzLmRpc3RyaWJ1dGVkLXRyYWNpbmctbGF1bmNoZXIiLCJzb3J0SW5kZXgiOjAsInNvcnREaXJlY3Rpb24iOiJERVNDIiwicXVlcnkiOnsib3BlcmF0b3IiOiJBTkQiLCJpbmRleFF1ZXJ5Ijp7ImNvbmRpdGlvblR5cGUiOiJJTkRFWCIsIm9wZXJhdG9yIjoiQU5EIiwiY29uZGl0aW9ucyI6W119LCJzcGFuUXVlcnkiOnsib3BlcmF0b3IiOiJBTkQiLCJjb25kaXRpb25TZXRzIjpbeyJjb25kaXRpb25UeXBlIjoiU1BBTiIsIm9wZXJhdG9yIjoiQU5EIiwiY29uZGl0aW9ucyI6W3siYXR0ciI6InNlcnZpY2UubmFtZSIsIm9wZXJhdG9yIjoiRVEiLCJ2YWx1ZSI6IlRlc3QgU2VydmljZSBBIn1dfV19fX0=)). Because the sample payload contains an error attribute, the error sampler will mark it for keeping. If you modify the payload to remove the error attributes, the random sampler may not choose to keep this particular trace.
 
@@ -329,7 +327,7 @@ Once you have a trace observer, you need to specify which data sources (services
     id="lambda-sampling"
     title="How does Lambda sampling work?"
   >
-  By default, when you set up Lambda layers, you automatically get head-based sampling. When you enable Infinite Tracing for Lambda, your head-based sampling data is additionally sampled by the trace observer. The main benefit to enabling Infinite Tracing for your Lambda functions is to ensure their spans are included with spans from other services tracked by Infinite Tracing. 
+    By default, when you set up Lambda layers, you automatically get head-based sampling. When you enable Infinite Tracing for Lambda, your head-based sampling data is additionally sampled by the trace observer. The main benefit to enabling Infinite Tracing for your Lambda functions is to ensure their spans are included with spans from other services tracked by Infinite Tracing. 
   </Collapser>
 </CollapserGroup>
 
@@ -360,7 +358,7 @@ To finish the configuration for browser, mobile, and Lambda in the UI:
 ## (Optional) Additional configuration for all service types [#follow-up-config]
 
 <Callout variant="tip">
-You may want to postpone these optional configurations until after you've worked with this feature for a while.
+  You may want to postpone these optional configurations until after you've worked with this feature for a while.
 </Callout>
 
 You can control the behavior of the trace observer with various configurations. Here are some of the features you can configure:


### PR DESCRIPTION
The cURL commands has `<var>` around the vars reading as plain text, I removed them and formatted the codeblock a little while I was here, also some minor indentation in the file which won't have any effect on the live page. I also replaced the text `<var>`s with just backticks which accomplish the same thing.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.