### PR TITLE
docs: fixed section links, add language identifiers

### DIFF
--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
@@ -59,28 +59,28 @@ Here are detailed descriptions of each configuration method:
 
     1. Add the following in the `main` function or in an `init` block:
 
-       ```
+       ```go
        app, err := newrelic.NewApplication(
-           newrelic.ConfigAppName("<var>Your Application Name</var>"),
-           newrelic.ConfigLicense("<var>__YOUR_NEW_RELIC_LICENSE_KEY__</var>"),
+           newrelic.ConfigAppName("Your Application Name"),
+           newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
        )
        ```
     2. Update values on the `newrelic.Config` struct to configure your application using `newrelic.ConfigOption`s. These are functions that accept a pointer to the `newrelic.Config` struct. Add additional `newrelic.ConfigOption`s to further configure your application. For example, you can use one of the predefined options to do common configurations:
 
-       ```
+       ```go
        app, err := newrelic.NewApplication(
-           newrelic.ConfigAppName("<var>Your Application Name</var>"),
-           newrelic.ConfigLicense("<var>__YOUR_NEW_RELIC_LICENSE_KEY__</var>"),
+           newrelic.ConfigAppName("Your Application Name"),
+           newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
            // add debug level logging to stdout
            newrelic.ConfigDebugLogger(os.Stdout),
        )
        ```
     3. Or, you can create your own `newrelic.ConfigOption` to do more complex configurations:
 
