### PR TITLE
fix: correct OTLP attribute value length limit

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-attributes.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-attributes.mdx
@@ -10,7 +10,7 @@ metaDescription: Here are some tips for working with OpenTelemetry attribute len
 New Relic's limits on attributes apply to data from any source, including OTLP-sourced data. See [metric attribute limits](https://docs.newrelic.com/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes/) and [event attribute limits](https://docs.newrelic.com/docs/data-apis/ingest-apis/event-api/introduction-event-api/#limits) for other limits:
 
 * Maximum length of attribute name: 255 characters
-* Maximum length of attribute value: 4096 characters
+* Maximum length of attribute value: 4095 characters
 
 If a span attribute exceeds the limit, you can use [span limits environment variables](https://github.com/open-telemetry/opentelemetry-specification/blob/d6bcc0cb072d8d6f6ced856f1f23c451648a3caa/specification/sdk-environment-variables.md#span-limits-) to configure the maximum length(s). If a [resource attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/d6bcc0cb072d8d6f6ced856f1f23c451648a3caa/specification/sdk-environment-variables.md#general-sdk-configuration) is the offender, you can set `OTEL_RESOURCE_ATTRIBUTES=<offending-attribute>=unset` to override it.
 


### PR DESCRIPTION
This is a small one, but both @jack-berg and @TylerHelmuth have noted that sending an OpenTelemetry span with an attribute value containing more than 4095 characters will result in an NrIntegrationError in practice. 🔭 