### PR TITLE
Only add translation PRs to localization board

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -16,13 +16,13 @@ jobs:
       PROJECT_ID: 11873277
       PROJECT_NAME: Docs PRs and Issues
     steps:
-    - name: Triages NEW pull requests to the Content Project
-      if: github.event.action == 'opened'
-      run: |
-        HEADER="Accept: application/vnd.github.inertia-preview+json"
-        PR_ID=${{ github.event.pull_request.id }}
-        COLUMN=$(gh api -H "$HEADER" projects/$PROJECT_ID/columns --jq ".[] | select(.name == \"$COLUMN_NAME\").id")
-        gh api -H "$HEADER" -X POST projects/columns/$COLUMN/cards -f content_type='PullRequest' -F content_id=$PR_ID
+      - name: Triages NEW pull requests to the Content Project
+        if: github.event.action == 'opened'
+        run: |
+          HEADER="Accept: application/vnd.github.inertia-preview+json"
+          PR_ID=${{ github.event.pull_request.id }}
+          COLUMN=$(gh api -H "$HEADER" projects/$PROJECT_ID/columns --jq ".[] | select(.name == \"$COLUMN_NAME\").id")
+          gh api -H "$HEADER" -X POST projects/columns/$COLUMN/cards -f content_type='PullRequest' -F content_id=$PR_ID
 
   localization_project:
     name: pr added to the localization github board (optional)
@@ -31,12 +31,12 @@ jobs:
       PROJECT_ID: 12004783
       PROJECT_NAME: Docs Site Localization PRs and Issues
     steps:
-    - name: Triages NEW pull requests to the Localization Project
-      if: |
-        github.event.action == 'labeled' &&
-        contains(github.event.pull_request.labels.*.name, 'localization')
-      run: |
-        HEADER="Accept: application/vnd.github.inertia-preview+json"
-        PR_ID=${{ github.event.pull_request.id }}
-        COLUMN=$(gh api -H "$HEADER" projects/$PROJECT_ID/columns --jq ".[] | select(.name == \"$COLUMN_NAME\").id")
-        gh api -H "$HEADER" -X POST projects/columns/$COLUMN/cards -f content_type='PullRequest' -F content_id=$PR_ID
+      - name: Triages NEW pull requests to the Localization Project
+        if: |
+          github.event.action == 'labeled' &&
+          contains(github.event.pull_request.labels.*.name, 'translations')
+        run: |
+          HEADER="Accept: application/vnd.github.inertia-preview+json"
+          PR_ID=${{ github.event.pull_request.id }}
+          COLUMN=$(gh api -H "$HEADER" projects/$PROJECT_ID/columns --jq ".[] | select(.name == \"$COLUMN_NAME\").id")
+          gh api -H "$HEADER" -X POST projects/columns/$COLUMN/cards -f content_type='PullRequest' -F content_id=$PR_ID


### PR DESCRIPTION
## Description

Change label this workflow looks for to `translations` so only PRs back from translation vendors are added to the [board](https://github.com/newrelic/docs-website/projects/4) so we can better keep track of them.

