### PR TITLE
Add notice that CAT has been deprecated in Python Agent

### DIFF
--- a/src/content/docs/apm/agents/python-agent/supported-features/cross-application-tracing.mdx
+++ b/src/content/docs/apm/agents/python-agent/supported-features/cross-application-tracing.mdx
@@ -1,10 +1,10 @@
 ---
-title: Cross application tracing (deprecated)
+title: 'Cross application tracing (deprecated)'
 tags:
   - Agents
   - Python agent
   - Supported features
-metaDescription: Cross-app tracing is deprecated for New Relic's Python agent. 
+metaDescription: Cross-application tracing is deprecated for new versions of the New Relic Python agent. 
 redirects:
   - /docs/agents/python-agent/supported-features/cross-application-tracing
 ---
@@ -23,7 +23,7 @@ The protocol used to communicate between applications involves attaching metadat
 
 ## Requirements
 
-[New Relic Python agent version 2.92.0.78](/docs/release-notes/agent-release-notes/python-release-notes/python-agent-292078) up to version 7.0.0.166. It is deprecated for versions higher than that. 
+Requires [New Relic Python agent version 2.92.0.78](/docs/release-notes/agent-release-notes/python-release-notes/python-agent-292078) up to version 7.0.0.166. It's deprecated for versions above that. 
 
 ## Custom client (HTTP)
 

--- a/src/content/docs/apm/agents/python-agent/supported-features/cross-application-tracing.mdx
+++ b/src/content/docs/apm/agents/python-agent/supported-features/cross-application-tracing.mdx
@@ -1,10 +1,10 @@
 ---
-title: Cross application tracing
+title: Cross application tracing (deprecated)
 tags:
   - Agents
   - Python agent
   - Supported features
-metaDescription: Our Python agent supports cross-app tracing through built in instrumentation and the use of APIs for custom instrumentation.
+metaDescription: Cross-app tracing is deprecated for New Relic's Python agent. 
 redirects:
   - /docs/agents/python-agent/supported-features/cross-application-tracing
 ---
@@ -16,16 +16,14 @@ import clientCustomTransport from 'images/client_custom_transport.png'
 import serverNonhttpTransport from 'images/server_nonhttp_transport.png'
 
 <Callout variant="important">
-  Cross application tracing has been deprecated since [v7.0.0.166](/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70000166).  A [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) feature is now available. Distributed tracing improves on cross application tracing and is recommended for monitoring activity in complex distributed systems.
+For our Python agent, [cross application tracing](/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces) has been deprecated since [agent version v7.0.0.166](/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70000166). A [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) feature is now available. Distributed tracing improves on cross application tracing and is recommended for monitoring activity in complex distributed systems.
 </Callout>
-
-[Cross application tracing](/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces) is supported by the Python agent through built in instrumentation and through the use of APIs for custom instrumentation.
 
 The protocol used to communicate between applications involves attaching metadata to requests and responses. The metadata is processed by each application and the resulting data is reported by the agent.
 
 ## Requirements
 
-You must have [Python agent version 2.92.0.78](/docs/release-notes/agent-release-notes/python-release-notes/python-agent-292078) or higher.
+[New Relic Python agent version 2.92.0.78](/docs/release-notes/agent-release-notes/python-release-notes/python-agent-292078) up to version 7.0.0.166. It is deprecated for versions higher than that. 
 
 ## Custom client (HTTP)
 

--- a/src/content/docs/apm/agents/python-agent/supported-features/cross-application-tracing.mdx
+++ b/src/content/docs/apm/agents/python-agent/supported-features/cross-application-tracing.mdx
@@ -16,7 +16,7 @@ import clientCustomTransport from 'images/client_custom_transport.png'
 import serverNonhttpTransport from 'images/server_nonhttp_transport.png'
 
 <Callout variant="important">
-  A [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) feature is now available. Distributed tracing improves on cross application tracing and is recommended for monitoring activity in complex distributed systems.
+  Cross application tracing has been deprecated since [v7.0.0.166](/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70000166).  A [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) feature is now available. Distributed tracing improves on cross application tracing and is recommended for monitoring activity in complex distributed systems.
 </Callout>
 
 [Cross application tracing](/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces) is supported by the Python agent through built in instrumentation and through the use of APIs for custom instrumentation.


### PR DESCRIPTION
This commit adds a note in the Cross Application Tracing docs that the functionality has been deprecated in the Python Agent.