### PR TITLE
Migrate some 'collect data' dev site content

### DIFF
--- a/src/content/docs/data-apis/custom-data/custom-events/collect-custom-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/collect-custom-attributes.mdx
@@ -24,7 +24,7 @@ redirects:
   - /docs/using-new-relic/data/customize-data/collect-custom-attributes
 ---
 
-For some New Relic solutions, one way to [report custom data to New Relic](/docs/telemetry-data-platform/custom-data/intro-custom-data) is to use custom [attributes](/docs/agents/manage-apm-agents/agent-data/agent-attributes). For example, for New Relic browser monitoring, you might create a custom attribute to track the user name associated with a slow or failing request.
+For some New Relic solutions, one way to [report custom data to New Relic](/docs/telemetry-data-platform/custom-data/intro-custom-data) is to use custom [attributes](/docs/agents/manage-apm-agents/agent-data/agent-attributes). By adding custom attributes to your data, you can do more in-depth and customized analysis of your business. For example, for New Relic browser monitoring, you might create a custom attribute to track the user name associated with a slow or failing request.
 
 ## Requirements [#requirements]
 
@@ -35,7 +35,19 @@ Custom attributes are available for these New Relic solutions:
 * Mobile monitoring
 * Infrastructure monitoring
 
-For other custom data solutions, see [Intro to custom data](/docs/telemetry-data-platform/custom-data/intro-custom-data).
+We'll go into more detail on these options below. For other solutions for reporting custom data, see [Custom data](/docs/telemetry-data-platform/custom-data/intro-custom-data).
+
+## Recommendations for creating and using custom attributes [#best-practices]
+
+A common pattern when creating custom attributes is to capture user information, such as name, ID, email, and more. This allows you to create an association between your operational data and your business data. For example, if you have the user information, you tie together your service desk and CRM data with the operational data in New Relic.
+
+Once you add a custom attribute, you can query it in New Relic and create custom charts from that data. For example, if you used the [Java agent API](#java-att) to add a `userId` attribute to your `Transaction` and `TransactionError` events, you could then create a NRQL query using that attribute, like:
+
+```
+SELECT count(*) FROM TransactionError 
+  WHERE userId = '1401961100' FACET dateOf(timestamp), `error.message` 
+  SINCE 1 week ago
+```  
 
 ## APM: Record custom attributes [#enabling-custom]
 

--- a/src/content/docs/data-apis/custom-data/custom-events/collect-custom-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/collect-custom-attributes.mdx
@@ -24,6 +24,8 @@ redirects:
   - /docs/using-new-relic/data/customize-data/collect-custom-attributes
 ---
 
+When it comes to reporting custom data not reported by default by New Relic solutions, two of the most popular solutions are [custom attributes and custom events](/docs/data-apis/custom-data/custom-events/report-custom-event-data). This doc will go into more detail about why you'd use custom attributes.
+
 For some New Relic solutions, one way to [report custom data to New Relic](/docs/telemetry-data-platform/custom-data/intro-custom-data) is to use custom [attributes](/docs/agents/manage-apm-agents/agent-data/agent-attributes). By adding custom attributes to your data, you can do more in-depth and customized analysis of your business. For example, for New Relic browser monitoring, you might create a custom attribute to track the user name associated with a slow or failing request.
 
 ## Requirements [#requirements]
@@ -34,12 +36,30 @@ Custom attributes are available for these New Relic solutions:
 * Browser monitoring
 * Mobile monitoring
 * Infrastructure monitoring
+* Synthetic monitors
 
-We'll go into more detail on these options below. For other solutions for reporting custom data, see [Custom data](/docs/telemetry-data-platform/custom-data/intro-custom-data).
+We'll go into more detail on these options below. 
 
 ## Recommendations for creating and using custom attributes [#best-practices]
 
+At New Relic, [attributes](/docs/new-relic-solutions/get-started/glossary/#attribute) are key-value pairs that provide metadata about the [events](/docs/new-relic-solutions/get-started/glossary/#event) they're attached to.  
+
 A common pattern when creating custom attributes is to capture user information, such as name, ID, email, and more. This allows you to create an association between your operational data and your business data. For example, if you have the user information, you tie together your service desk and CRM data with the operational data in New Relic.
+
+Other types of business context might include:
+
+* Customer token
+* Customer market segment
+* Customer value classification
+* Workflow control values not obvious in the URIStem
+* User/product/account privilege context
+
+Operational context might include:
+
+* Which feature flags were used
+* What datastore was accessed
+* What cache was accessed
+* What errors were detected and ignored (fault partitioning)
 
 Once you add a custom attribute, you can query it in New Relic and create custom charts from that data. For example, if you used the [Java agent API](#java-att) to add a `userId` attribute to your `Transaction` and `TransactionError` events, you could then create a NRQL query using that attribute, like:
 
@@ -261,3 +281,7 @@ Mobile agents include API calls to record custom attributes:
 * For an overview of mobile monitoring custom data, see [Insert custom events and attributes](/docs/insights/insights-data-sources/custom-events/insert-custom-events-attributes-mobile-data)
 * Android method: [`setAttribute`](/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-attribute)
 * iOS method: [`setAttribute`](/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/set-attribute)
+
+## Synthetic monitors: Record custom attributes [#synthetics]
+
+See [Synthetic monitor custom attributes](/docs/synthetics/synthetic-monitoring/scripting-monitors/add-custom-attributes-synthetic-monitoring-data). 

--- a/src/content/docs/data-apis/custom-data/custom-events/collect-custom-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/collect-custom-attributes.mdx
@@ -3,7 +3,7 @@ title: Collect custom attributes
 tags:
   - Using New Relic
   - Cross-product functions
-  - Install and configure
+  - Install and configure 
 metaDescription: How to add custom attributes to data reported from some New Relic products.
 redirects:
   - /docs/features/collecting-custom-parameters

--- a/src/content/docs/data-apis/custom-data/custom-events/report-custom-event-data.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/report-custom-event-data.mdx
@@ -1,5 +1,5 @@
 ---
-title: Report custom events and attributes
+title: Introduction to custom events and attributes
 metaDescription: An overview of the options to send custom events and attributes to New Relic.
 redirects:
   - /docs/telemetry-data-platform/custom-data/custom-events/report-custom-event-data
@@ -9,13 +9,11 @@ redirects:
   - /docs/insights/event-data-sources/custom-events/report-custom-event-data
 ---
 
-One of the ways to report custom data to New Relic is with custom events and attributes.
-
-Have questions about why you'd use custom data? See [Introduction to custom data](/docs/data-apis/custom-data/intro-custom-data).
+One of the ways to report [custom data](/docs/data-apis/custom-data/intro-custom-data) to New Relic is using custom events and/or custom attributes.
 
 ## Requirements [#requirements]
 
-For event and attribute formatting requirements and best practices, see our documentation about [data limits and requirements](/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data).
+For event and attribute formatting requirements and best practices, see our [data limits and requirements docs](/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data).
 
 ## Avoid rate limits [#rate-limits]
 
@@ -28,34 +26,21 @@ Be aware of the following data and subscription requirements for inserting and a
 
 ## Example use cases [#examples]
 
-Two popular custom data solutions are custom events and custom attributes. There are several ways to accomplish this (more on that later in this doc), depending on your New Relic implementation and tools.
+Two popular solutions for reporting custom data are reporting custom events and custom attributes. There are several ways to accomplish this, depending on your New Relic implementation and tools, and we'll go into more detail on this later in this doc. But first, here are some common use cases for why you'd use either custom events or custom attributes.
 
-Here are some common use cases for implementing custom events and attributes.
+### Use cases for custom attributes
 
-### Using custom attributes
+Custom attributes are often used to add important business and operational context to existing events. For example, for New Relic browser monitoring, you might create a custom attribute to track the user name associated with a slow or failing request. This would then allow you to create queries and custom charts to analyze that data. 
 
-Custom attributes are often used to add important business and operational context to existing events.
+Custom attributes are a good option when you're using a New Relic solution (like APM, browser, mobile, infrastructure, and synthetic monitoring) and want to decorate existing events with your own metadata.  
 
-Business context might include:
+### Use cases for custom events
 
-* Customer token
-* Customer market segment
-* Customer value classification
-* Workflow control values not obvious in the URIStem
-* User/product/account privilege context
-
-Operational context might include:
-
-* Which feature flags were used
-* What datastore was accessed
-* What cache was accessed
-* What errors were detected and ignored (fault partitioning)
-
-### Using custom events
+Whereas adding custom attributes adds metadata to an existing event, a custom event creates an entirely new event type. Create custom events to define, visualize, and get alerts on additional data, just as you would with any data we provide from our core agents. Custom events can be inserted through our agent APIs or directly via our Event API.
 
 Event data is one of New Relic's four core [data types](/docs/data-apis/understand-data/new-relic-data-types/#event-data). We recommend reading that definition to understand what we mean by "event" and why that data type is most used for reporting specific types of activity.
 
-The use cases for custom events vary widely. Basically they are used for any type of activity that an organization deems important and that is not already being monitored. For example:
+The use cases for custom events vary widely. Basically they're used for any type of activity that an organization deems important and that's not already being monitored. For example:
 
 * An event can represent an activity involving multiple actions, like a customer purchasing a certain combination of products.
 * An event can record backup activity. For example, you can set up reporting of events that represent production backups of SOLR instances into an event table, with a timestamp of when it occurred, which cluster, and the duration.
@@ -67,7 +52,7 @@ Methods for sending custom events and attributes include:
 <table>
   <thead>
     <tr>
-      <th width="150px">
+      <th width="200px">
         Source
       </th>
 
@@ -144,12 +129,4 @@ Methods for sending custom events and attributes include:
   </tbody>
 </table>
 
-For ways to report other types of custom data, see:
-
-* [Metric API](/docs/data-apis/ingest-apis/metric-api/introduction-metric-api)
-* [Log API](/docs/logs/log-api/introduction-log-api)
-* [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api)
-
-## Extend data retention [#data-retention]
-
-To learn how to extend how long events are retained in your account, see our documentation about [data retention](/docs/data-apis/manage-data/manage-data-retention/).
+For other options for reporting custom data, see [Custom data](/docs/data-apis/custom-data/intro-custom-data). 

--- a/src/content/docs/data-apis/custom-data/get-custom-data-from-any-source.mdx
+++ b/src/content/docs/data-apis/custom-data/get-custom-data-from-any-source.mdx
@@ -34,9 +34,13 @@ You can review all our integrations on [our quickstarts page](https://newrelic.c
 * [DropWizard](/docs/more-integrations/open-source-telemetry-integrations/dropwizard/dropwizard-reporter)
 * [Micrometer](/docs/more-integrations/open-source-telemetry-integrations/micrometer/micrometer-metrics-registry)
 
-## Report custom events [#events]
+## Report custom attributes and events [#events]
 
-To send arbitrary events to New Relic, you can use our [Event API](/docs/data-apis/ingest-apis/event-api/introduction-event-api/). We save these events as a new [event type](/docs/new-relic-solutions/get-started/glossary/#custom-event), which can then be queried via NRQL.
+You can decorate some New Relic-reported events with custom metadata. For more on that, see [Custom attributes](/docs/data-apis/custom-data/custom-events/collect-custom-attributes). 
+
+You can also report entirely custom events to New Relic with our [Event API](/docs/data-apis/ingest-apis/event-api/introduction-event-api). 
+
+Custom attributes and events can then be queried and charted. 
 
 ## Report custom trace data [#tracing]
 

--- a/src/content/docs/data-apis/ingest-apis/event-api/introduction-event-api.mdx
+++ b/src/content/docs/data-apis/ingest-apis/event-api/introduction-event-api.mdx
@@ -37,24 +37,84 @@ redirects:
   - /docs/data-apis/ingest-apis/introduction-event-api
 ---
 
-The New Relic Event API is one way to report [custom events](/docs/insights/insights-data-sources/custom-data/report-custom-event-data) to New Relic. The Event API lets you send custom [event data](/docs/using-new-relic/data/understand-data/new-relic-data-types#event-data) to your New Relic account with a POST command. These events are then queryable and chartable using [NRQL](/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql).
+The Event API lets you send custom [event data](/docs/using-new-relic/data/understand-data/new-relic-data-types#event-data) to New Relic. These events can then be queried and charted. 
 
 Want to try out our Event API? [Create a New Relic account](https://newrelic.com/signup) for free! No credit card required.
 
 Related content:
 
 * Learn about [all options for reporting custom events](/docs/insights/insights-data-sources/custom-data/report-custom-event-data).
-* For details about how event data is retained, see [Event data retention](/docs/insights/use-insights-ui/manage-account-data/extend-event-data-retention).
 * For how to add attributes to existing events, see [Add custom attributes](/docs/agents/manage-apm-agents/agent-data/collect-custom-attributes).
 
-## Requirements
+## Why use the Event API? [#overview]
+
+Our Event API is one option for reporting custom data. Another option is reporting custom attributes. For an overview of why you'd use the Event API versus other options, see [Custom events and attributes](/docs/data-apis/custom-data/custom-events/report-custom-event-data#using-custom-events).
+
+## Requirements [#requirements]
 
 For Event API limits and restricted attributes, see [Limits](#limits).
 
-Ensure outbound connectivity on TCP port 443 is allowed to the [CIDR range](/docs/using-new-relic/cross-product-functions/install-configure/networks/#infrastructure) that matches your [region](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers).
-The preferred configuration method is to use the DNS name `insights-collector.newrelic.com` or `insights-collector.eu01.nr-data.net`.
+Ensure outbound connectivity on TCP port 443 is allowed to the [CIDR range](/docs/using-new-relic/cross-product-functions/install-configure/networks/#infrastructure) that matches your [region](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers). The preferred configuration method is to use the DNS name `insights-collector.newrelic.com` or `insights-collector.eu01.nr-data.net`.
 
-## Basic workflow [#workflow]
+## Example of submitting and querying a custom event [#example-use-case]
+
+Here's an example of the Event API in action: 
+
+<CollapserGroup>
+  <Collapser
+    id="ruby-example"
+    title="Calling the Event API from a Ruby app"
+  >
+
+Custom events can be inserted through the [agent APIs](/docs/data-apis/custom-data/custom-events/report-custom-event-data#ways) or directly via the Event API. The following example shows how to send a custom event type `CLIRun`, which tracks when a command line tool written in Ruby has its process exit due to an exception.
+
+```ruby
+# Hook into the runtime 'at_exit' event
+at_exit do
+  # Name the custom event
+  payload = { 'eventType' => 'CLIRun' }
+
+  # Check to see if the process is exiting due to an error
+  if $!.nil? || $!.is_a?(SystemExit) && $!.success?
+    payload[:status] = 0
+  else
+    # Gather any known errors
+    errors = ""
+    (Thread.current[:errors] ||= []).each do |err|
+      errors += "#{err}\n"
+    end
+    payload[:errors] = errors
+  end
+
+  # Send the errors to New Relic as a custom event
+  insights_url = URI.parse("https://insights-collector.newrelic.com/v1/accounts/YOUR_ACCOUNT_ID/events")
+  headers = { "Api-Key" => "YOUR_LICENSE_KEY", "content-type" => "application/json" }
+
+  http = Net::HTTP.new(insights_url.host, insights_url.port)
+  http.use_ssl = true
+  request = Net::HTTP::Post.new(insights_url.request_uri, headers)
+  request.body = payload.to_json
+
+  puts "Sending run summary to New Relic: #{payload.to_json}"
+  begin
+    response = http.request(request)
+    puts "Response from New Relic: #{response.body}"
+  rescue Exception => e
+    puts "There was an error posting to New Relic. Error: #{e.inspect}"
+  end
+end
+```
+
+Then you could run a NRQL query to get more detail about that custom event, like: 
+
+```sql
+SELECT count(*) FROM CLIRun FACET errors SINCE 1 week ago
+```
+
+</Collapser>
+</CollapserGroup>
+
+## How to use the Event API [#workflow]
 
 The Event API is an asynchronous endpoint. This allows you to send a very large volume of POSTS, reliably, with very low response latency.
 
@@ -70,15 +130,7 @@ To send a custom event to a New Relic account:
 4. [Submit a compressed JSON payload](#submit-event) (for example, `gzip` or `deflate`) to the HTTPS endpoint using curl in a **POST** request.
 5. **Recommendation:** Set up [NRQL alert conditions](/docs/alerts/new-relic-alerts/defining-conditions/create-alert-conditions-nrql-queries) to notify you when [parsing errors](#errors-parsing) occur.
 
-This method will send the events directly into your account, where they will be accessible from any NRQL interface or with the Query API.
-
-The Event API [limits the size, rate, and characters](#limits) allowed in custom events. Also, like other events available in NRQL, custom events cannot be updated or deleted after they are created. If you have problems with your custom event, follow the [troubleshooting procedures](#verify) or create a new custom event.
-
-## Get the license key [#register]
-
-You'll need a [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key). License keys are associated with an account, not a specific user. This means that anyone in the account with access to that key can use it.
-
-You can submit multiple event types to the same account with the same license key. However, to help ensure security, we recommend that you use different keys for different applications or data sources.
+The Event API [limits the size, rate, and characters](#limits) allowed in custom events. Also, like other data available in NRQL, custom events cannot be updated or deleted after they're created. If you have problems with your custom event, follow the [troubleshooting procedures](#verify) or create a new custom event.
 
 ## Format the JSON [#instrument]
 

--- a/src/content/docs/new-relic-solutions/get-started/glossary.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/glossary.mdx
@@ -184,18 +184,14 @@ Whether you're considering New Relic or you're already using our capabilities, t
     Data points are collected together based their timestamps and reported as a batch. The customizable aggregation window provides greater flexibility and fewer false violations when alerting on irregular or less frequent data points.
   </Collapser>
 
-<CollapserGroup>
   <Collapser
     className="freq-link"
     id="AI"
     title="AI"
   >
-  Applied intelligence (AI) helps you find, troubleshoot, and resolve problems more quickly. Specifically, it's a hybrid machine learning engine that reduces alert noise, correlates incidents, and automatically detects anomalies.
-
-  Our detection and applied intelligence capability includes alerts, incident correlation, automatic anomaly detection, and customizable workflows.
+  This may refer to an acronym for [applied intelligence](#applied-intelligence). 
   </Collapser>
 
-</CollapserGroup>
   <Collapser
     id="alert"
     title="alert"
@@ -319,9 +315,9 @@ Whether you're considering New Relic or you're already using our capabilities, t
 
   <Collapser
     id="applied-intelligence"
-    title="Applied intelligence (AI)"
+    title="Applied intelligence"
   >
-    Applied intelligence (AI) helps you find, troubleshoot, and resolve problems more quickly. Specifically, it's a hybrid machine learning engine that reduces alert noise, correlates incidents, and automatically detects anomalies.
+    Applied intelligence helps you find, troubleshoot, and resolve problems more quickly. Specifically, it's a hybrid machine learning engine that reduces alert noise, correlates incidents, and automatically detects anomalies.
 
     Applied intelligence includes alerts, incident intelligence, and proactive detection.
   </Collapser>

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language.mdx
@@ -118,7 +118,7 @@ Ready to get started? If you haven't already, be sure to [sign up for a New Reli
 
 ## What is NRQL?
 
-NRQL is New Relic's SQL-like query language. You can use NRQL to retrieve detailed New Relic data and get insight into your applications, hosts, and business-important activity.
+NRQL is New Relic's SQL-like query language. You can use NRQL to retrieve detailed New Relic data and get insight into your applications, hosts, and business-important activity. 
 
 Reasons to use NRQL include:
 
@@ -126,7 +126,9 @@ Reasons to use NRQL include:
 * To create a new chart
 * To make API queries of New Relic data (for example, using our [NerdGraph](/docs/apis/graphql-api/tutorials/nerdgraph-graphiql-nrql-tutorial) API)
 
-NRQL is used behind the scenes to generate some New Relic charts:
+NRQL queries can be as simple as fetching rows of data in a raw tabular form to inspect individual events. NRQL can also be used to run powerful calculations on the data before it's presented to you, such as crafting funnels based on how end users are using your site or application.
+
+NRQL is used behind the scenes to generate many of the charts and dashboards in our curated UI experiences:
 
 <img
   title="new-relic-view-chart-nrql-query.png"

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language.mdx
@@ -118,7 +118,7 @@ Ready to get started? If you haven't already, be sure to [sign up for a New Reli
 
 ## What is NRQL?
 
-NRQL is New Relic's SQL-like query language. You can use NRQL to retrieve detailed New Relic data and get insight into your applications, hosts, and business-important activity. 
+NRQL is an acronym of New Relic query language. It's a query language similar to ANSI SQL ([see the syntax](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language#syntax)). You can use NRQL to retrieve detailed New Relic data and get insight into your applications, hosts, and business-important activity. 
 
 Reasons to use NRQL include:
 
@@ -126,7 +126,7 @@ Reasons to use NRQL include:
 * To create a new chart
 * To make API queries of New Relic data (for example, using our [NerdGraph](/docs/apis/graphql-api/tutorials/nerdgraph-graphiql-nrql-tutorial) API)
 
-NRQL queries can be as simple as fetching rows of data in a raw tabular form to inspect individual events. NRQL can also be used to run powerful calculations on the data before it's presented to you, such as crafting funnels based on how end users are using your site or application.
+NRQL queries can be as simple as fetching rows of data in a raw tabular form to inspect individual events. NRQL can also be used to run powerful calculations on the data before it's presented to you, such as crafting funnels based on how end users are using your site or application. 
 
 NRQL is used behind the scenes to generate many of the charts and dashboards in our curated UI experiences:
 

--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -70,10 +70,10 @@ pages:
   - title: Custom data
     pages:
       - title: Intro to custom data
-        path: /docs/data-apis/custom-data/intro-custom-data
+        path: /docs/data-apis/custom-data/get-custom-data-from-any-source
       - title: Custom events and attributes
         pages:
-          - title: Report custom events
+          - title: Intro to custom events and attributes
             path: /docs/data-apis/custom-data/custom-events/report-custom-event-data
           - title: Requirements and limits
             path: /docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data


### PR DESCRIPTION
Related to dev site migration: bringing over content from dev site for 'Custom attributes and events' content and 'NRQL' content, and assorted edits to clean up things a bit. 