### PR TITLE
AccountId() NRQL function (not yet ready for publish)

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -1833,11 +1833,7 @@ Use non-aggregator functions for non-numerical data in NRQL queries.
     className="freq-link"
     title={<InlineCode>accountId()</InlineCode>}
   >
-Use the `accountId()` function to return the [account ID](/docs/accounts/accounts-billing/account-structure/account-id) for queried events. This is useful when querying data that crosses multiple New Relic accounts.
-
-This function takes no arguments.
-
-Here are some example queries: 
+Use the `accountId()` function to return the [account ID](/docs/accounts/accounts-billing/account-structure/account-id) associated with queried data. This function takes no arguments. Here are some example queries: 
 
     <CollapserGroup>
       <Collapser title="Get the account ID for each Transaction event">

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -1831,6 +1831,46 @@ Use non-aggregator functions for non-numerical data in NRQL queries.
 <CollapserGroup>
   <Collapser
     className="freq-link"
+    title={<InlineCode>accountId()</InlineCode>}
+  >
+    Use the `accountId()` function to return the account id for each event returned. This is especially useful for queries that run across multiple accounts.
+
+    This function takes no arguments.
+
+    See below:
+
+    <CollapserGroup>
+      <Collapser title="Get the account id for each Transaction event">
+        This query returns the account id associated with each Transaction event returned.
+
+        ```
+        SELECT accountId() FROM Transaction SINCE 1 day ago
+        ```
+      </Collapser>
+    </CollapserGroup>
+
+    <CollapserGroup>
+      <Collapser title="Get the count of Transaction events for each account id">
+        This query returns the number of Transaction events in the last day that are associated with each account id.
+
+        ```
+        SELECT count(*) FROM Transaction FACET accountId() SINCE 1 day ago
+        ```
+      </Collapser>
+    </CollapserGroup>
+
+    <CollapserGroup>
+      <Collapser title="Get the count of Transaction events for each account id specified in WHERE clause">
+        This query returns the number of Transaction events in the last day where the account id is specifically one of 1, 2, or 3.
+
+        ```
+        SELECT count(*) FROM Transaction WHERE accountId() IN (1,2,3) SINCE 1 day ago
+        ```
+      </Collapser>
+    </CollapserGroup>
+  </Collapser>
+  <Collapser
+    className="freq-link"
     title={<InlineCode>earliest(attribute)</InlineCode>}
   >
     Use the `earliest( )` function to return the earliest value for an attribute over the specified time range.

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -1833,15 +1833,15 @@ Use non-aggregator functions for non-numerical data in NRQL queries.
     className="freq-link"
     title={<InlineCode>accountId()</InlineCode>}
   >
-    Use the `accountId()` function to return the account id for each event returned. This is especially useful for queries that run across multiple accounts.
+Use the `accountId()` function to return the [account ID](/docs/accounts/accounts-billing/account-structure/account-id) for queried events. This is useful when querying data that crosses multiple New Relic accounts.
 
-    This function takes no arguments.
+This function takes no arguments.
 
-    See below:
+Here are some example queries: 
 
     <CollapserGroup>
-      <Collapser title="Get the account id for each Transaction event">
-        This query returns the account id associated with each Transaction event returned.
+      <Collapser title="Get the account ID for each Transaction event">
+        This query returns the account ID associated with each `Transaction` event returned:
 
         ```
         SELECT accountId() FROM Transaction SINCE 1 day ago
@@ -1850,8 +1850,8 @@ Use non-aggregator functions for non-numerical data in NRQL queries.
     </CollapserGroup>
 
     <CollapserGroup>
-      <Collapser title="Get the count of Transaction events for each account id">
-        This query returns the number of Transaction events in the last day that are associated with each account id.
+      <Collapser title="Get the count of Transaction events for each account">
+        This query returns the number of `Transaction` events in the last day that are associated with each account ID:
 
         ```
         SELECT count(*) FROM Transaction FACET accountId() SINCE 1 day ago
@@ -1860,8 +1860,8 @@ Use non-aggregator functions for non-numerical data in NRQL queries.
     </CollapserGroup>
 
     <CollapserGroup>
-      <Collapser title="Get the count of Transaction events for each account id specified in WHERE clause">
-        This query returns the number of Transaction events in the last day where the account id is specifically one of 1, 2, or 3.
+      <Collapser title="Get the count of Transaction events for each account specified in WHERE clause">
+        This query returns the number of `Transaction` events in the last day where the account ID is specifically one of `1`, `2`, or `3`:
 
         ```
         SELECT count(*) FROM Transaction WHERE accountId() IN (1,2,3) SINCE 1 day ago


### PR DESCRIPTION
This is waiting to be published until some time in April. This is documenting a NRQL function accountId() that allows you to return the accounts associated with the data queried. This is currently only for nerdgraph; query builder ability will come later (currently you can only run queries in UI query builder that are constrained by the account you're in but with nerdgraph you can cross account boundaries). 

…-website/commit/567d3b1ea5975e0e12fcdfb7c002087166bfe1c7

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.