### PR TITLE
docs: update default max span value

### DIFF
--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -420,7 +420,7 @@ If no environment is specified, the agent will use the default settings as speci
 
 The basic structure of the configuration file is:
 
-```
+```py
 [newrelic]
 <var>... default settings</var>
 
@@ -994,7 +994,7 @@ These settings are available in the agent configuration file.
         id="example-2-labels"
         title="Two tags"
       >
-        ```
+        ```py
         <var>Server</var>:<var>One</var>;<var>Data Center</var>:<var>Primary</var>
         ```
       </Collapser>
@@ -1841,7 +1841,7 @@ For more information about transaction traces, see [Transaction traces](/docs/tr
     For example, if you want to add function tracing to all validation functions in the below file:
 
     <b>my-app/common/utils.py</b>
-    ```
+    ```py
     def validate_credentials():
     …
     def validate_status():
@@ -1853,7 +1853,7 @@ For more information about transaction traces, see [Transaction traces](/docs/tr
     Add the following line to the agent config file to include function tracing to all validation functions in `my-app/common/utils.py` by using wildcarding.
 
     <b>my-app/newrelic.ini</b>
-    ```
+    ```py
     [newrelic]
     ...
     transaction_tracer.function_trace = common.utils:validate*
@@ -2582,7 +2582,7 @@ Here are browser monitoring settings available via the agent configuration file.
       >
         If you are generating HTML page responses and using the `Content-Type` of `application/xhtml+xml`, you can override the allowed content types to list both this content type and the default `text/html` by using:
 
-        ```
+        ```py
         browser_monitoring.content_type = text/html application/xhtml+xml
         ```
 
@@ -3393,7 +3393,7 @@ Event harvest configuration settings include:
           </th>
 
           <td>
-            `1000`
+            `2000`
           </td>
         </tr>
 
@@ -4042,7 +4042,7 @@ Here are assorted other settings available via the agent configuration file.
 
     **Example: Built-in exception and user-defined exception**
 
-    ```
+    ```py
     <var>KeyError</var> <var>my_module</var>:<var>MyException</var>
     ```
   </Collapser>
@@ -4302,7 +4302,7 @@ To disable default instrumentation, provide a special `import-hook` section corr
   >
     Add the following to the configuration file:
 
-    ```
+    ```py
     [import-hook:MySQLdb]
     enabled = false
     ```


### PR DESCRIPTION
Updated default limit for span events sent up per minute from 1000 to 2000. Here is the agent code for this value:
```py
def _environ_as_int(name, default=0):
    val = os.environ.get(name, default)
    try:
        return int(val)
    except ValueError:
        return default
...
SPAN_EVENT_RESERVOIR_SIZE = 2000
...
_settings.event_harvest_config.harvest_limits.span_event_data = _environ_as_int(
    "NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED", SPAN_EVENT_RESERVOIR_SIZE
)
```
[I confirmed this is correct with the dev team in slack.](https://newrelic.slack.com/archives/C0511NL6X/p1648143316224569)

I also added the language types to the codeblocks while I was in the file.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.