### PR TITLE
doc: Add in release not for New Relic for iOS version 4.0.0.

### DIFF
--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-4000.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-4000.mdx
@@ -1,0 +1,16 @@
+---
+subject: Mobile app for iOS
+releaseDate: '2022-06-07'
+version: 4.0.0
+downloadLink: 'https://apps.apple.com/app/id594038638'
+---
+
+### Notes
+
+Updated logo and colors to our new brand, added in saved filters, and improved filters with `or` support
+
+### New features
+
+* Brand updates to align with a new logo and colors
+* Added support for saved filters that were created on the web
+* Added support for OR statements to entity and dashboard filters


### PR DESCRIPTION
## Give us some context

* Adds in release note for version 4.0.0 of the New Relic for iOS app.
