### PR TITLE
feat(K8sRancher): adding info to monitor rancher CP

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/configure-control-plane-monitoring.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/configure-control-plane-monitoring.mdx
@@ -203,6 +203,44 @@ controlPlane:
 
 Please note that this only applies to the API Server and that etcd, the scheduler, and the controller manager remain inaccessible in cloud environments.
 
+#### Control plane monitoring for Rancher RKE1 [#rancher]
+
+Clusters deployed leveraging Rancher Kubernetes Engine (RKE1) run Control Plane components as Docker containers and not as Pods managed by the Kubelet. 
+Therefore, the integration cannot autodiscover those containers and every endpoint needs to be manually specified in the `staticEndpoint` section of the integration configuration.
+
+Notice that the integration requires to be able to reach the different endpoints either connecting directly, with the available authentication methods (no-auth / token authentication / MTLS authentication), or thorugh a proxy.
+
+For example, in order to make reachable the `Scheduler` and the `Controller Manager` metrics you might need to add the [flag](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/) `--authorization-always-allow-paths` allowing `/metrics` or `--authentication-kubeconfig` and `--authorization-kubeconfig` to enable token authentication.
+
+Assuming that every component is reachable at the specified port, the following configuration will monitor the `Api Server`, the `Scheduler` and the`Controller Manager` 
+
+```yaml
+  scraper:
+    verbose: true
+    config:
+      scheduler:
+        enabled: true
+        staticEndpoint:
+          url: https://localhost:10259
+          insecureSkipVerify: true
+          auth:
+            type: bearer
+      controllerManager:
+        enabled: true
+        staticEndpoint:
+          url: https://localhost:10257
+          insecureSkipVerify: true
+          auth:
+            type: bearer
+      apiServer:
+        enabled: true
+        staticEndpoint:
+          url: https://localhost:6443
+          insecureSkipVerify: true
+          auth:
+            type: bearer
+```
+
 ## Monitoring control plane with integration version 2 [#monitoring-control-plane]
 
 This section covers how to configure control plane monitoring on versions 2 and earlier of the integration.

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/configure-control-plane-monitoring.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/configure-control-plane-monitoring.mdx
@@ -205,15 +205,13 @@ Please note that this only applies to the API Server and that etcd, the schedule
 
 #### Control plane monitoring for Rancher RKE1 [#rancher]
 
-Clusters deployed leveraging Rancher Kubernetes Engine (RKE1) run control plane components as Docker containers and not as Pods managed by the Kubelet. 
-Therefore, the integration cannot autodiscover those containers and every endpoint needs to be manually specified in the `staticEndpoint` section of the integration configuration.
+Clusters deployed leveraging Rancher Kubernetes Engine (RKE1) run control plane components as Docker containers, and not as Pods managed by the Kubelet. 
+That's why the integration can't autodiscover those containers, and every endpoint needs to be manually specified in the `staticEndpoint` section of the integration configuration.
 
-Notice that the integration requires to be able to reach the different endpoints either connecting directly, with the available authentication methods 
+The integration needs to be able to reach the different endpoints either by connecting directly, with the available authentication methods 
 (service account token, custom mTLS certificates, or none), or through a proxy.
 
-For example, in order to make reachable the Scheduler and the Controller Manager metrics you might need to add the 
-[flag](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/) `--authorization-always-allow-paths` 
-allowing `/metrics` or `--authentication-kubeconfig` and `--authorization-kubeconfig` to enable token authentication.
+For example, in order to make the Scheduler and the Controller Manager metrics reachable, you might need to add the `--authorization-always-allow-paths` [flag](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/), allowing `/metrics` or `--authentication-kubeconfig` and `--authorization-kubeconfig` to enable token authentication.
 
 Assuming that every component is reachable at the specified port, the following configuration will monitor the API Server, the Scheduler and the Controller Manager: 
 
