### PR TITLE
Add Python Agent Application Logging Feature Docs

### DIFF
--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -3802,6 +3802,221 @@ The following settings are available for configuration of CodeStream code level 
   </Collapser>
 </CollapserGroup>
 
+
+## Application logging settings [#application-logging]
+
+The following settings are available for configuration of application logging in the agent.
+
+<Callout variant="important">
+  Requires [Python agent version 7.12.0.176 or higher](/docs/agents/python-agent/installation-configuration/upgrade-python-agent).
+</Callout>
+
+<CollapserGroup>
+  <Collapser
+    id="application_logging.enabled"
+    title="application_logging.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
+
+    If `true`, enables log decoration and the collection of log events and metrics if these sub-feature configurations are also enabled.  If `false`, no logging instrumentation features are enabled.
+
+  <Collapser
+    id="application_logging.forwarding.enabled"
+    title="application_logging.forwarding.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures log records emitted by your application and forwards them to New Relic. `application_logging.enabled` must also be `true` for this setting to take effect.
+  </Collapser>
+  <Collapser
+    id="event_harvest_config.harvest_limits.log_event_data"
+    title="event_harvest_config.harvest_limits.log_event_data"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            10000
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+  Defines the maximum number of log records to buffer in memory at a time.
+  </Collapser>
+
+   <Collapser
+    id="application_logging.local_decorating.enabled"
+    title="application_logging.local_decorating.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent decorates logs with metadata to link to entities, hosts, traces, and spans. `application_logging.enabled` must also be `true` for this setting to take effect.
+  </Collapser>
+</CollapserGroup>
+
+
 ## Other configuration settings [#other-settings]
 
 Here are assorted other settings available via the agent configuration file.

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -3859,11 +3859,10 @@ The following settings are available for configuration of application logging in
         </tr>
       </tbody>
     </table>
+     If `true`, enables log decoration and the collection of log events and logging metrics if these sub-feature configurations are also enabled.  If `false`, no logging instrumentation features are enabled.
   </Collapser>
 
-    If `true`, enables log decoration and the collection of log events and metrics if these sub-feature configurations are also enabled.  If `false`, no logging instrumentation features are enabled.
-
-  <Collapser
+<Collapser
     id="application_logging.forwarding.enabled"
     title="application_logging.forwarding.enabled"
   >
@@ -3913,7 +3912,8 @@ The following settings are available for configuration of application logging in
 
   If `true`, the agent captures log records emitted by your application and forwards them to New Relic. `application_logging.enabled` must also be `true` for this setting to take effect.
   </Collapser>
-  <Collapser
+
+   <Collapser
     id="event_harvest_config.harvest_limits.log_event_data"
     title="event_harvest_config.harvest_limits.log_event_data"
   >
@@ -3961,10 +3961,61 @@ The following settings are available for configuration of application logging in
       </tbody>
     </table>
 
-  Defines the maximum number of log records to buffer in memory at a time.
+  Number of log records to send per minute to New Relic. This setting controls overall memory consumption when using the log forwarding feature.
   </Collapser>
 
-   <Collapser
+  <Collapser
+    id="application_logging.metrics.enabled"
+    title="application_logging.metrics.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures metrics related to the log lines being sent up by your application. `application_logging.enabled` must also be `true` for this setting to take effect.
+  </Collapser>
+
+  <Collapser
     id="application_logging.local_decorating.enabled"
     title="application_logging.local_decorating.enabled"
   >

--- a/src/content/docs/logs/logs-context/configure-logs-context-python.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-python.mdx
@@ -14,22 +14,122 @@ redirects:
   - /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-python
 ---
 
-Logs in context for the Python agent connects your logs and APM data in New Relic. Bringing all of this data together in a single tool helps you quickly get to the root cause of an issue and find the log lines that you need to identify and resolve a problem.
+APM logs in context connects your logs with all of your telemetry data for your apps, hosts, and other entities. Bringing all of this data together in a single tool helps you quickly:
 
-## Set up your Python app [#configure-python]
+* Cut through the noise of thousands of logs when troubleshooting time-critical issues, so you automatically see only the most relevant logs.
+* Navigate within multiple types of telemetry data, and have the data correlate back to the original issue.
+* Easily drill down into more detailed information from the same place in the UI.
+* Find the log lines that you need to identify and resolve a problem.
 
