### PR TITLE
Remove feature flag for post

### DIFF
--- a/src/content/whats-new/2022/03/whats-new-03-28-futurestack-22.md
+++ b/src/content/whats-new/2022/03/whats-new-03-28-futurestack-22.md
@@ -3,7 +3,6 @@ title: 'FutureStack is back in-person at the Cosmopolitan of Las Vegas'
 summary: 'Join us May 17-19 for inspiring keynotes, hands-on labs, technical breakouts, 
 and amazing entertainment, Vegas style.' 
 releaseDate: '2022-03-28' 
-isFeatured: true
 learnMoreLink: 'https://www.futurestack.com/anqQXE?RefId=WHATSNEW' 
 ---
 


### PR DESCRIPTION
We had a request to remove the feature flag for the original FutureStack post to let it fall down the list chronologically.