### PR TITLE
Create workflow to add files to translation queue by string

### DIFF
--- a/.github/workflows/manual-add-files-to-translation-queue.yml
+++ b/.github/workflows/manual-add-files-to-translation-queue.yml
@@ -1,0 +1,53 @@
+name: Manually Add Slugs to Translation Queue
+
+on:
+  workflow_dispatch:
+    inputs:
+      files:
+        description: 'String of filenames separated by comma'
+        required: true
+        type: string
+      machineTranslation:
+        description: 'Send for machine translation'
+        required: false
+        type: boolean
+      locale:
+        description: 'Define locale'
+        required: false
+        type: string
+
+env:
+  DB_CONNECTION_INFO: ${{ secrets.DB_CONNECTION_INFO }}
+  HUMAN_TRANSLATION_PROJECT_ID: ${{ secrets.TRANSLATION_VENDOR_PROJECT }} # human project id
+  MACHINE_TRANSLATION_PROJECT_ID: ${{ secrets.TRANSLATION_VENDOR_MT_PROJECT }} # machine project id
+  NEW_RELIC_ACCOUNT_ID: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+  NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
+
+jobs:
+  get-and-save-slugs:
+    name: Get and Save Slugs
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+
+      - name: Cache dependencies
+        id: yarn-cache
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+
+      - name: Get slugs and save
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          yarn manual-add-files-to-translate -f ${{ github.event.inputs.files }} -l {{ github.event.inputs.locale }} -mt {{ github.event.inputs.machineTranslation }}

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "postinstall": "patch-package",
     "extract-i18n": "i18next",
     "add-files-to-translate": "node scripts/actions/add-files-to-translation-queue.js",
+    "manual-add-files-to-translate": "node scripts/actions/manual-add-files-to-translation-queue.js",
     "check-for-outdated-translations": "node scripts/actions/check-for-outdated-translations.js",
     "verify-mdx": "node scripts/verify_mdx.js",
     "add-remove-redirects": "node scripts/utils/docs-content-tools/add-remove-redirects.js",

--- a/scripts/actions/manual-add-files-to-translation-queue.js
+++ b/scripts/actions/manual-add-files-to-translation-queue.js
@@ -1,0 +1,36 @@
+const { Command } = require('commander');
+const {
+  addFilesToTranslationQueue,
+} = require('./add-files-to-translation-queue');
+
+const getCommandLineOptions = () => {
+  const program = new Command();
+  program
+    .option('-f, --files <files>', 'files to translate')
+    .option(
+      '-mt, --machine-translation',
+      'Boolean to only send files needing machine translation'
+    )
+    .option(
+      '-l, --locale <locale>',
+      'Specifiy specific language to be sent to smartling for translation'
+    );
+  program.parse(process.argv);
+  return program.opts();
+};
+
+const parseFilesString = (filesString) =>
+  filesString.split(',').map((str) => str.trim());
+
+const main = async () => {
+  const options = getCommandLineOptions();
+  const filesString = options.files || null;
+
+  if (filesString) {
+    const fileNames = parseFilesString(filesString);
+    await addFilesToTranslationQueue(fileNames, options);
+  }
+  process.exit(0);
+};
+
+main();


### PR DESCRIPTION
PR to create a workflow to manually add files to the translation queue! Learned about github action inputs here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs

I have 0 idea what inputs look like in a github action, and I can't really test this action until after it is merged in. I tested locally by running 
 
```bash
yarn manual-add-files-to-translate -f "src/content/docs/codestream/how-use-codestream/discuss-code.mdx,src/content/docs/infrastructure/host-integrations/host-integrations-list/nginx/nginx-integration.mdx"
```
and it worked but since it is dispatched - not run on `push` or for a `pull_request` - it's hard to test the actual action with the inputs 