### PR TITLE
Update net-agent-configuration.mdx

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -147,10 +147,14 @@ Our .NET agent relies on environment variables to tell the .NET Common Language 
     NEWRELIC_INSTALL_PATH=<var>path\to\agent\directory</var>
     ```
 
-    The .NET agent installer will add these to IIS or as system-wide environment variables.
+    The Windows .NET agent installer will add these to IIS by default, or as system-wide environment variables when enabling **Instrument All**.
 
     <Callout variant="important">
       When using the Windows .NET agent installer, ensure that `NEWRELIC_INSTALL_PATH` is set to `C:\Program Files\New Relic\.NET Agent\` which is where the agent DLLs are placed on the system.
+    </Callout>
+    
+    <Callout variant="important">
+      When installing the agent via the Nuget package, the agent requires [a different set of environment variables](/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget/#nuget-framework).
     </Callout>
   </Collapser>
 
@@ -178,7 +182,15 @@ Our .NET agent relies on environment variables to tell the .NET Common Language 
     CORECLR_NEWRELIC_HOME=<var>path\to\agent\directory</var>
     ```
 
-    The .NET agent installer will add these to IIS or as system-wide environment variables.
+    The Windows .NET agent installer will add these to IIS by default, or as system-wide environment variables when enabling **Instrument All** (with the exception of `CORECLR_ENABLE_PROFILING` which would need to be set manually in order to instrument non-IIS hosted .NET Core applications as described [here](/docs/apm/agents/net-agent/installation/install-net-agent-windows/#enable-net-core)).
+    
+    <Callout variant="important">
+      When installing the agent via the Nuget package in Windows, the agent requires a [different set of environment variables](/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget/#nuget-windows).
+    </Callout>
+    
+    <Callout variant="important">
+      When using the Windows .NET agent installer, ensure that `NEWRELIC_INSTALL_PATH` is set to `C:\Program Files\New Relic\.NET Agent\` which is where the agent DLLs are placed on the system, and `CORECLR_NEWRELIC_HOME` is set to `C:\ProgramData\New Relic\.NET Agent\` which is where configuration and logs exist on the system.
+    </Callout>
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
After reviewing this in [with an engineer](https://newrelic.slack.com/archives/C7HNR7WNR/p1650411810705179), added some environment variable configuration subtleties in Windows including that `NEWRELIC_INSTALL_PATH` should set to `C:\Program Files\New Relic\.NET Agent\` which is where the agent DLLs are placed on the system, and `CORECLR_NEWRELIC_HOME` is set to `C:\ProgramData\New Relic\.NET Agent\` which is where configuration and logs exist on the system, and that the Nuget packages use a different set of environment variables. Linux install and Nuget packages use the same set.

Github issue: https://github.com/newrelic/newrelic-dotnet-agent/issues/1064

This PR solves some questions about what the paths should be using a standard Windows install of the agent.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.