### PR TITLE
feat(Pixie): add memory mgmt info

### DIFF
--- a/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/install-auto-telemetry-pixie.mdx
+++ b/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/install-auto-telemetry-pixie.mdx
@@ -5,7 +5,7 @@ tags:
   - Service monitoring
   - Kubernetes
   - eBPF
-metaDescription: 
+metaDescription:
 redirects:
   - /docs/auto-telemetry-pixie/install-auto-telemetry-pixie
   - /docs/auto-telemetry-pixie/get-started-auto-telemetry-pixie/#install-auto-telemetry-with-pixie
@@ -22,7 +22,7 @@ Ready to get started? If you don't already have one, [sign up for a New Relic ac
 Tips before getting started:
 
 * Review this [Pixie data security overview](/docs/auto-telemetry-pixie/pixie-data-security-overview) for actions to take to secure your data.
-* Make sure your clusters have sufficient memory. Pixie requires at least 8Gb of memory on each node in your cluster. More memory may be required for larger clusters.
+* Make sure your clusters have sufficient memory. Pixie requires 2Gb of memory on each node in your cluster for the default installation. Review this [Pixie memory management overview](/docs/auto-telemetry-pixie/manage-pixie-memory) for actions to take to tune memory usage.
 * Pixie needs to run in privileged mode.
 * Review the other [Pixie technical requirements](https://docs.px.dev/installing-pixie/requirements/).
 

--- a/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/manage-pixie-memory.mdx
+++ b/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/manage-pixie-memory.mdx
@@ -14,30 +14,30 @@ redirects:
   - /docs/auto-telemetry-pixie/manage-pixie-memory
 ---
 
-You have options for configuring the amount of memory Pixie uses. During install, use Helm to set the memory requests and limits, or reduce the amount of memory Pixie uses for short-term data storage.
+You can configure the amount of memory Pixie uses. During the installation, use Helm to set the memory requests and limits, or to reduce the amount of memory Pixie uses for short-term data storage.
 
 ## How does Pixie use memory? [#memory-usage]
 
-The primary focus of the [open source Pixie project](https://github.com/pixie-io/pixie) is to build a real-time debugging platform. Pixie is [not intended to be a long-term durable storage solution](https://docs.px.dev/about-pixie/faq/#data-collection-how-much-data-does-pixie-store) and is best used in conjunction with New Relic. The New Relic integration queries Pixie every few minutes and persists Pixie's telemetry data in New Relic One.
+The primary focus of the [open source Pixie project](https://github.com/pixie-io/pixie) is to build a real-time debugging platform. Pixie [isn't intended to be a long-term durable storage solution](https://docs.px.dev/about-pixie/faq/#data-collection-how-much-data-does-pixie-store) and is best used in conjunction with New Relic. The New Relic integration queries Pixie every few minutes and persists Pixie's telemetry data in New Relic.
 
 When you install the New Relic Pixie integration, a `vizier-pem` agent is deployed to each node in your cluster via a DaemonSet. The `vizier-pem` agents use memory for two main purposes:
 
-* **Collecting telemetry data**: tracing application traffic, CPU profiles, etc requires that those values are stored in memory somewhere as they are processed.
-* **Short-term storage of telemetry data**: before it is durably persisted in New Relic One.
+* **Collecting telemetry data**: tracing application traffic or CPU profiles, amongst other. Those values must be stored in memory somewhere, as they're processed.
+* **Short-term storage of telemetry data**: before it's stored in New Relic.
 
-By default, `vizier-pem` pods have a `2Gi` memory limit, a `2Gi` memory request, and reserve 60% of their allocated memory for short-term data storage (leaving the other 40% for the data collection).
+By default, `vizier-pem` pods have a `2Gi` memory limit, and a `2Gi` memory request. They set aside 60% of their allocated memory for short-term data storage, leaving the other 40% for the data collection.
 
 ### Why does Pixie's memory use increase after installation? [#memory-increase]
 
-After installing the Pixie, it is normal to see an increase in memory usage of the `vizier-pem` pods as they begin storing telemetry data. Once the `vizier-pem`'s memory limit is reached, old telemetry data is expired to make room for new data and memory utilization should not increase any further.
+After installing Pixie, memory usage of the `vizier-pem` pods increases as they begin storing telemetry data. Once you reach `vizier-pem`'s memory limit, old telemetry data is expired to make room for new data, and so memory utilization shouldn't increase any further.
 
 ## Configuring Pixie's memory usage [#configure-memory]
 
-For most clusters, we recommend using the default (`2Gi`) memory configuration. To accommodate your application pods, we recommend that this amount be no more than 25% of your nodes' total memory. If your nodes only have `4Gi` total memory, you'll want to configure Pixie to use a `1Gi` memory limit.
+For most clusters, we recommend using the default `2Gi` memory configuration. For your application pods, we recommend you to set the default `2Gi` memory to a maximum of 25% of your nodes' total memory. For instance, if your nodes have a total memory of `4Gi`, you'll want to configure Pixie to use a `1Gi` memory limit.
 
 ### Deploy Pixie with a particular memory limit [#set-memory-limit]
 
-If you want to specify a different memory limit than the default `2Gi` for Pixie's `vizier-pem` agents, you can add the following config parameter to your Helm chart during installation. For example, for a `1Gi` memory limit you would use:
+If you want to specify a different memory limit than the default `2Gi` for Pixie's `vizier-pem` agents, you can add the following configuration parameter to your Helm chart during installation. For example, for a `1Gi` memory limit, you'd use:
 
 ```
 -set pixie-chart.pemMemoryLimit=1Gi
@@ -45,29 +45,36 @@ If you want to specify a different memory limit than the default `2Gi` for Pixie
 
 ### Deploy Pixie with a particular memory request [#set-memory-request]
 
-By default, the `vizier-pem`'s memory request will be the same as the limit. If you want to specify a different memory [request](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) you can add the following config parameter to your Helm chart during installation. For example, for a `1Gi` memory request you would use:
+By default, the `vizier-pem`'s memory request is the same as the limit. If you want to specify a different memory [request](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits), you can add the following configuration parameter to your Helm chart during installation. For example, for a `1Gi` memory request you'd use:
 
 ```
 --set pixie-chart.pemMemoryRequest=1Gi
 ```
 
-Please note that the `vizier-pem` memory request must be less than or equal to the `vizier-pem` memory limit.
+<Callout variant="important">
+The `vizier-pem` memory request must be less than or equal to the `vizier-pem` memory limit.
+</Callout>
 
 ### Deploy Pixie with a particular short-term data storage [#reduce-data-storage]
 
-By default, `vizier-pem` pods reserve 60% of their allocated memory for short-term data storage (leaving the other 40% for the collection). For the default `2Gi` memory limit, this means that a `vizier-pem` pod will reserve `1.2Gi` memory for data storage.
+By default, `vizier-pem` pods set aside 60% of their allocated memory for short-term data storage, leaving the other 40% for the collection. For the default `2Gi` memory limit, this means that a `vizier-pem` pod keeps `1.2Gi` memory for data storage.
 
-If you want to specify a different amount for memory to reserve for short-term storage, you can add the following config parameter to your Helm chart during installation. For example, for `750MiB` of short-term data storage you would use:
+If you want to specify a different amount for memory for short-term storage, you can add the following configuration parameter to your Helm chart during installation. For example, for `750MiB` of short-term data storage you'd use:
 
 ```
 --set pixie-chart.dataCollectorParams.customPEMFlags.PL_TABLE_STORE_DATA_LIMIT_MB=750
 ```
-## Troubleshooting
 
-### Why did the `vizier-pem` pods fail to schedule?
+## Troubleshooting [#troubleshooting]
 
-When the `vizier-pem` pods fail to schedule, this is usually because there are node(s) that do not have the requested amount of memory. In this situation, try [reducing the memory request](#set-memory-request) down as far as `1Gi`. Note that for particularly large or high traffic clusters, `1Gi` may not be sufficient and some `vizier-pem` OOMKills might occur. For these clusters it might be good to set a higher limit than request, such as `2Gi` for the limit. `1Gi` limit deployments are recommended for smaller clusters with less traffic.
+### Why did the `vizier-pem` pods fail to schedule? [#schedule-fail]
 
-### Why did the `vizier-pem` pods get OOMKilled?
+When the `vizier-pem` pods fail to schedule, this is usually because there are nodes that don't have the requested amount of memory.
 
-Part of the benefit of deploying on Kubernetes is that Kubernetes will OOMKill pods that are using too many resources in order to protect the other pods in the cluster. When Pixie's `vizier-pem` pods are OOMKilled, this means that they are exceeding the memory limit. This is a step that Kubernetes takes to protect the other applications, and therefore will not cause problems on the other pods. For `vizier-pem` pods that are regularly OOMKilling, try [deploying Pixie with more memory](#set-memory-limit).
+Try [reducing the memory request](#set-memory-request) down as far as `1Gi`. For particularly large or high traffic clusters, `1Gi` may not be enough and some `vizier-pem` OOMKills might occur. For these clusters, you can set a higher limit than request, such as `2Gi` for the limit. We recommend `1Gi` limit deployments for smaller clusters with less traffic.
+
+### Why did the `vizier-pem` pods get OOMKilled? [#oomkilled-pods]
+
+Part of the benefit of deploying on Kubernetes is that Kubernetes will OOMKill pods that are using too many resources to protect the other pods in the cluster.
+
+When Pixie's `vizier-pem` pods exceed the memory limit, they are OOMKilled. Kubernetes does this to protect the other applications, so it won't cause problems on other pods. For `vizier-pem` pods that are regularly being OOMKilled, try [deploying Pixie with more memory](#set-memory-limit).

--- a/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/manage-pixie-memory.mdx
+++ b/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/manage-pixie-memory.mdx
@@ -1,0 +1,73 @@
+---
+title: Manage the memory used by Pixie
+tags:
+  - Pixie Auto-telemetry
+  - lowmemorymode
+  - low memory mode
+  - reduce memory
+  - Kubernetes pods
+  - Kubernetes
+  - manage Pixie memory
+  - oomkill Pixie
+metaDescription:
+redirects:
+  - /docs/auto-telemetry-pixie/manage-pixie-memory
+---
+
+You have options for configuring the amount of memory Pixie uses. During install, use Helm to set the memory requests and limits, or reduce the amount of memory Pixie uses for short-term data storage.
+
+## How does Pixie use memory? [#memory-usage]
+
+The primary focus of the [open source Pixie project](https://github.com/pixie-io/pixie) is to build a real-time debugging platform. Pixie is [not intended to be a long-term durable storage solution](https://docs.px.dev/about-pixie/faq/#data-collection-how-much-data-does-pixie-store) and is best used in conjunction with New Relic. The New Relic integration queries Pixie every few minutes and persists Pixie's telemetry data in New Relic One.
+
+When you install the New Relic Pixie integration, a `vizier-pem` agent is deployed to each node in your cluster via a DaemonSet. The `vizier-pem` agents use memory for two main purposes:
+
+* **Collecting telemetry data**: tracing application traffic, CPU profiles, etc requires that those values are stored in memory somewhere as they are processed.
+* **Short-term storage of telemetry data**: before it is durably persisted in New Relic One.
+
+By default, `vizier-pem` pods have a `2Gi` memory limit, a `2Gi` memory request, and reserve 60% of their allocated memory for short-term data storage (leaving the other 40% for the data collection).
+
+### Why does Pixie's memory use increase after installation? [#memory-increase]
+
+After installing the Pixie, it is normal to see an increase in memory usage of the `vizier-pem` pods as they begin storing telemetry data. Once the `vizier-pem`'s memory limit is reached, old telemetry data is expired to make room for new data and memory utilization should not increase any further.
+
+## Configuring Pixie's memory usage [#configure-memory]
+
+For most clusters, we recommend using the default (`2Gi`) memory configuration. To accommodate your application pods, we recommend that this amount be no more than 25% of your nodes' total memory. If your nodes only have `4Gi` total memory, you'll want to configure Pixie to use a `1Gi` memory limit.
+
+### Deploy Pixie with a particular memory limit [#set-memory-limit]
+
+If you want to specify a different memory limit than the default `2Gi` for Pixie's `vizier-pem` agents, you can add the following config parameter to your Helm chart during installation. For example, for a `1Gi` memory limit you would use:
+
+```
+-set pixie-chart.pemMemoryLimit=1Gi
+```
+
+### Deploy Pixie with a particular memory request [#set-memory-request]
+
+By default, the `vizier-pem`'s memory request will be the same as the limit. If you want to specify a different memory [request](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) you can add the following config parameter to your Helm chart during installation. For example, for a `1Gi` memory request you would use:
+
+```
+--set pixie-chart.pemMemoryRequest=1Gi
+```
+
+Please note that the `vizier-pem` memory request must be less than or equal to the `vizier-pem` memory limit.
+
+### Deploy Pixie with a particular short-term data storage [#reduce-data-storage]
+
+By default, `vizier-pem` pods reserve 60% of their allocated memory for short-term data storage (leaving the other 40% for the collection). For the default `2Gi` memory limit, this means that a `vizier-pem` pod will reserve `1.2Gi` memory for data storage.
+
+If you want to specify a different amount for memory to reserve for short-term storage, you can add the following config parameter to your Helm chart during installation. For example, for `750MiB` of short-term data storage you would use:
+
+```
+--set pixie-chart.dataCollectorParams.customPEMFlags.PL_TABLE_STORE_DATA_LIMIT_MB=750
+```
+## Troubleshooting
+
+### Why did the `vizier-pem` pods fail to schedule?
+
+When the `vizier-pem` pods fail to schedule, this is usually because there are node(s) that do not have the requested amount of memory. In this situation, try [reducing the memory request](#set-memory-request) down as far as `1Gi`. Note that for particularly large or high traffic clusters, `1Gi` may not be sufficient and some `vizier-pem` OOMKills might occur. For these clusters it might be good to set a higher limit than request, such as `2Gi` for the limit. `1Gi` limit deployments are recommended for smaller clusters with less traffic.
+
+### Why did the `vizier-pem` pods get OOMKilled?
+
+Part of the benefit of deploying on Kubernetes is that Kubernetes will OOMKill pods that are using too many resources in order to protect the other pods in the cluster. When Pixie's `vizier-pem` pods are OOMKilled, this means that they are exceeding the memory limit. This is a step that Kubernetes takes to protect the other applications, and therefore will not cause problems on the other pods. For `vizier-pem` pods that are regularly OOMKilling, try [deploying Pixie with more memory](#set-memory-limit).

--- a/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/manage-pixie-memory.mdx
+++ b/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/manage-pixie-memory.mdx
@@ -9,9 +9,7 @@ tags:
   - Kubernetes
   - manage Pixie memory
   - oomkill Pixie
-metaDescription:
-redirects:
-  - /docs/auto-telemetry-pixie/manage-pixie-memory
+metaDescription: How to manage the memory used by Pixie
 ---
 
 You can configure the amount of memory Pixie uses. During the installation, use Helm to set the memory requests and limits, or to reduce the amount of memory Pixie uses for short-term data storage.

--- a/src/nav/kubernetes-pixie.yml
+++ b/src/nav/kubernetes-pixie.yml
@@ -79,5 +79,7 @@ pages:
         path: /docs/kubernetes-pixie/auto-telemetry-pixie/auto-telemetry-pixie-data-model
       - title: Manage Pixie data
         path: /docs/kubernetes-pixie/auto-telemetry-pixie/manage-pixie-data
+      - title: Manage Pixie memory
+        path: /docs/kubernetes-pixie/auto-telemetry-pixie/manage-pixie-memory
       - title: Data and security for Auto-telemetry with Pixie
         path: /docs/kubernetes-pixie/auto-telemetry-pixie/pixie-data-security-overview


### PR DESCRIPTION
This PR adds a "Manage the memory used by Pixie" page under the Kubernetes-Pixie section. This page includes info about:
- how Pixie uses memory
- when and how to configure Pixie's memory usage. 

cc @nserrino

Signed-off-by: Hannah Troisi <htroisi@pixielabs.ai>