### PR TITLE
Added permissions for the custom query file

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
@@ -165,6 +165,20 @@ If you also want to obtain table and index-related metrics (for example, table s
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO new_relic;
 ```
 
+If you also want to obtain query-level metrics from the Postgres custom query config file, the PostgreSQL role used by the integration (`new_relic`) also needs to be added to the (`pg_read_all_stats`) role. This is due to the user leveraging the (`pg_stat_statements`) extension. This extension may require additional steps mentioned in the (`Additional notes`) section below.
+
+```
+GRANT pg_read_all_stats TO new_relic;
+```
+
+Additional notes:
+
+- **Enabling the Extension** Enabling the pg_stat_statements extension may require you to manually create it from a query prompt.
+
+```
+CREATE EXTENSION pg_stat_statements;
+```
+
 ### postgresql-config.yml sample files [#examples]
 
 <CollapserGroup>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
@@ -165,15 +165,12 @@ If you also want to obtain table and index-related metrics (for example, table s
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO new_relic;
 ```
 
-If you also want to obtain query-level metrics from the Postgres custom query config file, the PostgreSQL role used by the integration (`new_relic`) also needs to be added to the (`pg_read_all_stats`) role. This is due to the user leveraging the (`pg_stat_statements`) extension. This extension may require additional steps mentioned in the (`Additional notes`) section below.
-
+If you also want to obtain query-level metrics from the PostgreSQL custom query config file, the PostgreSQL role used by the integration (`new_relic`)  needs to be added to the (`pg_read_all_stats`) role. This is due to the user leveraging the (`pg_stat_statements`) extension. 
 ```
 GRANT pg_read_all_stats TO new_relic;
 ```
 
-Additional notes:
-
-- **Enabling the Extension** Enabling the pg_stat_statements extension may require you to manually create it from a query prompt.
+Enabling the `pg_stat_statements` extension may require you to manually create it from a query prompt:
 
 ```
 CREATE EXTENSION pg_stat_statements;


### PR DESCRIPTION
Adding an entry for permissions needed by the last query in the custom query file. The last query allows for query-level metrics and is critical for some customers.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.