### PR TITLE
fix: remove h3 tags in favor of markdown

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
@@ -78,15 +78,12 @@ Kafka is a complex piece of software that is built as a distributed system. For 
   >
     Given the distributed nature of Kafka, the actual number and list of brokers is usually not fixed by the configuration, and it is instead quite dynamic. For this reason, the Kafka integration offers two mechanisms to perform automatic discovery of the list of brokers in the cluster: Bootstrap and Zookeeper. The mechanism you use depends on the setup of the Kafka cluster being monitored.
 
-    <h3>
-      Bootstrap
-    </h3>
+    ### Bootstrap
+
 
     With the [bootstrap mechanism](#bootstrap), the integration uses a bootstrap broker to perform the autodiscovery. This is a broker whose address is well known and that will be asked for any other brokers it is aware of. The integration needs to be able to contact this broker in the address provided in the bootstrap_broker_host parameter for bootstrap discovery to work.
 
-    <h3>
-      Zookeeper
-    </h3>
+    ### Zookeeper
 
     Alternatively, the Kafka integration can also talk to a [Zookeeper server](#zookeeper) in order to obtain the list of brokers. To do this, the integration needs to be provided with the following:
 
@@ -183,10 +180,6 @@ To install the Kafka integration, follow the instructions for your environment:
 
     5. Restart the infrastructure agent. See how to [restart the infrastructure agent in different Linux environments](/docs/infrastructure/install-infrastructure-agent/manage-your-agent/start-stop-restart-infrastructure-agent/#linux).
   </Collapser>
-
-  {
-    ' '
-  }
 
   <Collapser
     id="ecs-install"


### PR DESCRIPTION
## Description

Removes rogue `h3` tags from a file to fix recent serialization error

https://github.com/newrelic/docs-website/runs/5878416593?check_suite_focus=true