### PR TITLE
feat(aws): percentiles in stream

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
@@ -200,6 +200,24 @@ Follow these steps in order to browse and import dashboards:
 
 Have an interesting dashboard to share with the community? See [contribution guidelines](https://github.com/newrelic/newrelic-quickstarts#getting-started) in the Instant Observability Github repository.
 
+## Custom metrics and percentiles [#custom-metrics]
+
+The CloudWatch metric stream integration will automatically ingest new metrics configured in the stream, including custom metrics and percentiles.
+
+### Custom metrics
+To ingest CloudWatch custom metrics, make sure your custom namespace is visible in the CloudWatch metric stream configuration and it's not being filtered with inclusion or exclusion rules.  
+
+### Percentiles
+AWS CloudWatch allow customers to [define additional statistics](https://aws.amazon.com/about-aws/whats-new/2022/04/amazon-cloudwatch-metric-streams-additional-statistics/), including percentiles. 
+Follow these steps to add percentiles to any metric available in the CloudWatch stream:
+1. On AWS side, update the CloudWatch stream configuration (via API, cli or AWS Console) with required percentiles in the `StatisticConfiguration` setting. In example, it is possible to add p90, p95 and p99 percentiles to the `ELB latency metric (aws.elb.Latency)`.
+2. After few minutes, the new statistic should be made available in the stream and ingested by New Relic. Percentiles can be queried using this naming convention:
+  ```
+    From Metric select max(aws.elb.Latency.p99) where collector.name = 'cloudwatch-metric-streams' timeseries
+  ```
+Although AWS supports other statistics in the stream (beyond percentiles), those are not made available in the Open Telemetry export format (only JSON) and are currently not supported by New Relic.
+Learn more about pricing, limitations and advance configurations from the [AWS documentation](https://aws.amazon.com/about-aws/whats-new/2022/04/amazon-cloudwatch-metric-streams-additional-statistics/).
+
 ## Manage your data [#manage-data]
 
 New Relic provides a [set of tools](/docs/telemetry-data-platform/ingest-manage-data/manage-data/manage-your-data/) to keep track of the data being ingested in your account. Go to **Manage your data** in the settings menu to see all details. Metrics ingested from AWS Metric Streams integrations are considered in the **Metric** bucket.

--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
@@ -39,7 +39,7 @@ Our current system, which relies on individual integrations, runs on a polling f
       <td>
         **All CloudWatch metrics from all AWS services and custom namespaces are available** in New Relic at once, without needing a specific integration to be built or updated.
 
-        There are two exceptions: percentiles and a small number of metrics that are made available to CloudWatch with more than 2 hours delay, and therefore not included in the stream.
+        There's one exception: metrics that are made available to CloudWatch with more than 2 hours delay are not included in the stream.
       </td>
     </tr>
 

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-aws-stream-percentiles.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/new-aws-stream-percentiles.mdx
@@ -1,0 +1,10 @@
+---
+title: 'Percentiles in AWS CloudWatch metric streams'
+subject: Cloud integrations
+releaseDate: '2022-04-19'
+---
+
+### New
+
+* AWS CloudWatch metric stream now supports [adding percentile statistics](https://aws.amazon.com/about-aws/whats-new/2022/04/amazon-cloudwatch-metric-streams-additional-statistics/) to CloudWatch metrics. The New Relic CloudWatch metric stream integration has been updated in order to automatically ingest percentiles defined in metric streams.
+Learn more about this capability from the [CloudWatch metric stream integration documentation](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup#custom-metrics).


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* AWS released a new capability in CloudWatch that let customers add percentile statistics to metrics. 
* New Relic updated the CloudWatch metric stream integration to ingest percentiles. 