### PR TITLE
chore: minor change to try and queue file up for translation

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -99,10 +99,10 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
         id="one-event"
         title="Query one data type"
       >
-        This query returns the count of all [APM transactions](/docs/insights/new-relic-insights/decorating-events/insights-attributes#transaction-defaults) over the last three days:
+        This query returns the count of all [APM transactions](/docs/insights/new-relic-insights/decorating-events/insights-attributes#transaction-defaults) over the last seven days:
 
         ```
-        SELECT count(*) FROM Transaction SINCE 3 days ago
+        SELECT count(*) FROM Transaction SINCE 7 days ago
         ```
       </Collapser>
 


### PR DESCRIPTION
## Description

Exclusions YAML was updated and the `kr` frontmatter was added to the NRQL file so it would be translated. But it was not queued up in postgres DB.

I looked over the code and could not figure out why that would happen. Looks like it should queue up. 

This would be the first Korean doc sent for human translation.

Trying a trivial edit to see if this file is queued up when it's merged to `main`

