### PR TITLE
Clarify billing on publicly-defined golden metrics

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing.mdx
@@ -17,13 +17,12 @@ For how to find billing and usage information in the UI, see [Billing-related UI
 
 ## Data ingest calculation [#usage-calculation]
 
-For the [New Relic One pricing model](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing), “ingested data” refers to the data saved for your New Relic organization after we apply various data trimming and data transformation rules. In other words, it’s not the amount of raw data sent to New Relic, but the size of the data that actually ends up being stored.
+For the [New Relic One pricing model](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing), “ingested data” refers to the data saved to New Relic by your organization after we apply various data trimming and data transformation rules. In other words, it’s not the amount of raw data sent to New Relic, but the size of the data that actually ends up being stored.
 
 Here are some notes about New Relic features and data that **do not** count towards ingest and billing:
-
 * [Basic alerting functionality](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/alerts-concepts-workflow) doesn't count towards billing.
 * [Applied intelligence](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence) data reported from third-party services counts towards billing but internally generated data (for example, `NrIncidentEvent` data) does not.
-* [Golden metrics](/docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial) based on our [entity definitions](https://github.com/newrelic/entity-definitions) and other data derived from your ingested data doesn't count towards billing.
+* [Golden metrics](/docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial) don't count towards billing. (For details about how those are defined, see our [entity definitions](https://github.com/newrelic/entity-definitions)). 
 * Usage-tracking data (for example, `NrUsage`, `NrMTDConsumption`, `NrConsumption`) doesn't count towards billing.
 * Data related to organization and account administration (for example, `NrIntegrationError`, `NrAuditEvent`) doesn't count towards billing.
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing.mdx
@@ -23,6 +23,7 @@ Here are some notes about New Relic features and data that **do not** count towa
 
 * [Basic alerting functionality](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/alerts-concepts-workflow) doesn't count towards billing.
 * [Applied intelligence](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence) data reported from third-party services counts towards billing but internally generated data (for example, `NrIncidentEvent` data) does not.
+* [Golden Metrics](/docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial) based on public [entity definitions](https://github.com/newrelic/entity-definitions) do not count towards billing.
 * Usage-tracking data (for example, `NrUsage`, `NrMTDConsumption`, `NrConsumption`) doesn't count towards billing.
 * Data related to organization and account administration (for example, `NrIntegrationError`, `NrAuditEvent`) doesn't count towards billing.
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing.mdx
@@ -23,7 +23,7 @@ Here are some notes about New Relic features and data that **do not** count towa
 
 * [Basic alerting functionality](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/alerts-concepts-workflow) doesn't count towards billing.
 * [Applied intelligence](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence) data reported from third-party services counts towards billing but internally generated data (for example, `NrIncidentEvent` data) does not.
-* [Golden Metrics](/docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial) based on public [entity definitions](https://github.com/newrelic/entity-definitions) do not count towards billing.
+* [Golden metrics](/docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial) based on public [entity definitions](https://github.com/newrelic/entity-definitions) do not count towards billing.
 * Usage-tracking data (for example, `NrUsage`, `NrMTDConsumption`, `NrConsumption`) doesn't count towards billing.
 * Data related to organization and account administration (for example, `NrIntegrationError`, `NrAuditEvent`) doesn't count towards billing.
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing.mdx
@@ -23,7 +23,7 @@ Here are some notes about New Relic features and data that **do not** count towa
 
 * [Basic alerting functionality](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/alerts-concepts-workflow) doesn't count towards billing.
 * [Applied intelligence](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence) data reported from third-party services counts towards billing but internally generated data (for example, `NrIncidentEvent` data) does not.
-* [Golden metrics](/docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial) based on public [entity definitions](https://github.com/newrelic/entity-definitions) do not count towards billing.
+* [Golden metrics](/docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial) based on our [entity definitions](https://github.com/newrelic/entity-definitions) and other data derived from your ingested data doesn't count towards billing.
 * Usage-tracking data (for example, `NrUsage`, `NrMTDConsumption`, `NrConsumption`) doesn't count towards billing.
 * Data related to organization and account administration (for example, `NrIntegrationError`, `NrAuditEvent`) doesn't count towards billing.
 


### PR DESCRIPTION
Golden metrics synthesized by our platform based on public definitions don't count toward usage-based billing. This is not clearly stated anywhere and can result in confusion depending on the tool used to calculate usage. /cc @pfraziernr @jsgithub1 