### PR TITLE
CLM typo fixes for the Ruby agent

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -920,7 +920,7 @@ Defines the maximum number of request events reported from a single harvest.
       <tbody>
         <tr><th>Type</th><td>Boolean</td></tr>
         <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_APPLICATION_CODE_LEVEL_METRICS_ENABLED`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_CODE_LEVEL_METRICS_ENABLED`</td></tr>
       </tbody>
     </table>
 

--- a/src/content/docs/apm/agents/ruby-agent/features/ruby-codestream-integration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/features/ruby-codestream-integration.mdx
@@ -14,7 +14,7 @@ Display context-sensitive APM data directly in your IDE by integrating [New Reli
 First, [install](/docs/codestream/start-here/install-codestream) the New Relic CodeStream extension into your supported IDE of choice and log in.
 
 <Callout variant="important">
-  The New Relic CodeStream integration is available in Ruby agent version 8.8.0 and higher and is disabled by default. To enable the integration, either set `code_level_metrics.enabled = true` in `newrelic.yml` or `NEW_RELIC_APPLICATION_CODE_LEVEL_METRICS_ENABLED=true` as an environment variable.
+  The New Relic CodeStream integration is available in Ruby agent version 8.8.0 and higher and is disabled by default. To enable the integration, either set `code_level_metrics.enabled = true` in `newrelic.yml` or `NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=true` as an environment variable.
 </Callout>
 
 ## Agent attributes

--- a/src/content/docs/apm/agents/ruby-agent/features/ruby-codestream-integration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/features/ruby-codestream-integration.mdx
@@ -14,7 +14,7 @@ Display context-sensitive APM data directly in your IDE by integrating [New Reli
 First, [install](/docs/codestream/start-here/install-codestream) the New Relic CodeStream extension into your supported IDE of choice and log in.
 
 <Callout variant="important">
-  The New Relic CodeStream integration is available in Ruby agent version 8.8.0 and higher and is disabled by default. To enabled the integration, either set `code_level_metrics.enabled = true` in `newrelic.yml` or `NEW_RELIC_APPLICATION_CODE_LEVEL_METRICS_ENABLED=true` as an environment variable.
+  The New Relic CodeStream integration is available in Ruby agent version 8.8.0 and higher and is disabled by default. To enable the integration, either set `code_level_metrics.enabled = true` in `newrelic.yml` or `NEW_RELIC_APPLICATION_CODE_LEVEL_METRICS_ENABLED=true` as an environment variable.
 </Callout>
 
 ## Agent attributes


### PR DESCRIPTION
The correct environment variable to enable/disable code-level metrics
for the Ruby agent is: `NEW_RELIC_CODE_LEVEL_METRICS_ENABLED`

Fix `enabled` -> `enable` in the configuration description.