### PR TITLE
Fix deserialization formatting bug

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -1109,6 +1109,7 @@ global:
     title="Optional API Polling configurations"
   >
     **Arista eAPI**
+    
     <table>
       <thead>
         <tr>

--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -1108,7 +1108,7 @@ global:
     id="api-polling-config"
     title="Optional API Polling configurations"
   >
-    **Arista eAPI**
+    ### Arista eAPI
     
     <table>
       <thead>


### PR DESCRIPTION
## Description

Without a line between the paragraph and the table, the serialized HTML nests the `table` inside a `p` like so:

```html
<p><strong>Arista eAPI</strong>
<table data-type="component">
...
</table>
</p>
```

Adding the line closes the `p` tag like so which puts `table` on its own when deserializing it from serialized html:

```html
<p><strong>Arista eAPI</strong></p>
<table data-type="component">
...
</table>
```

converts to

```
  <Collapser
    id="api-polling-config"
    title="オプションのAPIポーリング構成"
  >
    **Arista eAPI**

    <table>
      <thead>
```

