### PR TITLE
Fix config examples in .NET logging doc

### DIFF
--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -24,7 +24,7 @@ redirects:
   - /docs/logs/enable-log-management-new-relic/configure-logs-context/net-configure-logs-context-all
 ---
 
-APM logs in context connects your logs with all of your telemetry data for your apps, hosts, and other entities. Bringing all of this data together in a single tool helps you quickly:
+APM [logs in context](/docs/logs/logs-context/logs-in-context) connects your logs with all of your telemetry data for your apps, hosts, and other entities. Bringing all of this data together in a single tool helps you quickly:
 
 import logsInContextLog4Net from 'images/LogsInContext-Log4Net.png'
 

--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -58,7 +58,7 @@ You have three options to configure APM logs in context to send your app's logs 
 
   ```
   <applicationLogging enabled="true">
-    <logForwarding enabled="true" />
+    <forwarding enabled="true" />
   </applicationLogging>
   ```
 
@@ -72,7 +72,7 @@ You have three options to configure APM logs in context to send your app's logs 
 
   ```
   <applicationLogging enabled="true">
-    <logForwarding enabled="true" maxSamplesStored="10000" />
+    <forwarding enabled="true" maxSamplesStored="10000" />
   </applicationLogging>
   ```
 
@@ -95,7 +95,7 @@ You have three options to configure APM logs in context to send your app's logs 
 
   ```
   <applicationLogging enabled="true">
-    <logForwarding enabled="true" />
+    <localDecorating enabled="true" />
   </applicationLogging>
   ```
 


### PR DESCRIPTION
Resolves this issue in the .NET agent repo: https://github.com/newrelic/newrelic-dotnet-agent/issues/1050

Some config elements were mis-typed in the initial version of this document.