### PR TITLE
OTLP HTTP/JSON support

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-browser.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-browser.mdx
@@ -1,0 +1,19 @@
+---
+title: 'OpenTelemetry JavaScript and Browser: Best practices'
+tags:
+  - Integrations
+  - Open source telemetry integrations
+  - OpenTelemetry
+metaDescription: Here are some tips for working with OpenTelemetry, browser applications, and New Relic.
+---
+
+<Callout variant="caution">
+It is not recommended to send telemetry data from a browser application or other client-side code directly to New Relic's OTLP endpoint in order to avoid exposing your license key.
+</Callout>
+
+Support for instrumenting browser, mobile, and other client-side applications to enable Real User Monitoring  with OpenTelemetry is currently limited and under active development, see [OTEP-169](https://github.com/open-telemetry/oteps/issues/169). While you may use the OpenTelemetry API or OpenTelemetry JS to instrument an application running in the browser, it is never safe to include your New Relic license key or other sensitive data as they may be easily obtained. The following practices may be layered to mitigate the risks associated with an exposed key:
+
+* Run the OpenTelemetry Collector between your application and New Relic's OTLP endpoint to avoid exposing your key in a client's browser
+* Create a dedicated license key to ingest telemetry data from browser applications that can be easily revoked if it is used maliciously
+* Understand the many risks associated with an exposed key including the possiblility of running into usage limits or billing problems
+* Use a separate, isolated account for browser telemetry data sent via OTLP to limit the potential negative effects of an exposed key

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-browser.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-browser.mdx
@@ -8,10 +8,10 @@ metaDescription: Here are some tips for working with OpenTelemetry, browser appl
 ---
 
 <Callout variant="caution">
-We recommend that you do not send telemetry data from a browser application or other client-side code directly to New Relic's OTLP endpoint because this could expose your license key.
+We recommend that you do not send telemetry directly to New Relic's OTLP endpoint from a browser application because this could expose your license key.
 </Callout>
 
-Support for instrumenting browser, mobile, and other client-side applications to enable real user monitoring (RUM) with OpenTelemetry is currently limited and under active development (see [OTEP-169](https://github.com/open-telemetry/oteps/issues/169)). While you may use the OpenTelemetry API or OpenTelemetry JS to instrument an application running in the browser, it is never safe to include your New Relic license key or other sensitive data as they may be easily obtained.
+Support for instrumenting browser, mobile, and other client-side applications to enable real user monitoring (RUM) with OpenTelemetry is currently limited and under active development. While you may use the OpenTelemetry API or OpenTelemetry JS to instrument an application running in the browser, it is never safe to include your New Relic license key or other sensitive data as they may be easily obtained.
 
 You can layer the following practices to mitigate the risks associated with an exposed key:
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-browser.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-browser.mdx
@@ -8,12 +8,14 @@ metaDescription: Here are some tips for working with OpenTelemetry, browser appl
 ---
 
 <Callout variant="caution">
-It is not recommended to send telemetry data from a browser application or other client-side code directly to New Relic's OTLP endpoint in order to avoid exposing your license key.
+We recommend that you do not send telemetry data from a browser application or other client-side code directly to New Relic's OTLP endpoint because this could expose your license key.
 </Callout>
 
-Support for instrumenting browser, mobile, and other client-side applications to enable Real User Monitoring  with OpenTelemetry is currently limited and under active development, see [OTEP-169](https://github.com/open-telemetry/oteps/issues/169). While you may use the OpenTelemetry API or OpenTelemetry JS to instrument an application running in the browser, it is never safe to include your New Relic license key or other sensitive data as they may be easily obtained. The following practices may be layered to mitigate the risks associated with an exposed key:
+Support for instrumenting browser, mobile, and other client-side applications to enable real user monitoring (RUM) with OpenTelemetry is currently limited and under active development (see [OTEP-169](https://github.com/open-telemetry/oteps/issues/169)). While you may use the OpenTelemetry API or OpenTelemetry JS to instrument an application running in the browser, it is never safe to include your New Relic license key or other sensitive data as they may be easily obtained.
 
-* Run the OpenTelemetry Collector between your application and New Relic's OTLP endpoint to avoid exposing your key in a client's browser
-* Create a dedicated license key to ingest telemetry data from browser applications that can be easily revoked if it is used maliciously
-* Understand the many risks associated with an exposed key including the possiblility of running into usage limits or billing problems
-* Use a separate, isolated account for browser telemetry data sent via OTLP to limit the potential negative effects of an exposed key
+You can layer the following practices to mitigate the risks associated with an exposed key:
+
+* Run the OpenTelemetry Collector between your application and New Relic's OTLP endpoint to avoid exposing your key in a client's browser.
+* Create a dedicated license key to ingest telemetry data from browser applications that can be easily revoked if it is used maliciously.
+* Understand the many risks associated with an exposed key including the possibility of running into usage limits or billing problems.
+* Use a separate, isolated account for browser telemetry data sent via OTLP to limit the potential negative effects of an exposed key.

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-overview.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-overview.mdx
@@ -17,6 +17,7 @@ OpenTelemetry can be complex, so to make sure you're optimizing your experience 
 * [Alerts](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-alerts): Notify yourself about problems by using alerts
 * [Attribute lengths](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-attributes): Stay within the limits for attribute names and values
 * [Batching](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-batching): Use batching to avoid rate limiting
+* [Browser](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-browser): Avoid exposing license keys in browser applications
 * [Compression](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-compression): Maximize your payloads
 * [Logs](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs): Send logs to New Relic using OpenTelemetry tooling
 * [Metrics](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-metrics): Explore how OpenTelemetry metrics are processed in New Relic

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup.mdx
@@ -344,7 +344,6 @@ New Relic currently supports [opentelemetry-specification](https://github.com/op
 
 * Successful responses from New Relic have no response body, instead of a [Protobuf-encoded response](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/protocol/otlp.md#success) based on the data type. New Relic also responds with success after authenticating, before decoding and validation.
 * [Failure responses](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/protocol/otlp.md#failures) from New Relic do not include `Status.message` or `Status.details`, since OTLP clients don't use the `Status` object.
-* [JSON-encoded Protobuf](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/protocol/otlp.md#otlphttp-connection) messages are not yet supported.
 
 ## What's next? [#next]
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-troubleshooting.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-troubleshooting.mdx
@@ -21,7 +21,7 @@ You sent OpenTelemetry metrics, logs, or traces using OTLP and are unable to vie
 * Confirm that you are using the correct endpoint based on your region. For example, if you are based in Europe and configure your exporter to send data to our US endpoint, data will fail to be exported as the endpoints are region-specific.
 * The outbound traffic is not restricted by a firewall. Our [Networks](/docs/using-new-relic/cross-product-functions/install-configure/networks/#opentelemetry) document explains domains and network blocks that you may need to explicitly allow.
 * The client is configured to use TLS 1.2 or higher and the request includes the `api-key` header with a valid New Relic account (ingest) [license key](https://one.newrelic.com/launcher/api-keys-ui.launcher).
-* Requests include valid protobuf payloads and use gRPC or HTTP transport, preferably with [gzip compression](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts/#compression) enabled. Request payloads should be no larger than 1MB (10^6 bytes). Sending JSON-encoded payloads is not supported at this time.
+* Requests include valid protobuf payloads and use gRPC or HTTP transport, preferably with [gzip compression](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-concepts/#compression) enabled. Request payloads should be no larger than 1MB (10^6 bytes). [JSON-encoded protobuf](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/protocol/otlp.md#otlphttp-connection) payloads are also supported.
 * Client output and logs do not indicate `4xx` or `5xx` response codes are being returned.
 
 ### Solution

--- a/src/nav/integrations.yml
+++ b/src/nav/integrations.yml
@@ -24,6 +24,8 @@ pages:
             path: /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-attributes
           - title: Batching
             path: /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-batching
+          - title: Browser
+            path: /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-browser
           - title: Compression
             path: /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-compression
           - title: Logs


### PR DESCRIPTION
This PR updates a few areas to reference our support for sending JSON-encoded protobuf payloads with OTLP and discourages sending data from browser apps directly to our OTLP endpoint to avoid license key exposure.