### PR TITLE
fix: updated references to Node.js to use the proper branding

### DIFF
--- a/scripts/actions/translation_workflow/testing/README.md
+++ b/scripts/actions/translation_workflow/testing/README.md
@@ -44,7 +44,7 @@ You'll need to fill out values for variables in `script.sh`.
 
 This section assumes you are using Docker for the local environment, so be sure to install Docker if you don't have it installed already.
 
-Once you have Docker installed, from the `root` of the repository, run `yarn db:start`. This executes a `docker-compose` command using [this compose file](./docker-compose.yml). Three containers will be spun up: one for postgres, one for pgadmin, and one for executing a migration (using NodeJS sequelize).
+Once you have Docker installed, from the `root` of the repository, run `yarn db:start`. This executes a `docker-compose` command using [this compose file](./docker-compose.yml). Three containers will be spun up: one for postgres, one for pgadmin, and one for executing a migration (using Node.js sequelize).
 
 The migration takes the longest to execute. Once you see text similar to:
 ```

--- a/src/content/docs/data-apis/ingest-apis/telemetry-sdks-report-custom-telemetry-data.mdx
+++ b/src/content/docs/data-apis/ingest-apis/telemetry-sdks-report-custom-telemetry-data.mdx
@@ -78,7 +78,7 @@ The Telemetry SDKs are open source software on GitHub. Use the language-specific
       </td>
 
       <td>
-        [NodeJS library on GitHub](https://github.com/newrelic/newrelic-telemetry-sdk-node)
+        [Node.js library on GitHub](https://github.com/newrelic/newrelic-telemetry-sdk-node)
       </td>
 
       <td>

--- a/src/content/docs/release-notes/diagnostics-release-notes/diagnostics-cli-release-notes/new-relic-diagnostics-1418.mdx
+++ b/src/content/docs/release-notes/diagnostics-release-notes/diagnostics-cli-release-notes/new-relic-diagnostics-1418.mdx
@@ -16,7 +16,7 @@ redirects:
 
 **New Relic APM**
 
-* **Node/Env/Version** - Determine version of NodeJS present on the system.
+* **Node/Env/Version** - Determine version of Node.js present on the system.
 
 **New Relic Infrastructure**
 

--- a/src/content/docs/release-notes/diagnostics-release-notes/diagnostics-cli-release-notes/new-relic-diagnostics-1524.mdx
+++ b/src/content/docs/release-notes/diagnostics-release-notes/diagnostics-cli-release-notes/new-relic-diagnostics-1524.mdx
@@ -12,4 +12,4 @@ redirects:
 * Changed Infrastructure agent debug log collection to wait 3 minutes instead of 5 minutes
 * Added user prompt before collection of Infrastructure on-host integration configuration files
 * Updated diagnostic check explanation verbiage to be more consistent
-* Updated collection of NodeJS application dependencies to ignore some errors
+* Updated collection of Node.js application dependencies to ignore some errors

--- a/src/content/docs/release-notes/diagnostics-release-notes/diagnostics-cli-release-notes/new-relic-diagnostics-1727.mdx
+++ b/src/content/docs/release-notes/diagnostics-release-notes/diagnostics-cli-release-notes/new-relic-diagnostics-1727.mdx
@@ -19,6 +19,6 @@ redirects:
 * Improve error messaging when there is an issue uploading support ticket attachments
 * Improve detection and usage of proxies configured for installed New Relic products
 * Always collect latest New Relic log file, regardless of file age
-* Detected NodeJS application NPM packages are now visible `nrdiag-output.json`
+* Detected Node.js application NPM packages are now visible `nrdiag-output.json`
 * Fixed bug where **Infra/Log/Collect** would report "Success" when no New Relic Infrastructure log file path was configured
 * Improve messaging when New Relic configuration files are not detected on system

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-example.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-example.mdx
@@ -31,7 +31,7 @@ Our examples are published, alongside the New Relic Lambda Extension, in this
 [GitHub repository](https://github.com/newrelic/newrelic-lambda-extension). There's one for each Lambda runtime that
 New Relic can instrument:
 
-* [NodeJS](https://github.com/newrelic/newrelic-lambda-extension/tree/main/examples/sam/node)
+* [Node.js](https://github.com/newrelic/newrelic-lambda-extension/tree/main/examples/sam/node)
 * [Python](https://github.com/newrelic/newrelic-lambda-extension/tree/main/examples/sam/python)
 * [Go](https://github.com/newrelic/newrelic-lambda-extension/tree/main/examples/sam/go)
 * [Java](https://github.com/newrelic/newrelic-lambda-extension/tree/main/examples/sam/java)

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own.mdx
@@ -50,12 +50,12 @@ In the long term, it's usually less work to integrate New Relic into your existi
     YAML or JSON, and an execution service that makes API calls to other services (such as AWS Lambda) to achieve that
     target state.
 
-    Here's an example of a simple CloudFormation template for a NodeJS Lambda function:
+    Here's an example of a simple CloudFormation template for a Node.js Lambda function:
 
     ```yaml
     AWSTemplateFormatVersion: '2010-09-09'
     Transform: AWS::Serverless-2016-10-31
