### PR TITLE
docs(Alerts): Amend 'Api-Key' header to 'X-Api-Key'

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/scope-alert-thresholds-specific-instances.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/scope-alert-thresholds-specific-instances.mdx
@@ -149,7 +149,7 @@ Here is an example of the API request format and JSON response.
 
     ```
     curl -X PUT 'https://api.newrelic.com/v2/alerts_entity_conditions/<var>12345</var>.json' \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
          -H 'Content-Type: application/json' \
          -G -d 'entity_type=<var>application</var>&condition_id=<var>234567</var>'
     ```

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/disable-enable-alerts-conditions-using-api.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/disable-enable-alerts-conditions-using-api.mdx
@@ -84,7 +84,7 @@ The following example shows how to disable a condition for an `apm_app_metric` c
 
    ```
    curl -X GET 'https://api.newrelic.com/v2/alerts_policies.json' \
-        -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+        -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
         -G --data-urlencode 'filter[name]= <var>Logjam Alert</var>'    <---<<<  {policy_name}
    ```
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/manage-entities-alerts-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/manage-entities-alerts-conditions.mdx
@@ -49,7 +49,7 @@ Only the first step in this example is unique to choosing the Ruby app as the en
 
    ```
    curl -X GET 'https://api.newrelic.com/v2/applications.json' \
-        -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
+        -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
    ```
 
    OR
@@ -58,7 +58,7 @@ Only the first step in this example is unique to choosing the Ruby app as the en
 
    ```
    curl -X GET 'https://api.newrelic.com/v2/applications.json' \
-        -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+        -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
         -d 'filter[name]=<var>TimberTime</var>'
    ```
 2. Review the output to find the `{application_id}`, and use it as the `{entity_id}`:
@@ -78,7 +78,7 @@ Only the first step in this example is unique to choosing the Ruby app as the en
 
    ```
    curl -X GET 'https://api.newrelic.com/v2/alerts_policies.json' \
-        -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+        -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
         -G -d 'filter[name]= <var>Logjam Alert</var>'    <---<<<  {policy_name}
    ```
 4. Review the policy output; for example:
@@ -98,7 +98,7 @@ Only the first step in this example is unique to choosing the Ruby app as the en
 
    ```
    curl -X GET 'https://api.newrelic.com/v2/alerts_conditions.json' \
-        -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+        -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
         -G -d 'policy_id=<var>85</var>'
    ```
 
@@ -135,7 +135,7 @@ Only the first step in this example is unique to choosing the Ruby app as the en
 
    ```
    curl -X PUT 'https://api.newrelic.com/v2/alerts_entity_conditions/<var>12345</var>.json' \
-        -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+        -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
         -H 'Content-Type: application/json' \
         -G -d 'entity_type=Application&condition_id=<var>234567</var>'
    ```
@@ -144,6 +144,6 @@ Only the first step in this example is unique to choosing the Ruby app as the en
 
    ```
    curl -X DELETE 'https://api.newrelic.com/v2/alerts_entity_conditions/<var>8288171</var>.json' \
-        -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+        -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
         -G -d 'entity_type=Application&condition_id=<var>234567</var>'
    ```

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
@@ -180,7 +180,7 @@ These API functions include links to the API Explorer, where you can create, del
 
     ```
     curl -X POST 'https://api.newrelic.com/v2/alerts_policies.json' \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
          -H 'Content-Type: application/json' \
          -d \
     '{
@@ -257,7 +257,7 @@ These API functions include links to the API Explorer, where you can create, del
 
     ```
     curl -X PUT 'https://api.newrelic.com/v2/alerts_policies/{id}.json' \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
          -H 'Content-Type: application/json' \
          -d \
     '{
@@ -279,7 +279,7 @@ These API functions include links to the API Explorer, where you can create, del
 
     ```
     curl -X DELETE 'https://api.newrelic.com/v2/alerts_policies/<var>$POLICY_ID</var>.json' \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
+         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
     ```
   </Collapser>
 
@@ -296,7 +296,7 @@ These API functions include links to the API Explorer, where you can create, del
 
       ```
       curl -X GET 'https://api.newrelic.com/v2/alerts_policies.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
       ```
   </Collapser>
 </CollapserGroup>
@@ -326,7 +326,7 @@ These API functions include links to the API Explorer, where you can create, del
 
       ```
       curl -X POST 'https://api.newrelic.com/v2/alerts_channels.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -520,7 +520,7 @@ These API functions include links to the API Explorer, where you can create, del
 
     ```
     curl -X DELETE 'https://api.newrelic.com/v2/alerts_channels/<var>{channel_id}</var>.json' \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
+         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
     ```
   </Collapser>
 
@@ -534,7 +534,7 @@ These API functions include links to the API Explorer, where you can create, del
 
     ```
     curl -X GET 'https://api.newrelic.com/v2/alerts_channels.json' \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
+         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
     ```
   </Collapser>
 
@@ -551,7 +551,7 @@ These API functions include links to the API Explorer, where you can create, del
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_policy_channels.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -H 'Content-Type: application/json' \
            -G -d 'policy_id=<var>$POLICY_ID</var>&channel_ids=<var>channel_id</var>'
       ```
@@ -572,7 +572,7 @@ These API functions include links to the API Explorer, where you can create, del
 
       ```
       curl -X DELETE 'https://api.newrelic.com/v2/alerts_policy_channels.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -d 'channel_id=<var>CHANNEL_ID</var>&policy_id=<var>POLICY_ID</var>'
       ```
   </Collapser>
