### PR TITLE
Java agent - Add new Scala instrumentation page for Akka HTTP Core

### DIFF
--- a/src/content/docs/apm/agents/java-agent/frameworks/scala-akka-http-core.mdx
+++ b/src/content/docs/apm/agents/java-agent/frameworks/scala-akka-http-core.mdx
@@ -1,0 +1,42 @@
+---
+title: Scala Akka HTTP core instrumentation
+tags:
+  - Agents
+  - Java agent
+  - Scala instrumentation
+  - Custom instrumentation
+metaDescription: Supplemental directions for instrumenting the New Relic Java agent with Scala applications using the Akka HTTP Core framework.
+redirects:
+---
+
+With the introduction of Java agent release 7.8.0, changes were made to *remove* the default instrumentation of the `bindAndHandle` method, to eliminate scenarios that could result in erroenously duplicated transactions being reported. In some situations, it may be necessary for you to make explicit method calls to compensate for this change.
+
+## Background - HttpExt instrumentation
+Instrumentation for Akka HTTP Core is carried out in the `akka.http.scaladsl.HttpExt` class that serves as the 
+main entry point for a server. Two convenience methods from `HttpExt` that can be used to start an HTTP server have 
+been instrumented, they are :
+
+- ` bindAndHandleAsync`: A convenience method which starts a new HTTP server at the given endpoint and uses a handler that is a function recieving an `HttpRequest` and returning a `Future[HttpResponse]`
+- ` bindAndHandleSync`: A convenience method which starts a new HTTP server at the given endpoint and uses a handler that is a function recieving an `HttpRequest` and returning a `HttpResponse`
+
+To eliminate the erroneous duplication of transactions from being reported, intrumentation is *no longer* being applied to the `bindAndHandle` method, which starts a new HTTP server using a `akka.stream.scaladsl.Flow` instance. 
+
+The duplication of transactions is due to a clash in the Akka Http Routing DSL instrumentation. 
+
+## Solution - explicitly call bindAndHandleAsync
+If you wish to start an HTTP server from an `akka.stream.scaladsl.Flow`, you must explicitly invoke the `bindAndHandleAsync` method. For example:
+
+```
+    ...
+
+    val flow: Flow[HttpRequest, HttpResponse, NotUsed] = ???
+    val asyncHandler: HttpRequest => Future[HttpResponse] = request => Source.single(request).via(flow).runWith(Sink.head)
+
+    Http().bindAndHandleAsync(asyncHandler, host, port)
+
+    ...
+```
+
+<Callout variant="important">
+A similar workaround - calling `bindAndHandle` when starting an HTTP server from a `akka.http.scaladsl.Route` using the Akka HTTP Routing DSL - is *not* necessary. Agent instrumentation will work normally when being called from other convenience methods.
+</Callout>


### PR DESCRIPTION
Describes a change with release 7.8.0 that may impact some Scala customers and what they will need to do to compensate for it.

Docs hero : If possible, can we have this new page linked in the left side navigation under Install application performance monitoring -> Java monitoring -> Custom instrumentation -> Scala instrumentation -> Akka HTTP Core instrumentation?