### PR TITLE
fix: Correct regular expression in drop rule

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
@@ -1415,14 +1415,14 @@ Here's some guidance for using drop rules to optimize data ingest for specific t
   The following example could drop about 25% of spans:
 
   ```
-  SELECT * FROM Span WHERE trace.id rlike r'^[0-3].*' and appName = 'myApp'
+  SELECT * FROM Span WHERE trace.id rlike r'.*[0-3]' and appName = 'myApp'
   ```
 
   Useful expressions include:
-  * `^0.*` approximates 6.25%
-  * `^[0-1].*` approximates 12.5%
-  * `^[0-2].*` approximates 18.75%
-  * `^[0-3].*` approximates 25.0%
+  * `r'.*0'` approximates 6.25%
+  * `r'.*[0-1]'` approximates 12.5%
+  * `r'.*[0-2]'` approximates 18.75%
+  * `r'.*[0-3]'` approximates 25.0%
 
   Here's an example of a full mutation:
 
@@ -1431,7 +1431,7 @@ Here's some guidance for using drop rules to optimize data ingest for specific t
       nrqlDropRulesCreate(accountId: <var>YOUR_ACCOUNT_ID</var>, rules: [
           {
               action: DROP_ATTRIBUTES
-              nrql: "SELECT * FROM Span WHERE trace.id rlike r'^[0-3].*' and appName = 'myApp'"
+              nrql: "SELECT * FROM Span WHERE trace.id rlike r'.*[0-3]' and appName = 'myApp'"
               description: "Drops approximately 25% of spans for myApp"
           }
       ])


### PR DESCRIPTION
While a valid regex the existing examples will not have the intended sampling results.
These new expressions have the effect of looking at only the last digit.  These have been tested on some data in the Demotron account.