-       ```
+       ```go
        app, err := newrelic.NewApplication(
-           newrelic.ConfigAppName("<var>Your Application Name</var>"),
-           newrelic.ConfigLicense("<var>__YOUR_NEW_RELIC_LICENSE_KEY__</var>"),
+           newrelic.ConfigAppName("Your Application Name"),
+           newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
            newrelic.ConfigDebugLogger(os.Stdout),
            func(config *newrelic.Config) {
            	// add more specific configuration of the agent within a custom ConfigOption
@@ -96,10 +96,10 @@ Here are detailed descriptions of each configuration method:
 
 To make Go agent configuration changes, set the values in the `newrelic.Config` struct from within a custom `newrelic.ConfigOption`. For example, to turn New Relic monitoring off temporarily for testing purposes, change the `Enabled` value to `false`:
 
-```
+```go
 app, err := newrelic.NewApplication(
-    newrelic.ConfigAppName("<var>Your Application Name</var>"),
-    newrelic.ConfigLicense("<var>__YOUR_NEW_RELIC_LICENSE_KEY__</var>"),
+    newrelic.ConfigAppName("Your Application Name"),
+    newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
     func(config *newrelic.Config) {
     	config.Enabled = false
     },
@@ -194,10 +194,10 @@ In this and the following examples, `config` represents your New Relic config st
 
     To report data to [multiple apps at the same time](/docs/apm/new-relic-apm/installation-configuration/using-multiple-names-app), specify a list of names separated with a semicolon. Do not put a space before the semicolon itself. For example:
 
-    ```
+    ```go
     app, err := newrelic.NewApplication(
-        newrelic.ConfigAppName("<var>YOUR_APP_NAME</var>;<var>APP_GROUP_1</var>;<var>ALL_APPS</var>"),
-        newrelic.ConfigLicense("<var>__YOUR_NEW_RELIC_LICENSE_KEY__</var>"),
+        newrelic.ConfigAppName("YOUR_APP_NAME;APP_GROUP_1;ALL_APPS"),
+        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
     )
     ```
   </Collapser>
@@ -246,10 +246,10 @@ In this and the following examples, `config` represents your New Relic config st
 
     For example:
 
-    ```
+    ```go
     app, err := newrelic.NewApplication(
-        newrelic.ConfigAppName("<var>Your Application Name</var>"),
-        newrelic.ConfigLicense("<var>__YOUR_NEW_RELIC_LICENSE_KEY__</var>"),
+        newrelic.ConfigAppName("Your Application Name"),
+        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
         func(config *newrelic.Config) {
         	config.Enabled = false
         },
@@ -310,10 +310,10 @@ In this and the following examples, `config` represents your New Relic config st
       >
         Here's an example of setting four tags:
 
-        ```
+        ```go
         app, err := newrelic.NewApplication(
-            newrelic.ConfigAppName("<var>Your Application Name</var>"),
-            newrelic.ConfigLicense("<var>__YOUR_NEW_RELIC_LICENSE_KEY__</var>"),
+            newrelic.ConfigAppName("Your Application Name"),
+            newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
             func(config *newrelic.Config) {
                 config.Labels = map[string]string{
                     "Env":    "Dev",
@@ -329,7 +329,7 @@ In this and the following examples, `config` represents your New Relic config st
   </Collapser>
 
   <Collapser
-    id="labels"
+    id="logger"
     title="Logger"
   >
     <table>
@@ -419,10 +419,10 @@ In this and the following examples, `config` represents your New Relic config st
 
       This setting must match the corresponding account setting in the UI. For example:
 
-      ```
+      ```go
       app, err := newrelic.NewApplication(
-          newrelic.ConfigAppName("<var>Your Application Name</var>"),
-          newrelic.ConfigLicense("<var>__YOUR_NEW_RELIC_LICENSE_KEY__</var>"),
+          newrelic.ConfigAppName("Your Application Name"),
+          newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
           func(config *newrelic.Config) {
               config.HighSecurity = true
           },
@@ -650,10 +650,10 @@ You can create custom events and make them available for querying and analysis.
 
     To disable custom events, place the following in your Go app after the [New Relic config](/docs/agents/go-agent/get-started/get-new-relic-go#get-new-relic) is initiated:
 
-    ```
+    ```go
     app, err := newrelic.NewApplication(
-        newrelic.ConfigAppName("<var>Your Application Name</var>"),
-        newrelic.ConfigLicense("<var>__YOUR_NEW_RELIC_LICENSE_KEY__</var>"),
+        newrelic.ConfigAppName("Your Application Name"),
+        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
         func(config *newrelic.Config) {
             config.CustomInsightsEvents.Enabled = false
         },
@@ -748,7 +748,7 @@ Transaction events are used in collecting events corresponding to web requests a
 
     `TransactionEvents.Attributes` is a struct with three fields:
 
-    ```
+    ```go
     Enabled bool
     Include []string
     Exclude []string
@@ -758,10 +758,10 @@ Transaction events are used in collecting events corresponding to web requests a
 
     An example of excluding an attribute slice named `allAgentAttributeNames` from transaction events:
 
-    ```
+    ```go
     app, err := newrelic.NewApplication(
-        newrelic.ConfigAppName("<var>Your Application Name</var>"),
-        newrelic.ConfigLicense("<var>__YOUR_NEW_RELIC_LICENSE_KEY__</var>"),
+        newrelic.ConfigAppName("Your Application Name"),
+        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
         func(config *newrelic.Config) {
             config.TransactionEvents.Attributes.Exclude = allAgentAttributeNames
         },
@@ -966,7 +966,7 @@ The following settings are used to configure the error collector:
 
     This function's default form is:
 
-    ```
+    ```go
     config.ErrorCollector.IgnoreStatusCodes = []int{
         0,                   // gRPC OK
         5,                   // gRPC NOT_FOUND
@@ -987,10 +987,10 @@ The following settings are used to configure the error collector:
       >
         To add HTTP response code 418 to the default ignore list, which includes 0, 5, and 404:
 
-        ```
+        ```go
         app, err := newrelic.NewApplication(
-            newrelic.ConfigAppName("<var>Your Application Name</var>"),
-            newrelic.ConfigLicense("<var>__YOUR_NEW_RELIC_LICENSE_KEY__</var>"),
+            newrelic.ConfigAppName("Your Application Name"),
+            newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
             func(config *newrelic.Config) {
                 config.ErrorCollector.IgnoreStatusCodes = []int{0, 5, 404, 418}
             },
@@ -1040,7 +1040,7 @@ The following settings are used to configure the error collector:
 
     `ErrorCollector.Attributes` is a struct with three fields:
 
-    ```
+    ```go
     Enabled bool
     Include []string
     Exclude []string
@@ -1050,10 +1050,10 @@ The following settings are used to configure the error collector:
 
     An example of excluding an attribute slice named `allAgentAttributeNames` from errors:
 
-    ```
+    ```go
     app, err := newrelic.NewApplication(
-        newrelic.ConfigAppName("<var>Your Application Name</var>"),
-        newrelic.ConfigLicense("<var>__YOUR_NEW_RELIC_LICENSE_KEY__</var>"),
+        newrelic.ConfigAppName("Your Application Name"),
+        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
         func(config *newrelic.Config) {
             config.ErrorCollector.Attributes.Exclude = allAgentAttributeNames
         },
@@ -1308,7 +1308,7 @@ Here are settings for changing transaction tracer configuration. For more inform
 
     `TransactionTracer.Segments.Attributes` is a struct with three fields:
 
-    ```
+    ```go
     Enabled bool
     Include []string
     Exclude []string
@@ -1318,10 +1318,10 @@ Here are settings for changing transaction tracer configuration. For more inform
 
     An example of excluding an attribute slice named `allSegmentAttributeNames` from traces:
 
-    ```
+    ```go
     app, err := newrelic.NewApplication(
-        newrelic.ConfigAppName("<var>Your Application Name</var>"),
-        newrelic.ConfigLicense("<var>__YOUR_NEW_RELIC_LICENSE_KEY__</var>"),
+        newrelic.ConfigAppName("Your Application Name"),
+        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
         func(config *newrelic.Config) {
             config.TransactionTracer.Segments.Attributes.Exclude = allSegmentAttributeNames
         },
@@ -1424,7 +1424,7 @@ Here are settings for changing transaction tracer configuration. For more inform
 
     `TransactionTracer.Attributes` is a struct with three fields:
 
-    ```
+    ```go
     Enabled bool
     Include []string
     Exclude []string
@@ -1434,10 +1434,10 @@ Here are settings for changing transaction tracer configuration. For more inform
 
     An example of excluding an attribute slice named `allAgentAttributeNames` from traces:
 
-    ```
+    ```go
     app, err := newrelic.NewApplication(
-        newrelic.ConfigAppName("<var>Your Application Name</var>"),
-        newrelic.ConfigLicense("<var>__YOUR_NEW_RELIC_LICENSE_KEY__</var>"),
+        newrelic.ConfigAppName("Your Application Name"),
+        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
         func(config *newrelic.Config) {
             config.TransactionTracer.Attributes.Exclude = allAgentAttributeNames
         },
@@ -1493,7 +1493,7 @@ Here are datastore settings, including [slow query](/docs/apm/applications-menu/
   </Collapser>
 
   <Collapser
-    id="instance-reporting"
+    id="name-reporting"
     title="DatastoreTracer.NameReporting.Enabled"
   >
     <table>
@@ -1902,7 +1902,7 @@ When distributed tracing is enabled, you can collect [span events](/docs/apm/dis
 
     `SpanEvents.Attributes` is a struct with three fields:
 
-    ```
+    ```go
     Enabled bool
     Include []string
     Exclude []string
@@ -1912,10 +1912,10 @@ When distributed tracing is enabled, you can collect [span events](/docs/apm/dis
 
     An example of excluding an attribute slice named `allSpanAttributeNames` from traces:
 
-    ```
+    ```go
     app, err := newrelic.NewApplication(
-        newrelic.ConfigAppName("<var>Your Application Name</var>"),
-        newrelic.ConfigLicense("<var>__YOUR_NEW_RELIC_LICENSE_KEY__</var>"),
+        newrelic.ConfigAppName("Your Application Name"),
+        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
         func(config *newrelic.Config) {
             config.TransactionTracer.Segments.Attributes.Exclude = allSpanAttributeNames
         },


### PR DESCRIPTION
Two section links were duplicates of the links above them.

To add language syntax highlighting I had to remove the `<var>` tags in every codeblock. Mostly they weren't particularly helpful in my opinion, and having the syntax highlighting would be easier to read.  They only one I wasn't sure about was this example:

```go
newrelic.ConfigAppName("YOUR_APP_NAME;APP_GROUP_1;ALL_APPS"),
```

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.