### PR TITLE
docs(node.js) Add instrumenting already loaded module

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
@@ -70,6 +70,21 @@ To install the Node.js agent:
   ```
   node -r newrelic ./dist/server.js
   ```
+  If you are unable to `require('newrelic');` as the first line of your app's main module and you are unable to use the require flag as above (e.g. asynchronously loading api keys from a remote location during application bootstrapping), you may also add stock instrumentation to an already loaded [supported module](https://github.com/newrelic/node-newrelic/blob/0113eb5f0e707dc662a17d262a841503bab88841/lib/instrumentations.js#L6#L6) by using [`newrelic.instrumentLoadedModule`](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#instrumentLoadedModule):
+  
+  ```js
+  // load the agent
+  const newrelic = require('newrelic');
+
+  // module loaded before newrelic 
+  const expressModule = require('express');
+
+  // instrument express after the agent has been loaded
+  newrelic.instrumentLoadedModule(
+    'express',    // the module's name, as a string
+    expressModule // the module instance
+  );
+  ```
 </Callout>
 
 7. Optional: For additional [Node.js runtime-level statistics](/docs/agents/nodejs-agent/supported-features/node-vms-statistics-page), ensure the [`@newrelic/native-metrics` package is installed](/docs/agents/nodejs-agent/supported-features/node-vm-measurements).

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
@@ -15,7 +15,7 @@ redirects:
   - /docs/agents/nodejs-agent/installation-configuration/install-maintain-nodejs
 ---
 
-To complete a basic Node.js agent installation, you can use our guided installation for an automated install, (choose EU if you're in the EU) or follow the instructions in this document. Either way, you need a New Relic account if you don't already have one. ([It's free, forever!](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/#how-pricing-works))
+To complete a basic Node.js agent installation, you can use our guided installation for an automated install, (choose EU if you're in the EU) or follow the instructions in this document. Either way, you need a New Relic account if you don't already have one. ([It's free, forever!](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/#how-pricing-works))
 
 <ButtonGroup>
   <ButtonLink
@@ -70,7 +70,7 @@ To install the Node.js agent:
   ```
   node -r newrelic ./dist/server.js
   ```
-  If you are unable to `require('newrelic');` as the first line of your app's main module and you are unable to use the require flag as above (e.g. asynchronously loading api keys from a remote location during application bootstrapping), you may also add stock instrumentation to an already loaded [supported module](https://github.com/newrelic/node-newrelic/blob/0113eb5f0e707dc662a17d262a841503bab88841/lib/instrumentations.js#L6#L6) by using [`newrelic.instrumentLoadedModule`](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#instrumentLoadedModule):
+  If you are unable to `require('newrelic');` as the first line of your app's main module and you are unable to use the require flag as above (e.g. asynchronously loading api keys from a remote location during application bootstrapping), you may also add stock instrumentation to an already loaded [supported module](https://github.com/newrelic/node-newrelic/blob/0113eb5f0e707dc662a17d262a841503bab88841/lib/instrumentations.js#L6#L6) by using [`newrelic.instrumentLoadedModule`](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#instrumentLoadedModule):
   
   ```js
   // load the agent


### PR DESCRIPTION
Provide additional information for instrumenting supported Node.js modules that have been already loaded using `newrelic.instrumentLoadeModule` for cases where a user may have to delay instrumenting. An example of this might be asynchronously loading and decrypting api keys from a remote location.
