### PR TITLE
docs: fixed many formatting errors

### DIFF
--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -54,20 +54,20 @@ You have three options to configure APM logs in context to send your app's logs 
 
   All you need to do is install an agent version with log forwarding capabilities ([.NET agent 9.7.0 or higher](/docs/release-notes/agent-release-notes/net-release-notes)), and update your configuration to enable forwarding:
 
-  ```
+  ```xml
   <applicationLogging enabled="true">
     <forwarding enabled="true" maxSamplesStored="10000" />
     <localDecorating enabled="false" />
   </applicationLogging>
   ```
-  Environment variable:
+  Environment variables:
 
-    ```
-    NEW_RELIC_APPLICATION_LOGGING_ENABLED=true
-    NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=true
-    NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED=10000
-    NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED=false
-    ```
+  ```
+  NEW_RELIC_APPLICATION_LOGGING_ENABLED=true
+  NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=true
+  NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED=10000
+  NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED=false
+  ```
     
   Note: The environment variable value, if present, takes precedence over the config file value.
 
@@ -79,21 +79,21 @@ You have three options to configure APM logs in context to send your app's logs 
   
   Set it to a higher number to receive more logs. Set it to a lower number to receive fewer logs. Any integer is valid.
 
-  ```
+  ```xml
   <applicationLogging enabled="true">
     <forwarding enabled="true" maxSamplesStored="10000" />
     <localDecorating enabled="false" />
   </applicationLogging>
   ```
     
-   Environment variable:
+  Environment variables:
 
-    ```
-    NEW_RELIC_APPLICATION_LOGGING_ENABLED=true
-    NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=true
-    NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED=10000
-    NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED=false
-    ```
+  ```
+  NEW_RELIC_APPLICATION_LOGGING_ENABLED=true
+  NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=true
+  NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED=10000
+  NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED=false
+  ```
   Note: The environment variable value, if present, takes precedence over the config file value.
 
   If you have an existing log forwarding solution and are updating your agent to use automatic logs in context, be sure to **disable your manual log forwarder**. Otherwise, your app will be sending double log lines. Depending on your account, this could result in double billing. For more information, follow the procedures to disable your [specific log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding).
@@ -117,25 +117,25 @@ You have three options to configure APM logs in context to send your app's logs 
 
   2. Enable log decorating in your configuration, then relaunch the agent to start decorating your logs.
 
-  ```
+  ```xml
   <applicationLogging enabled="true">
     <forwarding enabled="false" />
     <localDecorating enabled="true" />
   </applicationLogging>
   ```
   
-   Environment variable:
+  Environment variables:
 
-    ```
-    NEW_RELIC_APPLICATION_LOGGING_ENABLED=true
-    NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=false
-    NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED=true
-    ```
+  ```
+  NEW_RELIC_APPLICATION_LOGGING_ENABLED=true
+  NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=false
+  NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED=true
+  ```
   Note: The environment variable value, if present, takes precedence over the config file value.
 
   Our decorator adds five attributes to every log message: `entity.guid`, `entity.name`, `hostname`, `trace.id`, and  `span.id`. Example:
 
-  ```
+  ```log
   This is my log message. NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|
   ```
 
@@ -150,7 +150,7 @@ You have three options to configure APM logs in context to send your app's logs 
   For log4net, the .NET agent stores the NR-LINKING token as a property called `NR_LINKING` in the log event object.  The following common layout examples demonstrate how to configure log4net to write out out the NR-LINKING token.   Other layouts are supported, but not listed below.  SimpleLayout is not supported since it cannot be altered.
 
   **PatternLayout/DynamicPatternLayout**:
-  Update the conversionPattern to include the NR_LINKING property at the end of the line.
+  Update the conversionPattern to include the `NR_LINKING` property at the end of the line.
 
   ```xml
   <layout type="log4net.Layout.PatternLayout">
@@ -159,7 +159,7 @@ You have three options to configure APM logs in context to send your app's logs 
   ```
 
   **log4net.Ext.Json**:
