### PR TITLE
feat: Add documentation for CodeStream apache2 reverse proxy issues 

### DIFF
--- a/src/content/docs/codestream/troubleshooting/reverse-proxy.mdx
+++ b/src/content/docs/codestream/troubleshooting/reverse-proxy.mdx
@@ -1,0 +1,18 @@
+---
+title: Issues with Reverse Proxy
+metaDescription: "How to configure apache2 reverse proxy to work with Gitlab"
+---
+
+When opening Merge Requests in CodeStream you may get a `404 Not Found` error. GitLab group / project URLs are
+generated with an encoded forward slash which isn't handled by the default apache2 reverse proxy. In order to allow
+apache2 to successfully resolve these URLs add the following to your apache2 config:
+
+* Add the AllowEncodedSlashes
+* Add `nocanon` to the end of your ProxyPass line
+
+For example:
+
+```
+AllowEncodedSlashes NoDecode
+ProxyPass / http://33.211.55.3:9000/ nocanon
+```

--- a/src/nav/codestream.yml
+++ b/src/nav/codestream.yml
@@ -24,7 +24,7 @@ pages:
       - title: Monitor performance
         path: /docs/codestream/how-use-codestream/performance-monitoring
       - title: UI overview and shortcuts
-        path: /docs/codestream/how-use-codestream/ui-overview  
+        path: /docs/codestream/how-use-codestream/ui-overview
   - title: CodeStream integrations
     pages:
       - title: Slack and CodeStream
@@ -57,3 +57,5 @@ pages:
         path: /docs/codestream/troubleshooting/keychain-issues
       - title: Proxy issues
         path: /docs/codestream/troubleshooting/proxy-support
+      - title: Reverse proxy
+        path: /docs/codestream/troubleshooting/reverse-proxy


### PR DESCRIPTION

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Adding documentation to CodeStream troubleshooting section for handling a GitLab / apache2 reverse proxy issue. 

https://github.com/TeamCodeStream/codestream/issues/495
