### PR TITLE
chore:Updated bottom of the funnel analysis to refer the reader to th…

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/customer-experience/bottom-funnel-analysis-customer-journey-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/customer-experience/bottom-funnel-analysis-customer-journey-guide.mdx
@@ -225,7 +225,7 @@ For example, you may have a checkout flow that calls a different payment API dep
   src={cxBotfaDashboard}
 />
 
-Follow the instructions in our [bottom-of-the-funnel analysis README on GitHub](https://github.com/newrelic/oma-resource-center/blob/main/src/content/docs/oma/value-drivers/customer-experience/use-cases/bottom-of-the-funnel-analysis/README.md).
+Follow the instructions in the [bottom-of-the-funnel analysis quickstart](https://newrelic.com/instant-observability/customer-experience-bottom-funnel-analysis/8d339aa7-69e3-4efa-abc2-9eba600db91c) to install the dashboard and configure it.
 
 ### Capture current performance
 


### PR DESCRIPTION
…e quickstart for dthe dashboard instead of to github

This is just a one-line change.  Now that a quickstart is available, readers should go there to get their dashboard. 

I ran up gatsby and checked the link work prior to commit. 