### PR TITLE
fix: fix markdown images to use new syntax

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/sc-implementation-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/sc-implementation-guide.mdx
@@ -10,6 +10,36 @@ redirects:
   - /docs/agents/manage-apm-agents/agent-data/custom-instrumentation/
 ---
 
+import omaOeSeServiceDiagram from 'images/oma-oe-sc-service-diagram.png'
+
+import OmaOeScTransactionBreakdown from 'images/oma-oe-sc-transaction-breakdown.png'
+
+import omaOeScTransactionBreakdownWeighted from 'images/oma-oe-sc-transaction-breakdown-weighted.png'
+
+import OmaOeScTransactionBreakdownHistorgramNonNormal from 'images/oma-oe-sc-transaction-breakdown-histogram-non-normal.png'
+
+import OmaOeScTransactionBreakdownHistogramNormal from 'images/oma-oe-sc-transaction-breakdown-histogram-normal.png'
+
+import OmaOeScTransactionAttributes from 'images/oma-oe-sc-transaction-attributes.png'
+
+import OmaOeScErrorAttributes from 'images/oma-oe-sc-error-attributes.png'
+
+import omaOeScTransactionNrqlCustomAttribute from 'images/oma-oe-sc-transaction-nrql-custom-attributes.png'
+
+import omaOeScTransactionNrqlFeatureFlag from 'images/oma-oe-sc-transaction-nrql-feature-flag.png'
+
+import omaOeScSummaryComponents from 'images/oma-oe-sc-summary-components.png'
+
+import omaOeScTransactionComponents from 'images/oma-oe-sc-transaction-components.png'
+
+import omaOeScSummaryClient from 'images/oma-oe-sc-summary-client.png'
+
+import omaOeScExternalServices from 'images/oma-oe-sc-external-services.png'
+
+import omaOeScDatabases from 'images/oma-oe-sc-databases.png'
+
+import omaOeScSyntheticsMenu from 'images/oma-oe-sc-synthetics-menu.png'
+
 ## Overview [#overview]
 
 **"Do I have all the telemetry I need to adequately measure my service?"**
@@ -160,7 +190,8 @@ As a first step you should evaluate the default instrumentation you obtain from 
 
 Think about what your service does. Perhaps it receives an order, needs to validate the order for integrity, conveys that order to a clearinghouse service, and receives a confirmation code that is relayed back to the requestor. This example gives a clear path to break down the function of service and evaluate if we have enough telemetry and context to make informed appraisals of how the service is functioning.
 
-![Service Diagram](images/oma-oe-sc-service-diagram.png)
+<img src={omaOeSeServiceDiagram} alt="Service Diagram" title="Service Diagram" />
+
 <figcaption>Conceptual service that receives and processes http requests.</figcaption>
 
 If this conceptual diagram represents the implementation of the service, you need to know at any moment in time:
@@ -329,19 +360,22 @@ However, even after the agent transaction naming protocol has been applied, it m
 
 The goal for transaction naming should be an APM transactions view that provides good segmentation of the services functions in an approach that is easy to understand for a non-developer.
 
-![Transaction Breakdown](images/oma-oe-sc-transaction-breakdown.png)
+<img src={OmaOeScTransactionBreakdown} alt="Transaction Breakdown" title="Transaction Breakdown" />
+
 <figcaption>New Relic service transaction breakdown view.</figcaption>
 
 The transaction breakdown image is a good example of transaction segmentation. It provides detailed tracking of the amount of work being done by each transaction within the broader codebase of the service. It also displays the transaction with a plain user-friendly name that offers some hint of its business context (what the transaction does). As you learn more about naming transactions and including attributes, be sure to make your naming approach accessible for non-technical observers of the data.
 
-![Transaction Breakdown Weighted](images/oma-oe-sc-transaction-breakdown-weighted.png)
+<img src={omaOeScTransactionBreakdownWeighted} alt="Transaction Breakdown Weighted" title="Transaction Breakdown Weighted" />
+
 <figcaption>Transaction breakdown: the transactions in this service seem to be highly weighted to one transaction name with a pretty generic name. Breakdowns like this beg the question: "Is this a good representation of the work my service does?"</figcaption>
 
 The obtuse transaction breakdown image demonstrates a bad example of transaction name segmentation. In this case we have about 60% of the transaction volume being named `OperationHandler/handle`. Both the percentage attribution of the transaction volume and the generic nature of the name indicate there might be an overly zealous aggregation of transactions underneath that transaction namespace.
 
 A good way to validate your transaction naming approach is to review the distribution of response times for your transaction over a significant period of time in the service web transaction histogram dashboard.
 
