### PR TITLE
Cloud inventory EOL notes

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/eol-cloud-inventory.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/eol-cloud-inventory.mdx
@@ -6,31 +6,36 @@ releaseDate: '2022-05-01'
 
 ## Updated
 
-As [previously announced](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-and-support-across-errors-classic-labels-service-infrastructure-on-host-snmp-integration-and-inventory-data-in-cloud-integrations/175370#inventory-data-in-cloud-integrations-aws-azure-gcp-polling-integrations-4) we are ending support for Inventory data pushed from our Cloud Integrations (AWS, Azure, GCP).
+As [previously announced](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-and-support-across-errors-classic-labels-service-infrastructure-on-host-snmp-integration-and-inventory-data-in-cloud-integrations/175370#inventory-data-in-cloud-integrations-aws-azure-gcp-polling-integrations-4), we're ending support for Inventory data pushed from our Cloud Integrations (AWS, Azure, GCP).
 
 ### What is changing?
-Inventory data is currently collected on many AWS, Azure and GCP integrations and represents static configuration data or resource metadata. Information from hosts or on-host integrations in Inventory is not affected by this change.
+
+Inventory data is currently collected on many AWS, Azure, and GCP integrations. It represents static configuration data or resource metadata. Information from hosts or on-host integrations in Inventory is not affected by this change.
 
 ### What is Inventory? 
-Inventory data is information about the state and configuration of a service (e.g. service settings). Data appears in the Inventory page and some integration dashboards in the original infrastructure experience. Changes to inventory data generate New Relic `InfrastructureEvent` events that can be queried and alerted on.
+
+Inventory data is information about the state and configuration of a service, e.g. service settings. Data appears in the Inventory page and some integration dashboards in the original infrastructure experience. Changes to inventory data generate New Relic `InfrastructureEvent` events that can be queried and alerted on.
 
 ### Capabilities that will no longer be available
+
 * When browsing to Infrastructure > Inventory, any source from `aws/*`, `azure/*` or `gcp/*` will no longer be available.
-* Built-in dashboards available in Infrastructure > AWS | Azure | GCP | GovCloud that contains inventory or infrastructure events widgets will no longer display data. These dashboards are planned to be migrated as standard New Relic dashboards enabling all the new capabilities (edit, sharing, new visualizations, and more) which are not available in the original dashboard experience for Infrastructure.  
+* Built-in dashboards available in Infrastructure > AWS | Azure | GCP | GovCloud that contain inventory or infrastructure events widgets will no longer display data. These dashboards are planned to be migrated as standard New Relic dashboards enabling all the new capabilities (edit, sharing, new visualizations, and more) which are not available in the original dashboard experience for Infrastructure.  
 * Queries using `aws`, `azure` or `gcp` sources from `InfrastructureEvent` will no longer report data.
 
 ### Why is this capability being deprecated?
-* Customers find more value in Host Inventory (which is not being deprecated), but less value in Cloud Integrations. 
+
+* Customers find more value in Host Inventory, which is not being deprecated, but less value in Cloud Integrations. 
 
 ### Alternatives
-* Most of the attributes available as Inventory in the polling integrations are also available as metric metadata or tags so the information should be queryable.
+
+* Most of the attributes available as Inventory in the polling integrations are also available as metric metadata or tags, so you can query for this information.
 * A limited set of integrations also published the same information available in Inventory as standard New Relic Events. In example, the AWS Health integration.
-If you encounter any problems after this feature is deprecated or with any of the alternative solutions, please reach out to us at support@newrelic.com.
-Why?
 
 ### How does this affect AWS CloudWatch metric streams and future integrations for Azure & GCP?
-* Inventory is no available in AWS CloudWatch metric stream so there's no impact on this capability.
-* New integrations for Azure and GCP will be focused on MELT telemetry: Metrics, Events, Logs & Traces (with special focus on Metrics).
+
+* Inventory isn't available in AWS CloudWatch metric stream, so there's no impact on this capability.
+* New integrations for Azure and GCP will be focused on MELT telemetry: Metrics, Events, Logs & Traces, with special focus on Metrics.
 
 ### Feedback
-If you encounter any problems after this feature is deprecated, please reach out to us at support@newrelic.com.
+
+If you have any problems after this feature is deprecated, please reach out to us at support@newrelic.com.

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/eol-cloud-inventory.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/eol-cloud-inventory.mdx
@@ -1,0 +1,36 @@
+---
+title: 'Deprecating Inventory for Cloud Integrations'
+subject: Cloud integrations
+releaseDate: '2022-05-01'
+---
+
+## Updated
+
+As [previously announced](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-and-support-across-errors-classic-labels-service-infrastructure-on-host-snmp-integration-and-inventory-data-in-cloud-integrations/175370#inventory-data-in-cloud-integrations-aws-azure-gcp-polling-integrations-4) we are ending support for Inventory data pushed from polling Cloud Integrations (AWS, Azure, GCP).
+
+### What is changing?
+Inventory data is currently collected on many AWS, Azure and GCP integrations and represents static configuration data or resource metadata. Information from hosts or on-host integrations in Inventory is not affected.
+
+### What is Inventory? 
+Inventory data is information about the state and configuration of a service (e.g. service settings). Data appears in the Inventory page and some integration dashboards in the original infrastructure experience. Changes to inventory data generate New Relic `InfrastructureEvent` events that can be queried and alerted on.
+
+### Capabilities that will no longer be available
+* When browsing to Infrastructure > Inventory, any source from `aws/*`, `azure/*` or `gcp/*` will no longer be available.
+* Built-in dashboards available in Infrastructure > AWS | Azure | GCP | GovCloud that contains inventory or infrastructure events widgets will no longer display data. These dashboards are planned to be migrated as standard New Relic dashboards enabling all the new capabilities (edit, sharing, new visualizations, and more) which are not available in the original dashboard experience for Infrastructure.  
+* Queries using `aws`, `azure` or `gcp` sources from `InfrastructureEvent` will no longer report data.
+
+### Why is this capability being deprecated?
+* Customers find more value in Host Inventory (which is not being deprecated), but less value in Cloud Integrations. 
+
+### Alternatives
+* Most of the attributes available as Inventory in the polling integrations are also available as metric metadata or tags so the information should be queryable.
+* A limited set of integrations also published the same information available in Inventory as standard New Relic Events. In example, the AWS Health integration.
+If you encounter any problems after this feature is deprecated or with any of the alternative solutions, please reach out to us at support@newrelic.com.
+Why?
+
+### How does this affect AWS CloudWatch metric streams and future integrations for Azure & GCP?
+* Inventory is no available in AWS CloudWatch metric stream so there's no impact on this capability.
+* New integrations for Azure and GCP will be focused on MELT telemetry: Metrics, Events, Logs & Traces (with special focus on Metrics).
+
+### Feedback
+If you encounter any problems after this feature is deprecated, please reach out to us at support@newrelic.com.

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/eol-cloud-inventory.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/eol-cloud-inventory.mdx
@@ -6,10 +6,10 @@ releaseDate: '2022-05-01'
 
 ## Updated
 
-As [previously announced](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-and-support-across-errors-classic-labels-service-infrastructure-on-host-snmp-integration-and-inventory-data-in-cloud-integrations/175370#inventory-data-in-cloud-integrations-aws-azure-gcp-polling-integrations-4) we are ending support for Inventory data pushed from polling Cloud Integrations (AWS, Azure, GCP).
+As [previously announced](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-and-support-across-errors-classic-labels-service-infrastructure-on-host-snmp-integration-and-inventory-data-in-cloud-integrations/175370#inventory-data-in-cloud-integrations-aws-azure-gcp-polling-integrations-4) we are ending support for Inventory data pushed from our Cloud Integrations (AWS, Azure, GCP).
 
 ### What is changing?
-Inventory data is currently collected on many AWS, Azure and GCP integrations and represents static configuration data or resource metadata. Information from hosts or on-host integrations in Inventory is not affected.
+Inventory data is currently collected on many AWS, Azure and GCP integrations and represents static configuration data or resource metadata. Information from hosts or on-host integrations in Inventory is not affected by this change.
 
 ### What is Inventory? 
 Inventory data is information about the state and configuration of a service (e.g. service settings). Data appears in the Inventory page and some integration dashboards in the original infrastructure experience. Changes to inventory data generate New Relic `InfrastructureEvent` events that can be queried and alerted on.


### PR DESCRIPTION
## Give us some context

* The inventory capability for Cloud Integrations has been deprecated. We are publishing additional details on top of the EOl announcement.
* Multiple docs update will follow-up in the next few weeks to gradually remove inventory docs from AWS/GCP/Azure integrations (this PR is focused on the FAQs). 