### PR TITLE
Remove translated section-break

### DIFF
--- a/src/i18n/nav/kr.json
+++ b/src/i18n/nav/kr.json
@@ -7939,7 +7939,6 @@
     "title": "가이드 및 모범 사례",
     "locale": "kr"
   },
-  { "englishTitle": "section-break", "title": "구역 나누기", "locale": "kr" },
   {
     "englishTitle": "Application monitoring (APM)",
     "title": "애플리케이션 모니터링(APM)",


### PR DESCRIPTION
we accidentally translated the "title" of section-break so it fell through our check and no `<br/>`s were added to the nav in korean

<img width="277" alt="Screen Shot 2022-06-09 at 3 29 24 PM" src="https://user-images.githubusercontent.com/39655074/172956089-0799a34a-a55d-4db7-a4eb-10c6b8bd505f.png">
