### PR TITLE
Mention hosts in intro and setup doc

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-basic.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-basic.mdx
@@ -15,54 +15,56 @@ The collector setup is part of the larger process of setting up OpenTelemetry wi
 
 1. Save the following as `otel-config.yaml`:
 
-```
-receivers:
-  otlp:
-    protocols:
-      grpc:
-      http:
+    ```
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
 
-processors:
-  batch:
+    processors:
+      batch:
 
-exporters:
-  otlp:
-    endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
-    headers:
-      api-key: ${NEW_RELIC_LICENSE_KEY}
+    exporters:
+      otlp:
+        endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+        headers:
+          api-key: ${NEW_RELIC_LICENSE_KEY}
 
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [otlp]
-    metrics:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [otlp]
-    logs:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [otlp]
-```
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [otlp]
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [otlp]
+        logs:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [otlp]
+    ```
 
 2. Run the OpenTelemetry collector after you make the following changes:
    * Replace <var>OTLP_ENDPOINT_HERE</var> with the appropriate [endpoint](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-basic#review-settings).
    * Replace <var>YOUR_KEY_HERE</var> with your account's [license key](https://one.newrelic.com/launcher/api-keys-ui.launcher).
 
-```
-export OTEL_EXPORTER_OTLP_ENDPOINT=<var>OTLP_ENDPOINT_HERE</var>
-export NEW_RELIC_LICENSE_KEY=<var>YOUR_KEY_HERE</var>
 
-docker run --rm \
-  -e OTEL_EXPORTER_OTLP_ENDPOINT \
-  -e NEW_RELIC_LICENSE_KEY \
-  -p 4317:4317 \
-  -v "${PWD}/otel-config.yaml":/otel-config.yaml \
-  --name otelcol \
-  otel/opentelemetry-collector \
-  --config otel-config.yaml
-```
+
+    ```
+    export OTEL_EXPORTER_OTLP_ENDPOINT=<var>OTLP_ENDPOINT_HERE</var>
+    export NEW_RELIC_LICENSE_KEY=<var>YOUR_KEY_HERE</var>
+
+    docker run --rm \
+      -e OTEL_EXPORTER_OTLP_ENDPOINT \
+      -e NEW_RELIC_LICENSE_KEY \
+      -p 4317:4317 \
+      -v "${PWD}/otel-config.yaml":/otel-config.yaml \
+      --name otelcol \
+      otel/opentelemetry-collector \
+      --config otel-config.yaml
+    ```
 
 3. If you are completing the installation steps, return to [Step 5. View your data in the New Relic UI](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup/#view-data).

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
@@ -9,11 +9,16 @@ metaDescription: The OpenTelemetry collector is a central tool to collect, proce
 
 You can collect metrics about your infrastructure hosts with OpenTelemetry if you set up the host receiver in a  collector. The collector is a component of OpenTelemetry that collects, processes, and exports telemetry data to New Relic (or any observability back-end).
 
-The collector setup is part of the larger process of setting up OpenTelemetry with New Relic. Before following the collector steps below, make sure you've completed the [preceding setup steps](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start).
-
 If you're looking for help with other collector use cases, see the [newrelic-opentelemetry-examples](https://github.com/newrelic/newrelic-opentelemetry-examples) repository.
 
-## Step 1: Install the OpenTelemetry collector [#install-generic]
+## Step 1: Prerequisites [#prereqs]
+
+Make sure you've completed the following before going further:
+
+* If you haven't already done so, sign up for a free [New Relic account](https://newrelic.com/signup).
+* Get the [license key](https://one.newrelic.com/launcher/api-keys-ui.launcher) for the New Relic account to which you want to report data.
+
+## Step 2: Install the OpenTelemetry collector [#install-generic]
 
 To do a basic installation for single hosts in the cloud or on-premises, see [OpenTelemetry's instructions](https://opentelemetry.io/docs/collector/getting-started/#linux-packaging) for up-to-date installation steps from the community. Instructions are available for the following:
 
@@ -28,7 +33,7 @@ Your deployment experience might vary depending on which vendor-specific distrib
   To set up infrastructure monitoring, you need to install and configure components that are included in the `collector-contrib` release. For example, the host receiver is required to collect basic host metrics such as CPU, memory, disk, and network stats and is only available in the [OpenTelemetry collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) release.
 </Callout>
 
-## Step 2: Configure host monitoring using the host receiver [#host-receiver]
+## Step 3: Configure host monitoring using the host receiver [#host-receiver]
 
 This collector example is meant to serve as a starting point from which you can extend, customize, and validate configurations before using them in production.
 
@@ -216,7 +221,7 @@ service:
   extensions: [health_check]
 ```
 
-## Step 3: View your data [#view-data]
+## Step 4: View your data [#view-data]
 
 You can view your collector data in a variety of places in the New Relic UI.
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction.mdx
@@ -17,7 +17,7 @@ redirects:
 dataSource: opentelemetry
 ---
 
-OpenTelemetry is a toolkit you can use to gather telemetry data from your applications and to export that data to New Relic. Once the data is in New Relic, you can use the New Relic platform to analyze the data and resolve application issues.
+OpenTelemetry is a toolkit you can use to gather telemetry data from your applications and hosts and then export that data to New Relic. Once the data is in New Relic, you can use the New Relic platform to analyze the data and resolve application issues.
 
 OpenTelemetry has features that overlap with New Relic agents, so review the information below to see if it will help you accomplish your telemetry goals. If you're already familiar with OpenTelemetry and want to get started, see our [setup](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup) instructions.
 
@@ -29,7 +29,7 @@ Here are some topics to help you get acquainted with OpenTelemetry:
 
 ## Benefits of OpenTelemetry [#benefits]
 
-OpenTelemetry provides a secure, vendor-neutral [specification](https://github.com/open-telemetry/opentelemetry-specification) for service instrumentation so that you can export data to distinct back-ends of your choice, such as New Relic. OpenTelemetry offers a single set of APIs and libraries that standardize how you collect and transfer telemetry data for your services.
+OpenTelemetry provides a secure, vendor-neutral [specification](https://github.com/open-telemetry/opentelemetry-specification) for service and host instrumentation so that you can export data to distinct back-ends of your choice, such as New Relic. OpenTelemetry offers a single set of APIs and libraries that standardize how you collect and transfer telemetry data for your services and hosts.
 
 The following components make up the OpenTelemetry project:
 
@@ -130,9 +130,9 @@ The components of OpenTelemetry work together to create some distinct advantages
 
 As you consider OpenTelemetry, you may also be looking at New Relic APM agents that also capture telemetry data.
 
-As you'd expect, there is a lot of overlap between features available from OpenTelemetry agents and SDKs versus those available from New Relic APM agents. This is especially true if you're interested in distributed tracing telemetry data. The choice you make depends on what you need.
+As you'd expect, there is a lot of overlap between features available from OpenTelemetry agents and SDKs versus those available from New Relic agents. This is especially true if you're interested in distributed tracing telemetry data. The choice you make depends on what you need.
 
-We recommend that you explore both New Relic and OpenTelemetry instrumentation, and welcome you to discuss this with us in our [CNCF Slack channel, #otel-newrelic](https://cloud-native.slack.com/archives/C024DRQ63UP), to decide what works best for you. You may have to first [sign up for CNCF's Slack account here](https://slack.cncf.io/). 
+We recommend that you explore both New Relic and OpenTelemetry instrumentation, and we welcome you to discuss this in our [CNCF Slack channel, #otel-newrelic](https://cloud-native.slack.com/archives/C024DRQ63UP) to decide what works best for you. You may have to first [sign up for CNCF's Slack account here](https://slack.cncf.io/).
 
 ### OpenTelemetry: A work in progress [#emerging-standard]
 
@@ -142,11 +142,11 @@ The current state of language-specific OpenTelemetry APIs and SDKs varies: some 
 
 For languages where New Relic does not currently provide an agent or SDK, OpenTelemetry may offer you a good alternative. Also, in cases where you want explicit control over sampling of your telemetry data, OpenTelemetry provides a lot of flexibility.
 
-As OpenTelemetry matures, New Relic will continue to support new OpenTelemetry data models and to provide a curated UI experience for our customers.
+As OpenTelemetry matures, we will continue to support new OpenTelemetry data models and provide you curated UI experiences in our platform.
 
-### New Relic's APM agents [#apm-agents]
+### New Relic agents [#apm-agents]
 
-In general, New Relic's APM agents will collect more telemetry data for your services, and they offer a wide range of configuration options and an extensive set of auto-instrumentation capabilities.
+In general, New Relic's APM and infrastructure agents will collect more telemetry data for your services and hosts. Plus, they offer a wide range of configuration options and an extensive set of auto-instrumentation capabilities.
 
 New Relic's APM agents offer detailed transaction trace visibility for individual services. They also offer predefined sampling to balance the performance impact of your instrumentation against the need to capture enough data to gain helpful insights.
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry setup
+title: OpenTelemetry setup for services
 tags:
   - Integrations
   - Open source telemetry integrations
@@ -18,7 +18,9 @@ import nativeOtlpNoCollector from 'images/native-otlp-no-collector.png'
 
 import nativeOtlpWithCollector from 'images/native_otlp_with_collector.png'
 
-OpenTelemetry is a flexible toolkit that you can implement in a variety of ways. We recommend a basic five-step approach for setting up OpenTelemetry with New Relic. Here's an overview of the process, followed by details for each step.
+OpenTelemetry is a flexible toolkit that you can implement in a variety of ways for services. If you are planning to gather telemetry about hosts, skip to our [collector instructions](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro).
+
+To gather telemetry from services, we recommend a basic five-step approach:
 
 1. [Prerequisites](#prereqs)
 2. [Instrument your service with OpenTelemetry](#instrument)
@@ -35,7 +37,9 @@ First things first:
 
 ## Step 2: Instrument your service with OpenTelemetry [#instrument]
 
-To get started, you instrument your service with OpenTelemetry. OpenTelemetry has language-specific products and SDKs to help you. Many languages offer out-the-box instrumentation for common libraries and frameworks. Each language also provides an API for further instrumenting your service manually.
+These instructions focus on instrumenting a service. To learn about instrumenting hosts, jump to our [collector instructions](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro).
+
+To help you instrument a service, OpenTelemetry provides language-specific products and SDKs. Many languages offer out-the-box instrumentation for common libraries and frameworks. Each language also provides an API for further instrumenting your service manually.
 
 Go to the repository for your language and follow the instructions to instrument your service. When you're done, return here to complete [Step 3: Review configurations for exporting telemetry data to New Relic](#review-settings).
 


### PR DESCRIPTION
Here's what I did to increase the presence of host references in the docs:

        * I renamed the setup doc so it's clearly about services.
        * I added a new intro to clarify what to do if you want hosts.
        * I added another off ramp to hosts in step 2 of the setup. 
        * I made the host collector doc independent of the services setup doc by adding a prerequisites step.
        * I also added a variety of host references in the introduction topic.