### PR TITLE
fix(synthetics): Fix setProxyAdvanced examples

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/set-proxy-settings-properties-scripted-monitors.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/set-proxy-settings-properties-scripted-monitors.mdx
@@ -2,7 +2,6 @@
 title: Set proxy settings and properties for scripted monitors
 tags:
   - Synthetics
-  - Synthetic monitoring
   - Scripting monitors
 metaDescription: How to control network proxy settings for synthetic scripted monitors.
 redirects:

--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/set-proxy-settings-properties-scripted-monitors.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/set-proxy-settings-properties-scripted-monitors.mdx
@@ -432,7 +432,7 @@ The global object `$network` allows you to control the network configuration use
 
         ```
         var proxyRules =
-          {singleProxy: {host:"http://entproxy.mycompany.com"},
+          {singleProxy: {host:"entproxy.mycompany.com", port:8888, scheme:"http"},
           bypassList:['s3.amazonaws.com','*.localcdn.com']
           }
         $network.setProxyAdvanced(proxyRules)


### PR DESCRIPTION
The setProxyAdvanced example was incorrect and would result in an err_no_supported_proxies error. The host, port, and scheme must be defined if using a non default port (varies by scheme) or a non default scheme (http).