### PR TITLE
Update write-synthetic-api-tests.mdx

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests.mdx
@@ -129,13 +129,13 @@ To make a POST request, use the [`$http.post`](https://github.com/request/reques
     ```
     // Define your authentication credentials
     const myAccountId = '{YOUR_ACCOUNT_ID}';
-    const myAPIKey = '{YOUR_LICENSE_KEY}';
+    const myAPIKey = '{YOUR_API_KEY}';
 
     const options = {
       // Define endpoint URI, https://api.eu.newrelic.com/graphql for EU accounts
       uri: 'https://api.newrelic.com/graphql',
       headers: {
-        'API-key': myLicenseKey,
+        'API-key': myAPIKey,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
@@ -178,7 +178,7 @@ To make a POST request, use the [`$http.post`](https://github.com/request/reques
     ```
     //Define your authentication credentials.
     var myAccountID = '{YOUR_ACCOUNT_ID}';
-    var myLicenseKey = '{YOUR_LICENSE_KEY}';
+    var myAPIKey = '{YOUR_API_KEY}';
     //Import the <a href="https://nodejs.org/docs/latest/api/assert.html">'assert' module</a> to validate results.
     var assert = require('assert');
 
@@ -187,9 +187,9 @@ To make a POST request, use the [`$http.post`](https://github.com/request/reques
         url: "https://insights-collector.newrelic.com/v1/accounts/"+myAccountID+"/events",
         //Define body of POST request.
         body: '[{"eventType":"SyntheticsEvent","integer1":1000,"integer2":2000}]',
-        //Define New Relic license key and expected data type.
+        //Define New Relic API key and expected data type.
         headers: {
-            'Api-Key': myLicenseKey,
+            'Api-Key': myAPIKey,
             'Content-Type': 'application/json'
             }
     };
@@ -232,7 +232,7 @@ To validate your results, import the `assert` module to define your test case. C
     ```
     //Define your authentication credentials.
     var myAccountID = '{YOUR_ACCOUNT_ID}';
-    var myLicenseKey = '{YOUR_LICENSE_KEY}';
+    var myAPIKey = '{YOUR_API_KEY}';
     //Import the `assert` module to validate results.
     var assert = require('assert');
 
@@ -241,9 +241,9 @@ To validate your results, import the `assert` module to define your test case. C
         url: "https://insights-collector.newrelic.com/v1/accounts/"+myAccountID+"/events",
         //Define body of POST request.
         body: '[{"eventType":"SyntheticsEvent","integer1":1000,"integer2":2000}]',
-        //Define New Relic license key and expected data type.
+        //Define New Relic API key and expected data type.
         headers: {
-            'Api-Key': myLicenseKey,
+            'Api-Key': myAPIKey,
             'Content-Type': 'application/json'
             }
     };


### PR DESCRIPTION
There's one incidence in this doc of properly calling the Api Key `myAPIKey` - but for the most part is using the terminology License Key (`myLicenseKey`). API Key is the right terminology AFAIK.

If I'm wrong, then line 132 `const myAPIKey = '{YOUR_LICENSE_KEY}';` should instead be `const myLicenseKey ='{YOUR_LICENSE_KEY}'`.

Thanks!

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.