### PR TITLE
doc: fix max_samples_stored value type

### DIFF
--- a/src/content/docs/logs/logs-context/configure-logs-context-ruby.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-ruby.mdx
@@ -66,7 +66,7 @@ You have three options to configure APM logs in context to send your app's logs 
     ```
     application_logging:
       forwarding:
-        max_samples_stored: 10_000
+        max_samples_stored: 10000
     ```
 
     Environment variable:


### PR DESCRIPTION


<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

## Give us some context

* What problems does this PR solve?

`max_samples_stored` value for the ruby `newrelic` gem should be an integer.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

https://docs.newrelic.com/docs/logs/logs-context/configure-logs-context-ruby#automatic

* If your issue relates to an existing GitHub issue, please link to it.
n/a