### PR TITLE
DO NOT MERGE: Add troubleshooting for ksm crashloopBackoff

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/troubleshooting/ksm-pod-crashing.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/troubleshooting/ksm-pod-crashing.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Kubernetes integration troubleshooting: nrk8s-ksm pod in CrashLoopBackOff'
+type: troubleshooting
+tags:
+  - Integrations
+  - Kubernetes integration
+  - Troubleshooting
+metaDescription: Some troubleshooting tips if you see the nrk8s-ksm pod in CrashLoopBackoff.
+redirects:
+  - /docs/integrations/kubernetes-integration/troubleshooting/ksm-pod-crashing
+---
+
+## Problem
+
+The nrk8s-ksm pod is in CrashLoopBackoff.
+
+## Solution
+
+Check the logs for the ksm container in the pod:
+```
+kubectl logs nr-2-nrk8s-ksm-xxx-xx -c ksm
+```
+
+If the error message is the following:
+```
+"[...] KSM data was not populated after trying all endpoints, check if namespace filters are set properly"
+```
+
+Then the namespaceSelector for the namespace Filter is not matching any namespaces, so the integration is discarding all KSM data.
+You must fix the selector to match at least one namespace [Link-to-namespace-filter-waiting-on-carlos-pr]().
+If not scraping any namespace is the intended behaviour, you can disable scraping the KSM as described in the [Kubernetes integration Helm installation guide](/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm#installing-and-configuring-nri-bundle-with-helm).


### PR DESCRIPTION
Signed-off-by: Alvaro Cabanas <acabanas@newrelic.com>

Add the troubleshooting steps when the nri-kubernetes ksm scraper pod is in CrashLoopBackoff.