### PR TITLE
chore(heroku_log_forwarding) - Add deletion info

### DIFF
--- a/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
@@ -17,7 +17,7 @@ If your log data is already being monitored by Heroku's built-in [Logplex](https
 
 Forwarding your Heroku logs to New Relic will give you enhanced log management capabilities to collect, process, explore, query, and alert on your log data.
 
-## Create a Heroku Syslog drain [#create-syslog-drain]
+## Create a Heroku syslog drain [#create-syslog-drain]
 
 To enable our log management capabilities, start by creating a Heroku Syslog drain.
 
@@ -54,7 +54,7 @@ To enable our log management capabilities, start by creating a Heroku Syslog dra
    }
    ```
 
-## Register a Heroku Syslog drain [#register-syslog]
+## Register a Heroku syslog drain [#register-syslog]
 
 Next, you'll need to register your newly created Heroku Syslog drain in New Relic:
 
@@ -83,6 +83,48 @@ Next, you'll need to register your newly created Heroku Syslog drain in New Reli
 <Callout variant="important">
   Heroku currently doesn't support customizing the format of logs sent from Logplex. For more information, see [Heroku's log format documentation](https://devcenter.heroku.com/articles/logging#log-format).
 </Callout>
+
+## Delete a Heroku syslog drain token mapping [#create-syslog-drain]
+
+To delete a Heroku syslog drain token mapping via the New Relic UI
+
+1. Make sure your New Relic user account has the [Admin role](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model/#roles) assigned to it.
+2. Navigate to the [New Relic Marketplace](https://one.newrelic.com/marketplace)
+3. Run a search for **Heroku**
+4. Under Logging, click on the Heroku tile
+5. If you have multiple accounts, select the desired account from the drop-down and click **Continue**. Otherwise proceed to step 6.
+6. Click the vertical three-dot icon next to the drain token mapping you wish to delete, and click "Delete Heroku drain token".
+7. Your Heroku drain token mapping is deleted.
+
+To delete a Heroku syslog drain token mapping via REST API
+
+1. [Find or generate](https://one.newrelic.com/api-keys) an API key with a key type of **USER**.
+2. Run the command below to retrieve a list of Heroku drain token mappings from your New Relic account, making sure to update values for [<NR_LICENSE_KEY>](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#license-key) and [<NR_ACCOUNT_ID>](https://docs.newrelic.com/docs/accounts/accounts-billing/account-structure/account-id/):
+
+
+   ```shell
+   curl -H 'api-key: <NR_LICENSE_KEY>' https://log-syslog-configuration-api.service.newrelic.com/heroku-account-mappings?accountId=<NR-ACCOUNT-ID>
+   ```
+The result (formatted) will look something like this:
+
+   ```json
+   [
+     {
+       "herokuMappingId": 1549,
+       "drainToken": "<DRAIN-TOKEN>",
+       "nrApiInsertKey": "<DRAIN-TOKEN-NR-API-KEY>",
+       "createdAt": "2022-05-13T07:47:23",
+       "createdBy": "jclark@newrelic.com"
+     }
+   ]
+   ```
+   You will need the herokuMappingId for each drain token that you want to remove.
+ 3. To delete a drain token, run the command below. Make sure to update values for [<NR_LICENSE_KEY>](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#license-key),[<NR_ACCOUNT_ID>](https://docs.newrelic.com/docs/accounts/accounts-billing/account-structure/account-id/), and the herokuMappingId you retrieved in the last step:
+
+   ```shell
+   curl -XDELETE -H 'api-key: <NR_LICENSE_KEY>' https://log-syslog-configuration-api.service.newrelic.com/heroku-account-mappings/<herokuMappingId>?accountId=<NR-ACCOUNT-ID>
+   ```
+ 4. The API will return a HTTP 204 response and the drain token mapping will be deleted. 
 
 ## View log data [#find-data]
 

--- a/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
@@ -86,45 +86,48 @@ Next, you'll need to register your newly created Heroku Syslog drain in New Reli
 
 ## Delete a Heroku syslog drain token mapping [#create-syslog-drain]
 
-To delete a Heroku syslog drain token mapping via the New Relic UI
+Complete these steps to delete a Heroku syslog drain token mapping via the New Relic UI.
 
-1. Make sure your New Relic user account has the [Admin role](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model/#roles) assigned to it.
-2. Navigate to the [New Relic Marketplace](https://one.newrelic.com/marketplace)
-3. Run a search for **Heroku**
-4. Under Logging, click on the Heroku tile
-5. If you have multiple accounts, select the desired account from the drop-down and click **Continue**. Otherwise proceed to step 6.
-6. Click the vertical three-dot icon next to the drain token mapping you wish to delete, and click "Delete Heroku drain token".
+1. Make sure your New Relic user account has the [admin role](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model/#roles) assigned to it.
+2. Go to the [New Relic Marketplace](https://one.newrelic.com/marketplace).
+3. Search for "Heroku".
+4. Under Logging, click the **Heroku** tile.
+5. If you have multiple accounts, select the account you want to use and click **Continue**. Otherwise, go to step 6.
+6. Find the drain token mapping you want to delete, then click the vertical three-dot icon next it, and then click **Delete Heroku drain token**.
 7. Your Heroku drain token mapping is deleted.
 
-To delete a Heroku syslog drain token mapping via REST API
+Complete these steps to delete a Heroku syslog drain token mapping via REST API.
 
 1. [Find or generate](https://one.newrelic.com/api-keys) an API key with a key type of **USER**.
-2. Run the command below to retrieve a list of Heroku drain token mappings from your New Relic account, making sure to update values for [<NR_LICENSE_KEY>](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#license-key) and [<NR_ACCOUNT_ID>](https://docs.newrelic.com/docs/accounts/accounts-billing/account-structure/account-id/):
+2. Run the command below to retrieve a list of Heroku drain token mappings from your New Relic account, making sure to update values for [YOUR_NR_LICENSE_KEY](/docs/apis/intro-apis/new-relic-api-keys/#license-key) and [YOUR_NR_ACCOUNT_ID](/docs/accounts/accounts-billing/account-structure/account-id/):
 
 
    ```shell
