### PR TITLE
Add OTEL logging references to bullet list

### DIFF
--- a/src/content/docs/logs/get-started/get-started-log-management.mdx
+++ b/src/content/docs/logs/get-started/get-started-log-management.mdx
@@ -48,6 +48,9 @@ To forward your log data to New Relic, you can use any of these options:
 * Use our [guided install for infrastructure monitoring](/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent) as a lightweight data collector for your apps' and hosts' logs.
 * Select from a wide range of [log forwarding plugins](/docs/logs/forward-logs/enable-log-management-new-relic/), including Amazon, Microsoft, Fluentd, Fluent Bit, Kubernetes, Logstash, and more.
 * Send your log data by using the [Log API](/docs/logs/log-api/introduction-log-api/) or [TCP endpoint](/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic).
+* Send us OpenTelemetry log data:
+  * Send it directly from your apps to New Relic via OTLP.
+  * Send it to an [OpenTelemetry collector](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs), which can forward it to New Relic via OTLP.
 
 ## View your logging data in New Relic [#find-data]
 

--- a/src/content/docs/logs/get-started/get-started-log-management.mdx
+++ b/src/content/docs/logs/get-started/get-started-log-management.mdx
@@ -48,9 +48,9 @@ To forward your log data to New Relic, you can use any of these options:
 * Use our [guided install for infrastructure monitoring](/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent) as a lightweight data collector for your apps' and hosts' logs.
 * Select from a wide range of [log forwarding plugins](/docs/logs/forward-logs/enable-log-management-new-relic/), including Amazon, Microsoft, Fluentd, Fluent Bit, Kubernetes, Logstash, and more.
 * Send your log data by using the [Log API](/docs/logs/log-api/introduction-log-api/) or [TCP endpoint](/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic).
-* Send us OpenTelemetry log data:
-  * Send it directly from your apps to New Relic via OTLP.
-  * Send it to an [OpenTelemetry collector](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs), which can forward it to New Relic via OTLP.
+* Send us OpenTelemetry log data using either of these options:
+  * Use the SDK to send logs directly from your apps to New Relic via OTLP.
+  * Use the SDK to send logs from your apps to an [OpenTelemetry collector](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs), which can forward them to New Relic via OTLP.
 
 ## View your logging data in New Relic [#find-data]
 

--- a/src/content/docs/logs/get-started/get-started-log-management.mdx
+++ b/src/content/docs/logs/get-started/get-started-log-management.mdx
@@ -48,7 +48,7 @@ To forward your log data to New Relic, you can use any of these options:
 * Use our [guided install for infrastructure monitoring](/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent) as a lightweight data collector for your apps' and hosts' logs.
 * Select from a wide range of [log forwarding plugins](/docs/logs/forward-logs/enable-log-management-new-relic/), including Amazon, Microsoft, Fluentd, Fluent Bit, Kubernetes, Logstash, and more.
 * Send your log data by using the [Log API](/docs/logs/log-api/introduction-log-api/) or [TCP endpoint](/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic).
-* Send us OpenTelemetry log data using the SDK to send logs from your apps to an [OpenTelemetry collector](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs), which can forward them to New Relic via OTLP.
+* Use the OpenTelemetry SDK to send logs from your apps to an [OpenTelemetry collector](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs), which can forward them to New Relic via OTLP.
 
 ## View your logging data in New Relic [#find-data]
 

--- a/src/content/docs/logs/get-started/get-started-log-management.mdx
+++ b/src/content/docs/logs/get-started/get-started-log-management.mdx
@@ -48,9 +48,7 @@ To forward your log data to New Relic, you can use any of these options:
 * Use our [guided install for infrastructure monitoring](/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent) as a lightweight data collector for your apps' and hosts' logs.
 * Select from a wide range of [log forwarding plugins](/docs/logs/forward-logs/enable-log-management-new-relic/), including Amazon, Microsoft, Fluentd, Fluent Bit, Kubernetes, Logstash, and more.
 * Send your log data by using the [Log API](/docs/logs/log-api/introduction-log-api/) or [TCP endpoint](/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic).
-* Send us OpenTelemetry log data using either of these options:
-  * Use the SDK to send logs directly from your apps to New Relic via OTLP.
-  * Use the SDK to send logs from your apps to an [OpenTelemetry collector](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs), which can forward them to New Relic via OTLP.
+* Send us OpenTelemetry log data using the SDK to send logs from your apps to an [OpenTelemetry collector](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs), which can forward them to New Relic via OTLP.
 
 ## View your logging data in New Relic [#find-data]
 


### PR DESCRIPTION
We need a reference to OpenTelemetry in the logs docs. This is a small start to increase visibility.