### PR TITLE
fix(php_agent): Improve guidelines for per-directory INI config

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-directory-ini-settings.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-directory-ini-settings.mdx
@@ -22,7 +22,9 @@ For other app naming options, see [Name your PHP application](/docs/agents/php-a
 
 ## Another option: API calls [#api-calls]
 
-If you are trying to change the name the application reports as, you can use the [`newrelic_set_appname()`](/docs/agents/php-agent/php-agent-api/newrelic_set_appname) API call instead of per-directory settings. For other settings that you can modify with the API, see [PHP agent API](/docs/php/the-php-api).
+The preferred method to change the application name is to use the global or per-directory INI settings (as described on this page).  However, in some cases it may not be possible to modify the configuration files, for example, due to provider limitations.  In that case you can use the [`newrelic_set_appname()`](/docs/agents/php-agent/php-agent-api/newrelic_set_appname) API call instead of per-directory settings. For other settings that you can modify with the API, see [PHP agent API](/docs/php/the-php-api).
+
+It is recommended to read the [guidelines](/docs/apm/agents/php-agent/php-agent-api/newrelic_set_appname/#call-and-location-behavior) for the [`newrelic_set_appname()`](/docs/agents/php-agent/php-agent-api/newrelic_set_appname) API call to ensure the most complete capture of transaction traces assigned to the desired application name.
 
 If you do not have access to the code for your application, or if you need to isolate your applications to their own virtual hosts for other reasons, then use the following per-directory settings to override any [configuration file settings](/docs/agents/php-agent/configuration/php-agent-configuration).
 
@@ -246,16 +248,6 @@ When using PHP-FPM, there are two mechanisms for setting PHP variables outside t
       fastcgi_param PHP_VALUE "newrelic.enabled=false";
       ...
     }
-    ```
-
-    <Callout variant="tip">
-      A better approach for NGINX may be to use API calls. The following code snippet (for PHP agent 2.7 or higher) is an example.
-    </Callout>
-
-    ```
-    if (extension_loaded ('newrelic')) {
-        newrelic_set_appname ("<var>My App 1</var>");
-      }
     ```
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/apm/agents/php-agent/configuration/php-directory-ini-settings.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-directory-ini-settings.mdx
@@ -20,14 +20,6 @@ The process for setting per-directory values depends on the environment. This do
 
 For other app naming options, see [Name your PHP application](/docs/agents/php-agent/configuration/name-your-php-application).
 
-## Another option: API calls [#api-calls]
-
-The preferred method to change the application name is to use the global or per-directory INI settings (as described on this page).  However, in some cases it may not be possible to modify the configuration files, for example, due to provider limitations.  In that case you can use the [`newrelic_set_appname()`](/docs/agents/php-agent/php-agent-api/newrelic_set_appname) API call instead of per-directory settings. For other settings that you can modify with the API, see [PHP agent API](/docs/php/the-php-api).
-
-It is recommended to read the [guidelines](/docs/apm/agents/php-agent/php-agent-api/newrelic_set_appname/#call-and-location-behavior) for the [`newrelic_set_appname()`](/docs/agents/php-agent/php-agent-api/newrelic_set_appname) API call to ensure the most complete capture of transaction traces assigned to the desired application name.
-
-If you do not have access to the code for your application, or if you need to isolate your applications to their own virtual hosts for other reasons, then use the following per-directory settings to override any [configuration file settings](/docs/agents/php-agent/configuration/php-agent-configuration).
-
 ## Apache per-directory settings for PHP [#perdir-apache]
 
 When using the PHP module, Apache provides two mechanisms for setting PHP variables outside the INI file:
@@ -251,6 +243,16 @@ When using PHP-FPM, there are two mechanisms for setting PHP variables outside t
     ```
   </Collapser>
 </CollapserGroup>
+
+## Another option: API calls [#api-calls]
+
+Although we recommend changing the application name with global or per-directory INI settings, in some cases that may not be possible. For example, provider limitations may prevent you from modifying configuration files. 
+
+Another option is to use the [`newrelic_set_appname()`](/docs/agents/php-agent/php-agent-api/newrelic_set_appname) API call. For other settings that you can modify with the API, see [PHP agent API](/docs/php/the-php-api).
+
+Before getting started, we recommend you read the [API call guidelines](/docs/apm/agents/php-agent/php-agent-api/newrelic_set_appname/#call-and-location-behavior) for [`newrelic_set_appname()`](/docs/agents/php-agent/php-agent-api/newrelic_set_appname) to ensure the most complete capture of transaction traces assigned to your application name.
+
+If you don't have access to the code for your application, or if you need to isolate your applications to their own virtual hosts for other reasons, then use the following per-directory settings to override any [configuration file settings](/docs/agents/php-agent/configuration/php-agent-configuration).
 
 ## Roll-up application names [#perdir-rollup]
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

The APM PHP agent team would like to refine the guidelines for using the newrelic_set_appname() API call, including removing a previous tip which is not recommended now.

