### PR TITLE
Small update to correct case of appName example

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -591,7 +591,7 @@ Here are some tips for creating and using a NRQL condition:
       </td>
 
       <td>
-        In order for a NRQL alert condition [health status display](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/view-entity-health-status-find-entities-without-alert-conditions) to function properly, use a FACET clause to scope each signal to a single entity (for example, `FACET hostname` or `FACET appname`).
+        In order for a NRQL alert condition [health status display](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/view-entity-health-status-find-entities-without-alert-conditions) to function properly, use a FACET clause to scope each signal to a single entity (for example, `FACET hostname` or `FACET appName`).
       </td>
     </tr>
 


### PR DESCRIPTION
NRQL is case-sensitive. Updating example query to correct case of `appName` attribute.