### PR TITLE
[Update] Limit of NRQL queries

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries.mdx
@@ -33,7 +33,7 @@ We'll go into more detail on these limits.
 
 ### Limits on number of queries [#query-count-limits]
 
-The limit on NRQL queries is 3,000 queries per account per minute. When this limit is exceeded, queries may be rejected until the number of queries sent per minute no longer exceeds the limit. 
+The limit on NRQL queries is 3,000 queries per account per minute. When this limit is exceeded, queries may be rejected until the number of queries sent per minute no longer exceeds the limit. Note: This limit is applicable only to the NRQL Query API requests and not the queries run from the query builder, UI or custom dashboards. The limits that govern the rate of resource consumption for this category of queries run on UI, query builder ot customer dashboards are only the Inspected count limits.
 
 ### Limits on number of data points inspected [#inspected-count-limits]
 


### PR DESCRIPTION
3k per min Limit of NRQL queries is only for NRQL Query APIs and not for the UI based queries run from Query builder or Custom dashboards. This need to be clearly called out

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve? - Clarity in documentation for limits
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.