### PR TITLE
Sticky not really cache fix for data dictionary

### DIFF
--- a/plugins/gatsby-source-data-dictionary/gatsby-node.js
+++ b/plugins/gatsby-source-data-dictionary/gatsby-node.js
@@ -41,11 +41,13 @@ exports.sourceNodes = (
   { actions, createNodeId, createContentDigest, getNodesByType },
   pluginOptions
 ) => {
-  const { createNode, createRedirect } = actions;
+  const { createNode, createRedirect, touchNode } = actions;
 
   const dataDictionaryNodes = getNodesByType('MarkdownRemark').filter((node) =>
     node.fileAbsolutePath.includes(pluginOptions.path)
   );
+
+  dataDictionaryNodes.forEach((node) => touchNode(node));
 
   const attributeEvents = uniq(
     dataDictionaryNodes

--- a/plugins/gatsby-source-data-dictionary/gatsby-node.js
+++ b/plugins/gatsby-source-data-dictionary/gatsby-node.js
@@ -41,13 +41,11 @@ exports.sourceNodes = (
   { actions, createNodeId, createContentDigest, getNodesByType },
   pluginOptions
 ) => {
-  const { createNode, createRedirect, touchNode } = actions;
+  const { createNode, createRedirect } = actions;
 
   const dataDictionaryNodes = getNodesByType('MarkdownRemark').filter((node) =>
     node.fileAbsolutePath.includes(pluginOptions.path)
   );
-
-  dataDictionaryNodes.forEach((node) => touchNode(node));
 
   const attributeEvents = uniq(
     dataDictionaryNodes

--- a/plugins/utils/handlers.js
+++ b/plugins/utils/handlers.js
@@ -94,7 +94,10 @@ module.exports = {
       node,
       isBlockImage(parent, node) ? 'div' : 'span',
       stripNulls({
-        className: [isBlockImage ? 'block-image' : 'inline-image', 'image'],
+        className: [
+          isBlockImage(parent, node) ? 'block-image' : 'inline-image',
+          'image',
+        ],
         style: get(node, 'data.style', null),
       }),
       [

--- a/plugins/utils/handlers.js
+++ b/plugins/utils/handlers.js
@@ -94,10 +94,7 @@ module.exports = {
       node,
       isBlockImage(parent, node) ? 'div' : 'span',
       stripNulls({
-        className: [
-          isBlockImage(parent, node) ? 'block-image' : 'inline-image',
-          'image',
-        ],
+        className: [isBlockImage ? 'block-image' : 'inline-image', 'image'],
         style: get(node, 'data.style', null),
       }),
       [


### PR DESCRIPTION
this is kind of a weird one but turns out it was a redux issue not a caching issue???
In the data dictionary service, we create nodes for all the data dictionary events and attributes. When they are updated, we want to make sure the redux store reflects that change. We can ensure that by running touchNode on all data dictionary files.

this section of the gatsby docs on node creation explains it: https://www.gatsbyjs.com/docs/node-creation/#freshstale-nodes