### PR TITLE
[DO NOT MERGE] Try to repro stale cache in GC

### DIFF
--- a/src/content/docs/accounts/accounts/account-maintenance/synthetics-results-access-individual-monitor-runs.mdx
+++ b/src/content/docs/accounts/accounts/account-maintenance/synthetics-results-access-individual-monitor-runs.mdx
@@ -9,6 +9,7 @@ redirects:
   - /docs/synthetics/new-relic-synthetics/dashboards/synthetics-results-dashboard
   - /docs/synthetics/new-relic-synthetics/dashboards/synthetics-results-dashboard-access-individual-monitor-runs
   - /docs/synthetics/new-relic-synthetics/dashboards/synthetics-results-access-individual-monitor-runs
+  - /docs/synthetics/new-relic-synthetics/pages/synthetics-results-access-individual-monitor-runs
 ---
 
 import results from 'images/results.png'


### PR DESCRIPTION
Trying to repro stale cache in gatsby cloud by moving a file and adding a redirect for it

this page moved from here

/docs/synthetics/new-relic-synthetics/pages/synthetics-results-access-individual-monitor-runs

to here
/docs/accounts/accounts/account-maintenance/synthetics-results-access-individual-monitor-runs

i left old page url in left nav.

in theory, any page within `/docs/synthetics` should have broken JS