### PR TITLE
Fix OpenTelemetry batching dead links

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-batching.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-batching.mdx
@@ -11,8 +11,8 @@ metaDescription: Here are some tips for working with OpenTelemetry batching and 
   To avoid getting rate limited, we recommend these practices:
 
   * Batch requests sent to the OTLP endpoint as described in this section
-  * Explicitly enable [gzip compression](#compression)
-  * Ensure your [attribute lengths](#attribute-lengths) don't exceed New Relic maximums
+  * Explicitly enable [gzip compression](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-compression)
+  * Ensure your [attribute lengths](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-attributes) don't exceed New Relic maximums
 </Callout>
 
 By default, the OpenTelemetry SDKs and Collector send one (1) data point per request. Using these defaults, it is likely your account will be rate limited.


### PR DESCRIPTION
Fix links to compression and attribute lengths pages, which are currently dead links.