### PR TITLE
fix(oma-data-gov): Added MobileRequest to NrConsumption table

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/dg-baselining.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/dg-baselining.mdx
@@ -212,7 +212,7 @@ Understand exactly which groups within the org are contributing which types of d
           </td>
 
           <td>
-            `Mobile`, `MobileRequestError`, `MobileSession`, `MobileHandleException`, `MobileCrash`
+            `Mobile`, `MobileRequest`, `MobileRequestError`, `MobileSession`, `MobileHandleException`, `MobileCrash`
           </td>
 
           <td>


### PR DESCRIPTION
I found one missing event type in the NrConsumption to Event table.  This was an glaring omission.