### PR TITLE
Removing deprecated/internal options

### DIFF
--- a/src/content/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/pass-command-line-options-nrdiag.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/pass-command-line-options-nrdiag.mdx
@@ -26,15 +26,6 @@ To use the following command line options with the Diagnostics CLI:
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        `-attachment-endpoint STRING`
-      </td>
-
-      <td>
-        Attachment endpoint to include with the support ticket.
-      </td>
-    </tr>
 
     <tr>
       <td>
@@ -45,20 +36,6 @@ To use the following command line options with the Diagnostics CLI:
 
       <td>
         Attach for automatic upload to a New Relic account. This uses a validated license key from your environment.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        **DEPRECATED**
-
-        `-ak STRING`
-
-        `-attachment-key STRING`
-      </td>
-
-      <td>
-        Attachment key for automatic upload to a support ticket. This gets the attachment key from an existing ticket. (Note: this functionality will be removed soon. Please use the automatic upload option above)
       </td>
     </tr>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

Removing -attachment-endpoint as that's only intended for internal testing
Removing -attachment-key as it is deprecated

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.