### PR TITLE
Replace incorrect message limit on NoticeError api method

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/noticeerror-net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/noticeerror-net-agent-api.mdx
@@ -103,7 +103,7 @@ Errors reported with this API are still sent to New Relic when they are reported
       </td>
 
       <td>
-        Required. Specify a string to report to New Relic as though it's an exception. Only the first 1,000 characters are retained.
+        Required. Specify a string to report to New Relic as though it's an exception. This method creates both [Error Events](/docs/apm/apm-ui-pages/error-analytics/manage-error-data#events) and [Error Traces](/docs/apm/apm-ui-pages/error-analytics/manage-error-data#trace-details).  Only the first 255 characters are retained in Error Events while Error Traces will retain the full message.
       </td>
     </tr>
 
@@ -135,7 +135,7 @@ Errors reported with this API are still sent to New Relic when they are reported
       </td>
 
       <td>
-        Required. Specify a string to report to New Relic as though it's an exception. Only the first 1,000 characters are retained.
+         Required. Specify a string to report to New Relic as though it's an exception. This method creates both [Error Events](/docs/apm/apm-ui-pages/error-analytics/manage-error-data#events) and [Error Traces](/docs/apm/apm-ui-pages/error-analytics/manage-error-data#trace-details).  Only the first 255 characters are retained in Error Events while Error Traces will retain the full message.
       </td>
     </tr>
 


### PR DESCRIPTION
## Give us some context

The comments for the `string message` parameter in the .NET Agent's NoticeError API page refers to a 1000 character limit.   This is not correct (it might have been 8 or so years ago). 

This updates the comment for that parameter to match what my testing has shown to be correct.  We will also be updating the in-code comments to reflect this as well.