### PR TITLE
Update status of newrelicexporter for the collector

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-legacy-new-relic-exporters.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-legacy-new-relic-exporters.mdx
@@ -29,7 +29,7 @@ The exporters and their maintenance status are as follows:
 * [Java](https://github.com/newrelic/opentelemetry-exporter-java): Archived
 * [Python](https://github.com/newrelic/opentelemetry-exporter-python): Archived
 * [.NET](https://github.com/newrelic/newrelic-telemetry-sdk-dotnet/tree/main/src/NewRelic.OpenTelemetry): Archived
-* [Collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/newrelicexporter): Deprecated for removal May 1st, 2022.
+* [Collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.50.0/exporter/newrelicexporter): Removed as of May 10, 2022.
 
 ## Endpoint configuration for New Relic exporters [#h2-change-endpoints]
 


### PR DESCRIPTION
The newrelicexporter has been dropped. Updating documentation to reflect status.

See [PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9894).