### PR TITLE
improve readability of performance analysis charts

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/monitor-private-locations.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/monitor-private-locations.mdx
@@ -2344,7 +2344,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
               },
               "linkedEntityGuids": null,
               "visualization": {
-                "id": "viz.bar"
+                "id": "viz.billboard"
               },
               "rawConfiguration": {
                 "facet": {
@@ -2355,8 +2355,11 @@ The following Private Minion dashboard example JSON can be imported to your acco
                     "accountId": 1,
                     "query": "FROM SyntheticsPrivateMinion SELECT uniqueCount(minionId) AS 'number of minions' FACET minionLocation SINCE 5 minutes ago"
                   }
-                ]
-              }
+            ],
+            "platformOptions": {
+              "ignoreTimeRange": false
+            }
+          }
             },
             {
               "title": "non-ping monitors",
@@ -2368,19 +2371,21 @@ The following Private Minion dashboard example JSON can be imported to your acco
               },
               "linkedEntityGuids": null,
               "visualization": {
-                "id": "viz.bar"
+                "id": "viz.billboard"
               },
               "rawConfiguration": {
-                "dataFormatters": [],
                 "facet": {
                   "showOtherSeries": false
                 },
                 "nrqlQueries": [
                   {
                     "accountId": 1,
-                    "query": "FROM SyntheticCheck SELECT uniqueCount(monitorId) AS 'non-ping monitors' WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' FACET location"
+                    "query": "FROM SyntheticCheck SELECT uniqueCount(monitorId) AS 'non-ping monitors' WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' FACET location SINCE 2 days ago"
                   }
-                ]
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                }
               }
             },
             {
@@ -2393,7 +2398,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
               },
               "linkedEntityGuids": null,
               "visualization": {
-                "id": "viz.bar"
+                "id": "viz.billboard"
               },
               "rawConfiguration": {
                 "facet": {
@@ -2402,9 +2407,12 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 1,
-                    "query": "FROM SyntheticCheck SELECT rate(uniqueCount(id), 1 minute) AS 'jobs per minute' WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' FACET location"
+                    "query": "FROM SyntheticCheck SELECT rate(uniqueCount(id), 1 minute) AS 'jobs per minute' WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' FACET location SINCE 2 days ago"
                   }
-                ]
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                }
               }
             },
             {
@@ -2417,23 +2425,20 @@ The following Private Minion dashboard example JSON can be imported to your acco
               },
               "linkedEntityGuids": null,
               "visualization": {
-                "id": "viz.line"
+                "id": "viz.billboard"
               },
               "rawConfiguration": {
                 "facet": {
                   "showOtherSeries": false
                 },
-                "legend": {
-                  "enabled": true
-                },
                 "nrqlQueries": [
                   {
                     "accountId": 1,
-                    "query": "FROM SyntheticCheck SELECT average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'avg success duration (s)' WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' AND result = 'SUCCESS' FACET location"
+                    "query": "FROM SyntheticCheck SELECT average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'avg success duration (s)' WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' AND result = 'SUCCESS' FACET location SINCE 2 days ago"
                   }
                 ],
-                "yAxisLeft": {
-                  "zero": true
+                "platformOptions": {
+                  "ignoreTimeRange": false
                 }
               }
             },
@@ -2447,23 +2452,20 @@ The following Private Minion dashboard example JSON can be imported to your acco
               },
               "linkedEntityGuids": null,
               "visualization": {
-                "id": "viz.line"
+                "id": "viz.billboard"
               },
               "rawConfiguration": {
                 "facet": {
                   "showOtherSeries": false
                 },
-                "legend": {
-                  "enabled": true
-                },
                 "nrqlQueries": [
                   {
                     "accountId": 1,
-                    "query": "FROM SyntheticCheck SELECT average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'error duration (s)' WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' AND result = 'FAILED' FACET location,cases(WHERE error NOT LIKE '%timeout%' AS 'other error duration (s), just FYI', WHERE error LIKE '%timeout%' AS 'avg timeout duration (s)')"
+                    "query": "FROM SyntheticCheck SELECT average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'error duration (s)' WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' AND result = 'FAILED' FACET location,cases(WHERE error NOT LIKE '%timeout%' AS 'other error duration (s), just FYI', WHERE error LIKE '%timeout%' AS 'avg timeout duration (s)') SINCE 2 days ago"
                   }
                 ],
-                "yAxisLeft": {
-                  "zero": true
+                "platformOptions": {
+                  "ignoreTimeRange": false
                 }
               }
             },
@@ -2477,23 +2479,20 @@ The following Private Minion dashboard example JSON can be imported to your acco
               },
               "linkedEntityGuids": null,
               "visualization": {
-                "id": "viz.line"
+                "id": "viz.billboard"
               },
               "rawConfiguration": {
                 "facet": {
                   "showOtherSeries": false
                 },
-                "legend": {
-                  "enabled": true
-                },
                 "nrqlQueries": [
                   {
                     "accountId": 1,
-                    "query": "FROM SyntheticCheck SELECT percentage(count(*), WHERE error LIKE '%timeout%' OR error LIKE '%timed-out%') WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' FACET location"
+                    "query": "FROM SyntheticCheck SELECT percentage(count(*), WHERE error LIKE '%timeout%' OR error LIKE '%timed-out%') WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' FACET location SINCE 2 days ago"
                   }
                 ],
-                "yAxisLeft": {
-                  "zero": true
+                "platformOptions": {
+                  "ignoreTimeRange": false
                 }
               }
             }


### PR DESCRIPTION
- Change to billboard style, which is easier to read for input into the Google Sheet.
- Set a 2 day period on performance data to get more accurate results since some monitors may run infrequently.