### PR TITLE
fix(aws): note about missing metrics

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
@@ -125,3 +125,7 @@ Integrations based on CloudWatch Logs, [forwarded to New Relic via Lambda](/docs
 
 - AWS RDS Enhanced
 - AWS VPC Flow Logs
+
+## Metrics not available with CloudWatch metric streams
+AWS CloudWatch metric stream will not include metrics that are made available to CloudWatch with more than 2 hours delay. Examples of AWS namespaces that might contain metrics that are aggregated and exposed after 2 hours include: AWS DMS, AWS RDS, AWS DocDB, AWS S3 and AWS DAX.  
+Please refer to [AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-setup.html) to learn more.


### PR DESCRIPTION
## Give us some context

* From support tickets: customers expect a note explaining certain metrics might not be available in metric streams. There's no official list of metrics and these might be updated / implemented by AWS at any point of time so just keeping a reference of the namespaces where we've seen missing metrics. 