### PR TITLE
fix: include cgroupsns field in privileges so examples work properly on cgroup v2

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/docker-container-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/docker-container-infrastructure-monitoring.mdx
@@ -59,6 +59,7 @@ The following are basic instructions for creating a custom Docker image on Linux
        --cap-add=SYS_PTRACE \
        --privileged \
        --pid=host \
+       --cgroupns=host  # required on cgroup v2 \
        -v "/:/host:ro" \
        -v "/var/run/docker.sock:/var/run/docker.sock" \
        <var>YOUR_IMAGE_NAME</var>
@@ -151,6 +152,7 @@ To use the basic setup with a base New Relic infrastructure image:
       --cap-add=SYS_PTRACE \
       --privileged \
       --pid=host \
+       --cgroupns=host  # required on cgroup v2 \
       -v "/:/host:ro" \
       -v "/var/run/docker.sock:/var/run/docker.sock" \
       -e NRIA_LICENSE_KEY=<var>YOUR_LICENSE_KEY</var> \
@@ -263,6 +265,15 @@ The infrastructure agent collects data about its host using system files and sys
 
       <td/>
     </tr>
+
+    <tr>
+      <td>
+        `--cgroupns=host`
+      </td>
+        Required when using docker on cgroup v2 as it is private by default. This allows the agent to gather container metrics. It is available [since docker engine API v1.41](https://docs.docker.com/engine/reference/commandline/container_create/).
+      <td/>
+    </tr>
+
 
     <tr>
       <td>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Includes a required field in docker examples so nri-docker integration works when running inside a container and docker is on cgroup v2. This is required because, when running in cgroup v2, [default cgroup namespace mode is private](https://docs.docker.com/config/containers/runmetrics/#running-docker-on-cgroup-v2) and the integration cannot gather other containers metrics.

[nri-docker#131](https://github.com/newrelic/nri-docker/issues/131) was opened because those fields are missing.