### PR TITLE
chore: specify the maximum value for max_samples_stored

### DIFF
--- a/src/content/docs/logs/logs-context/configure-logs-context-ruby.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-ruby.mdx
@@ -59,7 +59,7 @@ You have three options to configure APM logs in context to send your app's logs 
 
     Once this is enabled, you also have control over the maximum number of logs sent to New Relic every minute. The default value is 10,000. If more than 10,000 logs are received in a 60-second window, your logs will begin to be sampled.
 
-    Set it to a higher number to receive more logs. Set it to a lower number to receive fewer logs. Any integer is valid.
+    Set it to a higher number to receive more logs. Set it to a lower number to receive fewer logs. Any integer up to 100,000 is valid.
 
     newrelic.yml:
 


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?

An upper limit was discovered for `application_logging.forwarding.max_samples_stored` This limit is now included in the description.