-  Update the layout to include a member called NR_LINKING.
+  Update the layout to include a member called `NR_LINKING`.
 
   ```xml
   <layout type='log4net.Layout.SerializedLayout, log4net.Ext.Json'>
@@ -319,38 +319,39 @@ You can use the [Apache log4net version 2.0.8 or higher](https://logging.apache.
 
     2. In your log4net configuration file, update your logging configuration to use the `NewRelicAppender` as the first level appender, and reference your existing appenders as its children. Also replace the layout of the appender that writes log messages to an output destination with the `NewRelicLayout`.
 
-       The following log4net configuration example enriches log events with New Relic linking metadata. In addition to the existing log files, it outputs new log files in a specific JSON format at `C:\logs\log4netExample.log.json` for consumption by the log forwarder:
+    The following log4net configuration example enriches log events with New Relic linking metadata. In addition to the existing log files, it outputs new log files in a specific JSON format at `C:\logs\log4netExample.log.json` for consumption by the log forwarder:
 
-       ```
-       <log4net>
-         <root>
-           <level value="ALL" />
-           <appender-ref ref="NewRelicAppender" />
-         </root>
+    ```xml
+    <log4net>
+     <root>
+       <level value="ALL" />
+       <appender-ref ref="NewRelicAppender" />
+     </root>
 
-         <appender name="NewRelicAppender" type="NewRelic.LogEnrichers.Log4Net.NewRelicAppender, NewRelic.LogEnrichers.Log4Net" >
-           <threshold value="ALL"/>
-           <appender-ref ref="FileAppender" />
-         </appender>
+     <appender name="NewRelicAppender" type="NewRelic.LogEnrichers.Log4Net.NewRelicAppender, NewRelic.LogEnrichers.Log4Net" >
+       <threshold value="ALL"/>
+       <appender-ref ref="FileAppender" />
+     </appender>
 
-         <appender name="FileAppender" type="log4net.Appender.FileAppender">
-           <file value="C:\logs\log4netExample.log.json" />
-           <param name="AppendToFile" value="true" />
-           <layout type="NewRelic.LogEnrichers.Log4Net.NewRelicLayout, NewRelic.LogEnrichers.Log4Net">
-           </layout>
-         </appender>
-       </log4net>
-       ```
+     <appender name="FileAppender" type="log4net.Appender.FileAppender">
+       <file value="C:\logs\log4netExample.log.json" />
+       <param name="AppendToFile" value="true" />
+       <layout type="NewRelic.LogEnrichers.Log4Net.NewRelicLayout, NewRelic.LogEnrichers.Log4Net">
+       </layout>
+     </appender>
+    </log4net>
+    ```
 
-       After you configure the log4net extension and update your logging file, you can configure your extension to send data to New Relic. There are [several options](https://docs.newrelic.com/docs/logs/forward-logs/enable-log-management-new-relic/#log-forwarding) for forwarding your logs. Here is an example configuration using the infrastructure agent for logs in context:
+    After you configure the log4net extension and update your logging file, you can configure your extension to send data to New Relic. There are [several options](https://docs.newrelic.com/docs/logs/forward-logs/enable-log-management-new-relic/#log-forwarding) for forwarding your logs. Here is an example configuration using the infrastructure agent for logs in context:
 
-       ```
+    ```yml
     logs:
       - name: application-log
 	      file: C:\logs\log4netExample.log.json # Path to a single log file
+    ```
     
     #[Documentation for using the infrastructure agent forwarder](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#file)
-       ```
+
   </Collapser>
 </CollapserGroup>
 
@@ -408,7 +409,7 @@ You can use our [NLog 4.5 or higher](https://nlog-project.org/) extension to lin
 
       The following code example enriches log events with New Relic linking metadata, but not with MDC or the MDLC data. In addition to the existing log files, it outputs new log files in a specific JSON format at `C:\logs\NLogExample.log.json` for consumption by the log forwarder:
 
-      ```
+      ```cs
       var loggerConfig = new LoggingConfiguration();
       var newRelicFileTarget = new FileTarget("NewRelicFileTarget");
       newRelicFileTarget.Layout = new NewRelicJsonLayout();
@@ -423,7 +424,7 @@ You can use our [NLog 4.5 or higher](https://nlog-project.org/) extension to lin
 
       If your application uses the MDC or the MDLC, you can configure the `NewRelicJsonLayout` to include items in those collections. The following code example adds the additional configuration to enable collecting MDC and MDLC data. As in the previous example, it outputs new log files in a specific JSON format at `C:\logs\NLogExample.log.json` for consumption by the log forwarder:
 
-      ```
+      ```cs
       var loggerConfig = new LoggingConfiguration();
       var newRelicFileTarget = new FileTarget("NewRelicFileTarget");
       var newRelicLayout = new NewRelicJsonLayout
@@ -442,14 +443,14 @@ You can use our [NLog 4.5 or higher](https://nlog-project.org/) extension to lin
 
       Once you have configured the NLog extension and updated your logging file, you can configure your extension to send data to New Relic. There are [several options](https://docs.newrelic.com/docs/logs/forward-logs/enable-log-management-new-relic/#log-forwarding) for forwarding your logs. Here is an example configuration using the infrastructure agent for logs in context:
 
+      ```yml
+      logs:
+        - name: application-log
+          file: C:\logs\log4netExample.log.json # Path to a single log file
       ```
-logs:
-	- name: application-log
-		file: C:\logs\log4netExample.log.json # Path to a single log file
 
 #[Documentation for using the infrastructure agent forwarder](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#file)
 
-      ```
   </Collapser>
 
   <Collapser
