### PR TITLE
improve oracledb ohi doc with skip metrics example

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
@@ -601,7 +601,7 @@ You can also decorate your metrics with labels. Labels allow you to add key/valu
 
 Even though our default sample configuration file includes examples of labels, they're optional. You can remove, modify, or add new ones.
 
-```
+```yml
  labels:
    env: production
    role: load_balancer
@@ -616,7 +616,7 @@ Even though our default sample configuration file includes examples of labels, t
   >
     This is the basic configuration used to collect metrics and inventory from your localhost. It uses default connection on port 1521. Do not forget to replace `SERVICE_NAME` and `ORACLE_HOME` with the correct values for your environment:
 
-    ```
+    ```yml
     integrations:
       - name: nri-oracledb
         env:
@@ -639,7 +639,7 @@ Even though our default sample configuration file includes examples of labels, t
   >
     This configuration collects metrics every 15 seconds and inventory every 60 seconds:
 
-    ```
+    ```yml
     integrations:
       - name: nri-oracledb
         env:
@@ -668,6 +668,7 @@ Even though our default sample configuration file includes examples of labels, t
           environment: production
         inventory_source: config/oracledb
     ```
+    
   </Collapser>
 
   <Collapser
@@ -676,7 +677,7 @@ Even though our default sample configuration file includes examples of labels, t
   >
     This configuration collects only metrics, including extended ones, filtering collection to only 2 tablespaces:
 
-    ```
+    ```yml
     integrations:
       - name: nri-oracledb
         env:
@@ -693,6 +694,7 @@ Even though our default sample configuration file includes examples of labels, t
         labels:
           environment: production
     ```
+    
   </Collapser>
 
   <Collapser
@@ -701,7 +703,7 @@ Even though our default sample configuration file includes examples of labels, t
   >
     This configuration skips collection of some metrics by disabling some of the queries using `SKIP_METRICS_GROUPS`. The allowed list of metric groups, together with the queries and affected metrics, are listed in this [document](https://github.com/newrelic/nri-oracledb/blob/master/METRIC_GROUPS.md):
 
-    ```
+    ```yml
     integrations:
       - name: nri-oracledb
         env:
@@ -717,6 +719,7 @@ Even though our default sample configuration file includes examples of labels, t
           environment: production
         inventory_source: config/oracledb
     ```
+    
   </Collapser>
 
   <Collapser
@@ -730,7 +733,7 @@ Even though our default sample configuration file includes examples of labels, t
     * If you need to use multiple custom queries, remove this setting and use [`CUSTOM_METRICS_CONFIG`](#multi-custom-query) instead.
     * Do not use `;` in custom SQL statements.
 
-      ```
+      ```yml
       integrations:
         - name: nri-oracledb
           env:
@@ -753,6 +756,7 @@ Even though our default sample configuration file includes examples of labels, t
           labels:
             environment: production
       ```
+    
   </Collapser>
 
   <Collapser
@@ -763,7 +767,7 @@ Even though our default sample configuration file includes examples of labels, t
 
     **NOTE**: `CUSTOM_METRICS_CONFIG` is only enabled if `CUSTOM_METRICS_QUERY` is not present.
 
-    ```
+    ```yml
     integrations:
       - name: nri-oracledb
         env:
@@ -782,7 +786,7 @@ Even though our default sample configuration file includes examples of labels, t
 
     Here's an example `oracledb-custom-query.yml`.
 
-    ```
+    ```yml
     queries:
       # Metric names are set to the column names in the query results
       - query: >-
@@ -803,6 +807,7 @@ Even though our default sample configuration file includes examples of labels, t
         # If unset, sample_name defaults to OracleCustomSample
         sample_name: MyCustomSample
     ```
+    
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
@@ -436,7 +436,7 @@ The Oracle DB integration collects both Metrics(**M**) and Inventory(**I**) info
     {
       ' '
     }
-    
+
     <tr>
       <td>
         **SKIP_METRICS_GROUPS**
@@ -444,8 +444,8 @@ The Oracle DB integration collects both Metrics(**M**) and Inventory(**I**) info
 
       <td>
         Collected metrics are grouped together depending on the query used to obtain the data.
-        These metric groups appear here and can be skipped from collection by adding the name 
-        of the group to `SKIP_METRICS_GROUPS` in JSON array format. By default no group is skipped.
+        These metric groups are listed [here](https://github.com/newrelic/nri-oracledb/blob/master/METRIC_GROUPS.md) and can be skipped from collection by adding the name
+        of the group to `SKIP_METRICS_GROUPS` in JSON array format. By default no group is skipped. See [example](#metrics-skip) below.
       </td>
 
       <td>
@@ -696,6 +696,30 @@ Even though our default sample configuration file includes examples of labels, t
   </Collapser>
 
   <Collapser
+    id="metrics-skip"
+    title="Skip metrics groups"
+  >
+    This configuration skips collection of some metrics by disabling some of the queries using `SKIP_METRICS_GROUPS`. The allowed list of metric groups, together with the queries and affected metrics, are listed in this [document](https://github.com/newrelic/nri-oracledb/blob/master/METRIC_GROUPS.md):
+
+    ```
+    integrations:
+      - name: nri-oracledb
+        env:
+          SERVICE_NAME: ORACLE
+          HOSTNAME: 127.0.0.1
+          PORT: 1521
+          USERNAME: oracledb_user
+          PASSWORD: oracledb_password
+          ORACLE_HOME: /app/oracle/product/version/database
+          SKIP_METRICS_GROUPS: '["sgauga_total_memory", "redo_log_waits"]'
+        interval: 15s
+        labels:
+          environment: production
+        inventory_source: config/oracledb
+    ```
+  </Collapser>
+
+  <Collapser
     id="custom-query"
     title="Custom Query"
   >
@@ -818,6 +842,7 @@ These attributes can be found by querying the `OracleDatabaseSample` event type.
     </tr>
   </thead>
 
+  <tbody>
   <tr>
     <td>
       `db.activeParallelSessions`
@@ -3104,7 +3129,7 @@ These attributes can be found by querying the `OracleDatabaseSample` event type.
     <td/>
   </tr>
 
-  <tbody/>
+  </tbody>
 </table>
 
 ### Tablespace metrics [#tablespace-metric]


### PR DESCRIPTION
This PR improves our oracledb OHI documentation for the skip_metrics_groups config option adding an example and link to github detailed doc