### PR TITLE
chore(java): Remove outdated update info

### DIFF
--- a/src/content/docs/apm/agents/java-agent/installation/update-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/installation/update-java-agent.mdx
@@ -27,14 +27,14 @@ Then, to update to the latest Java agent version:
 1. Back up the **entire** [Java agent root directory](/docs/agents/manage-apm-agents/troubleshooting/find-agent-root-directory#java-agent) to another location. Rename that directory to `NewRelic_Agent#.#.#`, where `#.#.#` is the agent version number.
 2. [Download the agent.](/docs/release-notes/agent-release-notes/java-release-notes)
 3. Unzip the new agent download file, then copy `newrelic-api.jar` and `newrelic.jar` into the original [Java agent root directory](/docs/agents/manage-apm-agents/troubleshooting/find-agent-root-directory#java-agent).
-4. `Diff` your current `newrelic.yml` with the newly downloaded `newrelic.yml` from the zip, and [update customized differences](#diff) as needed.
+4. Compare your old `newrelic.yml` with the newly downloaded `newrelic.yml` from the zip, and [update the file if needed](#diff).
 5. Restart your Java dispatcher.
 
 If you experience issues after the Java agent update, restore from the backed-up New Relic agent directory.
 
 ## Update agent config differences [#diff]
 
-If differences between the two versions are unrelated to your app's customizations, align the `newrelic.yml` you use moving forward with the latest updates to the default `newrelic.yml` from New Relic.
+We add new settings to `newrelic.yml` as we release new versions of the agent. You can use `diff` or another diffing utility to see what's changed, and add the new config settings to your old file. You don't want to  If differences between the two versions are unrelated to your app's customizations, align the `newrelic.yml` you use moving forward with the latest updates to the default `newrelic.yml` from New Relic.
 
 For example, if you `diff` the default `newrelic.yml` files for Java agent versions 3.29.0 and 3.30.0, the results printed to the console will be:
 
@@ -53,125 +53,3 @@ For example, if you `diff` the default `newrelic.yml` files for Java agent versi
 > gw.internal.gosu.compiler.SingleServingGosuClassLoader,
 >
 ```
-
-These lines were added to the default `newrelic.yml` in Java agent version 3.30.0. If you want to run Java agent version 3.30.0 or higher, ensure you include these lines in your `newrelic.yml`.
-
-## Java agent versions not supported [#eol-versions]
-
-**End of life notification:** As of January 26, 2015, New Relic will no longer accept data from Java agent versions earlier than **3.6.0**, except version [2.21.7](#legacy-2-21-7).
-
-These agent versions use an out-of-date protocol when communicating with New Relic's data collection services. In addition, many of these versions contain a potential security issue where they may incorrectly send sensitive data to the New Relic collector.
-
-## Update unsupported agent versions [#eol-update]
-
-<Callout variant="important">
-  If you are updating from an older agent version, including major version jumps, review the following list for changes in functionality.
-</Callout>
-
-<table>
-  <thead>
-    <tr>
-      <th style={{ width: "200px" }}>
-        Migration
-      </th>
-
-      <th>
-        Comments
-      </th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td id="migration-5-0-0">
-        5.0.0
-      </td>
-
-      <td>
-        Release notes: [Java agent 5.0.0](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-500)
-
-        **Self installer:**
-
-        The New Relic Java agent's self-installer has been removed in order to provide a more consistent user experience. To install the Java agent, add the full path to the `newrelic.jar` to the `-javaagent` flag in your JVM options. For more information, see the documentation on installing the agent on specific application servers, including Docker, Maven, or Gradle.
-
-        **Deprecated instrumentation:**
-
-        The following instrumentation modules have been moved out of the default Java agent. They are now provided as a [separate download](/docs/agents/java-agent/instrumentation/additional-instrumentation-modules-java-agent). To continue using these modules, just add them to the agent's extensions directory in your New Relic folder or wherever your extensions directory is configured. Deprecated modules include:
-
-        * Akka 2.0
-        * Akka 2.1
-        * Akka-http 1.0
-        * Akka-http 2.0 - 2.4.1
-        * Akka-http 2.4.2 - 2.4.4
-        * Hystrix 1.2
-        * Hystrix 1.3
-        * Play 1: Instrumentation for Play-1.x is not available as an extension.
-        * Play 2.0
-        * Play 2.1
-        * Play 2.2
-        * Solr 3.1 - 3.4
-        * Solr 3.5
-        * Solr 3.6
-      </td>
-    </tr>
-
-    <tr>
-      <td id="migration-4-12-0">
-        4.12.0
-      </td>
-
-      <td>
-        Release notes: [Java agent 4.12.0](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-4120)
-
-        **Deprecated APIs:**
-
-        The custom transport channel API is now deprecated in favor of the distributed tracing API.
-
-        The `skipTransactionTrace` attribute on the `@Trace` annotation is now deprecated. Instead, use the `excludeFromTransactionTrace` attribute.
-
-        **Deprecated instrumentation:**
-
-        JetS3t: Removed built-in instrumentation for JetS3t. The agent will continue to report external calls made with the JetS3t client.
-      </td>
-    </tr>
-
-    <tr>
-      <td id="migration-4-4-0">
-        4.4.0
-      </td>
-
-      <td>
-        Release notes: [Java agent 4.4.0](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-440)
-
-        **Java 6 support removed:**
-
-        You must use 4.3 or earlier.
-
-        **EU data center:**
-
-        Minimum version required for use in EU datacenter.
-
-        **Removed the SSL configuration option:**
-
-        SSL is now always used in communication with New Relic servers. The `newrelic.yml` ssl configuration and `-Dnewrelic.config.ssl` system property are no longer used. Setting either value to anything other than `true` will result in logging a warning.
-      </td>
-    </tr>
-
-    <tr>
-      <td id="legacy-2-21-7">
-        Legacy agent 2.21.7
-      </td>
-
-      <td>
-        Release notes: [Java agent 2.21.7](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-2217)
-
-        **Java SE 5.0:**
-
-        This is a bugfix release for the [legacy Java SE 5.0 version](/docs/java/java-se-5) of the agent. Unless you are a Java SE5 user, use the latest version of the New Relic Java agent. This affects:
-
-        * Oracle Hotspot JVM version 5.0 for Linux, Solaris, Windows, macOS
-        * Oracle JRockit up to and including 1.6.0_50
-      </td>
-    </tr>
-  </tbody>
-</table>


### PR DESCRIPTION
Removes a whole slew of info about upgrading from old versions of the agents. All of these agent versions are at least 3.5+ years old, some are even 5+ years old. 