### PR TITLE
fix indentation causing invalid yaml

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/windows-services-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/windows-services-integration.mdx
@@ -109,17 +109,17 @@ Here's an example of the Windows services integration configuration:
           #
           scrape_interval: 30s
 
-      # Timeout used by the agent to restart the integration if no heartbeats are
-      # sent from the integration. Heartbeats are sent every 5s, so this timeout
-      # shouldn't be less than that.
-      #
-      timeout: 60s
+        # Timeout used by the agent to restart the integration if no heartbeats are
+        # sent from the integration. Heartbeats are sent every 5s, so this timeout
+        # shouldn't be less than that.
+        #
+        timeout: 60s
 
-      # Since this is a long-running integration, interval is ignored. To
-      # configure the interval period for collecting and sending data, edit
-      # the scrape_interval parameter.
-      #
-      # interval:
+        # Since this is a long-running integration, interval is ignored. To
+        # configure the interval period for collecting and sending data, edit
+        # the scrape_interval parameter.
+        #
+        # interval:
     ```
 
     For more information, see our documentation about the [general structure of on-host integration configurations](/docs/integrations/integrations-sdk/file-specifications/host-integration-configuration-overview).


### PR DESCRIPTION
The example on the page 
https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/windows-services-integration/#example has invalid yaml and copying-pasting it to `winservices-config.yml` does not work

