### PR TITLE
Add guided installation post-installation doc

### DIFF
--- a/src/content/docs/apm/agents/java-agent/guided-install/java-guided-installation.mdx
+++ b/src/content/docs/apm/agents/java-agent/guided-install/java-guided-installation.mdx
@@ -1,0 +1,48 @@
+---
+title: 'How to manage the Java agent after a guided installation'
+tags:
+  - Agents
+  - Java agent
+  - Getting started
+metaDescription: Here are some tips for managing your APM Java agent following the guided installation.
+---
+
+If you installed the APM Java agent using our guided installation with the CLI, you are in the right place. When you install the Java agent with the guided installation, your post-installation routines vary from manual installations. This is because these Java agents instrument your applications a bit differently than manual Java agent installations.
+
+We’ve made it simple to set up our Java APM using New Relic's Guided Installation flow, so you can instrument java applications and start analyzing your telemetry data in 5 minutes - no instrumentation expertise required.​
+
+## Supported Environments
+The guided install will automatically instrument the following app/web servers running on Linux platforms, both on-host and running in Docker containers
+
+- JBoss 7.0 to latest
+- JBoss EAP 6.0 to 7.3
+- Jetty 7.0.0.M3 to 9.4.x (currently not supported in Docker containers)
+- Tomcat 7.0.0 to 9.0.x
+- WildFly 8.0.0.Final to latest
+
+The [infrastructure monitoring agent](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent/) is required for this feature and is included with this installation
+
+## Updating previous installations
+
+### Renaming an application
+To rename a New Relic application you have previously created, simply re-run the guided installation.  You will be prompted to enter a new application name during installation.  You will need to restart any previously-instrumented applications to start sending telemetry data using the application name.
+
+### Upgrading Java agent
+To upgrade to the latest Java agent, simply re-run the guided installation.  The latest Java APM agent will be downloaded to your host.  You will need to restart and previously-instrumented applications to start sending telemetry data using the latest Java agent.
+
+## Uninstall the Java agent
+
+### Disabling java process detection integration
+To disable this integration, remove the configuration file located below and restart the infrastruture service
+/etc/newrelic-infra/integrations.d/java-dynamic-attach.yml
+
+### Uninstalling 
+To remove this integration, delete the following directories and files:
+- `/etc/newrelic-infra/integrations.d/java-dynamic-attach.yml`
+- `/etc/newrelic-java/`
+
+And remove the following package:
+- `sudo apt remove nri-introspector-java`
+
+### Stop reporting telemetry data
+Once the integration has been disabled or removed, restart the previously-instrumented application server to stop reporting data to New Relic

--- a/src/content/docs/apm/agents/java-agent/guided-install/java-guided-installation.mdx
+++ b/src/content/docs/apm/agents/java-agent/guided-install/java-guided-installation.mdx
@@ -7,42 +7,53 @@ tags:
 metaDescription: Here are some tips for managing your APM Java agent following the guided installation.
 ---
 
-If you installed the APM Java agent using our guided installation with the CLI, you are in the right place. When you install the Java agent with the guided installation, your post-installation routines vary from manual installations. This is because these Java agents instrument your applications a bit differently than manual Java agent installations.
+If you are wondering how to manage your Java agent after using our CLI-based guided installation, you're in the right place. Because you used the CLI, the management tasks you can do with the agent after installation are somewhat different than if you had installed the agent manually. The goal of the CLI approach was to give you a quick view of what the Java agent can do for you, so it instrumented your apps in a streamlined way. As a result, you have a different set of options for managing this streamlined agent.
 
-We’ve made it simple to set up our Java APM using New Relic's Guided Installation flow, so you can instrument java applications and start analyzing your telemetry data in 5 minutes - no instrumentation expertise required.​
 
-## Supported Environments
-The guided install will automatically instrument the following app/web servers running on Linux platforms, both on-host and running in Docker containers
+## What's happening under the hood with this CLI installation [#overview]
 
