### PR TITLE
[postgres] make importing jobs table from aws db a little easier

### DIFF
--- a/scripts/actions/translation_workflow/testing/migrations/20211201221649-test.js
+++ b/scripts/actions/translation_workflow/testing/migrations/20211201221649-test.js
@@ -71,15 +71,15 @@ module.exports = {
           deferrable: Deferrable.INITIALLY_IMMEDIATE,
         },
       },
-      project_id: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-      },
       date_created: {
         type: DataTypes.DATE,
       },
       date_modified: {
         type: DataTypes.DATE,
+      },
+      project_id: {
+        type: DataTypes.TEXT,
+        allowNull: true,
       },
     });
     await queryInterface.createTable('translations', {


### PR DESCRIPTION
## Description

Minor change to the migration file that creates tables/columns in dockerized postgres when running `yarn db:start` to match the column order in AWS postgres (prod). The order matters when trying to import data from AWS into the same table locally.