### PR TITLE
Add CodeStream span attributes to data dictionary.

### DIFF
--- a/src/data-dictionary/events/Span/code.filepath.md
+++ b/src/data-dictionary/events/Span/code.filepath.md
@@ -1,0 +1,7 @@
+---
+name: code.filepath
+type: attribute
+events:
+  - Span
+---
+The absolute path to the source code file where the span's instrumented function is defined. Supports the New Relic CodeStream [code-level metrics integration](/src/content/docs/codestream/how-use-codestream/performance-monitoring).

--- a/src/data-dictionary/events/Span/code.function.md
+++ b/src/data-dictionary/events/Span/code.function.md
@@ -1,0 +1,7 @@
+---
+name: code.function
+type: attribute
+events:
+  - Span
+---
+The name of the instrumented function or method associated with the span. Supports the New Relic CodeStream [code-level metrics integration](/src/content/docs/codestream/how-use-codestream/performance-monitoring).

--- a/src/data-dictionary/events/Span/code.lineno.md
+++ b/src/data-dictionary/events/Span/code.lineno.md
@@ -1,0 +1,7 @@
+---
+name: code.lineno
+type: attribute
+events:
+  - Span
+---
+The line number where the span's instrumented function is defined. Supports the New Relic CodeStream [code-level metrics integration](/src/content/docs/codestream/how-use-codestream/performance-monitoring).

--- a/src/data-dictionary/events/Span/code.namespace.md
+++ b/src/data-dictionary/events/Span/code.namespace.md
@@ -1,0 +1,7 @@
+---
+name: code.namespace
+type: attribute
+events:
+  - Span
+---
+The namespace (class/ module name) in which the span's instrumented function is defined. Supports the New Relic CodeStream [code-level metrics integration](/src/content/docs/codestream/how-use-codestream/performance-monitoring).


### PR DESCRIPTION
This PR documents the four new span attributes that agents have/ will be adding to support the CodeStream code-level metrics integration within the NR  data dictionary: https://docs.newrelic.com/attribute-dictionary/?event=Span.