### PR TITLE
Remove outdated reference to September 2022

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-traces.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-traces.mdx
@@ -10,7 +10,7 @@ metaDescription: Here are some tips for working with OpenTelemetry traces and Ne
 Familiarize yourself with these OpenTelemetry trace topics to ensure your traces and spans appear in New Relic.
 
 <Callout variant="important">
-As the OpenTelemetry Protocol matures and more components are declared [stable](https://github.com/open-telemetry/opentelemetry-proto#maturity-level), we intend to move the version supported by our OTLP endpoints from v0.10.0 to a more recent release, at least v0.16.0, before September 2022.
+As the OpenTelemetry Protocol matures and more components are declared [stable](https://github.com/open-telemetry/opentelemetry-proto#maturity-level), we intend to move the version supported by our OTLP endpoints from v0.10.0 to a more recent release in the near future.
 
 Additional communication will be forthcoming regarding the EOL timeline for v0.10.0 support and actions you can take to minimize disruption as the community moves toward a more stable release of OTLP.
 </Callout>


### PR DESCRIPTION
This change wasn't completed by September 2022, so removing this outdated reference. It's still actively being worked on but we don't have a firm target date, so changing from a specific month to "in the near future".