### PR TITLE
fix(account nerdgraph): rolling back edit

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/manage-accounts-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/manage-accounts-nerdgraph.mdx
@@ -7,7 +7,7 @@ tags:
 metaDescription: "Examples of using New Relic's NerdGraph API to view, create, and rename accounts." 
 redirects:
   - /docs/apis/nerdgraph/examples/export-dashboards-pdfpng-api-tutorial
-  - /docs/apis/nerdgraph/examples 
+  - /docs/apis/nerdgraph/examples
 ---
 
 You can use [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) to view your organization's accounts, create accounts, and rename accounts. 

--- a/src/content/docs/apis/nerdgraph/examples/manage-accounts-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/manage-accounts-nerdgraph.mdx
@@ -4,7 +4,7 @@ tags:
   - APIs
   - NerdGraph
   - Examples
-metaDescription: "Examples of using New Relic's NerdGraph API to view, create, and rename accounts."
+metaDescription: "Examples of using New Relic's NerdGraph API to view, create, and rename accounts." 
 redirects:
   - /docs/apis/nerdgraph/examples/export-dashboards-pdfpng-api-tutorial
   - /docs/apis/nerdgraph/examples

--- a/src/content/docs/apis/nerdgraph/examples/manage-accounts-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/manage-accounts-nerdgraph.mdx
@@ -4,13 +4,13 @@ tags:
   - APIs
   - NerdGraph
   - Examples
-metaDescription: Examples of using New Relic's NerdGraph API to view, create, and rename accounts.  
+metaDescription: "Examples of using New Relic's NerdGraph API to view, create, and rename accounts."
 redirects:
   - /docs/apis/nerdgraph/examples/export-dashboards-pdfpng-api-tutorial
   - /docs/apis/nerdgraph/examples
 ---
 
-You can use [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) to view your organization’s accounts, create accounts, and rename accounts. 
+You can use [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) to view your organization's accounts, create accounts, and rename accounts. 
 
 ## Requirements [#requirements]
 
@@ -22,10 +22,11 @@ Requirements to manage accounts via NerdGraph include:
 
 ## Before you start [#concepts]
 
