### PR TITLE
feat(aws): EC2 metadata from the agent

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -451,7 +451,8 @@ For an example of how all these variables can be used, see our [sample configura
 
 ## Cloud variables
 
-If the agent is running in a cloud instance, the agent will try to detect the cloud type and fetch [metadata](/docs/integrations/new-relic-integrations/getting-started/understand-use-data-infrastructure-integrations#overview).
+If the agent is running in a cloud instance, the agent will try to detect the cloud type and fetch basic [metadata](/docs/integrations/new-relic-integrations/getting-started/understand-use-data-infrastructure-integrations#overview).
+Metrics can also be enriched with extended cloud metadata (including custom resource tags) when [connecting the cloud provider](/docs/infrastructure/infrastructure-integrations/get-started/introduction-infrastructure-integrations#cloud) account with New Relic. 
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/infrastructure/manage-your-data/data-instrumentation/default-infrastructure-monitoring-data.mdx
+++ b/src/content/docs/infrastructure/manage-your-data/data-instrumentation/default-infrastructure-monitoring-data.mdx
@@ -196,52 +196,59 @@ These attributes and their values are subject to change if Amazon changes the da
 
 <CollapserGroup>
   <Collapser
+    id="aws-account-id"
+    title={<InlineCode>awsAccountId</InlineCode>}
+  >
+    The AWS account id (determined by Amazon Web Services).
+  </Collapser>
+
+  <Collapser
     id="aws-region"
     title={<InlineCode>awsRegion</InlineCode>}
   >
-    The region (determined by Amazon Web Services) where the AWS server exists. This attribute exists only for customers using New Relic to monitor Amazon EC2 servers.
+    The region (determined by Amazon Web Services) where the AWS server exists.
   </Collapser>
 
   <Collapser
     id="aws-availability-zone"
     title={<InlineCode>awsAvailabilityZone</InlineCode>}
   >
-    The availability zone (determined by Amazon Web Services) where the AWS server exists. This attribute exists only for customers using New Relic to monitor Amazon EC2 servers.
+    The availability zone (determined by Amazon Web Services) where the AWS server exists.
   </Collapser>
 
   <Collapser
     id="ec2-instance-type"
     title={<InlineCode>ec2InstanceType</InlineCode>}
   >
-    The Amazon Web Services instance type, displayed in AWS-specific codes. This attribute exists only for customers using New Relic to monitor Amazon EC2 servers.
+    The Amazon Web Services instance type, displayed in AWS-specific codes.
   </Collapser>
 
   <Collapser
     id="ec2-instance-id"
     title={<InlineCode>ec2InstanceId</InlineCode>}
   >
-    The Amazon Web Services instance's unique identifying number for the server. This attribute exists only for customers using New Relic to monitor Amazon EC2 servers.
+    The Amazon Web Services instance's unique identifying number for the server.
   </Collapser>
 
   <Collapser
     id="ec2-ami-id"
     title={<InlineCode>ec2AmiId</InlineCode>}
   >
-    The Amazon Machine Image (AMI) identification number of the image used by Amazon Web Services to bootstrap the Amazon EC2 instance. This attribute exists only for customers using New Relic to monitor Amazon EC2 servers.
+    The Amazon Machine Image (AMI) identification number of the image used by Amazon Web Services to bootstrap the Amazon EC2 instance.
   </Collapser>
 
   <Collapser
     id="ec2-subnet-id"
     title={<InlineCode>ec2SubnetId</InlineCode>}
   >
-    The networking sub-net identifier on which the server is connected. This attribute exists only for customers using New Relic to monitor Amazon EC2 servers.
+    The networking sub-net identifier on which the server is connected.
   </Collapser>
 
   <Collapser
     id="ec2-vpc-id"
     title={<InlineCode>ec2VpcId</InlineCode>}
   >
-    The Virtual Private Cloud identifier (if any) for this server. This attribute exists only for customers using New Relic to monitor Amazon EC2 servers.
+    The Virtual Private Cloud identifier (if any) for this server.
   </Collapser>
 
   <Collapser
@@ -251,3 +258,10 @@ These attributes and their values are subject to change if Amazon changes the da
     If Amazon Web Services changes the metadata they make available to New Relic, other attributes and values collected also may be available.
   </Collapser>
 </CollapserGroup>
+
+A sub-set of these attributes are collected from the Infrastructure Agent when installed in the EC2 instances:
+* awsAccountId
+* awsRegion
+* awsAvailabilityZone
+* ec2AmiId
+* ec2InstanceType


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* Release 1.24.2 of the infra agent is collecting additional EC2 metadata attributes by default. 
* Added some notes documenting which attributes are collected by the agent. Customers can also connect the AWS Cloud Integration for additional metadata (including tags). 