### PR TITLE
fix: add tip that capture() regex must match entire input

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -1802,6 +1802,10 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
 
       Read how to [use regex capture to improve your query results](https://newrelic.com/blog/how-to-relic/using-regex-capture).
 
+      <Callout variant="tip">
+        The regular expression much match its entire input. If a capture expression is not extracting the expected results, check whether it needs `.*` at the beginning or end.
+      </Callout>
+
       Here's a short video (3:05 minutes) showing how to use `capture()` to improve dashboard readability:
 
       <Video


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Customers (internal and external) are often confused that capture() doesn't work as expected, because their regular expressions are designed to only match part of the attribute value and they must match the whole thing.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.