### PR TITLE
feat/npm troubleshooting doc

### DIFF
--- a/src/content/docs/network-performance-monitoring/troubleshooting/snmp-discovery-no-devices.mdx
+++ b/src/content/docs/network-performance-monitoring/troubleshooting/snmp-discovery-no-devices.mdx
@@ -24,4 +24,7 @@ To work around these problems, try one or both of the following solutions:
 
 1. Edit the `snmp-base.yaml` and increase the timeout value for the `timeout_ms` variable.
 2. For devices that still seem unresponsive, set all the `cidrs` values to a length of `/32`, which forces the discovery process to skip the responsiveness check and only attempts the SNMP connection.
-3. If you have a large set of devices that are being skipped because of the port scan you can edit the `snmp-base.yaml` file and enabling the option for [check_all_ips](/docs/network-performance-monitoring/advanced/advanced-config/#discovery) to skip the port scan and just go directly to testing SNMP credentials against every address in your discovery. Keep in mind that this option will dramatically increase the time it takes to complete a discovery.
+
+<Callout variant="tip">
+  If you have a large set of devices that are being skipped because of the port scan you can edit the `snmp-base.yaml` file and enable the option for [check_all_ips](/docs/network-performance-monitoring/advanced/advanced-config/#discovery) to skip the port scan and just go directly to testing SNMP credentials against every address in your discovery. Keep in mind that this option will dramatically increase the time it takes to complete a discovery.
+</Callout>

--- a/src/content/docs/network-performance-monitoring/troubleshooting/snmp-discovery-unexpected-profile.mdx
+++ b/src/content/docs/network-performance-monitoring/troubleshooting/snmp-discovery-unexpected-profile.mdx
@@ -51,6 +51,21 @@ In this case, you can manually override the matching from the discovery job usin
 
 *As mentioned in the [device configuration documentation](/docs/network-performance-monitoring/advanced/advanced-config/#devices), the value of the `provider` key also needs to be set to ensure a proper UI experience in New Relic.*
 
+You'll also need to ensure that you add any new MIBs for your config file into the global `mibs_enabled` key, which tells the running container to actively collect metrics for those MIBs.
+
+Following the above example for a Sonicwall firewall:
+
+```yaml
+# Snippet from global config
+  mibs_enabled:
+  - HOST-RESOURCES-MIB
+  - IF-MIB
+  - SONICWALL-SMA-APPLIANCE-SYSTEM-HEALTH-MIB
+  - SONICWALL-SMA-APPLIANCE-SERVICE-HEALTH-MIB
+  - SONICWALL-SMA-APPLIANCE-SECURITY-HISTORY-MIB
+  - SONICWALL-SMA-APPLIANCE-TUNNEL-SERVER-MIB
+```
+
 <Callout variant="tip">
   You should also set the discovery configuration key: "[replace_devices](/docs/network-performance-monitoring/advanced/advanced-config/#discovery)" to `false` to prevent accidentally overwriting these edits on a future discovery job.
 </Callout>

--- a/src/content/docs/network-performance-monitoring/troubleshooting/snmp-discovery-unexpected-profile.mdx
+++ b/src/content/docs/network-performance-monitoring/troubleshooting/snmp-discovery-unexpected-profile.mdx
@@ -35,7 +35,7 @@ For the second scenario, the most common situation is that your device maps to t
   provider: kentik-default
 ```
 
-Following the steps in the [SNMP discovery results in 'Kentik Default' entities](/docs/network-performance-monitoring/troubleshooting/snmp-discovery-kentik-default) documentation will resolve this for you.
+Follow the steps in the [SNMP discovery results in 'Kentik Default' entities](/docs/network-performance-monitoring/troubleshooting/snmp-discovery-kentik-default) troubleshooting guide to resolve this.
 
 ### Net-SNMP devices [#net-snmp]
 

--- a/src/content/docs/network-performance-monitoring/troubleshooting/snmp-discovery-unexpected-profile.mdx
+++ b/src/content/docs/network-performance-monitoring/troubleshooting/snmp-discovery-unexpected-profile.mdx
@@ -16,9 +16,9 @@ After running an SNMP discovery, your device is mapping to an unexpected profile
 The SNMP discovery process will attempt to automatically map devices to an existing profile from the [kentik/snmp-profiles](https://github.com/kentik/snmp-profiles) repository using the following process:
 
   * First, an attempt is made to match the value of the device's [sysObjectID](http://oid-info.com/get/1.3.6.1.2.1.1.2) with either a literal or wildcard match for the values in the `systemobjectid` key for a profile.
-  * In cases where a device's sysObjectID is one of the [Net-SNMP agent OIDs](http://oid-info.com/get/1.3.6.1.4.1.8072.3.2), there is a best-effort attempt to further isolate the device profile through a regex match against the device's [sysDescr](http://oid-info.com/get/1.3.6.1.2.1.1.1) value. *You can see the current options in the `matches` key of the [net-snmp.yml profile](https://github.com/kentik/snmp-profiles/blob/main/profiles/kentik_snmp/_general/net-snmp.yml).*
+  * In cases where a device's sysObjectID is one of the [Net-SNMP agent OIDs](http://oid-info.com/get/1.3.6.1.4.1.8072.3.2), there is a best-effort attempt to further isolate the device profile through a regex match against the device's [sysDescr](http://oid-info.com/get/1.3.6.1.2.1.1.1) value. You can see the current options in the `matches` key of the [net-snmp.yml profile](https://github.com/kentik/snmp-profiles/blob/main/profiles/kentik_snmp/_general/net-snmp.yml).
 
-There are 2 distinct scenarios that can exist after this process:
+There are two distinct scenarios that can exist after this process:
 
   1. Device is matched to an expected profile and collects metrics without issue.
   2. Device is unexpectedly matched to the wrong profile and is collecting the wrong metrics or is missing metrics.
@@ -27,7 +27,7 @@ There are 2 distinct scenarios that can exist after this process:
 
 ### Kentik Default devices [#kentik-default]
 
-For scenario 2, the most common situation is that your device will map to the following:
+For the second scenario, the most common situation is that your device maps to the following:
 
 ```yaml
 # Snippet from device config
@@ -41,7 +41,7 @@ Following the steps in the [SNMP discovery results in 'Kentik Default' entities]
 
 You may also see situations where the best-effort matching against the `sysDescr` value for a device either doesn't work or isn't available due to a lack of uniquely identifying information available in the value.
 
-In this case, you can manually override the matching from the discovery job using the **bang (!)** syntax: `"!profile-name.yml"`, which will allow you to force any profile you desire:
+In this case, you can manually override the matching from the discovery job using the **bang (!)** syntax: `"!profile-name.yml"`, which allows you to force any profile you desire:
 
 ```yaml
 # Snippet from device config
@@ -49,11 +49,11 @@ In this case, you can manually override the matching from the discovery job usin
   provider: kentik-firewall
 ```
 
-*As mentioned in the [device configuration documentation](/docs/network-performance-monitoring/advanced/advanced-config/#devices), the value of the `provider` key also needs to be set to ensure a proper UI experience in New Relic.*
+As mentioned in the [device configuration documentation](/docs/network-performance-monitoring/advanced/advanced-config/#devices), the value of the `provider` key also needs to be set to ensure a proper UI experience in New Relic.
 
-You'll also need to ensure that you add any new MIBs for your config file into the global `mibs_enabled` key, which tells the running container to actively collect metrics for those MIBs.
+Make sure you add any new MIBs for your config file into the global `mibs_enabled` key. This tells the running container to actively collect metrics for those MIBs.
 
-Following the above example for a Sonicwall firewall:
+Here's a Sonicwall firewall example:
 
 ```yaml
 # Snippet from global config

--- a/src/content/docs/network-performance-monitoring/troubleshooting/snmp-discovery-unexpected-profile.mdx
+++ b/src/content/docs/network-performance-monitoring/troubleshooting/snmp-discovery-unexpected-profile.mdx
@@ -1,0 +1,56 @@
+---
+title: SNMP discovery maps to an unexpected profile
+tags:
+  - Integrations
+  - Network monitoring
+  - Troubleshooting
+metaDescription: SNMP monitoring discovery maps your device to an unexpected profile.
+---
+
+## Problem [#problem]
+
+After running an SNMP discovery, your device is mapping to an unexpected profile in the `mib_profile` key of the device configuration.
+
+## Background [#background]
+
+The SNMP discovery process will attempt to automatically map devices to an existing profile from the [kentik/snmp-profiles](https://github.com/kentik/snmp-profiles) repository using the following process:
+
+  * First, an attempt is made to match the value of the device's [sysObjectID](http://oid-info.com/get/1.3.6.1.2.1.1.2) with either a literal or wildcard match for the values in the `systemobjectid` key for a profile.
+  * In cases where a device's sysObjectID is one of the [Net-SNMP agent OIDs](http://oid-info.com/get/1.3.6.1.4.1.8072.3.2), there is a best-effort attempt to further isolate the device profile through a regex match against the device's [sysDescr](http://oid-info.com/get/1.3.6.1.2.1.1.1) value. *You can see the current options in the `matches` key of the [net-snmp.yml profile](https://github.com/kentik/snmp-profiles/blob/main/profiles/kentik_snmp/_general/net-snmp.yml).*
+
+There are 2 distinct scenarios that can exist after this process:
+
+  1. Device is matched to an expected profile and collects metrics without issue.
+  2. Device is unexpectedly matched to the wrong profile and is collecting the wrong metrics or is missing metrics.
+
+## Solutions [#solutions]
+
+### Kentik Default devices [#kentik-default]
+
+For scenario 2, the most common situation is that your device will map to the following:
+
+```yaml
+# Snippet from device config
+  mib_profile: base.yml
+  provider: kentik-default
+```
+
+Following the steps in the [SNMP discovery results in 'Kentik Default' entities](/docs/network-performance-monitoring/troubleshooting/snmp-discovery-kentik-default) documentation will resolve this for you.
+
+### Net-SNMP devices [#net-snmp]
+
+You may also see situations where the best-effort matching against the `sysDescr` value for a device either doesn't work or isn't available due to a lack of uniquely identifying information available in the value.
+
+In this case, you can manually override the matching from the discovery job using the **bang (!)** syntax: `"!profile-name.yml"`, which will allow you to force any profile you desire:
+
+```yaml
+# Snippet from device config
+  mib_profile: "!sonicwall-sma.yml"
+  provider: kentik-firewall
+```
+
+*As mentioned in the [device configuration documentation](/docs/network-performance-monitoring/advanced/advanced-config/#devices), the value of the `provider` key also needs to be set to ensure a proper UI experience in New Relic.*
+
+<Callout variant="tip">
+  You should also set the discovery configuration key: "[replace_devices](/docs/network-performance-monitoring/advanced/advanced-config/#discovery)" to `false` to prevent accidentally overwriting these edits on a future discovery job.
+</Callout>

--- a/src/nav/network-performance-monitoring.yml
+++ b/src/nav/network-performance-monitoring.yml
@@ -33,7 +33,9 @@ pages:
         path: /docs/network-performance-monitoring/troubleshooting/snmp-discovery-no-devices
       - title: SNMP monitoring results have metrics missing
         path: /docs/network-performance-monitoring/troubleshooting/snmp-polling-missing-metrics
+      - title: SNMP discovery maps to an unexpected profile
+        path: /docs/network-performance-monitoring/troubleshooting/snmp-discovery-unexpected-profile
       - title: Collecting data for troubleshooting with the snmpwalk utility
         path: /docs/network-performance-monitoring/troubleshooting/snmp-walk
-      - title: Collecting data but no entity in Exporer
+      - title: Collecting data but no entity in Explorer
         path: /docs/network-performance-monitoring/troubleshooting/no-device-in-UI


### PR DESCRIPTION
  * minor copy edit to `snmp-discovery-no-devices` doc; moving 3rd option to a callout since it's more of a tip
  * typo edit on nav page
  * new troubleshooting doc (and nav entry) for network monitoring explaining how to manually override discovery results
