### PR TITLE
chore(insights): Remove references to Insights product

### DIFF
--- a/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
@@ -147,7 +147,6 @@ Account management
         * [Export dashboards to other accounts](/docs/apis/nerdgraph/examples/export-import-dashboards-using-api/)
         * [Export dashboards as files](/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api/)
         * [Manage externally shared dashboards](/docs/apis/nerdgraph/examples/manage-live-chart-urls-via-api)
-        * [Migrate from Insights Dashboard API to NerdGraph](/docs/new-relic-one/use-new-relic-one/core-concepts/dashboards-api-migration-insights-api-nerdgraph/)
       </td>
     </tr>    
     <tr>

--- a/src/content/docs/apis/rest-api-v2/get-started/admin-users-api-key-partnerships.mdx
+++ b/src/content/docs/apis/rest-api-v2/get-started/admin-users-api-key-partnerships.mdx
@@ -33,6 +33,5 @@ This partner-only authentication method will only work with the [New Relic REST 
 
 * [Deployment API](/docs/apm/new-relic-apm/maintenance/deployment-notifications#api)
 * [Infrastructure API for alerts](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts)
-* [Insights API](/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-insights-api)
 * [Partner API](/docs/accounts-partnerships/partnerships/partner-api/partner-api-reference)
 * [Synthetics API](/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api)

--- a/src/content/docs/data-apis/custom-data/custom-events/report-mobile-monitoring-custom-events-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/report-mobile-monitoring-custom-events-attributes.mdx
@@ -1,7 +1,6 @@
 ---
 title: Report mobile monitoring custom events and attributes
 tags:
-  - Insights
   - Event data sources
   - Custom events
 metaDescription: 'How to query your mobile events and attributes in New Relic, and how to create custom events and attributes.'
@@ -234,7 +233,7 @@ By default, New Relic transmits event data in any of these situations:
 * The app session ends by backgrounding.
 * The app crashes.
 
-If the app crashes, New Relic gathers the attributes and events for that session and sends them to Insights. (On iOS, this happens the next time the app is launched). You can then use Insights to query and analyze the event and attribute data.
+If the app crashes, New Relic collects the attributes and events for that session. (On iOS, this happens the next time the app is launched). You can then use NRQL to query and analyze the event and attribute data.
 
 To set the maximum time (in seconds) that the agent will store events in memory, use the following SDK calls:
 

--- a/src/content/docs/data-apis/ingest-apis/event-api/introduction-event-api.mdx
+++ b/src/content/docs/data-apis/ingest-apis/event-api/introduction-event-api.mdx
@@ -46,7 +46,6 @@ Related content:
 * Learn about [all options for reporting custom events](/docs/insights/insights-data-sources/custom-data/report-custom-event-data).
 * For details about how event data is retained, see [Event data retention](/docs/insights/use-insights-ui/manage-account-data/extend-event-data-retention).
 * For how to add attributes to existing events, see [Add custom attributes](/docs/agents/manage-apm-agents/agent-data/collect-custom-attributes).
-* Check out New Relic University’s tutorial [Adding custom events with the Event API](https://newrelic.wistia.com/medias/d530wfeqyo) (aka the Insights API). Or, go directly to the full online course [Custom data](https://learn.newrelic.com/custom-data-with-insights).
 
 ## Requirements
 
@@ -80,8 +79,6 @@ The Event API [limits the size, rate, and characters](#limits) allowed in custom
 You'll need a [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key). License keys are associated with an account, not a specific user. This means that anyone in the account with access to that key can use it.
 
 You can submit multiple event types to the same account with the same license key. However, to help ensure security, we recommend that you use different keys for different applications or data sources.
-
-Alternatively, you can use an [Insights insert key](/docs/apis/intro-apis/new-relic-api-keys/#insights-insert-key)for this API, but we recommend using a license key.
 
 ## Format the JSON [#instrument]
 
@@ -158,7 +155,7 @@ The Event API accepts specific formats for attributes included in the payload. O
           </td>
 
           <td>
-            For attributes that contain date information, use an unformatted Unix timestamp in the Insights [data formatter](/docs/insights/use-insights-ui/manage-account-data/data-formatter-set-default-formats-numeric-values). You can [define the date attribute](#timestamp) either in seconds or in milliseconds, both relative to the Unix epoch.
+            For attributes that contain date information, use an unformatted Unix timestamp in the [data formatter](/docs/insights/use-insights-ui/manage-account-data/data-formatter-set-default-formats-numeric-values). You can [define the date attribute](#timestamp) either in seconds or in milliseconds, both relative to the Unix epoch.
           </td>
         </tr>
 

--- a/src/content/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes.mdx
@@ -437,7 +437,7 @@ Additional restrictions include:
       </td>
 
       <td>
-        The Metric API inherits some [reserved words from New Relic Insights](/docs/insights/insights-data-sources/custom-data/insights-custom-data-requirements-limits#reserved-words), including `accountID`, `appId`, and `eventType`. Additionally, the syntax terms for NRQL are restricted unless you backtick (``` `` ```) them. For a full list, see [Reserved words: NRQL syntax terms](/docs/insights/insights-data-sources/custom-data/insights-custom-data-requirements-limits#reserved-syntax).
+        Avoid using [reserved words](/docs/insights/insights-data-sources/custom-data/insights-custom-data-requirements-limits#reserved-words), such as `accountID`, `appId`, and `eventType`. You should also avoid using NRQL syntax terms unless you backtick (``` `` ```) them. 
       </td>
     </tr>
 

--- a/src/content/docs/data-apis/understand-data/event-data/customized-security-settings-insights.mdx
+++ b/src/content/docs/data-apis/understand-data/event-data/customized-security-settings-insights.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Security for New Relic-reported events and attributes '
 tags:
-  - Insights
   - Event data sources
   - Default events
 metaDescription: How to manage the security of events and attributes reported to New Relic.

--- a/src/content/docs/data-apis/understand-data/event-data/default-events-reported-new-relic-products.mdx
+++ b/src/content/docs/data-apis/understand-data/event-data/default-events-reported-new-relic-products.mdx
@@ -1,7 +1,6 @@
 ---
 title: Default events reported by New Relic products
 tags:
-  - Insights
   - Event data sources
   - Default events
 metaDescription: A summary of the default events and attributes reported by New Relic products.

--- a/src/content/docs/data-apis/understand-data/event-data/events-reported-synthetic-monitoring.mdx
+++ b/src/content/docs/data-apis/understand-data/event-data/events-reported-synthetic-monitoring.mdx
@@ -1,7 +1,6 @@
 ---
 title: Events reported by synthetic monitoring
 tags:
-  - Insights
   - Event data sources
   - Default events
 metaDescription: Events and attributes reported by synthetic monitoring in New Relic.

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/analyze-network-requests-using-mobilerequest-event-data.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/analyze-network-requests-using-mobilerequest-event-data.mdx
@@ -10,7 +10,7 @@ redirects:
   - /docs/mobile-monitoring/mobile-monitoring-ui/network-pages
 ---
 
-Monitoring HTTP and network requests gives you insight into how your app is performing and provides data that can help you improve your app. To find HTTP and network requests and errors, you can view them in the [mobile monitoring UI](#view-mobile) or query [`MobileRequest` and `MobileRequestError` events](#query-insights) in Insights.
+Monitoring HTTP and network requests gives you insight into how your app is performing and provides data that can help you improve your app. To find HTTP and network requests and errors, you can view them in the [mobile monitoring UI](#view-mobile) or query [`MobileRequest` and `MobileRequestError` events](#query-insights) with NRQL.
 
 ## Enable MobileRequest for earlier versions of iOS and Android [#enable_mobilerequest]
 
@@ -56,7 +56,7 @@ For earlier versions, starting with Android version 5.14.0 or iOS version 5.14.0
   </Collapser>
 </CollapserGroup>
 
-## Query HTTP and network requests in Insights [#query-insights]
+## Query HTTP and network requests with NRQL [#query-insights]
 
 To create custom dashboards for HTTP and network requests, run queries using the following events and attributes:
 

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-requests-page.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-requests-page.mdx
@@ -128,8 +128,7 @@ For a description of the non-Enterprise **HTTP requests** UI page, see [Legacy H
 
 To view any **HTTP requests** chart in Insights:
 
-1. Select <Icon name="fe-more-horizontal"/>
-   for any chart.
+1. Select <Icon name="fe-more-horizontal"/> for any chart.
 2. Select **View query > View in Insights**.
 3. Optional: Add the data to a dashboard, or [share it by using a permalink](/docs/data-analysis/user-interface-functions/share-your-data/permalink).
 4. To delve deeper into your request data, query [`MobileRequest`](/docs/insights/nrql-new-relic-query-language/nrql-query-examples/insights-query-examples-new-relic-mobile#mobilerequest-examples) events and [attributes](/docs/insights/insights-data-sources/default-data/mobile-events-attributes#mobilerequest-attributes).

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags.mdx
@@ -42,7 +42,7 @@ All settings, including the call to invoke the agent, are called in the `onCreat
     id="ff-withAnalyticsEvents"
     title="withAnalyticsEvents"
   >
-    Enable or disable collection of event data. These events are reported to [Insights](/docs/insights/explore-data/attributes/mobile-default-attributes-insights) and used in the [**Crash analysis** page](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes).
+    Enable or disable collection of event data. These events [can be queried with NRQL](/docs/insights/explore-data/attributes/mobile-default-attributes-insights) and used in the [**Crash analysis** page](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes).
 
     <table>
       <tbody>
@@ -345,7 +345,7 @@ All settings, including the call to invoke the agent, are called in the `onCreat
     id="ff-networkRequests"
     title="FeatureFlag.NetworkRequests"
   >
-    Enable or disable reporting successful HTTP requests to the [MobileRequest](/docs/insights/nrql-new-relic-query-language/nrql-query-examples/insights-query-examples-new-relic-mobile#mobilerequest-examples) event type in Insights.
+    Enable or disable reporting successful HTTP requests to the [MobileRequest](/docs/insights/nrql-new-relic-query-language/nrql-query-examples/insights-query-examples-new-relic-mobile#mobilerequest-examples) event type.
 
     Available for Android agent version 5.14.0 or higher.
 
@@ -380,7 +380,7 @@ All settings, including the call to invoke the agent, are called in the `onCreat
     id="ff-networkErrorRequests"
     title="FeatureFlag.NetworkErrorRequests"
   >
-    Enable or disable reporting network and Http request errors to [MobileRequestError](/docs/insights/nrql-new-relic-query-language/nrql-query-examples/insights-query-examples-new-relic-mobile#mobilerequesterror-examples) event type in Insights.
+    Enable or disable reporting network and HTTP request errors to the [MobileRequestError](/docs/insights/nrql-new-relic-query-language/nrql-query-examples/insights-query-examples-new-relic-mobile#mobilerequesterror-examples) event type.
 
     Available for Android agent version 5.11.0 or higher.
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-sdk-api-guide.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-sdk-api-guide.mdx
@@ -26,7 +26,7 @@ The Android agent provides an SDK API to set up [custom instrumentation](/docs/m
 * [Instrument your own code](#instrumenting).
 * [Create](#creating), [name](#naming), and [end](#ending) interaction traces from events in your mobile app.
 * [Record custom metrics](#create-custom).
-* [Send custom attributes and events to New Relic Insights](#attributes-events-insights).
+* [Send custom attributes and events](#attributes-events-insights).
 * [Track networking from libraries not supported automatically](#track-custom).
 
 ## Install the SDK [#installing]

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/currentsessionid-android-sdk-api.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/currentsessionid-android-sdk-api.mdx
@@ -28,7 +28,7 @@ Compatible with all agent versions.
 
 Returns the current session ID. This method is useful for consolidating monitoring of app data (not just New Relic data) based on a single session definition and identifier. For example, you might want to use the same identifier for marketing analytics, or user analytics.
 
-For more context on how to use this API, see [Send custom attributes and events to Insights](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#attributes-events-insights).
+For more context on how to use this API, see [Send custom attributes and events](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#attributes-events-insights).
 
 ## Return values
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/increment-attribute.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/increment-attribute.mdx
@@ -28,7 +28,7 @@ Agent version 5.0.0 or higher.
 
 When passed with only a name value, this method increments the count for the specified attribute by 1. If the attribute does not exist, it creates the attribute with a value of 1. When passed an optional float value, it increments the count for the specified attribute by the float value.
 
-For context on how to use this API, see [Send custom attributes and events to Insights](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#attributes-events-insights).
+For context on how to use this API, see [Send custom attributes and events](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#attributes-events-insights).
 
 ## Parameters
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordbreadcrumb.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordbreadcrumb.mdx
@@ -25,11 +25,11 @@ Agent version 5.13.0 or higher.
 
 ## Description
 
-This call creates and records a `MobileBreadcrumb` event, which can be found in Insights and in the [crash event trail](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/mobile-crash-event-trail). Mobile breadcrumbs are useful for crash analysis; they should be created for app activity that may be helpful for troubleshooting crashes.
+This call creates and records a `MobileBreadcrumb` event, which can be queried with NRQL and in the [crash event trail](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/mobile-crash-event-trail). Mobile breadcrumbs are useful for crash analysis; they should be created for app activity that may be helpful for troubleshooting crashes.
 
 In addition to whatever custom attributes you choose, the event will also have associated [session attributes](/docs/insights/explore-data/attributes/mobile-default-attributes-insights#mobile-list). Unlike with using [`setAttribute`](/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-attribute), adding attributes to a breadcrumb event adds them only to that event; they are not session attributes.
 
-For related Android SDK API calls, see [Send custom attributes and events to Insights](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/guide-custom-instrumentation-api#send-insights).
+For related Android SDK API calls, see [Send custom attributes and events](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/guide-custom-instrumentation-api#send-insights).
 
 ## Parameters
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordcustomevent-android-sdk-api.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordcustomevent-android-sdk-api.mdx
@@ -6,7 +6,7 @@ tags:
   - Mobile monitoring
   - New Relic Mobile Android
   - Android SDK API
-metaDescription: 'New Relic API for Android mobile app monitoring: record a custom event for New Relic Insights.'
+metaDescription: 'New Relic API for Android mobile app monitoring: record a custom event.'
 redirects:
   - /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordevent-android-agent-api
   - /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/record-event
@@ -38,10 +38,10 @@ Important considerations and best practices include:
 <Callout variant="important">
   As of New Relic [Android agent version 5.12.0](/docs/release-notes/mobile-release-notes/android-release-notes/android-5120), the `recordEvent` method is deprecated and replaced with `recordCustomEvent`. The `recordEvent` method will continue to work for an unspecified period of time, but if your app contains `recordEvent` methods, New Relic recommends you replace them.
 
-  Updating these methods will affect any Insights queries and dashboards that use the deprecated event types. Be sure to adjust your NRQL queries and dashboards as needed.
+  Updating these methods will affect any NRQL queries and dashboards that use the deprecated event types. Be sure to adjust your NRQL queries and dashboards as needed.
 </Callout>
 
-For more on other Android APIs, see [Send custom attributes and events to Insights](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/guide-custom-instrumentation-api#send-insights).
+For more on other Android APIs, see [Send custom attributes and events](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/guide-custom-instrumentation-api#send-insights).
 
 ## Parameters
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordmetric-android-sdk-api.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordmetric-android-sdk-api.mdx
@@ -40,8 +40,6 @@ To get the most out of your metrics, follow these guidelines to create clear, co
 
 The `category` is also required; it is displayed in the UI and is useful for organizing custom metrics if you have many of them. It can be a custom category or it can be a predefined category using the [`MetricCategory` enum](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#cat).
 
-To view your custom metrics, use [Insights Metric Explorer](/docs/insights/new-relic-insights/explore/metric-data-explorer-search-chart-metrics-sent-new-relic-agents) to search metrics, create customizable charts, and add those charts to Insights dashboards. For more information, see the [Android SDK API usage guide](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api).
-
 ## Parameters
 
 This call accepts four sets of parameters.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/remove-all-attributes.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/remove-all-attributes.mdx
@@ -28,7 +28,7 @@ Agent version 5.0.0 or higher.
 
 Removes all attributes from the session.
 
-For context on how to use this API, see [Send custom attributes and events to Insights](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#attributes-events-insights).
+For context on how to use this API, see [Send custom attributes and events](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#attributes-events-insights).
 
 ## Return values
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/remove-attribute.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/remove-attribute.mdx
@@ -28,7 +28,7 @@ Agent version 5.0.0 or higher.
 
 This method removes the attribute specified by the name string.
 
-For context on how to use this API, see [Send custom attributes and events to Insights](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#attributes-events-insights).
+For context on how to use this API, see [Send custom attributes and events](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#attributes-events-insights).
 
 ## Parameters
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-attribute.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-attribute.mdx
@@ -6,7 +6,7 @@ tags:
   - Mobile monitoring
   - New Relic Mobile Android
   - Android SDK API
-metaDescription: 'New Relic API for Android mobile app monitoring: create an attribute for sending data to New Relic Insights.'
+metaDescription: 'New Relic API for Android mobile app monitoring: create a custom attribute to annotate your data.'
 redirects:
   - /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/setattribute-android-agent-api
   - /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/setattribute-android-sdk-api
@@ -30,7 +30,7 @@ This static method creates a session-level custom [attribute](/docs/insights/exp
 
 For more context on how to use this API, see the [Android API guide](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#attributes-events-insights).
 
-You can override any of the [MobileSession default attributes](/docs/insights/insights-data-sources/default-attributes/mobile-default-attributes-insights) for New Relic Insights except:
+You can override any of the [MobileSession default attributes](/docs/insights/insights-data-sources/default-attributes/mobile-default-attributes-insights) except:
 
 * `appId`
 * `appName`

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-max-event-buffer-time.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-max-event-buffer-time.mdx
@@ -40,7 +40,7 @@ See also [`setMaxEventPoolSize()`](/docs/mobile-monitoring/new-relic-mobile-andr
   Be aware that reporting a large number of events, or reporting events too frequently, may impact app performance.
 </Callout>
 
-For context on how to use this API, see [Send custom attributes and events to Insights](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#attributes-events-insights).
+For context on how to use this API, see [Send custom attributes and events](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#attributes-events-insights).
 
 ## Parameters
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-max-event-pool-size.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-max-event-pool-size.mdx
@@ -38,7 +38,7 @@ See also [`setMaxEventBufferTime()`](/docs/mobile-monitoring/new-relic-mobile-an
   Be aware that reporting a large number of events, or reporting events too frequently, may impact app performance.
 </Callout>
 
-For context on how to use this API, see [Send custom attributes and events to Insights](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#attributes-events-insights).
+For context on how to use this API, see [Send custom attributes and events](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#attributes-events-insights).
 
 ## Parameters
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-user-id.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-user-id.mdx
@@ -26,7 +26,7 @@ Agent version 5.0.0 or higher.
 
 ## Description
 
-This method sets a custom user identifier value to associate mobile user sessions with New Relic Insights events and attributes. This method can be called anytime after the New Relic Android agent starts.
+This method sets a custom user identifier value to associate mobile user sessions with events and attributes. This method can be called anytime after the New Relic Android agent starts.
 
 A user identifier is useful for several reasons. Using the [Crash Analysis UI](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes), you can:
 
@@ -35,7 +35,7 @@ A user identifier is useful for several reasons. Using the [Crash Analysis UI](/
 
 If you do not want to explicitly identify users because of privacy rules, this method is still useful when tracking user segments, such as paid vs. free end users, or registered vs. unregistered users. This allows you to filter or facet on the number and types of crashes experienced by each segment, and do outreach based on that segment.
 
-For more context on how to use this API, see [Send custom attributes and events to Insights](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#attributes-events-insights).
+For more context on how to use this API, see [Send custom attributes and events](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#attributes-events-insights).
 
 ## Parameters
 
@@ -75,7 +75,7 @@ Returns `true` if it succeeds, or `false` if it doesn't.
 
 ### Set user ID
 
-Set a user identifier to associate user session with New Relic Insights events and attributes:
+Set a user identifier to associate user session with events and attributes:
 
 ```
 boolean userIdWasSet = NewRelic.setUserId("SampleUserName");

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/introduction-new-relic-mobile-android.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/introduction-new-relic-mobile-android.mdx
@@ -21,7 +21,7 @@ Follow the [Android installation and configuration procedures](/docs/mobile-moni
 
 ## Extend your instrumentation [#extend]
 
-After you install the agent, extend the agent's instrumentation by using the [mobile monitoring UI](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/mobile-apps-index) and following up on information in [New Relic Insights](/docs/insights/use-insights-ui/getting-started/introduction-new-relic-insights).
+After you install the agent, you can extend the agent's instrumentation:
 
 <table>
   <thead>
@@ -79,7 +79,7 @@ After you install the agent, extend the agent's instrumentation by using the [mo
       </td>
 
       <td>
-        To view more information about crashes, [create NRQL queries to review Insights charts](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes#insights) related to crash data.
+        To view more information about crashes, [create NRQL queries](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes#insights) related to crash data.
       </td>
     </tr>
 
@@ -93,7 +93,7 @@ After you install the agent, extend the agent's instrumentation by using the [mo
       </td>
 
       <td>
-        Then, view those [custom events and attributes in New Relic Insights](/docs/insights/insights-data-sources/custom-events/insert-custom-events-attributes-mobile-data).
+        Then, view those [custom events and attributes](/docs/insights/insights-data-sources/custom-events/insert-custom-events-attributes-mobile-data).
       </td>
     </tr>
 
@@ -107,7 +107,7 @@ After you install the agent, extend the agent's instrumentation by using the [mo
       </td>
 
       <td>
-        To further improve performance, review [MobileHandledException](/docs/insights/insights-data-sources/default-data/mobile-events-attributes#mobilehandledexception-attributes) event records in New Relic Insights.
+        To further improve performance, review [MobileHandledException](/docs/insights/insights-data-sources/default-data/mobile-events-attributes#mobilehandledexception-attributes) event records.
       </td>
     </tr>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/android-agent-crash-reporting.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/android-agent-crash-reporting.mdx
@@ -11,7 +11,7 @@ redirects:
 
 By default, mobile monitoring enables crash reporting for your mobile applications to help track and diagnose crashes. When an Android application crashes, the agent uploads a crash report to the New Relic [collector](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#collector). The crash details will then be processed and de-obfuscated automatically if you are using ProGuard or DexGuard.
 
-You can view detailed information about crashes in the [**Crash analysis** UI](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes), or receive crash notifications by [email](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/receive-crash-notifications-email). You can also explore the crash data deeper with [New Relic Insights](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes#insights), or [integrate with ticketing systems](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/file-tickets-mobile-app-crashes) for further investigation.
+You can view detailed information about crashes in the [**Crash analysis** UI](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes), or receive crash notifications by [email](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/receive-crash-notifications-email). You can also [integrate with ticketing systems](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/file-tickets-mobile-app-crashes) for further investigation.
 
 ## Upload the ProGuard or DexGuard file [#upload-proguard]
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-new-relic-plugin-android-instant-apps.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-new-relic-plugin-android-instant-apps.mdx
@@ -114,4 +114,4 @@ If you are not whether the agent is auto-instrumenting an instant app project, t
    * ```
      BuildId<var>[1a2b34c5-def6-7890-g123-h4567890a]</var>
      ```
-3. The agent will add an attribute named `'instantApp'` to the app's Insights session attributes if the app appears to be an instant app.
+3. The agent will add an attribute named `'instantApp'` to the app's session attributes if the app appears to be an instant app.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/get-started/introduction-new-relic-cordova.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/get-started/introduction-new-relic-cordova.mdx
@@ -366,7 +366,7 @@ The Cordova plugin collects the following attributes:
       <td>
         The length of time for which the user used the application in seconds. If the session crashes, `sessionDuration` is not captured (although other events and attributes are still recorded).
 
-        For sessions longer than 10 minutes, events in the Interaction and Custom [event categories](#mobile-category) are sent to Insights while the session is ongoing, and therefore do not have `sessionDuration` attributes. Events recorded near the end of the session will include the duration, as will the Session event category.
+        For sessions longer than 10 minutes, events in the Interaction and Custom [event categories](#mobile-category) are sent to New Relic while the session is ongoing, and therefore do not have `sessionDuration` attributes. Events recorded near the end of the session will include the duration, as will the Session event category.
       </td>
     </tr>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/get-started/introduction-new-relic-mobile-ios.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/get-started/introduction-new-relic-mobile-ios.mdx
@@ -84,7 +84,7 @@ After you install the agent, you can extend the agent's default instrumentation 
       </td>
 
       <td>
-        To view more information about crashes, [create NRQL queries to review Insights charts](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes#insights) related to crash data.
+        To view more information about crashes, [create NRQL queries](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes#insights) related to crash data.
       </td>
     </tr>
 
@@ -98,7 +98,7 @@ After you install the agent, you can extend the agent's default instrumentation 
       </td>
 
       <td>
-        Then, view those [custom events and attributes in New Relic Insights](/docs/insights/insights-data-sources/custom-events/insert-custom-events-attributes-mobile-data).
+        Then, view those [custom events and attributes](/docs/insights/insights-data-sources/custom-events/insert-custom-events-attributes-mobile-data).
       </td>
     </tr>
 
@@ -112,7 +112,7 @@ After you install the agent, you can extend the agent's default instrumentation 
       </td>
 
       <td>
-        To further improve performance, review [MobileHandledException](/docs/insights/insights-data-sources/default-data/mobile-events-attributes#mobilehandledexception-attributes) event records in New Relic Insights.
+        To further improve performance, review [MobileHandledException](/docs/insights/insights-data-sources/default-data/mobile-events-attributes#mobilehandledexception-attributes) event records.
       </td>
     </tr>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/current-session-id.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/current-session-id.mdx
@@ -28,7 +28,7 @@ Compatible with all agent versions.
 
 Returns the current session ID. This method is useful for consolidating monitoring of app data (not just New Relic data) based on a single session definition and identifier. For example, you might want to use the same identifier for marketing analytics or user analytics.
 
-For context on how to use this API, see the documentation about sending custom attributes and events to Insights for:
+For context on how to use this API, see the documentation about sending custom attributes and events:
 
 * [Objective-C](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/work-ios-sdk-api#objc-custom-att-events)
 * [Swift](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/work-ios-sdk-api#swift-custom-att-events)

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/increment-attribute.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/increment-attribute.mdx
@@ -28,7 +28,7 @@ Compatible with all agent versions.
 
 When passed with only a name value, this method increments the count for the specified session attribute by 1. If the attribute does not exist, it creates the attribute with a value of 1. When passed an optional float value, it increments the count for the specified attribute by the float value.
 
-For context on how to use this API, see the documentation about sending custom attributes and events to Insights for:
+For context on how to use this API, see the documentation about sending custom attributes and events:
 
 * [Objective-C](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/work-ios-sdk-api#objc-custom-att-events)
 * [Swift](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/work-ios-sdk-api#swift-custom-att-events)

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/ios-sdk-api-guide.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/ios-sdk-api-guide.mdx
@@ -21,7 +21,7 @@ Use the iOS SDK API to [add custom data](/docs/mobile-monitoring/new-relic-mobil
 * Instrument your own code.
 * Start and stop interaction traces from events in your mobile app.
 * Record custom metrics.
-* Send custom attributes and events to Insights.
+* Send custom attributes and events
 * Track networking from libraries not supported automatically.
 * Set a custom identifier value with [Objective-C](#setUserId) or [Swift](#setUserId-swift) to associate user sessions with analysis events and attributes (iOS SDK [version 5.9.0 or higher](/docs/release-notes/mobile-release-notes/ios-release-notes)).
 
@@ -38,7 +38,7 @@ This document contains the iOS SDK instrumentation requirements for:
 * [Objective C](#objc-instrumentation)
 * [Swift](#swift-instrumentation)
 
-For details about the available methods for [custom attributes and events you can send to to New Relic Insights](/docs/insights/new-relic-insights/adding-querying-data/custom-attributes-events-new-relic-mobile), see the [iOS SDK API reference](/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api). You can also [configure feature flags](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/ios-agent-configuration-feature-flags) for:
+For details about the available methods for [custom attributes and events](/docs/insights/new-relic-insights/adding-querying-data/custom-attributes-events-new-relic-mobile), see the [iOS SDK API reference](/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api). You can also [configure feature flags](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/ios-agent-configuration-feature-flags) for:
 
 * Objective-C
 * Swift

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/record-breadcrumb.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/record-breadcrumb.mdx
@@ -26,11 +26,11 @@ Agent [version 5.13.0 or higher](/docs/release-notes/mobile-apps-release-notes/n
 
 ## Description
 
-This call creates and records a `MobileBreadcrumb` event, which can be found in Insights and in the [crash event trail](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/mobile-crash-event-trail). Mobile breadcrumbs are useful for crash analysis; create them for app activity that you think will help you troubleshoot crashes.
+This call creates and records a `MobileBreadcrumb` event, which can be queried with NRQL and in the [crash event trail](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/mobile-crash-event-trail). Mobile breadcrumbs are useful for crash analysis; create them for app activity that you think will help you troubleshoot crashes.
 
 In addition to whatever custom attributes you choose, the event will also have associated [session attributes](/docs/insights/explore-data/attributes/mobile-default-attributes-insights#mobile-list). Unlike using [`setAttribute`](/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/set-attribute), adding attributes to a breadcrumb event adds them only to that event; they are not session attributes.
 
-Using this call has the same result as using the [`recordCustomEvent` call](/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recordcustomevent-ios-sdk-ap) with `MobileBreadcrumb` as the event type. For context on how to use this API, see the documentation about sending custom attributes and events to Insights for:
+Using this call has the same result as using the [`recordCustomEvent` call](/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recordcustomevent-ios-sdk-ap) with `MobileBreadcrumb` as the event type. For context on how to use this API, see the documentation about sending custom attributes and events:
 
 * [Objective-C](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/work-ios-sdk-api#objc-custom-att-events)
 * [Swift](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/work-ios-sdk-api#swift-custom-att-events)

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/record-handled-exception.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/record-handled-exception.mdx
@@ -6,7 +6,7 @@ tags:
   - Mobile monitoring
   - New Relic Mobile iOS
   - iOS SDK API
-metaDescription: New Relic for iOS mobile app monitoring API to analyze handled exceptions and thrown exceptions via New Relic Insights.
+metaDescription: New Relic for iOS mobile app monitoring API to analyze handled exceptions and thrown exceptions.
 redirects:
   - /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recordhandledexception-ios-sdk-api
 ---

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recordcustomevent-ios-sdk-api.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recordcustomevent-ios-sdk-api.mdx
@@ -6,7 +6,7 @@ tags:
   - Mobile monitoring
   - New Relic Mobile iOS
   - iOS SDK API
-metaDescription: New Relic for iOS mobile app monitoring API to record a custom event for New Relic Insights.
+metaDescription: New Relic for iOS mobile app monitoring API to record a custom event.
 redirects:
   - /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recordcustomevent-ios-sdk-ap
   - /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/record-custom-event

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recorderror-ios-sdk-api.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recorderror-ios-sdk-api.mdx
@@ -6,7 +6,7 @@ tags:
   - Mobile monitoring
   - New Relic Mobile iOS
   - iOS SDK API
-metaDescription: New Relic for iOS mobile app monitoring API to analyze handled exceptions and thrown exceptions via New Relic Insights.
+metaDescription: New Relic for iOS mobile app monitoring API to analyze handled exceptions and thrown exceptions.
 ---
 
 ## Syntax

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recordmetric-ios-sdk-api.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recordmetric-ios-sdk-api.mdx
@@ -37,8 +37,6 @@ To get the most out of your metrics, follow these guidelines to create clear, co
 
 The `category` is also required; it is displayed in the UI and is useful for organizing custom metrics if you have many of them. It can be a custom category or it can be a predefined category using the [`MetricCategory` enum](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#cat).
 
-To view your custom metrics, use [Insights Metric Explorer](/docs/insights/new-relic-insights/explore/metric-data-explorer-search-chart-metrics-sent-new-relic-agents) to search metrics, create customizable charts, and add those charts to Insights dashboards.
-
 For variations that accept additional arguments and give you more control over the metrics you record, see **NewRelic.h**. For more information about using this API, see the [iOS SDK API usage guide](/docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-sdk-api-guide).
 
 ## Parameters

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/remove-all-attributes.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/remove-all-attributes.mdx
@@ -28,7 +28,7 @@ Compatible with all agent versions.
 
 Removes all attributes from the session.
 
-For context on how to use this API, see the documentation about sending custom attributes and events to Insights for:
+For context on how to use this API, see the documentation about sending custom attributes and events:
 
 * [Objective-C](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/work-ios-sdk-api#objc-custom-att-events)
 * [Swift](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/work-ios-sdk-api#swift-custom-att-events)

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/remove-attribute.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/remove-attribute.mdx
@@ -28,7 +28,7 @@ Compatible with all agent versions.
 
 This method removes the attribute specified by the name string from the session.
 
-For context on how to use this API, see the documentation about sending custom attributes and events to Insights for:
+For context on how to use this API, see the documentation about sending custom attributes and events:
 
 * [Objective-C](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/work-ios-sdk-api#objc-custom-att-events)
 * [Swift](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/work-ios-sdk-api#swift-custom-att-events)

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/set-attribute.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/set-attribute.mdx
@@ -6,7 +6,7 @@ tags:
   - Mobile monitoring
   - New Relic Mobile iOS
   - iOS SDK API
-metaDescription: New Relic for iOS mobile app monitoring API to create an attribute for sending data to New Relic Insights.
+metaDescription: New Relic for iOS mobile app monitoring API to create a custom attribute.
 redirects:
   - /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/setattribute-ios-sdk-api
 ---
@@ -30,7 +30,7 @@ This static method creates a session-level custom [attribute](/docs/insights/exp
 
 For more context on how to use this, see the [iOS API guide](/docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-sdk-api-guide).
 
-You can override any of the [MobileSession default attributes](/docs/insights/insights-data-sources/default-attributes/mobile-default-attributes-insights) for New Relic Insights except:
+You can override any of the [MobileSession default attributes](/docs/insights/insights-data-sources/default-attributes/mobile-default-attributes-insights) except:
 
 * `appId`
 * `appName`
@@ -57,7 +57,7 @@ You can override any of the [MobileSession default attributes](/docs/insights/in
 * `uuid`
 * Anything prefixed with `NewRelic`
 
-For context on how to use this API, see the documentation about sending custom attributes and events to Insights for:
+For context on how to use this API, see the documentation about sending custom attributes and events:
 
 * [Objective-C](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/work-ios-sdk-api#objc-custom-att-events)
 * [Swift](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/work-ios-sdk-api#swift-custom-att-events)

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/set-max-event-buffer-time.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/set-max-event-buffer-time.mdx
@@ -37,7 +37,7 @@ In other words, when the oldest event timestamp exceeds this custom configured t
 
 See also [`setMaxEventPoolSize()`](/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/setmaxeventpoolsize-ios-sdk-api), which lets you change the maximum size of the event pool.
 
-For context on how to use this API, see the documentation about sending custom attributes and events to Insights for:
+For context on how to use this API, see the documentation about sending custom attributes and events:
 
 * [Objective-C](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/work-ios-sdk-api#objc-custom-att-events)
 * [Swift](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/work-ios-sdk-api#swift-custom-att-events)

--- a/src/data-dictionary/events/InfrastructureEvent/provider.md
+++ b/src/data-dictionary/events/InfrastructureEvent/provider.md
@@ -7,10 +7,10 @@ events:
 
 For integrations that use generic event types (like the DatastoreSample event), the provider value specifies the source of the data (the service, or a sub-category of data from that service).
 
-Some Insights [events](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#event) are generic and are used by several integrations. For example, the `DatastoreSample` event is used by several integrations, including the [AWS DynamoDB integration](/docs/integrations/amazon-integrations/aws-integrations-list/aws-dynamodb-monitoring-integration) and the [AWS RDS integration](/docs/integrations/amazon-integrations/aws-integrations-list/aws-rds-monitoring-integration). In these cases, the `provider` attribute value represents the source of that attribute. This will usually be the service that data comes from or, for integrations that use several provider values, a certain sub-category of data from that service.
+Some [events](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#event) are generic and are used by several integrations. For example, the `DatastoreSample` event is used by several integrations, including the [AWS DynamoDB integration](/docs/integrations/amazon-integrations/aws-integrations-list/aws-dynamodb-monitoring-integration) and the [AWS RDS integration](/docs/integrations/amazon-integrations/aws-integrations-list/aws-rds-monitoring-integration). In these cases, the `provider` attribute value represents the source of that attribute. This will usually be the service that data comes from or, for integrations that use several provider values, a certain sub-category of data from that service.
 
 When a provider value is present for a generic event, that event will have additional integration-specific attributes attached to it.
 
-Here’s an example of an Insights NRQL query that returns the attributes present for a `DatastoreSample` event reported by the AWS RDS integration:
+Here’s an example of a NRQL query that returns the attributes present for a `DatastoreSample` event reported by the AWS RDS integration:
 
 SELECT \* from DatastoreSample where provider = 'RdsDbCluster'

--- a/src/data-dictionary/events/MobileSession/sessionDuration.md
+++ b/src/data-dictionary/events/MobileSession/sessionDuration.md
@@ -8,4 +8,4 @@ events:
 
 The length of time for which the user used the application in seconds. If the session crashes, sessionDuration is not captured (although other events and attributes are still recorded).
 
-For sessions longer than 10 minutes, events in the Interaction and Custom event categories are sent to Insights while the session is ongoing, and therefore do not have sessionDuration attributes. Events recorded near the end of the session will include the duration, as will the Session event category.
+For sessions longer than 10 minutes, events in the Interaction and Custom event categories are sent to New Relic while the session is ongoing, and therefore do not have sessionDuration attributes. Events recorded near the end of the session will include the duration, as will the Session event category.

--- a/src/data-dictionary/events/NrDailyUsage/NrDailyUsage.event-definition.md
+++ b/src/data-dictionary/events/NrDailyUsage/NrDailyUsage.event-definition.md
@@ -5,4 +5,4 @@ dataSources:
   - Account Usage
 ---
 
-Once per day, New Relic products generate a NrDailyUsage Insights event. Use the productLine attribute to identify and filter for the specific product's usage.
+Once per day, New Relic products generate a NrDailyUsage event. Use the productLine attribute to identify and filter for the specific product's usage.

--- a/src/data-dictionary/events/NrDailyUsage/insightsIncludedRetentionInHours.md
+++ b/src/data-dictionary/events/NrDailyUsage/insightsIncludedRetentionInHours.md
@@ -5,6 +5,6 @@ events:
   - NrDailyUsage
 ---
 
-Number of hours for which events of the given insightsEventNamespace are stored but are not counted toward your paid Insights Pro subscription.
+Number of hours for which events of the given insightsEventNamespace are stored but are not counted toward your paid  Pro subscription.
 
-For more information about the data reported in nrDailyUsage, see [Insights usage: Attributes and queries](https://docs.newrelic.com/docs/accounts/new-relic-account-usage/insights-usage/insights-usage-attributes-queries).
+For more information about the data reported in nrDailyUsage, see [ usage: Attributes and queries](https://docs.newrelic.com/docs/accounts/new-relic-account-usage/insights-usage/insights-usage-attributes-queries).

--- a/src/data-dictionary/events/PageAction/PageAction.event-definition.md
+++ b/src/data-dictionary/events/PageAction/PageAction.event-definition.md
@@ -5,4 +5,4 @@ dataSources:
   - Browser agent
 ---
 
-The Browser PageAction event is the result of the addPageAction API call that sends a user-defined name and optional attributes to Insights, along with several default attributes, such as app and geographic data. It is used to capture any event that is not already tracked automatically by the Browser agent, such as clicking a Subscribe button or accessing a tutorial.
+The Browser PageAction event is the result of the addPageAction API call that sends a user-defined name and optional attributes, along with several default attributes, such as app and geographic data. It is used to capture any event that is not already tracked automatically by the Browser agent, such as clicking a Subscribe button or accessing a tutorial.

--- a/src/data-dictionary/events/StorageSample/isReadOnly.md
+++ b/src/data-dictionary/events/StorageSample/isReadOnly.md
@@ -5,4 +5,4 @@ events:
   - StorageSample
 ---
 
-If the system is set to be read-only, this value will be true, otherwise false. These values are string literals, not booleans, to allow for faceting functionality in New Relic Insights.
+If the system is set to be read-only, this value will be true, otherwise false. These values are string literals, not booleans, to allow for faceting.


### PR DESCRIPTION
Remove numerous stray references to Insights. There are still a few, notably:

* Dashboard API
* Insights Query API
* Pricing and billing
* A handful of weird attributes https://docs.newrelic.com/attribute-dictionary/?attributeSearch=insights