@@ -460,14 +461,14 @@ logs:
 
     **Instantiating Logger using `.config` file**
 
-    ```
+    ```cs
     var logger = LogManager.GetLogger("NewRelicLog");
     logger.Info("Hello, New Relic!");
     ```
 
     **Sample `App.config` file**
 
-    ```
+    ```xml
     <?xml version="1.0" encoding="utf-8" ?>
     <configuration>
       <configSections>
@@ -537,24 +538,24 @@ You can use our [Serilog](https://serilog.net/) extension to link to your log da
 
     2. In your application code, update your logging configuration to add the `NewRelicEnricher` and `NewRelicFormatter`.
 
-       The following code example enriches log events with New Relic linking metadata. In addition to the existing log files, it outputs new log files in a specific JSON format at `C:\logs\SerilogExample.log.json` for consumption by the log forwarder:
+    The following code example enriches log events with New Relic linking metadata. In addition to the existing log files, it outputs new log files in a specific JSON format at `C:\logs\SerilogExample.log.json` for consumption by the log forwarder:
 
-       ```
-       var loggerConfig = new LoggerConfiguration()
-    
-         loggerConfig
-            .Enrich.WithThreadName()
-            .Enrich.WithThreadId()    
-            .Enrich.WithNewRelicLogsInContext()
-            .WriteTo.File( path: @"C:\logs\ExistingLoggingOutput.txt")
-            .WriteTo.File(
-                formatter: new NewRelicFormatter(), 
-                path: @"C:\logs\SerilogExample.log.json");
+    ```cs
+    var loggerConfig = new LoggerConfiguration();
 
-       var log = loggerConfig.CreateLogger();
-       ```
+    loggerConfig
+        .Enrich.WithThreadName()
+        .Enrich.WithThreadId()    
+        .Enrich.WithNewRelicLogsInContext()
+        .WriteTo.File( path: @"C:\logs\ExistingLoggingOutput.txt")
+        .WriteTo.File(
+            formatter: new NewRelicFormatter(), 
+            path: @"C:\logs\SerilogExample.log.json");
 
