### PR TITLE
Ruby CodeStream documentation: link update

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/features/ruby-codestream-integration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/features/ruby-codestream-integration.mdx
@@ -7,7 +7,7 @@ tags:
 metaDescription: The Ruby agent can be integrated with New Relic CodeStream to provide code-level metrics.
 ---
 
-Display context-sensitive APM data directly in your IDE by integrating [New Relic CodeStream](/docs/codestream/start-here/what-is-codestream) with the Ruby agent. Visualize code-level production telemetry in your editor as your write and review code with this integration.
+Display context-sensitive APM data directly in your IDE by integrating [New Relic CodeStream](/docs/codestream/how-use-codestream/performance-monitoring#code-level) with the Ruby agent. Visualize code-level production telemetry in your editor as your write and review code with this integration.
 
 ## Getting started
 


### PR DESCRIPTION
Update the Ruby agent CodeStream feature page to reference a more
agent context based document when referring to CodeStream itself.

(as per @angelatan2's request left on #7872)