### PR TITLE
docs(Alerts): Add 3 new term threshold operators for static NRQL conditions

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names.mdx
@@ -515,9 +515,15 @@ Not every field listed in this glossary is required for every condition type. Th
 
     * above
 
+    * above_or_equals (NRQL conditions only)
+
     * below
 
+    * below_or_equals (NRQL conditions only)
+
     * equal
+
+    * not_equals (NRQL conditions only)
 
       Used for:
 


### PR DESCRIPTION
## Give us some context

- We (Alerts!) just released some additional threshold operators for static NRQL conditions
- This adds those operators to the exiting documentation
- Bringing it more/less in line with what's in the Terraform provider docs: https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/nrql_alert_condition
