### PR TITLE
Updates docs to include NLOg support in .NET Agent for 9.9.0 r…

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -616,6 +616,14 @@ If your application is hosted in ASP.NET Core, the agent automatically creates a
             2.0.0 or later
           </td>
         </tr>
+        <tr>
+          <td>
+            NLog
+          </td>
+          <td>
+            4.0.0 or later
+          </td>
+        </tr>
       </tbody>
     </table>
   </Collapser>

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -782,6 +782,14 @@ The .NET agent does not directly monitor datastore processes. Also, by default t
             1.0.0 or later
           </td>
         </tr>
+        <tr>
+          <td>
+            NLog
+          </td>
+          <td>
+            4.0.0 or later
+          </td>
+        </tr>
       </tbody>
     </table>
   </Collapser>

--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -216,9 +216,13 @@ You have three options to configure APM logs in context to send your app's logs 
       .CreateLogger();
   ```
 
-  **Microsoft.Extensions.Logging configuration**
+  ### Microsoft.Extensions.Logging configuration
 
   For Microsoft.Extensions.Logging, the .NET agent stores the NR-LINKING token with the message in a newly created a Scope.  Since Microsoft.Extensions.Logging relies on other frameworks for output, please see either the log4net or Serilog configuration above for details.
+
+  ### NLog configuration
+
+  For NLog, the .NET agent is able to automatically append the NR-LINKING token directly to the end of the message so no additional configuration is required.
 
   </Collapser>
 


### PR DESCRIPTION
## Give us some context

.NET is adding support for NLog in the 9.9.0 release.

Updates docs to include NLOg support in .NET Agent for 9.9.0 release
- Updates compatibility docs to include NLog
- Updates logs-in-context .NET doc to include NLog

Also fixes a formatting mistake for the "Microsoft.Extensions.Logging configuration" heading.