### PR TITLE
Remove Linux system memory bug callout

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -561,7 +561,6 @@ If your application is hosted in ASP.NET Core, the agent automatically creates a
 
 The following features are not available for the .NET agent:
 
-* [Memory usage](/docs/apm/applications-menu/monitoring/apm-overview-page#infra-server) on Linux due to [an ongoing .NET Core issue](https://github.com/dotnet/corefx/issues/23449) (try using [.NET performance metrics](/docs/agents/net-agent/other-features/net-performance-metrics) to get this information)
 * Automatic brower monitoring script injection ([API](/docs/agents/net-agent/net-agent-api/get-browser-timing-header) or [manual instrumentation](/docs/agents/net-agent/additional-installation/new-relic-browser-net-agent#manual_instrumentation) is required)
 * The .NET agent does not support [trim self-contained deployments and executables](https://docs.microsoft.com/en-us/dotnet/core/deploying/trim-self-contained), because the compiler can potentially trim assemblies that the agent depends on.
 * [Infinite Tracing](https://newrelic.com/products/edge-infinite-tracing) is not supported on Alpine Linux due to a [GRPC compatibility issue](https://github.com/grpc/grpc/issues/21446). See [this agent issue](https://github.com/newrelic/newrelic-dotnet-agent/issues/289) for more information.


### PR DESCRIPTION
A community member pointed out that we fixed the bug where the .NET agent did not report total system memory usage on Linux, and that we should remove this bug from the list of known issues on the compatibility and requirements page for .NET core applications.