-Before you use NerdGraph to manage your accounts, it will help if you understand:
+Before you use NerdGraph to manage your accounts, it will probably help you to understand:
 
 * [What New Relic accounts are and what they're used for](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure)
 * [The basics of using NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph)
+* That you can [track changes to your New Relic account](/docs/data-apis/understand-data/event-data/query-account-audit-logs-nrauditevent)  
 
 This tutorial will show you how to: 
 * View accounts 
@@ -50,65 +51,15 @@ Here's an example of returning the accounts in your organization:
     organization {
       accountManagement {
         managedAccounts {
-          managedAccounts {
-            id
-            name
-            regionCode
-          }
+          name
+          id
+          regionCode
         }
       }
     }
   }
 }
 ```
-
-### View accounts with pagination [#view-accounts-pagination]
-
-The view-accounts query also has a cursor that can be used for pagination:
-
-```graphql
-{
-  actor {
-    organization {
-      accountManagement {
-        managedAccounts {
-          managedAccounts {
-            id
-            name
-
-          }
-          nextCursor
-          totalCount
-        }
-      }
-    }
-  }
-}
-```
-
-When `nextCursor` returns a string, that means you have reached the maximum number of accounts per request (1000). To get the next batch of accounts you query again with this returned `nextCursor`:
-
-```graphql
-{
-  actor {
-    organization {
-      accountManagement {
-        managedAccounts(cursor: "<value from the prior request's nextCursor here>") {
-          managedAccounts {
-            id
-            name
-            regionCode
-          }
-          nextCursor
-          totalCount
-        }
-      }
-    }
-  }
-}
-```
-
-When cycling through the pages, when you reach `nextCursor = null`, that's the end.
 
 ## Create accounts [#create-accounts]
 
@@ -128,7 +79,7 @@ mutation {
 
 ## Rename an account [#rename-accounts]
 
-Here's an example of how to rename an account: 
+Here's an example of how to rename an account. 
 
 ```graphql
 mutation {
@@ -198,3 +149,5 @@ Contact [support](/docs/new-relic-solutions/solve-common-issues/find-help-use-su
         </tr>        
 </tbody>
 </table>
+
+

--- a/src/content/docs/apis/nerdgraph/examples/manage-accounts-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/manage-accounts-nerdgraph.mdx
@@ -7,7 +7,7 @@ tags:
 metaDescription: "Examples of using New Relic's NerdGraph API to view, create, and rename accounts." 
 redirects:
   - /docs/apis/nerdgraph/examples/export-dashboards-pdfpng-api-tutorial
-  - /docs/apis/nerdgraph/examples
+  - /docs/apis/nerdgraph/examples 
 ---
 
 You can use [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) to view your organization's accounts, create accounts, and rename accounts. 

--- a/src/content/docs/data-apis/understand-data/event-data/nrauditevent-event-data-query-examples.mdx
+++ b/src/content/docs/data-apis/understand-data/event-data/nrauditevent-event-data-query-examples.mdx
@@ -14,7 +14,7 @@ To view changes made in your New Relic account, you can query [`NrAuditEvent` ev
 
 ## Available events and attributes [#attributes]
 
-The `NrAuditEvent` is created to record configuration changes made in our products. The data gathered for this event includes the type of account change, actor (user or API key) that made the change, a human-readable description of the action taken, and a timestamp for the change.
+The `NrAuditEvent` is created to record some important types of configuration changes made in New Relic. The data gathered for this event includes the type of account change, actor (user or API key) that made the change, a human-readable description of the action taken, and a timestamp for the change.
 
 To see all the attributes attached to this event, see [`NrAuditEvent`.](/attribute-dictionary/?event=NrAuditEvent)
 
@@ -32,7 +32,7 @@ These examples show some of the ways you can run [NRQL](/docs/insights/nrql-new-
     To view all changes to your New Relic account for a specific time frame, run this basic NRQL query:
 
     ```
-    SELECT * from NrAuditEvent SINCE <var>1 day ago</var>
+    SELECT * from NrAuditEvent SINCE 1 day ago
     ```
   </Collapser>
 
@@ -44,7 +44,18 @@ These examples show some of the ways you can run [NRQL](/docs/insights/nrql-new-
 
     ```
     SELECT count(*) AS Actions FROM NrAuditEvent 
-    FACET actionIdentifier SINCE <var>1 week ago</var>
+    FACET actionIdentifier SINCE 1 week ago
+    ```
+  </Collapser>
+
+  <Collapser
+    id="accounts-created"
+    title="What accounts were added to our organization?"
+  >
+    To query for information about created accounts and who created them, you can use something like:
+
+    ```
+    SELECT actorEmail, actorId, targetId FROM NrAuditEvent WHERE actionIdentifier = 'account.create' SINCE 1 month ago
     ```
   </Collapser>
 
@@ -55,7 +66,7 @@ These examples show some of the ways you can run [NRQL](/docs/insights/nrql-new-
     When you include `TIMESERIES` in a NRQL query, the results are shown as a line graph. For example:
 
     ```
-    SELECT count(*) from NrAuditEvent TIMESERIES facet actionIdentifier since <var>1 week ago</var>
+    SELECT count(*) from NrAuditEvent TIMESERIES facet actionIdentifier since 1 week ago
     ```
   </Collapser>
 
@@ -123,7 +134,7 @@ These examples show some of the ways you can run [NRQL](/docs/insights/nrql-new-
     ```
     SELECT actionIdentifier, description, actorEmail, actorId, targetType, targetId 
     FROM NrAuditEvent WHERE actorType = 'user' 
-    SINCE <var>1 week ago</var>
+    SINCE 1 week ago
     ```
   </Collapser>
 
@@ -135,7 +146,7 @@ These examples show some of the ways you can run [NRQL](/docs/insights/nrql-new-
 
     ```
     SELECT actionIdentifier FROM NrAuditEvent 
-    WHERE actorId = <var>829034</var> SINCE <var>1 week ago</var>
+    WHERE actorId = <var>829034</var> SINCE 1 week ago
     ```
   </Collapser>
 
@@ -148,7 +159,7 @@ These examples show some of the ways you can run [NRQL](/docs/insights/nrql-new-
     ```
     SELECT count(*) as Users FROM NrAuditEvent 
     WHERE actorType = 'user' 
-    FACET actorEmail SINCE <var>1 week ago</var>
+    FACET actorEmail SINCE 1 week ago
     ```
   </Collapser>
 
@@ -178,7 +189,7 @@ These examples show some of the ways you can run [NRQL](/docs/insights/nrql-new-
 
     ```
     SELECT actionIdentifier, description, targetType, targetId, actorAPIKey, actorId, actorEmail 
-    FROM NrAuditEvent WHERE actorType = 'api_key' SINCE <var>1 week ago</var>
+    FROM NrAuditEvent WHERE actorType = 'api_key' SINCE 1 week ago
     ```
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/data-apis/understand-data/event-data/query-account-audit-logs-nrauditevent.mdx
+++ b/src/content/docs/data-apis/understand-data/event-data/query-account-audit-logs-nrauditevent.mdx
@@ -9,7 +9,7 @@ redirects:
   - /docs/insights/event-data-sources/default-events/query-account-audit-logs-nrauditevent
 ---
 
-As an additional security measure for managing your New Relic account, you can use the `NrAuditEvent` event to view audit logs that show changes in your New Relic account. This includes:
+As an additional security measure for using and managing New Relic, you can use the `NrAuditEvent` event to view audit logs that show changes in your New Relic organization. This includes:
 
 * Individuals added or deleted
 * Role changes
@@ -28,7 +28,7 @@ Audit logging is different than configuring [audit mode](/docs/agents/manage-apm
 
 ## Run NrAuditEvent query [#nrql]
 
-To track and view changes in your New Relic account:
+To track and view changes in a New Relic account:
 
 1. At any [NRQL interface](/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql#where), run the following query, adjusting the time frame as needed up to thirteen months:
 


### PR DESCRIPTION
Replacing wrongful edit with original draft. 
Adding in info about NrAuditEvent and how you can track account changes with that. Added in example of querying about created accounts. 