### PR TITLE
Attempting to create a stale cache issue for testing

### DIFF
--- a/src/content/docs/style-guide/writing-docs/processes-procedures/github-intro.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/github-intro.mdx
@@ -1,10 +1,11 @@
 ---
-title: Get around GitHub
+title: Get started with GitHub
 topics:
   - Tech writer style guide
   - How to use GitHub
 redirects:
   - /docs/style-guide/writer-workflow/github-intro
+  - /docs/style-guide/writing-docs/writer-workflow/github-intro
 ---
 
 Tech doc writers (TW) are responsible for the docs. We [write and edit the docs](/docs/style-guide/writer-workflow/tech-writer-workflow/) and [exchange peer edits](/docs/style-guide/writer-workflow/peer-editor-workflow/), maintain our backlog, and `hero`. To make it all happen, we use our [Docs Team GitHub board](https://github.com/newrelic/docs-website) to manage filed issues and pull requests (PRs).

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/set-up-local.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/set-up-local.mdx
@@ -1,8 +1,10 @@
 ---
-title: Set up your local build environment
+title: Set up your local build 
 topics:
   - Tech writer style guide
   - Processes and procedures
+redirects:
+  - /docs/style-guide/writing-docs/writer-workflow/set-up-local
 ---
 
 Running the site locally makes testing and previewing large changes much easier. There are several things you need to do get this working. Fortunately, you only need to do this once.

--- a/src/nav/style-guide.yml
+++ b/src/nav/style-guide.yml
@@ -87,12 +87,12 @@ pages:
             path: /docs/style-guide/writing-docs/processes-procedures/delete-document
           - title: Update the home page
             path: /docs/style-guide/writing-docs/processes-procedures/edit-homepage
+          - title: Get started with GitHub
+            path: /docs/style-guide/writing-docs/processes-procedures/github-intro
+          - title: Set up your local build
+            path: /docs/style-guide/writing-docs/processes-procedures/set-up-local
       - title: Tech writer processes
         pages:
-          - title: Get around GitHub
-            path: /docs/style-guide/writing-docs/writer-workflow/github-intro
-          - title: Local build set up
-            path: /docs/style-guide/writing-docs/writer-workflow/set-up-local
           - title: Tech writer workflow
             path: /docs/style-guide/writing-docs/writer-workflow/tech-writer-workflow
           - title: Peer editor workflow


### PR DESCRIPTION
This PR moves two style guide files in an attempt to create a stale cache issue (where the taxonomy breaks when accessing the old link)

Once merged to main, the two "old" links will be:

https://docs.newrelic.com/docs/style-guide/writing-docs/writer-workflow/github-intro/
https://docs.newrelic.com/docs/style-guide/writing-docs/writer-workflow/set-up-local/