### PR TITLE
Add reference to newer OTEL Java agent that simplifies JVM metric collection

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-view-your-data.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-view-your-data.mdx
@@ -351,10 +351,10 @@ Review these additional topics about using the JVMs page:
   <Collapser
     className="freq-link"
     id="jvms-and-metric-types"
-    title="Gauges versus counters"
+    title="Recommended OpenTelemetry Java agent versions"
   >
 
-  We recommend you use the OpenTelemetry Java agent 1.13.0 or higher, which collects JVM memory usage as an async gauge. These versions allow you to view metrics in New Relic without the workarounds you'd need to do if you were using older agents.
+  We recommend you use the OpenTelemetry Java agent 1.13.0 or higher, which collects JVM memory usage as an async gauge. These agent versions allow you to view metrics in New Relic without the workarounds you'd need to do if you were using older agents.
 
   If you're using older OpenTelemtry Java agents (versions 1.10.0 thorugh 1.12.0), keep in mind that JVM memory usage switched from being collected as an async gauge to an async up down counter. This has implications on the exported data. Gauges and counters export differently:
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-view-your-data.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-view-your-data.mdx
@@ -356,7 +356,7 @@ Review these additional topics about using the JVMs page:
 
   We recommend you use the OpenTelemetry Java agent 1.13.0 or higher, which collects JVM memory usage as an async gauge. These versions allow you to view metrics in New Relic without the workarounds you'd need to do if you were using older agents.
 
-  If you're using older OpenTelemtry Java agents (versions 1.10.0 thorugh 1.12.0), JVM memory usage switched from being collected as an async gauge to an async up down counter. This has implications on the exported data. Gauges and counters export differently:
+  If you're using older OpenTelemtry Java agents (versions 1.10.0 thorugh 1.12.0), keep in mind that JVM memory usage switched from being collected as an async gauge to an async up down counter. This has implications on the exported data. Gauges and counters export differently:
 
     * Async gauges export as OTLP gauges.
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-view-your-data.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-view-your-data.mdx
@@ -353,7 +353,10 @@ Review these additional topics about using the JVMs page:
     id="jvms-and-metric-types"
     title="Gauges versus counters"
   >
-  Starting in OpenTelemetry Java agent 1.10.0, JVM memory usage switched from being collected as an async gauge to an async up down counter. This has implications on the exported data. Gauges and counters export differently:
+
+  We recommend you use the OpenTelemetry Java agent 1.13.0 or higher, which collects JVM memory usage as an async gauge. These versions allow you to view metrics in New Relic without the workarounds you'd need to do if you were using older agents.
+
+  If you're using older OpenTelemtry Java agents (versions 1.10.0 thorugh 1.12.0), JVM memory usage switched from being collected as an async gauge to an async up down counter. This has implications on the exported data. Gauges and counters export differently:
 
     * Async gauges export as OTLP gauges.
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-view-your-data.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-view-your-data.mdx
@@ -364,7 +364,7 @@ Review these additional topics about using the JVMs page:
 
   If you configure your SDK to export your metrics using delta aggregation temporality (which is required for counter and histogram instruments to function with New Relic), that results in async up down counters exported as non-monotonic delta sums. New Relic can't perform any useful analysis of non-monotonic delta sum data.
 
-  The solution for now (until a better solution is sorted out in the OpenTelemetry metric specification) is to use the View API to indicate that async up down counters should be aggregated using [last value aggregation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#last-value-aggregation) instead of the default sum aggregation. This results in JVM memory usage being exported as gauge data, which is required for a useful experience in New Relic.
+  If you have to use OpenTelemetry Java agent versions 1.10.0 through 1.12.0, the workaround is to use the View API to indicate that async up down counters should be aggregated using [last value aggregation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#last-value-aggregation) instead of the default sum aggregation. This results in JVM memory usage being exported as gauge data, which is required for a useful experience in New Relic.
 
   The way you configure the View API varies based on whether you’re using the OpenTelemetry Java agent:
 


### PR DESCRIPTION
The OpenTelemetry Java agent version 1.13.0 and higher now allows users to avoid workarounds to view JVM metrics.

This PR mentions that we recommend the newer agent.