### PR TITLE
Document environment variable options for configuring .NET agent logging features

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3086,7 +3086,12 @@ request.headers.user-agent
 </Callout>
 
 ### Application logging [#application_logging]
-
+    
+    
+<Callout variant="important">
+These configuration options are only available for .NET agent version 9.7.0 or higher.
+    </Callout>
+    
 The `applicationLogging` element is a child of the `configuration` element. Use `applicationLogging` to configure instrumentation of your application's logging activity.
 
 There are three main sub-features:
@@ -3114,10 +3119,6 @@ NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED="false"
 NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED="10000"
 NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED="false"
 ```
-
-<Callout variant="important">
-  This configuration option is only available in the .NET agent v9.7.0 or higher.
-</Callout>
 
 The `applicationLogging` element supports the following attributes and sub-elements:
 

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3105,6 +3105,16 @@ For more details, see our documentation about [APM logs in context](/docs/apm/ne
 </applicationLogging>
 ```
 
+These features can also be configured via environment variables:
+
+```
+NEW_RELIC_APPLICATION_LOGGING_ENABLED="true"
+NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED="true"
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED="false"
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED="10000"
+NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED="false"
+```
+
 <Callout variant="important">
   This configuration option is only available in the .NET agent v9.7.0 or higher.
 </Callout>

--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -62,6 +62,8 @@ You have three options to configure APM logs in context to send your app's logs 
   </applicationLogging>
   ```
 
+  This option can also be enabled by setting the environment variable `NEW_RELIC_APPLICATION_LOGGING_FOWARDING_ENABLED='true'`.  The environment variable value, if present, takes precedence over the config file value.
+
   This option may be on by default in a future agent version.
   
   **Optional adjustments:**
@@ -75,6 +77,8 @@ You have three options to configure APM logs in context to send your app's logs 
     <logForwarding enabled="true" maxSamplesStored="10000" />
   </applicationLogging>
   ```
+  
+  This setting can also be adjusted by setting the environment variable `NEW_RELIC_APPLICATION_LOGGING_FOWARDING_MAX_SAMPLES_STORED`.  The environment variable value, if present, takes precedence over the config file value.
 
   If you have an existing log forwarding solution and are updating your agent to use automatic logs in context, be sure to **disable your old log forwarder**. Otherwise, your app will be sending double log lines. Depending on your account, this could result in double billing. For more information, follow the procedures to disable your [specific log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding).
   
@@ -98,6 +102,8 @@ You have three options to configure APM logs in context to send your app's logs 
     <logForwarding enabled="true" />
   </applicationLogging>
   ```
+
+  This option can also be enabled by setting the environment variable `NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED='true'`.  The environment variable value, if present, takes precedence over the config file value.
 
   Our decorator adds five attributes to every log message: `entity.guid`, `entity.name`, `hostname`, `trace.id`, and  `span.id`. Example:
 


### PR DESCRIPTION
Update the new application logging feature config options for the .NET agent to include the environment variable config options.  Thanks to @Lonli-Lokli for pointing out this gap in our documentation.