### PR TITLE
Update FedRAMP blurb to fix taxonomy/typo

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup.mdx
@@ -200,7 +200,7 @@ Whether you export directly from your app or from a collector, you'll need to:
 
     <tr>
       <td>
-        US FedRamp OTLP<br/>(See see [FedRAMP compliance](/docs/security/security-privacy/compliance/fedramp-compliant-endpoints/#otlp-api) for more information)
+        US FedRAMP OTLP<br/>(See [FedRAMP compliance](/docs/security/security-privacy/compliance/fedramp-compliant-endpoints/#otlp-api) for more information)
       </td>
 
       <td>


### PR DESCRIPTION
Removing an extra "see" from the FedRAMP blurb + changing the capitalization to match the proper taxonomy/namesake of the regulation.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.