### PR TITLE
chore(java): Capping supported r2dbc-mariadb version

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -455,7 +455,7 @@ The agent automatically instruments these frameworks and libraries:
     * Oracle ojdbc5, ojdbc6, ojdbc7, ojdbc8, ojdbc10, ojdbc14
     * Postgres 8.0-312.jdbc3 to latest
     * R2DBC H2 0.8.x to 0.9.x
-    * R2DBC MariaDB 1.0.2 to latest
+    * R2DBC MariaDB 1.0.2 to 1.1.1
     * R2DBC MySQL 0.8.x to latest
     * R2DBC MSSQL 0.8.0 to latest
     * R2DBC Oracle 0.x to latest


### PR DESCRIPTION
## Give us some context
The Java agent team just found out that the new version of the mentioned instrumentation module will no longer work with the newly released version.