### PR TITLE
fix: add curly braces to Inline Code string

### DIFF
--- a/src/i18n/content/jp/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/i18n/content/jp/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -1511,7 +1511,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-dimensions"
-    title={<InlineCode>'dimensions(include: {attributes}, exclude: {attributes})'</InlineCode>}
+    title={<InlineCode>{'dimensions(include: {attributes}, exclude: {attributes})'}</InlineCode>}
   >
     `dimensions()`関数を使用して、データ型のすべての次元値を返します。
 

--- a/src/i18n/content/kr/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/i18n/content/kr/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -1511,7 +1511,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-dimensions"
-    title={<InlineCode>'차원(포함: {속성}, 제외: {속성})'</InlineCode>}
+    title={<InlineCode>{'차원(포함: {속성}, 제외: {속성})'}</InlineCode>}
   >
     `dimensions()` 함수를 사용하여 데이터 유형의 모든 차원 값을 반환합니다.
 


### PR DESCRIPTION
![Screen Shot 2022-06-24 at 2 10 51 PM](https://user-images.githubusercontent.com/26727669/175650372-59d5054e-374d-46de-8075-b8b8b20829dc.png)

This seems to be part of a deserialization issue with this page specifically.  Attached is a screen cap of a time last week when we needed to fix this particular line because part of it was still encoded.