### PR TITLE
Update Typo for 1.20.6 Agent Version

### DIFF
--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -147,7 +147,7 @@ To use the log forwarder of the infrastructure agent, make sure you meet the fol
 * Infrastructure agent version 1.11.4 or higher.
 * [Fluent Bit](https://fluentbit.io/). The infrastructure agent already installs the latest version for you. To update or downgrade it to a specfic version, refer to the [Fluent Bit installation](#install-fb-version) procedures.
 * OpenSSL library 1.1.0 or higher is required by the infrastructure agent starting from version 1.16.4.
-* Built-in support for ARM64 architecture on Linux systems (for example, AWS Graviton architecture) added in infrastructure agent [1.26.0](https://github.com/newrelic/infrastructure-agent/releases/tag/1.20.6).
+* Built-in support for ARM64 architecture on Linux systems (for example, AWS Graviton architecture) added in infrastructure agent [1.20.6](https://github.com/newrelic/infrastructure-agent/releases/tag/1.20.6).
 
 <Callout variant="important">
   The log forwarding feature is not supported with the [Docker container for infrastructure monitoring agents](/docs/infrastructure/install-infrastructure-agent/linux-installation/docker-container-infrastructure-monitoring/).


### PR DESCRIPTION
Found a small typo listing infra agent 1.26.0 but linking to 1.20.6

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.