### PR TITLE
docs: messaging headers alignment correction

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -643,26 +643,26 @@ The .NET agent does not directly monitor datastore processes. Also, by default t
 
     MSMQ:
 
-    * Puts and takes on messages.
+      * Puts and takes on messages.
 
     NServiceBus 5.0 or higher:
 
-    * Puts and takes on messages and [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing).
+      * Puts and takes on messages and [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing).
 
     RabbitMQ 3.5 or higher:
 
-    * Puts and takes on messages and queue purge.
+      * Puts and takes on messages and queue purge.
 
-    * When receiving messages using an `IBasicConsumer`, the `EventingBasicConsumer` is the only implementation that is instrumented by the .NET agent.
+      * When receiving messages using an `IBasicConsumer`, the `EventingBasicConsumer` is the only implementation that is instrumented by the .NET agent.
 
-    * `BasicGet` is instrumented, but the agent does not support [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) for `BasicGet`.
+      * `BasicGet` is instrumented, but the agent does not support [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) for `BasicGet`.
 
-    * The following methods are instrumented:
-      * `IModel.BasicGet`
-      * `IModel.BasicPublish`
-      * `IModel.BasicComsume`
-      * `IModel.QueuePurge`
-      * `EventingBasicConsumer.HandleBasicDeliver`
+      * The following methods are instrumented:
+        * `IModel.BasicGet`
+        * `IModel.BasicPublish`
+        * `IModel.BasicComsume`
+        * `IModel.QueuePurge`
+        * `EventingBasicConsumer.HandleBasicDeliver`
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -645,11 +645,11 @@ The .NET agent does not directly monitor datastore processes. Also, by default t
 
     * Puts and takes on messages.
 
-      NServiceBus 5.0 or higher:
+    NServiceBus 5.0 or higher:
 
     * Puts and takes on messages and [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing).
 
-      RabbitMQ 3.5 or higher:
+    RabbitMQ 3.5 or higher:
 
     * Puts and takes on messages and queue purge.
 
@@ -658,11 +658,11 @@ The .NET agent does not directly monitor datastore processes. Also, by default t
     * `BasicGet` is instrumented, but the agent does not support [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) for `BasicGet`.
 
     * The following methods are instrumented:
-      * IModel.BasicGet
-      * IModel.BasicPublish
-      * IModel.BasicComsume
-      * IModel.QueuePurge
-      * EventingBasicConsumer.HandleBasicDeliver
+      * `IModel.BasicGet`
+      * `IModel.BasicPublish`
+      * `IModel.BasicComsume`
+      * `IModel.QueuePurge`
+      * `EventingBasicConsumer.HandleBasicDeliver`
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
The headers 'MSMQ NServiceBus 5.0 or higher' and  'RabbitMQ 3.5 or higher' in the messaging section were being aligned with the bullet points, making it look like a single list under MSMQ. I alighted them left with the first header to illustrate the separate sections. I also added backticks around the methods lacking them.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.