-To enable logs in context for APM apps monitored by Python, you can use our manual installation option.
+For more information, including examples, learn how to get started with [APM logs in context](/docs/apm/new-relic-apm/getting-started/get-started-logs-context).
 
-1. Make sure you have already [set up logging in New Relic](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/enable-log-management-new-relic/). This includes configuring a supported log forwarder that collects your application logs and extends the metadata that is forwarded to New Relic.
-2. [Install](/docs/agents/python-agent/installation/standard-python-agent-install/) or [update](/docs/agents/python-agent/installation/update-python-agent) to the latest Python agent version, and [enable distributed tracing](/docs/distributed-tracing/enable-configure/quick-start/). Use [Python agent version 5.4.0 or higher](/docs/release-notes/agent-release-notes/python-release-notes/) for logs in context.
-3. Configure logs in context for your log handler.
+## Automatic logs in context options [#automatic]
+
+You have three options to configure APM logs in context to send your app's logs and linking metadata automatically to New Relic.
 
 <CollapserGroup>
   <Collapser
-    id="python-formatter"
-    title="Python StreamHandler example"
+    id="1-agent"
+    title="Option 1 (simplest): Let the agent decorate and forward your logs."
   >
-    Enabling logs in Python is as simple as instantiating a log formatter and adding it to your log handler. This example uses a `StreamHandler` which by default writes logs to `sys.stderr`, but any handler can be used. For more information about configuring log handlers, see the [Python.org documentation](https://docs.python.org/3/library/logging.handlers.html).
+    This is the simplest approach, and it's a great choice for developers who may not have the access or interest in setting up a log forwarder, or for accounts that want to see the power of logs and other linking metadata in context of their apps, without a lot of overhead.
+
+    Using this option, your logs will include `span.id`, `trace.id`, `hostname`, `entity.guid`, and `entity.name`. These attributes automatically link your logs to spans, traces, and other telemetry, making it easier to troubleshoot.
+
+    All you need to do is install an agent version with log forwarding capabilities ([Python agent 7.12.0.176 or higher](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/)), and update your configuration to enable forwarding.
+
+    newrelic.ini:
+
+    ```
+    application_logging.enabled=true
+    application_logging.forwarding.enabled=true
+    ```
+
+    Environment variable:
+
+    ```
+    NEW_RELIC_APPLICATION_LOGGING_ENABLED=true
+    NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=true
+    ```
+
+    This option may be on by default in a future agent version.
+
+    **Optional adjustments:**
+
+    Once this is enabled, you also have control over the maximum number of logs sent to New Relic every minute. The default value is 10,000. If more than 10,000 logs are received in a 60-second window, your logs will begin to be sampled.
+
+    Set it to a higher number to receive more logs. Set it to a lower number to receive fewer logs. Any integer up to 100,000 is valid.
+
+    newrelic.ini:
+
+    ```
+    event_harvest_config.harvest_limits.log_event_data=10000
+    ```
+
+    Environment variable:
+
+    ```
+    NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED=10000
+    ```
+
+    If you have an existing log forwarding solution and are updating your agent to use automatic logs in context, be sure to **disable your manual log forwarder**. Otherwise, your app will be sending double log lines. Depending on your account, this could result in double billing. For more information, follow the procedures to disable your [specific log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding).
+  </Collapser>
+
+  <Collapser
+    id="2-decorate"
+    title="Option 2: Let the agent decorate your logs."
+  >
+    Already have a log forwarder you like? We've got you covered! Language agents can decorate your logs with the linking metadata needed to provide access to automatic logs-in-context features.
+
+    This option should not be used with in-agent forwarding. Using an [external log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding) to send logs to New Relic while in-agent forwarding is enabled will cause your logs to be sent up twice to New Relic. Depending on your account, this may result in double billing.
+
+    This option should also not be used with [the manual log decorating formatter](#3-old-formatter). If you have references to the manual formatter in your codebase, please remove them before enabling this option.
+
+    1. If you want to use this option, make sure you have the in-agent forwarding configuration option disabled.
+
+       newrelic.ini:
+
+       ```
+       application_logging.forwarding.enabled=true
+       ```
+
+    2. Enable log decorating in your configuration, then relaunch the agent to start decorating your logs.
+
+       newrelic.ini:
+
+       ```
+       application_logging.enabled=true
+       application_logging.local_decorating.enabled=true
+       ```
+
+       Environment variable:
+
+       ```
+       NEW_RELIC_APPLICATION_LOGGING_ENABLED=true
+       NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED=true
+       ```
+
+       Our decorator adds five attributes to every log message: `entity.guid`, `entity.name`, `hostname`, `trace.id`, and  `span.id`. Example:
+
+       ```
+       This is my log message. NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|
+       ```
+
+      Some attributes may be empty if the log occurred outside a transaction or if they are not applicable to your application's context.
+
+       We recommend this option over the manual decorating formatter, `NewRelicContextFormatter`.
+  </Collapser>
+
+  <Collapser
+    id="3-old-formatter"
+    title="Option 3: Use the manual process to forward and decorate logs."
+  >
+    You can also use our manual installation option to enable logs in context for APM apps monitored by Python.
+
+    1. Make sure you have already [set up logging in New Relic](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/enable-log-management-new-relic/). This includes configuring a supported log forwarder that collects your application logs and extends the metadata that is forwarded to New Relic.
+    2. [Install](/docs/agents/python-agent/installation/standard-python-agent-install/) or [update](/docs/agents/python-agent/installation/update-python-agent) to the latest Python agent version, and [enable distributed tracing](/docs/distributed-tracing/enable-configure/quick-start/). Use [Python agent version 5.4.0 or higher](/docs/release-notes/agent-release-notes/python-release-notes/) for logs in context.
+    3. Configure logs in context for your log handler.
+   Before language agents had the ability to forward and decorate logs, you could enable logs in context by instantiating a log formatter and adding it to your log handler. This example uses a `StreamHandler` which by default writes logs to `sys.stderr`, but any handler can be used. For more information about configuring log handlers, see the [Python.org documentation](https://docs.python.org/3/library/logging.handlers.html).
 
     ```
     # Import the logging module and the New Relic log formatter
@@ -47,12 +147,19 @@ To enable logs in context for APM apps monitored by Python, you can use our manu
     root_logger = logging.getLogger()
     root_logger.addHandler(handler)
     ```
-  </Collapser>
-</CollapserGroup>
 
 4. To verify that you have configured the log appender correctly, run your application, then check your [logs data in New Relic](/docs/logs/log-management/ui-data/use-logs-ui/) using the query operator `has:span.id has:trace.id`.
 
 If everything is configured correctly and your data is being forwarded to New Relic with the enriched metadata, your logs should now be emitted as JSON and contain `trace.id` and `span.id` fields. If you don't see log data in the UI, follow the [troubleshooting procedures](/docs/logs/log-management/troubleshooting/no-log-data-appears-ui/).
+
+ </Collapser>
+</CollapserGroup>
+
+## Secure your data [#obfuscation]
+
+Your logs may include sensitive information protected by HIPAA or other compliance protocols. By default we obfuscate number patterns that appear to be for items such as credit cards or Social Security numbers, but you may need to hash or mask additional information.
+
+For more information, see our documentation about [obfuscation expressions and rules](/docs/logs/ui-data/obfuscation-ui/). You can hash or mask your log data by using the New Relic UI or by using NerdGraph, our GraphQL API.
 
 ## What's next? [#what-next]
 

--- a/src/content/docs/logs/logs-context/logs-in-context.mdx
+++ b/src/content/docs/logs/logs-context/logs-in-context.mdx
@@ -61,6 +61,7 @@ Not every language or logging framework is supported yet. The following are our 
 * [.NET logs in context procedures](/docs/logs/logs-context/net-configure-logs-context-all) for agent [v9.7.0.0 or higher](/docs/release-notes/agent-release-notes/net-release-notes)
 * [Node.js logs in context procedures](/docs/logs/logs-context/configure-logs-context-nodejs) for agent [v8.11.0 or higher](/docs/release-notes/agent-release-notes/nodejs-release-notes)
 * [Ruby logs in context procedures](/docs/logs/logs-context/configure-logs-context-ruby) for agent [v8.6.0 or higher](/docs/release-notes/agent-release-notes/ruby-release-notes)
+* [Python logs in context procedures](/docs/logs/logs-context/configure-logs-context-python) for agent [v7.12.0.176](/docs/release-notes/agent-release-notes/python-release-notes)
 
 If your APM agent doesn't support the automatic logs in context solution yet, you can continue to use our manual logs in context solutions, and forward your logs via our infrastructure agent or supported third-party forwarder.
 


### PR DESCRIPTION
This PR adds documentation for app logging settings in the python agent as well as logs in context docs.
@barbnewrelic 