### PR TITLE
Added PATHEXT env var example for Windows Hosts

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -1595,6 +1595,16 @@ If the agent is running in a cloud instance, the agent will try to detect the cl
     ```
     NRIA_PASSTHROUGH_ENVIRONMENT="HOST,PORT,NRIA_.*"
     ```
+    
+    For Windows Hosts:
+    PATHEXT is an environment variable of MS Windows. The function is to determine which file extensions mark files, that are executable from every commandline. This will resolve any errors reporting '... is not recognized as the name of a cmdlet, function, script file..." for common Flex integrations:
+    
+    ```
+    passthrough_environment:
+      - PATHEXT
+    ```
+    
+    
   </Collapser>
 
   <Collapser

--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -1596,8 +1596,8 @@ If the agent is running in a cloud instance, the agent will try to detect the cl
     NRIA_PASSTHROUGH_ENVIRONMENT="HOST,PORT,NRIA_.*"
     ```
     
-    For Windows Hosts:
-    PATHEXT is an environment variable of MS Windows. The function is to determine which file extensions mark files, that are executable from every commandline. This will resolve any errors reporting '... is not recognized as the name of a cmdlet, function, script file..." for common Flex integrations:
+    For Windows hosts:
+    `PATHEXT` is an MS Windows environment variable. The function is to determine which file extensions mark files that are executable from every command line. This will resolve any errors reporting '... is not recognized as the name of a cmdlet, function, script file..." for common Flex integrations:
     
     ```
     passthrough_environment:


### PR DESCRIPTION
Recently discovered solution for common Flex integration issue on Windows Hosts running infra agent 1.20.4+ and certain Powershell scripts. Will be adding to Flex docs as well.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.