### PR TITLE
Remove if  check from manual translation workflow

### DIFF
--- a/.github/workflows/manual-add-files-to-translation-queue.yml
+++ b/.github/workflows/manual-add-files-to-translation-queue.yml
@@ -27,7 +27,6 @@ jobs:
   get-and-save-slugs:
     name: Get and Save Slugs
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
the workflow is only running the job if a PR has been merged but we want to be able to manually trigger it outside of PRs