### PR TITLE
fix: Clarify section in Infra agent optimization

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
@@ -492,11 +492,9 @@ For more details, see [Feature flags](/docs/mobile-monitoring/new-relic-mobile-i
   * Log forwarding configuration
 </Callout>
 
-New Relic's [infrastructure agent configuration file](/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings) contains a couple of powerful ways to control ingest volume. The most important is using sampling rates. There are several distinct sampling rate configurations that can be used:
+New Relic's [infrastructure agent configuration file](/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings) contains a couple of powerful ways to control ingest volume. The most important ingest control is configuring sampling rates. There are several distinct sampling rate configurations that can be adjusted.  In addition it's possible to create regular expressions to control what gets collected from certain collectors such as for *ProcessSample* and *NetworkSample*.
 
-The other is through custom process sample filters.
-
-### Sampling rates
+### Configurable Sampling rates
 
 There are a number of sampling rates that can be configured in infrastructure, but these are the most commonly used.
 


### PR DESCRIPTION
Altered text to clarify that there are to primary ways to control infra agent ingest volume...

- Configure a variety of sampling rates
- Use regular expressions for select collectors to limit what gets collected.