### PR TITLE
fix/network monitoring clarifications

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -355,7 +355,7 @@ global:
           </td>
 
           <td>
-            Value used during entity synthesis for New Relic One. This is automatically created based on the matched `mib_profile`.
+            Value used during entity synthesis for New Relic One. This is automatically created based on the matched `mib_profile` and must match one of the rules in the [entity-definitions](https://github.com/newrelic/entity-definitions/search?q=%22attribute%3A+provider%22+filename%3Adefinition.yml) repository in order for an entity to be created. If you are manually adding devices, you will need to take caution to make sure this value is valid.
           </td>
         </tr>
 

--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -777,7 +777,7 @@ global:
           </td>
 
           <td>
-            Indicates whether to replace discovered devices if they already exist in the `devices` section of the `snmp-base.yaml` file. By default, it's set to `false`.
+            Indicates whether to replace discovered devices if they already exist in the `devices` section of the `snmp-base.yaml` file. By default, it's set to `true`.
           </td>
         </tr>
 

--- a/src/content/docs/network-performance-monitoring/advanced/snmp-profiles.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/snmp-profiles.mdx
@@ -88,6 +88,10 @@ You want to focus on collecting data that lets you know if there is anything tha
 
 For cases where you want to make a change to a profile, but you know that it is a scenario that is very unique and would not apply to other customers you can locally edit the profiles.
 
+<Callout variant="tip">
+  The value of `devices.[deviceName].provider` is critical to entity synthesis in New Relic. More details can be found in the [documentation on device configuration](/docs/network-performance-monitoring/advanced/advanced-config#devices/).
+</Callout>
+
 The way this is done is by using Docker's volume mount to pass in your customized files to the ktranslate container inside the `etc/ktranslate/profiles/` directory.
 There are other ways you could accomplish this but in this example we will demonstrate using a git fork and clone.
 


### PR DESCRIPTION
updating 2 pages on network monitoring docs to fix an incorrect default value and add more context to the usage of the `provider` key in device configs based on customer feedback.