### PR TITLE
Remove Oracle tablespace 200 limitation

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
@@ -353,8 +353,8 @@ The Oracle DB integration collects both Metrics(**M**) and Inventory(**I**) info
       </td>
 
       <td>
-        A JSON array of tablespaces to collect. If omitted, collects all tablespaces
-        up to a maximun of 200 tablespaces.
+        A JSON array of tablespaces to collect. If omitted, collects all tablespaces,
+        if empty skips tablespace metrics collection.
       </td>
 
       <td>
@@ -668,7 +668,7 @@ Even though our default sample configuration file includes examples of labels, t
           environment: production
         inventory_source: config/oracledb
     ```
-    
+
   </Collapser>
 
   <Collapser
@@ -694,7 +694,7 @@ Even though our default sample configuration file includes examples of labels, t
         labels:
           environment: production
     ```
-    
+
   </Collapser>
 
   <Collapser
@@ -719,7 +719,7 @@ Even though our default sample configuration file includes examples of labels, t
           environment: production
         inventory_source: config/oracledb
     ```
-    
+
   </Collapser>
 
   <Collapser
@@ -756,7 +756,7 @@ Even though our default sample configuration file includes examples of labels, t
           labels:
             environment: production
       ```
-    
+
   </Collapser>
 
   <Collapser
@@ -807,7 +807,7 @@ Even though our default sample configuration file includes examples of labels, t
         # If unset, sample_name defaults to OracleCustomSample
         sample_name: MyCustomSample
     ```
-    
+
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
@@ -353,8 +353,7 @@ The Oracle DB integration collects both Metrics(**M**) and Inventory(**I**) info
       </td>
 
       <td>
-        A JSON array of tablespaces to collect. If omitted, collects all tablespaces,
-        if empty skips tablespace metrics collection.
+        A JSON array of tablespaces to collect. If omitted, it collects all tablespaces. If empty, it skips tablespace metrics collection.
       </td>
 
       <td>


### PR DESCRIPTION
This PR is to remove a 200 tablespace limit, that was removed on a new integration version, adjusting the docs to this updated feature