### PR TITLE
Kafka integration fixes

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
@@ -256,7 +256,6 @@ The values for these settings can be defined in several ways:
           KAFKA_VERSION: "1.0.0"
           AUTODISCOVER_STRATEGY: zookeeper
           ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}, {"host": "localhost2", "port": 2181}]'
-          ZOOKEEPER_AUTH_SECRET: "username:password"
           ZOOKEEPER_PATH: "/kafka-root"
           DEFAULT_JMX_USER: username
           DEFAULT_JMX_PASSWORD: password
@@ -283,7 +282,6 @@ The values for these settings can be defined in several ways:
           KAFKA_VERSION: "1.0.0"
           AUTODISCOVER_STRATEGY: zookeeper
           ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}]'
-          ZOOKEEPER_AUTH_SECRET: "username:password"
           ZOOKEEPER_PATH: "/kafka-root"
           DEFAULT_JMX_USER: username
           DEFAULT_JMX_PASSWORD: password

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
@@ -46,7 +46,7 @@ For a comprehensive list of specific Windows and Linux versions, check the table
 ### System requirements [#system-reqs]
 
 * A New Relic account. Don't have one? [Sign up for free!](https://newrelic.com/signup) No credit card required.
-* If Kafka is not running on Kubernetes or Amazon ECS, you can [install the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) on a Linux or Windows OS host or on a host capable of remotely accessing where MySQL is installed. Otherwise:
+* If Kafka is not running on Kubernetes or Amazon ECS, you can [install the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) on a Linux or Windows OS host or on a host capable of remotely accessing where Kafka is installed. Otherwise:
   * If running on <img style={{ width: '32px', height: '32px'}} class="inline" title="Kubernetes" alt="Kubernetes" src={kubernetes}/>Kubernetes, see [these requirements](/docs/monitor-service-running-kubernetes#requirements).
   * If running on <img style={{ width: '32px', height: '32px'}} class="inline" title="ECS" alt="ECS" src={ecs}/>Amazon ECS, see [these requirements](/docs/integrations/host-integrations/host-integrations-list/monitor-services-running-amazon-ecs).
 * Java version 8 or higher.
@@ -167,9 +167,9 @@ To install the Kafka integration, follow the instructions for your environment:
   >
     1. [Download the .MSI installer image for New Relic's Kafka integration](http://download.newrelic.com/infrastructure_agent/windows/integrations/nri-kafka/nri-kafka-amd64.msi).
 
-    2. Install New Relic's MySQL integration by openning command prompt and running:
+    2. Install New Relic's Kafka integration by opening command prompt and running:
        ```shell
-       msiexec.exe /qn /i $PATH_TO\nri-mysql-amd64.msi
+       msiexec.exe /qn /i $PATH_TO\nri-kafka-amd64.msi
        ```
 
     3. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration file by running:


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?

- This PR is fixing wrong name of the msi file and other places where it was pointing to MySQL instead of Kafka
- Remove a zookeeper configuration that is not doing anything in the samples and is prone to error. If the users wants to add the ZOOKEEPER_AUTH_SECRET, they need to add ZOOKEEPER_AUTH_SECRET:digest as explained in the config section, by default that flag is empty so with the provided config it was never honoured, so it's better to remove it.