### PR TITLE
feat: agent install instructions for ubuntu 22.04

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -272,6 +272,12 @@ To install infrastructure in Linux, follow these instructions:
        ```
        printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt hirsute main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
+
+       **Ubuntu 22.04 (Jammy Jellyfish)**
+
+       ```
+       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt jammy main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       ```
      </Collapser>
 
      <Collapser


### PR DESCRIPTION
Add infra-agent installation instructions for ubuntu 22.04