### PR TITLE
Revert "Update OTLP supportability chart"

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup.mdx
@@ -212,7 +212,7 @@ Whether you export directly from your app or from a collector, you'll need to:
       </td>
 
       <td>
-        ❌
+        ✅
       </td>
 
       <td>


### PR DESCRIPTION
Reverts newrelic/docs-website#7384

New relic now supports HTTP/1.1 over the OTLP US FedRAMP endpoint.