### PR TITLE
Removing Fluentd Examples

### DIFF
--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -314,24 +314,14 @@ You can use the [Apache log4net version 2.0.8 or higher](https://logging.apache.
        </log4net>
        ```
 
-       After you configure the log4net extension and update your logging file, you can configure your extension to send data to New Relic. Here is an example configuration using the Fluentd plugin for logs in context:
+       After you configure the log4net extension and update your logging file, you can configure your extension to send data to New Relic. There are [several options](https://docs.newrelic.com/docs/logs/forward-logs/enable-log-management-new-relic/#log-forwarding) for forwarding your logs. Here is an example configuration using the infrastructure agent for logs in context:
 
        ```
-       <!--NewRelicLoggingExample.conf-->
-       <source>
-           @type tail 
-           path C:\logs\log4netExample.log.json
-           pos_file C:\logs\log4netExample.log.json.pos
-           tag logfile.*
-         <parse> 
-           @type json
-         </parse>
-       </source>
-         <match **> 
-           @type newrelic
-           license_key <YOUR NEW_RELIC_LICENSE_KEY>
-           base_uri https://log-api.newrelic.com/log/v1
-         </match>
+    logs:
+      - name: application-log
+	      file: C:\logs\log4netExample.log.json # Path to a single log file
+    
+    #[Documentation for using the infrastructure agent forwarder](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#file)
        ```
   </Collapser>
 </CollapserGroup>
@@ -422,24 +412,15 @@ You can use our [NLog 4.5 or higher](https://nlog-project.org/) extension to lin
       var logger = LogManager.GetLogger("Example");
       ```
 
-      Once you have configured the NLog extension and updated your logging file, you can configure your extension to send data to New Relic. Here is an example configuration using the Fluentd plugin to forward logs to New Relic:
+      Once you have configured the NLog extension and updated your logging file, you can configure your extension to send data to New Relic. There are [several options](https://docs.newrelic.com/docs/logs/forward-logs/enable-log-management-new-relic/#log-forwarding) for forwarding your logs. Here is an example configuration using the infrastructure agent for logs in context:
 
       ```
-      <!--NewRelicLoggingExample.conf-->
-      <source>
-        @type tail
-        path C:\logs\NLogExample.log.json
-        pos_file C:\logs\NLogExample.log.json.pos 
-        tag logfile.*
-        <parse>
-          @type json
-        </parse>
-      </source>
-      <match **>
-        @type newrelic
-        license_key <YOUR NEW_RELIC_LICENSE_KEY>
-        base_uri https://log-api.newrelic.com/log/v1
-      </match>
+logs:
+	- name: application-log
+		file: C:\logs\log4netExample.log.json # Path to a single log file
+
+#[Documentation for using the infrastructure agent forwarder](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#file)
+
       ```
   </Collapser>
 
@@ -555,26 +536,15 @@ You can use our [Serilog](https://serilog.net/) extension to link to your log da
 
       Although not required, using the [Serilog Asynchronous Sink Wrapper](https://www.nuget.org/packages/Serilog.Sinks.Async) may help improve the performance by performing formatting and output of log files on a different thread.
 
-    3. Once you have configured the Serilog extension and updated your logging file, you can configure your extension to send data to New Relic.
-
-       Here is an example configuration using the Fluentd plugin to forward logs to New Relic:
+    3. Once you have configured the Serilog extension and updated your logging file, there are [several options](https://docs.newrelic.com/docs/logs/forward-logs/enable-log-management-new-relic/#log-forwarding) for forwarding your logs. Here is an example configuration using the infrastructure agent for logs in context:
 
        ```
-        <!--NewRelicLoggingExample.conf-->
-        <source> 
-            @type tail 
-            path C:\logs\SerilogExample.log.json
-            pos_file C:\logs\SerilogExample.log.json.pos 
-            tag logfile.*
-         <parse> 
-            @type json 
-        </parse>
-        </source>
-        <match **> 
-            @type newrelic 
-            license_key <YOUR NEW_RELIC_LICENSE_KEY>
-            base_uri https://log-api.newrelic.com/log/v1
-        </match>
+logs:
+	- name: application-log
+		file: C:\logs\log4netExample.log.json # Path to a single log file
+
+#[Documentation for using the infrastructure agent forwarder](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#file)
+
        ```
   </Collapser>
 


### PR DESCRIPTION
Removing Fluentd examples because it confuses users and adding the infrastructure agent as default example. It is the fastest way to bootstrap this functionality. Also added link on all the options for log forwarding.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.