### PR TITLE
docs: update internal page link & add language identifiers

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/ispan.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/ispan.mdx
@@ -13,7 +13,7 @@ redirects:
 
 ## Syntax
 
-```
+```cs
 Public interface ISpan
 ```
 
@@ -54,7 +54,7 @@ This section contains descriptions and parameters of `ISpan` methods:
   </tbody>
 </table>
 
-## AddCustomAttribute [#acceptdistributedtracepayload]
+## AddCustomAttribute [#addcustomattribute]
 
 Adds contextual information about your application to the current span in the form of [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute).
 
@@ -62,7 +62,7 @@ This method requires .NET agent version and .NET agent API [version 8.25](/docs/
 
 ### Syntax
 
-```
+```cs
 ISpan AddCustomAttribute(string key, object value)
 ```
 
@@ -121,7 +121,7 @@ For details about supported data types, see the [Custom Attributes guide](/docs/
 
 ## Examples
 
-```
+```cs
 IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
 ISpan currentSpan = agent.CurrentSpan; 
 


### PR DESCRIPTION
The internal link to the ##AddCustomAttribute section didn't make sense, I think it was a cut/paste error. The place that linked there (line 47) didn't actually go anywhere.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.