### PR TITLE
chore: Update `manual_start` instructions

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/background-jobs/monitor-ruby-background-processes.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/background-jobs/monitor-ruby-background-processes.mdx
@@ -85,12 +85,20 @@ As an example, a background job periodically runs a task called `SalesOrganizati
 
 Make sure the process isn't running before the agent connects to the back-end servers. To do so, make the Ruby agent synchronously connect to New Relic, rather than the default asynchronous behavior.
 
-Use [`manual_start`](https://www.rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic%2FAgent%3Amanual_start) and pass in the `:sync_startup => true` option:
+First, in your Gemfile, add `require: false` to the end of your `newrelic_rpm` gem installation: 
+
+```
+gem 'newrelic_rpm', require: false
+```
+
+Then, call [`manual_start`](https://www.rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic%2FAgent%3Amanual_start) and pass in the `:sync_startup => true` option:
 
 ```
 require 'new_relic/agent'
 NewRelic::Agent.manual_start(:sync_startup => true)
 ```
+
+**Note:** Most configuration options can be passed to manual start.
 
 Using `require 'new_relic/agent'` will require the agent's code, and it will make sure the agent doesn't run until you manually start it.
 


### PR DESCRIPTION


## Give us some context

* What problems does this PR solve?
Adds a suggestion to update Gemfile to use `require: false` and let customers know they can set most configuration options there.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
Remove the `newrelic.yml` file from an application, update the gem installation, and try to install it manually by using `manual_start` with some additional configs, such as license key.

* If your issue relates to an existing GitHub issue, please link to it.
N/A... sorta this one: https://github.com/newrelic/newrelic-ruby-agent/issues/1050 