### PR TITLE
Infra-agent default config dir for macOS

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent.mdx
@@ -69,6 +69,7 @@ Here are detailed descriptions of each configuration method:
 
     * Linux: `/etc/newrelic-infra.yml`
     * Windows: `C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml`
+    * MacOS: `/usr/local/etc/newrelic-infra/newrelic-infra.yml`
 
       For a sample config file, see our [infrastructure config file template](https://github.com/newrelic/infrastructure-agent/blob/master/assets/examples/infrastructure/newrelic-infra-template.yml.example).
   </Collapser>


### PR DESCRIPTION
## Give us some context

* The default config dir and config file for macOS was missing in the main infra-agent config document.