### PR TITLE
fix(Logs): Add tip about guided installation and logging.yml

### DIFF
--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -339,9 +339,9 @@ To add a new configuration file for the log forwarding feature:
 
 2. Create a `logging.yml` configuration file, and add the parameters you need. The `logging.d` directory has various `.yml.example` files you can use as a reference or starting point.
 
-<Callout variant="tip">
-  If you install the infrastructure agent via [Add data](https://one.newrelic.com/marketplace?state=ed96137c-da6b-ba90-dbf6-5a8fe5c0d9be) in the UI, the file `logging.yml` is created automatically.
-</Callout>
+    <Callout variant="tip">
+      If you install the infrastructure agent via [Add data](https://one.newrelic.com/marketplace?state=ed96137c-da6b-ba90-dbf6-5a8fe5c0d9be) in the UI, the file `logging.yml` is created automatically.
+    </Callout>
 
 The agent automatically processes new configuration files without having to restart the infrastructure monitoring service. The only exception to this is when configuring a custom Fluent Bit configuration.
 

--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -340,7 +340,7 @@ To add a new configuration file for the log forwarding feature:
 2. Create a `logging.yml` configuration file, and add the parameters you need. The `logging.d` directory has various `.yml.example` files you can use as a reference or starting point.
 
 <Callout variant="tip">
-  If you install the infrastructure agent via [Add data](https://one.newrelic.com/marketplace?state=7ca7c800-845d-8b31-4677-d21bcc061961) in the UI, the file `logging.yml` is created automatically.
+  If you install the infrastructure agent via [Add data](https://one.newrelic.com/marketplace?state=ed96137c-da6b-ba90-dbf6-5a8fe5c0d9be) in the UI, the file `logging.yml` is created automatically.
 </Callout>
 
 The agent automatically processes new configuration files without having to restart the infrastructure monitoring service. The only exception to this is when configuring a custom Fluent Bit configuration.

--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -339,6 +339,10 @@ To add a new configuration file for the log forwarding feature:
 
 2. Create a `logging.yml` configuration file, and add the parameters you need. The `logging.d` directory has various `.yml.example` files you can use as a reference or starting point.
 
+<Callout variant="tip">
+  If you install the infrastructure agent via [Add data](https://one.newrelic.com/marketplace?state=7ca7c800-845d-8b31-4677-d21bcc061961) in the UI, the file `logging.yml` is created automatically.
+</Callout>
+
 The agent automatically processes new configuration files without having to restart the infrastructure monitoring service. The only exception to this is when configuring a custom Fluent Bit configuration.
 
 ## Log forwarding parameters [#parameters]


### PR DESCRIPTION
A request came in from a contributor asking why `logging.yml` was created automatically when we tell users elsewhere in the docs to create one manually. 

I inserted a callout explaining the rationale.