### PR TITLE
fix: Clarify specific OHI relevant to the sentence

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
@@ -1345,7 +1345,7 @@ Here's some guidance for using drop rules to optimize data ingest for specific t
     id="cloud-metrics"
     title="Cloud metrics"
   >
-  In some cases we can economize on data where we have redundant coverage. For example: in an environment where you have the AWS RDS integration running as well as the New Relic on-host integration you may be able to discard some overlapping metrics.
+  In some cases we can economize on data where we have redundant coverage. For example: in an environment where you have the AWS RDS integration running as well as one of the New Relic on-host integrations that monitor SQL databases such as nri-mysql or nri-postgresql you may be able to discard some overlapping metrics.
 
   For quick exploration we can run a query like this:
 


### PR DESCRIPTION
I have added two exemplary OHIs to a statement to clarify where you may have redundant metrics between an OHI and an AWS RDS integration.