### PR TITLE
fix(api keys): user key capabilities

### DIFF
--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -177,7 +177,7 @@ The license key is required for almost all New Relic data ingest. The exceptions
 
 The license key is a 40-character hexadecimal string associated with a New Relic account. When you first [sign up](/docs/subscriptions/creating-your-new-relic-account) for New Relic, an organization with a single account and its own license key are created. If more accounts are added, each account starts with its own license key. The license key originally created for an account cannot be deleted but you can create additional license keys that can be managed and deleted, and this is useful for implementing security-practices such as key rotation. If you need to delete an account's original license key, [contact support](https://support.newrelic.com).
 
-To restrict a user from being able to view or manage license keys, you can choose a role without those capabilities: [original user model](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model#add-on) | [New Relic One user model](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#capabilities). 
+To restrict a user from being able to view or manage license keys, assign them a role without those capabilities: [original user model](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model#add-on) | [New Relic One user model](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#capabilities). 
     
 </Collapser>
 
@@ -208,6 +208,9 @@ Mobile monitoring uses a mobile app token to report data, rather than the licens
 New Relic user keys, sometimes referred to as "personal API keys," are required for using [NerdGraph](/docs/apis/intro-apis/introduction-new-relic-apis/#graphql) and our [REST API](/docs/apis/intro-apis/introduction-new-relic-apis/#rest-api). 
 
 A user key is tied to both a specific New Relic user and a specific account, and they cannot be transferred. The user key allows you to make queries for any accounts you've been granted access to, not just the specific account the key was associated with. If a New Relic user is deleted in New Relic, their user keys are also deactivated and won't work. 
+
+To restrict a user from being able to view or manage user keys, assign them a role without those capabilities: [original user model](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model#add-on) | [New Relic One user model](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#capabilities). 
+
 
 </Collapser>
 


### PR DESCRIPTION
Capabilities UI had 'user key' added, alongside license key. 