### PR TITLE
fix(what's new): Broken link

### DIFF
--- a/src/content/whats-new/2020/10/monitor-asgi-apps-using-python-agent.md
+++ b/src/content/whats-new/2020/10/monitor-asgi-apps-using-python-agent.md
@@ -2,7 +2,7 @@
 title: Monitor ASGI apps using the Python agent
 summary: 'The Python agent now supports monitoring Uvicorn, Starlette, and FastAPI ASGI applications.'
 releaseDate: '2020-10-27'
-learnMoreLink: 'https://docs.newrelic.com/docs/agents/python-agent/async-instrumentation'
+learnMoreLink: 'https://docs.newrelic.com/docs/apm/agents/python-agent/web-frameworks-servers/uvicorn'
 ---
 
 The Python agent now provides out-of-the-box monitoring support for Uvicorn, Starlette, and FastAPI ASGI applications.


### PR DESCRIPTION
The Learn more link was pointing to a category level that we can't link directly to anymore. I linked to a prominent doc in that category.