### PR TITLE
Adding Node 16 to supported Lambda runtimes

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
@@ -11,7 +11,7 @@ Before [enabling serverless monitoring](/docs/serverless-function-monitoring/aws
 
 ## Recommended AWS Lambda language runtimes [#languages]
 
-* Node.js: `nodejs12.x`, `nodejs14.x`
+* Node.js: `nodejs12.x`, `nodejs14.x`, `nodejs16.x`
 * Python: `python3.7`, `python3.8`, `python3.9`
 * Go: `provided`, `provided.al2`
 * Java: `java8.al2`, `java11`


### PR DESCRIPTION
We've had Node 16 support, but this documents it.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.