### PR TITLE
Remove dead link from OpenTelemetry best practices

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-traces.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-traces.mdx
@@ -48,7 +48,7 @@ Check out this documentation about how to configure different types of sampling:
     id="ot-tail-based"
     title="OpenTelemetry tail-based samplers"
   >
-    The OpenTelemetry collector has a [tail-based sampling processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor). We have an [example](https://github.com/newrelic/newrelic-opentelemetry-examples/tree/main/collector/k8s-collector-tail-sampling) demonstrating the use of the tail-based sampling processor.
+    The OpenTelemetry collector has a [tail-based sampling processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor).
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
The example that was being linked to no longer exists. Users should reference the docs of the tailsamplingprocessor, which the docs already link to.