### PR TITLE
feat: add winevtlog to infra-agent logs forwarding

### DIFF
--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -467,6 +467,73 @@ What you use for the log source will depend on where you want to forward your lo
   </Collapser>
 
   <Collapser
+    id="winevtlog"
+    title="winevtlog"
+  >
+    <Callout variant="important">
+      Available since infrastructure agent v.1.24.3
+    </Callout>
+
+    Collect event from Windows log channels using new Windows Event Log API using the [winevtlog Fluent Bit plugin](https://docs.fluentbit.io/manual/pipeline/inputs/windows-event-log-winevtlog).
+
+    **Parameters:**
+
+    * `channel:` name of the channel logs will be collected from.
+    * `collect-eventids:` a list of Windows Event IDs to be collected and forwarded to New Relic. Event ID ranges are supported.
+    * `exclude-eventids:` a list of Windows Event IDs to be excluded from collection. Event ID ranges are supported.
+
+      All events are collected from the specified channel by default. Configure the `collect-eventids` and `exclude-eventids` sections to avoid sending unwanted logs to your New Relic account.
+
+      Add event IDs or ranges to `collect-eventids` or `exclude-eventids` to forward or drop specific events. `exclude-eventids` takes precedence over `collect-eventids` if the same event ID is present in both sections.
+
+      **Example:**
+
+      ```
+      logs:
+       # Winevtlog log ingestion with eventId filters.
+        - name: windows-security
+          winevtlog:
+            channel: Security
+            collect-eventids:
+              - 4624
+              - 4265
+              - 4700-4800
+            exclude-eventids:
+              - 4735
+
+       # entries for the application, system, powershell, and SCOM channels
+        - name: windows-application
+          winevtlog:
+            channel: Application
+        - name: windows-system
+          winevtlog:
+            channel: System
+        - name: windows-pshell
+          winevtlog:
+            channel: Windows Powershell
+        - name: scom
+          winevtlog:
+            channel: Operations Manager
+
+       # Entry for Windows Defender Logs
+        - name: windows-defender
+          winevtlog:
+            channel: Microsoft-Windows-Windows Defender/Operational
+
+       # Entry for Windows Clustering Logs
+        - name: windows-clustering
+          winevtlog:
+            channel: Microsoft-Windows-FailoverClustering/Operational
+
+       # Entry for IIS logs with logtype attribute for automatic parsing
+        - name: iis-log
+          file: C:\inetpub\logs\LogFiles\w3svc.log
+          attributes:
+            logtype: iis_w3c
+      ```
+  </Collapser>
+
+  <Collapser
     id="winlog"
     title="winlog"
   >
@@ -474,7 +541,7 @@ What you use for the log source will depend on where you want to forward your lo
 
     **Parameters:**
 
-    * `channel:` name of the channel logs will be collected from.
+    * `channel:` name of the channel logs will be collected from. It doesn't work for custom channels.
     * `collect-eventids:` a list of Windows Event IDs to be collected and forwarded to New Relic. Event ID ranges are supported.
     * `exclude-eventids:` a list of Windows Event IDs to be excluded from collection. Event ID ranges are supported.
 
@@ -942,9 +1009,9 @@ If you encounter problems with configuring your log forwarder, try these trouble
 
     7. Add the configuration option: `trace: ["log.fw"]`.
 
-       <Callout variant="caution">
-         Check whether you are using the [`fluentbit`] option. When setting `verbose: 3` **and** `trace: ["log.fw"]`, ensure that you don't define any `[OUTPUT]` section pointing to `stdout` in an external Fluent Bit configuration file,
-       </Callout>
+    <Callout variant="caution">
+      Check whether you are using the [`fluentbit`] option. When setting `verbose: 3` **and** `trace: ["log.fw"]`, ensure that you don't define any `[OUTPUT]` section pointing to `stdout` in an external Fluent Bit configuration file,
+    </Callout>
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
Adds a new available configuration for infra-agent log forwarding

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
It's just a new configuration that allows customers to use the https://docs.fluentbit.io/manual/pipeline/inputs/windows-event-log-winevtlog
The configuration remains the same as for winlog

* If your issue relates to an existing GitHub issue, please link to it.
N/A