### PR TITLE
docs: PHP now defaults to 2000 max spans/min

### DIFF
--- a/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
+++ b/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
@@ -535,7 +535,7 @@ Here are some trace-related limits:
       <td>
         Go: 1000. 
         
-        All other agents are configurable but defualt to: 2000.
+        All other agents are configurable but default to 2000.
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
+++ b/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
@@ -533,7 +533,9 @@ Here are some trace-related limits:
       </td>
 
       <td>
-        Go and PHP: 1000. All other agents: 2000.
+        Go: 1000. 
+        
+        All other agents are configurable but defualt to: 2000.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9210311/

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.