### PR TITLE
Quick apm best practice nav fix

### DIFF
--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -1274,10 +1274,8 @@ pages:
                 path: /docs/apm/agents/manage-apm-agents/troubleshooting/agent-nrintegrationerrors-appear-insights
               - title: Environment and services
                 path: /docs/apm/agents/manage-apm-agents/troubleshooting/get-environment-data-about-your-apm-app
-  - title: Guides
-    pages:
-      - title: APM best practices guide
-        path: /docs/apm/new-relic-apm/guides/apm-best-practices-guide  
+  - title: APM best practices guide
+    path: /docs/apm/new-relic-apm/guides/apm-best-practices-guide  
   - title: APM logs in context
     path: /docs/apm/new-relic-apm/getting-started/get-started-logs-context
   - title: APM UI pages


### PR DESCRIPTION
Current our APM guides category has only one doc. This makes it a standalone doc instead of living in a category.