### PR TITLE
feat: new circleci guide (DOC-7895)

### DIFF
--- a/src/content/docs/integration-guide/circleci-guide.mdx
+++ b/src/content/docs/integration-guide/circleci-guide.mdx
@@ -1,0 +1,57 @@
+---
+title: "Push CircleCI logs to New Relic"
+metaDescription: Integrate your CircleCI data with New Relic Observability.
+tags:
+  - CircleCI
+  - Instant Observability
+  - Logs
+  - Logpush
+  - CICD
+---
+
+Configure the [CircleCI Webhook](https://circleci.com/docs/2.0/webhooks/) service to send CICD Logs to New Relic.
+
+
+## Set up webhook trigger in CircleCI
+
+To set up a CircleCI webhook logpush to New Relic:
+
+1. Log in to [CircleCI](https://app.circleci.com/projects)
+
+2. Visit a specific project you have setup on CircleCI.
+
+3. Click on Project Settings.
+
+4. In the sidebar of your Project Settings, click on Webhooks.
+
+5. Click Add Webhook.
+
+6. Fill out the name of the webhook.
+
+7. Enter New Relic's **Logs Endpoint**:
+
+   US: `"https://log-api.newrelic.com/log/v1?Api-Key=<NR_LICENSE_KEY>"`
+
+   EU: `"https://log-api.eu.newrelic.com/log/v1?Api-Key=<NR_LICENSE_KEY>"`
+
+   Use the region you set on your New Relic account. Replace `<NR_LICENSE_KEY>` with your New Relic license key, which you can [retrieve from the UI or API](/docs/apis/intro-apis/new-relic-api-keys/#manage-license-key).
+
+8. Select either Workflow or Job, depending on which event you want to trigger the logpush from.
+
+9. Provided your receiving API or third party service is set up, click Test Ping Event to dispatch a test event.
+
+## What's next
+
+
+
+* Go to the [CircleCI quickstart](https://newrelic.com/instant-observability/circleci/39109d3d-b1d8-4366-8ca9-b8925005f727) in New Relic Instant Observability, and click **+ Install quickstart**.
+
+* Learn more about the integration by reading the blog post: [Integrations for CI-CD Analytics](https://newrelic.com/blog/nerdlog/integrations-for-ci-cd-analytics)
+
+* Explore logging data across your platform with our [Logs UI](/docs/logs/log-management/ui-data/use-logs-ui/).
+
+* Get deeper visibility into both your application and your platform performance data by forwarding your logs with our [logs in context](/docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-apm-agents/) capabilities.
+
+* Set up [alerts](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions/).
+
+* [Query your data](/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data/) and [create dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/).

--- a/src/content/docs/logs/forward-logs/circleci-logs.mdx
+++ b/src/content/docs/logs/forward-logs/circleci-logs.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Forward CircleCI logs to New Relic"
-metaDescription: "Integrate your CircleCI data with New Relic observability.""
+metaDescription: "Integrate your CircleCI data with New Relic observability."
 tags:
   - CircleCI
   - Instant Observability

--- a/src/content/docs/logs/forward-logs/circleci-logs.mdx
+++ b/src/content/docs/logs/forward-logs/circleci-logs.mdx
@@ -19,7 +19,7 @@ Complete these steps to set up a CircleCI webhook to forward your logs to New Re
 
 2. Go to one of your CircleCI projects.
 
-3. Click **Project Settings**.
+3. Click **Project settings**.
 
 4. In the sidebar of your Project Settings, click **Webhooks**.
 

--- a/src/content/docs/logs/forward-logs/circleci-logs.mdx
+++ b/src/content/docs/logs/forward-logs/circleci-logs.mdx
@@ -19,7 +19,7 @@ Complete these steps to set up a CircleCI webhook to forward your logs to New Re
 
 2. Go to one of your CircleCI projects.
 
-3. Click **Project settings**.
+3. Click **Project Settings**.
 
 4. In the sidebar of your Project Settings, click **Webhooks**.
 

--- a/src/content/docs/logs/forward-logs/circleci-logs.mdx
+++ b/src/content/docs/logs/forward-logs/circleci-logs.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Push CircleCI logs to New Relic"
-metaDescription: Integrate your CircleCI data with New Relic Observability.
+title: "Forward CircleCI logs to New Relic"
+metaDescription: "Integrate your CircleCI data with New Relic observability.""
 tags:
   - CircleCI
   - Instant Observability
@@ -9,24 +9,23 @@ tags:
   - CICD
 ---
 
-Configure the [CircleCI Webhook](https://circleci.com/docs/2.0/webhooks/) service to send CICD Logs to New Relic.
+Configure the [CircleCI webhook](https://circleci.com/docs/2.0/webhooks/) service to send CI/CD Logs to New Relic.
 
+## Set up a webhook trigger in CircleCI [#setup]
 
-## Set up webhook trigger in CircleCI
+Complete these steps to set up a CircleCI webhook to forward your logs to New Relic:
 
-To set up a CircleCI webhook logpush to New Relic:
+1. Log in to [CircleCI](https://app.circleci.com/projects).
 
-1. Log in to [CircleCI](https://app.circleci.com/projects)
+2. Go to one of your CircleCI projects.
 
-2. Visit a specific project you have setup on CircleCI.
+3. Click **Project Settings**.
 
-3. Click on Project Settings.
+4. In the sidebar of your Project Settings, click **Webhooks**.
 
-4. In the sidebar of your Project Settings, click on Webhooks.
+5. Click **Add Webhook**.
 
-5. Click Add Webhook.
-
-6. Fill out the name of the webhook.
+6. Name your webhook.
 
 7. Enter New Relic's **Logs Endpoint**:
 
@@ -36,22 +35,15 @@ To set up a CircleCI webhook logpush to New Relic:
 
    Use the region you set on your New Relic account. Replace `<NR_LICENSE_KEY>` with your New Relic license key, which you can [retrieve from the UI or API](/docs/apis/intro-apis/new-relic-api-keys/#manage-license-key).
 
-8. Select either Workflow or Job, depending on which event you want to trigger the logpush from.
+8. Select either **Workflow** or **Job**, depending on the type of event you want to trigger the logpush.
 
-9. Provided your receiving API or third party service is set up, click Test Ping Event to dispatch a test event.
+9. If you've set up your receiving API or third-party service, click **Test Ping Event** to create a test event.
 
-## What's next
-
-
+## What's next [#next]
 
 * Go to the [CircleCI quickstart](https://newrelic.com/instant-observability/circleci/39109d3d-b1d8-4366-8ca9-b8925005f727) in New Relic Instant Observability, and click **+ Install quickstart**.
-
-* Learn more about the integration by reading the blog post: [Integrations for CI-CD Analytics](https://newrelic.com/blog/nerdlog/integrations-for-ci-cd-analytics)
-
+* Learn more about the integration in this blog post: [Integrations for CI-CD Analytics](https://newrelic.com/blog/nerdlog/integrations-for-ci-cd-analytics)
 * Explore logging data across your platform with our [Logs UI](/docs/logs/log-management/ui-data/use-logs-ui/).
-
 * Get deeper visibility into both your application and your platform performance data by forwarding your logs with our [logs in context](/docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-apm-agents/) capabilities.
-
 * Set up [alerts](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions/).
-
 * [Query your data](/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data/) and [create dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/).

--- a/src/nav/logs.yml
+++ b/src/nav/logs.yml
@@ -21,6 +21,8 @@ pages:
         path: /docs/logs/forward-logs/aws-lambda-sending-logs-s3
       - title: AWS Lambda for CloudWatch logs
         path: /docs/logs/forward-logs/aws-lambda-sending-cloudwatch-logs
+      - title: CircleCI logs
+        path: /docs/logs/forward-logs/circleci-logs.mdx
       - title: Cloudflare Logpush 
         path: /docs/logs/forward-logs/cloudflare-logpush-forwarding
       - title: Fluentd plugin

--- a/src/nav/logs.yml
+++ b/src/nav/logs.yml
@@ -22,7 +22,7 @@ pages:
       - title: AWS Lambda for CloudWatch logs
         path: /docs/logs/forward-logs/aws-lambda-sending-cloudwatch-logs
       - title: CircleCI logs
-        path: /docs/logs/forward-logs/circleci-logs.mdx
+        path: /docs/logs/forward-logs/circleci-logs/
       - title: Cloudflare Logpush 
         path: /docs/logs/forward-logs/cloudflare-logpush-forwarding
       - title: Fluentd plugin


### PR DESCRIPTION
New guide for circleci/new relic integration.

IMPORTANT: I need help from the dev team to decide where this lives both in the repo and in the website as a whole.

A lot of the template I used came from the existing [cloudflare doc](https://docs.newrelic.com/docs/logs/forward-logs/cloudflare-logpush-forwarding/) since this is a very similar page, only for CircleCI. 

The guide covers 2 main areas:
1. how to set up a circleCI webhook to send logs to new relic
2. what you can do in New Relic with those logs (mainly the quickstart already built)