### PR TITLE
style(data types): Simplify language, add MELT mentions

### DIFF
--- a/src/content/docs/data-apis/understand-data/new-relic-data-types.mdx
+++ b/src/content/docs/data-apis/understand-data/new-relic-data-types.mdx
@@ -1,5 +1,5 @@
 ---
-title: New Relic data types: Metrics, Events, Logs, and Traces (MELT)
+title: "New Relic data types: Metrics, Events, Logs, and Traces (MELT)"
 tags:
   - Ingest and manage data
   - Understand data

--- a/src/content/docs/data-apis/understand-data/new-relic-data-types.mdx
+++ b/src/content/docs/data-apis/understand-data/new-relic-data-types.mdx
@@ -1,11 +1,11 @@
 ---
-title: New Relic data types
+title: New Relic MELT data types
 tags:
   - Ingest and manage data
   - Understand data
 translate:
   - jp
-metaDescription: 'An overview of the types of data New Relic reports: metrics, events, logs, and traces (spans).'
+metaDescription: 'An overview of the MELT data New Relic reports: metrics, events, logs, and traces (spans).'
 redirects:
   - /docs/telemetry-data-platform/understand-data/new-relic-data-types
   - /docs/data-analysis/metrics/analyze-your-metrics/data-types-new-relic-ui-how-analyze-them
@@ -26,21 +26,15 @@ redirects:
   - /docs/insights/event-data-sources/insights-api  
 ---
 
