### PR TITLE
fix(k8s): update release notes

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-3-1-0.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-3-1-0.mdx
@@ -6,6 +6,6 @@ version: 3.1.0
 
 ### Changed
 
- - controlplane/authenticator: now `kubernetes.io/tls` secrets are supported for mTLS 
+ - Now `kubernetes.io/tls` secrets are supported when configuring mTLS authentication for controlplane
 
 Full Changelog: https://github.com/newrelic/nri-kubernetes/compare/v3.0.0...v3.1.0

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-3-1-0.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-3-1-0.mdx
@@ -1,0 +1,13 @@
+---
+subject: Kubernetes integration
+releaseDate: '2022-02-22'
+version: 3.1.0
+---
+
+This new version makes significant changes to the number of components that are deployed to the cluster, and introduces many new configuration options to tune the behavior to your environment. We encourage you to take a look at what's changed in full detail [here](/docs/kubernetes-pixie/kubernetes-integration/get-started/changes-since-v3/).
+
+### Changed
+
+ - controlplane/authenticator: now `kubernetes.io/tls` secrets are supported for mTLS 
+
+Full Changelog: https://github.com/newrelic/nri-kubernetes/compare/v3.0.0...v3.1.0

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-3-1-0.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-3-1-0.mdx
@@ -4,8 +4,6 @@ releaseDate: '2022-02-22'
 version: 3.1.0
 ---
 
-This new version makes significant changes to the number of components that are deployed to the cluster, and introduces many new configuration options to tune the behavior to your environment. We encourage you to take a look at what's changed in full detail [here](/docs/kubernetes-pixie/kubernetes-integration/get-started/changes-since-v3/).
-
 ### Changed
 
  - controlplane/authenticator: now `kubernetes.io/tls` secrets are supported for mTLS 

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-3-2-0.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-3-2-0.mdx
@@ -1,0 +1,15 @@
+---
+subject: Kubernetes integration
+releaseDate: '2022-05-02'
+version: 3.2.0
+---
+
+### Added
+
+ - RestartCount metric for pods is now also available as `restartCountDelta`
+
+### Fixed
+
+ - `isReady` metric is now correctly reported as `false` (rather than `NULL`) for pending pods
+
+Full Changelog: https://github.com/newrelic/nri-kubernetes/compare/v3.1.0...v3.1.1

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-3-2-1.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-3-2-1.mdx
@@ -1,0 +1,15 @@
+---
+subject: Kubernetes integration
+releaseDate: '2022-05-31'
+version: 3.2.1
+---
+
+### Fixed
+
+ - Fixed rounding issue for allocatable cores https://github.com/newrelic/nri-kubernetes/issues/75
+
+### Changed
+
+ - Updated base alpine image from 3.15.4 to 3.16.0
+
+Full Changelog: https://github.com/newrelic/nri-kubernetes/compare/v3.2.0...v3.2.1

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-3-3-0.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-3-3-0.mdx
@@ -1,0 +1,12 @@
+---
+subject: Kubernetes integration
+releaseDate: '2022-06-13'
+version: 3.3.0
+---
+
+### Added
+
+Now it is possible to scrape data only from selected namespaces. For further information refer to [filtering namespaces](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm#filter-namespace)
+
+Full Changelog: https://github.com/newrelic/nri-kubernetes/compare/v3.2.1...v3.3.0
+

--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-3-3-1.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-3-3-1.mdx
@@ -1,0 +1,11 @@
+---
+subject: Kubernetes integration
+releaseDate: '2022-06-20'
+version: 3.3.1
+---
+
+### Added
+ - `nrFiltered` attribute has been added to K8sNamespaceSamples when using namespace filtering
+
+Full Changelog: https://github.com/newrelic/nri-kubernetes/compare/v3.3.0...v3.3.1
+


### PR DESCRIPTION
Release notes were forgotten for a while.

In the meanwhile they get automated this PR fixes them.

Source of the info -> https://github.com/newrelic/nri-kubernetes/blob/main/CHANGELOG.md