### PR TITLE
Improve 'delete simple org' wording

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/create-your-new-relic-account.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/create-your-new-relic-account.mdx
@@ -50,7 +50,7 @@ Here are some next steps after signing up:
 * Start reporting data using our [**Add your data** UI](https://one.newrelic.com/launcher/nr1-core.settings)
 * [Get ideas on how to bring all your data together](/docs/using-new-relic/welcome-new-relic/get-started/introduction-new-relic/#bring-your-data)
 * [Watch New Relic University videos](https://learn.newrelic.com/)
-* If you unintentionally signed up, see [Delete account](/docs/accounts/accounts-billing/account-setup/downgradecancel-account/#cancel-simple-org)
+* If you unintentionally signed up, see [Delete account](/docs/accounts/accounts-billing/account-setup/downgradecancel-account/#cancel-unused-org)
 
 ## Add accounts to an existing New Relic organization [#existing]
 
@@ -62,4 +62,4 @@ If you're having login or password problems, see [Login troubleshooting](/docs/a
 
 ## Delete an accidental sign-up [#delete]
 
-If you've unintentionally signed up and need to delete that organization, see [Delete organization](/docs/accounts/accounts-billing/account-setup/downgradecancel-account/#cancel-simple-org).
+If you've unintentionally signed up and need to delete that organization, see [Delete organization](/docs/accounts/accounts-billing/account-setup/downgradecancel-account/#cancel-unused-org).

--- a/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
@@ -17,12 +17,13 @@ redirects:
 
 Depending on your pricing edition and other factors, we offer various options for reducing data ingest, deleting or uninstalling an agent or integration, or downgrading or cancelling your [organization](/docs/accounts/accounts-billing/new-relic-one-pricing-users/new-relic-account-structure) (your account or group of accounts).
 
-## Reduce data ingest [#remove-tools]
+## Reduce or stop data ingest [#remove-tools]
 
-If you want to stop reporting some data to New Relic without downgrading or cancelling, you can configure our tools to send less data. For how to manage data ingest, see [Manage your data](/docs/telemetry-data-platform/get-data-new-relic/manage-data/manage-your-data).
+If you want to stop reporting some data to New Relic without downgrading or cancelling, you can configure our tools to send less data. 
+
+For how to manage data ingest, see [Manage your data](/docs/telemetry-data-platform/get-data-new-relic/manage-data/manage-your-data).
 
 To uninstall agents or integrations, here are some recommended procedures:
-
 * [Remove APM, browser, and mobile apps](/docs/apm/new-relic-apm/maintenance/remove-applications-new-relic/)
 * [Remove infrastructure agent](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/uninstall-infrastructure-agent/)
 * For how to disable other New Relic tools, see their specific docs. You can [search New Relic quickstarts here](https://newrelic.com/instant-observability/).
@@ -52,7 +53,7 @@ Options for downgrading your New Relic organization will differ depending on you
 
 ## Cancel organization [#cancel]
 
-If you've accidentally signed up for New Relic and want to delete that account, see [Delete simple organization](#cancel-simple-org).
+If you've accidentally signed up for New Relic and want to delete that account, see [Delete organization](#cancel-unused-org).
 
 Other options for cancelling your organization depend on your pricing edition:
 
@@ -65,19 +66,19 @@ Other options for cancelling your organization depend on your pricing edition:
   </Collapser>
 
   <Collapser
-    id="cancel-simple-org"
-    title="Standard edition: cancel simple organization"
+    id="cancel-unused-org"
+    title="Standard edition: cancel unused organization"
   >
-    If you've created a new New Relic organization that you don't need, and if it meets some requirements (below), you can delete that organization with these steps:
+If you've created a new New Relic organization that you don't need and haven't yet set up, and if it meets some requirements (below), you can delete that organization with these steps:
 
-    1. From the [account dropdown](/docs/using-new-relic/welcome-new-relic/get-started/glossary#account-dropdown), click **Administration**.
-    2. Then click **Organization and access**.
-    3. Click **Delete organization**.
+1. From the [account dropdown](/docs/using-new-relic/welcome-new-relic/get-started/glossary#account-dropdown), click **Administration**.
+2. Then click **Organization and access**.
+3. Click **Delete organization**. If you don't see that option, it's likely because you don't meet the requirements below. 
 
-       Requirements to be able to delete your own organization:
-
-    * Organization has a single account, and single user.
-    * Is on both the new [pricing model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model#pricing-plans) and the [New Relic One user model](/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models).
+Requirements to be able to delete an organization:
+* Organization has a single account, and a single user.
+* The organization is on Standard edition and on the new [pricing model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-changes-pricing-user-model#pricing-plans)
+* The user is on the [New Relic One user model](/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models).
   </Collapser>
 
   <Collapser

--- a/src/content/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems.mdx
@@ -146,7 +146,7 @@ Some general system problems and solutions:
     id="delete-account"
     title="Delete an account you recently created."
   >
-    If you created a New Relic account unnecessarily and want to delete it, and if that account is a simple one, you may be able to delete it yourself. See [Delete simple organization](/docs/accounts/accounts-billing/account-setup/downgradecancel-account/#cancel-simple-org).
+    If you created a New Relic account unnecessarily and want to delete it, you may be able to delete it yourself. See [Delete unused organization](/docs/accounts/accounts-billing/account-setup/downgradecancel-account/#cancel-unused-org).
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
Based on customer feedback, and talking with support, changing 'simple organization' language with 'unused organization' and making it more clear that if they don't have access to that 'delete org' button, it's because they don't meet the requirements.  