### PR TITLE
fix(Glossary): Update broken links

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/glossary.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/glossary.mdx
@@ -919,14 +919,14 @@ Use alert conditions to define when and why your team will be notified if your e
     id="nerdlet"
     title="Nerdlet"
   >
-    A Nerdlet is a component of a [New Relic app](/docs/new-relic-one/use-new-relic-one/build-new-relic-one/new-relic-one-build-your-own-custom-new-relic-one-application). It's a specific UI view, represented by a React JavaScript package. For more information, see [Nerdpack file structure](/docs/new-relic-one/use-new-relic-one/build-new-relic-one/new-relic-one-application-nerdpack-file-structure).
+    A Nerdlet is a component of a [New Relic app](/docs/new-relic-one/use-new-relic-one/build-new-relic-one/new-relic-one-build-your-own-custom-new-relic-one-application). It's a specific UI view, represented by a React JavaScript package. For more information, see [Nerdpack file structure](https://developer.newrelic.com/explore-docs/nerdpack-file-structure).
   </Collapser>
 
   <Collapser
     id="nerdpack"
     title="Nerdpack"
   >
-    A Nerdpack is a component of a [New Relic app](/docs/new-relic-one/use-new-relic-one/build-new-relic-one/new-relic-one-build-your-own-custom-new-relic-one-application). It's the package containing all the files needed by that application. For more information, see [Nerdpack file structure](/docs/new-relic-one/use-new-relic-one/build-new-relic-one/new-relic-one-application-nerdpack-file-structure).
+    A Nerdpack is a component of a [New Relic app](/docs/new-relic-one/use-new-relic-one/build-new-relic-one/new-relic-one-build-your-own-custom-new-relic-one-application). It's the package containing all the files needed by that application. For more information, see [Nerdpack file structure](https://developer.newrelic.com/explore-docs/nerdpack-file-structure).
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
It updates no longer existing link (https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/build-new-relic-one/new-relic-one-application-nerdpack-file-structure) to existing one: https://developer.newrelic.com/explore-docs/nerdpack-file-structure/