### PR TITLE
Remove image of signup page

### DIFF
--- a/src/content/docs/codestream/start-here/sign-up-codestream.mdx
+++ b/src/content/docs/codestream/start-here/sign-up-codestream.mdx
@@ -19,14 +19,7 @@ inviting your teammates.
 
 If you already have the CodeStream extension [installed in your
 IDE](/docs/codestream/start-here/install-codestream), you can start the sign up
-process from the CodeStream pane.
-
-<img
-  alt="Create an account"
-  src={createAnAccount6}
-/>
-
-There are three options for signing up:
+process from the CodeStream pane. There are three options for signing up:
 
 * Enter your work email address and a password
 * Authenticate using your GitHub, GitLab, or Bitbucket account


### PR DESCRIPTION
Was going to replace it with one that includes the new Region drodown, but instead we'll just remove the image.