### PR TITLE
chore: add workflow to add relevant prs to docs eng beta board

### DIFF
--- a/.github/workflows/pr-docs-eng-board-beta.yml
+++ b/.github/workflows/pr-docs-eng-board-beta.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Get project data
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}
           ORGANIZATION: newrelic
           PROJECT_NUMBER: 65
         run: |
@@ -44,7 +44,7 @@ jobs:
 
       - name: Add PR to project
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}
           PR_ID: ${{ github.event.pull_request.node_id }}
         run: |
           item_id="$( gh api graphql -f query='
@@ -60,7 +60,7 @@ jobs:
 
       - name: Set fields
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}
         run: |
           gh api graphql -f query='
             mutation (

--- a/.github/workflows/pr-docs-eng-board-beta.yml
+++ b/.github/workflows/pr-docs-eng-board-beta.yml
@@ -1,0 +1,82 @@
+name: Add PRs to DocsEng board
+
+on:
+  pull_request:
+    branches:
+      - develop
+    types:
+      - opened
+    paths-ignore:
+      - '**.mdx'
+      - '**.md'
+      - 'src/nav/*'
+      - '**/images/*'
+
+jobs:
+  track_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORGANIZATION: newrelic
+          PROJECT_NUMBER: 65
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectNext(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      id
+                      name
+                      settings
+                    }
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+
+          echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
+          echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
+          echo 'TODO_OPTION_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name=="Needs Review") |.id' project_data.json) >> $GITHUB_ENV
+
+      - name: Add PR to project
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_ID: ${{ github.event.pull_request.node_id }}
+        run: |
+          item_id="$( gh api graphql -f query='
+            mutation($project:ID!, $pr:ID!) {
+              addProjectNextItem(input: {projectId: $project, contentId: $pr}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f pr=$PR_ID --jq '.data.addProjectNextItem.projectNextItem.id')"
+
+          echo 'ITEM_ID='$item_id >> $GITHUB_ENV
+
+      - name: Set fields
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $status_field: ID!
+              $status_value: String!
+            ) {
+              set_status: updateProjectNextItemField(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: $status_value
+              }) {
+                projectNextItem {
+                  id
+                  }
+              }
+            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.TODO_OPTION_ID }} --silent

--- a/.github/workflows/pr-docs-eng-board-beta.yml
+++ b/.github/workflows/pr-docs-eng-board-beta.yml
@@ -1,6 +1,7 @@
 name: Add PRs to DocsEng board
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
## Description

Adds a workflow to add relevant PRs to Docs Eng board.

Had to use different API than other related workflows to triage issues / PRs to other boards because the Docs Eng Board is a beta project board.

## Links
The gihutb doc [Automating projects (beta)](https://docs.github.com/en/issues/trying-out-the-new-projects-experience/automating-projects) was helpful
