### PR TITLE
Update logs doc with tarball instruction

### DIFF
--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -301,6 +301,20 @@ To use the following links, make sure you are logged to your New Relic account.
 
 If you don't have a New Relic account yet, or if you prefer to follow the procedure manually, see our [tutorial to install the package manager](/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-agent-linux-using-package-manager).
 
+## Add logs forwarder to infrastructure agent tarball installation [#tarball-install]
+Our custom Linux installation process for infrastructure monitoring allows you to tailor all aspects of the installation process, and to place files and folders on your filesystem. If you choose the [assisted](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-assisted-install-infrastructure-agent-linux) or [manual](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-manual-install-infrastructure-agent-linux) tarball installation process, follow these steps to implement the log forwarder feature:
+
+1. Create the following directories
+
+   * /var/db/newrelic-infra/newrelic-integrations/logging
+   * /etc/newrelic-infra/logging.d
+
+2. Download the fluent-bit-package (RPM) from [this repo](https://github.com/newrelic/fluent-bit-package) and install it (eg. `yum localinstall td-agent-bit-<some-version>.rpm`)
+
+3. Download the New Relic fluentbit plugin (`out_newrelic.so`) from [this repo](https://github.com/newrelic/newrelic-fluent-bit-output) and copy it to `/var/db/newrelic-infra/newrelic-integrations/logging/`
+
+4. Copy parsers.conf from [here](https://github.com/newrelic/fluent-bit-package/blob/main/parsers.conf) and save it in `/var/db/newrelic-infra/newrelic-integrations/logging/`
+
 ## Configure the infrastructure agent [#configure]
 
 Configuration files describe which log sources are forwarded. Our infrastructure agent uses `.yml` files to configure logging. You can add as many config files as you want.

--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -301,19 +301,23 @@ To use the following links, make sure you are logged to your New Relic account.
 
 If you don't have a New Relic account yet, or if you prefer to follow the procedure manually, see our [tutorial to install the package manager](/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-agent-linux-using-package-manager).
 
-## Add logs forwarder to infrastructure agent tarball installation [#tarball-install]
-Our custom Linux installation process for infrastructure monitoring allows you to tailor all aspects of the installation process, and to place files and folders on your filesystem. If you choose the [assisted](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-assisted-install-infrastructure-agent-linux) or [manual](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-manual-install-infrastructure-agent-linux) tarball installation process, follow these steps to implement the log forwarder feature:
+## Add logs forwarder to the infrastructure agent installed through tarball [#tarball-install]
 
-1. Create the following directories
+Our custom Linux installation process for infrastructure monitoring allows you to tailor all aspects of the installation process, and to place files and folders on your machine. If you choose the [assisted](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-assisted-install-infrastructure-agent-linux) or [manual](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-manual-install-infrastructure-agent-linux) tarball installation process, follow these steps to implement the log forwarder feature:
 
-   * /var/db/newrelic-infra/newrelic-integrations/logging
-   * /etc/newrelic-infra/logging.d
+1. Create the following directories:
 
-2. Download the fluent-bit-package (RPM) from [this repo](https://github.com/newrelic/fluent-bit-package) and install it (eg. `yum localinstall td-agent-bit-<some-version>.rpm`)
+- `/var/db/newrelic-infra/newrelic-integrations/logging`
+- `/etc/newrelic-infra/logging.d`
 
-3. Download the New Relic fluentbit plugin (`out_newrelic.so`) from [this repo](https://github.com/newrelic/newrelic-fluent-bit-output) and copy it to `/var/db/newrelic-infra/newrelic-integrations/logging/`
+2. Download and install New Relic's [fluent-bit-package (RPM)](https://github.com/newrelic/fluent-bit-package) by running a command similar to:
+  ```shell
+   yum localinstall td-agent-bit-<some-version>.rpm`
+   ```
 
-4. Copy parsers.conf from [here](https://github.com/newrelic/fluent-bit-package/blob/main/parsers.conf) and save it in `/var/db/newrelic-infra/newrelic-integrations/logging/`
+3. Download New Relic's [fluentbit plugin (`out_newrelic.so`)](https://github.com/newrelic/newrelic-fluent-bit-output) and copy it to the `/var/db/newrelic-infra/newrelic-integrations/logging/` folder you created.
+
+4. Copy the `parsers.conf` file from [this Github repository](https://github.com/newrelic/fluent-bit-package/blob/main/parsers.conf), and save it in the `/var/db/newrelic-infra/newrelic-integrations/logging/` folder you created.
 
 ## Configure the infrastructure agent [#configure]
 


### PR DESCRIPTION
Many customers are forced to implement infra agents using the tarball installation. Unfortunately, the tarball doesn't contain the td-agent-bit binary (or any other integration), so if a customer still wants to use the log forwarding feature - they are left alone to figure out how to do that. The process is simple enough if you know it, so why not document it :)

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.