### PR TITLE
fix(Synthetics): Added redirect for a broken link

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime.mdx
@@ -5,6 +5,8 @@ tags:
   - Synthetic monitoring
   - Runtime conversion
 metaDescription: "Synthetic monitoring's new runtime requires that you make some changes to your already existing monitors."
+redirects: 
+  - /docs/synthetics/synthetic-monitoring/getting-started/new-runtime
 ---
 
 Synthetic monitoring has a new runtime available for your public locations. We recommend updating your synthetic monitors that were created using the legacy runtime to take advantage of the new runtime's capabilities.  By converting from the legacy runtime to the new runtime, you improve the backend environment that your public monitors execute from.


### PR DESCRIPTION
The broken link was: https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/getting-started/new-runtime

To test it, go to this page https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/scripting-monitors/custom-timing-details/ in the preview and click the link in the top callout.