### PR TITLE
Update recorderror-ios-sdk-api.mdx

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recorderror-ios-sdk-api.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recorderror-ios-sdk-api.mdx
@@ -75,10 +75,6 @@ For context on how to use this API, see the documentation about sending custom a
   </tbody>
 </table>
 
-## Return values
-
-Returns `true` if the error was recorded successfully, or `false` if not.
-
 ## Examples
 
 ### Objective-C [#obj-c]


### PR DESCRIPTION
function is void, so return values section should be empty.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
This function is void in the agent code and should be reflected as such.