### PR TITLE
feat(AWS Cloudfront): Cloudfront explicit delay increased

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/troubleshooting/metric-data-delays-amazon-aws-integrations.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/troubleshooting/metric-data-delays-amazon-aws-integrations.mdx
@@ -66,7 +66,7 @@ Depending on the AWS integration, the infrastructure agent may experience explic
 
         * [ELB](/docs/aws-elb-integration): 5 minutes
 
-        * [CloudFront](/docs/infrastructure/amazon-integrations/amazon-integrations/aws-cloudfront-monitoring-integration): 1 minute
+        * [CloudFront](/docs/infrastructure/amazon-integrations/amazon-integrations/aws-cloudfront-monitoring-integration): 3 minute
 
         * [RDS](/docs/infrastructure/amazon-integrations/amazon-integrations/aws-rds-monitoring-integration): 5 minutes
 


### PR DESCRIPTION
We have decided to increase the AWS Cloudfront polling explicit delay to 3 minutes after pulling incorrect data for some customers.

Internal: talk to me in slack 'ihernandez' if you need to see the internal tickets.

The change will be live today in some hours.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.