### PR TITLE
Dead link fix for Cloudflare I/O catalog item

### DIFF
--- a/src/content/docs/logs/forward-logs/cloudflare-logpush-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/cloudflare-logpush-forwarding.mdx
@@ -164,7 +164,7 @@ Get started in minutes with a pre-built dashboard to see key metrics from your C
   Our Instant Observability quickstart for Cloudflare network logs includes a pre-built dashboard.
 </figcaption>
 
-* Go the [Cloudflare Network Logs quickstart](https://newrelic.com/instant-observability/cloudflare-network-logs/fc2bb0ac-6622-43c6-8c1f-6a4c26ab5434) in New Relic Instant Observability, and click **+ Install quickstart**.
+* Go the [Cloudflare Network Logs quickstart](https://newrelic.com/instant-observability/cloudflare/fc2bb0ac-6622-43c6-8c1f-6a4c26ab5434) in New Relic Instant Observability, and click **+ Install quickstart**.
 
 * Learn more about the integration by reading the blog post: [A faster and cheaper way to send log insights to New Relic with the Cloudflare Logpush integration](https://newrelic.com/blog/how-to-relic/cloudflare-log-integration)
 


### PR DESCRIPTION
* Removes https://newrelic.com/instant-observability/cloudflare-network-logs/fc2bb0ac-6622-43c6-8c1f-6a4c26ab5434/ which 404s on the NR side
* Adds https://newrelic.com/instant-observability/cloudflare/fc2bb0ac-6622-43c6-8c1f-6a4c26ab5434 which is the current URL straight from the I/O catalog.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.