### PR TITLE
Update statsd-monitoring-integration-version-2.mdx

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
@@ -98,6 +98,7 @@ Here are examples of Kubernetes manifests for deployment and service objects:
           labels:
             app: newrelic-statsd
         spec:
+          serviceAccountName: newrelic-statsd
           containers:
           - name: newrelic-statsd
             image: newrelic/nri-statsd:latest
@@ -128,6 +129,17 @@ Here are examples of Kubernetes manifests for deployment and service objects:
       selector:
         app: newrelic-statsd
     ```
+    
+    **service-account.yml**:
+    
+    ```
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: newrelic-statsd
+      namespace: default
+    ```
+
 
     For configuration details, see [Kubernetes configuration](#k8s-config).
   </Collapser>


### PR DESCRIPTION
To allow integrations with Consul- Hashicorp

The service name registered in Consul will be set to the name of the Kubernetes service associated with the Pod. 
This can be customised with the consul.hashicorp.com/connect-service annotation. 
If using ACLs, this name must be the same as the Pod's ServiceAccount name.

The service account name on the deployment must match the name of the Kubernetes Service or the consul.hashicorp.com/connect-service annotation, default would not match the service name newrelic-statsd.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.