### PR TITLE
Java Agent 7.7.0 updates (HOLD FOR 5/3 PUBLISH!)

### DIFF
--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -3408,8 +3408,8 @@ If you are using a supported logging framework and want to use the agent to send
     Enables the sending of application logs to New Relic.
 
     <Callout variant="important">
-      Agent releases 7.7.0 and higher has this feature enabled in the agent configuration file by default.
-      
+      Agent releases 7.7.0 and higher have this feature enabled in the agent configuration file by default.
+
       Using the log forwarding feature will increase your data ingest, which may affect your billing. For more information, see our documentation about [tracking your data ingest](/docs/apm/new-relic-apm/getting-started/get-started-logs-context#ingest).
 
       If you have an existing log forwarding solution and are updating your agent to use automatic logs in context, be sure to **disable your old log forwarder**. Otherwise, your app will be sending double log lines. Depending on your account, this could result in double billing. For more information, follow the procedures to disable your [specific log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding).

--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -3358,13 +3358,17 @@ Logs in Context configuration is set in the `application_logging` stanza and can
           </th>
 
           <td>
-            `false`
+            `true`
           </td>
         </tr>
       </tbody>
     </table>
 
     Set to `true` to enable the core Logs in Context feature. When enabled, additional logging framework instrumentation is enabled, whether or not logs are decorated or sent to New Relic.
+
+    <Callout variant="important">
+      Agent releases 7.7.0 and higher has this feature enabled in the agent configuration file by default.
+    </Callout>
 
     Set to `false` to completely disable this feature, including the collection of log metrics.
   </Collapser>
@@ -3395,7 +3399,7 @@ If you are using a supported logging framework and want to use the agent to send
           </th>
 
           <td>
-            false
+            true
           </td>
         </tr>
       </tbody>
@@ -3404,9 +3408,9 @@ If you are using a supported logging framework and want to use the agent to send
     Enables the sending of application logs to New Relic.
 
     <Callout variant="important">
+      Agent releases 7.7.0 and higher has this feature enabled in the agent configuration file by default.
+      
       Using the log forwarding feature will increase your data ingest, which may affect your billing. For more information, see our documentation about [tracking your data ingest](/docs/apm/new-relic-apm/getting-started/get-started-logs-context#ingest).
-
-      This feature may be enabled by default in a future agent version.
 
       If you have an existing log forwarding solution and are updating your agent to use automatic logs in context, be sure to **disable your old log forwarder**. Otherwise, your app will be sending double log lines. Depending on your account, this could result in double billing. For more information, follow the procedures to disable your [specific log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding).
     </Callout>

--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -231,6 +231,21 @@ Before you install the Java agent, ensure your system meets these requirements:
             NA
           </td>
         </tr>
+
+        <tr>
+          <td>
+            Java 18
+          </td>
+
+          <td>
+            v7.7.0 to current
+          </td>
+
+          <td>
+            NA
+          </td>
+        </tr>
+
       </tbody>
     </table>
 
@@ -240,7 +255,11 @@ Before you install the Java agent, ensure your system meets these requirements:
 
     * Eclipse OpenJ9 versions 8 to 13 for Linux, Windows, and macOS
 
-    * OpenJDK and AdoptOpenJDK JVM versions 8 to 16 for Linux, Windows, and macOS
+    * OpenJDK versions 8 to 18 for Linux, Windows, and macOS
+
+    * AdoptOpenJDK versions 8 to 16 for Linux, Windows, and macOS
+
+    * Temurin version 17 for Linux, Windows, and macOS
 
     * Oracle Hotspot JVM versions 8 to 16 for Linux, Solaris, Windows, and macOS
 

--- a/src/content/docs/logs/logs-context/java-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/java-configure-logs-context-all.mdx
@@ -69,8 +69,8 @@ If you are using a supported framework, you have two options to configure APM lo
 
 
   <Callout variant="important">
-    Agent releases 7.7.0 and higher has this feature enabled in the agent configuration file by default.
-    
+    Agent releases 7.7.0 and higher have this feature enabled in the agent configuration file by default.
+
     Agent log forwarding will cause an increase in the consumption of data when a [supported framework](/docs/logs/logs-context/java-configure-logs-context-all#automatic) is detected. The amount depends on the application and amount of logs it produces. <span id="disabling-lic">This feature can be disabled. See [Disable automatic logging](https://docs.newrelic.com/docs/logs/logs-context/disable-automatic-logging/) for more information about your options.</span>
 
     If you already have a log forwarding solution in place, you should disable this feature.

--- a/src/content/docs/logs/logs-context/java-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/java-configure-logs-context-all.mdx
@@ -67,6 +67,16 @@ If you are using a supported framework, you have two options to configure APM lo
 * Log4j 2 2.6 or higher
 * Logback 1.1 or higher
 
+
+  <Callout variant="important">
+    Agent releases 7.7.0 and higher has this feature enabled in the agent configuration file by default.
+    
+    Agent log forwarding will cause an increase in the consumption of data when a [supported framework](/docs/logs/logs-context/java-configure-logs-context-all#automatic) is detected. The amount depends on the application and amount of logs it produces. <span id="disabling-lic">This feature can be disabled. See [Disable automatic logging](https://docs.newrelic.com/docs/logs/logs-context/disable-automatic-logging/) for more information about your options.</span>
+
+    If you already have a log forwarding solution in place, you should disable this feature.
+  </Callout>
+
+
 If you are using a different logging framework, our [manual logs in context](#enable-logs-java) solution might be right for you.
 
 <CollapserGroup>

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-770.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-770.mdx
@@ -8,12 +8,12 @@ downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/
 ### New features and improvements
 
 * Supports Java 18 [813](https://github.com/newrelic/newrelic-java-agent/pull/813)
-* APM logs in context. Automatic application log forwarding is now enabled by default. This version of the agent will automatically send enriched application logs to New Relic. To learn more about about this feature see [here](/docs/logs/logs-context/java-configure-logs-context-all), and additional configuration options are available [here](/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file/#Logs-in-Context). To learn about how to toggle log ingestion on or off by account see [here](/docs/logs/logs-context/disable-automatic-logging). [817](https://github.com/newrelic/newrelic-java-agent/pull/817)
-* Added instrumentation support for the Postgres, MySQL, Oracle & MSSQL R2DBC connectors [810](https://github.com/newrelic/newrelic-java-agent/pull/810) [816](https://github.com/newrelic/newrelic-java-agent/pull/816) [829](https://github.com/newrelic/newrelic-java-agent/pull/829) [828](https://github.com/newrelic/newrelic-java-agent/pull/828)
+* APM logs in context. Automatic application log forwarding is now enabled by default. This version of the agent will automatically send enriched application logs to New Relic. To learn more about this feature see [Java: Configure logs in context](/docs/logs/logs-context/java-configure-logs-context-all), and additional configuration options are available [Java agent configuration: Config file](/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file/#Logs-in-Context). To learn about how to toggle log ingestion on or off by account see [Disable automatic logging](/docs/logs/logs-context/disable-automatic-logging) [817](https://github.com/newrelic/newrelic-java-agent/pull/817)
+* Added instrumentation support for the Postgres, MySQL, Oracle & MSSQL R2DBC connectors [810](https://github.com/newrelic/newrelic-java-agent/pull/810), [816](https://github.com/newrelic/newrelic-java-agent/pull/816), [829](https://github.com/newrelic/newrelic-java-agent/pull/829), and [828](https://github.com/newrelic/newrelic-java-agent/pull/828)
 
 ### Fixes
 
-* Patches a security issue related to an older version of jszip that is included in the Java agent API Javadoc jar [820](https://github.com/newrelic/newrelic-java-agent/pull/820)
+* Patches a security issue related to an older version of `jszip`that is included in the Java agent API Javadoc jar [820](https://github.com/newrelic/newrelic-java-agent/pull/820)
 
 ### Support statement:
 

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-770.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-770.mdx
@@ -13,7 +13,7 @@ downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/
 
 ### Fixes
 
-* Fixed the build issue causing an older version of jszip to be included with Javadocsm [820](https://github.com/newrelic/newrelic-java-agent/pull/820)
+* Patches a security issue related to an older version of jszip that is included in the Java agent API Javadoc jar [820](https://github.com/newrelic/newrelic-java-agent/pull/820)
 
 ### Support statement:
 

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-770.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-770.mdx
@@ -1,0 +1,20 @@
+---
+subject: Java agent
+releaseDate: '2022-05-03'
+version: 7.7.0
+downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/7.7.0/'
+---
+
+### New features and improvements
+
+* Supports Java 18 [813](https://github.com/newrelic/newrelic-java-agent/pull/813)
+* APM logs in context. Automatic application log forwarding is now enabled by default. This version of the agent will automatically send enriched application logs to New Relic. To learn more about about this feature see [here](/docs/logs/logs-context/java-configure-logs-context-all), and additional configuration options are available [here](/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file/#Logs-in-Context). To learn about how to toggle log ingestion on or off by account see [here](/docs/logs/logs-context/disable-automatic-logging). [817](https://github.com/newrelic/newrelic-java-agent/pull/817)
+* Added instrumentation support for the Postgres, MySQL, Oracle & MSSQL R2DBC connectors [810](https://github.com/newrelic/newrelic-java-agent/pull/810) [816](https://github.com/newrelic/newrelic-java-agent/pull/816) [829](https://github.com/newrelic/newrelic-java-agent/pull/829) [828](https://github.com/newrelic/newrelic-java-agent/pull/828)
+
+### Fixes
+
+* Fixed the build issue causing an older version of jszip to be included with Javadocsm [820](https://github.com/newrelic/newrelic-java-agent/pull/820)
+
+### Support statement:
+
+New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach [end-of-life](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software/).


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Doc updates corresponding to the Java Agent 7.7.0 release, which will be published 5/3. Includes:

* New release note page
* Updates to the LiC feature page and the Config page to indicate that LiC is now enabled by default
*  Updates to the Compatibility page to reference support for Java 18