### PR TITLE
fix(nr apis): fixing out of dateness

### DIFF
--- a/src/content/docs/apis/intro-apis/introduction-new-relic-apis.mdx
+++ b/src/content/docs/apis/intro-apis/introduction-new-relic-apis.mdx
@@ -6,7 +6,7 @@ tags:
   - Intro to APIs
 translate:
   - jp
-metaDescription: An introduction to all of the available New Relic APIs.
+metaDescription: "An introduction to New Relic's APIs."
 redirects:
   - /docs/apis/server-api-v2
   - /docs/apm/apis/api-v2-examples/server-examples-api-v2
@@ -68,11 +68,11 @@ New Relic offers a variety of APIs and SDKs you can use to:
 * Retrieve data from New Relic.
 * View and configure settings.
 
-This document provides examples and reference information for our APIs.
+Looking for API keys? See [API keys](/docs/apis/intro-apis/new-relic-api-keys). 
 
 ## APIs for data ingest [#data-type-apis]
 
-Our four primary data ingest APIs are some of the [many solutions for reporting data to New Relic](/docs/telemetry-data-platform/get-started/introduction-new-relic-data-ingest-apis-sdks). These APIs can be used directly, but they're also the underlying ingest route for any of our tools that use those APIs (for example, our [OpenTelemetry integration](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/introduction-opentelemetry-new-relic), or our [Telemetry SDKs](/docs/telemetry-data-platform/ingest-apis/telemetry-sdks-report-custom-telemetry-data)).
+Our four primary data ingest APIs are some of our [many solutions for reporting data](/docs/telemetry-data-platform/get-started/introduction-new-relic-data-ingest-apis-sdks). These APIs can be used directly, but they're also the underlying ingest route for many of our data-reporting tools. To get started reporting data, we recommend the [guided install](/docs/new-relic-one/install-configure/new-relic-guided-install-overview). 
 
 <table>
   <thead>
