### PR TITLE
infrastructure-agent release-notes 1.24.3

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1243.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1243.mdx
@@ -1,0 +1,20 @@
+---
+subject: Infrastructure agent
+releaseDate: '2022-05-17'
+version: 1.24.3
+---
+
+## Notes
+A new version of the agent has been released. See these instructions on how to [update the Infrastructure agent](https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/update-or-uninstall/update-infrastructure-agent).  
+
+We recommend you to upgrade the agent regularly, at least, every 3 months.
+
+## Added
+- Add common Windows environment variables to integrations executions [#112](https://github.com/newrelic/infrastructure-agent/pull/112)
+- Support Winevtlog logging plugin [#1125](https://github.com/newrelic/infrastructure-agent/pull/1125)
+
+## Changed
+-  Update Fluentbit Windows package version to 1.9.3 [#115](https://github.com/newrelic/infrastructure-agent/pull/115)
+
+## Fixed
+- Update Containerd to fix [CVE-2022-23648](https://github.com/advisories/GHSA-crp2-qrr5-8pq7) [#114](https://github.com/newrelic/infrastructure-agent/pull/114)


### PR DESCRIPTION
Release notes for the new agent-version [1.24.3](https://github.com/newrelic/infrastructure-agent/releases/tag/1.24.3)