### PR TITLE
docs: Update event flow callout

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/choose-your-aggregation-method.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/choose-your-aggregation-method.mdx
@@ -59,7 +59,7 @@ The event flow aggregation window will continue collecting data points until tha
 Event flow works best for data that arrives frequently and consistently.
 
 <Callout variant="caution">
-  If you expect your data points to arrive more than 30 minutes apart, please use the event timer method described below.
+  If you expect your data points to arrive more than 65 minutes apart, please use the event timer method described below.
 </Callout>
 
 ## Event flow use cases [#event-flow-use-cases]


### PR DESCRIPTION
* The gap between data points, when using event flow, has been updated to 65 minutes.
* This change brings this page in line with the same information found [here](https://github.com/newrelic/docs-website/blob/develop/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts.mdx#L218).