### PR TITLE
Update docs with new winston-enricher signature

### DIFF
--- a/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
@@ -46,7 +46,8 @@ To enable logs in context for APM apps monitored by Node.js, you can use our man
        ```
        // index.js
        require('newrelic')
-       const newrelicFormatter = require('@newrelic/winston-enricher')
+       const winston = require('winston')
+       const newrelicFormatter = require('@newrelic/winston-enricher')(winston)
        ```
 
        The New Relic formatter can be used individually or combined with other formatters as the final format.


### PR DESCRIPTION
Since v3.0.0, the function signature of `@newrelic/winston-enricher` has changed. It now requires passing Winston to the formatter before the formatter can be used.

Context:
- https://github.com/newrelic/newrelic-node-log-extensions/issues/36
- https://github.com/newrelic/newrelic-node-log-extensions/pull/33