### PR TITLE
docs: fix in page link

### DIFF
--- a/src/content/docs/apm/agents/net-agent/troubleshooting/technical-support-net-framework-40-or-lower.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/technical-support-net-framework-40-or-lower.mdx
@@ -63,7 +63,7 @@ Limited technical support to troubleshoot running web apps with the .NET agent i
 1. Check for any running W3WP processes, and get their `pid`.
 2. Check for key `.dll` required for instrumentation. For example, if there are any W3WP processes, check if the New Relic profiler `.dll` and `mscorelib.dll` are loaded into the process.
 
-## Applications not hosted on IIS [#non-IIS apps]
+## Applications not hosted on IIS [#non-IIS-apps]
 
 Limited technical support to troubleshoot apps not hosted on IIS includes:
 


### PR DESCRIPTION
`[#non-IIS apps]` was showing up as plain text on the page, not as a link

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.