### PR TITLE
fix: convert md image to jsx img

### DIFF
--- a/src/content/docs/codestream/codestream-integrations/slack-integration.mdx
+++ b/src/content/docs/codestream/codestream-integrations/slack-integration.mdx
@@ -13,6 +13,8 @@ import shareOnSlack1 from 'images/ShareOnSlack1.png'
 
 import resolvedOnSlack from 'images/ResolvedOnSlack.png'
 
+import replyFromSlack from 'images/ReplyFromSlack.gif'
+
 Connect New Relic CodeStream to your team's Slack channel.
 
 When you post a comment, issue, or feedback request, your teammates are notified via the activity feed, and potentially via email. Sometimes, though, you might want to share to Slack as well. This allows you to reach people who haven’t yet joined CodeStream or maybe don’t spend a lot of time in their IDE.
@@ -67,7 +69,7 @@ A comment, issue, or feedback request shared to Slack is much more powerful than
 
 Your teammates can click **View Discussion & Reply** to add a reply.That reply is posted to CodeStream. Any previous replies are displayed as well so that they can catch up on the entire discussion.
 
-![Reply from Slack](images/ReplyFromSlack.gif)
+<img src={replyFromSlack} alt="Reply from Slack" title="Reply from Slack"/>
 
 Your teammates don’t need to be CodeStream users in order to participate in discussions via Slack.
 


### PR DESCRIPTION
## Description

Converts a .gif markdown image to jsx img syntax
