### PR TITLE
docs: add lang identifier and fix comment

### DIFF
--- a/src/content/docs/apm/agents/net-agent/troubleshooting/browser-injection-health-check-conflict.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/browser-injection-health-check-conflict.mdx
@@ -21,9 +21,9 @@ To prevent this, add the [`requestPathsExcluded` sub-element](/docs/agents/net-a
 
 For example, if your load balancer is set to ping a webpage in `https://www.mywebsite.com/healthmonitor/`, insert `/healthmonitor/` as the path regex value:
 
-```
-// If you use both the Exclude and Attribute elements
-// the Exclude element must be listed first.
+```xml
+<!-- If you use both the Exclude and Attribute elements
+     the Exclude element must be listed first. -->
 <browserMonitoring autoInstrument="true">
   <requestPathsExcluded>
     <path regex="/healthmonitor/"/>


### PR DESCRIPTION
The xml had the wrong syntax for a xml comment. It doesn't matter at all but I'm weird so I changed it.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.