### PR TITLE
fix(mysql): slaveRunning has been reintroduced

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mySQL/mysql-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mySQL/mysql-integration.mdx
@@ -42,7 +42,7 @@ To install the MySQL monitoring integration, you must run through the following 
 Our integration is compatible with MySQL version 5.6 or higher.
 
 <Callout variant="important">
-  For MySQL v8.0 and higher we do not support the following metrics: `cluster.slaveRunning`, `db.qCacheFreeMemoryBytes`, `db.qCacheHitRatio`, and `db.qCacheNotCachedPerSecond`.
+  For MySQL v8.0 and higher we do not support the following metrics: `db.qCacheFreeMemoryBytes`, `db.qCacheHitRatio`, and `db.qCacheNotCachedPerSecond`.
 </Callout>
 
 ### Supported operating systems [#supported-os]


### PR DESCRIPTION
Fix https://github.com/newrelic/nri-mysql/issues/100

Context:
We should remove from the callout in our mysql docs the deprecation of cluster.slaveRunning since [now we are calculating the metric ]( https://github.com/newrelic/nri-mysql/pull/89) in a different way.
