### PR TITLE
fix: references to OpenTelemetry array support

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/introduction-opentelemetry-new-relic.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/introduction-opentelemetry-new-relic.mdx
@@ -195,7 +195,7 @@ The tables in the sections below show the supported features for each telemetry 
 
 New Relic offers support for the OTLP ingest of trace signals. The maturity of the upstream specification is [stable](https://github.com/open-telemetry/opentelemetry-specification/blob/87a5ed7f0d4c403e2b336f275ce3e7fd66a8041b/specification/versioning-and-stability.md#stable). 
 
-OpenTelemetry traces and spans are compatible with New Relic traces and spans. OpenTelemetry spans optionally include attributes (name-value pairs) and resource attributes which map directly to dimensions that can be used to facet or filter span data at query time. OpenTelemetry span metadata (for example, `name`, `kind`, and `trace_id`) also map directly to dimensions on NewRelic spans. At this time, New Relic does not support span links or array attributes.
+OpenTelemetry traces and spans are compatible with New Relic traces and spans. OpenTelemetry spans optionally include attributes (name-value pairs) and resource attributes which map directly to dimensions that can be used to facet or filter span data at query time. OpenTelemetry span metadata (for example, `name`, `kind`, and `trace_id`) also map directly to dimensions on New Relic spans. At this time, New Relic does not support span links.
 
 For details, see the Traces section of our [best practices](/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts#traces) guide.
 
@@ -216,8 +216,8 @@ For details, see the Traces section of our [best practices](/docs/integrations/o
       <td>❌</td>
     </tr>
     <tr>
-      <td>[Array of primitives (homogeneous)](https://github.com/open-telemetry/opentelemetry-specification/blob/e13990125809a4ecc482553c32d05e38bb414acb/specification/common/common.md#attributes)</td>
-      <td>❌</td>
+      <td>[Array of primitives (homogeneous)](https://opentelemetry.io/docs/reference/specification/common/common/#attribute) </td>
+      <td>✅ (Must be non-nested and 64 or less elements)</td>
     </tr>
   </tbody>
 </table>
@@ -275,7 +275,7 @@ Here are the OpenTelemetry data types we support and their associated mappings. 
 
 New Relic offers support for the OTLP ingest of log signals. Note that the maturity of the upstream specification is [experimental](https://github.com/open-telemetry/opentelemetry-specification/blob/87a5ed7f0d4c403e2b336f275ce3e7fd66a8041b/specification/versioning-and-stability.md#experimental). We intend to follow potentially breaking upstream changes.
 
-OpenTelemetry logs are compatible with New Relic logs. OpenTelemetry logs optionally include attributes (name-value pairs) and resource attributes which map directly to dimensions that can be used to facet or filter log data at query time. OpenTelemetry log metadata (for example, `name`, `severity_text`, and `trace_id`) also map directly to dimensions on New Relic logs. NewRelic currently supports all OpenTelemetry log message types except for arrays.
+OpenTelemetry logs are compatible with New Relic logs. OpenTelemetry logs optionally include attributes (name-value pairs) and resource attributes which map directly to dimensions that can be used to facet or filter log data at query time. OpenTelemetry log metadata (for example, `name`, `severity_text`, and `trace_id`) also map directly to dimensions on New Relic logs. New Relic currently supports all OpenTelemetry log message types.
 
 For more details, see the Logs section of our [best practices](/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts#logs) guide.
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts.mdx
@@ -204,9 +204,9 @@ Summary metric data points include count, sum, and quantile values, with 0.0 as 
 
 ### Start time [#start-time]
 
-The `startTimeUnixNano` field is optional according to the OpenTelemetry [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/87a5ed7f0d4c403e2b336f275ce3e7fd66a8041b/specification/metrics/datamodel.md#temporality). When this field is provided, it is used for the timestamp on the resulting NewRelic metric, and the `duration` is calculated as `timeUnixNano - startTimeUnixNano`. The `duration` field is used to calculate the queryable `endTimeStamp` attribute on the New Relic metric, but it serves no other semantic purpose.
+The `startTimeUnixNano` field is optional according to the OpenTelemetry [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/87a5ed7f0d4c403e2b336f275ce3e7fd66a8041b/specification/metrics/datamodel.md#temporality). When this field is provided, it is used for the timestamp on the resulting New Relic metric, and the `duration` is calculated as `timeUnixNano - startTimeUnixNano`. The `duration` field is used to calculate the queryable `endTimeStamp` attribute on the New Relic metric, but it serves no other semantic purpose.
 
-If `startTimeUnixNano` is not provided, then `timeUnixNano` is used for the timestamp field on the resulting NewRelic metric, and the duration field is set to zero.
+If `startTimeUnixNano` is not provided, then `timeUnixNano` is used for the timestamp field on the resulting New Relic metric, and the duration field is set to zero.
 
 ### Array values for attributes [#array-values]
 


### PR DESCRIPTION
@bradleycamacho 

@jsgithub1 and I caught a few inconsistencies in our OpenTelemetry docs around array support that we are correcting here. Please review. This may be merged at any time.

This is a follow-up task for https://github.com/newrelic/docs-website/pull/6478. Thanks!