-![Transaction Histogram Non-normal](images/oma-oe-sc-transaction-breakdown-histogram-non-normal.png)
+<img src={OmaOeScTransactionBreakdownHistorgramNonNormal} alt="Transaction Histogram Non-normal" title="Transaction Histogram Non-normal"/>
+
 <figcaption>The service transaction histogram view shows the count of transactions that fall into each response time bucket. A good naming strategy tends to display a normal distribution.</figcaption>
 
 The service transaction image shows a wide range of transaction response rates. Although the bulk of the transactions land in the 0-200 millisecond range, it indicates values ranging from 200-1000 milliseconds. When you have a highly distributed range of responses for a transaction, you should ask yourself:
@@ -352,7 +386,8 @@ In many cases, non-normal distributions are a direct result of the parameters be
 
 Your objective is to create a transaction name that facilitates grouping transactions with the fewest unique characteristics.
 
-![Transaction Histogram](images/oma-oe-sc-transaction-breakdown-histogram-normal.png)
+<img src={OmaOeScTransactionBreakdownHistogramNormal} alt="Transaction Histogram" title="Transaction Histogram"/>
+
 <figcaption>A more normal distribution of transaction segmentation where individual transactions report more consistent response time attainment with fewer exceptions.</figcaption>
 
 The normal distribution image demonstrates more purposefully named transactions within a service. In this case the web transaction response times are more closely grouped, indicating consistent execution characteristics.
@@ -393,24 +428,28 @@ However, there are many occasions when you will want to get some additional cont
 
 You can add `name:value` pair attributes to decorate the details of each transaction. The attributes will be available in each transaction event through the APM transaction trace and errors UI, or through direct query of parameters from the NRDB transaction event type.
 
-![Transaction Attributes](images/oma-oe-sc-transaction-attributes.png)
+<img src={OmaOeScTransactionAttributes} alt="Transaction Attributes" title="Transaction Attributes"/>
+
 <figcaption>After you select a transaction trace, you can view the custom attributes you have set for your Service’s transaction.</figcaption>
 
 Here is an example of the transaction trace details you can see in the APM errors UI.
 
-![Error Attributes](images/oma-oe-sc-error-attributes.png)
+<img src={OmaOeScErrorAttributes} alt="Error Attributes" title="Error Attributes" />
+
 <figcaption>Custom attributes displayed in the APM errors UI.</figcaption>
 
 If you have developed a useful transaction name segmentation, you can use the additional context of the attributes to better understand the inputs, cohorts, or segments that led to an unexpected result.
 
 In addition to being able to understand the context of your transaction within the APM UI, the introduction of parameters is an extremely useful tool to aggregate and analyze transactions by querying transaction data directly. Custom attributes are added to each transaction, making it easy to isolate and facet on specific conditions.
 
-![NRQL Custom Attributes](images/oma-oe-sc-transaction-nrql-custom-attributes.png)
+<img src={omaOeScTransactionNrqlCustomAttribute} alt="NRQL Custom Attributes" title="NRQL Custom Attributes" />
+
 <figcaption>NRQL query expression that uses a custom attribute to facet database call duration.</figcaption>
 
 The parameter capture approach can also be used with feature flag systems like Split or LaunchDarkly. In this case, as you are implementing the decision handler for the feature flag, consider capturing the flag context (for example, `optimized_version = on`) that is being applied to the block of code controlling the version or feature the customer sees.
 
-![NRQL Custom Attributes Feature Flags](images/oma-oe-sc-transaction-nrql-feature-flag.png)
+<img src={omaOeScTransactionNrqlFeatureFlag} alt="NRQL Custom Attributes Feature Flags" title="NRQL Custom Attributes Feature Flags" />
+
 <figcaption>NRQL query that demonstrates the result when the state of a feature flag is captured by a transaction custom attribute. The feature flag state attribute allows us to understand the impact of the code execution path on performance, throughput, and dependency utilization.</figcaption>
 
 For example, to take the value of an http request parameter and save it as a custom attribute in the New Relic Java agent, you can use code similar to this:
@@ -427,12 +466,14 @@ The behavior of a specific transaction within the context of a service is a powe
 
 Within New Relic One there are two places we can observe component execution details. The service summary dashboard in APM provides a view of the composite execution of the service broken down by its component parts (for example, garbage collection execution or database calls).
 
