### PR TITLE
Release, config, and CLM content for Ruby v8.8.0

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -915,6 +915,17 @@ Defines the maximum number of request events reported from a single harvest.
   If `true`, the agent decorates logs with metadata to link to entities, hosts, traces, and spans.
   </Collapser>
 
+  <Collapser id="code_level_metrics-enabled" title="code_level_metrics.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_APPLICATION_CODE_LEVEL_METRICS_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent will report source code level metrics for traced methods
+  </Collapser>
 </CollapserGroup>
 
 ## Attributes

--- a/src/content/docs/apm/agents/ruby-agent/features/ruby-codestream-integration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/features/ruby-codestream-integration.mdx
@@ -1,0 +1,108 @@
+---
+title: New Relic CodeStream integration
+tags:
+  - Agents
+  - Ruby agent
+  - Supported features
+metaDescription: The Ruby agent can be integrated with New Relic CodeStream to provide code-level metrics.
+redirects:
+  - /docs/agents/ruby-agent/features/ruby-codestream-integration
+  - /docs/ruby/ruby-codestream-integration
+---
+
+Display context-sensitive APM data directly in your IDE by integrating [New Relic CodeStream](/docs/codestream/start-here/what-is-codestream) with the Ruby agent. Visualize code-level production telemetry in your editor as your write and review code with this integration.
+
+## Getting started
+
+First, [install](/docs/codestream/start-here/install-codestream) the New Relic CodeStream extension into your supported IDE of choice and log in.
+
+<Callout variant="important">
+      The New Relic CodeStream integration is available in Ruby Agent version 8.8.0 and higher and is disabled by default. To enabled the integration, either set `code_level_metrics.enabled = true` in `newrelic.yml` or `NEW_RELIC_APPLICATION_CODE_LEVEL_METRICS_ENABLED=true` as an environment variable.
+</Callout>
+
+## Agent attributes
+
+The Ruby agent reports and attaches the following attributes to spans produced by your application:
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        **Name**
+      </th>
+
+      <th>
+        **Description**
+      </th>
+
+      <th>
+        **Example**
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `code.function`
+      </td>
+
+      <td>
+        The name of the instrumented function (Ruby method). Note that class methods will be prefixed by `self.`.
+      </td>
+
+      <td>
+        create
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `code.filepath`
+      </td>
+
+      <td>
+        The absolute path to the source code file in which `code.function` is defined
+      </td>
+
+      <td>
+        /app/app/controllers/widgets_controller.rb
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `code.lineno`
+      </td>
+
+      <td>
+        The line number where `code.function` is defined in code.filepath
+      </td>
+
+      <td>
+        1138
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `code.namespace`
+      </td>
+
+      <td>
+       The namespace (class / module name) in which `code.function` is defined
+      </td>
+
+      <td>
+        WidgetsController
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="important">
+Not every method in your application code will be instrumented with the above attributes. As of version 8.8.0, the Ruby agent will provide code-level metrics for Rails controller methods, ActiveJob methods, and any Ruby method which has been configured to be manually traced.
+
+ </Callout>
+
+

--- a/src/content/docs/apm/agents/ruby-agent/features/ruby-codestream-integration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/features/ruby-codestream-integration.mdx
@@ -5,9 +5,6 @@ tags:
   - Ruby agent
   - Supported features
 metaDescription: The Ruby agent can be integrated with New Relic CodeStream to provide code-level metrics.
-redirects:
-  - /docs/agents/ruby-agent/features/ruby-codestream-integration
-  - /docs/ruby/ruby-codestream-integration
 ---
 
 Display context-sensitive APM data directly in your IDE by integrating [New Relic CodeStream](/docs/codestream/start-here/what-is-codestream) with the Ruby agent. Visualize code-level production telemetry in your editor as your write and review code with this integration.
