### PR TITLE
zfs filesystem support in infra-agent (1.26.0)

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -1054,7 +1054,7 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
           </td>
 
           <td>
-            Linux: `["xfs", "btrfs", "ext", "ext2", "ext3", "ext4", "hfs", "vxfs"]` Windows: `["NTFS", "ReFS"]`
+            Linux: `["xfs", "btrfs", "ext", "ext2", "ext3", "ext4", "hfs", "vxfs", "zfs"]` Windows: `["NTFS", "ReFS"]`
           </td>
 
           <td>

--- a/src/content/docs/infrastructure/manage-your-data/data-instrumentation/default-infrastructure-monitoring-data.mdx
+++ b/src/content/docs/infrastructure/manage-your-data/data-instrumentation/default-infrastructure-monitoring-data.mdx
@@ -115,6 +115,7 @@ Select an event name in the following table to see its attributes.
             * `ext3`
             * `ext4`
             * `hfs`
+            * `zfs`
           </Collapser>
 
           <Collapser


### PR DESCRIPTION
## Give us some context

* Infra-agent release 1.26.0 added support for ZFS.