### PR TITLE
fix(k8sDocs): pointing to correct metrics

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
@@ -340,7 +340,7 @@ To learn more about how to use your Kubernetes data, please head to our detailed
 
 Our charts support setting an option to reduce the amount of data ingested at the cost of dropping detailed information. To enable it, set `global.lowDataMode` to `true` in the `nri-bundle` chart.
 
-`lowDataMode` affects three specific components of the `nri-bundle` chart outlined below.
+`lowDataMode` affects four specific components of the `nri-bundle` chart outlined below.
 
 ### New Relic Infrastructure
 

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data.mdx
@@ -874,7 +874,7 @@ Query the `K8sNamespaceSample` event for namespace data:
 
     <tr>
       <td>
-        `namespace`
+        `namespaceName`
       </td>
 
       <td>
@@ -956,7 +956,7 @@ Query the `K8sDeploymentSample` event for deployment data:
 
     <tr>
       <td>
-        `namespace`
+        `namespaceName`
       </td>
 
       <td>
@@ -1086,7 +1086,7 @@ Query the `K8sReplicasetSample` event for `ReplicaSet` data:
 
     <tr>
       <td>
-        `namespace`
+        `namespaceName`
       </td>
 
       <td>
@@ -1610,7 +1610,7 @@ Query the `K8sPodSample` event for pod data:
 
     <tr>
       <td>
-        `namespace`
+        `namespaceName`
       </td>
 
       <td>
@@ -2002,7 +2002,7 @@ Query the `K8sContainerSample` event for container data:
 
     <tr>
       <td>
-        `namespace`
+        `namespaceName`
       </td>
 
       <td>
@@ -2184,7 +2184,7 @@ Query the `K8sVolumeSample` event for volume data:
 
     <tr>
       <td>
-        `namespace`
+        `namespaceName`
       </td>
 
       <td>


### PR DESCRIPTION
Related to https://github.com/newrelic/nri-kubernetes/issues/478

`Namespace` attribute has been deprecated and `NamespaceName` is the one used

Context -> https://github.com/newrelic/nri-kubernetes/blob/7741a5058e5b29121e47590a1f791217231e6a1d/src/metric/definition.go#L507