### PR TITLE
Removed unsupported agent versions from log_file

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -2213,16 +2213,6 @@ If the agent is running in a cloud instance, the agent will try to detect the cl
     Default paths:
 
     * Linux: If not defined, it logs only in the standard output.
-    * Windows, agent version 1.0.752 or lower:
-
-      ```
-      C:\Program Files\New Relic\newrelic-infra\newrelic-infra.log
-      ```
-    * Windows, agent version 1.0.775 to 1.0.944:
-
-      ```
-      C:\%APPDATA%\Roaming\New Relic\newrelic-infra\newrelic-infra.log
-      ```
     * Windows, agent version 1.0.944 or higher:
 
       ```


### PR DESCRIPTION
Removed unsupported agent version from log_file as they tend to cause confusion and we do not support those versions of the agent anymore anyways.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.