### PR TITLE
Update with note to sign up for CNCF Slack account

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction.mdx
@@ -132,7 +132,7 @@ As you consider OpenTelemetry, you may also be looking at New Relic APM agents t
 
 As you'd expect, there is a lot of overlap between features available from OpenTelemetry agents and SDKs versus those available from New Relic APM agents. This is especially true if you're interested in distributed tracing telemetry data. The choice you make depends on what you need.
 
-We recommend that you explore both New Relic and OpenTelemetry instrumentation or discuss this with us in our [CNCF Slack channel](https://cloud-native.slack.com/archives/C024DRQ63UP) to decide what works best for you.
+We recommend that you explore both New Relic and OpenTelemetry instrumentation, and welcome you to discuss this with us in our [CNCF Slack channel, #otel-newrelic](https://cloud-native.slack.com/archives/C024DRQ63UP), to decide what works best for you. You may have to first [sign up for CNCF's Slack account here](https://slack.cncf.io/). 
 
 ### OpenTelemetry: A work in progress [#emerging-standard]
 


### PR DESCRIPTION
This came about from a user pointing out [here](https://github.com/newrelic/newrelic-opentelemetry-examples/issues/111) that the existing link to our CNCF Slack channel did not work for them, and Tyler H suggested that we make a note that users may have to first sign up for CNCF Slack to access that link. This PR adds that note and the sign-up link. 