### PR TITLE
Update advanced-config.mdx

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -552,7 +552,7 @@ global:
           </td>
 
           <td>
-            Listening IP port for receiving SNMP traps. By default it's set to `127.0.0.1:1620`, using the SNMP Trap default of `162` requires running Docker as root.
+            Listening IP port for receiving SNMP traps. By default it's set to `127.0.0.1:1620`, using the SNMP Trap default of `162` requires replacing `--net=host` in your run command with `-p 162:1620/udp`.
           </td>
         </tr>
 

--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -552,7 +552,7 @@ global:
           </td>
 
           <td>
-            Listening IP port for receiving SNMP traps. By default it's set to `127.0.0.1:1620`, using the SNMP Trap default of `162` requires replacing `--net=host` in your run command with `-p 162:1620/udp`.
+            Listening IP port for receiving SNMP traps. By default it's set to `127.0.0.1:1620`. Using the SNMP Trap default of `162` requires replacing `--net=host` in your run command with `-p 162:1620/udp`.
           </td>
         </tr>
 


### PR DESCRIPTION
Updated information on howto receive SNMP trap information from the default port of `162`

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Updated information about how to receive SNMP trap information from the default port of `162`

* Add any context that will help us review your changes such as testing notes,
Tested with engineering to confirm this is the recommended solution, rather than running the container as root

* If your issue relates to an existing GitHub issue, please link to it.
* N/A