### PR TITLE
Changed URL for "Scripted browser reference"

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors.mdx
@@ -16,7 +16,7 @@ redirects:
   - /docs/synthetics/synthetic-monitoring/scripting-monitors
 ---
 
-You can use synthetic monitoring's [scripted browsers](/docs/synthetics/new-relic-synthetics/getting-started/types-synthetics-monitors) to emulate and monitor a custom user experience by scripting browsers that navigate your website, take specific actions, and ensure specific elements are present. For a list of all available functions, see [Scripted browser reference](/docs/synthetics/new-relic-synthetics/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050).
+You can use synthetic monitoring's [scripted browsers](/docs/synthetics/new-relic-synthetics/getting-started/types-synthetics-monitors) to emulate and monitor a custom user experience by scripting browsers that navigate your website, take specific actions, and ensure specific elements are present. For a list of all available functions, see [Scripted browser reference](/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100/).
 
 Scripted monitors are driven by [Selenium WebDriverJS](https://seleniumhq.github.io/selenium/docs/api/javascript/index.html). Each time your script runs, New Relic creates a fully virtualized Selenium-driven Google Chrome browser that navigates your website and follows each step of the script. Synthetic monitoring includes an IDE-style script editor what suggests functions, locators, and other elements to simplify scripting.
 


### PR DESCRIPTION
Link pointed to non-existent URL. Changed link to point to latest scripted browser reference page (Chrome 100, which has links to reference for previous agents as well)

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.