### PR TITLE
Ruby CodeStream integration: YAML syntax fix

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/features/ruby-codestream-integration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/features/ruby-codestream-integration.mdx
@@ -14,7 +14,7 @@ Display context-sensitive APM data directly in your IDE by integrating [New Reli
 First, [install](/docs/codestream/start-here/install-codestream) the New Relic CodeStream extension into your supported IDE of choice and log in.
 
 <Callout variant="important">
-  The New Relic CodeStream integration is available in Ruby agent version 8.8.0 and higher and is disabled by default. To enable the integration, either set `code_level_metrics.enabled = true` in `newrelic.yml` or `NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=true` as an environment variable.
+  The New Relic CodeStream integration is available in Ruby agent version 8.8.0 and higher and is disabled by default. To enable the integration, either set `code_level_metrics.enabled: true` in `newrelic.yml` or `NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=true` as an environment variable.
 </Callout>
 
 ## Agent attributes


### PR DESCRIPTION
for enabling CodeStream in the Ruby agent, a colon should be used to
separate the 'code_level_metrics.enabled' configuration key from the
'true' or 'false' configuration value.