### PR TITLE
fix: intent to upgrade OTLP notice

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs.mdx
@@ -12,9 +12,9 @@ Logs may represent application logs, machine generated events, or system logs. O
 You can send logs using OpenTelemetry tooling, correlate them with applications, and view them in New Relic.
 
 <Callout variant="important">
-Now that OpenTelemetry protocol for metrics is stable, we intend to move our support from v0.10 to v0.16. This means we'll be ending support for removed fields and data types, including `LogRecord.Name` for logs.
+As the OpenTelemetry Protocol matures and more components are declared [stable](https://github.com/open-telemetry/opentelemetry-proto#maturity-level), we intend to move the version supported by our OTLP endpoints from v0.10.0 to a more recent release, at least v0.16.0, before September 2022.
 
-Other significant changes include the renaming of `InstrumentationLibrary` to `InstrumentationScope`. We recommend you upgrade your collector or instrumentation if you depend on removed or deprecated features. We expect to make this change during or after the week of April 18, 2022.
+Additional communication will be forthcoming regarding the EOL timeline for v0.10.0 support and actions you can take to minimize disruption as the community moves toward a more stable release of OTLP.
 </Callout>
 
 ### Send logs to New Relic [#send-logs]

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-metrics.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-metrics.mdx
@@ -20,9 +20,9 @@ OpenTelemetry metrics are largely compatible with New Relic dimensional metrics.
 The OpenTelemetry [data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/datamodel.md#metric-points) for metrics defines a number of different metric types: sum, gauge, histogram, and summary.
 
 <Callout variant="important">
-Now that OpenTelemetry protocol for metrics is stable, we intend to move our support from v0.10 to v0.16. This means we'll be ending support for removed fields and data types, including the `Int` data point types for metrics.
+As the OpenTelemetry Protocol matures and more components are declared [stable](https://github.com/open-telemetry/opentelemetry-proto#maturity-level), we intend to move the version supported by our OTLP endpoints from v0.10.0 to a more recent release, at least v0.16.0, before September 2022.
 
-Other significant changes include the renaming of `InstrumentationLibrary` to `InstrumentationScope`. We recommend you upgrade your collector or instrumentation if you depend on removed or deprecated features. We expect to make this change during or after the week of April 18, 2022.
+Additional communication will be forthcoming regarding the EOL timeline for v0.10.0 support and actions you can take to minimize disruption as the community moves toward a more stable release of OTLP.
 </Callout>
 
 ### Sum metrics [#sums]

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-overview.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-overview.mdx
@@ -24,9 +24,9 @@ OpenTelemetry can be complex, so to make sure you're optimizing your experience 
 * [Traces](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-traces): See some requirements and options for traces and spans
 
 <Callout variant="important">
-Now that OpenTelemetry protocol for metrics is stable, we intend to move our support from v0.10 to v0.16. This means we'll be ending support for removed fields and data types, including the `Int` data point types for metrics, `LogRecord.Name` for logs, and status code for traces.
+As the OpenTelemetry Protocol matures and more components are declared [stable](https://github.com/open-telemetry/opentelemetry-proto#maturity-level), we intend to move the version supported by our OTLP endpoints from v0.10.0 to a more recent release, at least v0.16.0, before September 2022.
 
-Other significant changes include the renaming of `InstrumentationLibrary` to `InstrumentationScope`. We recommend you upgrade your collector or instrumentation if you depend on removed or deprecated features. We expect to make this change during or after the week of April 18, 2022.
+Additional communication will be forthcoming regarding the EOL timeline for v0.10.0 support and actions you can take to minimize disruption as the community moves toward a more stable release of OTLP.
 </Callout>
 
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-traces.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-traces.mdx
@@ -10,9 +10,9 @@ metaDescription: Here are some tips for working with OpenTelemetry traces and Ne
 Familiarize yourself with these OpenTelemetry trace topics to ensure your traces and spans appear in New Relic.
 
 <Callout variant="important">
-Now that OpenTelemetry protocol for metrics is stable, we intend to move our support from v0.10 to v0.16. This means we'll be ending support for removed fields and data types, including status code for traces.
+As the OpenTelemetry Protocol matures and more components are declared [stable](https://github.com/open-telemetry/opentelemetry-proto#maturity-level), we intend to move the version supported by our OTLP endpoints from v0.10.0 to a more recent release, at least v0.16.0, before September 2022.
 
-Other significant changes include the renaming of `InstrumentationLibrary` to `InstrumentationScope`. We recommend you upgrade your collector or instrumentation if you depend on removed or deprecated features. We expect to make this change during or after the week of April 18, 2022.
+Additional communication will be forthcoming regarding the EOL timeline for v0.10.0 support and actions you can take to minimize disruption as the community moves toward a more stable release of OTLP.
 </Callout>
 
 ### Required fields [#required]


### PR DESCRIPTION
This is a follow-up to #7043 and updates a repeated callout with new information about our intent to update our supported version of OpenTelemetry Protocol (OTLP). Further clarification to our plans and timeline will be made in subsequent PRs.