### PR TITLE
Add nerdgraph query with new fields

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
@@ -533,6 +533,29 @@ Entities in NerdGraph rely on [GraphQL interfaces](/docs/apis/graphql-api/gettin
       }
       ```
   </Collapser>
+  
+  <Collapser
+    id="filter-lastReportingchangeAt"
+    title="Get entities which stop reporting more than one day ago"
+  >
+    The NerdGraph GraphiQL explorer allows to filter entities with reporting is true|false and lastReportingChangeAt date field.
+
+    * You can retrieve entities which stop reporting (something happend to them) in last few hours
+
+      ```
+      {
+        actor {
+          entitySearch(query: "reporting is false and lastReportingChangeAt > 1651708800000") {
+            results {
+              entities {
+                name
+              }
+            }
+          }
+        }
+      }
+      ```
+  </Collapser>
 </CollapserGroup>
 
 ## Delete entities [#delete-entities]


### PR DESCRIPTION
Hi team, in ticket ESA-1177 we included a new field lastReportingChangeAt to filter entities. If you join with field reporting you can have this new kind of query.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.