### PR TITLE
Remove link to old TOC page for APIs

### DIFF
--- a/src/content/docs/data-apis/ingest-apis/telemetry-sdks-report-custom-telemetry-data.mdx
+++ b/src/content/docs/data-apis/ingest-apis/telemetry-sdks-report-custom-telemetry-data.mdx
@@ -18,7 +18,7 @@ redirects:
   - /docs/data-apis/ingest-apis
 ---
 
-Our Telemetry SDKs are an open source set of API client libraries that send data to the New Relic platform. Under the hood, these SDKs rely on our primary [data ingest APIs](/docs/data-apis/ingest-apis): the Metric API, Trace API, Log API, and Event API.
+Our Telemetry SDKs are an open source set of API client libraries that send data to the New Relic platform. Under the hood, these SDKs rely on our primary data ingest APIs: the Metric API, Trace API, Log API, and Event API.
 
 If our [pre-built solutions](https://newrelic.com/instant-observability) don't meet your needs, our Telemetry SDKs are one way to create a custom telemetry solution (see other [solutions for reporting custom data](/docs/data-apis/custom-data/intro-custom-data)).
 


### PR DESCRIPTION
This PR closes GitHub issue #7168 that points out we had a link to an old table of contents page for all the APIs. Since this no longer exists, I removed the link.