### PR TITLE
Remove hostmetrics to avoid doubledipping metrics

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes.mdx
@@ -132,7 +132,7 @@ exporters:
 service:
   pipelines:
     metrics:
-      receivers: [ hostmetrics, otlp ]
+      receivers: [ otlp ]
       processors: [ resourcedetection, k8sattributes, resource, cumulativetodelta, batch ]
       exporters: [ otlp ]
     traces:


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
Right now `hostmetrics` being present in the collector will lead to harvesting metrics already collected by the infra agent, so I propose we remove it from the docs. 