### PR TITLE
Expands out missing .NET log decoration documentation

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3181,7 +3181,7 @@ The `applicationLogging` element supports the following attributes and sub-eleme
     id="localDecorating"
     title="Local log decoration"
   >
-    Use this sub-element to enable decoration of your application's logs with New Relic linking metadata. The default value of attribute `enabled` is `false`.
+    Use this sub-element to enable decoration of your application's logs with New Relic linking metadata. The default value of attribute `enabled` is `false`.  Some additional configuration changes are required for local log decoration, please see [.NET: Configure logs in context](/docs/logs/logs-context/net-configure-logs-context-all#2-decorate) for more information.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -93,6 +93,10 @@ You have three options to configure APM logs in context to send your app's logs 
 
   This option should not be used with in-agent forwarding. Using an [external log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding) to send logs to New Relic while in-agent forwarding is enabled will cause your logs to be sent up twice to New Relic. Depending on your account, this may result in double billing.
 
+    <Callout variant="important">
+      Local log decoration for the .NET agent does not directly alter log messages.  Your logging framework configuration will need to be updated to write out the NR-LINKING token in messages.
+    </Callout>
+
   1. If you want to use this option, make sure you have the in-agent forwarding configuration option disabled.
 
   2. Enable log decorating in your configuration, then relaunch the agent to start decorating your logs.
@@ -112,6 +116,86 @@ You have three options to configure APM logs in context to send your app's logs 
   ```
 
   Some attributes may be empty if the log occurred outside a transaction or if they are not applicable to your application's context. We recommend this option over the old decorating formatter.
+
+  <Callout variant="important">
+    The key used to read out the NR-LINKING token from a logging framework is `NR_LINKING` not `NR-LINKING` in order to support logging frameworks that do not allow hyphens in key names.
+  </Callout>
+
+  ### log4net configuration
+
+  For log4net, the .NET agent stores the NR-LINKING token as a property called `NR_LINKING` in the log event object.  The following common layout examples demonstrate how to configure log4net to write out out the NR-LINKING token.   Other layouts are supported, but not listed below.  SimpleLayout is not supported since it cannot be altered.
+
+  **PatternLayout/DynamicPatternLayout**:
+  Update the conversionPattern to include the NR_LINKING property at the end of the line.
+
+  ```xml
+  <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%date %5level %logger.%method [%line] - MESSAGE: %message %property{NR_LINKING}%newline %exception" />
+  </layout>
+  ```
+
+  **log4net.Ext.Json**:
+  Update the layout to include a member called NR_LINKING.
+
+  ```xml
+  <layout type='log4net.Layout.SerializedLayout, log4net.Ext.Json'>
+      <decorator type='log4net.Layout.Decorators.StandardTypesFlatDecorator, log4net.Ext.Json' />
+      ...
+      <member value='NR_LINKING' />
+  </layout>
+  ```
+
+  **log4net.Appender.AdoNetAppender**:
+  This appender has a slightly different configuration than other layouts.  You will need to update the "message" parameter to include the metadata. The following example demonstrates this using a PatternLayout.
+
+  ```xml
+  <parameter>
+      <parameterName value="@message" />
+      <dbType value="String" />
+      <size value="4000" />
+      <layout type="log4net.Layout.PatternLayout">
+          <conversionPattern value="%message %property{NR_LINKING}" />
+      </layout>
+  </parameter>
+  ```
+
+  ### Serilog configuration
+
+  For Serilog, the .NET agent stores the NR-LINKING token as a property called `NR_LINKING` in the log event object.  The following common formatter and sink examples demonstrate how to configure Serilog to write out out the NR-LINKING token.   Other sinks and formatters are supported, but not listed below.
+
+  **Plain text using an outputTemplate**
+  Update the outputTemplate to include the NR_LINKING property at the end of the line.
+
+  ```csharp
+  Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+    .Enrich.FromLogContext()
+    .WriteTo.File(
+      path: @"plaintext_log.txt",
+      fileSizeLimitBytes: 1_000_000,
+      rollOnFileSizeLimit: true,
+      shared: true,
+      flushToDiskInterval: TimeSpan.FromSeconds(1),
+      outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} {NR_LINKING} {NewLine}{Exception}"
+    )
+    .CreateLogger();
+  ```
+
+  **JSON Formatter with automatic property output**
+  By default, the JsonFormatter will write out every property on a message.
+
+  ```csharp
+  Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+    .Enrich.FromLogContext()
+    .WriteTo.Console(new JsonFormatter());
+    .CreateLogger();
+  ```
+
+  **Microsoft.Extensions.Logging configuration**
+
+  For Microsoft.Extensions.Logging, the .NET agent stores the NR-LINKING token with the message in a newly created a Scope.  Since Microsoft.Extensions.Logging relies on other frameworks for output, please see either the log4net or Serilog configuration above for details.
+
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
## Give us some context

* Local log decoration configuration details are missing from .NET Agent documentation.
* This updates the .NET Agent  configuration page to point to the how-to for setting up log decoration
* Updates the .NET Agent  how-to for log decoration to include basic examples for setting up log4net, Serilog, and Microsoft.Extensions.Logging.