-       This configuration results in new JSON files that are written to disk. Some of these [configuration options](https://github.com/serilog/serilog-sinks-file) may be useful for managing the amount of disk space used and/or the performance of the sink.
+    var log = loggerConfig.CreateLogger();
+    ```
+
+    This configuration results in new JSON files that are written to disk. Some of these [configuration options](https://github.com/serilog/serilog-sinks-file) may be useful for managing the amount of disk space used and/or the performance of the sink.
 
     * `restrictedToMinimumLevel`
     * `buffered`
@@ -562,18 +563,18 @@ You can use our [Serilog](https://serilog.net/) extension to link to your log da
     * `rollOnFileSizeLimit`
     * `retainedFileCountLimit`
 
-      Although not required, using the [Serilog Asynchronous Sink Wrapper](https://www.nuget.org/packages/Serilog.Sinks.Async) may help improve the performance by performing formatting and output of log files on a different thread.
+    Although not required, using the [Serilog Asynchronous Sink Wrapper](https://www.nuget.org/packages/Serilog.Sinks.Async) may help improve the performance by performing formatting and output of log files on a different thread.
 
     3. Once you have configured the Serilog extension and updated your logging file, there are [several options](https://docs.newrelic.com/docs/logs/forward-logs/enable-log-management-new-relic/#log-forwarding) for forwarding your logs. Here is an example configuration using the infrastructure agent for logs in context:
 
-       ```
-logs:
-	- name: application-log
-		file: C:\logs\log4netExample.log.json # Path to a single log file
-
+    ```yml
+    logs:
+      - name: application-log
+        file: C:\logs\log4netExample.log.json # Path to a single log file
+    ```
+    
 #[Documentation for using the infrastructure agent forwarder](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#file)
 
-       ```
   </Collapser>
 
   <Collapser
@@ -585,74 +586,74 @@ logs:
     * [Microsoft.Extensions.Configuration](https://www.nuget.org/packages/Microsoft.Extensions.Configuration/)
     * [Serilog.Settings.Configuration](https://www.nuget.org/packages/Serilog.Settings.Configuration)
 
-      The following example code creates a logger based on settings contained in an `appSettings.json` file.
+    The following example code creates a logger based on settings contained in an `appSettings.json` file.
 
-      **Instantiating logger using `appsettings.json`**
+    **Instantiating logger using `appsettings.json`**
 
-      ```
-      var builder = new ConfigurationBuilder()
-              .AddJsonFile("appsettings.json");
+    ```cs
+    var builder = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json");
 
-      var configuration = builder.Build();
+    var configuration = builder.Build();
 
-      var logger = new LoggerConfiguration()
-              .ReadFrom.Configuration(configuration)
-              .CreateLogger();
-      ```
+    var logger = new LoggerConfiguration()
+            .ReadFrom.Configuration(configuration)
+            .CreateLogger();
+    ```
 
-      **Sample `appsettings.json` file**
+    **Sample `appsettings.json` file**
 
-      ```
-      {
-        "Serilog": {
-          "Using": [ 
-                "Serilog.Sinks.Console",
-                "Serilog.Sinks.File",
-                "NewRelic.LogEnrichers.Serilog" 
-          ],
-          "MinimumLevel": "Debug",
-          "Enrich": [ "WithNewRelicLogsInContext" ],
-          "WriteTo": [
-            {
-              "Name": "File",
-              "Args": {
-                "path": "C:\\Logs\\SerilogExample.log.json",
-                "formatter": "NewRelic.LogEnrichers.Serilog.NewRelicFormatter, NewRelic.LogEnrichers.Serilog"
-                }
-            }
-          ],
-
-          "Properties": {
-            "Application": "NewRelic Logging Serilog Example"
+    ```json
+    {
+      "Serilog": {
+        "Using": [ 
+              "Serilog.Sinks.Console",
+              "Serilog.Sinks.File",
+              "NewRelic.LogEnrichers.Serilog" 
+        ],
+        "MinimumLevel": "Debug",
+        "Enrich": [ "WithNewRelicLogsInContext" ],
+        "WriteTo": [
+          {
+            "Name": "File",
+            "Args": {
+              "path": "C:\\Logs\\SerilogExample.log.json",
+              "formatter": "NewRelic.LogEnrichers.Serilog.NewRelicFormatter, NewRelic.LogEnrichers.Serilog"
+              }
           }
+        ],
+
+        "Properties": {
+          "Application": "NewRelic Logging Serilog Example"
         }
       }
-      ```
+    }
+    ```
 
-      The following example code creates a logger based on settings contained in a `web.config` file. The [Serilog.Settings.AppSettings](https://www.nuget.org/packages/Serilog.Settings.AppSettings) NuGet Package is required.
+    The following example code creates a logger based on settings contained in a `web.config` file. The [Serilog.Settings.AppSettings](https://www.nuget.org/packages/Serilog.Settings.AppSettings) NuGet Package is required.
 
-      **Instantiating logger using `.config` file**
+    **Instantiating logger using `.config` file**
 
-      ```
-      var logger = new LoggerConfiguration()
-          .ReadFrom.AppSettings()
-          .CreateLogger();
-      ```
+    ```cs
+    var logger = new LoggerConfiguration()
+        .ReadFrom.AppSettings()
+        .CreateLogger();
+    ```
 
-      **Sample `web.config` file**
+    **Sample `web.config` file**
 
-      ```
-      <?xml version="1.0" encoding="utf-8"?>
-      <configuration>
-        <appSettings>
-          <add key="serilog:using:NewRelic" value="NewRelic.LogEnrichers.Serilog" />
-          <add key="serilog:using:File" value="Serilog.Sinks.File" />
-          <!--Add other enrichers here-->
-          <add key="serilog:enrich:WithNewRelicLogsInContext" />
-          <add key="serilog:write-to:File.path" value="C:\logs\SerilogExample.log.json" />
-          <add key="serilog:write-to:File.formatter" value="NewRelic.LogEnrichers.Serilog.NewRelicFormatter, NewRelic.LogEnrichers.Serilog" />
-        </appSettings>
-
-      ```
+    ```xml
+    <?xml version="1.0" encoding="utf-8"?>
+    <configuration>
+      <appSettings>
+        <add key="serilog:using:NewRelic" value="NewRelic.LogEnrichers.Serilog" />
+        <add key="serilog:using:File" value="Serilog.Sinks.File" />
+        <!--Add other enrichers here-->
+        <add key="serilog:enrich:WithNewRelicLogsInContext" />
+        <add key="serilog:write-to:File.path" value="C:\logs\SerilogExample.log.json" />
+        <add key="serilog:write-to:File.formatter" value="NewRelic.LogEnrichers.Serilog.NewRelicFormatter, NewRelic.LogEnrichers.Serilog" />
+      </appSettings>
+    ```
+      
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
There were a lot of codeblocks that shouldn't have been there or contained markdown for the page. Most caused by indentation (4 spaces in md makes a codeblock). I also added language identifiers.

I suspect this part is incorrect, it says it's a `.config` file but the code example is c# not xml

     **Instantiating Logger using `.config` file**

     ```cs
     var logger = LogManager.GetLogger("NewRelicLog");
     logger.Info("Hello, New Relic!");
     ```

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.