### PR TITLE
Improve skip metrics group documentation in oracledb ohi

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
@@ -436,7 +436,7 @@ The Oracle DB integration collects both Metrics(**M**) and Inventory(**I**) info
     {
       ' '
     }
-    
+
     <tr>
       <td>
         **SKIP_METRICS_GROUPS**
@@ -444,8 +444,8 @@ The Oracle DB integration collects both Metrics(**M**) and Inventory(**I**) info
 
       <td>
         Collected metrics are grouped together depending on the query used to obtain the data.
-        These metric groups appear here and can be skipped from collection by adding the name 
-        of the group to `SKIP_METRICS_GROUPS` in JSON array format. By default no group is skipped.
+        These metric groups are listed [here](https://github.com/newrelic/nri-oracledb/blob/master/METRIC_GROUPS.md) and can be skipped from collection by adding the name
+        of the group to `SKIP_METRICS_GROUPS` in JSON array format. By default no group is skipped. See [example](#metrics-skip) below.
       </td>
 
       <td>
@@ -696,6 +696,30 @@ Even though our default sample configuration file includes examples of labels, t
   </Collapser>
 
   <Collapser
+    id="metrics-skip"
+    title="Skip metrics groups"
+  >
+    This configuration skips collection of some metrics by disabling some of the queries using `SKIP_METRICS_GROUPS`. The allowed list of metric groups, together with the queries and affected metrics, are listed in this [document](https://github.com/newrelic/nri-oracledb/blob/master/METRIC_GROUPS.md):
+
+    ```
+    integrations:
+      - name: nri-oracledb
+        env:
+          SERVICE_NAME: ORACLE
+          HOSTNAME: 127.0.0.1
+          PORT: 1521
+          USERNAME: oracledb_user
+          PASSWORD: oracledb_password
+          ORACLE_HOME: /app/oracle/product/version/database
+          SKIP_METRICS_GROUPS: '["sgauga_total_memory", "redo_log_waits"]'
+        interval: 15s
+        labels:
+          environment: production
+        inventory_source: config/oracledb
+    ```
+  </Collapser>
+
+  <Collapser
     id="custom-query"
     title="Custom Query"
   >
@@ -818,6 +842,7 @@ These attributes can be found by querying the `OracleDatabaseSample` event type.
     </tr>
   </thead>
 
+  <tbody>
   <tr>
     <td>
       `db.activeParallelSessions`
@@ -3104,7 +3129,7 @@ These attributes can be found by querying the `OracleDatabaseSample` event type.
     <td/>
   </tr>
 
-  <tbody/>
+  </tbody>
 </table>
 
 ### Tablespace metrics [#tablespace-metric]


### PR DESCRIPTION
This PR improves our oracledb OHI documentation for the `skip_metrics_groups` config option adding an example and link to github detailed doc