### PR TITLE
Fix download links to be HTTPS

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/microsoft-sql/microsoft-sql-server-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/microsoft-sql/microsoft-sql-server-integration.mdx
@@ -48,8 +48,8 @@ For a comprehensive list of specific Windows versions, check the table of [compa
 To install the Microsoft SQL Server integration:
 
 1. Download the latest .MSI installer image for your environment:
-  - [32-bit Windows](http://download.newrelic.com/infrastructure_agent/windows/integrations/nri-mssql/386/nri-mssql-386.msi)
-  - [64-bit Windows](http://download.newrelic.com/infrastructure_agent/windows/integrations/nri-mssql/nri-mssql-amd64.msi)
+  - [32-bit Windows](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-mssql/386/nri-mssql-386.msi)
+  - [64-bit Windows](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-mssql/nri-mssql-amd64.msi)
 2. In an administrator account, run the install script using an absolute path. Use the corresponding example for your environment:
   
   <CollapserGroup>


### PR DESCRIPTION
While attempting to use the provided download links I got greeted by an error message in Edge (Chromium) that it couldn't be downloaded securely. After figuring out that that meant that the download link was HTTP I figured I might as well create a PR to fix the download links to use https. They seem to work just fine.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.