-The New Relic platform is built around the four fundamental telemetry data types we believe are necessary for complete and effective system monitoring: [metrics](#metrics), [events](#event-data), [logs](#log-data), and [traces](#trace-data). After you [sign up for a free New Relic account](https://newrelic.com/signup) and [install](/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic/) any of our monitoring services, you can start working with your data.
+The New Relic platform is built around the four fundamental telemetry data types we believe are necessary for complete and effective system monitoring: [Metrics](#metrics), [Events](#event-data), [Logs](#log-data), and [Traces](#trace-data) (often referred to as "MELT data" in the observability industry). After you [sign up for a free New Relic account](https://newrelic.com/signup) and [install](/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic/) any of our monitoring services, you can start working with your data.
 
 ## Get started with MELT data
 
-This doc will give you a fairly technical explanation of our core data types, their structure, and how they're used in our features. You can use most of our features without needing to understand the underlying data structure. But having a better understanding of this can help you [get data into New Relic](https://developer.newrelic.com/use-cases/collect-data-from-any-source), understand the data you see in our UI, and [query your data](/docs/query-new-relic-data).
-
-For a simpler explanation of these data types using real-world examples, see [Introduction to essential telemetry data types](https://newrelic.com/platform/telemetry-data-101/). Another good way to understand your data is to just [start querying it](/docs/query-your-data/explore-query-data/explore-data/introduction-querying-new-relic-data).
-
-<Callout variant="tip">
-  Access your data easily on [one.newrelic.com](https://one.newrelic.com): Click the **Browse data** dropdown menu and select the data type (metrics, events, logs, and traces) you want to explore.
-</Callout>
+This doc will give you a fairly technical explanation of our core MELT data types, their structure, and how they're used in our features. You can use most of our features without needing to understand the underlying data structure. But having a better understanding of this can help you [get data into New Relic](https://developer.newrelic.com/use-cases/collect-data-from-any-source), understand the data you see in our UI, and [query your data](/docs/query-new-relic-data).
 
 ## Metrics
 
-First, we’ll explain the definition of metrics from a monitoring industry perspective, and then we’ll explain how New Relic handles metrics. For a list of the metrics we collect, see [our documentation on metrics](/docs/telemetry-data-platform/ingest-manage-data/understand-data/metric-data-type).
+First, we’ll explain the definition of metrics from a monitoring industry perspective, and then we’ll explain how New Relic handles metrics. 
 
 ### Metrics in the monitoring industry [#metrics-conceptual]
 
@@ -58,6 +52,8 @@ Metrics are a strong solution for storing data long-term, and understanding tren
 ### Metrics at New Relic [#metrics-new-relic]
 
 Conceptually, "metrics" is a broad, general category. There are various ways New Relic measures and reports metrics but, in practice, when using the New Relic UI, you usually won't have to understand how exactly this happens. In our documentation, we typically will just refer to "metrics," regardless of how that data is reported, unless there's a reason you need to know more (like understanding [how to query your data](/docs/using-new-relic/data/understand-data/query-new-relic-data)).
+
+For a list of the metrics we collect, see [our documentation on metrics](/docs/telemetry-data-platform/ingest-manage-data/understand-data/metric-data-type).
 
 Here are some of the ways metrics are reported and stored across the New Relic platform:
 
@@ -782,7 +778,3 @@ Understanding New Relic data types can help you:
 
 * [Query data in New Relic](/docs/query-new-relic-data)
 * [Send data to New Relic](https://developer.newrelic.com/use-cases/collect-data-from-any-source)
-
-## Learn more
-
-For a simpler explanation of these data types using real-world examples, see [Introduction to essential telemetry data types](https://newrelic.com/platform/telemetry-data-101/).

--- a/src/content/docs/data-apis/understand-data/new-relic-data-types.mdx
+++ b/src/content/docs/data-apis/understand-data/new-relic-data-types.mdx
@@ -1,5 +1,5 @@
 ---
-title: New Relic MELT data types
+title: New Relic data types: Metrics, Events, Logs, and Traces (MELT)
 tags:
   - Ingest and manage data
   - Understand data
@@ -26,9 +26,9 @@ redirects:
   - /docs/insights/event-data-sources/insights-api  
 ---
 
-The New Relic platform is built around the four fundamental telemetry data types we believe are necessary for complete and effective system monitoring: [Metrics](#metrics), [Events](#event-data), [Logs](#log-data), and [Traces](#trace-data) (often referred to as "MELT data" in the observability industry). After you [sign up for a free New Relic account](https://newrelic.com/signup) and [install](/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic/) any of our monitoring services, you can start working with your data.
+The New Relic platform is built around the four fundamental telemetry data types we believe are necessary for complete and effective system monitoring: [Metrics](#metrics), [Events](#event-data), [Logs](#log-data), and [Traces](#trace-data) (often referred to as "MELT" in the observability industry). After you [sign up for a free New Relic account](https://newrelic.com/signup) and [install](/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic/) any of our monitoring services, you can start working with your data.
 
-## Get started with MELT data
+## Get started understanding our data
 
 This doc will give you a fairly technical explanation of our core MELT data types, their structure, and how they're used in our features. You can use most of our features without needing to understand the underlying data structure. But having a better understanding of this can help you [get data into New Relic](https://developer.newrelic.com/use-cases/collect-data-from-any-source), understand the data you see in our UI, and [query your data](/docs/query-new-relic-data).
 
@@ -53,26 +53,27 @@ Metrics are a strong solution for storing data long-term, and understanding tren
 
 Conceptually, "metrics" is a broad, general category. There are various ways New Relic measures and reports metrics but, in practice, when using the New Relic UI, you usually won't have to understand how exactly this happens. In our documentation, we typically will just refer to "metrics," regardless of how that data is reported, unless there's a reason you need to know more (like understanding [how to query your data](/docs/using-new-relic/data/understand-data/query-new-relic-data)).
 
-For a list of the metrics we collect, see [our documentation on metrics](/docs/telemetry-data-platform/ingest-manage-data/understand-data/metric-data-type).
-
 Here are some of the ways metrics are reported and stored across the New Relic platform:
 
 <CollapserGroup>
   <Collapser
     className="freq-link"
     id="dimensional-metrics"
-    title="Dimensional metrics (used by Metric API and many integrations)"
+    title="Dimensional metrics (our primary metric type)"
   >
     In the monitoring industry, "dimensional" metrics refer to metric data that has a variety of [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute) (dimensions) attached, such as duration-related attributes (start time, end time), entity ID, region, host, etc. This amount of detail allows for in-depth analysis and querying.
 
-    At New Relic, this metric data is attached to the [`Metric`](/docs/data-ingest-apis/get-data-new-relic/metric-api/view-query-you-metric-data) data type and is sent from several sources:
+    At New Relic, this metric data is attached to the [`Metric`](/docs/data-ingest-apis/get-data-new-relic/metric-api/view-query-you-metric-data) data type. It is our primary metric data type and is used by many of our tools, including:
 
-    * Some [open-source integrations](/docs/telemetry-sdks-send-custom-telemetry-data-new-relic#external-data), such as the Prometheus exporter.
-    * Our [Telemetry SDKs](/docs/telemetry-sdks-send-custom-telemetry-data-new-relic)
-    * [Infrastructure](/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/query-infrastructure-dimensional-metrics-nrql) services
-    * The [Metric API](/docs/introduction-new-relic-metric-api) (the underlying API used by the above tools)
+    * Our integrations with third-party telemetry services, like our [OpenTelemetry integration](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction), our [Prometheus integration](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic), and our [DropWizard integration](/docs/more-integrations/open-source-telemetry-integrations/dropwizard/dropwizard-reporter).
+    * The [Metric API](/docs/introduction-new-relic-metric-api) (the underlying API used by the above tools) and our [Telemetry SDKs](/docs/telemetry-sdks-send-custom-telemetry-data-new-relic).
     * The [events-to-metrics service](/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-events-metrics-service)
 
+Some of our other metric data types can be queried as dimensional metrics. For example: 
+    
+    * [APM metric timeslice data](/docs/data-apis/understand-data/metric-data/query-apm-metric-timeslice-data-nrql) 
+    * [Some infrastructure data](/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/query-infrastructure-dimensional-metrics-nrql)
+    
       To query this data and see its [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute) ("dimensions"), you could use a NRQL query like:
 
       ```
@@ -81,7 +82,7 @@ Here are some of the ways metrics are reported and stored across the New Relic p
 
       As time passes, these metrics are increasingly aggregated into larger time buckets. This is done to optimize your ability to query data over a long period of time.
 
-      For more details about the metric data type, see [our docs](/docs/telemetry-data-platform/ingest-manage-data/understand-data/metric-data-type). To learn how this data is ingested and stored, see the [Metric API documentation](/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-metric-api). For tips on querying, see [Metric query examples](/docs/data-ingest-apis/get-data-new-relic/metric-api/view-query-you-metric-data).
+      For more details about this data, read about the [`Metric` data type](/docs/telemetry-data-platform/ingest-manage-data/understand-data/metric-data-type). To learn how this data is ingested and stored, see the [Metric API documentation](/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-metric-api). For tips on querying, see [Metric query examples](/docs/data-ingest-apis/get-data-new-relic/metric-api/view-query-you-metric-data).
   </Collapser>
 
   <Collapser

--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -7,7 +7,7 @@ pages:
         path: /docs/data-apis/get-started/nrdb-horsepower-under-hood
   - title: Understand data
     pages:
-      - title: New Relic data types
+      - title: New Relic MELT data types
         path: /docs/data-apis/understand-data/new-relic-data-types
       - title: Query your data
         path: /docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data


### PR DESCRIPTION
Mostly minor language tweaks, plus inserting several references to MELT to make it clearer that this doc covers the four key observability data types.