### PR TITLE
fix(aws): use dataPointCound for raw metrics

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
@@ -249,10 +249,10 @@ To see data ingested by AWS service/namespace:
 FROM Metric SELECT bytecountestimate()/10e8 as 'GB Estimate' WHERE collector.name='cloudwatch-metric-streams' FACET aws.Namespace
 ```
 
-To see number of metric updates processed by AWS service/namespace:
+To see number of raw metric updates processed by AWS service/namespace:
 
 ```
-FROM Metric SELECT count(*) WHERE collector.name='cloudwatch-metric-streams' FACET aws.Namespace
+FROM Metric SELECT dataPointCount() WHERE collector.name='cloudwatch-metric-streams' FACET aws.Namespace
 ```
 
 We recommend the following actions to control the data being ingested:


### PR DESCRIPTION
## Give us some context

*Using dataPointCount() instead of count(*) when counting metric updates to avoid misleading results when querying over a long period of time.