### PR TITLE
docs: testing a fix for text in codeblocks

### DIFF
--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -319,38 +319,38 @@ You can use the [Apache log4net version 2.0.8 or higher](https://logging.apache.
 
     2. In your log4net configuration file, update your logging configuration to use the `NewRelicAppender` as the first level appender, and reference your existing appenders as its children. Also replace the layout of the appender that writes log messages to an output destination with the `NewRelicLayout`.
 
-    The following log4net configuration example enriches log events with New Relic linking metadata. In addition to the existing log files, it outputs new log files in a specific JSON format at `C:\logs\log4netExample.log.json` for consumption by the log forwarder:
+      The following log4net configuration example enriches log events with New Relic linking metadata. In addition to the existing log files, it outputs new log files in a specific JSON format at `C:\logs\log4netExample.log.json` for consumption by the log forwarder:
 
-    ```xml
-    <log4net>
-     <root>
-       <level value="ALL" />
-       <appender-ref ref="NewRelicAppender" />
-     </root>
+      ```xml
+      <log4net>
+       <root>
+         <level value="ALL" />
+         <appender-ref ref="NewRelicAppender" />
+       </root>
 
-     <appender name="NewRelicAppender" type="NewRelic.LogEnrichers.Log4Net.NewRelicAppender, NewRelic.LogEnrichers.Log4Net" >
-       <threshold value="ALL"/>
-       <appender-ref ref="FileAppender" />
-     </appender>
+       <appender name="NewRelicAppender" type="NewRelic.LogEnrichers.Log4Net.NewRelicAppender, NewRelic.LogEnrichers.Log4Net" >
+         <threshold value="ALL"/>
+         <appender-ref ref="FileAppender" />
+       </appender>
 
-     <appender name="FileAppender" type="log4net.Appender.FileAppender">
-       <file value="C:\logs\log4netExample.log.json" />
-       <param name="AppendToFile" value="true" />
-       <layout type="NewRelic.LogEnrichers.Log4Net.NewRelicLayout, NewRelic.LogEnrichers.Log4Net">
-       </layout>
-     </appender>
-    </log4net>
-    ```
+       <appender name="FileAppender" type="log4net.Appender.FileAppender">
+         <file value="C:\logs\log4netExample.log.json" />
+         <param name="AppendToFile" value="true" />
+         <layout type="NewRelic.LogEnrichers.Log4Net.NewRelicLayout, NewRelic.LogEnrichers.Log4Net">
+         </layout>
+       </appender>
+      </log4net>
+      ```
 
-    After you configure the log4net extension and update your logging file, you can configure your extension to send data to New Relic. There are [several options](https://docs.newrelic.com/docs/logs/forward-logs/enable-log-management-new-relic/#log-forwarding) for forwarding your logs. Here is an example configuration using the infrastructure agent for logs in context:
+      After you configure the log4net extension and update your logging file, you can configure your extension to send data to New Relic. There are [several options](https://docs.newrelic.com/docs/logs/forward-logs/enable-log-management-new-relic/#log-forwarding) for forwarding your logs. Here is an example configuration using the infrastructure agent for logs in context:
 
-    ```yml
-    logs:
-      - name: application-log
-	      file: C:\logs\log4netExample.log.json # Path to a single log file
-    ```
-    
-    #[Documentation for using the infrastructure agent forwarder](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#file)
+      ```yml
+      logs:
+        - name: application-log
+          file: C:\logs\log4netExample.log.json # Path to a single log file
+      ```
+
+      #[Documentation for using the infrastructure agent forwarder](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#file)
 
   </Collapser>
 </CollapserGroup>
@@ -567,11 +567,11 @@ You can use our [Serilog](https://serilog.net/) extension to link to your log da
 
     3. Once you have configured the Serilog extension and updated your logging file, there are [several options](https://docs.newrelic.com/docs/logs/forward-logs/enable-log-management-new-relic/#log-forwarding) for forwarding your logs. Here is an example configuration using the infrastructure agent for logs in context:
 
-    ```yml
-    logs:
-      - name: application-log
-        file: C:\logs\log4netExample.log.json # Path to a single log file
-    ```
+      ```yml
+      logs:
+        - name: application-log
+          file: C:\logs\log4netExample.log.json # Path to a single log file
+      ```
     
 #[Documentation for using the infrastructure agent forwarder](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#file)
 

--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -136,7 +136,7 @@ You have three options to configure APM logs in context to send your app's logs 
   Our decorator adds five attributes to every log message: `entity.guid`, `entity.name`, `hostname`, `trace.id`, and  `span.id`. Example:
 
   ```log
-  This is my log message. NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|
+  This is my log message. NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}
   ```
 
   Some attributes may be empty if the log occurred outside a transaction or if they are not applicable to your application's context. We recommend this option over the manual process to use a decorating formatter.
@@ -188,21 +188,21 @@ You have three options to configure APM logs in context to send your app's logs 
   For Serilog, the .NET agent stores the NR-LINKING token as a property called `NR_LINKING` in the log event object.  The following common formatter and sink examples demonstrate how to configure Serilog to write out out the NR-LINKING token.   Other sinks and formatters are supported, but not listed below.
 
   **Plain text using an outputTemplate**
-  Update the outputTemplate to include the NR_LINKING property at the end of the line.
+  Update the outputTemplate to include the `NR_LINKING` property at the end of the line.
 
   ```csharp
   Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-    .Enrich.FromLogContext()
-    .WriteTo.File(
-      path: @"plaintext_log.txt",
-      fileSizeLimitBytes: 1_000_000,
-      rollOnFileSizeLimit: true,
-      shared: true,
-      flushToDiskInterval: TimeSpan.FromSeconds(1),
-      outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} {NR_LINKING} {NewLine}{Exception}"
-    )
-    .CreateLogger();
+      .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+      .Enrich.FromLogContext()
+      .WriteTo.File(
+          path: @"plaintext_log.txt",
+          fileSizeLimitBytes: 1_000_000,
+          rollOnFileSizeLimit: true,
+          shared: true,
+          flushToDiskInterval: TimeSpan.FromSeconds(1),
+          outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} {NR_LINKING} {NewLine}{Exception}"
+      )
+      .CreateLogger();
   ```
 
   **JSON Formatter with automatic property output**
@@ -210,10 +210,10 @@ You have three options to configure APM logs in context to send your app's logs 
 
   ```csharp
   Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-    .Enrich.FromLogContext()
-    .WriteTo.Console(new JsonFormatter());
-    .CreateLogger();
+      .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+      .Enrich.FromLogContext()
+      .WriteTo.Console(new JsonFormatter());
+      .CreateLogger();
   ```
 
   **Microsoft.Extensions.Logging configuration**
@@ -350,7 +350,7 @@ You can use the [Apache log4net version 2.0.8 or higher](https://logging.apache.
           file: C:\logs\log4netExample.log.json # Path to a single log file
       ```
 
-      #[Documentation for using the infrastructure agent forwarder](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#file)
+      [Documentation for using the infrastructure agent forwarder](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#file)
 
   </Collapser>
 </CollapserGroup>
@@ -429,8 +429,8 @@ You can use our [NLog 4.5 or higher](https://nlog-project.org/) extension to lin
       var newRelicFileTarget = new FileTarget("NewRelicFileTarget");
       var newRelicLayout = new NewRelicJsonLayout
       {
-        IncludeMdc = `true,`
-        IncludeMdlc = `true`
+          IncludeMdc = `true,`
+          IncludeMdlc = `true`
       };
 
       newRelicFileTarget.Layout = newRelicLayout;
@@ -449,7 +449,7 @@ You can use our [NLog 4.5 or higher](https://nlog-project.org/) extension to lin
           file: C:\logs\log4netExample.log.json # Path to a single log file
       ```
 
-#[Documentation for using the infrastructure agent forwarder](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#file)
+      [Documentation for using the infrastructure agent forwarder](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#file)
 
   </Collapser>
 
@@ -573,7 +573,7 @@ You can use our [Serilog](https://serilog.net/) extension to link to your log da
           file: C:\logs\log4netExample.log.json # Path to a single log file
       ```
     
-#[Documentation for using the infrastructure agent forwarder](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#file)
+      [Documentation for using the infrastructure agent forwarder](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#file)
 
   </Collapser>
 
@@ -592,13 +592,13 @@ You can use our [Serilog](https://serilog.net/) extension to link to your log da
 
     ```cs
     var builder = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.json");
+        .AddJsonFile("appsettings.json");
 
     var configuration = builder.Build();
 
     var logger = new LoggerConfiguration()
-            .ReadFrom.Configuration(configuration)
-            .CreateLogger();
+        .ReadFrom.Configuration(configuration)
+        .CreateLogger();
     ```
 
     **Sample `appsettings.json` file**


### PR DESCRIPTION
These two sections were rendering text in codeblocks and code as text, I'm testing if changing the indentation will correct it

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.