### PR TITLE
fix(scim): adding google, other things

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more.mdx
@@ -46,8 +46,9 @@ Requirements to manage authentication domains:
   * [Active Directory Federation Services (ADFS)](http://technet.microsoft.com/en-us/library/hh831502.aspx)
   * [Auth0](https://marketplace.auth0.com/integrations/new-relic-sso)
   * [Azure AD (Microsoft Azure Active Directory)](https://docs.microsoft.com/en-us/azure/active-directory/saas-apps/new-relic-limited-release-tutorial) 
+  * [Google](https://support.google.com/a/answer/6363863) 
   * [Okta](http://www.okta.com/newrelic)
-  * [OneLogin](http://www.onelogin.com/partners/app-partners/new-relic/)
+  * [OneLogin](https://www.onelogin.com/partners/technology-partners/new-relic)
   * [Ping Identity](https://www.pingidentity.com/en.html)
   * [Salesforce](http://wiki.developerforce.com/page/Configuring-SAML-SSO-to-NewRelic)
   * Generic support for SSO systems that use SAML 2.0

--- a/src/content/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign.mdx
@@ -30,9 +30,7 @@ Benefits of enabling automated user management include:
 
 Requirements and recommendations:
 * Requires [Pro or Enterprise edition](https://newrelic.com/pricing).
-* SCIM: we support the SCIM 2.0 standard. Three identity providers have a New Relic app: Azure AD, Okta, and OneLogin. 
-  * For other identity providers that use SCIM 2.0, use our [SCIM API](/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management). 
-  * Exceptions: Ping Identity's PingOne is not supported because it doesn't allow provisioning of groups. 
+* SCIM: we support the SCIM 2.0 standard. Three identity providers have a New Relic app: Azure AD, Okta, and OneLogin. For other identity providers that use SCIM 2.0, use our [SCIM API](/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management). 
   * Ping Identity's PingOne is not supported because it doesn't allow provisioning of groups. 
 * Single sign-on (SSO): we support the SAML 2.0 standard.
 * Permissions-related requirements:

--- a/src/content/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management.mdx
@@ -10,23 +10,24 @@ redirects:
   - /docs/scim-support-automated-user-management
 ---
 
-If you want to implement New Relic's automated user management and import your users from an identity provider, first read [Introduction to automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) to learn about supported identity providers and when you'd want to use our SCIM API, documented below.
+To set up the provisioning and management of your New Relic users from an identity provider, we provide a SCIM API for the identity providers that don't already have [New Relic-specific apps and implementations](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign#requirements).   
 
-## Requirements 
+## Who should use the SCIM API? [#when-to-use]
 
-If you have an identity provider that has a New Relic app (Azure AD, Okta, and OneLogin), see [the guides for those](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign). The SCIM API is meant for organizations that either aren't using those identity providers, or that want to use the SCIM API for additional configuration not available with the apps (for example, **managing user type**).
+If you have an identity provider that has a New Relic app (Azure AD, Okta, and OneLogin), see [the guides for those](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign). The SCIM API is meant for organizations that either aren't using those identity providers, or that want to use the SCIM API for additional configuration not available with the apps (for example, **managing user type**). Additional restrictions: 
+* Ping Identity's PingOne is **not** supported because it doesn't allow provisioning of groups. 
 
-Before using our SCIM API, you must first [enable SCIM for an authentication domain](/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more/#source-users). 
+Before using our SCIM API, you should first [set up an authentication domain with SCIM enabled](/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more/#source-users). The authentication domain UI will give you values that you can use to integrate with your identity provider.  
 
 Note that after you set up an integration with the SCIM API, there are [next steps](#next-steps) to do, including downgrading some users to basic users, and granting user groups access to New Relic accounts. 
 
-## Tutorial [#tutorial]
+## Our SCIM API tutorial [#tutorial]
 
-See the [SCIM API tutorial](/docs/accounts/accounts/automated-user-management/tutorial-manage-users-groups-scim) for more specific instructions on using this API. 
+This doc contains technical information about our SCIM API. For detailed instructions on using it, see the [SCIM API tutorial](/docs/accounts/accounts/automated-user-management/tutorial-manage-users-groups-scim).
 
 ## SCIM service provider [#scim-provider]
 
-New Relic’s SCIM service provider follows the [SCIM 2.0 API](http://www.simplecloud.info/) as described in [RFCs 7643](https://tools.ietf.org/html/rfc7643) and [7644](https://tools.ietf.org/html/rfc7644). You do not need to implement all aspects of the SCIM 2.0 specification to integrate your user information with New Relic. In fact, the New Relic service provider itself does not implement all aspects of the specification. This document describes the features from the specification available for an integration with New Relic.
+New Relic's SCIM service provider follows the [SCIM 2.0 API](http://www.simplecloud.info/) as described in [RFCs 7643](https://tools.ietf.org/html/rfc7643) and [7644](https://tools.ietf.org/html/rfc7644). You do not need to implement all aspects of the SCIM 2.0 specification to integrate your user information with New Relic. In fact, the New Relic service provider itself does not implement all aspects of the specification. This document describes the features from the specification available for an integration with New Relic.
 
 ## Authentication [#authentication]
 


### PR DESCRIPTION
Work done: 
Adding Google to v2 SAML SSO doc
Correcting onelogin link in v2 SAML SSO doc
Improving some readability in the SCIM API intro 