### PR TITLE
Change the MySQL references to PostgreSQL on the page talking about PostgreSQL

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
@@ -37,7 +37,7 @@ To install the PostgreSQL monitoring integration, you must run through the follo
 
 ## Compatibility and requirements [#req]
 
-### PostgreSQL versions [#mysql-versions]
+### PostgreSQL versions [#postgresql-versions]
 
 Our integration is compatible with PostgreSQL version 9.0 or higher.
 
@@ -51,7 +51,7 @@ For a comprehensive list of specific Windows and Linux versions, check the table
 ### System requirements [#system-reqs]
 
 * A New Relic account. Don't have one? [Sign up for free!](https://newrelic.com/signup) No credit card required.
-* If MySQL is not running on Kubernetes or Amazon ECS, you can [install the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) on a Linux or Windows OS host or on a host capable of remotely accessing where MySQL is installed. Otherwise:
+* If PostgreSQL is not running on Kubernetes or Amazon ECS, you can [install the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) on a Linux or Windows OS host or on a host capable of remotely accessing where PostgreSQL is installed. Otherwise:
   * If running on <img style={{ width: '32px', height: '32px'}} class="inline" title="Kubernetes" alt="Kubernetes" src={kubernetes}/>Kubernetes, see [these requirements](/docs/monitor-service-running-kubernetes#requirements).
   * If running on <img style={{ width: '32px', height: '32px'}} class="inline" title="ECS" alt="ECS" src={ecs}/>Amazon ECS, see [these requirements](/docs/integrations/host-integrations/host-integrations-list/monitor-services-running-amazon-ecs).
 

--- a/src/i18n/content/jp/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
+++ b/src/i18n/content/jp/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
@@ -32,7 +32,7 @@ PostgreSQL監視統合をインストールするには、次の手順を実行�
 
 ## 互換性と要件 [#req]
 
-### PostgreSQLのバージョン [#mysql-versions]
+### PostgreSQLのバージョン [#postgresql-versions]
 
 弊社のインテグレーションは、PostgreSQLバージョン9.0以降と互換性があります。
 
@@ -52,7 +52,7 @@ PostgreSQL監視統合をインストールするには、次の手順を実行�
 
 * NewRelicアカウント。持っていませんか？[無料でお申し込み頂けます！](https://newrelic.com/signup)クレジットカードは必要ありません。
 
-* MySQLがKubernetesまたはAmazon ECSで実行されていない場合、LinuxまたはWindows OSホストに、またはMySQLがインストールされている場所にリモートアクセスできるホストに[Infrastructureエージェントをインストール](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic)できます。その他の場合：
+* PostgreSQLがKubernetesまたはAmazon ECSで実行されていない場合、LinuxまたはWindows OSホストに、またはPostgreSQLがインストールされている場所にリモートアクセスできるホストに[Infrastructureエージェントをインストール](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic)できます。その他の場合：
 
   * <img style={{ width: '32px', height: '32px'}} class="inline" title="Kubernetes" alt="Kubernetes" src={kubernetes}>で実行している場合</img>
 

--- a/src/i18n/content/kr/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
+++ b/src/i18n/content/kr/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
@@ -32,7 +32,7 @@ PostgreSQL 모니터링 통합을 설치하려면 다음 단계를 실행해야 
 
 ## 호환성 및 요구 사항 [#req]
 
-### PostgreSQL 버전 [#mysql-versions]
+### PostgreSQL 버전 [#postgresql-versions]
 
 통합은 PostgreSQL 버전 9.0 이상과 호환됩니다.
 
@@ -52,7 +52,7 @@ PostgreSQL 모니터링 통합을 설치하려면 다음 단계를 실행해야 
 
 * New Relic 계정. 하나가 없습니까? [무료 가입!](https://newrelic.com/signup) 신용 카드가 필요하지 않습니다.
 
-* MySQL이 Kubernetes 또는 Amazon ECS에서 실행되고 있지 않은 경우 Linux 또는 Windows OS 호스트 또는 MySQL이 설치된 위치에 원격으로 액세스할 수 있는 호스트에 [인프라 에이전트를 설치할](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) 수 있습니다. 그렇지 않으면:
+* PostgreSQL이 Kubernetes 또는 Amazon ECS에서 실행되고 있지 않은 경우 Linux 또는 Windows OS 호스트 또는 PostgreSQL이 설치된 위치에 원격으로 액세스할 수 있는 호스트에 [인프라 에이전트를 설치할](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) 수 있습니다. 그렇지 않으면:
 
   * <img style={{ width: '32px', height: '32px'}} class="inline" title="Kubernetes" alt="Kubernetes" src={kubernetes}>에서 실행하는 경우</img>
 


### PR DESCRIPTION
## Give us some context

![pg_agent_docs](https://user-images.githubusercontent.com/12992/174909598-e96c9511-7d47-4f7b-8fa8-ef4839d309de.png)

The PostgreSQL doc page makes several references to MySQL instead of PostgreSQL. My hunch is that the page was copied from the MySQL doc page, originally, and this has just never been fixed?

This PR fixes it.