### PR TITLE
Infra-agent: update supported platforms

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -55,7 +55,7 @@ The infrastructure agent supports these processor architectures:
 * **Linux**: 64-bit for x86 processor architectures (also requires 64-bit package manager and dependencies)
 * **Windows**: both 32 and 64-bit for x86 processor architectures
 * **ARM**: arm64 architecture including [AWS Graviton 2 processor](https://aws.amazon.com/ec2/graviton/) is supported on compatible Linux operating sytems. On-host integrations are also supported (with the exception of the Oracle integration).
-* **macOS**: 64-bit x86 processor (M1 processor is not supported yet).
+* **macOS**: 64-bit x86 processor (ARM processor is not supported yet).
 
 ## Operating systems
 
@@ -77,7 +77,7 @@ The infrastructure agent supports these operating systems up to their manufactur
   <tbody>
     <tr>
       <td>
-        <img style={{ width: '32px', height: '32px', verticalAlign: 'middle'}} class="inline" title="amazon linux" alt="amazon linux.png" src={amazonLinux}/>[Amazon Linux 2](/docs/infrastructure-install-amazon-linux-centos-debian-rhel-or-ubuntu)
+        <img style={{ width: '32px', height: '32px', verticalAlign: 'middle'}} class="inline" title="amazon linux" alt="amazon linux.png" src={amazonLinux}/>[Amazon Linux 2, Amazon Linux 2022 (Preview)](/docs/infrastructure-install-amazon-linux-centos-debian-rhel-or-ubuntu)
       </td>
 
       <td>
@@ -161,7 +161,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        [LTS](https://wiki.ubuntu.com/LTS) versions 16.04.x, 18.04.x, 20.04.x
+        [LTS](https://wiki.ubuntu.com/LTS) versions 16.04.x, 18.04.x, 20.04.x, 22.04.x
         Interim releases 20.10, 21.04.
       </td>
     </tr>


### PR DESCRIPTION
## Give us some context

* Infra-agent is now compatible with RHEL 9, Ubuntu 22.04 and Amazon Linux 2022 (Beta).