### PR TITLE
Add eu endpoint to heroku log forwarding docs

### DIFF
--- a/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
@@ -9,7 +9,7 @@ redirects:
   - /docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/heroku-log-forwarding/
 ---
 
-If your log data is already being monitored by Heroku's built-in [Logplex](https://devcenter.heroku.com/articles/logplex) router, you can use our integration to forward and enrich your log data in New Relic. This integration uses [Heroku Syslog drains](https://devcenter.heroku.com/articles/log-drains#syslog-drains). 
+If your log data is already being monitored by Heroku's built-in [Logplex](https://devcenter.heroku.com/articles/logplex) router, you can use our integration to forward and enrich your log data in New Relic. This integration uses [Heroku Syslog drains](https://devcenter.heroku.com/articles/log-drains#syslog-drains).
 
 Forwarding your Heroku logs to New Relic will give you enhanced log management capabilities to collect, process, explore, query, and alert on your log data.
 
@@ -25,11 +25,16 @@ To enable our log management capabilities, start by creating a Heroku Syslog dra
   $ heroku drains:add syslog+tls://newrelic.syslog.nr-data.net:6515 -a <var>YOUR_APP_NAME</var>
   ```
 
+  <Callout variant="important" title="EU Customers should use this instead">
+  ```
+  $ heroku drains:add syslog+tls://newrelic.syslog.eu.nr-data.net:6515 -a <var>YOUR_APP_NAME</var>
+  ```
+  </Callout>
+
 4. Run the following command and copy the Heroku Syslog [drain token](https://devcenter.heroku.com/articles/log-drains#drain-tokens) from the `token` attribute:
 
   ```
   $ heroku drains -a <var>YOUR_APP_NAME</var> --json
-
   ```
 
   ```


### PR DESCRIPTION
Hi!

Just adding the EU endpoint for heroku logs since it's different to the US one.
This will allow EU customers to configure heroku drains correctly

Regards!