### PR TITLE
Make aware of link to issue inactivity

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-violations/how-alert-condition-violations-are-closed.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-violations/how-alert-condition-violations-are-closed.mdx
@@ -55,6 +55,12 @@ The violation time limit setting will automatically force-close a long-lasting v
 * The default value, if one is not supplied during configuration, is 3 days (24 hours for Infrastructure conditions).
 * The violation time limit for non-Infrastructure conditions can be set as low as 5 minutes, and as high as 30 days. If, for some reason, the signal is still violating in 30 days, the violation will close, and a new violation will open. Infrastructure conditions can be set to the following hours: 1, 2, 4, 8, 12, 24, 48, or 72.
 
+<Callout variant="tip">
+This setting is related to the [inactive issue setting](docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/user-settings/#auto-close-issue-window).
+
+When the time periods in these two settings are different, our system uses the shorter time period, regardless of the setting. For example, if the close open violation time setting is 2 days and the inactive issue time setting is 3 days, our system would wait 2 days before closing the issue.
+</Callout>
+
 **Examples:**
 
 * You set the violation time limit to 12 hours. If that violation lasts for 12 hours, it will be closed at 12 hours and the condition's evaluation of that entity will be reset.


### PR DESCRIPTION
The issue inactivity setting and the violation/condition timeout setting are related. Whichever setting is shorter will win. This fact has been explained in the documentation about the issue inactivity, but not here.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.