### PR TITLE
Update OTLP supportability chart

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup.mdx
@@ -208,7 +208,7 @@ Whether you export directly from your app or from a collector, you'll need to:
       </td>
 
       <td>
-        ✅
+        ❌
       </td>
 
       <td>


### PR DESCRIPTION
HTTP/1.1 over the OTLP US FedRAMP endpoint is not currently supported.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
  * NR does not currently support HTTP/1.1 over the gov OTLP endpoint. This PR updates that support-ability, since it is showing as supported
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.