### PR TITLE
fix(Java): Restores the old generic Java install doc

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/introduction-new-relic-java.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/introduction-new-relic-java.mdx
@@ -28,7 +28,7 @@ To use the Java agent:
 
 1. Make sure your system meets the [Java agent's compatibility and requirements](/docs/compatibility-requirements-java-agent).
 2. [Sign up](https://newrelic.com/signup) for a New Relic account.
-3. Install the Java agent using our launcher, or by following the [standard installation procedures](/docs/agents/java-agent/installation/java-agent-manual-installation). Depending on your tools and frameworks, refer to [additional installation procedures](/docs/agents/java-agent/additional-installation) to install or configure the Java agent.
+3. Install the Java agent using our launcher, or by following the [standard installation procedures](/docs/agents/java-agent/installation/java-agent-manual-installation). Depending on your tools and frameworks, refer to [additional installation procedures](/docs/apm/agents/java-agent/installation/java-install-overview) to install or configure the Java agent.
 
 <ButtonGroup>
   <ButtonLink

--- a/src/content/docs/apm/agents/java-agent/getting-started/monitor-your-java-app.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/monitor-your-java-app.mdx
@@ -106,7 +106,7 @@ Want to learn more before you get started? [Introduction to APM](/docs/apm/new-r
     title="JVM installation arguments"
   >
 
-  * [Installation overview and configuration options](/docs/apm/agents/java-agent/getting-started/introduction-new-relic-java)
+  * [Installation overview and configuration options](/docs/apm/agents/java-agent/installation/java-install-overview)
   * [Installation with a JVM argument](/docs/apm/agents/java-agent/installation/include-java-agent-jvm-argument)
 
   </Collapser>

--- a/src/content/docs/apm/agents/java-agent/getting-started/monitor-your-java-app.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/monitor-your-java-app.mdx
@@ -47,7 +47,7 @@ import javaApmExampleImage from 'images/java-apm-example-dashboards.png'
 
 Want to start monitoring your Java application with New Relic right away? Use this guide to find the best path to start sending your application data to New Relic.
 
-Want to learn more before you get started? [Introduction to APM](/docs/apm/new-relic-apm/getting-started/introduction-apm) and [Introduction to New Relic for Java](/docs/apm/agents/java-agent/getting-started/introduction-new-relic-java) are a good place to start.
+Want to learn more before you get started? [Introduction to APM](/docs/apm/new-relic-apm/getting-started/introduction-apm) and [Introduction to New Relic for Java](/docs/apm/agents/java-agent/getting-started/introduction-new-relic-java) are a good place to start. If you'd like to learn more about the general installation process, see our [Java installation overview](/docs/apm/agents/java-agent/installation/java-install-overview).
 
 <img
   title="Example Java APM dashboards"

--- a/src/content/docs/apm/agents/java-agent/installation/java-install-overview.mdx
+++ b/src/content/docs/apm/agents/java-agent/installation/java-install-overview.mdx
@@ -120,7 +120,7 @@ Go to the unzipped installation file, and inside the `newrelic` subdirectory, ed
    license_key: 456n20n1367ov2s174v51nvn789d21s67v26NRAL
    ```
 3. Find the line with `app_name`.
-4. Replace <var>My Application</var> with a name that helps you identify the application. For example:
+4. Replace `My Application` with a name that helps you identify the application. For example:
 
    ```
    app_name: Tax Calculator
@@ -158,11 +158,11 @@ If you are using `newrelic.yml` to make configuration settings, consider the fol
 
 * We recommend you change the default `newrelic.yml` file permissions to read/write only for the owner of the application server process.
 * As you would with other important files, be sure `newrelic.yml` is part of your backup routine.
-* We recommend using New Relic Diagnostics to [validate your settings](/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics#h2-validate-your-config-file-settings), either before or after you deploy.
+* We recommend using New Relic Diagnostics to [validate your settings](/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/diagnostics-cli-nrdiag), either before or after you deploy.
 
 ## View logs for your APM and infrastructure data [#logs-context]
 
-You can also bring your logs and application's data together to make troubleshooting easier and faster. With [logs in context](/docs/logs/logs-context/java-configure-logs-context-all/), you can see log messages related to your errors and traces directly in your app's UI. You can also see logs in context of your [infrastructure data](/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/), such as Kubernetes clusters. No need to switch to another UI page in New Relic One.
+You can also bring your logs and application's data together to make troubleshooting easier and faster. With [logs in context](/docs/logs/logs-context/java-configure-logs-context-all/), you can see log messages related to your errors and traces directly in your app's UI. You can also see logs in context of your [infrastructure data](/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/), such as Kubernetes clusters. No need to switch to another page in the New Relic UI.
 
 ## What's next? [#next-steps]
 
@@ -170,6 +170,6 @@ Here are some additional topics to consider:
 
 * For Docker questions, see [Install New Relic Java agent for Docker](/docs/agents/java-agent/additional-installation/install-new-relic-java-agent-docker).
 * View your app in New Relic and get comfortable with the user interface.
-* Read the documentation about APM. For example, read about the [Summary page](/docs/apm/applications-menu/monitoring/apm-overview-page), the [**JVM metrics** page](/docs/agents/java-agent/features/jvm-metrics-page), the [**Transactions** page](/docs/apm/applications-menu/monitoring/transactions-page), and other [performance monitoring features](/docs/apm).
+* Read the documentation about APM. For example, read about the [Summary page](/docs/apm/applications-menu/monitoring/apm-overview-page), the [**JVM metrics** page](/docs/agents/java-agent/features/jvm-metrics-page), the [**Transactions** page](/docs/apm/applications-menu/monitoring/transactions-page), and [performance monitoring with CodeStream](/docs/codestream/how-use-codestream/performance-monitoring).
 * Query your data using [NRQL](/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql) (New Relic Query Language).
 * Learn about setting up [custom instrumentation](/docs/apm/agents/java-agent/custom-instrumentation) and [async instrumentation](/docs/apm/agents/java-agent/async-instrumentation) for application activity not monitored by default.

--- a/src/content/docs/apm/agents/java-agent/installation/java-install-overview.mdx
+++ b/src/content/docs/apm/agents/java-agent/installation/java-install-overview.mdx
@@ -1,0 +1,171 @@
+---
+title: An overview of the Java APM installation process
+tags:
+  - Agents
+  - Java agent
+  - Installation
+translate:
+  - jp
+metaDescription: An overview of how to download and install New Relic's APM agent for Java.
+---
+
+Our Java APM agent auto-instruments your code so you can start monitoring applications. Read this for an overview of the generic APM installation process. For more specific instructions, use [monitor your Java app](/docs/apm/agents/java-agent/getting-started/monitor-your-java-app) to find the specific resource for your Java app configuration.
+
+## 1. Prepare to install [#overview]
+
+Check the following:
+
+* Review the [compatibility and requirements](/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent).
+* Check if your environment requires [additional or alternative install steps](/docs/agents/java-agent/additional-installation).
+
+When you're ready, use the guided installation for an automated install. If you're in the EU, select that option. Or for a manual approach, follow the instructions in this document to complete a basic Java agent installation. Either way, you need a New Relic account. ([It's free, forever](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/#how-pricing-works).)
+
+<ButtonGroup>
+  <ButtonLink
+    data-tessen="stitchedPathLinkClick"
+    role="button"
+    to="https://newrelic.com/signup"
+    variant="primary"
+  >
+    Get an account
+  </ButtonLink>
+
+  <ButtonLink
+    data-tessen="stitchedPathLinkClick"
+    role="button"
+    to="https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJ0dWNzb24ucGxnLWluc3RydW1lbnQtZXZlcnl0aGluZyJ9&cards[0]=eyJuZXJkbGV0SWQiOiJzZXR1cC1uZXJkbGV0cy5zZXR1cC1qYXZhLWludGVncmF0aW9uIiwiYWNjb3VudElkIjoyNjQwNDA5fQ==&platform[accountId]=1"
+    variant="primary"
+  >
+    Guided agent install
+  </ButtonLink>
+
+  <ButtonLink
+    role="button"
+    to="https://one.eu.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJ0dWNzb24ucGxnLWluc3RydW1lbnQtZXZlcnl0aGluZyJ9&cards[0]=eyJuZXJkbGV0SWQiOiJzZXR1cC1uZXJkbGV0cy5zZXR1cC1qYXZhLWludGVncmF0aW9uIiwiYWNjb3VudElkIjoyNjQwNDA5fQ==&platform[accountId]=1"
+    variant="primary"
+  >
+    EU guided install
+  </ButtonLink>
+</ButtonGroup>
+
+## 2. Get the agent [#download-agent]
+
+Download `newrelic-java.zip` using `curl`, `Invoke-WebRequest` (PowerShell), or the New Relic UI:
+
+<CollapserGroup>
+  <Collapser
+    id="download-from-curl"
+    title={<>Download using <InlineCode>curl</InlineCode></>}
+  >
+    Complete the following:
+
+    1. Start a command-line session.
+    2. Change to a temporary directory where you can download the zip file.
+    3. Execute this `curl` command:
+
+       ```
+       curl -O https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic-java.zip
+       ```
+    4. Unzip `newrelic-java.zip`
+  </Collapser>
+
+  <Collapser
+    id="download-from-powershell"
+    title={<>Download using <InlineCode>Invoke-WebRequest</InlineCode> (PowerShell)</>}
+  >
+    Complete the following:
+
+    1. Start a PowerShell session.
+    2. Change to a temporary directory where you can download the zip file.
+    3. Execute this PowerShell command:
+
+       ```
+       Invoke-WebRequest -Uri https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic-java.zip -OutFile newrelic-java.zip
+       ```
+    4. Unzip `newrelic-java.zip`:
+
+       ```
+       Expand-Archive -Path newrelic-java.zip -DestinationPath <var>DESTINATION_PATH</var>
+       ```
+  </Collapser>
+
+  <Collapser
+    id="download-from-UI"
+    title="Download the agent"
+  >
+    From [Java agent release notes](/docs/release-notes/agent-release-notes/java-release-notes), download `newrelic-java.zip` to a temporary directory and unzip it.
+  </Collapser>
+</CollapserGroup>
+
+## 3. Configure the agent [#config-file]
+
+Here's how to do a basic setup with agent configuration settings in `newrelic.yml`.
+
+<Callout variant="tip">
+  For an advanced installation, you can pass settings with [environment variables](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#Environment_Variables), [Java system properties](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#System_Properties), or [server-side configuration](/docs/agents/manage-apm-agents/configuration/server-side-agent-configuration). To understand the precedence of these configuration settings, see [Java agent configuration: Config file](/docs/agents/java-agent/configuration/java-agent-configuration-config-file).
+</Callout>
+
+The Java agent requires the `license_key` and `app_name` settings at startup. All the other settings are optional, and you can review them in [Java agent configuration: Config file](/docs/agents/java-agent/configuration/java-agent-configuration-config-file).
+
+Go to the unzipped installation file, and inside the `newrelic` subdirectory, edit `newrelic.yml`:
+
+1. Find the line with `license_key`.
+2. Replace <var>'&lt;%= license_key %>'</var> with your [license](/docs/accounts/install-new-relic/account-setup/license-key). For example:
+
+   ```
+   license_key: 456n20n1367ov2s174v51nvn789d21s67v26NRAL
+   ```
+3. Find the line with `app_name`.
+4. Replace <var>My Application</var> with a name that helps you identify the application. For example:
+
+   ```
+   app_name: Tax Calculator
+   ```
+
+   <Callout variant="tip">
+     If you need tips about how to name your application, see [Name your application](/docs/agents/manage-apm-agents/app-naming/name-your-application).
+   </Callout>
+5. Add optional settings that you want, such as [agent logging](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#Logging-Configuration) and [distributed tracing](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#ev-NEW_RELIC_DISTRIBUTED_TRACING_ENABLED) (or add them later).
+6. Save and close `newrelic.yml`.
+
+## 4. Install the agent [#install-agent]
+
+The Java agent installation involves copying all the unzipped New Relic files into the directory structure of your application server/container. For example, you can create a `/opt/newrelic` directory, but if you want to put the files elsewhere, make sure of the following:
+
+* The .jar files in the directory cannot be on the classpath.
+* The .jar files cannot be in directories specified in `java.endorsed.dirs`.
+
+To install the Java agent:
+
+1. In your application server/container directory structure, create a directory for New Relic files (for example, `/opt/newrelic`).
+2. Copy all the New Relic files from your unzipped `newrelic` directory into your new directory.
+3. Make sure that your application server/container includes this option when it starts Java (for tips on how to do this with your tool or framework, see [JVM arguments](/docs/agents/java-agent/installation/start-java-agent-jvm-switch)):
+
+   ```
+   -javaagent:<var>/full/path/to/</var>newrelic.jar
+   ```
+4. Start or restart your application server/container.
+
+Generate some traffic for your app, and then wait a few minutes for data to appear in the [APM Summary page](/docs/applications-menu/applications-overview). If nothing appears, follow the [troubleshooting procedures](/docs/agents/java-agent/troubleshooting/no-data-appears-java).
+
+## 5. Post-installation tasks [#follow-up-tips]
+
+If you are using `newrelic.yml` to make configuration settings, consider the following:
+
+* We recommend you change the default `newrelic.yml` file permissions to read/write only for the owner of the application server process.
+* As you would with other important files, be sure `newrelic.yml` is part of your backup routine.
+* We recommend using New Relic Diagnostics to [validate your settings](/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics#h2-validate-your-config-file-settings), either before or after you deploy.
+
+## View logs for your APM and infrastructure data [#logs-context]
+
+You can also bring your logs and application's data together to make troubleshooting easier and faster. With [logs in context](/docs/logs/logs-context/java-configure-logs-context-all/), you can see log messages related to your errors and traces directly in your app's UI. You can also see logs in context of your [infrastructure data](/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/), such as Kubernetes clusters. No need to switch to another UI page in New Relic One.
+
+## What's next? [#next-steps]
+
+Here are some additional topics to consider:
+
+* For Docker questions, see [Install New Relic Java agent for Docker](/docs/agents/java-agent/additional-installation/install-new-relic-java-agent-docker).
+* View your app in New Relic and get comfortable with the user interface.
+* Read the documentation about APM. For example, read about the [Summary page](/docs/apm/applications-menu/monitoring/apm-overview-page), the [**JVM metrics** page](/docs/agents/java-agent/features/jvm-metrics-page), the [**Transactions** page](/docs/apm/applications-menu/monitoring/transactions-page), and other [performance monitoring features](/docs/apm).
+* Query your data using [NRQL](/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql) (New Relic Query Language).
+* Learn about setting up [custom instrumentation](/docs/apm/agents/java-agent/custom-instrumentation) and [async instrumentation](/docs/apm/agents/java-agent/async-instrumentation) for application activity not monitored by default.

--- a/src/content/docs/apm/agents/java-agent/installation/java-install-overview.mdx
+++ b/src/content/docs/apm/agents/java-agent/installation/java-install-overview.mdx
@@ -18,7 +18,7 @@ Check the following:
 * Review the [compatibility and requirements](/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent).
 * Check if your environment requires [additional or alternative install steps](/docs/agents/java-agent/additional-installation).
 
-When you're ready, use the guided installation for an automated install. If you're in the EU, select that option. Or for a manual approach, follow the instructions in this document to complete a basic Java agent installation. Either way, you need a New Relic account. ([It's free, forever](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/#how-pricing-works).)
+When you're ready, use the guided installation for an automated install. If you're in the EU, select that option. Or for a manual approach, follow the instructions in this document to complete a basic Java agent installation. Either way, you need a New Relic account. ([It's free, forever](https://newrelic.com/signup).)
 
 <ButtonGroup>
   <ButtonLink
@@ -66,7 +66,11 @@ Download `newrelic-java.zip` using `curl`, `Invoke-WebRequest` (PowerShell), or 
        ```
        curl -O https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic-java.zip
        ```
-    4. Unzip `newrelic-java.zip`
+    4. Unzip `newrelic-java.zip`:
+
+    ```
+    unzip newrelic-java.zip
+    ```
   </Collapser>
 
   <Collapser

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -153,6 +153,8 @@ pages:
           - title: Additional installation
             path: /docs/apm/agents/java-agent/installation
             pages:
+              - title: Java installation overview
+                path: /docs/apm/agents/java-agent/installation/java-install-overview.mdx
               - title: Include agent with JVM
                 path: /docs/apm/agents/java-agent/installation/include-java-agent-jvm-argument
               - title: Update the Java agent

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -154,7 +154,7 @@ pages:
             path: /docs/apm/agents/java-agent/installation
             pages:
               - title: Java installation overview
-                path: /docs/apm/agents/java-agent/installation/java-install-overview.mdx
+                path: /docs/apm/agents/java-agent/installation/java-install-overview
               - title: Include agent with JVM
                 path: /docs/apm/agents/java-agent/installation/include-java-agent-jvm-argument
               - title: Update the Java agent


### PR DESCRIPTION
I didn't realize the old generic Java installation doc had some content that wasn't anywhere else. I've restored it and added a bit of extra context for why someone might want to read it.