### PR TITLE
Change installation step order

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
@@ -55,22 +55,22 @@ To install the infrastructure monitoring agent, follow the step-by-step instruct
          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
        ```
 
-    3. Create the configuration file and add your [license key](/docs/accounts-partnerships/accounts/account-setup/license-key/):
-
-       ```
-         echo "license_key: YOUR_LICENSE_KEY" | sudo tee -a /usr/local/etc/newrelic-infra/newrelic-infra.yml
-       ```
-
-    4. Then, open the terminal and run the following command:
+    3. Then, open the terminal and run the following command:
 
        ```
          brew install newrelic/tap/newrelic-infra-agent -q
        ```
 
-    5. Start the infrastructure agent service:
+    4. Start the infrastructure agent service:
 
        ```
          brew services start newrelic-infra-agent
+       ```
+    
+    5. Create the configuration file and add your [license key](/docs/accounts-partnerships/accounts/account-setup/license-key/):
+
+       ```
+         echo "license_key: YOUR_LICENSE_KEY" | sudo tee -a /usr/local/etc/newrelic-infra/newrelic-infra.yml
        ```
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
## Give us some context

I tried to install the infrastructure agent on my Mac using the provided steps, however, an error was raised when I tried to do them in the order originally listed: 

```
tee: /usr/local/etc/newrelic-infra/newrelic-infra.yml: No such file or directory
```

This PR changes the steps to be listed in the order that was successful for me.

I was attempting to install the infrastructure agent on my Mac to run a test for the Ruby agent.