### PR TITLE
Rename some best practices pages 

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-alerts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-alerts.mdx
@@ -1,5 +1,5 @@
 ---
-title: Alerts best practices
+title: OpenTelemetry alerts (best practices)
 tags:
   - Integrations
   - Open source telemetry integrations

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-alerts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-alerts.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry alerts (best practices)
+title: 'OpenTelemetry alerts: Best practices'
 tags:
   - Integrations
   - Open source telemetry integrations

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-attributes.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-attributes.mdx
@@ -1,5 +1,5 @@
 ---
-title: Attribute lengths (best practices)
+title: OpenTelemetry and attribute lengths (best practices)
 tags:
   - Integrations
   - Open source telemetry integrations

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-attributes.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-attributes.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry and attribute lengths (best practices)
+title: 'OpenTelemetry and attribute lengths: Best practices'
 tags:
   - Integrations
   - Open source telemetry integrations

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-batching.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-batching.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry batching (best practices)
+title: 'OpenTelemetry batching: Best practices'
 tags:
   - Integrations
   - Open source telemetry integrations

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-compression.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-compression.mdx
@@ -1,5 +1,5 @@
 ---
-title: OTLP payload compression (best practices)
+title: 'OTLP payload compression: Best practices'
 tags:
   - Integrations
   - Open source telemetry integrations

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-compression.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-compression.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'OTLP payload compression: Best practices'
+title: 'OpenTelemetry OTLP payload compression: Best practices'
 tags:
   - Integrations
   - Open source telemetry integrations

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry logs (best practices)
+title: 'OpenTelemetry logs: Best practices'
 tags:
   - Integrations
   - Open source telemetry integrations

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-metrics.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry metrics (best practices)
+title: 'OpenTelemetry metrics: Best practices'
 tags:
   - Integrations
   - Open source telemetry integrations

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-overview.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview of best practices for OpenTelemetry with New Relic
+title: 'Overview of best practices for OpenTelemetry with New Relic'
 tags:
   - Integrations
   - Open source telemetry integrations

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry resources (best practices)
+title: 'OpenTelemetry resources: Best practices'
 tags:
   - Integrations
   - Open source telemetry integrations

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-traces.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-traces.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry traces (best practices)
+title: 'OpenTelemetry traces: Best practices'
 tags:
   - Integrations
   - Open source telemetry integrations


### PR DESCRIPTION
Clarify that some docs are related to OTEL, by adding "OpenTelemetry" in the titles.