### PR TITLE
chore(java): removing feature that is not supported for those versions

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -411,7 +411,7 @@ The agent automatically instruments these frameworks and libraries:
     * java.net.HttpURLConnection
     * JMS and Spring-JMS 1.1 to latest
     * [Kafka Clients](/docs/agents/java-agent/instrumentation/use-kafka-message-queues) 0.10.0.0 to 2.8.1 (for metric and event data)
-    * [Kafka Clients](/docs/agents/java-agent/instrumentation/use-kafka-message-queues) 0.11.0.0 to latest (for distributed tracing, metric, and event data)
+    * [Kafka Clients](/docs/agents/java-agent/instrumentation/use-kafka-message-queues) 0.11.0.0 to latest (for distributed tracing and event data)
     * OkHttp 3.x to 4.3.x
     * Ning AsyncHttpClient 1.x
     * Play WS


### PR DESCRIPTION
## Give us some context
We recently found out that we don't support metrics for Kafka 3. So removing it.