### PR TITLE
.NET Agent - NuGet agent install instructions - add callout regarding logs folder permissions

### DIFF
--- a/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
+++ b/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
@@ -21,6 +21,10 @@ Before installing the agent using NuGet, understand these important points:
 * In order to configure environment variables and directory permissions, you must have access to the systems where you are deploying your applications.
 * If you're using NuGet to update an existing .NET agent, this will overwrite previously made changes to [`newrelic.config`](/docs/agents/net-agent/configuration/net-agent-configuration). To preserve changes, first save the config file outside of your project, then restore it after updating.
 
+<Callout variant="important">
+  The agent's `logs` folder gets created as a subfolder of the `newrelic` folder in your application's build/publish output directory.  The `logs` folder gets created with default permissions, meaning that it may not be writable by the agent if your app is run by a different user than the user who built/published the app.  Make sure that the user your app runs as can write to the `logs` folder.
+</Callout>
+
 Here's an example of using NuGet via Visual Studio to install the .NET agent:
 
 1. Open your Visual Studio solution, or create a new one by selecting **File > New > Project**. For multi-project solutions, be sure to select the correct project (for example, a specific website project).


### PR DESCRIPTION
A recent .NET agent support ticket involved a situation where the customer did not have any agent log files to help troubleshoot, and the cause ended up being that the agent's `logs` folder, as created when the agent is installed with the NuGet package, is created with default permissions, which means that only the user who built/published the app can write to the logs folder.  If their app is executed by a different username (a common pattern), the agent will not be able to write logs.  This PR adds a callout to the NuGet package install instructions warning of this issue.

~Initially setting PR status to "Draft" to get feedback from .NET agent team members before it's ready for docs team review~.