@@ -17,7 +14,7 @@ Display context-sensitive APM data directly in your IDE by integrating [New Reli
 First, [install](/docs/codestream/start-here/install-codestream) the New Relic CodeStream extension into your supported IDE of choice and log in.
 
 <Callout variant="important">
-      The New Relic CodeStream integration is available in Ruby Agent version 8.8.0 and higher and is disabled by default. To enabled the integration, either set `code_level_metrics.enabled = true` in `newrelic.yml` or `NEW_RELIC_APPLICATION_CODE_LEVEL_METRICS_ENABLED=true` as an environment variable.
+  The New Relic CodeStream integration is available in Ruby agent version 8.8.0 and higher and is disabled by default. To enabled the integration, either set `code_level_metrics.enabled = true` in `newrelic.yml` or `NEW_RELIC_APPLICATION_CODE_LEVEL_METRICS_ENABLED=true` as an environment variable.
 </Callout>
 
 ## Agent attributes

--- a/src/content/docs/codestream/how-use-codestream/performance-monitoring.mdx
+++ b/src/content/docs/codestream/how-use-codestream/performance-monitoring.mdx
@@ -296,8 +296,8 @@ has setup wizards available for Node JS, Java, and .NET projects.
 
 Code-level metrics give you detailed insight into how your code is performing at
 the method level. For each method automatically instrumented by New Relic's
-Python APM agent, you'll see golden signals displayed via a line of text
-inserted above each method called a CodeLens. Response time, throughput and
+Python and Ruby APM agents, you'll see golden signals displayed via a line of
+text inserted above each method called a CodeLens. Response time, throughput and
 error rate are shown for the last 30 minutes.
 
 <img
@@ -306,10 +306,12 @@ error rate are shown for the last 30 minutes.
   src={codeLevelMetrics}
 />
 
-<figcaption>Code-level metrics are displayed above each instrumented method in your Python project.</figcaption>
+<figcaption>Code-level metrics are displayed above each instrumented method in your Python/Ruby project.</figcaption>
 
 <Callout variant="important">
-Code-level metrics are only available for projects monitored by the [Python APM agent](/docs/apm/agents/python-agent/getting-started/introduction-new-relic-python) implemented with a [supported Python framework](/docs/apm/agents/python-agent/getting-started/instrumented-python-packages).
+For Python, code-level metrics are only available for projects monitored by the [Python APM agent](/docs/apm/agents/python-agent/getting-started/introduction-new-relic-python) implemented with a [supported Python framework](/docs/apm/agents/python-agent/getting-started/instrumented-python-packages).
+
+For Ruby, code-level metrics are only available for Rails applications and Ruby methods will manual traces.
 </Callout>
 
 Click the CodeLens to see charts visualizing each of the golden signals. If

--- a/src/content/docs/codestream/start-here/codestream-new-relic.mdx
+++ b/src/content/docs/codestream/start-here/codestream-new-relic.mdx
@@ -272,12 +272,13 @@ This check only happens automatically when the initial connection is made. To do
 
  You can use CodeStream to enable dynamic logging for your Pixie-monitored Go applications. Just right-click on any method name and select **Dynamic Logging Using Pixie**.
 
-## Code-level metrics with Python [#code-level-metrics]
+## Code-level metrics with Python and Ruby [#code-level-metrics]
 
  * [New Relic account](https://newrelic.com/signup)
  * [New Relic user API key](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher)
  * [CodeStream and New Relic connection](#connect)
  * [Your repository's commit hash and release tag](#apm)
  * A Python application written with a [supported framework](/docs/apm/agents/python-agent/getting-started/instrumented-python-packages)
+ * A Ruby on Rails application or a Ruby application with manually traced methods
 
-You can use CodeStream and New Relic to instrument your Python application code performance. Once enabled, metrics are shown as a CodeLens, or text inserted above your code's methods, in your IDE.
+You can use CodeStream and New Relic to instrument your Python or Ruby application code performance. Once enabled, metrics are shown as a CodeLens, or text inserted above your code's methods, in your IDE.

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-880.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-880.mdx
@@ -1,0 +1,28 @@
+---
+subject: Ruby agent
+releaseDate: '2022-06-02'
+version: 8.8.0
+downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.8.0.gem'
+---
+
+  ## v8.8.0
+
+  * **Support Makara database adapters with ActiveRecord**
+
+    Thanks to a community submission from @lucasklaassen with [PR #1177](https://github.com/newrelic/newrelic-ruby-agent/pull/1177), the Ruby agent will now correctly work well with the [Makara gem](https://github.com/instacart/makara). Functionality such as SQL obfuscation should now work when Makara database adapters are used with Active Record.
+
+  * **Lowered the minimum payload size to compress**
+
+    Previously the Ruby agent used a particularly large payload size threshold of 64KiB that would need to be met before the agent would compress data en route to New Relic's collector. The original value stems from segfault issues that very old Rubies (< 2.2) used to encounter when compressing smaller payloads. This value has been lowered to 2KiB (2048 bytes), which should provide a more optimal balance between the CPU cycles spent on compression and the bandwidth savings gained from it.
+
+  * **Provide Code Level Metrics for New Relic CodeStream**
+
+    For Ruby on Rails applications and/or those with manually traced methods, the agent is now capable of reporting metrics with Ruby method-level granularity. When the new `code_level_metrics.enabled` configuration parameter is set to a `true` value, the agent will associate source-code-related metadata with the metrics for things such as Rails controller methods. Then, when the corresponding Ruby class file that defines the methods is loaded up in a [New Relic CodeStream](https://www.codestream.com/)-powered IDE, [the four golden signals](https://sre.google/sre-book/monitoring-distributed-systems/) for each method will be presented to the developer directly.
+
+  * **Supportability Metrics will always report uncompressed payload size**
+
+    New Relic's agent specifications call for Supportability Metrics to always reference the uncompressed payload byte size. Previously, the Ruby agent was calculating the byte size after compression. Furthermore, compression is only performed on payloads of a certain size. This means that sometimes the value could have represented a compressed size and sometimes an uncompressed one. Now the uncompressed value is always used, bringing consistency for comparing two instances of the same metric and alignment with the New Relic agent specifications.
+
+## Support statement
+
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [6.5.0.357](https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-650357).

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-880.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-880.mdx
@@ -9,7 +9,7 @@ downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.8.0.gem'
 
   * **Support Makara database adapters with ActiveRecord**
 
-    Thanks to a community submission from @lucasklaassen with [PR #1177](https://github.com/newrelic/newrelic-ruby-agent/pull/1177), the Ruby agent will now correctly work well with the [Makara gem](https://github.com/instacart/makara). Functionality such as SQL obfuscation should now work when Makara database adapters are used with Active Record.
+    Thanks to a community submission from lucasklaassen with [PR #1177](https://github.com/newrelic/newrelic-ruby-agent/pull/1177), the Ruby agent will now correctly work well with the [Makara gem](https://github.com/instacart/makara). Functionality such as SQL obfuscation should now work when Makara database adapters are used with Active Record.
 
   * **Lowered the minimum payload size to compress**
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-880.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-880.mdx
@@ -13,7 +13,7 @@ downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.8.0.gem'
 
   * **Lowered the minimum payload size to compress**
 
-    Previously the Ruby agent used a particularly large payload size threshold of 64KiB that would need to be met before the agent would compress data en route to New Relic's collector. The original value stems from segfault issues that very old Rubies (< 2.2) used to encounter when compressing smaller payloads. This value has been lowered to 2KiB (2048 bytes), which should provide a more optimal balance between the CPU cycles spent on compression and the bandwidth savings gained from it.
+    Previously the Ruby agent used a particularly large payload size threshold of 64KiB that would need to be met before the agent would compress data en route to New Relic's collector. The original value stems from segfault issues that very old Rubies (older than 2.2) used to encounter when compressing smaller payloads. This value has been lowered to 2KiB (2048 bytes), which should provide a more optimal balance between the CPU cycles spent on compression and the bandwidth savings gained from it.
 
   * **Provide Code Level Metrics for New Relic CodeStream**
 

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -1128,6 +1128,8 @@ pages:
                 path: /docs/apm/agents/ruby-agent/features/record-deployments-ruby-agent
               - title: Message queues
                 path: /docs/apm/agents/ruby-agent/features/message-queues
+              - title: Ruby CodeStream integration
+                path: /docs/apm/agents/ruby-agent/features/ruby-codestream-integration
               - title: Ruby HTTP client tracing
                 path: /docs/apm/agents/ruby-agent/features/http-client-tracing-ruby
               - title: Ruby cross application tracing


### PR DESCRIPTION
To coincide with the release of version 8.8.0 of the Ruby agent, the
following changes have been made:

* Added a new v8.8.0 release notes page (with @hannahramadan, thank you!)
* Added code-level metrics / CodeStream functionality documentation to
  the Ruby agent section
* Updated existing (previously Python only) code-level metrics /
  CodeStream documentation to reference the Ruby agent as well