### PR TITLE
fix: Update client span duration text labels

### DIFF
--- a/src/content/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui.mdx
+++ b/src/content/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui.mdx
@@ -643,9 +643,9 @@ Here are some additional distributed tracing UI details, rules, and limits:
         src={newRelicDistributedTracingClientSpanTime}
       />
 
-    1. When a client span is longer than the server span, this could be due to latency in a number of areas, such as: network time, queue time, DNS resolution time, or from a load balancer that we cannot see.
-    2. When a client span starts and ends before a server span begins, this could be due to clock skew, or due to the server doing asynchronous work that continues after sending the response.
-    3. When a client span starts after a server span, this is most likely clock skew.
+    A. When a client span is longer than the server span, this could be due to latency in a number of areas, such as: network time, queue time, DNS resolution time, or from a load balancer that we cannot see.
+    B. When a client span starts and ends before a server span begins, this could be due to clock skew, or due to the server doing asynchronous work that continues after sending the response.
+    C. When a client span starts after a server span, this is most likely clock skew.
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
In the image the three scenarios are labeled A/B/C but in the text they are 1/2/3. This is confusing.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

Adds greater clarity by correlating letter-based labels in the image to their descriptions immediately below.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.