-   curl -H 'api-key: <NR_LICENSE_KEY>' https://log-syslog-configuration-api.service.newrelic.com/heroku-account-mappings?accountId=<NR-ACCOUNT-ID>
+   curl -H 'api-key: <var>YOUR_NR_LICENSE_KEY</var>' https://log-syslog-configuration-api.service.newrelic.com/heroku-account-mappings?accountId=<var>YOUR_NR_ACCOUNT_ID</var>
    ```
-The result (formatted) will look something like this:
+
+The formatted result looks something like this:
 
    ```json
    [
      {
        "herokuMappingId": 1549,
-       "drainToken": "<DRAIN-TOKEN>",
-       "nrApiInsertKey": "<DRAIN-TOKEN-NR-API-KEY>",
+       "drainToken": "<var>YOUR_DRAIN_TOKEN</var>",
+       "nrApiInsertKey": "<var>YOUR_DRAIN_TOKEN_NR_API_KEY</var>",
        "createdAt": "2022-05-13T07:47:23",
-       "createdBy": "jclark@newrelic.com"
+       "createdBy": "<var>YOUR_EMAIL_ADDRESS</var>"
      }
    ]
    ```
-   You will need the herokuMappingId for each drain token that you want to remove.
- 3. To delete a drain token, run the command below. Make sure to update values for [<NR_LICENSE_KEY>](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#license-key),[<NR_ACCOUNT_ID>](https://docs.newrelic.com/docs/accounts/accounts-billing/account-structure/account-id/), and the herokuMappingId you retrieved in the last step:
+
+   You need the `herokuMappingId` for each drain token that you want to remove.
+
+ 3. To delete a drain token, run the command below. Make sure to update values for [YOUR_NR_LICENSE_KEY](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#license-key),[YOUR_NR_ACCOUNT_ID](https://docs.newrelic.com/docs/accounts/accounts-billing/account-structure/account-id/), and the `herokuMappingId` you retrieved in the last step:
 
    ```shell
-   curl -XDELETE -H 'api-key: <NR_LICENSE_KEY>' https://log-syslog-configuration-api.service.newrelic.com/heroku-account-mappings/<herokuMappingId>?accountId=<NR-ACCOUNT-ID>
+   curl -XDELETE -H 'api-key: <varYOUR_NR_LICENSE_KEY</var>' https://log-syslog-configuration-api.service.newrelic.com/heroku-account-mappings/<herokuMappingId>?accountId=<var>YOUR_NR_ACCOUNT_ID</var>
    ```
- 4. The API will return a HTTP 204 response and the drain token mapping will be deleted. 
+ 4. The API returns an HTTP 204 response and the drain token mapping is deleted. 
 
 ## View log data [#find-data]
 


### PR DESCRIPTION
Added section covering how to delete Heroku syslog log drain token mappings via UI and API. Made a few minor capitalization changes throughout.