### PR TITLE
fix: typo in parsing logs

### DIFF
--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -90,7 +90,7 @@ Here's an overview of how New Relic implements parsing of logs:
       <td>
         * Parsing will only be applied once to each log message. If multiple parsing rules match the log, only the first that succeeds will be applied.
         * Parsing takes place during log ingestion, before data is written to NRDB. Once data has been written to storage, it can no longer be parsed.
-        * Parsing occurs in the pipeline **before** data enrichments take place. Be careful when defining the matching criteria for a parsing rule. If the criteria is based on an attribute that doesn't exist untail after parsing or enrichment take place, that data won't be present in the logs when matching occurs. As a result, no parsing will happen.
+        * Parsing occurs in the pipeline **before** data enrichments take place. Be careful when defining the matching criteria for a parsing rule. If the criteria is based on an attribute that doesn't exist until after parsing or enrichment take place, that data won't be present in the logs when matching occurs. As a result, no parsing will happen.
       </td>
     </tr>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
* Fixes a typo in the log data parsing section. (untail -> until)