### PR TITLE
chore(C SDK): Remove all references to C SDK

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
@@ -24,7 +24,6 @@ Access to the New Relic EU region requires the latest agent version.
 
 Minimum agent version required:
 
-* [C SDK 1.0.0](/docs/release-notes/agent-release-notes/c-sdk-release-notes) or higher
 * [Go 2.0.0](/docs/release-notes/agent-release-notes/go-release-notes) or higher
 * [Java 4.0.0](/docs/release-notes/agent-release-notes/java-release-notes) or higher
 * [.NET 8.0.0](/docs/release-notes/agent-release-notes/net-release-notes) or higher

--- a/src/content/docs/apis/intro-apis/introduction-new-relic-apis.mdx
+++ b/src/content/docs/apis/intro-apis/introduction-new-relic-apis.mdx
@@ -190,7 +190,6 @@ See [Manage alerts with NerdGraph](/docs/apis/nerdgraph/examples/nerdgraph-api-a
           <td>
             Every APM language agent has an API that lets you customize the agent's default behavior, including reporting custom data. APM agent APIs include:
 
-            * [C SDK API](/docs/agents/c-sdk/instrumentation/guide-using-c-sdk-api)
             * [Go agent API](/docs/agents/go-agent/get-started/instrument-go-transactions)
             * [Java agent API](/docs/agents/java-agent/api-guides/guide-using-java-agent-api)
             * [.NET agent API](/docs/agents/net-agent/api-guides/guide-using-net-agent-api)

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/agent-attributes.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/agent-attributes.mdx
@@ -211,7 +211,6 @@ User attributes, request attributes, and message queue parameters are limited by
 
 Each APM agent [collects custom attributes](/docs/agents/manage-apm-agents/agent-data/collect-custom-attributes). The supported attributes depend on the specific agent:
 
-* [C SDK](/docs/agents/c-sdk/instrumentation/use-default-or-custom-attributes-c-sdk)
 * [Go](/docs/agents/go-agent/instrumentation/go-agent-attributes)
 * [Java](/docs/agents/java-agent/attributes/enabling-disabling-attributes-java)
 * [.NET](/docs/agents/net-agent/attributes/net-agent-attributes)

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/collect-custom-metrics.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/collect-custom-metrics.mdx
@@ -68,7 +68,6 @@ Implementing custom metrics requires API calls. The exact details of the API cal
       </td>
 
       <td>
-        * **C SDK:** [`newrelic_record_custom_metric()`](https://newrelic.github.io/c-sdk/libnewrelic_8h.html#aee71182588ace508cc816044d2024ff3)
         * **Go:** [`app.RecordCustomMetric`](/docs/agents/go-agent/instrumentation/create-custom-metrics-go)
         * **Java:** [`recordMetric`](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/NewRelic.html#recordMetric(java.lang.String,%20float))
         * **.NET:** [`RecordMetric`](/docs/agents/net-agent/net-agent-api/recordmetric-net-agent)

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/custom-instrumentation.mdx
@@ -48,12 +48,6 @@ If you are using a [supported framework](/docs/agents/manage-apm-agents/installa
 Each agent implements custom instrumentation differently:
 
 <CollapserGroup>
-  <Collapser
-    id="c-sdk"
-    title="C SDK custom instrumentation"
-  >
-    For applications monitored by the C SDK, you must manually instrument transactions, segments, and errors. For more information, see the [C SDK instrumentation procedures](/docs/agents/c-sdk/instrumentation/instrument-your-app-c-sdk).
-  </Collapser>
 
   <Collapser
     id="go"

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
@@ -25,7 +25,6 @@ APM agents include API calls to report (or "notice") errors. These are useful wh
 
 To learn how to get an APM agent to report an error, see the agent-specific API documentation:
 
-* **C SDK**: [`newrelic_notice_error()`](https://newrelic.github.io/c-sdk/libnewrelic_8h.html#a02a9a959015a0ca68ce11c750f690475)
 * **Go**: [`NoticeError()`](https://github.com/newrelic/go-agent/blob/master/transaction.go)
 * **Java**: [`NoticeError()`](http://newrelic.github.io/java-agent-api/javadoc/index.html?com/newrelic/api/agent/NewRelic.html)
 * **.NET**: [`NoticeError()`](/docs/agents/net-agent/net-agent-api/notice-error)
@@ -63,7 +62,6 @@ There are two ways to ignore errors: through the agent configuration or through 
   >
     To ignore an error using the agent configuration, see the configuration documentation for your agent:
 
-    * **C SDK**: Not available. For more information, see the [C SDK errors example on GitHub](https://newrelic.github.io/c-sdk/ex_notice_error_8c-example.html).
     * **Go**: [`ErrorCollector.IgnoreStatusCodes`](/docs/agents/go-agent/instrumentation/go-agent-configuration#error-ignore-status).
     * **Java**: `error_collector.ignore_classes`, `error_collector.ignore_classes.message`, or `error_collector.ignore_status_codes`. For additional information, see [Java agent error configuration](/docs/agents/java-agent/configuration/java-agent-error-configuration).
     * **.NET**: [`ignoreErrors`](/docs/agents/net-agent/configuration/net-agent-configuration#error-ignoreErrors) or [`ignoreStatusCodes`](/docs/agents/net-agent/configuration/net-agent-configuration#error-ignoreStatusCodes).

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/real-time-streaming.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/real-time-streaming.mdx
@@ -45,7 +45,6 @@ To enable real time streaming, [update](/docs/agents/manage-apm-agents/installat
 
 Real time streaming is supported by all APM agents. Here are the minimum agent versions:
 
-* **C SDK:** [v1.3.0 or higher](/docs/release-notes/agent-release-notes/c-sdk-release-notes)
 * **Go:** [v2.8.0 or higher](/docs/release-notes/agent-release-notes/go-release-notes)
 * **Java:** [v5.5.0 or higher](/docs/release-notes/agent-release-notes/java-release-notes)
 * **.NET:** [v8.23.107.0 or higher](/docs/release-notes/agent-release-notes/net-release-notes)

--- a/src/content/docs/apm/agents/manage-apm-agents/configuration/add-rename-remove-hosts.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/configuration/add-rename-remove-hosts.mdx
@@ -56,15 +56,6 @@ To set a display name:
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        C SDK
-      </td>
-
-      <td>
-        Edit the [`newrelic_datastore_segment_params_t::host`](https://newrelic.github.io/c-sdk/structnewrelic__datastore__segment__params__t.html#a6a2595298045f0174b9b9c39ea31b6eb) datastore segment.
-      </td>
-    </tr>
 
     <tr>
       <td>

--- a/src/content/docs/apm/agents/manage-apm-agents/configuration/enable-configurable-security-policies.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/configuration/enable-configurable-security-policies.mdx
@@ -30,7 +30,6 @@ For more information about New Relic's security measures, see our [security and 
 
 APM agent versions that support this feature include:
 
-* C SDK: not available
 * [Go](/docs/agents/go-agent/installation/install-new-relic-go): 2.1 or higher
 * [Java](/docs/agents/java-agent/installation/upgrade-java-agent): 4.1 or higher
 * [.NET](/docs/agents/net-agent/installation/update-net-agent): 8.1 or higher

--- a/src/content/docs/apm/agents/manage-apm-agents/configuration/high-security-mode.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/configuration/high-security-mode.mdx
@@ -39,15 +39,6 @@ Currently there are two versions of high security mode. [Version 1](#version1des
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        C SDK
-      </td>
-
-      <td>
-        n/a
-      </td>
-    </tr>
 
     <tr>
       <td>
@@ -164,7 +155,6 @@ To enable high security, you must update both the local configuration on your se
       <td>
         Enable high security mode in your agent configuration file. High security mode is disabled by default, and the exact procedure to enable it varies by agent:
 
-        * C SDK: n/a
         * [Go](/docs/agents/go-agent/instrumentation/go-agent-configuration#high_security)
         * [Java](/docs/java/java-agent-configuration#cfg-enable_high_security)
         * [.NET](/docs/dotnet/dotnet-agent-configuration#high_security_mode)

--- a/src/content/docs/apm/agents/manage-apm-agents/configuration/server-side-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/configuration/server-side-agent-configuration.mdx
@@ -23,7 +23,7 @@ Server-side configuration transitions some core settings from your language agen
 
 ## Requirements [#requirements]
 
-Server-side configuration is not available for our C SDK agent or our PHP agent.
+Server-side configuration is not available for our PHP agent.
 
 ## Centralization and security [#features]
 
@@ -37,7 +37,6 @@ This feature provides the convenience of managing the available configuration se
 
 For more information about the hierarchy of settings, see the illustration for the specific agent:
 
-* [C SDK configuration](/docs/agents/c-sdk/install-configure/c-sdk-configuration): A hierarchy is not applicable, because configuration values come from API calls. Also, server-side configuration is not supported. However, you can change the app name from the [UI](/docs/agents/c-sdk/install-configure/c-sdk-configuration#change-ui) or from the C SDK [configuration settings](/docs/agents/c-sdk/install-configure/c-sdk-configuration#change-app-name).
 * [Go hierarchy](/docs/agents/go-agent/instrumentation/go-agent-configuration#options)
 * [Java hierarchy](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#config-options-precedence)
 * [.NET hierarchy](/docs/agents/net-agent/installation-configuration/net-agent-configuration#config-options-precedence)
@@ -48,7 +47,9 @@ For more information about the hierarchy of settings, see the illustration for t
 
 ## Configure from the UI [#enable-ssc]
 
-The C SDK and PHP agent do not support server-side configuration. To enable server-side configuration settings for monitored apps from the UI:
+The PHP agent doesn't support server-side configuration. 
+
+To enable server-side configuration settings for monitored apps from the UI:
 
 1. Go to **[one.newrelic.com](https://one.newrelic.com)** and click **APM**.
 2. Click on your app. Then click **Settings > Application > Server-side agent configuration**.
@@ -63,7 +64,9 @@ For how to enable this with NerdGraph, see the [NerdGraph tutorial](/docs/apis/n
 
 If you use server-side configuration, you must still include your `license_key` and `app_name` in the local config file. These settings are required for the agent to communicate with the New Relic collector.
 
-The C SDK and PHP agent do not support server-side configuration. To view or change the available server-side configuration settings through the UI for apps that use other New Relic agents:
+The PHP agent doesn't support server-side configuration. 
+
+To view or change the available server-side configuration settings through the UI for apps that use other New Relic agents:
 
 1. Go to **[one.newrelic.com](https://one.newrelic.com)** and click **APM**.
 2. Click on your app. Then click **Settings > Application > Server-side agent configuration**.

--- a/src/content/docs/apm/agents/manage-apm-agents/troubleshooting/agent-nrintegrationerrors-appear-insights.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/troubleshooting/agent-nrintegrationerrors-appear-insights.mdx
@@ -91,5 +91,5 @@ This is caused by a configuration mismatch with the agent. See the relevant agen
 </CollapserGroup>
 
 <Callout variant="tip">
-  This error does not apply to the C SDK or PHP agents.
+  This error does not apply to the PHP agent.
 </Callout>

--- a/src/content/docs/apm/apm-ui-pages/error-analytics/manage-error-data.mdx
+++ b/src/content/docs/apm/apm-ui-pages/error-analytics/manage-error-data.mdx
@@ -100,6 +100,7 @@ Sometimes you want to collect error data, but not have those errors wake you up 
 
 To prevent certain errors from being reported to New Relic, disable them in your agent's configuration file. For most agents, you can ignore certain error codes or disable errors completely. For more information, see your specific agent's configuration documentation:
 
+ * Go (not applicable; the agent only reports errors when configured to do so)
 * [Java](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#Error_Collector)
 * [.NET](/docs/agents/net-agent/installation-configuration/net-agent-configuration#error_collector)
 * [Node.js](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#error_config)

--- a/src/content/docs/apm/apm-ui-pages/error-analytics/manage-error-data.mdx
+++ b/src/content/docs/apm/apm-ui-pages/error-analytics/manage-error-data.mdx
@@ -100,8 +100,6 @@ Sometimes you want to collect error data, but not have those errors wake you up 
 
 To prevent certain errors from being reported to New Relic, disable them in your agent's configuration file. For most agents, you can ignore certain error codes or disable errors completely. For more information, see your specific agent's configuration documentation:
 
-* [C SDK](https://github.com/newrelic/c-sdk/blob/master/GUIDE.md#error-instrumentation)
-* Go (not applicable; the agent only reports errors when configured to do so)
 * [Java](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#Error_Collector)
 * [.NET](/docs/agents/net-agent/installation-configuration/net-agent-configuration#error_collector)
 * [Node.js](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#error_config)

--- a/src/content/docs/apm/apm-ui-pages/features/analyze-database-instance-level-performance-issues.mdx
+++ b/src/content/docs/apm/apm-ui-pages/features/analyze-database-instance-level-performance-issues.mdx
@@ -31,7 +31,6 @@ Using APM's [transaction traces](/docs/apm/transactions/transaction-traces/trans
 
 New Relic collects instance details for a variety of databases and database drivers. The ability to view specific instances and the types of database information in APM depends on your database driver and agent version:
 
-* **C SDK:** See [C SDK compatibility](/docs/agents/c-sdk/instrumentation/instrument-your-app-c-sdk#datastore-segments) for datastore segments.
 * **Go:** See [Go agent instance-level compatibility](/docs/agents/go-agent/get-started/go-agent-compatibility-requirements#datastores) for datastores.
 * **Java:** See [Java agent instance-level compatibility](/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent#instance-level-db) for databases.
 * **.NET:** See [.NET agent instance-level compatibility](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#instance-details) for datastores.

--- a/src/content/docs/apm/apm-ui-pages/monitoring/agent-specific-ui-pages.mdx
+++ b/src/content/docs/apm/apm-ui-pages/monitoring/agent-specific-ui-pages.mdx
@@ -15,7 +15,6 @@ redirects:
 
 The following agents also have custom UI pages for certain features:
 
-* C SDK: no C-specific UI pages
 * Go: [**Go runtime**](/docs/agents/go-agent/features/go-runtime-ui-page) page
 * Java: [**JVMs**](/docs/agents/java-agent/features/jvm-metrics-page) page and [**Instrumentation editor**](/docs/agents/java-agent/custom-instrumentation/custom-instrumentation-editor-quickly-customize-your-java-instrumentation) feature
 * .NET: no .NET-specific UI pages

--- a/src/content/docs/apm/apm-ui-pages/monitoring/databases-page-view-operations-throughput-response-time.mdx
+++ b/src/content/docs/apm/apm-ui-pages/monitoring/databases-page-view-operations-throughput-response-time.mdx
@@ -93,7 +93,6 @@ To delete all traces for your app permanently:
 
 Additional features on the **Databases** page are available with following agent versions. For more information, see [Update the New Relic agent](/docs/agents/manage-apm-agents/installation/update-new-relic-agent).
 
-* C SDK 1.0.0 or higher
 * Go 1.4 or higher
 * Java 3.14.0 or higher
 * .NET 4.1.134 or higher

--- a/src/content/docs/apm/apm-ui-pages/monitoring/external-services/external-services-setup.mdx
+++ b/src/content/docs/apm/apm-ui-pages/monitoring/external-services/external-services-setup.mdx
@@ -35,15 +35,6 @@ Complete the following for each service you want to view in external services:
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        C SDK
-      </td>
-
-      <td>
-        See the documentation about [instrumenting segments](/docs/apm/agents/c-sdk/instrumentation/instrument-your-app-c-sdk/#external-segments).
-      </td>
-    </tr>
 
     <tr>
       <td>
@@ -166,15 +157,6 @@ If you’re not seeing the type of detail you want in the UI, you can increase t
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        C SDK
-      </td>
-
-      <td>
-        The reservoir is not currently configurable
-      </td>
-    </tr>
 
     <tr>
       <td>

--- a/src/content/docs/apm/apm-ui-pages/monitoring/view-slow-query-details.mdx
+++ b/src/content/docs/apm/apm-ui-pages/monitoring/view-slow-query-details.mdx
@@ -55,12 +55,6 @@ In general, you can configure your slow query settings either of these ways:
 Agent configuration gives you more options than server-side configuration does. How you choose to configure slow queries will depend on your own setup and preferences. For more information, see the documentation for the specific agent:
 
 <CollapserGroup>
-  <Collapser
-    id="c-sdk"
-    title="C SDK"
-  >
-    You can report slow query traces for SQL databases only. For more information, see [Instrument your application with the C SDK](/docs/agents/c-sdk/instrumentation/instrument-your-app-c-sdk#slow-query-datastore).
-  </Collapser>
 
   <Collapser
     id="go"

--- a/src/content/docs/apm/applications-menu/features/configure-request-queue-reporting.mdx
+++ b/src/content/docs/apm/applications-menu/features/configure-request-queue-reporting.mdx
@@ -25,10 +25,6 @@ Most New Relic agents will interpret an `X-Queue-Start` or `X-Request-Start` hea
 
 Nearly any front-end HTTP server or load balancer can be configured to add this header. Additional details depend on your specific agent and server configuration. For more information, see the [request queue configuration examples](/docs/apm/applications-menu/features/request-queue-server-configuration-examples).
 
-## C SDK
-
-The C SDK does not support request queuing.
-
 ## Go agent [#go]
 
 With the Go agent, set either header to record a metric for it.

--- a/src/content/docs/apm/new-relic-apm/getting-started/apm-agent-data-security.mdx
+++ b/src/content/docs/apm/new-relic-apm/getting-started/apm-agent-data-security.mdx
@@ -21,7 +21,6 @@ Our APM agent is a publicly accessible plugin for web applications. The agent do
 
 Most of our agents are open source, so you can see what our code does:
 
-* [C SDK](https://github.com/newrelic/c-sdk)
 * [Go](https://github.com/newrelic/go-agent)
 * [.NET](https://github.com/newrelic/newrelic-dotnet-agent)
 * [Node.js](https://github.com/newrelic/node-newrelic)
@@ -106,7 +105,6 @@ If you want to restrict the information that New Relic receives, you can enable 
   >
     Depending on the agent, the default settings provide security for request parameters, HTTPS usage, and SQL:
 
-    * [C SDK default security settings](/docs/agents/c-sdk/get-started/apm-security-c-sdk#default)
     * [Go default security settings](/docs/agents/go-agent/get-started/apm-agent-security-go#default)
     * [Java default security settings](/docs/agents/java-agent/getting-started/apm-agent-security-java#default)
     * [.NET default security settings](/docs/agents/net-agent/getting-started/apm-agent-security-net#default)
@@ -124,7 +122,6 @@ If you want to restrict the information that New Relic receives, you can enable 
 
     In addition, high security mode applies restrictions to custom events, custom instrumentation, user attributes, exception messages, or message queue parameters, depending on the agent:
 
-    * C SDK: n/a
     * [Go high security mode settings](/docs/agents/go-agent/get-started/apm-agent-security-go#restricted)
     * [Java high security mode settings](/docs/agents/java-agent/getting-started/apm-agent-security-java#restricted)
     * [.NET high security mode settings](/docs/agents/net-agent/getting-started/apm-agent-security-net#restricted)
@@ -140,7 +137,6 @@ If you want to restrict the information that New Relic receives, you can enable 
   >
     If you want custom security settings, you can customize the configuration file, change custom attribute settings, or use the API, depending on your agent:
 
-    * [C SDK custom security settings](/docs/agents/c-sdk/get-started/apm-security-c-sdk#customize)
     * [Go custom security settings](/docs/agents/go-agent/get-started/apm-agent-security-go#custom)
     * [Java custom security settings](/docs/agents/java-agent/getting-started/apm-agent-security-java#custom)
     * [.NET custom security mode settings](/docs/agents/net-agent/getting-started/apm-agent-security-net#custom)
@@ -239,7 +235,6 @@ This information applies to all APM agents no matter what security settings you 
 
 [Our preferred protocol for all domains](/docs/apm/new-relic-apm/getting-started/networks#tls) is TLS 1.2. APM agents enable SSL by default. To verify which release includes SSL by default and to ensure that you have the most up-to-date version, refer to your agent's release notes:
 
-* [C SDK](/docs/release-notes/agent-release-notes/c-sdk-release-notes)
 * [Go](/docs/release-notes/agent-release-notes/go-release-notes)
 * [Java](/docs/release-notes/agent-release-notes/java-release-notes)
 * [.NET](/docs/release-notes/agent-release-notes/net-release-notes)
@@ -249,8 +244,6 @@ This information applies to all APM agents no matter what security settings you 
 * [Ruby](/docs/release-notes/agent-release-notes/ruby-release-notes)
 
 The configuration file also includes an optional flag (`ssl`) to enable or disable SSL using HTTPS. New Relic does not do host authentication with HTTPS, just communication encryption.
-
-**Exception:** You cannot disable SSL for the C SDK. The C SDK daemon can only connect with SSL.
 
 New Relic requires HTTPS for all traffic to APM and the REST API. This includes both inbound and outbound traffic. If your [REST API call uses HTTP](/docs/apis/rest-api-v2/troubleshooting/301-response-rest-api-calls), or if you have disabled SSL in your configuration file, change your script or program to HTTPS.
 
@@ -278,15 +271,6 @@ Optional settings are available so that you can configure the agent to communica
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        C SDK
-      </td>
-
-      <td>
-        `-proxy` at daemon startup
-      </td>
-    </tr>
 
     <tr>
       <td>

--- a/src/content/docs/apm/new-relic-apm/getting-started/introduction-apm.mdx
+++ b/src/content/docs/apm/new-relic-apm/getting-started/introduction-apm.mdx
@@ -20,7 +20,7 @@ redirects:
 
 import apmScreenshot from 'images/apm-screenshot.png'
 
-Application performance monitoring (APM) is exactly what it sounds like: Monitoring of your web or non-web application's performance. APM supports apps for several programming languages, including [Go](/docs/agents/go-agent/get-started/introduction-new-relic-go), [Java](/docs/agents/java-agent/getting-started/introduction-new-relic-java), [.NET](/docs/agents/net-agent/getting-started/introduction-new-relic-net), [Node.js](/docs/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs), [PHP](/docs/agents/php-agent/getting-started/introduction-new-relic-php), [Python](/docs/agents/python-agent/getting-started/introduction-new-relic-python), and [Ruby](/docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby), as well as a [C SDK](/docs/agents/c-sdk/get-started/introduction-c-sdk).
+Application performance monitoring (APM) is exactly what it sounds like: Monitoring of your web or non-web application's performance. You can monitor apps in the most popular web development languages, including [Go](/docs/agents/go-agent/get-started/introduction-new-relic-go), [Java](/docs/agents/java-agent/getting-started/introduction-new-relic-java), [.NET](/docs/agents/net-agent/getting-started/introduction-new-relic-net), [Node.js](/docs/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs), [PHP](/docs/agents/php-agent/getting-started/introduction-new-relic-php), [Python](/docs/agents/python-agent/getting-started/introduction-new-relic-python), and [Ruby](/docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby).
 
 <img
   title="APM example"

--- a/src/content/docs/apm/new-relic-apm/getting-started/introduction-apm.mdx
+++ b/src/content/docs/apm/new-relic-apm/getting-started/introduction-apm.mdx
@@ -20,7 +20,7 @@ redirects:
 
 import apmScreenshot from 'images/apm-screenshot.png'
 
-Application performance monitoring (APM) is exactly what it sounds like: Monitoring of your web or non-web application's performance. You can monitor apps in the most popular web development languages, including [Go](/docs/agents/go-agent/get-started/introduction-new-relic-go), [Java](/docs/agents/java-agent/getting-started/introduction-new-relic-java), [.NET](/docs/agents/net-agent/getting-started/introduction-new-relic-net), [Node.js](/docs/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs), [PHP](/docs/agents/php-agent/getting-started/introduction-new-relic-php), [Python](/docs/agents/python-agent/getting-started/introduction-new-relic-python), and [Ruby](/docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby).
+Application performance monitoring (APM) is exactly what it sounds like: Monitoring of your web or non-web application's performance. You can monitor apps in most popular web development languages, including [Go](/docs/agents/go-agent/get-started/introduction-new-relic-go), [Java](/docs/agents/java-agent/getting-started/introduction-new-relic-java), [.NET](/docs/agents/net-agent/getting-started/introduction-new-relic-net), [Node.js](/docs/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs), [PHP](/docs/agents/php-agent/getting-started/introduction-new-relic-php), [Python](/docs/agents/python-agent/getting-started/introduction-new-relic-python), and [Ruby](/docs/agents/ruby-agent/getting-started/introduction-new-relic-ruby).
 
 <img
   title="APM example"

--- a/src/content/docs/apm/new-relic-apm/maintenance/disable-apm-agent.mdx
+++ b/src/content/docs/apm/new-relic-apm/maintenance/disable-apm-agent.mdx
@@ -20,12 +20,6 @@ Related procedures:
 Select your agent type for instructions:
 
 <CollapserGroup>
-  <Collapser
-    id="c-sdk"
-    title="C SDK"
-  >
-    The C SDK cannot be turned on or off directly. However, you can write your code for the SDK so that a quick recompile and deploy can enable or disable your instrumentation. Follow standard procedures to [disable or uninstall the C SDK](/docs/agents/c-sdk/install-configure/uninstall-remove-c-sdk).
-  </Collapser>
 
   <Collapser
     id="go"

--- a/src/content/docs/apm/new-relic-apm/maintenance/remove-applications-new-relic.mdx
+++ b/src/content/docs/apm/new-relic-apm/maintenance/remove-applications-new-relic.mdx
@@ -43,7 +43,6 @@ Before you can remove an application monitored by New Relic APM, browser monitor
     title="APM applications"
   >
     1. Disable an APM agent using these instructions:
-       * [**C SDK**](/docs/agents/c-sdk/install-configure/uninstall-remove-c-sdk#disable): Do a quick recompile and deploy. For example, surround your instrumentation in `#ifdef`, and set the value of `YOURNAMESPACE_NEWRELIC_ENABLED` with your build system.
        * [**Go**](/docs/agents/go-agent/instrumentation/go-agent-configuration#enabled): Set `Enabled` to `false`.
        * [**Java**](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#cfg-agent_enabled): Set `agent_enabled` to `false`.
        * [**.NET**](/docs/agents/net-agent/installation-configuration/net-agent-configuration#app-cfg-agent-enabled): Set `Newrelic.AgentEnabled` to `false`.

--- a/src/content/docs/apm/transactions/cross-application-traces/troubleshoot-cross-application-tracing.mdx
+++ b/src/content/docs/apm/transactions/cross-application-traces/troubleshoot-cross-application-tracing.mdx
@@ -31,15 +31,6 @@ Make sure you meet these requirements for your agent's version, protocols, inter
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        C SDK
-      </td>
-
-      <td>
-        Use [distributed tracing](/docs/agents/c-sdk/instrumentation/enable-distributed-tracing-your-c-applications).
-      </td>
-    </tr>
 
     <tr>
       <td>
@@ -119,7 +110,6 @@ Make sure you meet these requirements for your agent's version, protocols, inter
 
 In general, New Relic's cross application tracing feature is enabled by default. Requirements to change your configuration file vary, depending on your New Relic agent:
 
-* C SDK (not supported)
 * Go (not supported)
 * [Java](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#Cross_Application_Tracer)
 * [.NET](/docs/agents/net-agent/installation-and-configuration/net-agent-configuration#cross_application_tracer)

--- a/src/content/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions.mdx
+++ b/src/content/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions.mdx
@@ -83,12 +83,6 @@ Some non-web transactions from supported frameworks or services are detected aut
 To create new non-web transactions, follow the procedures for your APM language agent.
 
 <CollapserGroup>
-  <Collapser
-    id="c-sdk"
-    title="C SDK"
-  >
-    Follow the procedures for [instrumenting a non-web transaction](/docs/agents/c-sdk/instrumentation/instrument-your-app-c-sdk#instrument-c-txn).
-  </Collapser>
 
   <Collapser
     id="go"

--- a/src/content/docs/apm/transactions/intro-transactions/transactions-new-relic-apm.mdx
+++ b/src/content/docs/apm/transactions/intro-transactions/transactions-new-relic-apm.mdx
@@ -35,46 +35,6 @@ Cumulative transaction data appears in APM on the [Transactions page](/docs/apm/
 Our agents have these transaction sub-types:
 
 <CollapserGroup>
-  <Collapser
-    id="agent-c-sdk"
-    title="C SDK"
-  >
-    <table>
-      <thead>
-        <tr>
-          <th style={{ width: "200px" }}>
-            Sub-type
-          </th>
-
-          <th>
-            Description
-          </th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr>
-          <td>
-            Custom
-          </td>
-
-          <td>
-            The execution of the named custom transaction. Usually recorded via manual instrumentation APIs.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Function
-          </td>
-
-          <td>
-            The invocation of the named function.
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </Collapser>
 
   <Collapser
     id="agent-go"

--- a/src/content/docs/apm/transactions/transaction-traces/configure-transaction-traces.mdx
+++ b/src/content/docs/apm/transactions/transaction-traces/configure-transaction-traces.mdx
@@ -26,7 +26,6 @@ In APM, [transaction traces](/docs/apm/transactions/transaction-traces/transacti
 
 You can customize your transaction trace settings via New Relic agent configuration files and other "local" configuration methods such as environment variables. For more information about transaction trace configuration options, see the specific New Relic language agent's documentation:
 
-* [C SDK](/docs/agents/c-sdk/instrumentation/instrument-your-app-c-sdk#instrument-c-txn)
 * [Go](/docs/agents/go-agent/instrumentation/go-agent-configuration#transaction-tracer)
 * [Java](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#h2-transaction-tracer)
 * [.NET](/docs/agents/net-agent/installation-configuration/net-agent-configuration#transaction_tracer)
@@ -77,7 +76,6 @@ You can create custom transactions for app activity that isn't being automatical
 
 For [data security reasons](/docs/apm/transactions/transaction-traces/security-options-transaction-traces), transaction traces do not collect potentially sensitive HTTP request attributes, sometimes called **parameters**. Traces do collect some basic HTTP request attributes, which New Relic calls **agent attributes**. To edit attribute collection settings, see the specific New Relic agent:
 
-* [C SDK](/docs/agents/c-sdk/instrumentation/use-default-or-custom-attributes-c-sdk)
 * [Go](/docs/agents/go-agent/instrumentation/go-agent-attributes)
 * [Java](/docs/agents/java-agent/attributes/java-agent-attributes)
 * [.NET](/docs/agents/net-agent/attributes/net-agent-attributes)

--- a/src/content/docs/apm/transactions/transaction-traces/transaction-traces-trace-details-page.mdx
+++ b/src/content/docs/apm/transactions/transaction-traces/transaction-traces-trace-details-page.mdx
@@ -217,21 +217,6 @@ The APM agents have differing rules for when to truncate segments.
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        C SDK
-      </td>
-
-      <td>
-        Truncates based on segment priority:
-
-        * The root segment has the highest priority.
-        * Segments that have seen distributed tracing activity have second-highest priority.
-        * Slow segments have third-highest priority.
-
-          For more information, see the C SDK's documentation about [`newrelic_transaction_tracer_config_t` on GitHub](https://newrelic.github.io/c-sdk/structnewrelic__transaction__tracer__config__t.html).
-      </td>
-    </tr>
 
     <tr>
       <td>

--- a/src/content/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent.mdx
+++ b/src/content/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent.mdx
@@ -81,7 +81,6 @@ Our APM agents can instrument webpages with the required JavaScript for page loa
 
 For more information, see the instructions for your APM agent:
 
-* [C SDK](/docs/agents/c-sdk/instrumentation/guide-using-c-sdk-api/#browser)
 * [Go](/docs/agents/go-agent/features/install-new-relic-browser-go-apps)
 * [Java](/docs/agents/java-agent/instrumentation/page-load-timing-java)
 * [.NET](/docs/agents/net-agent/features/page-load-timing-net)

--- a/src/content/docs/browser/browser-monitoring/troubleshooting/troubleshoot-your-browser-monitoring-installation.mdx
+++ b/src/content/docs/browser/browser-monitoring/troubleshooting/troubleshoot-your-browser-monitoring-installation.mdx
@@ -80,7 +80,6 @@ These troubleshooting steps apply to problems when the browser monitoring agent 
 
     Also verify that a second script element exists in one of two locations, depending on the app server agent language.
 
-    * **C SDK**: n/a
     * **Go**: n/a
     * **Java**: Before the `</body>` tag (which must be added to the page if missing)
     * **.NET**: Immediately before the first script element
@@ -112,7 +111,6 @@ These troubleshooting steps apply to problems when the browser monitoring agent 
   >
     If you are using New Relic's automatic instrumentation feature, ensure your agent is configured properly. Each agent has a configuration file setting and specific instructions to turn auto-instrumentation on or off:
 
-    * **C SDK**: n/a
     * **Go**: n/a
     * [Java](/docs/agents/java-agent/instrumentation/page-load-timing-java#auto_instrumentation)
     * [.NET](/docs/agents/net-agent/features/page-load-timing-net#auto_instrumentation)
@@ -132,7 +130,6 @@ These troubleshooting steps apply to problems when the browser monitoring agent 
   >
     If you are manually calling the New Relic agent API to generate and insert the JavaScript, verify that the calls are actually being made. The APIs and how to use them are specific to your agent:
 
-    * **C SDK**: n/a
     * **Go**: n/a
     * [Java agent](/docs/agents/java-agent/instrumentation/page-load-timing-java#manual_instrumentation)
     * [.NET agent](/docs/agents/net-agent/features/page-load-timing-net#manual_instrumentation)

--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing.mdx
@@ -44,7 +44,6 @@ Make sure you have the necessary minimum versions for your browser and APM agent
   * [Browser agent version 1173](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1173) or higher (required for [w3c trace context](https://www.w3.org/TR/trace-context/) support)
 * APM agent versions:
 
-  * [C SDK 1.3](/docs/release-notes/agent-release-notes/c-sdk-release-notes) or higher
   * [Java 5.9.0](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-590) or higher
   * [PHP](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-940249) 9.4.0 or higher
   * [Other APM agent version requirements](/docs/understand-dependencies/distributed-tracing/enable-configure/enable-distributed-tracing#compatibility-requirements)

--- a/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
+++ b/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
@@ -121,7 +121,6 @@ You can deploy the browser agent for apps monitored by APM, or you can deploy th
 
 If you're deploying browser for an app using APM, make sure your agent supports browser monitoring:
 
-* [C SDK](/docs/release-notes/agent-release-notes/c-sdk-release-notes): Version 1.0.0 or higher
 * [Go](/docs/release-notes/agent-release-notes/go-release-notes): Version 2.5.0 or higher
 * [Java](/docs/release-notes/agent-release-notes/java-release-notes): Version 3.4.0 or higher
 * [.NET](/docs/release-notes/agent-release-notes/net-release-notes): Version 2.20.25.0 or higher

--- a/src/content/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes.mdx
@@ -53,13 +53,6 @@ When creating your own custom events and attributes, follow data requirements fo
 * [Reserved words](/docs/telemetry-data-platform/custom-data/custom-events/data-requirements-limits-custom-event-data/#reserved-words)
 
 <CollapserGroup>
-  <Collapser
-    className="freq-link"
-    id="c-sdk"
-    title="C SDK"
-  >
-    To add a custom event to apps monitored by the C SDK, start a transaction and use the `newrelic_create_custom_event` and `newrelic_record_custom_event` functions. For more information, see the [Guide to using the C SDK API](/docs/agents/c-sdk/instrumentation/guide-using-c-sdk-api#custom-events). You can then add [custom attributes](/docs/agents/manage-apm-agents/agent-data/collect-custom-attributes#c-sdk-att) for your C SDK app.
-  </Collapser>
 
   <Collapser
     className="freq-link"

--- a/src/content/docs/data-apis/custom-data/custom-events/collect-custom-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/collect-custom-attributes.mdx
@@ -46,12 +46,6 @@ For other custom data solutions, see [Intro to custom data](/docs/telemetry-data
 To enable and use custom attributes for APM, follow the procedure for your APM agent:
 
 <CollapserGroup>
-  <Collapser
-    id="c-sdk-att"
-    title="C SDK"
-  >
-    To add custom attributes to applications monitored by the C SDK, call one of the [attribute functions](https://newrelic.github.io/c-sdk/libnewrelic_8h.html#abfe6f64a8eec7d60d8588f8969781d34); for example, `newrelic_add_attribute_double()`. The key name for your custom attribute depends on what you specify when you call the function.
-  </Collapser>
 
   <Collapser
     id="go-att"

--- a/src/content/docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes.mdx
@@ -138,15 +138,6 @@ There are two ways to add custom attributes to the `PageView` event:
          </thead>
 
          <tbody>
-           <tr>
-             <td>
-               C SDK
-             </td>
-
-             <td>
-               Not supported.
-             </td>
-           </tr>
 
            <tr>
              <td>

--- a/src/content/docs/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing.mdx
+++ b/src/content/docs/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing.mdx
@@ -168,7 +168,7 @@ For more help finding your traces in the UI:
 
 ## Set up Infinite Tracing (advanced option) [#infinite-tracing]
 
-Standard distributed tracing for APM agents (above) use [adaptive sampling](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works/#trace-origin-sampling) to capture up to 10 traces per minute, but if you want us to analyze all your data and find the most relevant traces, you can set up Infinite Tracing. This alternative to standard distributed tracing is available for all APM language agents except C SDK.
+Standard distributed tracing for APM agents (above) use [adaptive sampling](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works/#trace-origin-sampling) to capture up to 10 traces per minute, but if you want us to analyze all your data and find the most relevant traces, you can set up Infinite Tracing. This alternative to standard distributed tracing is available for all APM language agents.
 
 <Callout variant="tip">
   To learn more about this feature, see [Infinite Tracing](/docs/understand-dependencies/distributed-tracing/infinite-tracing/introduction-infinite-tracing).
@@ -189,12 +189,6 @@ The trace observer is a New Relic AWS-based service that collects and analyzes a
 Infinite Tracing configuration settings include the standard distributed tracing plus information about the trace observer. Find the settings for your language agent below:
 
 <CollapserGroup>
-  <Collapser
-    id="c-sdk-config"
-    title="C SDK"
-  >
-    Infinite tracing is not available for C SDK.
-  </Collapser>
 
   <Collapser
     id="go-config"
@@ -579,48 +573,6 @@ Following the compatibility information is a section showing the basic configura
 Find your language agents below to confirm if you can use your existing agents with distributed tracing:
 
 <CollapserGroup>
-  <Collapser
-    id="c-sdk"
-    title="C SDK"
-  >
-    [Install (compile)](/docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code) or [update](/docs/agents/c-sdk/install-configure/update-your-c-sdk-library) to the required C SDK version. For best results, update to the [latest C SDK version](/docs/release-notes/agent-release-notes/c-sdk-release-notes).
-
-    <table>
-      <thead>
-        <tr>
-          <th style={{ width: "250px" }}>
-            Option
-          </th>
-
-          <th>
-            C SDK version
-          </th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr>
-          <td>
-            Standard distributed tracing
-          </td>
-
-          <td>
-            1.1.0 or higher (W3C Trace Context not available)
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Infinite Tracing
-          </td>
-
-          <td>
-            Not available
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </Collapser>
 
   <Collapser
     id="go-version"
@@ -975,46 +927,6 @@ Distributed tracing is enabled through configuration settings. Review the follow
 </Callout>
 
 <CollapserGroup>
-  <Collapser
-    id="c-sdk-config-standard"
-    title="C SDK"
-  >
-    Here's an overview of the settings. For more help with configuration, see [Enable distributed tracing for your C applications](/docs/agents/c-sdk/instrumentation/enable-distributed-tracing-your-c-applications).
-
-    <table>
-      <thead>
-        <tr>
-          <th style={{ width: "200px" }}>
-            Type
-          </th>
-
-          <th>
-            Required configuration
-          </th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr>
-          <td>
-            Standard distributed tracing
-          </td>
-
-          <td>
-            Configuration options:
-
-            * `newrelic_app_config_t` structure:
-
-              ```
-              newrelic_app_config_t* config;
-              config = newrelic_create_app_config(app_name, license_key);
-              config->distributed_tracing.enabled = true;
-              ```
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </Collapser>
 
   <Collapser
     id="go-config-standard"
@@ -1388,7 +1300,7 @@ If a service is not passing the trace header to other services, you can use the 
     To instrument the calling service:
 
     1. Ensure the [version of the APM agent](#compatibility-requirements) that monitors the calling service supports distributed tracing.
-    2. Invoke the agent API call for generating a distributed trace payload: [C SDK](/docs/agents/c-sdk/instrumentation/enable-distributed-tracing-your-c-applications) \| [Go](/docs/agents/go-agent/features/distributed-tracing-go#create-manually) \| [Java](/docs/agents/java-agent/api-guides/guide-using-java-agent-api#trace-calls) \| [.NET](/docs/agents/net-agent/net-agent-api/itransaction#CreateDistributedTracePayload) \| [Node.js](/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#transaction-handle-createDistributedTracePayload) \| [PHP](/docs/agents/php-agent/features/distributed-tracing-php#manual) \| [Python](/docs/agents/python-agent/python-agent-api/create_distributed_trace_payload) \| [Ruby](/docs/agents/ruby-agent/api-guides/guide-using-ruby-agent-api#distributed).
+    2. Invoke the agent API call for generating a distributed trace payload:  [Go](/docs/agents/go-agent/features/distributed-tracing-go#create-manually) \| [Java](/docs/agents/java-agent/api-guides/guide-using-java-agent-api#trace-calls) \| [.NET](/docs/agents/net-agent/net-agent-api/itransaction#CreateDistributedTracePayload) \| [Node.js](/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#transaction-handle-createDistributedTracePayload) \| [PHP](/docs/agents/php-agent/features/distributed-tracing-php#manual) \| [Python](/docs/agents/python-agent/python-agent-api/create_distributed_trace_payload) \| [Ruby](/docs/agents/ruby-agent/api-guides/guide-using-ruby-agent-api#distributed).
 
        <Callout variant="important">
          To maintain proper ordering of spans in a trace, ensure you **generate the payload in the context of the span that sends it**.
@@ -1396,7 +1308,6 @@ If a service is not passing the trace header to other services, you can use the 
     3. Add that payload to the call made to the destination service (for example, in a header).
     4. (Optional) Identify the call as an external call:
 
-       * [C SDK](https://github.com/newrelic/c-sdk/blob/master/GUIDE.md#distributed-tracing)
        * [Go](/docs/agents/go-agent/get-started/instrument-go-segments#go-external-segments)
        * [Java](https://newrelic.github.io/java-agent-api/javadoc/index.html?com/newrelic/api/agent/TracedMethod.html)
        * .NET: n/a
@@ -1416,12 +1327,6 @@ If a service is not passing the trace header to other services, you can use the 
     2. If the New Relic agent on the called service does not identify a New Relic transaction, use the agent API to declare a transaction:
 
        <CollapserGroup>
-         <Collapser
-           id="c-sdk-create"
-           title="C SDK"
-         >
-           One way to tell that a transaction is not in progress: when `newrelic_create_distributed_trace_payload()` is called, a `NULL` pointer is returned. To solve this problem, follow the procedures to [create a transaction](/docs/agents/c-sdk/instrumentation/instrument-your-app-c-sdk) with the C SDK.
-         </Collapser>
 
          <Collapser
            id="go-create"
@@ -1478,6 +1383,6 @@ If a service is not passing the trace header to other services, you can use the 
          </Collapser>
        </CollapserGroup>
     3. Extract the payload from the call that you received (for example, in a header).
-    4. Invoke the call for accepting the payload: [C SDK](/docs/agents/c-sdk/instrumentation/enable-distributed-tracing-your-c-applications) \| [Go](/docs/agents/go-agent/features/distributed-tracing-go#create-manually) \| [Java](/docs/agents/java-agent/api-guides/guide-using-java-agent-api#trace-calls) \| [.NET](/docs/agents/net-agent/net-agent-api/itransaction#AcceptDistributedTracePayload) \| [PHP](/docs/agents/php-agent/features/distributed-tracing-php#manual) \| [Node.js](/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#transaction-handle-acceptDistributedTracePayload) \| [Python](/docs/agents/python-agent/python-agent-api/accept_distributed_trace_payload) \| [Ruby](/docs/agents/ruby-agent/api-guides/guide-using-ruby-agent-api#distributed).
+    4. Invoke the call for accepting the payload: [Go](/docs/agents/go-agent/features/distributed-tracing-go#create-manually) \| [Java](/docs/agents/java-agent/api-guides/guide-using-java-agent-api#trace-calls) \| [.NET](/docs/agents/net-agent/net-agent-api/itransaction#AcceptDistributedTracePayload) \| [PHP](/docs/agents/php-agent/features/distributed-tracing-php#manual) \| [Node.js](/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#transaction-handle-acceptDistributedTracePayload) \| [Python](/docs/agents/python-agent/python-agent-api/accept_distributed_trace_payload) \| [Ruby](/docs/agents/ruby-agent/api-guides/guide-using-ruby-agent-api#distributed).
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/glossary/glossary.mdx
+++ b/src/content/docs/glossary/glossary.mdx
@@ -106,8 +106,6 @@ Whether you're considering New Relic One or you're already using our capabilitie
 
     **APM agents:**
 
-    * [C SDK API](/docs/agents/c-sdk/instrumentation/guide-using-c-sdk-api)
-
     * [Go agent API](/docs/agents/go-agent/api-guides/guide-using-go-agent-api)
 
     * [Java agent API](/docs/java/java-agent-api)
@@ -555,7 +553,6 @@ Whether you're considering New Relic One or you're already using our capabilitie
 
     New Relic automatically instruments many common frameworks. For more about the frameworks New Relic supports, see the agent-specific documentation:
 
-    * [C SDK supported frameworks](/docs/agents/c-sdk/get-started/c-sdk-compatibility-requirements)
     * [Go supported frameworks](/docs/agents/go-agent/get-started/go-agent-compatibility-requirements)
     * [Java supported frameworks](/docs/agents/java-agent/getting-started/new-relic-java#h2-compatibility)
     * [.NET supported frameworks](/docs/agents/net-agent/getting-started/new-relic-net#requirements)

--- a/src/content/docs/logs/logs-context/logs-in-context.mdx
+++ b/src/content/docs/logs/logs-context/logs-in-context.mdx
@@ -71,7 +71,6 @@ To use our manual solution to set up logs in context for APM and for infrastruct
 
 2. Update to the supported APM agent version for your app, and enable [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing). For specific instructions, select your agent:
 
-* [C SDK](/docs/logs/enable-log-management-new-relic/configure-logs-context/c-sdk-configure-logs-context)
 * [Go](/docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-go/)
 * [Java](/docs/logs/enable-log-management-new-relic/configure-logs-context/java-configure-logs-context-all/)
 * [.NET](/docs/logs/enable-log-management-new-relic/configure-logs-context/net-configure-logs-context-all/)

--- a/src/content/docs/new-relic-one/core-concepts/use-tags-help-organize-find-your-data.mdx
+++ b/src/content/docs/new-relic-one/core-concepts/use-tags-help-organize-find-your-data.mdx
@@ -201,8 +201,6 @@ Here are some details about how tags are added for some specific data sources:
 
       Here are links to the agent configuration options:
 
-    * C SDK: not available
-
     * [Java](/docs/agents/java-agent/configuration/java-agent-configuration-config-file/#labels)
 
     * [Go](/docs/agents/go-agent/configuration/go-agent-configuration#labels)

--- a/src/content/docs/new-relic-one/install-configure/compatibility-requirements-new-relic-agents-products.mdx
+++ b/src/content/docs/new-relic-one/install-configure/compatibility-requirements-new-relic-agents-products.mdx
@@ -19,7 +19,6 @@ In this doc, we have links to some of our most popular tools. For a complete lis
 
 ## APM compatibility and requirements [#apm-compatibility]
 
-* [C SDK](/docs/agents/c-sdk/get-started/c-sdk-compatibility-requirements)
 * [Go](/docs/agents/go-agent/get-started/go-agent-compatibility-requirements)
 * [Java](/docs/compatibility-requirements-java-agent)
 * [.NET Core](/docs/agents/net-agent/installation/compatibility-requirements-net-core-agent)

--- a/src/content/docs/new-relic-one/install-configure/configure-new-relic-agents.mdx
+++ b/src/content/docs/new-relic-one/install-configure/configure-new-relic-agents.mdx
@@ -29,7 +29,6 @@ The only required settings for the APM agents are your [license key](/docs/apis/
 
 For additional configuration options, see:
 
-* [C SDK](/docs/agents/c-sdk/install-configure/c-sdk-configuration)
 * [Go](/docs/agents/go-agent/instrumentation/go-agent-configuration)
 * [Java](/docs/agents/java-agent/configuration/java-agent-configuration-config-file)
 * [.NET](/docs/agents/net-agent/installation-configuration/net-agent-configuration)

--- a/src/content/docs/new-relic-one/install-configure/install-new-relic.mdx
+++ b/src/content/docs/new-relic-one/install-configure/install-new-relic.mdx
@@ -63,12 +63,6 @@ If you're on our EU data center, [start here](https://one.eu.newrelic.com/nr1-co
   />
 
   <TechTile
-    name="C SDK"
-    icon="logo-c"
-    to="https://one.newrelic.com/nr1-core?state=af6becca-be1e-7436-bfaf-6d953ecb6d17"
-  />
-
-  <TechTile
     name="Go agent"
     icon="logo-go"
     to="https://one.newrelic.com/nr1-core?state=0545168b-2b10-a80e-e884-e4012df58a54"

--- a/src/content/docs/new-relic-one/install-configure/uninstall-agent.mdx
+++ b/src/content/docs/new-relic-one/install-configure/uninstall-agent.mdx
@@ -30,7 +30,6 @@ If you encounter problems, see [support.newrelic.com](https://support.newrelic.c
 
 After uninstalling APM agents or making a change to your startup script, you must restart your app (or the app server or web server where it is located). You must do this because New Relic agents typically run in the memory of the process running the app. Simply removing those files will **not** stop the applications that are currently running from sending data to New Relic.
 
-* [C SDK](/docs/agents/c-sdk/install-configure/uninstall-remove-c-sdk)
 * [Go](/docs/agents/go-agent/installation-configuration/uninstall-go-agent)
 * [Java](/docs/agents/java-agent/installation/uninstall-java-agent)
 * [.NET](/docs/agents/net-agent/installation-configuration/uninstall-net-agent)

--- a/src/content/docs/new-relic-one/install-configure/update-new-relic-agent.mdx
+++ b/src/content/docs/new-relic-one/install-configure/update-new-relic-agent.mdx
@@ -22,7 +22,6 @@ Some [New Relic quickstarts](https://newrelic.com/instant-observability/ "Link o
 
 See the docs for your agent:
 
-* **C SDK**: [Update](/docs/agents/c-sdk/install-configure/update-your-c-sdk-library) \| [Release notes](/docs/release-notes/agent-release-notes/c-sdk-release-notes)
 * **Go**: [Update](/docs/agents/go-agent/installation/update-go-agent) \| [Release notes](/docs/release-notes/agent-release-notes/go-release-notes)
 * **Java**: [Update](/docs/agents/java-agent/installation/upgrading-java-agent) \| [Release notes](/docs/release-notes/agent-release-notes/java-release-notes)
 * **.NET**: [Update](/docs/agents/net-agent/installation-configuration/upgrading-net-agent) \| [Release notes](/docs/release-notes/agent-release-notes/net-release-notes)

--- a/src/content/docs/new-relic-one/ui-data/explore-downstream-dependencies-new-relic-one.mdx
+++ b/src/content/docs/new-relic-one/ui-data/explore-downstream-dependencies-new-relic-one.mdx
@@ -21,7 +21,6 @@ Similar to [service maps](/docs/understand-dependencies/understand-system-depend
 
 To view an entity's dependencies, make sure your app uses the minimum required APM agent version:
 
-* [C 1.0.0 or higher](/docs/release-notes/agent-release-notes/c-sdk-release-notes)
 * [Go 1.11 or higher](/docs/release-notes/agent-release-notes/go-release-notes)
 * [Java 3.9.0 or higher](/docs/release-notes/agent-release-notes/java-release-notes)
 * [.NET 4.2 or higher](/docs/release-notes/agent-release-notes/net-release-notes)

--- a/src/content/docs/new-relic-one/ui-data/service-maps/how-use-service-maps.mdx
+++ b/src/content/docs/new-relic-one/ui-data/service-maps/how-use-service-maps.mdx
@@ -37,7 +37,6 @@ For best results, update existing agents to the latest version. The required min
   >
     The required minimum agent versions for maps using distributed tracing are:
 
-    * [C SDK 1.1.0 or higher](/docs/release-notes/agent-release-notes/c-sdk-release-notes)
     * [Go agent 2.1.0 or higher](/docs/release-notes/agent-release-notes/go-release-notes)
     * [Java agent 4.3.0 or higher](/docs/release-notes/agent-release-notes/java-release-notes)
     * [.NET agent 8.6.45.0 or higher](/docs/release-notes/agent-release-notes/net-release-notes)
@@ -53,7 +52,6 @@ For best results, update existing agents to the latest version. The required min
   >
     The minimum version requirements for maps not using distributed tracing are:
 
-    * C SDK: not available
     * [Go 1.11 or higher](/docs/release-notes/agent-release-notes/go-release-notes)
     * [Java 3.9.0 or higher](/docs/release-notes/agent-release-notes/java-release-notes)
     * [.NET 4.2 or higher](/docs/release-notes/agent-release-notes/net-release-notes)

--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
@@ -360,7 +360,7 @@ This section includes various ways to configure New Relic features to optimize d
 
   Data volume will also vary based on whether you are using [Infinite Tracing](/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing).
 
-  Standard distributed tracing for APM agents (above) captures up to 10% of your traces, but if you want us to analyze all your data and find the most relevant traces, you can set up Infinite Tracing. This alternative to standard distributed tracing is available for all APM language agents except C SDK.
+  Standard distributed tracing for APM agents (above) captures up to 10% of your traces, but if you want us to analyze all your data and find the most relevant traces, you can set up Infinite Tracing. This alternative to standard distributed tracing is available for all APM language agents.
 
   The main parameters that could drive a small increase in monthly ingest are:
   * Configure trace observer monitoring

--- a/src/content/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/diagnostics-cli-nrdiag.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/diagnostics-cli-nrdiag.mdx
@@ -43,7 +43,7 @@ For additional troubleshooting steps for your agent, check out [Not seeing data]
 
 The Diagnostics CLI is available for Linux, macOS, and Windows. It can detect common configuration issues for:
 
-* **APM**: Available for all APM agents except C SDK. For the Go agent, only basic connectivity checks are available.
+* **APM**: Available for all APM agents. For the Go agent, only basic connectivity checks are available.
 * **Browser monitoring**: Browser agent detection
 * **Infrastructure monitoring**: Linux and Windows agents
 * **Mobile agents**: iOS and Android

--- a/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/find-agent-root-directory.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/find-agent-root-directory.mdx
@@ -31,13 +31,6 @@ The agent root directory depends on the agent you're using:
 
 <CollapserGroup>
   <Collapser
-    id="c-sdk"
-    title="C SDK"
-  >
-    The C SDK may not necessarily be [installed](/docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code) in a single place, and it does not have an installation tool or script. The "root directory" depends on what the user does. In general, the root directory is the location of the `libnewrelic.so` or `libnewrelic.a` library file as well as the location of the `libnewrelic.h` file.
-  </Collapser>
-
-  <Collapser
     id="go-agent"
     title="Go agent"
   >

--- a/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/generate-new-relic-agent-logs-troubleshooting.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/generate-new-relic-agent-logs-troubleshooting.mdx
@@ -20,7 +20,6 @@ Related docs:
 
 ## APM agent logging [#apm-install]
 
-* [C SDK logs](/docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code#logging)
 * [Go agent logs](/docs/agents/go-agent/configuration/go-agent-logging)
 * [Java logs](/docs/agents/java-agent/troubleshooting/generate-debug-logs-troubleshooting-java)
 * [.NET logs](/docs/agents/net-agent/troubleshooting/generate-logs-troubleshooting-net)

--- a/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/log-audit-all-data-your-new-relic-agent-transmits.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/log-audit-all-data-your-new-relic-agent-transmits.mdx
@@ -37,19 +37,6 @@ For details about the audit logging options for your APM agent's configuration f
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        C SDK
-      </td>
-
-      <td>
-        When [starting the C SDK daemon](/docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code#daemon), add `-auditlog <file>` to the daemon configuration file. For example:
-
-        ```
-        ./newrelic-daemon -f -logfile stdout -loglevel debug -auditlog audit.log
-        ```
-      </td>
-    </tr>
 
     <tr>
       <td>

--- a/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/metric-grouping-issues.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/metric-grouping-issues.mdx
@@ -90,16 +90,6 @@ If the problem persists, follow the procedures for your agent:
 
     <tr>
       <td>
-        C SDK
-      </td>
-
-      <td>
-        Avoid using URLs to name your transactions. Instead, follow the procedures to [instrument your app with the C SDK](/docs/agents/c-sdk/instrumentation/instrument-your-app-c-sdk).
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         Go
       </td>
 

--- a/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/not-seeing-data.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/not-seeing-data.mdx
@@ -29,7 +29,6 @@ You should start seeing data within a few minutes after installing a New Relic a
 
 Follow the troubleshooting procedures for your APM agent:
 
-* [C SDK](/docs/agents/c-sdk/troubleshooting/no-data-appears-c)
 * [Go](/docs/agents/go-agent/troubleshooting/no-data-appears-go)
 * [Java](/docs/agents/java-agent/troubleshooting/no-data-appears-java)
 * [.NET](/docs/agents/net-agent/troubleshooting/no-data-appears-net)

--- a/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
+++ b/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
@@ -60,21 +60,6 @@ To ensure FedRAMP compliance, all [APM agent configurations](/docs/using-new-rel
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        C SDK
-      </td>
-
-      <td>
-        In code:
-
-        ```
-        strcpy(_newrelic_app_config_t->redirect_collector, "gov-collector.newrelic.com");
-        ```
-
-        Environment variable: none
-      </td>
-    </tr>
 
     <tr>
       <td>

--- a/src/content/docs/style-guide/structure/lists.mdx
+++ b/src/content/docs/style-guide/structure/lists.mdx
@@ -32,7 +32,7 @@ Here's an example of an ordered list as a table. Because each step is a row, the
 
 ## In-line lists [#inline-lists]
 
-As an alternative to using bullet point lists, you can do an in-line list, like this: [C SDK](/docs/agents/c-sdk/instrumentation/enable-distributed-tracing-your-c-applications) \| [Go](/docs/agents/go-agent/features/distributed-tracing-go#create-manually) \| [Java](/docs/agents/java-agent/api-guides/guide-using-java-agent-api#trace-calls).
+As an alternative to using bullet point lists, you can do an in-line list, like this: [Java](/docs/apm/agents/java-agent/getting-started/introduction-new-relic-java/) \| [.NET](/docs/apm/agents/net-agent/getting-started/introduction-new-relic-net/) \| [Node.js](/docs/apm/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs/) \| [PHP](/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php/) \| [Python](/docs/apm/agents/python-agent/getting-started/introduction-new-relic-python/) \| [Ruby](/docs/apm/agents/ruby-agent/getting-started/introduction-new-relic-ruby/)
 
 You might want to use an in-line list when:
 

--- a/src/content/docs/style-guide/writing-strategies/install-docs-guidance.mdx
+++ b/src/content/docs/style-guide/writing-strategies/install-docs-guidance.mdx
@@ -34,12 +34,12 @@ This is intended to help you decide where to send your reader when they want to 
       <td>
         * Infrastructure agent
         * Logs
-        * APM agents (except C SDK, Go, PHP, and Ruby)
+        * APM agents (except Go, PHP, and Ruby)
         * One or more of these [on-host integrations](/docs/new-relic-one/install-configure/new-relic-guided-install-overview/#ohi-recipes)
       </td>
 
       <td>
-        * APM agents (especially C SDK, Go, PHP, and Ruby)
+        * APM agents (especially Go, PHP, and Ruby)
         * Browser monitoring
         * Cloud and on-host monitoring integrations
         * Distributed tracing


### PR DESCRIPTION
April 27 note: Austin said this could wait until @barbnewrelic gets back.
May 3, 2022 note: hold on this pending addl EOL team discussions. Moving this to draft. See Jira.

Work done: 
- Remove all references to C SDK
- Except in
    - C SDK docs
    - Logs-in-context docs
    - Legal
    - Taxonomy files
    - Release notes
- Assuming those more complex areas will be tackled in DOC-7958 or followup ticket
    
Related Jira: DOC-7958