@@ -124,7 +124,7 @@ Our four primary data ingest APIs are some of the [many solutions for reporting 
       </td>
 
       <td>
-        Send [distributed tracing data](/docs/data-apis/understand-data/new-relic-data-types/#trace-data) (also referred to as "spans") to New Relic without the use of an agent or integration.
+        Send [distributed tracing data](/docs/data-apis/understand-data/new-relic-data-types/#trace-data) (`Span` data) to New Relic without the use of an agent or integration.
       </td>
     </tr>
   </tbody>
@@ -134,11 +134,11 @@ Our four primary data ingest APIs are some of the [many solutions for reporting 
 
 [NerdGraph](/docs/apis/graphql-api/getting-started/introduction-new-relic-graphql-api) is the API we recommend for querying New Relic data, querying account information, and making a range of feature configurations. To learn what you can do, check out [the NerdGraph tutorials](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/#tutorials).
 
-NerdGraph is our newest API and is our attempt to bring together in one place some of our older APIs, like our [REST API](#product-apis). Note that there is still some functionality you can do with REST APIs that can't yet be done with NerdGraph, and this is why some New Relic organizations still use the REST API.
+NerdGraph is our newest API and is our attempt to bring together in one place some of our older APIs. Note that there is still some functionality you can do with [REST APIs](#rest-api) that can't yet be done with NerdGraph, and this is why some New Relic organizations still use the REST API.
 
 ## REST API [#rest-api]
 
-Our [REST API](/docs/apis/rest-api-v2) is our older API for querying and configuration, which [NerdGraph](#graphql) is in the process of replacing. The REST API has some configuration abilities that NerdGraph doesn't yet have, but when possible you should use NerdGraph. The REST API can be used for a wide range of features: for detail, see [APIs by feature](#product-apis).
+Our [REST API](/docs/apis/rest-api-v2) is our older API for querying and configuration, which [NerdGraph](#graphql) is in the process of replacing. We are doing minimal ongoing work on the REST API. The REST API still has some configuration abilities that NerdGraph doesn't yet have, but your first choice should be to use NerdGraph because that will be where we are focusing our attention and adding features. 
 
 ## APIs by feature [#product-apis]
 
@@ -149,11 +149,7 @@ New Relic tools and features, like APM, infrastructure monitoring, browser monit
     id="alerts-api"
     title="Alerts"
   >
-    Use the [REST API for alerts](/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api/rest-api-calls-new-relic-alerts) and the API Explorer to:
-
-    * Create and manage policies, conditions, and notification channels.
-    * Create alert conditions based on NRQL queries.
-    * Create alert conditions based on data from other New Relic capabilities.
+See [Manage alerts with NerdGraph](/docs/apis/nerdgraph/examples/nerdgraph-api-alerts-policies). 
   </Collapser>
 
   <Collapser
@@ -178,15 +174,11 @@ New Relic tools and features, like APM, infrastructure monitoring, browser monit
       <tbody>
         <tr>
           <td>
-            REST API
+            Query and configure APM
           </td>
 
           <td>
-            [REST API](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2) features include:
-
-            * [Retrieve APM data](/docs/apis/rest-api-v2/application-examples-v2), including metrics, Apdex, error rates, and host data.
-            * [Report deployments](/docs/apm/new-relic-apm/maintenance/recording-deployments).
-            * [Change the app name in the UI](/docs/apis/rest-api-v2/application-examples-v2/change-alias-your-application-v2).
+            See [NerdGraph APM docs](/docs/apis/nerdgraph/examples/apm-config-nerdgraph)
           </td>
         </tr>
 
@@ -211,23 +203,14 @@ New Relic tools and features, like APM, infrastructure monitoring, browser monit
 
         <tr>
           <td>
-            Query API
+            REST API
           </td>
 
           <td>
-            To query APM data, use [NerdGraph](#nerdgraph).
+            NerdGraph is recommended over the REST API ([learn more](#graphql)). See the [REST API docs](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2). 
           </td>
         </tr>
 
-        <tr>
-          <td>
-            Account management APIs
-          </td>
-
-          <td>
-            For APIs related to accounts and subscription usage, see the [account-related APIs](#account-api).
-          </td>
-        </tr>
       </tbody>
     </table>
   </Collapser>
@@ -236,7 +219,7 @@ New Relic tools and features, like APM, infrastructure monitoring, browser monit
     id="browser-api"
     title="Browser monitoring"
   >
-    The browser API resources include:
+    Browser monitoring-related API resources include:
 
     <table>
       <thead>
@@ -269,35 +252,21 @@ New Relic tools and features, like APM, infrastructure monitoring, browser monit
 
         <tr>
           <td>
-            REST API
+            Query
           </td>
 
           <td>
-            With the [REST API](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2) you can:
-
-            * Retrieve [page load timing data](/docs/apis/rest-api-v2/browser-examples-v2/obtaining-browser-end-user-page-load-time-data-v2) and [throughput](/docs/apis/rest-api-v2/browser-examples-v2/average-browser-end-user-page-throughput-example-v2).
-            * [Add or list apps monitored by browser monitoring](/docs/apis/rest-api-v2/browser-examples-v2/adding-or-listing-browser-apps-api-v2).
-            * [Manage alerts conditions for your browser data](/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api/rest-api-calls-new-relic-alerts).
+            To query your data and configure various New Relic features, use [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph).
           </td>
         </tr>
 
         <tr>
           <td>
-            Query API
+REST API
           </td>
 
           <td>
-            To query New Relic data, use [NerdGraph](#nerdgraph).
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Account management APIs
-          </td>
-
-          <td>
-            For APIs related to accounts and subscription usage, see the [account-related APIs](#account-api).
+NerdGraph is recommended over the REST API ([learn more](#graphql)). See the [REST API docs](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2). 
           </td>
         </tr>
       </tbody>
@@ -308,7 +277,7 @@ New Relic tools and features, like APM, infrastructure monitoring, browser monit
     id="infrastructure-api"
     title="Infrastructure monitoring"
   >
-    The Infrastructure API resources include:
+    Infrastructure monitoring-related API resources include:
 
     <table>
       <thead>
@@ -326,41 +295,31 @@ New Relic tools and features, like APM, infrastructure monitoring, browser monit
       <tbody>
         <tr>
           <td>
-            Query API
+            Query your data
           </td>
 
           <td>
-            To query New Relic data, use [NerdGraph](#nerdgraph).
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Infrastructure alert API
-          </td>
-
-          <td>
-            To manage your infrastructure alerts, use the [Infrastructure alert API](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts).
+            To query your data, use [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph).
           </td>
         </tr>
 
         <tr>
           <td>
-            Integrations SDK
+            Make your own integration
           </td>
 
           <td>
-            To make your own custom integrations for reporting data to infrastructure monitoring, use the [Integrations SDK](/docs/integrations/integrations-sdk/getting-started/intro-infrastructure-integrations-sdk).
+            To make your own custom integrations for reporting data to New Relic infrastructure monitoring, use the [Flex integration](/docs/infrastructure/host-integrations/host-integrations-list/flex-integration-tool-build-your-own-integration).
           </td>
         </tr>
 
         <tr>
           <td>
-            NerdGraph
+            Configurations
           </td>
 
           <td>
-            You can use [NerdGraph (our GraphQL API)](/docs/apis/graphql-api/getting-started/introduction-new-relic-graphql-api) to query your [cloud integration data](/docs/apis/graphql-api/tutorials/access-your-cloud-integrations-new-relic-graphql-api-explorer) and make changes to cloud integration settings.
+            You can use [NerdGraph](/docs/apis/graphql-api/getting-started/introduction-new-relic-graphql-api) to query and manage your [cloud integrations](/docs/apis/graphql-api/tutorials/access-your-cloud-integrations-new-relic-graphql-api-explorer), set up alerting, and more. 
           </td>
         </tr>
       </tbody>
@@ -368,10 +327,19 @@ New Relic tools and features, like APM, infrastructure monitoring, browser monit
   </Collapser>
 
   <Collapser
+    id="logs-api"
+    title="Logs"
+  >
+For querying your data and managing your logging, see the [NerdGraph docs](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph).
+
+  </Collapser>
+
+
+  <Collapser
     id="mobile-api"
     title="Mobile monitoring"
   >
-    Mobile API resources include:
+    Mobile monitoring-related API resources include:
 
     <table>
       <thead>
@@ -399,42 +367,28 @@ New Relic tools and features, like APM, infrastructure monitoring, browser monit
             * [Android](/docs/mobile-monitoring/new-relic-mobile-android/api-guides/android-sdk-api-guide)
           </td>
         </tr>
-
         <tr>
           <td>
-            REST API
+            Query your data
           </td>
 
           <td>
-            Use the [REST API](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2) for such tasks as:
+            To query your data, use [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph).
+          </td>
+        </tr>
+        <tr>
+          <td>
+REST API
+          </td>
 
-            * [Retrieve a list of monitored apps](https://rpm.newrelic.com/api/explore/mobile_applications/list).
-            * [Get subscription usage data](/docs/apis/rest-api-v2/account-examples-v2/retrieving-account-usage-metrics-rest-api).
-            * [Get metric names and data](https://rpm.newrelic.com/api/explore/mobile_applications/metric_names).
-            * [Get crash count and crash rate data](/docs/apis/rest-api-v2/mobile-examples-v2/mobile-crash-count-crash-rate-example-v2).
-            * [Manage New Relic alerts conditions for your mobile apps](/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api/rest-api-calls-new-relic-alerts).
+          <td>
+NerdGraph is recommended over the REST API ([learn more](#graphql)). See the [REST API docs](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2). 
+
           </td>
         </tr>
 
-        <tr>
-          <td>
-            Query API
-          </td>
 
-          <td>
-            To query New Relic data, use [NerdGraph](#nerdgraph).
-          </td>
-        </tr>
 
-        <tr>
-          <td>
-            Account management APIs
-          </td>
-
-          <td>
-            For account-related APIs, see [Account APIs](#account-api).
-          </td>
-        </tr>
       </tbody>
     </table>
   </Collapser>
@@ -443,7 +397,7 @@ New Relic tools and features, like APM, infrastructure monitoring, browser monit
     id="synthetics-api"
     title="Synthetic monitoring"
   >
-    Synthetics API resources include:
+    Synthetic monitoring-related API resources include:
 
     <table>
       <thead>
@@ -459,37 +413,34 @@ New Relic tools and features, like APM, infrastructure monitoring, browser monit
       </thead>
 
       <tbody>
+
         <tr>
           <td>
-            Synthetics REST API
+            Query your data
           </td>
 
           <td>
-            The [Synthetics REST API](/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api) functionality includes:
-
-            * [Create and manage synthetics monitors](/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api).
-            * [Manage synthetics alert notifications](/docs/apis/synthetics-rest-api/alert-examples/manage-synthetics-alert-notifications-rest-api).
-            * [Add labels to monitors, and retrieve monitors with specific labels](/docs/apis/synthetics-rest-api/label-examples/use-synthetics-label-apis).
+            To query your data, use [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph).
           </td>
         </tr>
 
+
         <tr>
           <td>
-            Query API
+            Add and configure monitors
           </td>
 
           <td>
-            To query New Relic data, use [NerdGraph](#nerdgraph).
+            See [NerdGraph synthetics docs](/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial). 
           </td>
         </tr>
-
         <tr>
           <td>
-            Alerts API
+REST API
           </td>
 
           <td>
-            To create and manage alert conditions that target synthetics monitors, use the [alerts API](/docs/alerts/rest-api-alerts/new-relic-alerts-rest-api/rest-api-calls-new-relic-alerts#synthetics-conditions).
+NerdGraph is recommended over the REST API ([learn more](#graphql)). See the [REST API docs](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2). 
           </td>
         </tr>
       </tbody>
@@ -497,107 +448,3 @@ New Relic tools and features, like APM, infrastructure monitoring, browser monit
   </Collapser>
 </CollapserGroup>
 
-## Account management, admin, and usage APIs [#account-api]
-
-Like any other New Relic product or service, you want to be confident that your APIs protect you and your customers' data privacy. The following are API resources related to New Relic account administration and usage.
-
-For more information about API capabilities, see the specific [New Relic API](#product-apis). For more information about New Relic's security measures, see our [security and privacy documentation](/docs/using-new-relic/new-relic-security/security/security-matters-data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
-
-<table>
-  <thead>
-    <tr>
-      <th style={{ width: "220px" }}>
-        Resource
-      </th>
-
-      <th>
-        Details
-      </th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td id="account-rest">
-        REST API
-      </td>
-
-      <td>
-        [REST API](/docs/apis/rest-api-v2) features include:
-
-        * Find your [API keys, account ID, and information](/docs/apis/rest-api-v2/requirements) needed to use the REST API.
-        * Return a [list of account users](/docs/apis/rest-api-v2/account-examples-v2/listing-users-your-account) ([original user model](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model) only).
-        * [Get SLA report data](/docs/apm/reports/service-level-agreements/api-examples-sla-reports) for browser and application monitoring.
-      </td>
-    </tr>
-
-    <tr>
-      <td id="usage-transition">
-        Subscription usage (original pricing model)
-      </td>
-
-      <td>
-        For organizations on our original pricing model, you can use [NerdGraph](#nerdgraph) to query subscription usage data. This can be helpful to see how usage compares to your current subscription level, or for doing departmental chargebacks.
-      </td>
-    </tr>
-
-    <tr>
-      <td id="partner-account">
-        Partner API
-      </td>
-
-      <td>
-        If you're a New Relic partnership organization, you can use the [Partner API](/docs/new-relic-partnerships/partnerships/partner-api) to retrieve data and make configurations.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-## Other APIs
-
-<CollapserGroup>
-  <Collapser
-    id="insights"
-    title="Insights"
-  >
-    New Relic Insights was the name of our original product that governed custom event reporting and querying. The features associated with Insights have been rolled into our New Relic One platform ([learn more](/docs/new-relic-one/use-new-relic-one/core-concepts/transition-new-relic-one-insights)), but there are still some APIs and original pricing models that use the term "Insights" for these historical reasons.
-
-    Insights-related APIs include:
-
-    <table>
-      <thead>
-        <tr>
-          <th style={{ width: "220px" }}>
-            Resource
-          </th>
-
-          <th>
-            Details
-          </th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr>
-          <td>
-            Event API
-          </td>
-
-          <td>
-            To report custom events, use the [Event API](/docs/insights/insights-data-sources/custom-data/insert-custom-events-insights-api).
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Query API
-          </td>
-
-          <td>
-            Our Insights [Query API](/docs/insights/insights-api/get-data/query-insights-event-data-api) is mostly deprecated. Instead, use [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) for querying your New Relic data.
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </Collapser>
-</CollapserGroup>


### PR DESCRIPTION
Noticed that these were quite out of date in terms of recommending REST APIs prominently and not having nerdgraph mentioned in the 'product APIs' section. 