### PR TITLE
feat: add infra-agent installation instructions for RHEL 9

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -324,6 +324,18 @@ To install infrastructure in Linux, follow these instructions:
        ```
        sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/8/aarch64/newrelic-infra.repo
        ```
+
+       **RHEL 9.x (x86)**
+
+       ```
+       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/9/x86_64/newrelic-infra.repo
+       ```
+
+       **RHEL 9.x (arm64)**
+
+       ```
+       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/9/aarch64/newrelic-infra.repo
+       ```
      </Collapser>
 
      <Collapser


### PR DESCRIPTION
Do not merge: RHEL 9 building files ready and tests performed on the infra-agent, but artifacts have not been released yet.

PR state will be changed once artifacts are available. 
