### PR TITLE
AWS metric stream ingest limit

### DIFF
--- a/src/content/docs/data-apis/manage-data/view-system-limits.mdx
+++ b/src/content/docs/data-apis/manage-data/view-system-limits.mdx
@@ -265,6 +265,7 @@ This table includes general max limits that apply across all New Relic accounts.
         * Number of infrastructure agents and/or integrations: 5K per account
         * Gross number of new monitored containers: 5K per hour per account
         * Gross number of new monitored entities from Cloud integrations (AWS, Azure, GCP): 30K per hour, per account
+        * AWS Metric Streams - Kinesis Data Firehose requests per minute: 50
       </td>
     </tr>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* Documenting the ingest limit for AWS Kinesis Data Firehose when integrating AWS CloudWatch metric stream. 