### PR TITLE
Include 17 LTS JVM for Amazon Corretto

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -267,7 +267,7 @@ Before you install the Java agent, ensure your system meets these requirements:
 
     * Azul Zulu JVM versions 8 to 12 for Linux, Windows, and macOS
 
-    * Amazon Corretto JVM versions 8 and 11 for Linux, Windows, and macOS
+    * Amazon Corretto JVM versions 8, 11, and 17 for Linux, Windows, and macOS
 
     * Alibaba Dragonwell JVM versions 8 and 11 for Linux, Windows, and macOS
 


### PR DESCRIPTION
Added Java 17 to supported versions for  Amazon Corretto


* What problems does this PR solve?
More accurate description of supported versions