### PR TITLE
docs(Alerts): Fix incorrect link to Alerts NerdGraph API

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
@@ -57,7 +57,7 @@ redirects:
   - /docs/alerts/new-relic-alerts/rest-api-alerts
 ---
 
-Our REST API is New Relic's original API for programmatically configuring New Relic alerting settings ([learn about NerdGraph, our preferred API](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts)). 
+Our REST API is New Relic's original API for programmatically configuring New Relic alerting settings ([learn about NerdGraph, our preferred API](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/alerts-nerdgraph/nerdgraph-api-examples)).
 
 The [REST API Explorer](/docs/apm/apis/api-explorer-v2/getting-started-new-relics-api-explorer) also includes the curl request format, available parameters, potential response status codes, and JSON response structure for each of the available API calls. You can also [create alert conditions in the UI](/docs/alerts/new-relic-alerts/defining-conditions/define-alert-conditions).
 


### PR DESCRIPTION
## Give us some context

Issue #7854 points out an incorrect link in the Alerts REST API docs; the link _was_ pointing to Infrastructure API docs when it _should have been_ pointing to Alerts NerdGraph API docs. This updates the link.