@@ -245,10 +243,9 @@ Assuming that every component is reachable at the specified port, the following 
             type: bearer
 ```
 
-In this example, the integration needs to run on the same node of each control plane component having the `hostNetwork` option set to true, since it is connecting locally to each `staticEndpoint`. 
-Therefore, `controlPlane.kind` has to be kept as `DaemonSet`, moreover, the DaemonSet needs affinity rules, nodeSelector and tolerations configured so that all instances are running on all control plane nodes you want to monitor.
+In this example, the integration needs to run on the same node of each control plane component that has the `hostNetwork` option set to true, since it's connecting locally to each `staticEndpoint`. Therefore, `controlPlane.kind` has to be kept as `DaemonSet`. Also, the DaemonSet needs affinity rules, nodeSelector, and tolerations configured so that all instances are running on all control plane nodes you want to monitor.
 
-You can recognize the control plane nodes checking the label `node-role.kubernetes.io/controlplane`. Notice that, such label is already taken into account by the integration default affinity rules.
+You can recognize the control plane nodes by checking the `node-role.kubernetes.io/controlplane` label. This label is already taken into account by the integration default affinity rules.
 
 ## Monitoring control plane with integration version 2 [#monitoring-control-plane]
 

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/configure-control-plane-monitoring.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/configure-control-plane-monitoring.mdx
@@ -208,15 +208,19 @@ Please note that this only applies to the API Server and that etcd, the schedule
 Clusters deployed leveraging Rancher Kubernetes Engine (RKE1) run control plane components as Docker containers and not as Pods managed by the Kubelet. 
 Therefore, the integration cannot autodiscover those containers and every endpoint needs to be manually specified in the `staticEndpoint` section of the integration configuration.
 
-Notice that the integration requires to be able to reach the different endpoints either connecting directly, with the available authentication methods (service account token, custom mTLS certificates, or none), or through a proxy.
+Notice that the integration requires to be able to reach the different endpoints either connecting directly, with the available authentication methods 
+(service account token, custom mTLS certificates, or none), or through a proxy.
 
-For example, in order to make reachable the Scheduler and the Controller Manager metrics you might need to add the [flag](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/) `--authorization-always-allow-paths` allowing `/metrics` or `--authentication-kubeconfig` and `--authorization-kubeconfig` to enable token authentication.
+For example, in order to make reachable the Scheduler and the Controller Manager metrics you might need to add the 
+[flag](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/) `--authorization-always-allow-paths` 
+allowing `/metrics` or `--authentication-kubeconfig` and `--authorization-kubeconfig` to enable token authentication.
 
 Assuming that every component is reachable at the specified port, the following configuration will monitor the API Server, the Scheduler and the Controller Manager: 
 
 ```yaml
   scraper:
-    verbose: true
+    enabled: true
+    kind: DaemonSet
     config:
       scheduler:
         enabled: true
