### PR TITLE
fix(Alerts): Amends Alerts-related navigation click paths

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/alert-custom-violation-descriptions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/alert-custom-violation-descriptions.mdx
@@ -58,7 +58,7 @@ The hostname is : ip-123-45-67-89.us-west-1.compute.internal
 />
 
 <figcaption>
-  In the **[one.newrelic.com](https://one.newrelic.com)** top nav, click **Alerts & AI**, click **Alert policies**, **(select a policy)**, then **(select a condition)**: Click **+ Add custom violation description** to open the field.
+  In the **[one.newrelic.com](https://one.newrelic.com)** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, **(select a policy)**, then **(select a condition)**: Click **+ Add custom violation description** to open the field.
 </figcaption>
 
 You can create a custom violation description using [the dedicated field for NRQL alerts](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/), or the [Describe this condition section for infrastructure alerts](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/infrastructure-alerts-add-edit-or-view-host-alert-information/).

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/define-custom-metrics-alert-condition.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/define-custom-metrics-alert-condition.mdx
@@ -34,7 +34,7 @@ Use the policy's **Thresholds** section to define the custom metric values. Thes
 
 To define the custom metric values for your condition:
 
-1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, then **(select a policy)** or [add a new alert policy](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/name-or-rename-alert-policy).
+1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, then **(select a policy)** or [add a new alert policy](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/name-or-rename-alert-policy).
 2. From the policy's **Alert conditions** page, click **Add a condition**.
 3. From the **Categorize** section, select the [product and type of condition](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions) for the custom metric.
 4. From the **Select entities** section, add one or more [targets (entities)](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/select-product-targets-alert-condition) that use your custom metric.
@@ -52,5 +52,5 @@ After you save the condition, you can view the selected policy's **Alert conditi
 
 The **Condition name** does not appear in the **Thresholds** section for a saved condition. If you want to [change the condition name](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions#rename-condition) for a custom metric, edit it from the selected policy's **Alert conditions** page:
 
-1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, then **(select a policy)**.
+1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, then **(select a policy)**.
 2. Click a condition name to edit it, and then type a meaningful name for the condition.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/multi-location-synthetic-monitoring-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/multi-location-synthetic-monitoring-alert-conditions.mdx
@@ -104,7 +104,7 @@ Here's a diagram that shows how a four-location condition will be triggered for 
 
 Before creating a condition, read the [rules for multi-location conditions](#rules).
 
-1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, and start the process to [create a condition](/docs/alerts/new-relic-alerts/defining-conditions/define-alert-conditions#create-condition).
+1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, and start the process to [create a condition](/docs/alerts/new-relic-alerts/defining-conditions/define-alert-conditions#create-condition).
 2. Click **Synthetics**, then click **Multiple location failures**.
 
 <Callout variant="important">

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/select-product-targets-alert-condition.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/select-product-targets-alert-condition.mdx
@@ -38,12 +38,12 @@ For your convenience, the user interface organizes targeted entities into logica
 />
 
 <figcaption>
-  **Alerts & AI > Policies > (selected policy) > (selected condition) > Notification channels:** As part of the policy setup process, select one or more entities monitored by the selected product that will be the target entity for the condition.
+  **Alerts & AI > Alert conditions (Policies) > (selected policy) > (selected condition) > Notification channels:** As part of the policy setup process, select one or more entities monitored by the selected product that will be the target entity for the condition.
 </figcaption>
 
 To identify which entities or components monitored by the selected product will be the targets for the selected condition:
 
-1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, then **(select a policy)**.
+1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, then **(select a policy)**.
 2. In the conditions list, **(select a condition)**, then click **Notification channels**.
 3. Click **Add notification channels**, and then choose your notification channels.
 4. When you're done, click **Update policy**.
@@ -56,7 +56,7 @@ After you select the targeted entities for the alert condition, select **Define 
 
 The policies index lists them in alphabetical order. To view or search for existing entities for an alert condition:
 
-1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, then click **Alert policies**
+1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, then click **Alert conditions (Policies)**
 2. To select a policy name: Use the search box, sort any column, or scroll the list.
 3. Optional: From the **Alert conditions** page, use the search box to locate a specific condition.
 4. To view detailed information about entities associated with a condition, click **Notification channels**.
@@ -69,7 +69,7 @@ The policies index lists them in alphabetical order. To view or search for exist
 
 To change the list of selected targeted entities for an existing condition:
 
-1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, then **(select a policy)**.
+1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, then **(select a policy)**.
 2. From the list of existing conditions, select the entity name (for example, `My app - Production`) or number of entities (for example, `3 Targets`).
 3. Click **Notification channels**.
 4. In the channels list, click a channel to edit it.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/alerts-nerdgraph/nerdgraph-api-nrql-condition-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/alerts-nerdgraph/nerdgraph-api-nrql-condition-alerts.mdx
@@ -42,7 +42,7 @@ Follow these steps:
 2. Find your relevant `policyID` by doing one of the following:
 
    * Use the [NerdGraph policies API](/docs/alerts/alerts-nerdgraph/nerdgraph-examples/nerdgraph-api-alerts-policies).
-   * Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, then click **Policies**. Choose a policy. Find the ID under the policy name.
+   * Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, then click **Alert conditions (Policies)**. Choose a policy. Find the ID under the policy name.
 3. Provide the appropriate mutation for your NRQL condition type and the relevant values.
 
 <Callout variant="tip">

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/provide-runbook-instructions-alert-activity.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/provide-runbook-instructions-alert-activity.mdx
@@ -25,12 +25,12 @@ Alert [conditions](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies
 />
 
 <figcaption>
-  In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, **(select a policy)**, then **(select a condition)**: You can add a runbook URL so that personnel handling the incident that triggered the alert will know what to do.
+  In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, **(select a policy)**, then **(select a condition)**: You can add a runbook URL so that personnel handling the incident that triggered the alert will know what to do.
 </figcaption>
 
 To edit the runbook URL associated with a condition:
 
-1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, **(select a policy)**, then **(select a condition)**.
+1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, **(select a policy)**, then **(select a condition)**.
 2. On the **Edit conditions** page, click **Add runbook URL**, then provide the full path for your runbook URL (runbook URL, URL to internal wiki page, etc.), and then save.
 3. Optional: To change or delete an existing runbook URL from the alert condition, click **Remove**.
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions.mdx
@@ -171,7 +171,7 @@ If you want to change the default condition name, make it short and descriptive.
 
 To change an existing condition's name:
 
-1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, then **(select a policy)**.
+1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, then **(select a policy)**.
 2. Click a condition name to edit it, and then type a meaningful name for the condition.
 
 You can't edit the product and condition type associated with a condition. Instead, you must delete the condition and create a new one with a different product and condition type.
@@ -193,7 +193,7 @@ You may also manage your policies via [the policies NerdGraph API](/docs/alerts/
 
 The policies index lists them in alphabetical order. To view or search for existing conditions:
 
-1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, then click **Alert policies**.
+1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, then click **Alert conditions (Policies)**.
 2. Use the search box, sort any column, or scroll the list, then select a policy's name to see its conditions.
 
 To view [policy and condition information for a specific entity](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/view-policy-conditions-new-relic-products): From that entity's product UI, select **Settings**, then click **Alert conditions**.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -34,7 +34,7 @@ Read on to learn more about how to do this.
 />
 
 <figcaption>
-  Go to **[one.newrelic.com](https://one.newrelic.com)**, click **Alerts & AI**, in the left sidebar click **Policies**, select a policy, then **Add a condition**. Click **NRQL**, and then **Next, define thresholds**.
+  Go to **[one.newrelic.com](https://one.newrelic.com)**, click **Alerts & AI**, in the left sidebar click **Alert conditions (Policies)**, select a policy, then **Add a condition**. Click **NRQL**, and then **Next, define thresholds**.
 </figcaption>
 
 <Callout variant="tip">
@@ -47,7 +47,7 @@ Ready to get started? If you haven't already, be sure to [sign up for a New Reli
 
 To create a NRQL alert condition for a policy:
 
-* On [one.newrelic.com](https://one.newrelic.com), in the header click **Alerts & AI**, then in the left sidebar click **Policies**.
+* On [one.newrelic.com](https://one.newrelic.com), in the header click **Alerts & AI**, then in the left sidebar click **Alert conditions (Policies)**.
 * Select an existing policy or click **New alert policy** to [create a new policy](/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/create-edit-or-find-alert-policy).
 * Click **Add a condition**.
 * Under **Select a product** click **NRQL**, and then click **Next, define thresholds**.
@@ -678,7 +678,7 @@ Loss of signal occurs when no data matches the NRQL condition over a specific pe
 />
 
 <figcaption>
-  Go to **[one.newrelic.com](https://one.newrelic.com)**, click **Alerts & AI**, in the left sidebar click **Policies**, select a policy, then **Add a condition**. Loss of signal is only available for NRQL conditions.
+  Go to **[one.newrelic.com](https://one.newrelic.com)**, click **Alerts & AI**, in the left sidebar click **Alert conditions (Policies)**, select a policy, then **Add a condition**. Loss of signal is only available for NRQL conditions.
 </figcaption>
 
 You may also manage these settings using the GraphQL API (recommended), or the REST API. Go here for specific [GraphQL API examples](/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling).

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/delete-alert-notification-channels.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/delete-alert-notification-channels.mdx
@@ -22,7 +22,7 @@ You can delete a notification channel when your alerts needs change, for example
 
 To delete a channel permanently:
 
-1. Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, then click **Notification channels**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, then click **Channels**.
 2. Optional: To find the notification channel easily, search the **Notification channels** index.
 3. From the **Notification channels** index, select the channel's delete icon, and then select the confirmation prompt to cancel or continue.
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts.mdx
@@ -39,7 +39,7 @@ Alerts offers several notification channels, including webhooks, Slack rooms, em
 
 ## View notification channels [#view-channels]
 
-To see all notification channels in your account: Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, then click **Notification channels**.
+To see all notification channels in your account: Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, then click **Channels**.
 
 ## Add or remove notification channels [#add-channel]
 
@@ -66,7 +66,7 @@ These are the available notification channel types.
   >
     **Requirement**: This feature is not available for users on the New Relic One user model, only to users on the original user model (learn about [user model differences](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-user-models)). As a workaround, you can use the [email notification channel](#email).
 
-    Use the **User** notification channel to select existing account team members and admins. To view the **Users** list or to [add users to alert policies](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/view-or-update-user-email-channels): Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, then click **Notification channels**.
+    Use the **User** notification channel to select existing account team members and admins. To view the **Users** list or to [add users to alert policies](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/view-or-update-user-email-channels): Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, then click **Channels**.
 
     If a user has [configured the New Relic mobile app](/docs/mobile-apps/new-relic-mobile-apps/authentication-alerts/alerting-new-relic-mobile-apps/), the user notification channel also sends [push notifications](#mobile-push) to any of the user's registered mobile devices.
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/test-alert-notification-channels.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/test-alert-notification-channels.mdx
@@ -24,7 +24,7 @@ Read about how to request and troubleshoot an alert notification channel test.
 
 To test a notification channel:
 
-1. Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, then click **Notification channels**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, then click **Channels**.
 2. Follow standard procedures to [add a new notification channel](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/notification-channels-controlling-where-send-alerts#add-channel) or to [update an existing notification channel](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/update-alert-notification-channels), and save it.
 3. Select a notification channel, and then click <Icon style={{color: '#b7b7b7'}} name="fe-mail"/>
    **Send a test notification**.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/update-alert-notification-channels.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/update-alert-notification-channels.mdx
@@ -37,7 +37,7 @@ Here's a quick reference for updating channels which also includes links to more
   >
     Alerts automatically includes the [email addresses](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/notification-channels-controlling-where-send-alerts#email) for all users in the selected account as individual notification channels. If the account is a [child account](/docs/accounts/original-accounts-billing/original-users-roles/mastersub-account-structure), the list shows only the users on the child account, not the users in the parent account.
 
-    To view or search the list of user names and emails: Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, then click **Notification channels**. In the search field, search for 'user'.
+    To view or search the list of user names and emails: Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, then click **Channels**. In the search field, search for 'user'.
   </Collapser>
 
   <Collapser
@@ -49,7 +49,7 @@ Here's a quick reference for updating channels which also includes links to more
 
     To add or update account users as notification channels for a policy:
 
-    1. Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Policies**, and then choose the policy you want to change.
+    1. Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Alert conditions (Policies)**, and then choose the policy you want to change.
     2. Optional: You can update notification channels for specific users. On the **Notification channels page,** select a user, select any policy subscription already associated with the user as applicable to view policy details.
     3. Click **Notification channels**, then follow [standard procedures](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/add-or-remove-policy-channels) to add notification channels.
     4. Click **Update policy**.
@@ -61,7 +61,7 @@ Here's a quick reference for updating channels which also includes links to more
   >
     To create a [new notification channel](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/notification-channels-controlling-where-send-alerts#add-channel):
 
-    1. Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Notification channels**.
+    1. Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Channels**.
     2. Click **New notification channel**.
   </Collapser>
 
@@ -82,7 +82,7 @@ Here's a quick reference for updating channels which also includes links to more
   >
     To [add a notification channel to one or more policies](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/add-or-remove-policy-channels):
 
-    1. Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Policies**.
+    1. Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Alert conditions (Policies)**.
     2. Choose a policy, click **Notification channels**, and then click **Add notification channels**.
     3. Choose a channel, and then click **Update policy**.
   </Collapser>
@@ -93,7 +93,7 @@ Here's a quick reference for updating channels which also includes links to more
   >
     To [rename](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/notification-channels-controlling-where-send-alerts#channel-types) an existing notification channel:
 
-    1. Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Notification channels**, then choose a channel.
+    1. Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Channels**, then choose a channel.
     2. From the **Channel details**, change the name (maximum 64 characters) based on the channel type if applicable, and then save.
   </Collapser>
 
@@ -114,7 +114,7 @@ Here's a quick reference for updating channels which also includes links to more
   >
     To check whether a notification channel has any [policies assigned](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/add-or-remove-policy-channels):
 
-    Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Notification channels**.
+    Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Channels**.
 
     The **Policy subscriptions** column lists how many policies are assigned to the channel.
   </Collapser>
@@ -125,13 +125,13 @@ Here's a quick reference for updating channels which also includes links to more
   >
     To view the [policies assigned to a notification channel](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/add-or-remove-policy-channels):
 
-    Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Notification channels**, choose a channel, and then click **Alert policies**.
+    Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Channels**, choose a channel, and then click **Alert policies**.
 
     OR
 
     To view the [notification channels assigned to a policy](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/add-or-remove-policy-channels):
 
-    Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Policies**, choose a policy, then click **Notification channels.**
+    Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Alert conditions (Policies)**, choose a policy, then click **Notification channels.**
   </Collapser>
 
   <Collapser
@@ -140,14 +140,14 @@ Here's a quick reference for updating channels which also includes links to more
   >
     To [delete a notification channel](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/delete-alert-notification-channels):
 
-    1. Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Notification channels**.
+    1. Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Channels**.
     2. In the list, click the **Delete** <img title="icon delete.png" alt="icon delete.png" src={iconDelete}/> icon.
   </Collapser>
 </CollapserGroup>
 
 ## Basic process [#basic-process-channel-changes]
 
-1. Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Notification channels**, then choose a channel.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")**, in the top nav click **Alerts & AI**, click **Channels**, then choose a channel.
 2. From the **Channel details** page, make any necessary changes, and then save.
 
 The user interface shows a **Last modified** time stamp for any changes to policies, including their conditions and notification channels.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/create-edit-or-find-alert-policy.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/create-edit-or-find-alert-policy.mdx
@@ -107,7 +107,7 @@ We recommend three common patterns and practices for structuring and naming poli
 
 As part of the [policy workflow](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/alert-policy-workflow), start by giving the policy a meaningful name:
 
-1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, then click **Policies.**
+1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, then click **Alert conditions (Policies).**
 2. On the policy index page, click <Icon name="fe-plus-circle"/>
    **New alert policy**.
 3. Type a [meaningful name](#best-practices-policies) for the policy (maximum 64 characters).
@@ -122,7 +122,7 @@ For your convenience, we allow you to use the same name for different policies, 
 
 To rename an existing policy:
 
-1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, then click **Policies**, and then (**select a policy)**.
+1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, then click **Alert conditions (Policies)**, and then (**select a policy)**.
 2. Click the policy name to edit it, then type a [meaningful name](#best-practices-policies) for the policy (maximum 64 characters).
 
 Alerts automatically updates any of the policy's conditions and notification channels.
@@ -131,7 +131,7 @@ Alerts automatically updates any of the policy's conditions and notification cha
 
 The policies index lists policies in alphabetical order. To view or search for existing policies:
 
-1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, then click **Policies.**
+1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, then click **Alert conditions (Policies).**
 2. Use the search box, sort any column, or scroll the list.
 3. To view detailed information, click a policy name.
 
@@ -160,7 +160,7 @@ Here is a quick reference which also includes links to more detailed information
   >
     To [add or remove policies](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/add-or-remove-policy-channels) assigned to a channel:
 
-    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Notification channels**, then **(select a channel)**.
+    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Channels**, then **(select a channel)**.
     2. Click **Alert policies**, then **(select a policy)**.
     3. From the selected policy, use the windows to select, remove, or clear all.
   </Collapser>
@@ -171,7 +171,7 @@ Here is a quick reference which also includes links to more detailed information
   >
     To [rename](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/name-or-rename-alert-policy#rename-policy) a policy:
 
-    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, then **(select a policy)**.
+    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, then **(select a policy)**.
     2. Click the policy name to edit it, then type a [meaningful name](#best-practices-policies) for the policy (maximum 64 characters).
   </Collapser>
 
@@ -181,7 +181,7 @@ Here is a quick reference which also includes links to more detailed information
   >
     To check whether an [account user has been assigned any policies](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/view-or-update-user-email-channels):
 
-    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Policies**, **(select a policy)**, then click **Notification channels**.
+    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, **(select a policy)**, then click **Notification channels**.
     2. Select a user, and then click **Alert policies**.
   </Collapser>
 
@@ -189,7 +189,7 @@ Here is a quick reference which also includes links to more detailed information
     id="check-channel-policies"
     title="Check policy channel assignment"
   >
-    To check whether a notification channel has any [policies assigned](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/add-or-remove-policy-channels) to it: In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Notification channels**.
+    To check whether a notification channel has any [policies assigned](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/add-or-remove-policy-channels) to it: In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Channels**.
 
     The **Policy subscriptions** column lists how many policies are assigned to the channel.
   </Collapser>
@@ -200,7 +200,7 @@ Here is a quick reference which also includes links to more detailed information
   >
     To create a [new alert policy](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/name-or-rename-alert-policy):
 
-    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Policies**.
+    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**.
     2. Click **New alert policy**.
     3. Follow standard procedures to complete the [basic setup process](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/alert-policy-workflow).
   </Collapser>
@@ -224,7 +224,7 @@ Here is a quick reference which also includes links to more detailed information
 
     To delete a policy completely:
 
-    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, then click **Alert policies.**
+    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, then click **Alert conditions (Policies).**
     2. From the policy row, click the delete <Icon name="fe-trash-2"/>
        icon.
 
@@ -253,7 +253,7 @@ Here is a quick reference which also includes links to more detailed information
   >
     To select how [violations to your thresholds](/docs/alerts/new-relic-alerts-beta/reviewing-alert-incidents/specify-when-new-relic-creates-incidents) are grouped into incident records (by policy, by condition, or by target and condition):
 
-    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, then **(select a policy)**.
+    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, then **(select a policy)**.
     2. Click <Icon name="fe-settings"/>
        **Incident preference**.
   </Collapser>

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/specify-when-alerts-create-incidents.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/specify-when-alerts-create-incidents.mdx
@@ -109,7 +109,7 @@ By default, a single incident record will be created for each policy.
 
 To change the incident preference for the selected policy:
 
-1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, then click **Policies**, and then (**select a policy)**.
+1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, then click **Alert conditions (Policies)**, and then (**select a policy)**.
 2. Click **Incident preference**, select your choice of available [options](#preference-options), and then save.
 
 Repeat these steps for each policy as needed.
@@ -127,7 +127,7 @@ Repeat these steps for each policy as needed.
 />
 
 <figcaption>
-  **[one.newrelic.com](https://one.newrelic.com) > Alerts & AI > Policies > (select a policy):** The selected policy page shows how alerts rolls up incidents for alert notifications and UI details. (Default is **By policy**). To choose a different option for this policy, click **Incident preference**.
+  **[one.newrelic.com](https://one.newrelic.com) > Alerts & AI > Alert conditions (Policies) > (select a policy):** The selected policy page shows how alerts rolls up incidents for alert notifications and UI details. (Default is **By policy**). To choose a different option for this policy, click **Incident preference**.
 </figcaption>
 
 ## By policy (default) [#preference-policy]

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/update-or-disable-policies-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/update-or-disable-policies-conditions.mdx
@@ -33,11 +33,11 @@ Here's a quick reference for maintaining conditions. This includes the condition
     id="add-conditions"
     title="Add more conditions"
   >
-    To [add more conditions to a policy](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions): In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, select a policy, then click **Add a condition**.
+    To [add more conditions to a policy](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions): In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, select a policy, then click **Add a condition**.
 
     OR
 
-    To [copy a condition](/docs/alerts/new-relic-alerts-beta/updating-alert-policies/copy-alert-conditions) from any policy and add it to another policy: In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, select a policy, then click **Copy**.
+    To [copy a condition](/docs/alerts/new-relic-alerts-beta/updating-alert-policies/copy-alert-conditions) from any policy and add it to another policy: In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, select a policy, then click **Copy**.
   </Collapser>
 
   <Collapser
@@ -46,7 +46,7 @@ Here's a quick reference for maintaining conditions. This includes the condition
   >
     To copy an existing condition, including its [targets](/docs/apm/new-relic-apm/getting-started/glossary#alert-target) and [thresholds](/docs/apm/new-relic-apm/getting-started/glossary#alert-threshold), and add it to another policy for the selected account:
 
-    1. In the **[one.newrelic.com](https://one.newrelic.com)** top nav, click **Alerts & AI**, click **Alert policies**, then select a policy.
+    1. In the **[one.newrelic.com](https://one.newrelic.com)** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, then select a policy.
     2. From the policy's list of one or more **Alert conditions**, click **Copy**.
     3. From the **Copy alert condition** list, search or scroll the list to select the policy where you want to add this condition.
     4. Optional: Change the condition's name if necessary.
@@ -59,7 +59,7 @@ Here's a quick reference for maintaining conditions. This includes the condition
     id="update-condition"
     title="Change a condition"
   >
-    To change a policy condition: In the **[one.newrelic.com](https://one.newrelic.com)** top nav, click **Alerts & AI**, click **Alert policies**, then select a policy. Then, from the list of **Alert conditions** for the selected policy:
+    To change a policy condition: In the **[one.newrelic.com](https://one.newrelic.com)** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, then select a policy. Then, from the list of **Alert conditions** for the selected policy:
 
     * To [change the condition's name](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions#rename-condition), click **Edit**.
     * To add, change, or remove targets (entities), select the name or number of targets for the condition, and then select **Browse and select targets**.
@@ -77,7 +77,7 @@ Here's a quick reference for maintaining conditions. This includes the condition
   >
     You can enable <img title="Alerts v3: Condition enabled" alt="041715icon-condition-on" src={img0041715IconConditionOn}/> or disable <img title="Alerts v3: Condition disabled" alt="041715icon-condition-off" src={img1041715IconConditionOff}/> any policy conditions, and the policy will continue to apply. To disable or re-enable a condition:
 
-    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, then select a policy. Then, from the list of **Alert conditions** select a condition).
+    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, then select a policy. Then, from the list of **Alert conditions** select a condition).
     2. Click the **On/Off** switch to toggle it.
 
        <Callout variant="tip">
@@ -93,7 +93,7 @@ Here's a quick reference for maintaining conditions. This includes the condition
   >
     If a policy has multiple conditions, you can delete any or all of them, and the remaining conditions for the policy will continue to apply. To turn a condition off but keep it with the policy, [disable](/docs/alerts/new-relic-alerts-beta/updating-alert-policies/disable-or-delete-alert-policies-conditions#condition-on-off) it. To delete one or more conditions:
 
-    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert policies**, then select a policy.
+    1. In the **[one.newrelic.com](https://one.newrelic.com/ "Link opens in a new window.")** top nav, click **Alerts & AI**, click **Alert conditions (Policies)**, then select a policy.
     2. From the list of **Alert conditions**, select a condition, then click **Delete**.
 
        <Callout variant="tip">


### PR DESCRIPTION
## Give us some context

Observed that some of the Alerts-related documentation had clickpaths that referred to old navigation labels that have since been updated. **I have amended the labels in these clickpaths to reflect the current state of the NR1 navigation for "Alerts & AI".**