### PR TITLE
update_docs_for_apache_logs_and_parsing

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/apache-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/apache-monitoring-integration.mdx
@@ -110,6 +110,13 @@ To install the Apache integration, follow the instructions for your environment:
        ```
     4. Edit the `apache-config.yml` file as described in the [configuration settings](#config).
     5. [Restart the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
+    6. To enable automatic Apache and Apache error log parsing and forwarding, copy (or rename) the `apache-log.yml.example` file to `apache-log.yml`. No need to restart the agent.  Note that you may need to update the yml with the location of your apache log files if not using the default locations. 
+
+       **Example:**
+
+       ```
+       sudo cp /etc/newrelic-infra/logging.d/apache-log.yml.example /etc/newrelic-infra/logging.d/apache-log.yml
+       ```  
   </Collapser>
 
   <Collapser

--- a/src/content/docs/logs/ui-data/built-log-parsing-rules.mdx
+++ b/src/content/docs/logs/ui-data/built-log-parsing-rules.mdx
@@ -46,6 +46,32 @@ New Relic can parse common log formats according to built-in rules, so that you 
   </Collapser>
 
   <Collapser
+    id="apache_error"
+    title="Apache Error"
+  >
+    **Source:** `logtype = 'apache_error'`
+
+    **Grok:**
+
+    ```
+    \[%{DATA:apache_error.timestamp}\] \[%{WORD:apache_error.source}:%{DATA:level}\] \[pid %{NUMBER:apache_error.pid}(:tid %{NUMBER:apache_error.tid})?\] (%{DATA:apache_error.sourcecode}\(%{NUMBER:apache_error.linenum}\): )?(?:\[client %{IPORHOST:apache_error.clientip}:%{POSINT:apache_error.port}\] ){0,1}%{GREEDYDATA:apache_error.message}
+    ```
+
+    **Results:**
+
+    * `apache_error.timestamp`: The timestamp of the log statement
+    * `apache_error.source`: The source module
+    * `level`: The log level
+    * `apache_error.pid`: The apache PID (process identifier)
+    * `apache_error.tid`: The apache TID (thread identifier)
+    * `apache_error.sourcecode`: The apache sourcecode
+    * `apache_error.linenum`: The sourcecode line number
+    * `apache_error.clientip`: The client IP address
+    * `apache_error.port`: The client IP port number
+    * `apache_error.message`: The error message
+  </Collapser>
+
+  <Collapser
     id="application-load-balancer"
     title="Application Load Balancer"
   >


### PR DESCRIPTION
Update docs to reflect new apache-logs.yml.example to enable log forwarding and parsing of logs with apache OHI
Updates to OHI section and built-in parsing rules section of docs

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.