@@ -240,6 +244,11 @@ Assuming that every component is reachable at the specified port, the following 
           auth:
             type: bearer
 ```
+
+In this example, the integration needs to run on the same node of each control plane component having the `hostNetwork` option set to true, since it is connecting locally to each `staticEndpoint`. 
+Therefore, `controlPlane.kind` has to be kept as `DaemonSet`, moreover, the DaemonSet needs affinity rules, nodeSelector and tolerations configured so that all instances are running on all control plane nodes you want to monitor.
+
+You can recognize the control plane nodes checking the label `node-role.kubernetes.io/controlplane`. Notice that, such label is already taken into account by the integration default affinity rules.
 
 ## Monitoring control plane with integration version 2 [#monitoring-control-plane]
 

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/configure-control-plane-monitoring.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/configure-control-plane-monitoring.mdx
@@ -205,14 +205,14 @@ Please note that this only applies to the API Server and that etcd, the schedule
 
 #### Control plane monitoring for Rancher RKE1 [#rancher]
 
-Clusters deployed leveraging Rancher Kubernetes Engine (RKE1) run Control Plane components as Docker containers and not as Pods managed by the Kubelet. 
+Clusters deployed leveraging Rancher Kubernetes Engine (RKE1) run control plane components as Docker containers and not as Pods managed by the Kubelet. 
 Therefore, the integration cannot autodiscover those containers and every endpoint needs to be manually specified in the `staticEndpoint` section of the integration configuration.
 
-Notice that the integration requires to be able to reach the different endpoints either connecting directly, with the available authentication methods (no-auth / token authentication / MTLS authentication), or thorugh a proxy.
+Notice that the integration requires to be able to reach the different endpoints either connecting directly, with the available authentication methods (service account token, custom mTLS certificates, or none), or through a proxy.
 
-For example, in order to make reachable the `Scheduler` and the `Controller Manager` metrics you might need to add the [flag](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/) `--authorization-always-allow-paths` allowing `/metrics` or `--authentication-kubeconfig` and `--authorization-kubeconfig` to enable token authentication.
+For example, in order to make reachable the Scheduler and the Controller Manager metrics you might need to add the [flag](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/) `--authorization-always-allow-paths` allowing `/metrics` or `--authentication-kubeconfig` and `--authorization-kubeconfig` to enable token authentication.
 
-Assuming that every component is reachable at the specified port, the following configuration will monitor the `Api Server`, the `Scheduler` and the`Controller Manager` 
+Assuming that every component is reachable at the specified port, the following configuration will monitor the API Server, the Scheduler and the Controller Manager: 
 
 ```yaml
   scraper:

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
@@ -11,7 +11,7 @@ redirects:
 
 [New Relic's Kubernetes integration](/docs/integrations/kubernetes-integration/get-started/introduction-kubernetes-integration) can be [installed directly](/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration#install) on a server or VM, or through several [cloud platforms](/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration#cloud-platforms), such as GKE, EKS, AKS, or OpenShift. Each has a different compatibility with our integration.
 
-## Compatibility
+## Compatibility [#compatibility]
 
 Our Kubernetes is compatible and is continously tested on the following versions:
 
@@ -150,14 +150,14 @@ New Relic's Kubernetes integration is compatible with different flavors. We test
   </tbody>
 </table>
 
-Notice that, depending on the installation method, the [control plane monitoring](/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring) is not available or may need extra configuration. 
+Depending on the installation method, the [control plane monitoring](/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring) is not available or may need extra configuration. 
 
 For example:
 
-* to instrument managed clusters (GKE, EKS, AKS) control plane, since no endpoint exposes the needed metrics for etcd, Scheduler and Controller manager, only API Server metrics are scrapable and available
-* to instrument Rancher control plane, since compoenents `/metrics` are not always reachable by default and cannot be autodiscovered, some [extra configuration](/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring#rancher) is needed.
+* Only API Server metrics are scrapable and available to instrument managed clusters (GKE, EKS, AKS) control plane because no endpoint exposes the needed metrics for etcd, Scheduler and Controller manager.
+* To instrument Rancher control plane, since components `/metrics` are not always reachable by default and can't be autodiscovered, some [extra configuration](/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring#rancher) is needed.
 
-## Requirements
+## Requirements [#reqs]
 
 The New Relic Kubernetes integration has the following requirements:
 

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
@@ -154,7 +154,7 @@ Notice that, depending on the installation method, the [control plane monitoring
 
 For example:
 
-* to instrument managed clusters (GKE, EKS, AKS) control plane, since no endpoint exposes the needed metrics for ETCD, Scheduler and Controller manager, only API Server metrics are scrapable and available
+* to instrument managed clusters (GKE, EKS, AKS) control plane, since no endpoint exposes the needed metrics for etcd, Scheduler and Controller manager, only API Server metrics are scrapable and available
 * to instrument Rancher control plane, since compoenents `/metrics` are not always reachable by default and cannot be autodiscovered, some [extra configuration](/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring#rancher) is needed.
 
 ## Requirements

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
@@ -154,8 +154,8 @@ Notice that, depending on the installation method, the [control plane monitoring
 
 For example:
 
-* to instrument managed clusters (GKE, EKS, AKS) control plane, since no endpoint exposes the needed metrics for `ETCD`, `Scheduler` and `Controller manager`, only `API Server` metrics are scrapable and available
-* to instrument Rancher Control Plane, since compoenents `/metrics` are not always reachable by default and cannot be autodiscovered, some [extra configuration](/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring#rancher) is needed.
+* to instrument managed clusters (GKE, EKS, AKS) control plane, since no endpoint exposes the needed metrics for ETCD, Scheduler and Controller manager, only API Server metrics are scrapable and available
+* to instrument Rancher control plane, since compoenents `/metrics` are not always reachable by default and cannot be autodiscovered, some [extra configuration](/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring#rancher) is needed.
 
 ## Requirements
 

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
@@ -71,7 +71,7 @@ New Relic's Kubernetes integration is compatible with different flavors. We test
     </tr>
     <tr>
       <td>
-        k3s
+        K3s
       </td>
       <td>
         
@@ -79,7 +79,7 @@ New Relic's Kubernetes integration is compatible with different flavors. We test
     </tr>
     <tr>
       <td>
-        kubeadm
+        Kubeadm
       </td>
       <td>
         
@@ -112,7 +112,7 @@ New Relic's Kubernetes integration is compatible with different flavors. We test
         Rancher Kubernetes Engine (RKE1)
       </td>
       <td>
-        
+        [Extra configuration](/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring#rancher) is needed to instrument control plane compoenents
       </td>
     </tr>
     <tr>
@@ -154,8 +154,8 @@ Notice that, depending on the installation method, the [control plane monitoring
 
 For example:
 
-* only `API Server` monitoring is available for managed clusters (GKE, EKS, AKS) since no endpoint is available exposing the needed metrics for `ETCD`, `Scheduler` and `Controller manager` componentes monitoring
-* extra configuration is needed to monitor rancher external control plane
+* to instrument managed clusters (GKE, EKS, AKS) control plane, since no endpoint exposes the needed metrics for `ETCD`, `Scheduler` and `Controller manager`, only `API Server` metrics are scrapable and available
+* to instrument Rancher Control Plane, since compoenents `/metrics` are not always reachable by default and cannot be autodiscovered, some [extra configuration](/docs/integrations/kubernetes-integration/installation/configure-control-plane-monitoring#rancher) is needed.
 
 ## Requirements
 


### PR DESCRIPTION
Adding info regarding Rancher CP monitoring.

Leaving etcd out for now due to the node ip limitation

Please wait as well for a coreint approval before merging.
