### PR TITLE
doc: update kafka config to make consumers/producers jmx's name optional

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-config.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-config.mdx
@@ -1202,7 +1202,12 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
         It is also possible to set the value `default` to let the `name` undefined and use the default values for `host`, `port`, `username` and `password`.
         Required to produce KafkaProducerSample.
 
-        **Example: `[{"name": "myProducer", "host": "localhost", "port": 24, "username": "me", "password": "secret"}]` **
+        **Examples:**
+
+        `[{"host": "localhost", "port": 24, "username": "me", "password": "secret"}]`
+
+        `[{"name": "myProducer", "host": "localhost", "port": 24, "username": "me", "password": "secret"}]`
+
       </td>
 
       <td>
@@ -1226,7 +1231,12 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
         It is also possible to set the value `default` to let the `name` undefined and use the default values for `host`, `port`, `username` and `password`.
         Required to produce KafkaConsumerSample.
 
-        **Example: `[{"name": "myConsumer", "host": "localhost", "port": 24, "username": "me", "password": "secret"}]` **
+        **Examples:**
+
+        `[{"host": "localhost", "port": 24, "username": "me", "password": "secret"}]`
+
+        `[{"name": "myConsumer", "host": "localhost", "port": 24, "username": "me", "password": "secret"}]`
+
       </td>
 
       <td>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-config.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-config.mdx
@@ -1196,7 +1196,10 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
       </td>
 
       <td>
-        Producers to collect. For each provider a `name`, `hostname`, `port`, `username`, and `password` can be provided in JSON form. `name` is the producer’s name as it appears in Kafka. `hostname`, `port`, `username`, and `password` are the optional JMX settings and use the default if unspecified.
+        Producers to collect. For each producer a `name`, `hostname`, `port`, `username`, and `password` can be specified in JSON form.
+        `name` is the producer’s name as it appears in Kafka. If it is not set, metrics from all producers in the host:port will be gathered.
+        `host`, `port`, `username`, and `password` are the optional JMX settings and use the default if unspecified.
+        It is also possible to set the value `default` to let the `name` undefined and use the default values for `host`, `port`, `username` and `password`.
         Required to produce KafkaProducerSample.
 
         **Example: `[{"name": "myProducer", "host": "localhost", "port": 24, "username": "me", "password": "secret"}]` **
@@ -1217,7 +1220,10 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
       </td>
 
       <td>
-        Consumers to collect. For each consumer a `name`, `hostname`, `port`, `username`, and `password` can be specified in JSON form. `name` is the consumer’s name as it appears in Kafka. `hostname`, `port`, `username`, and `password` are the optional JMX settings and use the default if unspecified.
+        Consumers to collect. For each consumer a `name`, `hostname`, `port`, `username`, and `password` can be specified in JSON form.
+        `name` is the consumer’s name as it appears in Kafka. If it is not set, metrics from all consumers in the host:port will be gathered.
+        `host`, `port`, `username`, and `password` are the optional JMX settings and use the default if unspecified.
+        It is also possible to set the value `default` to let the `name` undefined and use the default values for `host`, `port`, `username` and `password`.
         Required to produce KafkaConsumerSample.
 
         **Example: `[{"name": "myConsumer", "host": "localhost", "port": 24, "username": "me", "password": "secret"}]` **

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
@@ -481,8 +481,8 @@ The values for these settings can be defined in several ways:
         env:
           METRICS: "true"
           CLUSTER_NAME: "testcluster3"
-          PRODUCERS: '[{"name": "myProducer", "host": "localhost", "port": 24, "username": "me", "password": "secret"}]'
-          CONSUMERS: '[{"name": "myConsumer", "host": "localhost", "port": 24, "username": "me", "password": "secret"}]'
+          PRODUCERS: '[{"host": "localhost", "port": 24, "username": "me", "password": "secret"}]'
+          CONSUMERS: '[{"host": "localhost", "port": 24, "username": "me", "password": "secret"}]'
           DEFAULT_JMX_HOST: "localhost"
           DEFAULT_JMX_PORT: "9999"
         interval: 15s


### PR DESCRIPTION
Update docs to reflect the integration's new configuration possibilities implemented in [nri-kafkfa#178](https://github.com/newrelic/nri-kafka/pull/178)