### PR TITLE
Fix name of log fowarding config element

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3100,7 +3100,7 @@ For more details, see our documentation about [APM logs in context](/docs/apm/ne
 ```xml
 <applicationLogging enabled="true">
  <metrics enabled="true" />
- <logForwarding enabled="false" maxSamplesStored="10000" />
+ <forwarding enabled="false" maxSamplesStored="10000" />
  <localDecorating enabled="false" />
 </applicationLogging>
 ```
@@ -3151,7 +3151,7 @@ The `applicationLogging` element supports the following attributes and sub-eleme
   </Collapser>
 
   <Collapser
-    id="logForwarding"
+    id="forwarding"
     title="Log forwarding"
   >
     Use this sub-element to enable forwarding of your application's logs to New Relic. The default value of attribute `enabled` is `false`.  The default value of attribute `maxSamplesStored` is `10000`.


### PR DESCRIPTION
Fix incorrect name of config element (for log fowarding, the name of the config element is just `forwarding`, not `logForwarding`) in main .NET agent config doc.