### PR TITLE
statsd: added arm64 support

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
@@ -35,6 +35,7 @@ SELECT count(*) FROM NrIntegrationError
   FACET category, message
   LIMIT 100 since 1 day ago
 ```
+The integration is available as a linux container image in [DockerHub](https://hub.docker.com/r/newrelic/nri-statsd/tags) for amd64 and arm64 architectures. 
 
 ## Install
 


### PR DESCRIPTION
## Give us some context

* StatsD integration is available on arm64 archictures. 