### PR TITLE
Remove callout for --devel flag

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
@@ -119,10 +119,6 @@ helm upgrade --install newrelic newrelic/nri-bundle \
 --debug
 ```
 
-<Callout variant="tip">
-  By specifying `--devel`, you will be installing the version 3 of our solution, currently in Beta and scheduled to be generally available during Spring 2022. We strongly encourage you to try it out as it includes significant improvements over the v2. [See what's changed](/docs/kubernetes-pixie/kubernetes-integration/get-started/changes-since-v3).
-</Callout>
-
 Please notice and adjust the following flags:
 
 * `global.licenseKey=YOUR_NEW_RELIC_LICENSE_KEY`: Must be set to a valid License Key for your account.


### PR DESCRIPTION
This is a follow-up to PR #7740. We need to also remove the `--devel` callout.