### PR TITLE
chore: Use current name for setting

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/background-jobs/rake-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/background-jobs/rake-instrumentation.mdx
@@ -31,7 +31,7 @@ rake:
   tasks: ["deploy", "deploy:all"]
 ```
 
-Since task name matching is with regex, you can instrument all of your app's Rake tasks by using a wildcard regex like `[".+"]`. However, this will not include Rake tasks that are in your deny list by default from the [`autostart.blacklisted_rake_tasks`](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#autostart-blacklisted_rake_tasks) configuration setting, such as `db:migrate`.
+Since task name matching is with regex, you can instrument all of your app's Rake tasks by using a wildcard regex like `[".+"]`. However, this will not include Rake tasks that are in your deny list by default from the [`autostart.denylisted_rake_tasks`](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#autostart-denylisted_rake_tasks) configuration setting, such as `db:migrate`.
 
 * To include any Rake tasks that are in your deny list by default, include them in your customized deny list.
 * To ensure the tasks are instrumented before they run if you are using Rails but your Rake task does not require the Rails environment, add `require 'tasks/newrelic'` to the top of the Rake tasks.


### PR DESCRIPTION
## Give us some context
I'm not sure when this changed, but the setting is now called `autostart.denylisted_rake_tasks`

## Relates to
https://github.com/newrelic/newrelic-ruby-agent/issues/1087 