### PR TITLE
Add the right unit for MongoDB memory metrics as specified in the docs

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb-monitoring-integration.mdx
@@ -1920,7 +1920,7 @@ Different metrics are available depending on whether a cluster or a standalone i
           </td>
 
           <td>
-            The amount of mapped memory by the database, in bytes.
+            The amount of mapped memory by the database, in mebibyte (MiB).
           </td>
         </tr>
 
@@ -1930,7 +1930,7 @@ Different metrics are available depending on whether a cluster or a standalone i
           </td>
 
           <td>
-            The amount of mapped memory, including the memory used for journaling, in bytes.
+            The amount of mapped memory, including the memory used for journaling, in mebibyte (MiB).
           </td>
         </tr>
 
@@ -1940,7 +1940,7 @@ Different metrics are available depending on whether a cluster or a standalone i
           </td>
 
           <td>
-            The amount of memory currently used by the database process, in bytes.
+            The amount of memory currently used by the database process, in mebibyte (MiB).
           </td>
         </tr>
 
@@ -1950,7 +1950,7 @@ Different metrics are available depending on whether a cluster or a standalone i
           </td>
 
           <td>
-            The amount of virtual memory used by the mongod process, in bytes.
+            The amount of virtual memory used by the mongod process, in mebibyte (MiB).
           </td>
         </tr>
 
@@ -4066,7 +4066,7 @@ Different metrics are available depending on whether a cluster or a standalone i
           </td>
 
           <td>
-            The amount of mapped memory by the database, in bytes.
+            The amount of mapped memory by the database, in mebibyte (MiB).
           </td>
         </tr>
 
@@ -4076,7 +4076,7 @@ Different metrics are available depending on whether a cluster or a standalone i
           </td>
 
           <td>
-            The amount of mapped memory, including the memory used for journaling, in bytes.
+            The amount of mapped memory, including the memory used for journaling, in mebibyte (MiB).
           </td>
         </tr>
 
@@ -4086,7 +4086,7 @@ Different metrics are available depending on whether a cluster or a standalone i
           </td>
 
           <td>
-            The amount of memory currently used by the database process, in bytes.
+            The amount of memory currently used by the database process, in mebibyte (MiB).
           </td>
         </tr>
 
@@ -4096,7 +4096,7 @@ Different metrics are available depending on whether a cluster or a standalone i
           </td>
 
           <td>
-            The amount of virtual memory used by the mongod process, in bytes.
+            The amount of virtual memory used by the mongod process, in mebibyte (MiB).
           </td>
         </tr>
 
@@ -5890,7 +5890,7 @@ Different metrics are available depending on whether a cluster or a standalone i
           </td>
 
           <td>
-            The amount of mapped memory by the database, in bytes.
+            The amount of mapped memory by the database, in mebibyte (MiB).
           </td>
         </tr>
 
@@ -5900,7 +5900,7 @@ Different metrics are available depending on whether a cluster or a standalone i
           </td>
 
           <td>
-            The amount of mapped memory, including the memory used for journaling, in bytes.
+            The amount of mapped memory, including the memory used for journaling, in mebibyte (MiB).
           </td>
         </tr>
 
@@ -5910,7 +5910,7 @@ Different metrics are available depending on whether a cluster or a standalone i
           </td>
 
           <td>
-            The amount of memory currently used by the database process, in bytes.
+            The amount of memory currently used by the database process, in mebibyte (MiB).
           </td>
         </tr>
 
@@ -5920,7 +5920,7 @@ Different metrics are available depending on whether a cluster or a standalone i
           </td>
 
           <td>
-            The amount of virtual memory used by the mongod process, in bytes.
+            The amount of virtual memory used by the mongod process, in mebibyte (MiB).
           </td>
         </tr>
 


### PR DESCRIPTION
* What problems does this PR solve?
* Im our documentation we specify the mongodb have the memory metrics in Bytes but they are in MiB.