### PR TITLE
Use `minionId` changes to count restarts

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/monitor-private-locations.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/monitor-private-locations.mdx
@@ -293,7 +293,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 1,
-                    "query": "FROM SyntheticsPrivateMinion SELECT uniqueCount(minionHostname) WHERE minionLocation NOT LIKE 'AWS_%' FACET minionHostname TIMESERIES LIMIT 50"
+                    "query": "FROM SyntheticsPrivateMinion SELECT uniqueCount(minionId) WHERE minionLocation NOT LIKE 'AWS_%' FACET minionId TIMESERIES LIMIT 50"
                   }
                 ],
                 "platformOptions": {


### PR DESCRIPTION
- change from `minionHostname` to `minionId`, which should work better for Kubernetes containers where the container name doesn't change.