### PR TITLE
Fix broken collapsers

### DIFF
--- a/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data.mdx
@@ -111,6 +111,7 @@ Here are some examples of common ways to use tags to organize data:
 
 <CollapserGroup>
   <Collapser
+    className="freq-link"
     id="team-tags"
     title="Team-related tags"
   >
@@ -142,6 +143,7 @@ Here are some examples of common ways to use tags to organize data:
   </Collapser>
 
   <Collapser
+    className="freq-link"
     id="environment-tags"
     title="Environment-related tags"
   >
@@ -154,6 +156,7 @@ Here are some examples of common ways to use tags to organize data:
   </Collapser>
 
   <Collapser
+    className="freq-link"
     id="criticality-tags"
     title="Criticality-related tags"
   >
@@ -175,6 +178,7 @@ Here are some details about how tags are added for some specific data sources:
 
 <CollapserGroup>
   <Collapser
+    className="freq-link"
     id="add-via-ui-api"
     title="Add tags via UI or API"
   >
@@ -191,6 +195,7 @@ Here are some details about how tags are added for some specific data sources:
   </Collapser>
 
   <Collapser
+    className="freq-link"
     id="add-tags-apm-agents"
     title="APM agent tags"
   >
@@ -227,6 +232,7 @@ Here are some details about how tags are added for some specific data sources:
   </Collapser>
 
   <Collapser
+    className="freq-link"
     id="add-tags-infrastructure"
     title="Infrastructure data tags"
   >
@@ -239,6 +245,7 @@ Here are some details about how tags are added for some specific data sources:
   </Collapser>
 
   <Collapser
+    className="freq-link"
     id="programmatic-add-tags"
     title="Automate tags with our CLI"
   >
@@ -298,6 +305,7 @@ Here are some query examples:
 
 <CollapserGroup>
   <Collapser
+    className="freq-link"
     id="apm-shard-distribution"
     title="Throughput across shards"
   >
@@ -311,6 +319,7 @@ Here are some query examples:
   </Collapser>
 
   <Collapser
+    className="freq-link"
     id="apm-team-tag"
     title="Transactions per team"
   >
@@ -324,6 +333,7 @@ Here are some query examples:
   </Collapser>
 
   <Collapser
+    className="freq-link"
     id="apm-errors-team"
     title="Alert on error rate for teams"
   >

--- a/src/content/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic.mdx
@@ -185,6 +185,7 @@ Use our application performance monitoring (APM) monitoring to learn about your 
 * [Python](/docs/apm/agents/python-agent/installation)
 * [Ruby](/docs/agents/ruby-agent/installation-configuration/ruby-agent-installation)
   </Collapser>
+
   <Collapser
     className="freq-link"
     id="browser-install"
@@ -196,6 +197,7 @@ Browser monitoring in New Relic measures full page life cycle and session data, 
 See [browser monitoring install](/docs/browser/new-relic-browser/installation/install-new-relic-browser-agent).
 
   </Collapser>
+  
   <Collapser
     className="freq-link"
     id="infra-install"


### PR DESCRIPTION
There are some broken collapsers on our site and I'm trying to get to the bottom of it.

I noticed these collapsers were missing `className="freq-link"` so I added that.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>