### PR TITLE
fix(DT): add account family glossary

### DIFF
--- a/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
+++ b/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
@@ -108,7 +108,7 @@ With Infinite Tracing, you can send us 100% of your trace data from your applica
       Only your spans go to the trace observer—all other data such as metrics, custom events, and transaction traces are sent the normal route to New Relic and are subject to local sampling.
     </Callout>
 
-    You configure a unique trace observer endpoint for the AWS region you want to send data to. Because tracing is a cross-account feature, there can only be one trace observer per region per [account family](/docs/glossary/glossary/#account-family). The endpoint represents a trace observer for a particular workload. For example, all spans from a single trace (request) must go to that endpoint.
+    You configure a unique trace observer endpoint for the AWS region you want to send data to. Because tracing is a cross-account feature, you can have only one trace observer per region, per [account family](/docs/glossary/glossary/#account-family). The endpoint represents a trace observer for a particular workload. For example, all spans from a single trace (request) must go to that endpoint.
 
     Here are two architectural diagrams: one showing how data flows if you use APM agents and another if you use New Relic integrations like OpenTelemetry exporters:
 

--- a/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
+++ b/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
@@ -108,7 +108,7 @@ With Infinite Tracing, you can send us 100% of your trace data from your applica
       Only your spans go to the trace observer—all other data such as metrics, custom events, and transaction traces are sent the normal route to New Relic and are subject to local sampling.
     </Callout>
 
-    You configure a unique trace observer endpoint for the AWS region you want to send data to. Since Tracing is a cross-account feature, the trace observers are limited to one observer per region per [account family](https://docs.newrelic.com/docs/accounts/original-accounts-billing/original-users-roles/parent-child-account-structure/). You can request multiple endpoints, one per AWS region.  The endpoint represents a trace observer for a particular workload. For example, all spans from a single trace (request) must go to that endpoint.
+    You configure a unique trace observer endpoint for the AWS region you want to send data to. Because tracing is a cross-account feature, there can only be one trace observer per region per [account family](/docs/glossary/glossary/#account-family). The endpoint represents a trace observer for a particular workload. For example, all spans from a single trace (request) must go to that endpoint.
 
     Here are two architectural diagrams: one showing how data flows if you use APM agents and another if you use New Relic integrations like OpenTelemetry exporters:
 

--- a/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
@@ -31,7 +31,7 @@ Do some of your requests communicate with services that are still using standard
 To create a new trace observer if you're using New Relic APM agents or third-party integrations:
 
 1. Go to [one.newrelic.com](https://one.newrelic.com) and click **Apps**, and then under **Your apps**, click **New Relic Edge**.
-2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled. Since Tracing is a cross-account feature, the trace observers are limited to one observer per region per [account family](https://docs.newrelic.com/docs/accounts/original-accounts-billing/original-users-roles/parent-child-account-structure/).
+2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled. If you can't add an observer, it's likely due to there being only [one observer allowed per region per account family](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works/#infinite-architecture).
 3. If no trace observers are already present, click **New trace observer** to add one, fill out the information, and click **Create**. Note that we offer the following regions:
 
     * **us-east-1 (US)**
@@ -176,7 +176,7 @@ If you already created a trace observer while setting up another type of service
 If you haven't already set up a trace observer, complete the following:
 
 1. Go to [one.newrelic.com](https://one.newrelic.com) and click **Apps**, and then under **Your apps**, click **New Relic Edge**.
-2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled. Since Tracing is a cross-account feature, the trace observers are limited to one observer per region per [account family](https://docs.newrelic.com/docs/accounts/original-accounts-billing/original-users-roles/parent-child-account-structure/).
+2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled. If you can't add an observer, it's likely due to there being only [one observer allowed per region per account family](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works/#infinite-architecture).
 3. If no trace observers are already present, click **New trace observer** to add one, fill out the information, and click **Create**. Note that we offer the following regions:
 
     * **us-east-1 (US)**

--- a/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
@@ -31,7 +31,7 @@ Do some of your requests communicate with services that are still using standard
 To create a new trace observer if you're using New Relic APM agents or third-party integrations:
 
 1. Go to [one.newrelic.com](https://one.newrelic.com) and click **Apps**, and then under **Your apps**, click **New Relic Edge**.
-2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled. If you can't add an observer, it's likely due to there being only [one observer allowed per region per account family](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works/#infinite-architecture).
+2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled. If you can't add an observer, it's likely due to there being only [one observer allowed per region, per account family](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works/#infinite-architecture).
 3. If no trace observers are already present, click **New trace observer** to add one, fill out the information, and click **Create**. Note that we offer the following regions:
 
     * **us-east-1 (US)**
@@ -176,7 +176,7 @@ If you already created a trace observer while setting up another type of service
 If you haven't already set up a trace observer, complete the following:
 
 1. Go to [one.newrelic.com](https://one.newrelic.com) and click **Apps**, and then under **Your apps**, click **New Relic Edge**.
-2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled. If you can't add an observer, it's likely due to there being only [one observer allowed per region per account family](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works/#infinite-architecture).
+2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled. If you can't add an observer, it's likely due to there being only [one observer allowed per region, per account family](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works/#infinite-architecture).
 3. If no trace observers are already present, click **New trace observer** to add one, fill out the information, and click **Create**. Note that we offer the following regions:
 
     * **us-east-1 (US)**

--- a/src/content/docs/glossary/glossary.mdx
+++ b/src/content/docs/glossary/glossary.mdx
@@ -24,6 +24,25 @@ Whether you're considering New Relic One or you're already using our capabilitie
 
 <CollapserGroup>
   <Collapser
+    id="account"
+    title="account"
+  >
+A New Relic organization can have one or more accounts. An account can be considered a workspace: a space to monitor or analyze data relating to a specific project or a specific team. Each account has its own account ID, and that ID is used for some account-specific tasks, like making API calls. For more on why you'd create an account, see [Account structure](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure).
+
+We have two different user models, which define how accounts relate to the larger organization structure and to the organization's users. For more on our two user models and their separate set of docs, see [User models](/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models).
+
+  </Collapser>
+
+  <Collapser
+    id="account-family"
+    title="account family"
+  >
+A New Relic organization can have one or more [accounts](#account). 
+
+An "account family" refers to a parent account and the children accounts under it. For users on our [New Relic One user model](/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models), "account family" is synonymous with "organization": it's the group of related accounts in an organization. For our original user model, things are a little more complex: see [Original account structure](/docs/accounts/original-accounts-billing/original-users-roles/parent-child-account-structure).
+  </Collapser>  
+
+  <Collapser
     id="account-dropdown"
     title="account dropdown"
   >
@@ -851,6 +870,16 @@ All our integrations can be found at [New Relic Instant Observability](https://n
   >
     **On-host integrations** refer to integrations that reside on your own servers or hosts and that communicate with our infrastructure agent. For more information, see [Introduction to on-host integrations](/docs/infrastructure/host-integrations/getting-started/introduction-host-integrations).
   </Collapser>
+
+  <Collapser
+    id="organization"
+    title="organization"
+  >
+At New Relic, "organization" can refer to one or more concepts: 
+
+* We sometimes use "organization" in a general way to refer to a business or non-profit entity.  
+* For New Relic account management purposes, a "New Relic organization" refers to all the assets and data belonging to a New Relic customer (for example, their accounts, their users, and their data). For more about this concept, see [Organization and account structure](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure).
+  </Collapser>  
 
   <Collapser
     id="owner"


### PR DESCRIPTION
A follow-up to https://github.com/newrelic/docs-website/pull/6726. Work done: 
* Added 'account', 'account family' and 'organization' in glossary. 
* Finessed some of the DT additions. Pointed back to the architecture doc for more information from the Infinite Tracing procedure docs. 
