### PR TITLE
chore: Update usage for start-transaction-or-segment

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
@@ -204,14 +204,12 @@ The agent will ensure that a transaction exists, and will create a segment withi
 
 ### Starting a transaction or segment [#start-transaction-or-segment]
 
-If you need to start a transaction at one location in your code but finish it in another (as can happen with callback-based events), call `Tracer.start_transaction_or_segment`. You **must** call `finish` on the return value of this method:
+If you need to start a transaction at one location in your code but finish it in another (as can happen with callback-based events), call `NewRelic::Agent::Tracer.start_transaction_or_segment`. You **must** call `finish` on the return value of this method:
 
 ```
-require 'new_relic/agent/tracer'
-
 class MyEventWatcher
   def event_started
-    @transaction = Tracer.start_transaction_or_segment(
+    @transaction = NewRelic::Agent::Tracer.start_transaction_or_segment(
       partial_name: 'MyEventWatcher/my_event',
       category:     :task)
   end
@@ -222,4 +220,4 @@ class MyEventWatcher
 end
 ```
 
-For more information, see [trace_execution_scoped in the New Relic RubyDoc](https://www.rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent/MethodTracer#trace_execution_scoped-instance_method).
+For more information, see [Tracer#start_transaction_or_segment in the New Relic RubyDoc](https://www.rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent/Tracer#start_transaction_or_segment-class_method).


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?

The latest version of the agent does not allow you to access the NewRelic::Agent::Tracer.start_transaction_or_segment method using the process previously outlined in the code example. This change updates the snippet to call the method in a way we commonly do in our playground applications. I'm not sure when this regression occurred, but it was prior to the 8.5.0 release.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  
Testing can be performed using the [Ruby Agent Playground (Internal) Multi-Threading application](https://source.datanerd.us/ruby-agent/ruby_agent_playground/tree/master/multi-threading) by running: 

```
$ cd multi-threading
$ bundle install 
$ rackup
```
and visiting `localhost:9292`. An error is raised if the old strategy is used for calls to `start_transaction_or_segment`.

* If your issue relates to an existing GitHub issue, please link to it.
N/A

cc @tannalynn, @fallwith 