### PR TITLE
Update network-syslog-monitoring.mdx

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-syslog-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-syslog-monitoring.mdx
@@ -157,7 +157,7 @@ Set up your network devices so they send syslog data to New Relic One.
     </table>
 
     <Callout variant="tip">
-      The default listening port for **ktranslate** is `5143 (TCP/UDP)`. If you need to use the default syslog port of `514` (or any other port), you can do so by providing a new listening endpoint during Docker runtime. For example: `-syslog="0.0.0.0:514"`.
+      The default listening port for **ktranslate** is `5143 (TCP/UDP)`. If you need to use the default syslog port of `514`, you can do so by removing `--net=host` from your run command, replacing it with `-p 514:5143/udp`. To bind the listener to a port above `1024`, add `-syslog.source="0.0.0.0:<port>"` to the end of the run command instead.
     </Callout>
   </Collapser>
 </CollapserGroup>
@@ -236,7 +236,7 @@ If you prefer to do the setup manually, see the instructions below.
            -tee_logs=true \
            -service_name=syslog \
            ## Optional: To override the default listening port of "0.0.0.0:5143":
-           ## -syslog="<ip_address>:<port>"
+           ## -syslog.source="<ip_address>:<port>"
            nr1.syslog
        ```
   </Collapser>


### PR DESCRIPTION
Updated the tip regarding binding to default syslog port. Also fixed an incorrect argument (-syslog= vs -syslog.source=)

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Information about getting syslogs from port 514 was updated. Incorrect command argument was also fixed

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
Tested locally, as well as with Kentik engineers

* If your issue relates to an existing GitHub issue, please link to it.
* N/A