### PR TITLE
Change data dictionary page type

### DIFF
--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -73,7 +73,7 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
     <>
       <SEO
         location={location}
-        type={TYPES.ATTRIBUTE_DICTIONARY}
+        type={TYPES.BASIC_PAGE.default}
         title="New Relic data dictionary"
       />
       <div

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -12,6 +12,5 @@ export const TYPES = {
   API_LANDING_PAGE: 'term_page_api_menu',
   TABLE_OF_CONTENTS: 'views_page_menu',
   AUTO_INDEX_PAGE: 'views_page_menu',
-  ATTRIBUTE_DICTIONARY: 'views_page_content',
   WHATS_NEW_PAGE: 'views_page_content',
 };


### PR DESCRIPTION
The page type for the data dictionary is currently being filtered out of search results, this PR updates it to be a non filtered type