### PR TITLE
Mobile: Missing event types in Manage Data doc

### DIFF
--- a/src/content/docs/data-apis/manage-data/manage-data-coming-new-relic.mdx
+++ b/src/content/docs/data-apis/manage-data/manage-data-coming-new-relic.mdx
@@ -181,12 +181,11 @@ The [data ingestion UI](#data-ingest-ui) chart shows you a high level breakdown 
       </td>
 
       <td>
-        [Mobile events](/docs/insights/insights-data-sources/default-data/mobile-default-events-insights), including the general `Mobile` event, `MobileRequestError`, `MobileBreadcrumb`, `MobileSession`, `MobileHandledException`, `MobileCrash`.
+        [Mobile events](/docs/insights/insights-data-sources/default-data/mobile-default-events-insights), including the general `Mobile` event, `MobileRequestError`, `MobileBreadcrumb`, `MobileSession`, `MobileHandledException`, `MobileCrash`, `MobileRequest`, and `MobileJavaScriptError`.
 
         Usage metric group: `MobileEventsBytes`.
       </td>
     </tr>
-
     <tr>
       <td>
         Tracing


### PR DESCRIPTION
This is a hero request that I'm getting to today. Added another missing Event type in addition to the requested "MobileRequest".

Issue here: https://github.com/newrelic/docs-website/issues/8206 