### PR TITLE
Update whats-new-05-25: Link image to blog post

### DIFF
--- a/src/content/whats-new/2022/05/whats-new-05-25-fs-recap-blog.md
+++ b/src/content/whats-new/2022/05/whats-new-05-25-fs-recap-blog.md
@@ -6,7 +6,7 @@ isFeatured: true
 learnMoreLink: 'https://newrelic.com/blog/nerdlog/futurestack-2022-recap' 
 ---
 
-![FutureStack 2022 blog graphic, green logo](./images/FS_Blog_Graphic_520x250.png "FutureStack 2022 blog graphic, green logo")
+[![FutureStack 2022 blog graphic, green logo](./images/FS_Blog_Graphic_520x250.png "FutureStack 2022 blog graphic, green logo")](https://newrelic.com/blog/nerdlog/futurestack-2022-recap)
 
 At FutureStack 2022, we announced more than 30 capabilities that make it even easier for your teams to monitor, debug, and improve your entire stack—and embed observability practices and telemetry data throughout the entire software development lifecycle. The lineup included:
 


### PR DESCRIPTION
In the in-app version of this post, the image is linked to this URL: https://one.newrelic.com/nr1-core/5f39d192fe7bd3f1de03301b982acf9c/1ff84/FS_Blog_Graphic_520x250.png - and returns this error message: 404 - Nerdlet "5f39d192fe7bd3f1de03301b982acf9c.1ff84" not found.

In the docs version of this post, the image is linked to this URL: https://docs.newrelic.com/static/5f39d192fe7bd3f1de03301b982acf9c/1ff84/FS_Blog_Graphic_520x250.png - which shows up correctly. 

If we link the image to the blog URL, will this send users to the blog from both locations - and eliminate the 404 error associated with the in-app version?

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.