### PR TITLE
Add logging configuration information to main .NET agent config page (publish with 9.7.0)

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3070,17 +3070,17 @@ request.headers.user-agent
   ```
 </Callout>
 
-### Application logging
+### Application logging [#application_logging]
 
 The `applicationLogging` element is a child of the `configuration` element. Use `applicationLogging` to configure instrumentation of your application's logging activity.
 
 There are three main sub-features:
 
-1. Metrics - collect metrics on the total number of log lines written per harvest cycle (`Logging/lines`), as well as the number of log lines written at particular logging levels (e.g. `Logging/lines/ERROR`).
+1. Metrics - collect metrics on the total number of log lines written per harvest cycle (`Logging/lines`), as well as the number of log lines written at particular logging levels (for example, `Logging/lines/ERROR`).
 2. Log forwarding - when enabled, the agent will capture log data and send it to New Relic.
-3. Local log decoration - when enabled, your existing logs will be decorated with metadata which links logs with other New Relic data (e.g. Errors).
+3. Local log decoration - when enabled, your existing logs will be decorated with metadata which links logs with other New Relic data, such as errors.
 
-For more details, see [.NET Telemetry in Context](/docs/logs/logs-everywhere/net-telemetry-in-context).
+For more details, see our documentation about [.NET telemetry in context](/docs/logs/logs-everywhere/net-telemetry-in-context).
 
 ```xml
 <applicationLogging enabled="true">
@@ -3091,7 +3091,7 @@ For more details, see [.NET Telemetry in Context](/docs/logs/logs-everywhere/net
 ```
 
 <Callout variant="important">
-  This configuration option is only available in the .NET Agent v9.7.0 or higher.
+  This configuration option is only available in the .NET agent v9.7.0 or higher.
 </Callout>
 
 The `applicationLogging` element supports the following attributes and sub-elements:
@@ -3125,14 +3125,14 @@ The `applicationLogging` element supports the following attributes and sub-eleme
       </tbody>
     </table>
 
-    Enable or disable all logging instrumentation features.  If "true", the individual sub-feature configurations take effect.  If "false", no logging instrumentation features are enabled.
+    Enable or disable all logging instrumentation features. If `true`, the individual sub-feature configurations take effect.  If `false`, no logging instrumentation features are enabled.
   </Collapser>
 
   <Collapser
     id="metrics"
     title="metrics"
   >
-    Use this sub-element to enable collection of logging metrics (e.g. `Logging/lines`) for common .NET logging frameworks. The default value of attribute `enabled` is `true`.
+    Use this sub-element to enable collection of logging metrics (such as `Logging/lines`) for common .NET logging frameworks. The default value of attribute `enabled` is `true`.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1596,6 +1596,7 @@ Use these options to enable, disable, and configure New Relic features. New Reli
 * [Distributed tracing](#distributed_tracing)
 * [Span events](#span-events)
 * [Capture HTTP Request Headers](#capture_http_request_headers)
+* [Application logging](#application_logging)
 
 ### App pools [#include_exclude_apps]
 
@@ -3068,6 +3069,92 @@ request.headers.user-agent
   </attributes>
   ```
 </Callout>
+
+### Application logging
+
+The `applicationLogging` element is a child of the `configuration` element. Use `applicationLogging` to configure instrumentation of your application's logging activity.
+
+There are three main sub-features:
+
+1. Metrics - collect metrics on the total number of log lines written per harvest cycle (`Logging/lines`), as well as the number of log lines written at particular logging levels (e.g. `Logging/lines/ERROR`).
+2. Log forwarding - when enabled, the agent will capture log data and send it to New Relic.
+3. Local log decoration - when enabled, your existing logs will be decorated with metadata which links logs with other New Relic data (e.g. Errors).
+
+For more details, see [.NET Telemetry in Context](/docs/logs/logs-everywhere/net-telemetry-in-context).
+
+```xml
+<applicationLogging enabled="true">
+ <metrics enabled="true" />
+ <logForwarding enabled="false" maxSamplesStored="10000" />
+ <localDecorating enabled="false" />
+</applicationLogging>
+```
+
+<Callout variant="important">
+  This configuration option is only available in the .NET Agent v9.7.0 or higher.
+</Callout>
+
+The `applicationLogging` element supports the following attributes and sub-elements:
+
+<CollapserGroup>
+  <Collapser
+    id="paragrp-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable all logging instrumentation features.  If "true", the individual sub-feature configurations take effect.  If "false", no logging instrumentation features are enabled.
+  </Collapser>
+
+  <Collapser
+    id="metrics"
+    title="metrics"
+  >
+    Use this sub-element to enable collection of logging metrics (e.g. `Logging/lines`) for common .NET logging frameworks. The default value of attribute `enabled` is `true`.
+  </Collapser>
+
+  <Collapser
+    id="logForwarding"
+    title="Log forwarding"
+  >
+    Use this sub-element to enable forwarding of your application's logs to New Relic. The default value of attribute `enabled` is `false`.  The default value of attribute `maxSamplesStored` is `10000`.
+
+    <Callout variant="caution">
+      If you are already sending your application's logs to New Relic using an existing log forwarding solution, be sure to disable that before enabling log forwarding in the agent, in order to prevent being billed for duplicate log data.
+    </Callout>
+
+  </Collapser>
+
+  <Collapser
+    id="localDecorating"
+    title="Local log decoration"
+  >
+    Use this sub-element to enable decoration of your application's logs with New Relic linking metadata. The default value of attribute `enabled` is `false`.
+
+  </Collapser>
+</CollapserGroup>
 
 ## Settings in app.config or web.config [#app-config-settings]
 

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3080,7 +3080,7 @@ There are three main sub-features:
 2. Log forwarding - when enabled, the agent will capture log data and send it to New Relic.
 3. Local log decoration - when enabled, your existing logs will be decorated with metadata which links logs with other New Relic data, such as errors.
 
-For more details, see our documentation about [.NET telemetry in context](/docs/logs/logs-everywhere/net-telemetry-in-context).
+For more details, see our documentation about [APM logs in context](/docs/apm/new-relic-apm/getting-started/get-started-logs-context).
 
 ```xml
 <applicationLogging enabled="true">


### PR DESCRIPTION
This PR updates the main .NET agent configuration page with new configuration options for application logging instrumentation features.  It contains a link back to a draft of a new document, note that the name and location of this document may change in the next week or so.  I'm not particularly attached to the way I've formatted these instructions so any suggestions would be appreciated.

This is a draft PR and the content should not be published until the next .NET agent release, 9.7.0, which should take place next week.

@barbnewrelic 