### PR TITLE
Update manage-pixie-memory.mdx

### DIFF
--- a/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/manage-pixie-memory.mdx
+++ b/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/manage-pixie-memory.mdx
@@ -38,7 +38,7 @@ For most clusters, we recommend using the default `2Gi` memory configuration. Ho
 If you want to specify a different memory limit than the default `2Gi` for Pixie's `vizier-pem` agents, you can add the following configuration parameter to your Helm chart during installation. For example, for a `1Gi` memory limit, you'd use:
 
 ```
--set pixie-chart.pemMemoryLimit=1Gi
+--set pixie-chart.pemMemoryLimit=1Gi
 ```
 
 ### Deploy Pixie with a particular memory request [#set-memory-request]


### PR DESCRIPTION
Added missing `-` on `--set`

Command will not work without two dashes.