### PR TITLE
fix(style guide): Doc how to delete i18n equivalents

### DIFF
--- a/src/content/docs/style-guide/writing-docs/processes-procedures/delete-document.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/delete-document.mdx
@@ -10,15 +10,16 @@ redirects:
 ---
 
 <Callout variant="caution">
-  When you delete a document, its content and its redirects will still be available in the GitHub commit history. In general, if you're not on the New Relic Docs team, please don't delete any docs. Instead, [file an issue](https://github.com/newrelic/docs-website/issues/new/choose) and someone on our team will help you out.
+  When you delete a document, its content and its redirects will still be available in the GitHub commit history.
 </Callout>
 
-If you are certain you want to delete a document, do this:
+To delete a doc:
 
-1. Locate the mdx file of the doc you want to delete.
+1. Locate the MDX file of the doc you want to delete.
 2. Take care of redirects:
    1. Find the most relevant doc to redirect readers to.
    2. [Add the deleted doc's URL as a redirect](/docs/style-guide/rename-or-redirect-document).
    3. Copy any existing redirects from the deleted doc and add them to the new doc.
 3. Delete the doc's title and path from the appropriate nav file.
-4. Delete the doc mdx file.
+4. Delete the doc MDX file.
+5. Delete the corresponding MDX files from the `src/i18n/content` directory. For each English doc, there is an MDX file for each of the localized languages.


### PR DESCRIPTION
Currently style guide does not mention impact on i18n folders from deleting docs