### PR TITLE
fix(apm): add missing redirects from apm reorg

### DIFF
--- a/src/content/docs/apm/new-relic-apm/apdex/apdex-measure-user-satisfaction.mdx
+++ b/src/content/docs/apm/new-relic-apm/apdex/apdex-measure-user-satisfaction.mdx
@@ -13,6 +13,8 @@ redirects:
   - /docs/site/setting-apdex-t
   - /docs/site/apdex-measuring-user-satisfaction
   - /docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction
+  - /docs/apm/new-relic-apm/apdex/view-your-apdex-score/
+  - /docs/apm/new-relic-apm/apdex/change-your-apdex-settings/
 ---
 
 [Apdex](https://www.apdex.org/) is an industry standard to measure users' satisfaction with the response time of web applications and services. It's a simplified Service Level Agreement (SLA) solution that helps you see how satisfied users are with your app through metrics such as Apdex score and dissatisfaction percentage instead of easily skewed traditional metrics such as average response time.

--- a/src/content/docs/apm/reports/api-examples-sla-reports.mdx
+++ b/src/content/docs/apm/reports/api-examples-sla-reports.mdx
@@ -11,6 +11,7 @@ redirects:
   - /docs/instrumentation/sla-reports
   - /docs/instrumentation/sla-report-examples
   - /docs/reports/api-examples-for-sla-reports
+  - /docs/apm/reports/service-level-agreements/api-examples-sla-reports
 ---
 
 New Relic stores SLA data forever for [eligible accounts](http://newrelic.com/application-monitoring/pricing), so you can use the [New Relic REST API](/docs/apm/apis/requirements/new-relic-rest-api-v2-getting-started) to generate service level agreement reports over any time period. For example, you can create SLA reports going back more than 12 days, weeks, or months.

--- a/src/content/docs/apm/reports/apm-sla-reports.mdx
+++ b/src/content/docs/apm/reports/apm-sla-reports.mdx
@@ -10,6 +10,7 @@ redirects:
   - /docs/apm/reports/service-level-agreements/sla-reports
   - /docs/apm/reports/service-level-agreements/apm-sla-reports-dashboard
   - /docs/apm/reports
+  - /docs/apm/reports/service-level-agreements/apm-sla-reports
 ---
 
 APM provides service level agreement (SLA) reports. SLA reports help you better understand your application performance by showing application downtime and trends over time.

--- a/src/content/docs/apm/reports/performance-reports.mdx
+++ b/src/content/docs/apm/reports/performance-reports.mdx
@@ -7,6 +7,16 @@ tags:
 metaDescription: New Relic's Background jobs analysis report helps you analyze performance of production jobs using frameworks and non-web transactions.
 redirects:
   - /docs/reports/background-jobs-analysis-report
+  - /docs/reports/capacity-analysis-report
+  - /docs/reports/database-analysis-report
+  - /docs/reports/scalability-analysis-report
+  - /docs/reports/web-transactions-analysis-report
+  - /docs/apm/reports/other-performance-analysis/background-jobs-analysis-report
+  - /docs/apm/reports/other-performance-analysis/capacity-analysis-report/
+  - /docs/apm/reports/other-performance-analysis/scalability-analysis-report/
+  - /docs/apm/reports/other-performance-analysis/web-transactions-analysis-report/
+  - /docs/apm/reports/other-performance-analysis/weekly-performance-report/
+  - /docs/apm/reports/other-performance-analysis/database-analysis-report/
 ---
 
 Our performance analysis reports provide simple and pre-defined views of your application's health and performance. Choose any report below to learn more:


### PR DESCRIPTION
Fixes redirect issues stemming from #8243.

When I moved the taxonomy around and combined/deleted pages, I missed a few redirects in the reports and apdex categories. This PR adds them in correctly.

