### PR TITLE
docs: custom types must implement `ToString()`

### DIFF
--- a/src/content/docs/apm/agents/net-agent/attributes/custom-attributes-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/attributes/custom-attributes-net.mdx
@@ -101,7 +101,7 @@ When adding custom attribute values to transactions, custom events, spans, and e
       </td>
 
       <td>
-        the `ToString()` method will be applied.
+        The `ToString()` method will be applied. Custom types must have an implementation of `Object.ToString()` or they will throw an exception.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Per this [GTSE](https://newrelic.atlassian.net/browse/GTSE-14535?focusedCommentId=1074117), primitive type objects will always work, custom type objects will fail if they haven't implemented `ToString()`.

https://docs.microsoft.com/en-us/dotnet/api/system.object.tostring?view=net-6.0#extending-the-objecttostring-method

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.