### PR TITLE
fix: Fix broken code format

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
@@ -990,9 +990,11 @@ This section includes various ways to configure New Relic features to optimize d
   This field works in a way similar to grep -E in Unix systems. For example, for a given file being captured, you can filter for records containing either `WARN` or `ERROR` using:
     
   ```
-  - name: only-records-with-warn-and-error
-  file: /var/log/logFile.log
-  pattern: WARN|ERROR
+
+    - name: only-records-with-warn-and-error
+      file: /var/log/logFile.log
+      pattern: WARN|ERROR
+
   ```
 
   If you have pre-written Fluentd configurations for Fluentbit that do valuable filtering or parsing, you can import them into our New Relic logging config. To do this, use the `config_file` and `parsers` parameters in any `.yaml` file in your `logging.d` folder: 


### PR DESCRIPTION
I've tweaked this a few times over the past couple of months.  Due to the `-` the block needs some indentation to render correctly.  Any help would be appreciated it.  I will convert it to an image if needed, but prefer a markdown code block.

<img width="931" alt="image" src="https://user-images.githubusercontent.com/8333200/171207996-812e13cc-50a8-4596-999c-50dd9420311a.png">

<img width="838" alt="image" src="https://user-images.githubusercontent.com/8333200/171208027-bbba7251-8c78-4b11-bb43-475e1eee496c.png">
