### PR TITLE
fix F5 integration CA_FILE_FILE setting

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/f5-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/f5-monitoring-integration.mdx
@@ -173,7 +173,7 @@ The F5 integration collects both metrics(**M**) and inventory(**I**) information
 <tr>
   <td>**CA_BUNDLE_FILE**</td>
   <td>
-    Location of SSL certificate on the host. Only required if `USE_SSL` is true.
+    Alternative Certificate Authority bundle file.
   </td>
   <td>N/A</td>
   <td style={{ 'text-align': 'center' }}>M/I</td>
@@ -975,7 +975,7 @@ These attributes can be found by querying the `F5BigIpVirtualServerSample` event
 
 ### Pool sample metrics [#pool-sample]
 
-These attributes can be found by querying the `F5BigIpPoolSample` event type. 
+These attributes can be found by querying the `F5BigIpPoolSample` event type.
 
 <table>
   <thead>
@@ -1393,7 +1393,7 @@ These attributes can be found by querying the `F5BigIpPoolMemberSample` event ty
 
 ### Node sample metrics [#node-sample]
 
-These attributes can be found by querying the `F5BigIpNodeSample` event type. 
+These attributes can be found by querying the `F5BigIpNodeSample` event type.
 
 <table>
   <thead>


### PR DESCRIPTION
our `CA_BUNDLE_FILE` config setting mentions a `USE_SSL` setting that does not exist. This PR removes that. 