### PR TITLE
fix: remove autoLinkHeaders from md files

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -209,10 +209,6 @@ module.exports = {
               maxWidth: 850,
             },
           },
-          autoLinkHeaders,
-          // This MUST come after `gatsby-remark-autolink-headers` to ensure the
-          // link created for the icon has the proper id
-          'gatsby-remark-custom-heading-ids',
         ],
       },
     },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -209,6 +209,7 @@ module.exports = {
               maxWidth: 850,
             },
           },
+          'gatsby-remark-custom-heading-ids',
         ],
       },
     },


### PR DESCRIPTION
Removing the plugin feature that was adding links to headers via gatsby and creating icons as links that didn't go anywhere:

<img width="542" alt="Screen Shot 2022-03-29 at 10 54 45 AM" src="https://user-images.githubusercontent.com/26727669/160705266-727e1f9b-cdf9-4748-9e8e-d2149ed22e94.png">
