### PR TITLE
Add Python agent 7.10.0.175 release notes. (CodeStream integration)

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-71000175.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-71000175.mdx
@@ -1,0 +1,18 @@
+---
+subject: Python agent
+releaseDate: '2022-04-06'
+version: 7.10.0.175
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+---
+
+## Notes
+
+This release of the Python agent adds CodeStream integration support which includes code level metrics.
+
+Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the New Relic [download site](http://download.newrelic.com/python_agent/release).
+
+## New features
+
+* **Add integration with CodeStream**
+  Now Introducing Code-Level Metrics! Golden Signals visible in your IDE through New Relic CodeStream.
+  Learn more [here](docs/apm/agents/python-agent/supported-features/python-codestream-integration). For any issues or direct feedback, please reach out to support@codestream.com


### PR DESCRIPTION
This PR adds Python agent release notes for v7.10.0.175. It includes a link which has dependency on https://github.com/newrelic/docs-website/pull/6957. 