### PR TITLE
Removing the requirement for installing aws-sdk

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
@@ -349,22 +349,13 @@ On this page, you will learn how to manually instrument your lambda function. It
 
        ```
 
-    2. Install our AWS SDK module alongside the Node.js agent:
-
-       ```bash
-
-       npm install @newrelic/aws-sdk --save
-
-       ```
-
-    3. In your Lambda code, require the agent module and the AWS SDK at the top of the file, and wrap the handler function. For example:
+    2. In your Lambda code, require the agent module at the top of the file, and wrap the handler function. For example:
 
        ```js
 
        const newrelic = require('newrelic');
-       require('@newrelic/aws-sdk');
 
-       // Other module loads go under the two require statements above
+       // Other module loads go under the require statement above
 
        module.exports.handler = newrelic.setLambdaHandler((event, context, callback) => {
          // This is your handler function code
@@ -374,7 +365,7 @@ On this page, you will learn how to manually instrument your lambda function. It
 
        ```
 
-    4. Optional: You can also add [custom events](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#custom-event) to your Lambda using the [`recordCustomEvent` API](/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#record_custom_event). For example:
+    3. Optional: You can also add [custom events](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#custom-event) to your Lambda using the [`recordCustomEvent` API](/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#record_custom_event). For example:
 
        ```js
        module.exports.handler = newrelic.setLambdaHandler((event, context, callback) => {
@@ -384,29 +375,29 @@ On this page, you will learn how to manually instrument your lambda function. It
        });
        ```
 
-    5. Zip your Lambda function and the Node.js agent folder together. Requirements and recommendations:
+    4. Zip your Lambda function and the Node.js agent folder together. Requirements and recommendations:
 
        * The New Relic files outside the New Relic agent folder don't need to be included.
        * If your Lambda function file name is, for example, `lambda_function.node`, we recommend naming your zip file `lambda_function.zip`. Do not use a tarball.
        * Your Lambda and its associated modules must all be in the zip file's root directory. This means that if you zip a folder that contains the files, it won't work.
 
-    6. Upload the zipped file to your AWS Lambda account.
+    5. Upload the zipped file to your AWS Lambda account.
 
-    7. In the AWS console, set these [environment variables](https://docs.aws.amazon.com/lambda/latest/dg/env_variables.html):
+    6. In the AWS console, set these [environment variables](https://docs.aws.amazon.com/lambda/latest/dg/env_variables.html):
 
        * `NEW_RELIC_NO_CONFIG_FILE`. Set to `true` if not using a configuration file.
        * `NEW_RELIC_APP_NAME`: Your application name.
        * `NEW_RELIC_ACCOUNT_ID`. Your [account ID](/docs/accounts/install-new-relic/account-setup/account-id).
        * `NEW_RELIC_TRUSTED_ACCOUNT_KEY`. This is also your [account ID](/docs/accounts/install-new-relic/account-setup/account-id). If your account is a child account, this needs to be the account ID for the root/parent account.
 
-    8. Optional: To run the agent in serverless mode outside of AWS in a local environment, set the environment variable `NEW_RELIC_SERVERLESS_MODE_ENABLED` to `true`. (When executing this in an AWS Lambda environment, the agent will automatically run in serverless mode. **Do not use this variable if you're running in AWS**.)
+    7. Optional: To run the agent in serverless mode outside of AWS in a local environment, set the environment variable `NEW_RELIC_SERVERLESS_MODE_ENABLED` to `true`. (When executing this in an AWS Lambda environment, the agent will automatically run in serverless mode. **Do not use this variable if you're running in AWS**.)
 
-    9. Optional: To enable logging in serverless mode, set these environment variables:
+    8. Optional: To enable logging in serverless mode, set these environment variables:
        * Set `NEW_RELIC_LOG_ENABLED` to `true`.
        * Set `NEW_RELIC_LOG` to `stdout` for output to CloudWatch, or set to any writeable file location.
        * `NEW_RELIC_LOG_LEVEL` is set to `info` by default, and it's only used when sending function logs in your Lamba. See [other log levels](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#logging_config).
 
-    10. Invoke the Lambda at least once. This creates a CloudWatch log group, which must be present for the next step to work.
+    9. Invoke the Lambda at least once. This creates a CloudWatch log group, which must be present for the next step to work.
 
         Our wrapper gathers data about the Lambda execution, generates a JSON message, and logs it to CloudWatch Logs. Next you'll [configure CloudWatch to send those logs to New Relic](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own/#manual-stream-logs).
 


### PR DESCRIPTION
The latest Node agents have the aws-sdk bundled with them, so a separate installation and import/require are not necessary.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.