### PR TITLE
fix(npm): Revert accidental rollback

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-syslog-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-syslog-monitoring.mdx
@@ -154,7 +154,7 @@ Set up your network devices so they send syslog data to New Relic.
 </table>
 
 <Callout variant="tip">
-  The default listening port for **ktranslate** is `5143 (TCP/UDP)`. If you need to use the default syslog port of `514` (or any other port), you can do so by providing a new listening endpoint during Docker runtime. For example: `-syslog="0.0.0.0:514"`.
+The default listening port for **ktranslate** is `5143 (TCP/UDP)`. If you need to use the default syslog port of `514`, you can do so by removing `--net=host` from your run command, replacing it with `-p 514:5143/udp`. To bind the listener to a port above `1024`, add `-syslog.source="0.0.0.0:<port>"` to the end of the run command instead.
 </Callout>
 
 ## Set up network syslog monitoring in New Relic [#setup-network-syslog-monitoring]


### PR DESCRIPTION
Accidentally rolled back an update from #7460 during the branding sweep. This brings it back