@@ -611,7 +611,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X POST 'https://api.newrelic.com/v2/alerts_conditions/policies/<var>$POLICY_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -661,7 +661,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_conditions/<var>$CONDITION_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -709,7 +709,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X DELETE 'https://api.newrelic.com/v2/alerts_conditions/<var>$CONDITION_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
       ```
   </Collapser>
 
@@ -723,7 +723,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
     ```
     curl -X GET 'https://api.newrelic.com/v2/alerts_conditions.json' \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
          -d 'policy_id=<var>$POLICY_ID</var>'
     ```
   </Collapser>
@@ -752,7 +752,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
     ```
     curl -X POST 'https://api.newrelic.com/v2/alerts_nrql_conditions/policies/<var>$POLICY_ID</var>.json' \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
          -H 'Content-Type: application/json' \
          -d \
     '{
@@ -809,7 +809,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_nrql_conditions/<var>$CONDITION_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -848,7 +848,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X DELETE 'https://api.newrelic.com/v2/alerts_nrql_conditions/<var>$CONDITION_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
       ```
   </Collapser>
 
@@ -862,7 +862,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
     ```
     curl -X GET 'https://api.newrelic.com/v2/alerts_nrql_conditions.json' \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
          -d 'policy_id=<var>$POLICY_ID</var>'
     ```
   </Collapser>
@@ -891,7 +891,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X POST 'https://api.newrelic.com/v2/alerts_external_service_conditions/policies/<var>$POLICY_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -935,7 +935,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_external_service_conditions/<var>$CONDITION_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -976,7 +976,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X DELETE 'https://api.newrelic.com/v2/alerts_external_service_conditions/<var>$CONDITION_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
       ```
   </Collapser>
 
@@ -990,7 +990,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
     ```
     curl -X GET 'https://api.newrelic.com/v2/alerts_external_service_conditions.json' \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
          -d 'policy_id=<var>$POLICY_ID</var>'
     ```
   </Collapser>
@@ -1015,7 +1015,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X POST 'https://api.newrelic.com/v2/alerts_synthetics_conditions/policies/<var>$POLICY_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -1045,7 +1045,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_synthetics_conditions/<var>$CONDITION_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -1072,7 +1072,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X DELETE 'https://api.newrelic.com/v2/alerts_synthetics_conditions/<var>$CONDITION_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
       ```
   </Collapser>
 
@@ -1086,7 +1086,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
     ```
     curl -X GET 'https://api.newrelic.com/v2/alerts_synthetics_conditions.json' \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
          -d 'policy_id=<var>$POLICY_ID</var>'
     ```
   </Collapser>
@@ -1111,7 +1111,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X POST 'https://api.newrelic.com/v2/alerts_location_failure_conditions/policies/<var>$POLICY_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -1151,7 +1151,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_location_failure_conditions/<var>$CONDITION_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -1188,7 +1188,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X DELETE 'https://api.newrelic.com/v2/alerts_location_failure_conditions/<var>$CONDITION_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
       ```
   </Collapser>
 
@@ -1202,7 +1202,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
     ```
     curl -X GET 'https://api.newrelic.com/v2/alerts_location_failure_conditions.json' \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
          -d 'policy_id=<var>$POLICY_ID</var>'
     ```
   </Collapser>
@@ -1231,7 +1231,7 @@ These API functions include links to the API Explorer, where you can view inform
 
       ```
       curl -X GET 'https://api.newrelic.com/v2/alerts_events.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
       ```
   </Collapser>
 
@@ -1249,7 +1249,7 @@ These API functions include links to the API Explorer, where you can view inform
 
       ```
       curl -X GET 'https://api.newrelic.com/v2/alerts_violations.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
       ```
 
       <Callout variant="tip">
@@ -1272,7 +1272,7 @@ These API functions include links to the API Explorer, where you can view inform
 
       ```
       curl -X GET 'https://api.newrelic.com/v2/alerts_incidents.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
       ```
   </Collapser>
 
@@ -1289,7 +1289,7 @@ These API functions include links to the API Explorer, where you can view inform
 
       ```
       curl -X GET 'https://api.newrelic.com/v2/alerts_incidents/<var>{id}</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i
       ```
   </Collapser>
 
@@ -1306,7 +1306,7 @@ These API functions include links to the API Explorer, where you can view inform
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_incidents/<var>{id}</var>/acknowledge.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -H 'Content-Type: application/json'
       ```
   </Collapser>
@@ -1324,7 +1324,7 @@ These API functions include links to the API Explorer, where you can view inform
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_incidents/<var>{id}</var>/close.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -H 'Content-Type: application/json'
       ```
   </Collapser>
@@ -1358,7 +1358,7 @@ These API functions include links to the API Explorer, where you can list, add a
 
       ```
       curl -X GET 'https://api.newrelic.com/v2/alerts_entity_conditions/<var>$ENTITY_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -G -d 'entity_type=<var>$ENTITY_TYPE</var>'
       ```
   </Collapser>
@@ -1383,7 +1383,7 @@ These API functions include links to the API Explorer, where you can list, add a
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_entity_conditions/<var>$ENTITY_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -H 'Content-Type: application/json' \
            -G -d 'entity_type=<var>$ENTITY_TYPE</var>&condition_id=<var>$CONDITION_ID</var>'
       ```
@@ -1409,7 +1409,7 @@ These API functions include links to the API Explorer, where you can list, add a
 
       ```
       curl -X DELETE 'https://api.newrelic.com/v2/alerts_entity_conditions/<var>$ENTITY_ID</var>.json' \
-           -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
+           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>' -i \
            -G -d 'entity_type=<var>$ENTITY_ID</var>&condition_id=<var>$CONDITION_ID</var>'
       ```
   </Collapser>


### PR DESCRIPTION
## Give us some context

- In response to #6923 
- Amends Alerts REST API docs to refer to `X-Api-Key` (instead of `Api-Key`)
- Cross-referenced against the [API explorer](https://rpm.newrelic.com/api/explore)
