### PR TITLE
chore(k8s): Fix a malformed code block

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure.mdx
@@ -130,15 +130,10 @@ Before starting our [automated installer](https://one.newrelic.com/launcher/k8s-
     3. If you're using signed certificates, make sure they are properly configured by using the following variables in the `DaemonSet` portion of your manifest to set the `.pem` file:
 
        ```
-
-       ```
-
     * name: NRIA_CA_BUNDLE_DIR
       value: <var>YOUR_CA_BUNDLE_DIR</var>
     * name: NRIA_CA_BUNDLE_FILE
       value: <var>YOUR_CA_BUNDLE_NAME</var>
-
-      ```
 
       YAML key path: `spec.template.spec.containers.name.env`
       ```


### PR DESCRIPTION
Hey @x8a , this area of the k8s doc seems like it has a code formatting issue. I _think_ this is a fix for this, but I'd love your eyes on it as someone who knows the docs and domain better than me. 

This is the issue (in the OpenShift section of https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure ):

![image](https://user-images.githubusercontent.com/55203603/172891726-7bb5525b-e241-4b3c-8893-5ef253e1bb9c.png)
