### PR TITLE
fix: update nerdgraph-synthetics-tutorial.mdx

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial.mdx
@@ -89,7 +89,7 @@ For [scripted API monitors](#create-scripted-API):
 
 * <var>SCRIPT_CONTENT</var>: The actual contents of the script. This should **not** be based64 encoded. 
 * <var>RUNTIME_TYPE</var>: The runtime type used by your monitor. "NODE_API" is the only accepted value.
-* <var>RUNTIME_TYPE_VERSION</var>: The runtime type version used by your monitor. The only accepted value is `16.10.0`. 
+* <var>RUNTIME_TYPE_VERSION</var>: The runtime type version used by your monitor. The only accepted value is `16.10`. 
 * <var>SCRIPT_LANGUAGE</var>: The language used in your monitor. "JAVASCRIPT" is the only accepted value. 
 
 For [scripted browser monitors](#create-scripted-browser):


### PR DESCRIPTION
The only accepted runtime type version value for Scripted API monitors is 16.10, not 16.10.0

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
 Fixes an incorrect configuration value in the docs
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
On the Synthetics team, we got a user writing in saying that they could not create a scripted API monitor, despite following the NerdGraph docs. After we investigated, we realized that the cause was an incorrect field (runtimeTypeVersion).
* If your issue relates to an existing GitHub issue, please link to it.