### PR TITLE
docs: python agent is also 2000 spans/min

### DIFF
--- a/src/content/docs/data-apis/manage-data/view-system-limits.mdx
+++ b/src/content/docs/data-apis/manage-data/view-system-limits.mdx
@@ -168,8 +168,7 @@ The following table includes general max limits that apply across all New Relic 
       </td>
 
       <td>
-        Metric, Trace, and Event API: 4096
-        Log API: 4094
+        Metric, Trace, and Event API: 4096. Log API: 4094.
       </td>
     </tr>
 

--- a/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
+++ b/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
@@ -22,16 +22,6 @@ Here are some technical details about how New Relic distributed tracing works:
 * [How trace context is passed between applications](#headers)
 * [Trace-related limits](#limits)
 
-### Exceeding trace limits [#exceed-limits]
-
-When you exceed your span rate limit, an [`NrIntegrationError` event](/docs/telemetry-data-platform/manage-data/nrintegrationerror) is generated. You can get rate limit messages with this NRQL query:
-
-```sql
-SELECT * FROM NrIntegrationError WHERE newRelicFeature = 'Distributed Tracing' AND category = 'RateLimit' AND rateLimitType = 'SpansPerMinute'
-```
-
-To get a notification when you exceed the limit, you can set up a [NRQL alert](/docs/alerts/new-relic-alerts/defining-conditions/create-alert-conditions-nrql-queries).
-
 ## Trace sampling [#sampling]
 
 How your traces are sampled will depend on your setup and the New Relic tracing tool you're using. For example, you may be using a third-party telemetry service (like OpenTelemetry) to implement sampling of traces before your data gets to us. Or, if you're using [Infinite Tracing](/docs/understand-dependencies/distributed-tracing/infinite-tracing/introduction-infinite-tracing), you'd probably send us all your trace data and rely on our sampling.
@@ -517,3 +507,13 @@ Go and PHP: 1000. All other agents: 2000.
 For more rules related to using the Trace API, see [Trace API requirements and limits](/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits).
 
 For other New Relic limits, see [Limits](/docs/data-apis/manage-data/view-system-limits#limits-ui).
+
+### Exceeding trace limits [#exceed-limits]
+
+When you exceed your span rate limit, an [`NrIntegrationError` event](/docs/telemetry-data-platform/manage-data/nrintegrationerror) is generated. You can get rate limit messages with this NRQL query:
+
+```sql
+SELECT * FROM NrIntegrationError WHERE newRelicFeature = 'Distributed Tracing' AND category = 'RateLimit' AND rateLimitType = 'SpansPerMinute'
+```
+
+To get a notification when you exceed the limit, you can set up a [NRQL alert](/docs/alerts/new-relic-alerts/defining-conditions/create-alert-conditions-nrql-queries).

--- a/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
+++ b/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
@@ -75,7 +75,7 @@ Here are some trace-related limits:
       </td>
 
       <td>
-        Go, PHP, Python: 1000
+        Go, PHP: 1000
         Other agents: 2000
       </td>
     </tr>

--- a/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
+++ b/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
@@ -90,7 +90,7 @@ For other New Relic limits, see [Limits](/docs/data-apis/manage-data/view-system
 
 When you exceed your span rate limit, an [`NrIntegrationError` event](/docs/telemetry-data-platform/manage-data/nrintegrationerror) is generated. You can get rate limit messages with this NRQL query:
 
-```
+```sql
 SELECT * FROM NrIntegrationError WHERE newRelicFeature = 'Distributed Tracing' AND category = 'RateLimit' AND rateLimitType = 'SpansPerMinute'
 ```
 


### PR DESCRIPTION
I confirmed in slack with python devs that this value was not up to date in the python docs: https://newrelic.slack.com/archives/C0511NL6X/p1648143316224569

I have now updated the python config doc as well to reflect the 2000 value.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.