### PR TITLE
test(Security bulletins): Move in taxonomy

### DIFF
--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-04.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-04.mdx
@@ -6,8 +6,6 @@ tags:
   - Security bulletin
   - Log4j
 metaDescription: 'Apache Log4j CVE 2021-44228, Security Bulletin NR21-04 (Containerized Private Minions)'
-redirects: 
-  - /docs/security/new-relic-security/security-bulletins
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletins.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletins.mdx
@@ -1,5 +1,5 @@
 ---
-title: Security bulletins
+title: Security bulletins quick reference
 tags:
   - Security
   - Security and Privacy
@@ -16,7 +16,7 @@ redirects:
   - /docs/security/security-privacy/information-security/security-bulletins
 ---
 
-This document contains important information regarding security vulnerabilities that could affect some versions of New Relic products and service. Security bulletins are a way for us to let you know about security vulnerabilities, remediation strategies, and applicable updates for affected software. For more information, see our documentation about [security, data privacy, and compliance](/docs/security), or visit the [New Relic security website](https://newrelic.com/security).
+This document contains important information regarding security vulnerabilities that could affect some versions of New Relic products and services. Security bulletins are a way for us to let you know about security vulnerabilities, remediation strategies, and applicable updates for affected software. For more information, see our documentation about [security, data privacy, and compliance](/docs/security), or visit the [New Relic security website](https://newrelic.com/security).
 
 ## Get security notifications [#notifications]
 

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletins.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletins.mdx
@@ -13,6 +13,7 @@ redirects:
   - /docs/security/new-relic-security/data-privacy/security-bulletins
   - /docs/security/new-relic-security/information-security/security-bulletins
   - /docs/security/security-and-privacy/security-bulletins
+  - /docs/security/security-privacy/information-security/security-bulletins
 ---
 
 This document contains important information regarding security vulnerabilities that could affect some versions of New Relic products and service. Security bulletins are a way for us to let you know about security vulnerabilities, remediation strategies, and applicable updates for affected software. For more information, see our documentation about [security, data privacy, and compliance](/docs/security), or visit the [New Relic security website](https://newrelic.com/security).

--- a/src/nav/new-relic-security.yml
+++ b/src/nav/new-relic-security.yml
@@ -45,10 +45,10 @@ pages:
             path: /docs/security/security-privacy/information-security/report-security-vulnerabilities-hackerone
           - title: Software Development Lifecycle
             path: /docs/security/security-privacy/information-security/software-development-lifecycle
-          - title: Security bulletins
-            path: /docs/security/security-privacy/information-security/security-bulletins
       - title: Security bulletins
         pages:
+          - title: Security bulletins
+            path: /docs/security/new-relic-security/security-bulletins/security-bulletins
           - title: 'Apache Log4j - CPM, NR22-01'
             path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr22-01
           - title: 'Apache Log4j - CPM, NR21-04'


### PR DESCRIPTION
Testing to see if main security bulletins doc will appear at the top of the list if I move it to the "Security bulletins" taxonomy

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.