### PR TITLE
Clarify Wistia and YouTube options with Video components

### DIFF
--- a/src/content/docs/style-guide/images/embed-videos.mdx
+++ b/src/content/docs/style-guide/images/embed-videos.mdx
@@ -74,7 +74,7 @@ Here's how it is displayed:
 
 ### Use our Video component [#video-comp]
 
-You can use the `Video` component in the same way you use it for videos hosted on Wistia. Copy the video ID from YouTube and insert it into the `Video` component. Note that you can also add properties to control the video (see [Sizing videos](#sizing)).
+You can use the `Video` component in the same way you use it for videos hosted on [Wistia](#wistia-options). Copy the video ID from YouTube and insert it into the `Video` component. Note that you can also add properties to control the video (see [Sizing videos](#sizing)).
 
 Here's an example without any additional properties:
 ```
@@ -101,13 +101,14 @@ We recommend that you only set width and not height. Here's an example:
 ```
 <Video
   type="wistia"
-  id="qyk74p7j56"
-  width='290px'
+  id="04JP0ky_hjI"
+  width='400px'
 />
+```
 
 ### Aspect ratio [#tall-skinny]
 
-If you have some videos that are much smaller than the width of the main body, they can appear in the center of a full-width video box. To address this, you can do the following:
+If you have some videos that are much smaller than the width of the main body, they can appear as tiny videos in the center of a full-width video box. To address this, you can do the following:
 
 * Add the `vertical` property of the component because it shrinks the container to the width of the video.
 * To size tall, skinny companion images that need to match the narrow videos, use `maxWidth` instead of `width`. For example: `style={{ maxWidth: '290px' }}`.
@@ -122,3 +123,12 @@ Here's an example of the `vertical` property:
   width='290px'
 />
 ```
+
+Here's how it is displayed:
+
+<Video
+  type="wistia"
+  id="qyk74p7j56"
+  vertical
+  width='290px'
+/>

--- a/src/content/docs/style-guide/images/embed-videos.mdx
+++ b/src/content/docs/style-guide/images/embed-videos.mdx
@@ -15,10 +15,10 @@ Embedding videos helps readers who prefer to learn by watching rather than readi
 
 New Relic maintains video in a few places:
 
-* [learn.newrelic.com](https://learn.newrelic.com/) (embeddable via Wistia)
-* [youtube.com/c/NewRelicInc](https://www.youtube.com/c/NewRelicInc) (embeddable in YouTube)
-* [newrelic.com/resources/webinars](https://newrelic.com/resources/webinars) (live videos, not embeddable)
-* [twitch.tv/new_relic](https://www.twitch.tv/new_relic) (live and video on demand, not currently embeddable)
+* [Wistia](https://wistia.com/) (Besides the docs site, Wistia hosts videos for [learn.newrelic.com](https://learn.newrelic.com/))
+* [YouTube](https://www.youtube.com/c/NewRelicInc)
+* [New Relic Webinars](https://newrelic.com/resources/webinars) (Use for live videos&#8212;not embeddable)
+* [Twitch](https://www.twitch.tv/new_relic) (Use for live and video on demand&#8212;not currently embeddable)
 
 Videos are hosted externally and are embedded in the docs site's page, linking to the external source.
 
@@ -26,24 +26,89 @@ Videos are hosted externally and are embedded in the docs site's page, linking t
 
 Write introductory text before the embedded video or add a video caption after it. Include the approximate running time in your text, because some video formats will not show the video length until you click on them.
 
-To embed a Wistia video, add this code:
 
-```
-<Video
-  type="wistia"
-  id="<var>WISTIA_ID</var>"
-/>
-```
+<CollapserGroup>
+  <Collapser
+    className="freq-link"
+    id="wistia"
+    title="Wistia"
+  >
+    To embed a Wistia video, add this code:
 
-To embed a YouTube video, add this code (the ID is what comes after `v=`in the URL:
+    1. Log on to [Wistia.com](https://wistia.com).
+    2. Click **Projects** in the left navigation pane.
+    3. In the center pane, page through until you find **docs.newrelic.com Videos**.
+    4. Click **Add > Upload**.
+    5. Click **Embed &#38; Share**.
+    6. Copy the video ID from the embed code so you can insert it into your video link. For example:
 
-```
-<Video id="<var>YOUTUBE_ID</var>" type="youtube" />
-```
+      ```
+      <script src="https://fast.wistia.com/embed/medias/<var>jsh48c18dq</var>.jsonp" async></script><script src="https://fast.wistia.com/assets/external/E-v1.js" async></script><div class="wistia_responsive_padding" style="padding:216.88% 0 0 0;position:relative;"><div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;"><div class="wistia_embed wistia_async_jsh48c18dq videoFoam=true" style="height:100%;position:relative;width:100%"><div class="wistia_swatch" style="height:100%;left:0;opacity:0;overflow:hidden;position:absolute;top:0;transition:opacity 200ms;width:100%;"><img src="https://fast.wistia.com/embed/medias/jsh48c18dq/swatch" style="filter:blur(5px);height:100%;object-fit:contain;width:100%;" alt="" aria-hidden="true" onload="this.parentNode.style.opacity=1;" /></div></div></div></div>
+      ```
+    7. Insert the ID into the video tag in your document:
 
-## A video example [#videos]
+      ```
+      <Video
+        type="wistia"
+        id=”jsh48c18dq"
+        vertical
+        width='290px'
+      />
+      ```
 
-<Video
-  type="wistia"
-  id="kpriqz9wy7"
-/>
+    Here are some tips for using the `<video>` component for tall, skinny videos that are less than the width of the main screen:
+
+    * Add the `vertical` property of the component because it shrinks the container to the width of the video.
+    * To size tall, skinny images that need to match the narrow videos, use `maxWidth` instead of `width`. For example: `style={{ maxWidth: '290px' }}`.
+
+    Here's an example of the `vertical` property:
+
+    ```
+    <Video
+      type="wistia"
+      id="qyk74p7j56"
+      vertical
+      width='290px'
+    />
+    ```
+  </Collapser>
+  <Collapser
+    className="freq-link"
+    id="youtube"
+    title="YouTube"
+  >
+    You have two options to embed videos from YouTube:
+
+    **Use iFrame tag from YouTube**
+
+    Use the embed code that you can Get from the YouTube site:
+
+    1. Go to the YouTube and find the video you want to embed.
+    2. Click **Share** and then click **Embed**.
+    3. Copy the entire `<iframe>` tag. For example:
+
+      ```
+      <iframe width="560" height="315" src="https://www.youtube.com/embed/<var>04JP0ky_hjI</var>" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      ```
+    4. Paste that tag into your document.
+
+    Here's how it is displayed:
+
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/04JP0ky_hjI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+    **Use our `Video` component**
+
+    You can use the `Video` component in the same way you use it for videos hosted on Wistia. Copy the video ID from YouTube and insert it into the `Video` component. For example:
+    ```
+    <Video
+      type="youtube"
+      id="<var>GGyCx9WgGV8</var>"  />
+    ```
+    Here's an example of how it displays:
+
+    <Video type="youtube" id="GGyCx9WgGV8" />
+
+    You can also add properties to control the video, such as `width` and `vertical` (for tall, skinny videos).
+
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/style-guide/images/embed-videos.mdx
+++ b/src/content/docs/style-guide/images/embed-videos.mdx
@@ -36,7 +36,7 @@ To use Wistia to host videos:
 3. In the center pane, page through until you find **docs.newrelic.com Videos**.
 4. Click **Add > Upload**.
 5. Click **Embed &#38; Share**.
-6. Copy the video ID from the embed code so you can insert it into your video link. For example, `jsh48c18dq` from this link:
+6. Copy the video ID from the embed code so you can insert it into your video link. For example, `jsh48c18dq` from this tag:
 
   ```
   <script src="https://fast.wistia.com/embed/medias/<var>jsh48c18dq</var>.jsonp" async></script><script src="https://fast.wistia.com/assets/external/E-v1.js" async></script><div class="wistia_responsive_padding" style="padding:216.88% 0 0 0;position:relative;"><div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;"><div class="wistia_embed wistia_async_jsh48c18dq videoFoam=true" style="height:100%;position:relative;width:100%"><div class="wistia_swatch" style="height:100%;left:0;opacity:0;overflow:hidden;position:absolute;top:0;transition:opacity 200ms;width:100%;"><img src="https://fast.wistia.com/embed/medias/jsh48c18dq/swatch" style="filter:blur(5px);height:100%;object-fit:contain;width:100%;" alt="" aria-hidden="true" onload="this.parentNode.style.opacity=1;" /></div></div></div></div>

--- a/src/content/docs/style-guide/images/embed-videos.mdx
+++ b/src/content/docs/style-guide/images/embed-videos.mdx
@@ -13,22 +13,23 @@ redirects:
 
 Embedding videos helps readers who prefer to learn by watching rather than reading. It also adds some visual pizzazz to the docs, and can be an easier way to explain complex processes. Our team usually doesn't create videos, but we work with teams that do to show off their content across the site.
 
-New Relic maintains video in a few places, but you can only embed Wistia and YouTube videos in our docs:
+Videos are hosted externally and are embedded in the doc site's page, linking to the external source.
+New Relic maintains video in several places, but you can only embed Wistia and YouTube videos in our docs:
 
-* [Wistia](https://wistia.com/) (Besides the docs site, Wistia hosts videos for [learn.newrelic.com](https://learn.newrelic.com/))
+* [Wistia](https://wistia.com/) 
 * [YouTube](https://www.youtube.com/c/NewRelicInc)
 * [New Relic Webinars](https://newrelic.com/resources/webinars) (Use for live videos&#8212;not embeddable)
-* [Twitch](https://www.twitch.tv/new_relic) (Use for live and video on demand&#8212;not currently embeddable)
+* [Twitch](https://www.twitch.tv/new_relic) (Use for live and video on demand&#8212;not embeddable)
 
-Videos are hosted externally and are embedded in the docs site's page, linking to the external source.
-
-## Before you add the video 
+## Before you add the video [#before-embed] 
 
 Write introductory text above the embedded video or add a video caption after it. Include the approximate running time in your text, because some video formats will not show the video length until you click on them.
 
 ## Wistia [#wistia-options]
 
-To embed a video hosted on Wistia:
+Besides the docs site, Wistia hosts videos for [learn.newrelic.com](https://learn.newrelic.com/). Wistia is a good place to host videos you create as a writer, as well as videos we receive from other teams.
+
+To use Wistia to host videos:
 
 1. Log on to [Wistia.com](https://wistia.com).
 2. Click **Projects** in the left navigation pane.
@@ -51,11 +52,11 @@ To embed a video hosted on Wistia:
 
 ## YouTube  [#youtube-options] 
 
-You have two options to embed videos from YouTube: the `<iframe>` tag or our `<Video>` tag.
+You have two options to embed videos from YouTube: the `<iframe>` tag or our `<Video>` component.
 
 ### Use iframe tag from YouTube [#use-iframe]
 
-Use the embed code that you can find from the YouTube site:
+Use the embed code that you can find on the YouTube site:
 
 1. Go to the YouTube and find the video you want to embed.
 2. Click **Share** and then click **Embed**.
@@ -71,27 +72,27 @@ Here's how it is displayed:
 <iframe width="560" height="315" src="https://www.youtube.com/embed/04JP0ky_hjI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
-## Use our Video component [#video-comp]
+### Use our Video component [#video-comp]
 
-You can use the `Video` component in the same way you use it for videos hosted on Wistia. Copy the video ID from YouTube and insert it into the `Video` component. Note that you can also add properties to control the video, such as `width` and `vertical` (for tall, skinny videos).
+You can use the `Video` component in the same way you use it for videos hosted on Wistia. Copy the video ID from YouTube and insert it into the `Video` component. Note that you can also add properties to control the video, such as `width` and `vertical` (see [Formatting tall, skinny videos](#tall-skinny)).
 
 Here's an example without any additional properties:
 ```
 <Video
   type="youtube"
-  id="<var>GGyCx9WgGV8</var>"
+  id="<var>04JP0ky_hjI/var>"
 />
 ```
 The video appears like this:
 
 <Video
   type="youtube"
-  id="GGyCx9WgGV8"
+  id="04JP0ky_hjI"
 />
 
-### Formatting tall, skinny videos [#tall-skinny]
+## Formatting tall, skinny videos [#tall-skinny]
 
-Here are some tips for using the `<video>` component for tall, skinny videos that are less than the width of the main screen:
+Here are some tips for using the `<video>` component with tall, skinny videos that are less than the width of the main screen:
 
 * Add the `vertical` property of the component because it shrinks the container to the width of the video.
 * To size tall, skinny companion images that need to match the narrow videos, use `maxWidth` instead of `width`. For example: `style={{ maxWidth: '290px' }}`.

--- a/src/content/docs/style-guide/images/embed-videos.mdx
+++ b/src/content/docs/style-guide/images/embed-videos.mdx
@@ -96,7 +96,7 @@ When you use the `<Video>` component you can add properties to control how it is
 
 ### Width [#width]
 
-We recommend that you only set width and not height. Here's an example:
+You can only set width&#8212;not height. Here's an example:
 
 ```
 <Video

--- a/src/content/docs/style-guide/images/embed-videos.mdx
+++ b/src/content/docs/style-guide/images/embed-videos.mdx
@@ -41,7 +41,7 @@ To use Wistia to host videos:
   ```
   <script src="https://fast.wistia.com/embed/medias/<var>jsh48c18dq</var>.jsonp" async></script><script src="https://fast.wistia.com/assets/external/E-v1.js" async></script><div class="wistia_responsive_padding" style="padding:216.88% 0 0 0;position:relative;"><div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;"><div class="wistia_embed wistia_async_jsh48c18dq videoFoam=true" style="height:100%;position:relative;width:100%"><div class="wistia_swatch" style="height:100%;left:0;opacity:0;overflow:hidden;position:absolute;top:0;transition:opacity 200ms;width:100%;"><img src="https://fast.wistia.com/embed/medias/jsh48c18dq/swatch" style="filter:blur(5px);height:100%;object-fit:contain;width:100%;" alt="" aria-hidden="true" onload="this.parentNode.style.opacity=1;" /></div></div></div></div>
   ```
-7. Insert the ID into the video tag in your document:
+7. Insert the ID into the video tag in your document. Note that you can also add properties to control the video (see [Sizing videos](#sizing)).
 
   ```
   <Video
@@ -50,7 +50,7 @@ To use Wistia to host videos:
   />
   ```
 
-## YouTube  [#youtube-options] 
+## YouTube  [#youtube-options]
 
 You have two options to embed videos from YouTube: the `<iframe>` tag or our `<Video>` component.
 
@@ -74,7 +74,7 @@ Here's how it is displayed:
 
 ### Use our Video component [#video-comp]
 
-You can use the `Video` component in the same way you use it for videos hosted on Wistia. Copy the video ID from YouTube and insert it into the `Video` component. Note that you can also add properties to control the video, such as `width` and `vertical` (see [Formatting tall, skinny videos](#tall-skinny)).
+You can use the `Video` component in the same way you use it for videos hosted on Wistia. Copy the video ID from YouTube and insert it into the `Video` component. Note that you can also add properties to control the video (see [Sizing videos](#sizing)).
 
 Here's an example without any additional properties:
 ```
@@ -83,16 +83,31 @@ Here's an example without any additional properties:
   id="<var>04JP0ky_hjI/var>"
 />
 ```
-The video appears like this:
+Here's how it is displayed:
 
 <Video
   type="youtube"
   id="04JP0ky_hjI"
 />
 
-## Formatting tall, skinny videos [#tall-skinny]
+## Sizing videos [#sizing]
 
-Here are some tips for using the `<video>` component with tall, skinny videos that are less than the width of the main screen:
+When you use the `<Video>` component you can add properties to control how it is displayed.
+
+### Width [#width]
+
+We recommend that you only set width and not height. Here's an example:
+
+```
+<Video
+  type="wistia"
+  id="qyk74p7j56"
+  width='290px'
+/>
+
+### Aspect ratio [#tall-skinny]
+
+If you have some videos that are much smaller than the width of the main body, they can appear in the center of a full-width video box. To address this, you can do the following:
 
 * Add the `vertical` property of the component because it shrinks the container to the width of the video.
 * To size tall, skinny companion images that need to match the narrow videos, use `maxWidth` instead of `width`. For example: `style={{ maxWidth: '290px' }}`.

--- a/src/content/docs/style-guide/images/embed-videos.mdx
+++ b/src/content/docs/style-guide/images/embed-videos.mdx
@@ -13,7 +13,7 @@ redirects:
 
 Embedding videos helps readers who prefer to learn by watching rather than reading. It also adds some visual pizzazz to the docs, and can be an easier way to explain complex processes. Our team usually doesn't create videos, but we work with teams that do to show off their content across the site.
 
-New Relic maintains video in a few places:
+New Relic maintains video in a few places, but you can only embed Wistia and YouTube videos in our docs:
 
 * [Wistia](https://wistia.com/) (Besides the docs site, Wistia hosts videos for [learn.newrelic.com](https://learn.newrelic.com/))
 * [YouTube](https://www.youtube.com/c/NewRelicInc)
@@ -22,93 +22,87 @@ New Relic maintains video in a few places:
 
 Videos are hosted externally and are embedded in the docs site's page, linking to the external source.
 
-## Embed a video
+## Before you add the video 
 
-Write introductory text before the embedded video or add a video caption after it. Include the approximate running time in your text, because some video formats will not show the video length until you click on them.
+Write introductory text above the embedded video or add a video caption after it. Include the approximate running time in your text, because some video formats will not show the video length until you click on them.
+
+## Wistia [#wistia-options]
+
+To embed a video hosted on Wistia:
+
+1. Log on to [Wistia.com](https://wistia.com).
+2. Click **Projects** in the left navigation pane.
+3. In the center pane, page through until you find **docs.newrelic.com Videos**.
+4. Click **Add > Upload**.
+5. Click **Embed &#38; Share**.
+6. Copy the video ID from the embed code so you can insert it into your video link. For example, `jsh48c18dq` from this link:
+
+  ```
+  <script src="https://fast.wistia.com/embed/medias/<var>jsh48c18dq</var>.jsonp" async></script><script src="https://fast.wistia.com/assets/external/E-v1.js" async></script><div class="wistia_responsive_padding" style="padding:216.88% 0 0 0;position:relative;"><div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;"><div class="wistia_embed wistia_async_jsh48c18dq videoFoam=true" style="height:100%;position:relative;width:100%"><div class="wistia_swatch" style="height:100%;left:0;opacity:0;overflow:hidden;position:absolute;top:0;transition:opacity 200ms;width:100%;"><img src="https://fast.wistia.com/embed/medias/jsh48c18dq/swatch" style="filter:blur(5px);height:100%;object-fit:contain;width:100%;" alt="" aria-hidden="true" onload="this.parentNode.style.opacity=1;" /></div></div></div></div>
+  ```
+7. Insert the ID into the video tag in your document:
+
+  ```
+  <Video
+    type="wistia"
+    id=”jsh48c18dq"
+  />
+  ```
+
+## YouTube  [#youtube-options] 
+
+You have two options to embed videos from YouTube: the `<iframe>` tag or our `<Video>` tag.
+
+### Use iframe tag from YouTube [#use-iframe]
+
+Use the embed code that you can find from the YouTube site:
+
+1. Go to the YouTube and find the video you want to embed.
+2. Click **Share** and then click **Embed**.
+3. Copy the entire `<iframe>` tag. For example:
+
+  ```
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/<var>04JP0ky_hjI</var>" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  ```
+4. Paste that tag into your document.
+
+Here's how it is displayed:
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/04JP0ky_hjI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
-<CollapserGroup>
-  <Collapser
-    className="freq-link"
-    id="wistia"
-    title="Wistia"
-  >
-    To embed a Wistia video, add this code:
+## Use our Video component [#video-comp]
 
-    1. Log on to [Wistia.com](https://wistia.com).
-    2. Click **Projects** in the left navigation pane.
-    3. In the center pane, page through until you find **docs.newrelic.com Videos**.
-    4. Click **Add > Upload**.
-    5. Click **Embed &#38; Share**.
-    6. Copy the video ID from the embed code so you can insert it into your video link. For example:
+You can use the `Video` component in the same way you use it for videos hosted on Wistia. Copy the video ID from YouTube and insert it into the `Video` component. Note that you can also add properties to control the video, such as `width` and `vertical` (for tall, skinny videos).
 
-      ```
-      <script src="https://fast.wistia.com/embed/medias/<var>jsh48c18dq</var>.jsonp" async></script><script src="https://fast.wistia.com/assets/external/E-v1.js" async></script><div class="wistia_responsive_padding" style="padding:216.88% 0 0 0;position:relative;"><div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;"><div class="wistia_embed wistia_async_jsh48c18dq videoFoam=true" style="height:100%;position:relative;width:100%"><div class="wistia_swatch" style="height:100%;left:0;opacity:0;overflow:hidden;position:absolute;top:0;transition:opacity 200ms;width:100%;"><img src="https://fast.wistia.com/embed/medias/jsh48c18dq/swatch" style="filter:blur(5px);height:100%;object-fit:contain;width:100%;" alt="" aria-hidden="true" onload="this.parentNode.style.opacity=1;" /></div></div></div></div>
-      ```
-    7. Insert the ID into the video tag in your document:
+Here's an example without any additional properties:
+```
+<Video
+  type="youtube"
+  id="<var>GGyCx9WgGV8</var>"
+/>
+```
+The video appears like this:
 
-      ```
-      <Video
-        type="wistia"
-        id=”jsh48c18dq"
-        vertical
-        width='290px'
-      />
-      ```
+<Video
+  type="youtube"
+  id="GGyCx9WgGV8"
+/>
 
-    Here are some tips for using the `<video>` component for tall, skinny videos that are less than the width of the main screen:
+### Formatting tall, skinny videos [#tall-skinny]
 
-    * Add the `vertical` property of the component because it shrinks the container to the width of the video.
-    * To size tall, skinny images that need to match the narrow videos, use `maxWidth` instead of `width`. For example: `style={{ maxWidth: '290px' }}`.
+Here are some tips for using the `<video>` component for tall, skinny videos that are less than the width of the main screen:
 
-    Here's an example of the `vertical` property:
+* Add the `vertical` property of the component because it shrinks the container to the width of the video.
+* To size tall, skinny companion images that need to match the narrow videos, use `maxWidth` instead of `width`. For example: `style={{ maxWidth: '290px' }}`.
 
-    ```
-    <Video
-      type="wistia"
-      id="qyk74p7j56"
-      vertical
-      width='290px'
-    />
-    ```
-  </Collapser>
-  <Collapser
-    className="freq-link"
-    id="youtube"
-    title="YouTube"
-  >
-    You have two options to embed videos from YouTube:
+Here's an example of the `vertical` property:
 
-    **Use iFrame tag from YouTube**
-
-    Use the embed code that you can Get from the YouTube site:
-
-    1. Go to the YouTube and find the video you want to embed.
-    2. Click **Share** and then click **Embed**.
-    3. Copy the entire `<iframe>` tag. For example:
-
-      ```
-      <iframe width="560" height="315" src="https://www.youtube.com/embed/<var>04JP0ky_hjI</var>" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-      ```
-    4. Paste that tag into your document.
-
-    Here's how it is displayed:
-
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/04JP0ky_hjI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-    **Use our `Video` component**
-
-    You can use the `Video` component in the same way you use it for videos hosted on Wistia. Copy the video ID from YouTube and insert it into the `Video` component. For example:
-    ```
-    <Video
-      type="youtube"
-      id="<var>GGyCx9WgGV8</var>"  />
-    ```
-    Here's an example of how it displays:
-
-    <Video type="youtube" id="GGyCx9WgGV8" />
-
-    You can also add properties to control the video, such as `width` and `vertical` (for tall, skinny videos).
-
-  </Collapser>
-</CollapserGroup>
+```
+<Video
+  type="wistia"
+  id="qyk74p7j56"
+  vertical
+  width='290px'
+/>
+```


### PR DESCRIPTION
I realized that I hadn't updated the instructions for embedding videos as I thought I had. So, here's an improvement:

* Added instructions for upload videos to Wistia and getting the ID.
* Divided the YouTube instructions into iframe and Video sections.
* Added some basic instructions about using the new `vertical` property for images.