### PR TITLE
fix: full file path not shown

### DIFF
--- a/src/data-dictionary/events/ProcessSample/commandName.md
+++ b/src/data-dictionary/events/ProcessSample/commandName.md
@@ -8,5 +8,5 @@ events:
 The command name of the process corresponds, in most cases, to the base name of the command line's path to the form of the process.
 
 <Callout variant="tip">
-  In Linux, this attribute is retrieved from `/proc/<PID>/stat`, in which strings longer than 16 characters are silently truncated. Internally, linux command names can be up to 16 bytes long. More information can be found in the [proc manual pages](https://man7.org/linux/man-pages/man5/proc.5.html).
+  In Linux, this attribute is retrieved from `/proc/PID/stat`, in which strings longer than 16 characters are silently truncated. Internally, linux command names can be up to 16 bytes long. More information can be found in the [proc manual pages](https://man7.org/linux/man-pages/man5/proc.5.html).
 </Callout>


### PR DESCRIPTION
The characters "<" and  ">" seems that was preventing the code section to be rendered correctly. In addition, the whole "tip" was not rendered, neither the link.

Do you think this would solve the issue?