### PR TITLE
AWS metric streams: notes about filters and useful queries

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
@@ -49,6 +49,10 @@ First, you need to link each of your AWS accounts with your New Relic account. T
 
 Next, set up the metric stream using the [CloudFormation template](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https://nr-downloads-main.s3.amazonaws.com/cloud_integrations/aws/cloudformation/MetricStreams_CloudFormation.yml&stackName=NewRelic-Metric-Stream&param_NewRelicDatacenter=US) we provide in the last step of our UI. This template is provided as a base to setup the integration on a single region, and can be customized and extended based on your requirements.
 
+<Callout variant="tip">
+  The provided CloudFormation template does not include any inclusion nor exclusion namespace filter in CloudWatch metric streams. Consider adapting the base template based on your business requirements.
+</Callout>
+
 ## Manual setup using AWS Console, API, or calls [#manual-setup]
 
 1. **Create a Kinesis Data Firehose Delivery Stream** and configure the following destination parameters:
@@ -234,13 +238,25 @@ New Relic provides a [set of tools](/docs/telemetry-data-platform/ingest-manage-
 If you need a more granular view of the data you can use the `bytecountestimate()` function on Metric in order to estimate the data being ingested. For example, the following query represents data ingested from all metrics processed via AWS Metric Streams integration in the last 30 days (in bytes):
 
 ```
-FROM Metric SELECT bytecountestimate() where collector.name='cloudwatch-metric-streams' since 30 day ago
+FROM Metric SELECT bytecountestimate()/10e8 as 'GB Estimate' WHERE collector.name='cloudwatch-metric-streams' SINCE 30 day ago
+```
+
+To see data ingested by AWS service/namespace:
+
+```
+FROM Metric SELECT bytecountestimate()/10e8 as 'GB Estimate' WHERE collector.name='cloudwatch-metric-streams' FACET aws.Namespace
+```
+
+To see number of metric updates processed by AWS service/namespace:
+
+```
+FROM Metric SELECT count(*) WHERE collector.name='cloudwatch-metric-streams' FACET aws.Namespace
 ```
 
 We recommend the following actions to control the data being ingested:
 
 * Make sure metric streams are enabled only on the AWS accounts and regions you want to monitor with New Relic.
-* Use the inclusion and exclusion filters in the CloudWatch Metric Stream in order to select which services / namespaces are being collected.
+* *Use the inclusion and exclusion filters* in the CloudWatch Metric Streams in order to select which services / namespaces are being monitored by New Relic.
 * Consider using [drop data rules](/docs/telemetry-data-platform/manage-data/drop-data-using-nerdgraph/) to discard metrics based on custom filters (for example, drop metrics by namespace and tag, tag value, or any other valid NRQL criteria).
 
 <Callout variant="important">

--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
@@ -6,7 +6,7 @@ tags:
   - AWS integrations list
 ---
 
-With the new AWS Metric Streams integration, you only need a **single service**, [AWS CloudWatch](https://aws.amazon.com/cloudwatch/), to gather all AWS metrics and custom namespaces and send them to New Relic.
+With the AWS Metric Streams integration, you only need a **single service**, [AWS CloudWatch](https://aws.amazon.com/cloudwatch/), to gather all AWS metrics and custom namespaces and send them to New Relic.
 
 To stream CloudWatch metrics to New Relic:
 
@@ -16,7 +16,7 @@ To stream CloudWatch metrics to New Relic:
 4. Follow the [guided](#setup-cloudformation) or [manual](#manual-setup) setup instructions.
 5. Validate [data reception](#validate-data).
 
-If you're migrating from AWS polling integrations, [read our considerations](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream#migrating-from-poll-integrations).
+If applicable, read our documentation about [migrating from AWS polling integrations](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream#migrating-from-poll-integrations).
 
 <Callout variant="tip">
   You can use Terraform to automate the process of enabling cloud integrations. Read how in the [Terraform official documentation site](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/cloud_integrations_guide).
@@ -34,7 +34,7 @@ tag:GetResources
 
 The New Relic UI currently recommends the `ReadOnlyAccess` policy over these individual items so that New Relic has proper permissions to collect service data that's not available in AWS CloudWatch Metric Streams.
 
-### New Relic and AWS accounts and regions mapping [#map-accounts-regions]
+## New Relic and AWS accounts and regions mapping [#map-accounts-regions]
 
 * If you manage multiple AWS accounts, then each account needs to be connected to New Relic.
 * If you manage multiple regions within those accounts, then each region needs to be configured with a different Kinesis Data Firehose pointing to New Relic.
@@ -42,12 +42,12 @@ The New Relic UI currently recommends the `ReadOnlyAccess` policy over these ind
 
 ## Guided setup using CloudFormation [#setup-cloudformation]
 
-First, you need to link each of your AWS accounts with your New Relic account. To do so:
+First, you need to link each of your AWS accounts with your New Relic account. To do so, use either of these options:
 
 * Go to **[one.newrelic.com](https://one.newrelic.com/) > Infrastructure > AWS**, click on **Add an AWS account**, then on **Use metric streams**, and follow the steps.
-* You may [automate this step with NerdGraph](/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial/#link-aws).
+* [Automate this step with NerdGraph](/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial/#link-aws).
 
-Next, set up the metric stream using the [CloudFormation template](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https://nr-downloads-main.s3.amazonaws.com/cloud_integrations/aws/cloudformation/MetricStreams_CloudFormation.yml&stackName=NewRelic-Metric-Stream&param_NewRelicDatacenter=US) we provide in the last step of our UI. This template is provided as a base to setup the integration on a single region, and can be customized and extended based on your requirements.
+Next, set up the metric stream using the [CloudFormation template](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https://nr-downloads-main.s3.amazonaws.com/cloud_integrations/aws/cloudformation/MetricStreams_CloudFormation.yml&stackName=NewRelic-Metric-Stream&param_NewRelicDatacenter=US) we provide in the last step of our UI. This template is provided as a base to set up the integration on a single region. You can customize and extend it to meet your requirements.
 
 <Callout variant="tip">
   The provided CloudFormation template does not include any inclusion nor exclusion namespace filter in CloudWatch metric streams. Consider adapting the base template based on your business requirements.
@@ -78,13 +78,13 @@ Next, set up the metric stream using the [CloudFormation template](https://conso
 
 2. **Create the metric stream**.
 
-* Go to CloudWatch service in your AWS console and select the **Streams** option under the Metrics menu.
-* Click on Create metric stream.
+* Go to **CloudWatch service** in your AWS console and select the **Streams** option under the **Metrics** menu.
+* Click **Create metric stream**.
 * Determine the right configuration based on your use cases:
   * Use inclusion and exclusion filters to select which services should push metrics to New Relic.
   * Select your Kinesis Data Firehose.
-  * Define a meaningful name for the stream (for example, newrelic-metric-stream).
-* Change default output format to `Open Telemetry 0.7` (JSON is not supported)
+  * Define a meaningful name for the stream (for example, `newrelic-metric-stream)`.
+* Change default output format to `Open Telemetry 0.7`. (JSON is not supported.)
 * Confirm the creation of the metric stream.
 
   Alternatively, you can find instructions on the AWS documentation in order to create the CloudWatch metric stream using a CloudFormation template, API, or the CLI.
@@ -94,15 +94,15 @@ Next, set up the metric stream using the [CloudFormation template](https://conso
 
 ## Validate your data is received correctly [#validate-data]
 
-To confirm you are receiving data from the Metric Streams, follow the steps below:
+To confirm you are receiving data from the Metric Streams, follow these steps:
 
 1. Go to **[one.newrelic.com](https://one.newrelic.com/) > Infrastructure > AWS**, and search for the **Stream** accounts.
-2. You can check the following:
+2. Check the following:
 
 * Account status dashboard. Useful to confirm that metric data is being received (errors, number of namespaces/metrics ingested, etc.)
-* Explore your data. Use the Data Explorer to find a specific set of metrics, access all dimensions available for a given metric and more.
+* Explore your data. Use the data explorer to find a specific set of metrics, access all dimensions available for a given metric, and more.
 
-It may take few minutes until new resources are detected and synthesized as entities. See Cloud integrations [system limits](/docs/data-apis/manage-data/view-system-limits) for more information.
+It may take few minutes until new resources are detected and synthesized as entities. See [cloud integrationssystem limits](/docs/data-apis/manage-data/view-system-limits) for more information.
 
 <Callout variant="tip">
   AWS CloudWatch metrics for global services such as AWS S3 or AWS Billing are only availble in the **us-east-1** region. Make sure there's an active CloudWatch metric stream configured in that region.
@@ -110,7 +110,7 @@ It may take few minutes until new resources are detected and synthesized as enti
 
 ## Queries, metric storage, and mapping [#query-experience]
 
-Metrics coming from AWS CloudWatch are stored as dimensional metrics of type `summary`, and can be [queried](/docs/telemetry-data-platform/get-data/apis/query-metric-data-type/) using [NRQL](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language/).
+Metrics coming from AWS CloudWatch are stored as dimensional metrics of type `summary`. You can [query](/docs/telemetry-data-platform/get-data/apis/query-metric-data-type/) using [NRQL](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language/).
 
 We've mapped metrics from the current cloud integrations to the new mappings that will come from AWS Metric Streams. You can continue to use the current metric naming, and queries will continue to work and pick data from AWS Metric Streams and the current cloud integrations.
 
@@ -119,18 +119,18 @@ Check our documentation on how [current cloud integrations metrics map to the ne
 All metrics coming from the metric stream will have these attributes:
 
 * `aws.MetricStreamArn`
-* `collector.name = ‘cloudwatch-metric-streams’`.
+* `collector.name = 'cloudwatch-metric-streams'`.
 
-## AWS namespaces' entities in the New Relic Explorer [#aws-entities]
+## AWS namespaces' entities in the New Relic explorer [#aws-entities]
 
 We generate New Relic [entities](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/) for most used AWS namespaces and will continue adding support for more namespaces.
 
 When we generate New Relic entities for a namespace you can expect to:
 
-* Browse those entities in the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts/).
-* Access an out-of-the-box entity dashboard for those entities.
-* Get metrics and entities from that namespace decorated with AWS tags. Collecting AWS tags requires that you have given New Relic the `tag:GetResources` permission which is part of the setup process in the UI. AWS tags show in metrics as `tag.AWSTagName`; for example, if you have set a Team AWS tag on the resource, it will show as `tag.Team`.
-* Leverage all the built-in features that are part of the Explorer.
+* Browse those entities in the [New Relic explorer](/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts/).
+* Access an entity dashboard automatically created for those entities.
+* Get metrics and entities from that namespace decorated with AWS tags. Collecting AWS tags requires that you have given New Relic the `tag:GetResources` permission, which is part of the setup process in the UI. AWS tags show in metrics as `tag.AWSTagName`; for example, if you have set a `Team` AWS tag on the resource, it will show as `tag.Team`.
+* Leverage all the built-in features that are part of the explorer.
 
 <Callout variant="important">
   [Lookout view](/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-lookout-monitor-your-estate-glance/) in **Entity Explorer** is not compatible with entities created from the AWS Metric Streams integration at this time.
@@ -144,7 +144,7 @@ You can create NRQL alert conditions on metrics from a metric stream. Make sure 
 SELECT sum(aws.s3.5xxErrors) FROM Metric WHERE collector.name = 'cloudwatch-metric-streams' FACET aws.accountId, aws.s3.BucketName
 ```
 
-Then, to make sure that alerts processes the data correctly, configure the advanced signal settings. These settings are needed because AWS CloudWatch receives metrics from services with a certain delay (for example, Amazon guarantees that 90% of EC2 metrics are available in CloudWatch within 7 minutes of them being generated). Moreover, streaming metrics from AWS to New Relic adds up to 1 minute additional delay, mostly due to buffering data in the Firehose.
+Then, to make sure that alerts processes the data correctly, configure the advanced signal settings. These settings are needed because AWS CloudWatch receives metrics from services with a certain delay. (For example, Amazon guarantees that 90% of EC2 metrics are available in CloudWatch within 7 minutes of them being generated.) Moreover, streaming metrics from AWS to New Relic adds up to 1 minute additional delay, mostly due to buffering data in the Firehose.
 
 To configure the signal settings, under **Condition Settings**, click on **Advanced Signal Settings** and enter the following values:
 
@@ -164,7 +164,7 @@ The following query shows an example of tags being collected and queried as dime
 SELECT average(`aws.rds.CPUUtilization`) FROM Metric FACET `tags.mycustomtag` SINCE 30 MINUTES AGO TIMESERIES
 ```
 
-Note that not all metrics have their custom tags as dimensions. Currently, only metrics linked to entities in the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts/) have their custom tags associated. The AWS CloudWatch metric stream doesn't include tags as part of the stream message, hence, additional processing is required on the New Relic side.
+Note that not all metrics have their custom tags as dimensions. Currently, only metrics linked to entities in the [New Relic explorer](/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts/) have their custom tags associated. The AWS CloudWatch metric stream doesn't include tags as part of the stream message; hence, additional processing is required on the New Relic side.
 
 ## Metadata collection [#metadata-collection]
 
@@ -172,22 +172,22 @@ Like with custom tags, New Relic also pulls metadata information from relevant A
 
 The solution relies on [AWS Config](https://docs.aws.amazon.com/config/index.html), which might incur in additional costs in your AWS account. AWS Config provides [granular controls](https://docs.aws.amazon.com/config/latest/developerguide/select-resources.html) to determine which services and resources are recorded. New Relic will only ingest metadata from the available resources in your AWS account.
 
-The following services / namespaces are supported:
+The following services and namespaces are supported:
 
+* ALB/NLB
+* API Gateway (excluding API v1)
+* DynamoDB
+* EBS
 * EC2
+* ECS
+* ELB
 * Lambda
 * RDS
-* ALB/NLB
 * S3
-* API Gateway (excluding API v1)
-* ELB
-* EBS
-* DynamoDB
-* ECS
 
 ### Infrastructure agent metrics and EC2 metadata decoration [#infra-data-decoration]
 
-As with the EC2 API polling integration, when the infrastructure agent is installed on, a host and the EC2 namespace is active via AWS CloudWatch metric stream integration, then all the infrastructure agent events and metrics are decorated with additional metadata.
+As with the EC2 API polling integration, when the infrastructure agent is installed on a host and the EC2 namespace is active via AWS CloudWatch metric stream integration, then all the infrastructure agent events and metrics are decorated with additional metadata.
 
 The following attributes will decorate infrastructure samples. Some of these may not be applicable on all environments: `awsAvailabilityZone`, `ec2InstanceId`, `ec2PublicDnsName`, `ec2State`, `ec2EbsOptimized`, `ec2PublicIpAddress`, `ec2PrivateIpAddress`, `ec2VpcId`, `ec2AmiId`, `ec2PrivateDnsName`, `ec2KeyName`, `ec2SubnetId`, `ec2InstanceType`, `ec2Hypervisor`, `ec2Architecture`, `ec2RootDeviceType`, `ec2RootDeviceName`, `ec2VirtualizationType`, `ec2PlacementGroupName`, `ec2PlacementGroupTenancy`.
 
@@ -206,15 +206,15 @@ Follow these steps in order to browse and import dashboards:
 5. Click **Done** to confirm that AWS metric stream is already configured.
 6. Browse and adapt the dashboard according to your needs.
 
-Have an interesting dashboard to share with the community? See [contribution guidelines](https://github.com/newrelic/newrelic-quickstarts#getting-started) in the Instant Observability Github repository.
+Have an interesting dashboard to share with the community? See [contribution guidelines](https://github.com/newrelic/newrelic-quickstarts#getting-started) in the Instant Observability GitHub repository.
 
 ## Custom metrics and percentiles [#custom-metrics-percentiles]
 
-The CloudWatch metric stream integration will automatically ingest new metrics configured in the stream, including custom metrics and percentiles.
+The CloudWatch metric stream integration automatically ingests new metrics configured in the stream, including custom metrics and percentiles.
 
 ### Custom metrics [#custom-metrics]
 
-To ingest CloudWatch custom metrics, make sure your custom namespace is visible in the CloudWatch metric stream configuration and it's not being filtered  by inclusion or exclusion rules.  
+To ingest CloudWatch custom metrics, make sure your custom namespace is visible in the CloudWatch metric stream configuration and it's not being filtered by inclusion or exclusion rules.  
 
 ### Percentiles [#percentiles]
 
@@ -224,18 +224,20 @@ Follow these steps to add percentiles to any metric available in the CloudWatch 
 
 1. On AWS, update the CloudWatch stream configuration (via API, CLI, or AWS Console) with the required percentiles in the `StatisticConfiguration` setting. For example, you can add p90, p95, and p99 percentiles to the `ELB latency metric (aws.elb.Latency)`.
 2. After a few minutes, the new statistic should be made available in the stream and ingested by New Relic. Percentiles can be queried using this naming convention:
+
   ```sql
     From Metric select max(aws.elb.Latency.p99) where collector.name = 'cloudwatch-metric-streams' timeseries
   ```
+
 Although AWS supports other statistics in the stream beyond percentiles, those aren't made available in the Open Telemetry export format (only JSON) and are currently not supported by New Relic.
 
-Learn more about pricing, limitations and advance configurations from the [AWS documentation](https://aws.amazon.com/about-aws/whats-new/2022/04/amazon-cloudwatch-metric-streams-additional-statistics/).
+Learn more about pricing, limitations, and advance configurations from the [AWS documentation](https://aws.amazon.com/about-aws/whats-new/2022/04/amazon-cloudwatch-metric-streams-additional-statistics/).
 
 ## Manage your data [#manage-data]
 
-New Relic provides a [set of tools](/docs/telemetry-data-platform/ingest-manage-data/manage-data/manage-your-data/) to keep track of the data being ingested in your account. Go to **Manage your data** in the settings menu to see all details. Metrics ingested from AWS Metric Streams integrations are considered in the **Metric** bucket.
+The New Relic UI provides a [set of tools](/docs/telemetry-data-platform/ingest-manage-data/manage-data/manage-your-data/) to keep track of the data being ingested in your account. Go to **Manage your data** in the settings menu to see all details. Metrics ingested from AWS Metric Streams integrations are considered in the **Metric** bucket.
 
-If you need a more granular view of the data you can use the `bytecountestimate()` function on Metric in order to estimate the data being ingested. For example, the following query represents data ingested from all metrics processed via AWS Metric Streams integration in the last 30 days (in bytes):
+If you need a more granular view of the data, use the `bytecountestimate()` function on `Metric` in order to estimate the data being ingested. For example, the following query represents data ingested from all metrics processed via AWS Metric Streams integration in the last 30 days (in bytes):
 
 ```
 FROM Metric SELECT bytecountestimate()/10e8 as 'GB Estimate' WHERE collector.name='cloudwatch-metric-streams' SINCE 30 day ago
@@ -256,8 +258,8 @@ FROM Metric SELECT count(*) WHERE collector.name='cloudwatch-metric-streams' FAC
 We recommend the following actions to control the data being ingested:
 
 * Make sure metric streams are enabled only on the AWS accounts and regions you want to monitor with New Relic.
-* *Use the inclusion and exclusion filters* in the CloudWatch Metric Streams in order to select which services / namespaces are being monitored by New Relic.
-* Consider using [drop data rules](/docs/telemetry-data-platform/manage-data/drop-data-using-nerdgraph/) to discard metrics based on custom filters (for example, drop metrics by namespace and tag, tag value, or any other valid NRQL criteria).
+* **Use the inclusion and exclusion filters** in the CloudWatch Metric Streams in order to select which services or namespaces are being monitored by New Relic.
+* Consider using [drop data rules](/docs/telemetry-data-platform/manage-data/drop-data-using-nerdgraph/) to discard metrics based on custom filters. (For example, drop metrics by namespace and tag, tag value, or any other valid NRQL criteria.)
 
 <Callout variant="important">
   Metrics sent via AWS Metric Streams count against your Metric API limits for the New Relic account where data will be ingested.

--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
@@ -67,15 +67,17 @@ Before CloudWatch metric streams, the only solution for AWS monitoring partners 
 
 Want to try out our Amazon CloudWatch Metric Streams integration? [Sign up with New Relic](https://newrelic.com/signup) for free, forever!
 
-### Cost considerations [#cost-considerations]
+## Cost considerations [#cost-considerations]
 
 Consider the following when evaluating the cost of the AWS CloudWatch metric streams integration with New Relic:
 
 * [AWS CloudWatch metric updates](https://aws.amazon.com/cloudwatch/pricing/).
 * [AWS Kinesis Firehose ingest](https://aws.amazon.com/kinesis/data-firehose/pricing/).
 * [AWS Kinesis Firehose data transfer](https://aws.amazon.com/kinesis/data-firehose/pricing/).
-* Optional: [AWS Config service](https://aws.amazon.com/config/pricing/) API calls to enrich metrics with resource metadata.
+* Optional: [AWS Config service](https://aws.amazon.com/config/pricing/) used to enrich metrics with resource metadata on select AWS namespaces.
 
+Learn about the mechanisms available for [data management](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup#manage-data), including filters in AWS and New Relic side.
+When applicable, make sure to complete an initial integration in a pre-production environment to evaluate the total cost of the solution based on a limited number of AWS resources and services. 
 
 ## Migrating from AWS API polling integrations [#migrating-from-poll-integrations]
 


### PR DESCRIPTION
## Give us some context

* Made cost considerations more prominent and added links to ways to filter data as needed. 
* Included query examples to break down the ingest data and number of metrics based on namespaces. 