### PR TITLE
Remove Tracing rate limit documentation as there are no longer limits 

### DIFF
--- a/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
+++ b/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
@@ -216,6 +216,7 @@ Some of our tools don't use sampling. Sampling details for these tools:
 
     Our APM language agents are often used in conjunction with browser and mobile monitoring, and our language agents [use sampling](#trace-origin-sampling). This means that there will likely be many more browser and mobile spans than back-end spans, which can result in browser and mobile app spans disconnected from back-end spans. For tips on querying for traces that contain front and back-end spans, see [Find browser span data](/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing#find-data).
   </Collapser>
+</CollapserGroup> 
 
 ## How trace data is structured [#trace-structure]
 

--- a/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
+++ b/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
@@ -32,7 +32,6 @@ Here are some technical details about how New Relic distributed tracing works:
 * [How we structure trace data](#trace-structure)
 * [How we store trace data](#trace-storage)
 * [How trace context is passed between applications](#headers)
-* [Trace-related limits](#limits)
 
 ## Trace sampling [#sampling]
 
@@ -79,17 +78,6 @@ Here are some details about how head-based sampling is implemented in our standa
     However, some requests to services will generate many spans, and the agent span limit will be reached. As a result, some traces will not have full detail for that service. One solution to this would be to custom instrument an agent to report less activity and therefore report fewer spans.
 
     To read about how browser monitoring of trace data may vary from our language agents, see [Browser traces](#browser-spans).
-  </Collapser>
-
-  <Collapser
-    id="span-rate-limiting"
-    title="Trace rate limiting"
-  >
-    If the above sampling methods still result in too much trace data, we may limit incoming data by sampling traces after they're received. By making this decision at the trace level, it avoids fragmenting traces (accepting only part of a trace).
-
-    This process works similarly to [adaptive sampling](#trace-origin-sampling). The total spans received in a minute are totaled. If too many spans are received, fewer spans may be accepted in the following minute, in order to achieve a floating-average throughput rate.
-
-    For other details about limits, see [New Relic data usage limits and policies](/docs/licenses/license-information/general-usage-licenses/new-relic-data-usage-limits-policies/#all_products).
   </Collapser>
 
   <Collapser
@@ -228,14 +216,6 @@ Some of our tools don't use sampling. Sampling details for these tools:
 
     Our APM language agents are often used in conjunction with browser and mobile monitoring, and our language agents [use sampling](#trace-origin-sampling). This means that there will likely be many more browser and mobile spans than back-end spans, which can result in browser and mobile app spans disconnected from back-end spans. For tips on querying for traces that contain front and back-end spans, see [Find browser span data](/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing#find-data).
   </Collapser>
-
-  <Collapser
-    id="trace-api"
-    title="Trace API"
-  >
-    If you don't have [Infinite Tracing](/docs/understand-dependencies/distributed-tracing/infinite-tracing/introduction-infinite-tracing) enabled, our Trace API does no sampling (unless the default [data limits](/docs/understand-dependencies/distributed-tracing/trace-api/trace-api-general-requirements-limits) are exceeded). It's expected that you set up the Trace API to send us the traces you think are important.
-  </Collapser>
-</CollapserGroup>
 
 ## How trace data is structured [#trace-structure]
 
@@ -482,79 +462,3 @@ The scenarios below show various types of successful header propagation.
     />
   </Collapser>
 </CollapserGroup>
-
-## Trace limits [#limits]
-
-Here are some trace-related limits:
-
-<table>
-  <thead>
-    <tr>
-      <th style={{ width: "180px" }}>
-        Limited aspect
-      </th>
-
-      <th>
-        Limit
-      </th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td>
-        Max age of span timestamp values
-      </td>
-
-      <td>
-        20 minutes. Timestamp must be within 20 minutes of current time at ingest or within 20 minutes from the time the last span with the same `trace.id` was received by New Relic.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Max spans per trace
-      </td>
-
-      <td>
-        50K
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Max attributes per span
-      </td>
-
-      <td>
-        200
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Max spans per minute per APM agent instance
-      </td>
-
-      <td>
-        Go: 1000. 
-        
-        All other agents are configurable but default to 2000.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-For more rules related to using the Trace API, see [Trace API requirements and limits](/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits).
-
-For other New Relic limits, see [Limits](/docs/data-apis/manage-data/view-system-limits#limits-ui).
-
-### Exceeding trace limits [#exceed-limits]
-
-When you exceed your span rate limit, an [`NrIntegrationError` event](/docs/telemetry-data-platform/manage-data/nrintegrationerror) is generated. You can get rate limit messages with this NRQL query:
-
-```sql
-SELECT * FROM NrIntegrationError WHERE newRelicFeature = 'Distributed Tracing' AND category = 'RateLimit' AND rateLimitType = 'SpansPerMinute'
-```
-
-To get a notification when you exceed the limit, you can set up a [NRQL alert](/docs/alerts/new-relic-alerts/defining-conditions/create-alert-conditions-nrql-queries).


### PR DESCRIPTION
Fixes #6763

Ran a search and confirmed that these section headers are not referenced in other documentation, 