### PR TITLE
feat(security): Updated intro to reflect new processes, removed FEDRA…

### DIFF
--- a/src/content/docs/security/security-privacy/compliance/key-management-encryption-rest.mdx
+++ b/src/content/docs/security/security-privacy/compliance/key-management-encryption-rest.mdx
@@ -9,13 +9,11 @@ redirects:
   - /docs/security/new-relic-security/compliance/key-management-encryption-rest
 ---
 
-Regardless of your subscription level, data that's in transit to or at rest with New Relic receives [disk-based encryption](/docs/security/security-privacy/compliance/data-encryption). This means that our default encryption methods already meet requirements for [FIPS-compliance](https://csrc.nist.gov/publications/detail/fips/140/2/final) and [FedRAMP](https://www.fedramp.gov/) accreditation.
-
-To achieve enhanced security in the past, New Relic used a two-tier security system that gave you a data encryption key (DEK) and a master key. Although you can continue to use this method, it's no longer necessary for our enhanced security.
+This doc is for legacy encryption users. If you’re not using our previous encryption method, you can read how New Relic [encrypts all data-at-rest](https://docs.newrelic.com/docs/security/security-privacy/compliance/data-encryption/). When we moved to the public cloud, New Relic changed how we encrypted data-at-rest. This change had no impact on our security posture. The details below apply to anyone still using our previous method of encryption-at-rest.
 
 ## Encryption and decryption process [#process]
 
-When you opt for in-file encryption, each new file is encrypted (AES-GCM with 256 bit keys) with a data encryption key that is unique to the account and the server writing the data. Each DEK is generated locally using a FIPS 140-2 validated cryptographic module on the server. Each account’s DEK is rotated every 24 hours or when it has been used to encrypt 64 GB of data. It can also be rotated manually, as-needed.
+Our previous  encryption-at-rest method encrypts each new file (AES-GCM with 256 bit keys) with a data encryption key that is unique to the account and the server writing the data. Each DEK is generated locally using a FIPS 140-2 validated cryptographic module on the server. Each account’s DEK is rotated every 24 hours or when it has been used to encrypt 64 GB of data. It can also be rotated manually, as-needed.
 
 The DEK that is used to encrypt a file is subsequently encrypted with the master key and appended in this wrapped format onto the encrypted data file. The key is encrypted remotely on our key management service (KMS), which is provided by [AWS](https://aws.amazon.com/kms/).
 

--- a/src/content/docs/security/security-privacy/compliance/key-management-encryption-rest.mdx
+++ b/src/content/docs/security/security-privacy/compliance/key-management-encryption-rest.mdx
@@ -9,32 +9,26 @@ redirects:
   - /docs/security/new-relic-security/compliance/key-management-encryption-rest
 ---
 
-For customers with heightened regulatory or privacy needs, New Relic offers account-based, [FIPS-compliant](https://csrc.nist.gov/publications/detail/fips/140/2/final) encryption-at-rest capabilities with unique keys per account. This protects data from inadvertent or intentional exposure, even in the event an attacker has access to the file system.
+Regardless of your subscription level, data that's in transit to or already at rest with New Relic receives [disk-based encryption](/docs/security/security-privacy/compliance/data-encryption). This means that our default encryption methods already meet requirements for [FIPS-compliance](https://csrc.nist.gov/publications/detail/fips/140/2/final) and [FedRAMP](https://www.fedramp.gov/) accreditation.
 
-It's important to maintain both a high level of protection and also optimal performance and long-term storage and retrieval of data. To do this, New Relic uses a two-tier system consisting of a data encryption key (DEK) and a master key, each with separate usage, storage, and rotation policies.
-
-For an overview of how we handle your data in transit and at rest, including details about the key management process for data encryption, see [data encryption documentation](/docs/security/new-relic-security/compliance/data-encryption).
+You'll still receive support if you've opted for the two-tier system that uses a data encryption key (DEK) and a master key, but it's no longer necessary for anyone wanting enhanced security.  
 
 ## Encryption and decryption process [#process]
 
-When encryption at rest is enabled for an account, each new file is encrypted (AES-GCM with 256 bit keys) with a data encryption key that is unique to the account and the server writing the data. Each DEK is generated locally using a FIPS 140-2 validated cryptographic module on the server. Each account’s DEK is rotated every 24 hours or when it has been used to encrypt 64 GB of data. It can also be rotated manually, as-needed.
+When you opt for in-file encryption, each new file is encrypted (AES-GCM with 256 bit keys) with a data encryption key that is unique to the account and the server writing the data. Each DEK is generated locally using a FIPS 140-2 validated cryptographic module on the server. Each account’s DEK is rotated every 24 hours or when it has been used to encrypt 64 GB of data. It can also be rotated manually, as-needed.
 
-The DEK that is used to encrypt a file is subsequently encrypted with the Master Key and appended in this wrapped format onto the encrypted data file. The key is encrypted remotely on our key management service (KMS), which is provided by [AWS](https://aws.amazon.com/kms/).
+The DEK that is used to encrypt a file is subsequently encrypted with the master key and appended in this wrapped format onto the encrypted data file. The key is encrypted remotely on our key management service (KMS), which is provided by [AWS](https://aws.amazon.com/kms/).
 
 In order to read a file, the process is reversed: First, the [NRDB](/docs/telemetry-data-platform/get-started/nrdb-horsepower-under-hood/) host on which the data resides extracts the wrapped DEK from the file and sends it to the KMS to be decrypted (unwrapped). Finally, the host decrypts the data file and processes it.
 
 ## Key rotation [#rotation]
 
-To prevent ciphertext attacks, a new data encryption key is generated for each account when the existing DEK has been used to encrypt 64 GB of data or every 24 hours if the data threshold is not met before then.
+A new data encryption key is generated for each account when the existing DEK has been used to encrypt 64 GB of data, or every 24 hours if the data threshold is not met before then.
 
-The master key is used only to encrypt DEKs, so a ciphertext attack against it is improbable. In compliance with FIPS guidelines, the KMS automatically rotates the master key once a year. Each New Relic region contains a single master key, which is never transmitted out of the KMS.
+The master key is used only to encrypt DEKs, so a ciphertext attack against it is unlikely. In compliance with FIPS guidelines, the KMS automatically rotates the master key once a year. Each New Relic region contains a single master key, which is never transmitted out of the KMS.
 
 ## Key handling
 
 New Relic servers generate each DEK locally, and the plain text DEK is never written to disk. If an attacker gained access to process memory, they could retrieve the unencrypted DEK for that server and time period, but they would be unable to read data from any other time periods.
 
-The Master key is generated, stored, and used within a FIPS 140-2 validated hardware security module (HSM) on the KMS. Neither New Relic nor AWS employees can retrieve the plain text of the master key. Secure generation, management, backup, storage, and destruction are all handled and guaranteed by the KMS. Administrator access to key management functions is controlled and audited using AWS permissions and CloudTrail.
-
-## FedRAMP authorization [#fedramp]
-
-In addition to our usual review process for security-critical components, New Relic’s encryption system has been reviewed by a third party and found to meet all requirements of [NIST SC-28(1)](https://nvd.nist.gov/800-53/Rev4/control/SC-28) Protection of Information at Rest, [SC-12(3)](https://nvd.nist.gov/800-53/Rev4/control/SC-12) Cryptographic Key Establishment and Management, and [SC-13](https://nvd.nist.gov/800-53/Rev4/control/SC-13) Cryptographic Protection. It is approved as part of our authorization for [FedRAMP Moderate](https://marketplace.fedramp.gov/#/product/new-relic?sort=productName&productNameSearch=new%20relic) impact.
+The master key is generated, stored, and used within a FIPS 140-2 validated hardware security module (HSM) on the KMS. Neither New Relic nor AWS employees can retrieve the plain text of the master key. Secure generation, management, backup, storage, and destruction are all handled and guaranteed by the KMS. Administrator access to key management functions is controlled and audited using AWS permissions and CloudTrail.

--- a/src/content/docs/security/security-privacy/compliance/key-management-encryption-rest.mdx
+++ b/src/content/docs/security/security-privacy/compliance/key-management-encryption-rest.mdx
@@ -9,9 +9,9 @@ redirects:
   - /docs/security/new-relic-security/compliance/key-management-encryption-rest
 ---
 
-Regardless of your subscription level, data that's in transit to or already at rest with New Relic receives [disk-based encryption](/docs/security/security-privacy/compliance/data-encryption). This means that our default encryption methods already meet requirements for [FIPS-compliance](https://csrc.nist.gov/publications/detail/fips/140/2/final) and [FedRAMP](https://www.fedramp.gov/) accreditation.
+Regardless of your subscription level, data that's in transit to or at rest with New Relic receives [disk-based encryption](/docs/security/security-privacy/compliance/data-encryption). This means that our default encryption methods already meet requirements for [FIPS-compliance](https://csrc.nist.gov/publications/detail/fips/140/2/final) and [FedRAMP](https://www.fedramp.gov/) accreditation.
 
-You'll still receive support if you've opted for the two-tier system that uses a data encryption key (DEK) and a master key, but it's no longer necessary for anyone wanting enhanced security.  
+To achieve enhanced security in the past, New Relic used a two-tier security system that gave you a data encryption key (DEK) and a master key. Although you can continue to use this method, it's no longer necessary for our enhanced security.
 
 ## Encryption and decryption process [#process]
 


### PR DESCRIPTION
Some updates in New Relic encryption methods have rolled out since this doc was last edited. After talking a SME, it was decided to:

- Shorten the intro
- Remove mentions of enhanced security
- Remove FedRAMP section

The biggest concern with this doc is letting customers know that it's no longer necessary to do extra procedures for "enhanced security," as they already receive that as soon as they engage New Relic for data storage. We are keeping the doc live because we will still provide support for existing customers using the two-tiered system. 