### PR TITLE
feat(aws-health): new fields and remove EOL

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration.mdx
@@ -170,7 +170,7 @@ The following table shows the main attributes available for **AwsHealthNotificat
       </td>
 
       <td>
-        The date and time that the event began in string format.
+        The date and time that the event began (in string format).
       </td>
     </tr>
     
@@ -190,7 +190,7 @@ The following table shows the main attributes available for **AwsHealthNotificat
       </td>
 
       <td>
-        The date and time for event resolution in string format.
+        The date and time for event resolution (in string format).
       </td>
     </tr>
 
@@ -200,7 +200,27 @@ The following table shows the main attributes available for **AwsHealthNotificat
       </td>
 
       <td>
-        The epoch timestamp (in seconds) for event resolution in string format.
+        The epoch timestamp (in seconds) for event resolution.
+      </td>
+    </tr>
+    
+    <tr>
+      <td>
+        `lastUpdatedTime`
+      </td>
+
+      <td>
+        The date and time for the last event update received (in string format).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `lastUpdatedTimestamp`
+      </td>
+
+      <td>
+        The epoch timestamp (in seconds) for the last event update received.
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-health-monitoring-integration.mdx
@@ -23,6 +23,13 @@ AWS Health reports three types of events:
 * **Scheduled changes**: Informs you in advance of scheduled activities that might have an impact on AWS services and resources.
 * **Notifications**: Provides additional information.
 
+Health events will be linked to existing entities for AWS EC2 resources and will inherit all the entity metadata available such as region, availabilityZone, resource tags and more.
+
+To see the complete list of attributes available use the `keyset` function:
+```
+  FROM AwsHealthNotification SELECT keyset()
+```
+
 ## Requirements [#requirements]
 
 This integration is available only for AWS customers who have a Business or Enterprise support plan, because this is a requirement for using the [AWS Health API](https://docs.aws.amazon.com/health/latest/ug/health-api.html).
@@ -163,7 +170,37 @@ The following table shows the main attributes available for **AwsHealthNotificat
       </td>
 
       <td>
-        Date and time the event began.
+        The date and time that the event began in string format.
+      </td>
+    </tr>
+    
+    <tr>
+      <td>
+        `startTimestamp`
+      </td>
+
+      <td>
+        The epoch timestamp (in seconds) for event began.
+      </td>
+    </tr>
+    
+    <tr>
+      <td>
+        `endTime`
+      </td>
+
+      <td>
+        The date and time for event resolution in string format.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `endTimestamp`
+      </td>
+
+      <td>
+        The epoch timestamp (in seconds) for event resolution in string format.
       </td>
     </tr>
   </tbody>
@@ -176,154 +213,3 @@ For example, the following query monitors any open issues on EC2 by resource:
 ```
 SELECT uniqueCount(affectedEntityArn) FROM AwsHealthNotification where statusCode = 'open' and eventTypeCategory = 'Issue' and service = 'EC2'
 ```
-
-## Inventory data [#metrics]
-
-<Callout
-  variant="important"
-  title="EOL NOTICE"
->
-  After March 2022, we're discontinuing support for several capabilities, including inventory data for cloud integrations. For more details, including how you can easily prepare for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-and-support-across-errors-classic-labels-service-infrastructure-on-host-snmp-integration-and-inventory-data-in-cloud-integrations/175370).
-</Callout>
-
-Inventory data provides information about active AWS Health events. New Relic's AWS Health integration generates three types of entities, each of which have the same inventory data:
-
-* `aws/health/issue/`
-* `aws/health/scheduled-change/`
-* `aws/health/notification/`
-
-<table>
-  <thead>
-    <tr>
-      <th style={{ width: "300px" }}>
-        Name
-      </th>
-
-      <th>
-        Description
-      </th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td>
-        `affectedAvailabilityZone`
-      </td>
-
-      <td>
-        The AWS Availability Zone of the event.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `affectedEntities`
-      </td>
-
-      <td>
-        The ARNs of the entities that are affected by the event. Entities can refer to individual customer resources, groups of customer resources, or any other construct, depending on the AWS service.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `affectedRegion`
-      </td>
-
-      <td>
-        The AWS region of the affected entities.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `arn`
-      </td>
-
-      <td>
-        The unique identifier for the event.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `awsRegion`
-      </td>
-
-      <td>
-        The Personal Health Dashboard region.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `description`
-      </td>
-
-      <td>
-        The most recent description of the event.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `endTime`
-      </td>
-
-      <td>
-        The date and time that the event ended.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `eventTypeCategory`
-      </td>
-
-      <td>
-        The category of the event type. Possible values are `issue`, `scheduledChange`, or `accountNotification`.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `eventTypeCode`
-      </td>
-
-      <td>
-        The unique identifier for the event type.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `service`
-      </td>
-
-      <td>
-        The AWS service that is affected by the event.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `startTime`
-      </td>
-
-      <td>
-        The date and time that the event began.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `statusCode`
-      </td>
-
-      <td>
-        The most recent status of the event. Examples of possible values are `open`, `closed`, and `upcoming`.
-      </td>
-    </tr>
-  </tbody>
-</table>


### PR DESCRIPTION
## Give us some context

* We added the following new attributes to the AwsHealthNotification event: startTimestamp, endTimestamp and lastUpdateTimestamp.
* We are also taking the opportunity to remove the inventory section that has been EOL (we'll do the same for all integrations  in the next few weeks). 