### PR TITLE
docs: add latest NR for iOS 3.86.1 release note

### DIFF
--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3861.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-3861.mdx
@@ -1,0 +1,19 @@
+---
+subject: Mobile app for iOS
+releaseDate: '2022-04-20'
+version: 3.86.1
+downloadLink: 'https://apps.apple.com/app/id594038638'
+---
+
+### Notes
+
+Now view the third party visualization NRQL status widget within dashboards!
+
+### New features
+
+* Added in support for the NRQL status third party visualization
+
+### Improvements
+
+* Fixed a bug that prevented summary values from showing
+* Fixed a bug with the NRQL editor on iPad


### PR DESCRIPTION
Latest release note for the New Relic for iOS mobile app.
