### PR TITLE
fix: Update introduction-log-api.mdx

### DIFF
--- a/src/content/docs/logs/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-api/introduction-log-api.mdx
@@ -788,8 +788,7 @@ This will be treated as:
 ```
 {
   "timestamp": 1562767499238,
-  "message": "{\"service-name\": \"my-service\", \"user\": {\"id\": 123, \"name\": \"alice\"}}",
-  "service-name": "my-service",
+  "service-name": "login-service",
   "user": {
     "id": 123,
     "name": "alice"


### PR DESCRIPTION
This fixes the example showing how message is treated when it is JSON. The example seems to indicate that the JSON attributes are extracted from the message (which is correct) and the message attribute is retained as a JSON string (which is not correct). So I just removed the JSON string from the "This will be treated as" part of the example. Thanks!