-    Description: And example of a simple instrumented NodeJS Lambda
+    Description: And example of a simple instrumented Node.js Lambda
 
     Resources:
       NewRelicExample:
@@ -93,7 +93,7 @@ In the long term, it's usually less work to integrate New Relic into your existi
     id="serverless"
     title="Serverless Framework"
   >
-    Serverless Framework is a popular development and deployment tool for serverless applications. It's written in NodeJS,
+    Serverless Framework is a popular development and deployment tool for serverless applications. It's written in Node.js,
     and for AWS, acts mostly as a higher-level abstraction on top of CloudFormation templates. It works well for Node, Python and Java functions.
 
     New Relic offers a [Serverless Framework Plugin](https://github.com/newrelic/serverless-newrelic-lambda-layers) to
@@ -180,7 +180,7 @@ we used to recommend sending your telemetry through CloudWatch Logs. This path c
 ### Lambda console UI configuration [#console]
 
 While it is more error prone and labor intensive than the approaches above, it's possible to manually alter the
-configuration of a Lambda function to use New Relic from the AWS Lambda Console, for NodeJS, Python and Java.
+configuration of a Lambda function to use New Relic from the AWS Lambda Console, for Node.js, Python and Java.
 
 1. Find the [layer](https://layers.newrelic-external.com/) that matches your runtime and region.
 2. Copy the Amazon Resource Name (ARN) of the most recent version and add it in the AWS Lambda console for your function.
@@ -219,7 +219,7 @@ Configuration changes are not enough.
 The layer contains several components, depending on your runtime:
 
 1. For all runtimes, the extension executable is packaged in the layer.
-2. For Python, NodeJS and Java, we also include:
+2. For Python, Node.js and Java, we also include:
    1. The New Relic Agent
    2. The AWS SDK instrumentation package for the New Relic Agent
    3. A handler wrapper, which configures the agent, and intercepts invocations, to start the instrumentation

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
@@ -11,7 +11,7 @@ Before [enabling serverless monitoring](/docs/serverless-function-monitoring/aws
 
 ## Recommended AWS Lambda language runtimes [#languages]
 
-* NodeJS: `nodejs12.x`, `nodejs14.x`
+* Node.js: `nodejs12.x`, `nodejs14.x`
 * Python: `python3.7`, `python3.8`, `python3.9`
 * Go: `provided`, `provided.al2`
 * Java: `java8.al2`, `java11`
@@ -21,7 +21,7 @@ AWS has older runtimes for these languages as well, but AWS has not [chosen to s
 the latest Lambda APIs with those older runtimes. Integration for older runtimes requires a different strategy, but
 is possible.
 
-Python and NodeJS are by far the most popular languages in the Lambda ecosystem. The
+Python and Node.js are by far the most popular languages in the Lambda ecosystem. The
 [New Relic Lambda Layers](https://layers.newrelic-external.com/)
 for Node and Python include the very latest New Relic Agent version, and provide rich instrumentation with minimal
 configuration, right out of the box.

--- a/src/i18n/content/jp/docs/data-apis/ingest-apis/telemetry-sdks-report-custom-telemetry-data.mdx
+++ b/src/i18n/content/jp/docs/data-apis/ingest-apis/telemetry-sdks-report-custom-telemetry-data.mdx
@@ -67,7 +67,7 @@ Telemetry SDKはGitHub上のオープンソースソフトウェアです。下�
       </td>
 
       <td>
-        [GitHub上のNodeJSライブラリ](https://github.com/newrelic/newrelic-telemetry-sdk-node)
+        [GitHub上のNode.jsライブラリ](https://github.com/newrelic/newrelic-telemetry-sdk-node)
       </td>
 
       <td>

--- a/src/i18n/content/jp/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-example.mdx
+++ b/src/i18n/content/jp/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-example.mdx
@@ -36,7 +36,7 @@ translationType: machine
 
 [私たちの例は、New Relic Lambda Extension と共に、この ](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-aws-lambda-monitoring)[GitHub リポジトリ](https://github.com/newrelic/newrelic-lambda-extension) で公開されています。New Relic がインストルメントできる Lambda ランタイムごとに用意されています。
 
-* [NodeJS](https://github.com/newrelic/newrelic-lambda-extension/tree/main/examples/sam/node)
+* [Node.js](https://github.com/newrelic/newrelic-lambda-extension/tree/main/examples/sam/node)
 * [Python](https://github.com/newrelic/newrelic-lambda-extension/tree/main/examples/sam/python)
 * [Go](https://github.com/newrelic/newrelic-lambda-extension/tree/main/examples/sam/go)
 * [Java](https://github.com/newrelic/newrelic-lambda-extension/tree/main/examples/sam/java)

--- a/src/i18n/content/jp/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
+++ b/src/i18n/content/jp/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
@@ -12,7 +12,7 @@ translationType: machine
 
 ## 推奨されるAWS Lambda言語のランタイム [#languages]
 
-* NodeJS: `nodejs12.x`, `nodejs14.x`
+* Node.js: `nodejs12.x`, `nodejs14.x`
 * Python: `python3.7`, `python3.8`, `python3.9`
 * Go: `provided`, `provided.al2`
 * Java: `java8.al2`, `java11`
@@ -22,7 +22,7 @@ AWSはこれらの言語の古いランタイムも持っていますが、AWS�
 
 [](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html)
 
-[Python と NodeJS は、Lambda のエコシステムにおいて圧倒的に人気のある言語です。 ](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html)[New Relic Lambda Layers](https://layers.newrelic-external.com/) for Node and Python には最新の New Relic Agent バージョンが含まれており、最小限の設定で豊富なインストルメント機能をすぐに利用することができるようになっています。
+[Python と Node.js は、Lambda のエコシステムにおいて圧倒的に人気のある言語です。 ](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html)[New Relic Lambda Layers](https://layers.newrelic-external.com/) for Node and Python には最新の New Relic Agent バージョンが含まれており、最小限の設定で豊富なインストルメント機能をすぐに利用することができるようになっています。
 
 同様に、Go は New Relic Go Agent を使用します。最新のAWS Lambda APIは、AWS `go1.x` ランタイムではサポートされていないため、セルフホスティングのGo lambda関数を構築することをお勧めします。幸いなことに、これは AWS Lambda SDK for Go によって十分にサポートされています。New Relic では、エージェントモジュールを最新の状態に保つことを推奨しています。3.9.0より古いエージェントバージョンのサポートは限られています。
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve? 
References to Node.js are followed their recommended branding.  It's a peeve of mine but this is the right way. Maybe we can add it to our style guide?