### PR TITLE
Fix(APM): Broken link

### DIFF
--- a/src/content/docs/apm/agents/manage-apm-agents/app-naming/use-multiple-names-app.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/app-naming/use-multiple-names-app.mdx
@@ -283,6 +283,6 @@ Here are examples of how you could use multiple rollup names for a single app.
 
 ## Other options to organize your apps [#other]
 
-If you do not want to apply multiple names to your apps, you can organize them with [tags](docs/new-relic-one/use-new-relic-one/core-concepts/use-tags-help-organize-find-your-data). This allows you to easily sort, filter, and page through them from their product index pages in the New Relic UI.
+If you do not want to apply multiple names to your apps, you can organize them with [tags](/docs/new-relic-one/use-new-relic-one/core-concepts/use-tags-help-organize-find-your-data). This allows you to easily sort, filter, and page through them from their product index pages in the New Relic UI.
 
 You can also set distinct performance thresholds for each environment with [alert conditions](/docs/alerts/new-relic-alerts/getting-started/alerting-new-relic) and [key transactions](/docs/apm/transactions/key-transactions/key-transactions-tracking-important-transactions-or-events). These thresholds will apply to the individual apps, while the overall app will not have its own thresholds. The overall app will treat incoming data according to the threshold for the relevant enviroment.


### PR DESCRIPTION
The path was missing an initital `/`. This came in as a hero request.

