### PR TITLE
Do Not Merge - Adding namespace filters to K8s integration

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
@@ -312,6 +312,68 @@ newrelic-infrastructure:
   Setting `interval` to values larger than `40s` is not allowed.
 </Callout>
 
+### Filtering Namespaces [#filter-namespace]
+
+The Kubernetes Integration v3 and above allows filtering which namespaces will be scraped by allowing you to include or exclude namespaces based on labels. By default all namespaces will be scraped.
+
+In order to include only namespaces matching a certain label, change the `namespaceSelector` by adding the following to your `values-newrelic.yaml`, under the `newrelic-infratructure` section:
+
+```yaml
+common:
+  config:
+    namespaceSelector:
+      matchLabels:
+        newrelic.com/scrape: true
+```
+
+In this example only namespaces with the label `newrelic.com/scrape` set to true will be scraped. You can also use you own custom label:
+
+```yaml
+global:
+  licenseKey: _YOUR_NEW_RELIC_LICENSE_KEY_
+  cluster: _K8S_CLUSTER_NAME_
+
+# ... Other settings as shown above
+
+# Configuration for newrelic-infrastructure
+newrelic-infrastructure:
+  # ... Other settings as shown above
+  common:
+    config:
+      namespaceSelector:
+        matchLabels:
+          newrelic.com/scrape: true
+```
+
+To exclude certain namespaces use the following syntax:
+
+```yaml
+common:
+  config:
+    namespaceSelector:
+      matchExpressions:
+      - {key: newrelic.com/scrape, operator: NotIn, values: [false]}
+```
+
+In this example namespaces with the label `newrelic.com/scrape` set to false will be excluded:
+
+```yaml
+global:
+  licenseKey: _YOUR_NEW_RELIC_LICENSE_KEY_
+  cluster: _K8S_CLUSTER_NAME_
+
+# ... Other settings as shown above
+
+# Configuration for newrelic-infrastructure
+newrelic-infrastructure:
+  # ... Other settings as shown above
+  common:
+    config:
+      namespaceSelector:
+        matchExpressions:
+        - {key: newrelic.com/scrape, operator: NotIn, values: [false]}
+```
+
 A full list of the settings that can be modified can be found at the [chart's README](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-infrastructure-v3).
 
 ## Upgrade using Helm [#upgrade]


### PR DESCRIPTION
This PR adds documentation on configuring namespace filters to our Kubernetes integration.
This feature will be released soon.