### PR TITLE
Add recommended OTel Java agent version

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-find-entities.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-find-entities.mdx
@@ -45,7 +45,7 @@ When you're looking at OpenTelemetry data in the **Summary** page of the UI, you
   src={metricSpanToggleSummary}
 />
 
-The spans-metrics toggle defaults to spans, but you can set the toggle to what you want for each service. Your choice is saved as you move between entities.
+The spans-metrics toggle defaults to spans, but you can set the toggle to what you want for each service. Your choice is saved for each entity as you navigate between services.
 
 Before you change the toggle, consider these aspects of the feature:
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-jvms-page.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-jvms-page.mdx
@@ -7,7 +7,9 @@ tags:
 metaDescription: Here are some tips for understanding the OpenTelemetry JVMs page in the New Relic UI.
 ---
 
-After you've sent us your OpenTelemetry data and opened your service (entity) in the UI, you can click **JVMs** to identify which service instances instrumented with OpenTelemetry have unusual or unhealthy performance patterns. You can choose several service instances to compare based on summaries of key metrics: response time, throughput, error rate, garbage collection time, and memory usage. Then, you can compare all those instances' JVM metrics collected by OpenTelemetry instrumentation using timeseries charts to spot problems.
+After you've sent us your OpenTelemetry data and opened your service (entity) in the UI, you can click **JVMs** to identify which service instances instrumented with OpenTelemetry have unusual or unhealthy performance patterns.
+
+You can choose several service instances to compare based on summaries of key metrics: response time, throughput, error rate, garbage collection time, and memory usage. Then, you can compare all those instances' JVM metrics collected by OpenTelemetry instrumentation using timeseries charts to spot problems.
 
 Here's a typical workflow:
 
@@ -45,22 +47,23 @@ Review these additional topics about using the JVMs page:
     id="jvms-and-metric-types"
     title="Gauges versus counters"
   >
-  Starting in OpenTelemetry Java agent 1.10.0, JVM memory usage switched from being collected as an async gauge to an async up down counter. This has implications on the exported data. Gauges and counters export differently:
+  We recommend you use the OpenTelemetry Java agent 1.13.0 or higher, which collects JVM memory usage as an async gauge. These agent versions allow you to view metrics in New Relic without the workarounds you'd need to do if you were using older agents.
 
-    * Async gauges export as OTLP gauges.
+  If you're using older OpenTelemetry Java agents (versions 1.10.0 thorugh 1.12.0), keep in mind that JVM memory usage switched from being collected as an async gauge to an async up down counter. This has implications on the exported data. Gauges and counters export differently:
 
-    * Async up down counters export as OTLP non-monotonic sums.
+      * Async gauges export as OTLP gauges.
 
+      * Async up down counters export as OTLP non-monotonic sums.
 
   If you configure your SDK to export your metrics using delta aggregation temporality (which is required for counter and histogram instruments to function with New Relic), that results in async up down counters exported as non-monotonic delta sums. New Relic can't perform any useful analysis of non-monotonic delta sum data.
 
-  The solution for now (until a better solution is sorted out in the OpenTelemetry metric specification) is to use the View API to indicate that async up down counters should be aggregated using [last value aggregation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#last-value-aggregation) instead of the default sum aggregation. This results in JVM memory usage being exported as gauge data, which is required for a useful experience in New Relic.
+  If you have to use OpenTelemetry Java agent versions 1.10.0 through 1.12.0, the workaround is to use the View API to indicate that async up down counters should be aggregated using [last value aggregation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#last-value-aggregation) instead of the default sum aggregation. This results in JVM memory usage being exported as gauge data, which is required for a useful experience in New Relic.
 
   The way you configure the View API varies based on whether you’re using the OpenTelemetry Java agent:
 
-    * If you're not using the OpenTelemetry Java agent, review this simple [example](https://github.com/newrelic/newrelic-opentelemetry-examples/pull/89/files#diff-da355ef6d1092534a55829e95160ab8468884bdd521f9018feeaaa66aea6ac5bR82-R86) that shows how to register a view when configuring `SdkMeterProvider`.
+      * If you're not using the OpenTelemetry Java agent, review this simple [example](https://github.com/newrelic/newrelic-opentelemetry-examples/pull/89/files#diff-da355ef6d1092534a55829e95160ab8468884bdd521f9018feeaaa66aea6ac5bR82-R86) that shows how to register a view when configuring `SdkMeterProvider`.
 
-    * If you’re using the OpenTelemetry Java agent, you need to configure the View API in an [extension](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/agent-config.md#extensions). Extensions allow you to hook into the SDK configuration (among other things) and apply programmatic configuration that isn’t available by environment variable or system properties. This [example](https://github.com/newrelic/newrelic-opentelemetry-examples/tree/main/java/agent-nr-config) demonstrates how you can use an extension to [customize](https://github.com/newrelic/newrelic-opentelemetry-examples/blob/main/java/agent-nr-config/config-extension/src/main/java/com/newrelic/otel/extension/Customizer.java#L28-L37) the `SdkMeterProvider`’s views.
+      * If you’re using the OpenTelemetry Java agent, you need to configure the View API in an [extension](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/agent-config.md#extensions). Extensions allow you to hook into the SDK configuration (among other things) and apply programmatic configuration that isn’t available by environment variable or system properties. This [example](https://github.com/newrelic/newrelic-opentelemetry-examples/tree/main/java/agent-nr-config) demonstrates how you can use an extension to [customize](https://github.com/newrelic/newrelic-opentelemetry-examples/blob/main/java/agent-nr-config/config-extension/src/main/java/com/newrelic/otel/extension/Customizer.java#L28-L37) the `SdkMeterProvider`’s views.
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
This is a replacement for the older PR (#7317)  on the same topic since the branch became out of date (not the content).

The OpenTelemetry Java agent version 1.13.0 and higher now allows users to avoid workarounds to view JVM metrics.

This PR states that we recommend the newer agent.

This PR also includes a small wording change for the metrics-spans toggle memory.