### PR TITLE
fix(Pixie): fix wording in memory docs

### DIFF
--- a/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/install-auto-telemetry-pixie.mdx
+++ b/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/install-auto-telemetry-pixie.mdx
@@ -22,7 +22,7 @@ Ready to get started? If you don't already have one, [sign up for a New Relic ac
 Tips before getting started:
 
 * Review this [Pixie data security overview](/docs/auto-telemetry-pixie/pixie-data-security-overview) for actions to take to secure your data.
-* Make sure your clusters have sufficient memory. Pixie requires 2Gb of memory on each node in your cluster for the default installation. Review this [Pixie memory management overview](/docs/auto-telemetry-pixie/manage-pixie-memory) for actions to take to tune memory usage.
+* Make sure your clusters have sufficient memory. Pixie requires, at minimum, 1Gb of memory on each node in your cluster. Review this [Pixie memory management overview](/docs/auto-telemetry-pixie/manage-pixie-memory) for actions to take to tune memory usage.
 * Pixie needs to run in privileged mode.
 * Review the other [Pixie technical requirements](https://docs.px.dev/installing-pixie/requirements/).
 

--- a/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/install-auto-telemetry-pixie.mdx
+++ b/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/install-auto-telemetry-pixie.mdx
@@ -22,7 +22,7 @@ Ready to get started? If you don't already have one, [sign up for a New Relic ac
 Tips before getting started:
 
 * Review this [Pixie data security overview](/docs/auto-telemetry-pixie/pixie-data-security-overview) for actions to take to secure your data.
-* Make sure your clusters have sufficient memory. Pixie requires, at minimum, 1Gb of memory on each node in your cluster. Review this [Pixie memory management overview](/docs/auto-telemetry-pixie/manage-pixie-memory) for actions to take to tune memory usage.
+* Make sure your clusters have sufficient memory. Pixie requires, at minimum, 1Gib of memory on each node in your cluster. Review this [Pixie memory management overview](/docs/auto-telemetry-pixie/manage-pixie-memory) for actions to take to tune memory usage.
 * Pixie needs to run in privileged mode.
 * Review the other [Pixie technical requirements](https://docs.px.dev/installing-pixie/requirements/).
 

--- a/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/manage-pixie-memory.mdx
+++ b/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/manage-pixie-memory.mdx
@@ -31,7 +31,7 @@ After installing Pixie, memory usage of the `vizier-pem` pods increases as they 
 
 ## Configuring Pixie's memory usage [#configure-memory]
 
-For most clusters, we recommend using the default `2Gi` memory configuration. For your application pods, we recommend you to set the default `2Gi` memory to a maximum of 25% of your nodes' total memory. For instance, if your nodes have a total memory of `4Gi`, you'll want to configure Pixie to use a `1Gi` memory limit.
+For most clusters, we recommend using the default `2Gi` memory configuration. However, for certain low traffic clusters, Pixie can support a minimum memory limit of `1Gi`. To accommodate application pods, we recommend that no more than 25% of the nodes' total memory be allocated to Pixie. For example, if your nodes have a total memory of `4Gi`, you'll want to configure Pixie to use a `1Gi` memory limit.
 
 ### Deploy Pixie with a particular memory limit [#set-memory-limit]
 


### PR DESCRIPTION
Adjust wording to make it clear that the minimum memory limit is 1Gi. 