### PR TITLE
chore: add devices.response_time config option

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -469,13 +469,25 @@ global:
 
         <tr>
           <td>
+            response_time
+          </td>
+
+          <td/>
+
+          <td>
+            Indicates whether [response time](#response_time-attribute) polling is enabled for this device. By default, it's set to `false`.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
             ping_only
           </td>
 
           <td/>
 
           <td>
-            Disables all SNMP polling and enables [response time](#response_time-attribute) polling when `true`. This setting is used to override the `global.response_time` attribute. By default, it's set to `false`.
+            Disables all SNMP polling and enables [response time](#response_time-attribute) polling for this device when `true`. This setting will override the `global.response_time` attribute. By default, it's set to `false`.
           </td>
         </tr>
 


### PR DESCRIPTION
adding a missing config option to the network monitoring docs for `response_time` in the `devices` section of the config file.