### PR TITLE
fix(style guide): Add color around agent vs integration

### DIFF
--- a/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
@@ -34,7 +34,7 @@ For consistency across New Relic content, here are our general word usage guidel
 
     * Don't capitalize: use `the Ruby agent`, not `the Ruby Agent`.
     * Don't refer to a synthetics [`private minion`](/docs/synthetics/new-relic-synthetics/private-locations/install-configure-private-minions) as an `agent`.
-    * With regards to how `agents` relate `integrations`: An integration is anything not built by New Relic that we can inter-operate with. That could be something we monitor, an alerting service like PagerDuty, a service that pulls data from our APIs, etc. Agents are software that enable one or more  integrations. For example, our APM agents have integrations with various app frameworks and web servers and types of databases. One way to frame this is: "The integrations included with our agents are just some of [our many integrations](https://newrelic.com/instant-observability)" or "Our agent-based integrations..."
+    * With regards to how `agents` relate to `integrations`: An integration is anything not built by New Relic that we can inter-operate with. That could be something we monitor, an alerting service like PagerDuty, a service that pulls data from our APIs, etc. Agents are software that enable one or more integrations. For example, our APM agents have integrations with various app frameworks and web servers and types of databases. One way to frame this is: "The integrations included with our agents are just some of [our many integrations](https://newrelic.com/instant-observability)" or "Our agent-based integrations..."
   </Collapser>
 
   <Collapser

--- a/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
@@ -32,9 +32,9 @@ For consistency across New Relic content, here are our general word usage guidel
 
     Style guidelines:
 
-    * Don't capitalize: use "the Ruby agent," not "the Ruby Agent."
+    * Don't capitalize: use `the Ruby agent`, not `the Ruby Agent`.
     * Don't refer to a synthetics [`private minion`](/docs/synthetics/new-relic-synthetics/private-locations/install-configure-private-minions) as an `agent`.
-    * With regards to how the concept of "agents" relate to the concept of "integrations": agents can be understood as containing various integrations. For example, our APM agents have integrations with various app frameworks and web servers and types of databases. One way to frame this is: "The integrations included with our agents are just some of [our many integrations](https://newrelic.com/instant-observability)" or "Our agent-based integrations..."
+    * With regards to how `agents` relate `integrations`: An integration is anything not built by New Relic that we can inter-operate with. That could be something we monitor, an alerting service like PagerDuty, a service that pulls data from our APIs, etc. Agents are software that enable one or more  integrations. For example, our APM agents have integrations with various app frameworks and web servers and types of databases. One way to frame this is: "The integrations included with our agents are just some of [our many integrations](https://newrelic.com/instant-observability)" or "Our agent-based integrations..."
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
Just adding a bit more context on the distinctions and usage. And changing quotes into code.