-![Summary Components](images/oma-oe-sc-summary-components.png)
+<img src={omaOeScSummaryComponents} alt="Summary Components" title="Summary Components" />
+
 <figcaption>This summary dashboard provides a breakdown of major component types within the application. Memcached, External Web Invocations, MySQL and Dirac are all examples of shared code frameworks that the collective transactions of the Service are using to execute their business logic.</figcaption>
 
 A similar breakdown is provided on a transaction by transaction basis.
 
-![Transaction Components](images/oma-oe-sc-transaction-components.png)
+<img src={omaOeScTransactionComponents} alt="Transaction Components" title="Transaction Components" />
+
 <figcaption>This single transaction summary view breaks out the contributing execution time by component. This helps you see the aggregate performance of components within a transaction.</figcaption>
 
 Transaction component segments will tend to demonstrate consistent performance behavior, you can use this consistency to detect a change in its fundamental behavior. This can be a good indication of an underlying issue. Resource constraints tend to manifest more obviously within component frameworks than within individual transaction details. This allows you to infer characteristics of dependencies through the common constraints being experienced by all code running within a service.
@@ -445,7 +486,8 @@ Transaction component segments will tend to demonstrate consistent performance b
 
 The syntax for framework instrumentation is specific to the language your service is written in, but the general approach is consistent for all. Consider the threads of execution within your Services as an analogy for transactions within New Relic telemetry. Each method or function execution on the stack is an opportunity to add additional instrumentation. In this way New Relic maintains a time-annotated invocation stack for the transaction and uses those method/function start/stop timings to aggregate it into a series of component metrics.
 
-![Service Summary Components](images/oma-oe-sc-summary-client.png)
+<img src={omaOeScSummaryClient} alt="Service Summary Components" title="Service Summary Components" />
+
 <figcaption>A simple Node.js application making a call to a MongoDB. The two major components of the application are the receipt of the request and get/put operations to the MongoDB.</figcaption>
 
 If a particular segment of logic is crucial to the function of your Service or transaction, consider wrapping that call with callbacks to the New Relic agent so that the agent can understand that it has entered a discrete code component and can aggregate the time consumed within that component accordingly. By passing a metric name to the callback, you will create a component segment metric for your service and transaction.
@@ -481,12 +523,14 @@ public abstract class MQOutboundMessageContext implements OutboundTransportMessa
 
 Client instrumentation refers to encapsulating a call from your service to an external resource. Generally, New Relic agents are aware of clients popular for HTTP, gRPC, messaging, and database protocols and will apply the appropriate instrumentation pattern to aggregate calls to those clients as external services.
 
-![External Services](images/oma-oe-sc-external-services.png)
+<img src={omaOeScExternalServices} alt="External Services" title="External Services" />
+
 <figcaption>External service dashboard details within New Relic APM.</figcaption>
 
 If you have written your own client handler for a protocol, or are using something very new or somewhat niche, the New Relic agent may not recognize the client and record the behavior of the client call. To this end you should verify the external services and databases within APM to represent all expected externalities for your service.
 
-![Databases](images/oma-oe-sc-databases.png)
+<img src={omaOeScDatabases} alt="Databases" title="Databases" />
+
 <figcaption>Database protocol dashboard details within New Relic APM.</figcaption>
 
 It is important to validate that all your services' dependencies are represented here. If you do not see your service dependencies, you will need to introduce new instrumentation to intercept the external call so that your APM agent can track it accordingly. The following example demonstrates wrapping an external call in Golang for capture by the agent.
@@ -531,7 +575,8 @@ Endpoint testing provides two benefits to your Service Instrumentation program.
 
 New Relic’s synthetic monitoring offers the ability to create a variety of testing types by employing an enhanced Selenium JavaScript SDK. Once a Selenium-based test script has been defined, New Relic will manage the location of the script execution as well as its frequency.
 
-![Synthetics](images/oma-oe-sc-synthetics-menu.png)
+<img src={omaOeScSyntheticsMenu} alt="Synthetics" title="Synthetics" />
+
 <figcaption>New Relic synthetics launch dashboard.</figcaption>
 
 The synthetic test offers a variety of test options, each with its own focus. For more information see our [synthetic monitoring documentation](https://docs.newrelic.com/docs/synthetics/).


### PR DESCRIPTION
## Description

Fixes 15 broken images where the image path deviated from common convention (and other variations we saw).

## Related issues / PRs
Related to #6908  