-- JBoss 7.0 to latest
-- JBoss EAP 6.0 to 7.3
-- Jetty 7.0.0.M3 to 9.4.x (currently not supported in Docker containers)
-- Tomcat 7.0.0 to 9.0.x
-- WildFly 8.0.0.Final to latest
+When you installed the APM Java agent using the CLI, it installed the [New Relic infrastructure monitoring agent](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent/) as a foundation for the Java agent. [I AM MAKING THIS UP]. Along with the infrastructure agent, you also received a companion program called the Java process detection integration. These work in tandem to check to for Java applications on your host.
 
-The [infrastructure monitoring agent](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent/) is required for this feature and is included with this installation
+[ADD MORE DETAILS HERE]
 
-## Updating previous installations
+## What kinds of configurations can you make [#configurations]
 
-### Renaming an application
-To rename a New Relic application you have previously created, simply re-run the guided installation.  You will be prompted to enter a new application name during installation.  You will need to restart any previously-instrumented applications to start sending telemetry data using the application name.
+[INSERT SUBHEADINGS WITH CONFIGURATIONS YOU CAN CONTROL]
 
-### Upgrading Java agent
-To upgrade to the latest Java agent, simply re-run the guided installation.  The latest Java APM agent will be downloaded to your host.  You will need to restart and previously-instrumented applications to start sending telemetry data using the latest Java agent.
+### Rename an application [#rename]
 
-## Uninstall the Java agent
+To rename a New Relic application you created:
 
-### Disabling java process detection integration
-To disable this integration, remove the configuration file located below and restart the infrastruture service
-/etc/newrelic-infra/integrations.d/java-dynamic-attach.yml
+1. Re-run the guided installation.
+2. When you are prompted, enter a new application name.
+3. Restart any previously-instrumented applications to start sending telemetry data using the new application name.
 
-### Uninstalling 
-To remove this integration, delete the following directories and files:
-- `/etc/newrelic-infra/integrations.d/java-dynamic-attach.yml`
-- `/etc/newrelic-java/`
+## Update the Java agent [#update]
 
-And remove the following package:
-- `sudo apt remove nri-introspector-java`
+To update to the latest Java agent:
 
-### Stop reporting telemetry data
-Once the integration has been disabled or removed, restart the previously-instrumented application server to stop reporting data to New Relic
+1. Re-run the guided installation, which downloads the latest Java APM agent to your host.
+2. Restart your previously-instrumented applications to start sending telemetry data using the latest Java agent.
+
+
+## Disable the Java agent [#disable]
+
+If you ever need to disable the Java agent, but not remove it, you can disable its companion program called the Java process detection integration:
+
+1. Remove the configuration file (`/etc/newrelic-infra/integrations.d/java-dynamic-attach.yml`).
+2. Restart the infrastructure service. [HOW DO YOU DO THIS?]
+
+## Uninstall the Java agent [#uninstall]
+
+To remove the Java agent from a host, including the companion program Java process integration:
+
+1. Delete the following directories and files:
+
+    * `/etc/newrelic-infra/integrations.d/java-dynamic-attach.yml`
+    * `/etc/newrelic-java/`
+
+2. Remove the following package: `sudo apt remove nri-introspector-java`
+
+## Stop reporting telemetry data
+
+To ensure that you are no longer reporting telemetry data after you disable or remove the Java agent, restart the previously-instrumented application server to stop reporting data to New Relic.

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -177,6 +177,8 @@ pages:
                 path: /docs/apm/agents/java-agent/additional-installation/install-java-agent-using-maven
               - title: Gradle installation
                 path: /docs/apm/agents/java-agent/additional-installation/install-java-agent-using-gradle
+          - title: After your guided install
+            path: /docs/apm/agents/java-agent/guided-install/java-guided-installation
           - title: Heroku
             path: /docs/apm/agents/java-agent/heroku
             pages:


### PR DESCRIPTION
This is a guide to help users understand how to manage Java agents they installed with the guided installation.