### PR TITLE
feat(synthetics): Added google-auth-library

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/manage-monitor-runtimes.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/manage-monitor-runtimes.mdx
@@ -367,6 +367,7 @@ The API runtime is used for these monitor types:
       * [consoleplusplus](https://www.npmjs.com/package/consoleplusplus) 1.4.4
       * [crypto-js](https://code.google.com/p/crypto-js/) 4.1.1
       * [fs-extra](https://www.npmjs.com/package/fs-extra) 10.0.0
+      * [google-auth-library](https://www.npmjs.com/package/google-auth-library) 7.14.0
       * [got](https://www.npmjs.com/package/got) 11.8.3
       * [joi](https://github.com/hapijs/joi) 17.4.2
       * [js-yaml](https://www.npmjs.com/package/js-yaml) 4.1.0


### PR DESCRIPTION
Added google-auth-library to the Node.js modules supported in the Node 16.10.0 scripted API runtime. This was missed during the runtime related doc updates.