### PR TITLE
docs: fix broken link

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1627,7 +1627,7 @@ In this example, the agent excludes all attributes whose key begins with **myApi
 </attributes>
 ```
 
-You can view the .NET APM attributes on the [.NET agent attributes](/docs/agents/net-agent/attributes/net-agent-attributes) page. You can also define custom attributes with the agent API call [`AddCustomAttribute`](docs/agents/net-agent/net-agent-api/itransaction/#addcustomattribute).
+You can view the .NET APM attributes on the [.NET agent attributes](/docs/agents/net-agent/attributes/net-agent-attributes) page. You can also define custom attributes with the agent API call [`AddCustomAttribute`](/docs/agents/net-agent/net-agent-api/itransaction/#addcustomattribute).
 
 <CollapserGroup>
   <Collapser


### PR DESCRIPTION
`AddCustomAttribute` link was routing to `https://docs.newrelic.com/docs/apm/agents/net-agent/configuration/net-agent-configuration/docs/agents/net-agent/net-agent-api/itransaction/` which was broken, I think it's because of a missing `/` at the beginning of the URL, otherwise it looked the same as the other links on this page.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.