### PR TITLE
docs: change lang, jade -> pug

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/browser-monitoring-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/browser-monitoring-nodejs-agent.mdx
@@ -57,7 +57,7 @@ Here are some examples of how to set up browser monitoring with different framew
 
     In your `layout.jade`:
 
-    ```jade
+    ```pug
     doctype html
     html
     head


### PR DESCRIPTION
I changed `jade` to `pug` for a codeblock. Jade isn't a native prism language but pug is. It should come out looking like:

```pug
doctype html
html
head
    != newrelic.getBrowserTimingHeader()
    title= title
    link(rel='stylesheet', href='stylesheets/style.css')
body
    block content
```

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.