### PR TITLE
The Ruby agent now supports the "Makara" gem

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/troubleshooting/incompatible-gems.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/troubleshooting/incompatible-gems.mdx
@@ -65,13 +65,4 @@ While New Relic strives to be compatible with all gems, there are some that will
 
     **Solution:** No known workaround. Either remove the `ar-octopus` gem, or continue to use it, in which case no explain plans will be captured.
   </Collapser>
-
-  <Collapser
-    id="makara"
-    title="makara"
-  >
-    **Problem:** The [makara](https://github.com/instacart/makara) gem masks the Ruby agent's ability to detect the database adapter underlying ActiveRecord by modifying the name of the underlying connection. The original adapter name is needed to properly obfuscate queries. Some transaction traces display ActiveRecord content instead of MySQL content.
-
-    **Solution:** No known workaround. Either remove the `makara` gem, or continue to use it. Over-obfuscation will be the expected behavior.
-  </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
Thanks to a community contribution with Ruby agent
[PR #1177](https://github.com/newrelic/newrelic-ruby-agent/pull/1177),
the Makara gem is now supported and can be removed from the incompatible
gems list.