### PR TITLE
docs: added doc for infra-agent builtin log rotation

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs/infrastructure-agent-logging-behavior.mdx
+++ b/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs/infrastructure-agent-logging-behavior.mdx
@@ -55,10 +55,10 @@ Alternatively, logs can be formatted as a JSON file:
 
 To change the log format, see the [agent configuration settings](/docs/infrastructure/install-configure-infrastructure/configuration/infrastructure-configuration-settings#log-format).
 
-## Builtin log rotation
+## Built-in log rotation
 
 Starting with version [v1.28.0](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes), the infrastructure agent
-has a builtin log rotation mechanism.
+has a built-in log rotation mechanism.
 
 Built-in log rotation can be configured in `newrelic-infra.yml` configuration file:
 
@@ -73,7 +73,7 @@ log:
 ```
 
 <Callout variant="tip">
-    For a complete description of all `rotate` configuration options, see the [Infrastructure agent log configuration settings page](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#log).
+    For a complete description of all log `rotate` configuration options, see the [Infrastructure agent log configuration settings page](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#log).
 </Callout>
 
 ## Log rotation using `Logrotate`

--- a/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs/infrastructure-agent-logging-behavior.mdx
+++ b/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs/infrastructure-agent-logging-behavior.mdx
@@ -55,11 +55,30 @@ Alternatively, logs can be formatted as a JSON file:
 
 To change the log format, see the [agent configuration settings](/docs/infrastructure/install-configure-infrastructure/configuration/infrastructure-configuration-settings#log-format).
 
-## Log rotation
+## Builtin log rotation
 
-The infrastructure agent does not provide any native log rotation or compression mechanism. Instead, we encourage you to use consolidated log rotation tools, such as the [Linux logrotate tool](http://man7.org/linux/man-pages/man8/logrotate.8.html), which is usually installed by default in most Linux distributions.
+Starting with version [v1.28.0](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes), the infrastructure agent
+has a builtin log rotation mechanism.
 
-`Logrotate` can be configured as an entry in `/etc/logrotate.conf`, or as a file in the `/etc/logrotate.d` directory.
+Built-in log rotation can be configured in `newrelic-infra.yml` configuration file:
+
+```
+log:
+    level: info
+    file: /var/log/newrelic-infra/newrelic-infra.log
+    rotate:
+        max_size_mb: 1000
+        max_files: 5
+        compression_enabled: true
+```
+
+<Callout variant="tip">
+    For a complete description of all `rotate` configuration options, see the [Infrastructure agent log configuration settings page](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#log).
+</Callout>
+
+## Log rotation using `Logrotate`
+
+[Linux logrotate tool](http://man7.org/linux/man-pages/man8/logrotate.8.html), which is usually installed by default in most Linux distributions can be configured as an entry in `/etc/logrotate.conf`, or as a file in the `/etc/logrotate.d` directory.
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs/infrastructure-agent-logging-behavior.mdx
+++ b/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs/infrastructure-agent-logging-behavior.mdx
@@ -55,14 +55,14 @@ Alternatively, logs can be formatted as a JSON file:
 
 To change the log format, see the [agent configuration settings](/docs/infrastructure/install-configure-infrastructure/configuration/infrastructure-configuration-settings#log-format).
 
-## Built-in log rotation
+## Built-in log rotation [#builtin-log-rotation]
 
-Starting with version [v1.28.0](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes), the infrastructure agent
+From version [v1.28.0](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes) on, the infrastructure agent
 has a built-in log rotation mechanism.
 
-Built-in log rotation can be configured in `newrelic-infra.yml` configuration file:
+You can configure built-in log rotation in the `newrelic-infra.yml` configuration file:
 
-```
+```yml
 log:
     level: info
     file: /var/log/newrelic-infra/newrelic-infra.log
@@ -73,21 +73,21 @@ log:
 ```
 
 <Callout variant="tip">
-    For a complete description of all log `rotate` configuration options, see the [Infrastructure agent log configuration settings page](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#log).
+  For a comprehensive description of all log `rotate` configuration options, see the [Infrastructure agent log configuration settings page](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#log).
 </Callout>
 
-## Log rotation using `Logrotate`
+## Log rotation using `Logrotate` [#logrotate]
 
-[Linux logrotate tool](http://man7.org/linux/man-pages/man8/logrotate.8.html), which is usually installed by default in most Linux distributions can be configured as an entry in `/etc/logrotate.conf`, or as a file in the `/etc/logrotate.d` directory.
+You can configure the [Linux logrotate tool](http://man7.org/linux/man-pages/man8/logrotate.8.html), which is usually installed by default in most Linux distributions, as an entry in the `/etc/logrotate.conf` file, or as a file in the `/etc/logrotate.d` directory.
 
 <CollapserGroup>
   <Collapser
     id="logrotate-config-sample"
     title="Logrotate config file sample"
   >
-    A sample `logrotate` config file looks like this:
+    A sample `logrotate.conf` configuration file looks like this:
 
-    ```
+    ```conf
     /var/log/newrelic-infra/newrelic-infra.log { 
          copytruncate 
          compress 
@@ -107,7 +107,7 @@ log:
     * `maxage 7`: Makes `logrotate` remove rotated files after 7 days.
 
     <Callout variant="tip">
-      For a complete description of the `logrotate` configuration options, see the [Linux Logrotate documentation](https://linux.die.net/man/8/logrotate).
+      For a comprehensive description of the `logrotate` configuration options, see the [Linux Logrotate documentation](https://linux.die.net/man/8/logrotate).
     </Callout>
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -2554,11 +2554,11 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
       id="rotate"
       title="rotate"
     >
-      Starting with version [v1.28.0](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes), You can use the built-in log rotation feature.
-      By default, log rotation is disabled and in order to enable it you have to specify the maximum size of the log file using `max_size_mb` option.
-      When infrastructure agent log file has reached that value, the current log file will be rotated into a new file.
+      From version [v1.28.0](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes) on, you can use the built-in log rotation feature.
+      By default, log rotation is disabled. To enable it, you have to specify the maximum size of the log file with the `max_size_mb` option.
+      When the infrastructure agent log file reaches that size, the current log file will be rotated into a new file.
       
-      ```
+      ```yml
       log:
         level: info
         file: /var/log/newrelic-infra/newrelic-infra.log
@@ -2568,14 +2568,15 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
           compression_enabled: true                # Optional
           file_pattern: "YYYY-MM-DD_hh-mm-ss".log  # Optional
       ```
+
       <CollapserGroup>
         <Collapser
           className="rotate-max_size_mb"
           id="rotate-max_size_mb"
           title="max_size_mb"
         >
-        `max_size_mb` specifies the maximum size in MegaBytes of the infrastructure agent log file. When the file has reached this value the current logs will be rotated into a new file. 
-        When the `max_size_mb` is `0` built-in log rotation is disabled.
+        `max_size_mb` specifies the maximum size in MegaBytes of the infrastructure agent log file. When the file has reached this size, the current logs will be rotated into a new file. 
+        When the `max_size_mb` is `0`, built-in log rotation is disabled.
 
           <table>
             <thead>
@@ -2624,6 +2625,7 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
               </tr>
             </tbody>
           </table>
+
         </Collapser>
 
         <Collapser
@@ -2682,6 +2684,7 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
               </tr>
             </tbody>
           </table>
+
         </Collapser>
 
         <Collapser
@@ -2690,11 +2693,11 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
             title="compression_enabled"
         >
 
-          You can enable compression for the log archives by setting `compression_enabled` to `true`. If compression is activated,
-          rotated files will have `gzip` format and will use less disk space.
+          You can enable compression for the log files by setting `compression_enabled` to `true`. If compression is activated,
+          rotated files will have a `gzip` format and will use less disk space.
 
           <Callout variant="important">
-            During the log rotation, if compression is enabled, the agent CPU usage might increase, especially when `max_size_mb` value is greater than `1000`
+            During the log rotation, if compression is enabled, the agent CPU usage might increase, especially when `max_size_mb` value is greater than `1000`.
           </Callout>
 
           <table>
@@ -2744,6 +2747,7 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
               </tr>
             </tbody>
           </table>
+
         </Collapser>
 
         <Collapser
@@ -2752,10 +2756,10 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
           title="file_pattern"
         >
 
-          `file_pattern` specifies the name format for the archived log files. By default the new file name will use the following
+          `file_pattern` specifies the name format for the archived log files. By default, the new file name will use the following
           name pattern: `original-file_YYYY-MM-DD_hh-mm-ss.log`.
 
-          You can customize the file name pattern using the following timestamp fields:
+          You can customize the file name pattern with the following timestamp fields:
 
           * `YYYY`: Year
           * `MM`: Month
@@ -2764,11 +2768,9 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
           * `mm`: Minute
           * `ss`: Secound
 
-         The agent will automatically replace those timestamp fields with the time of the file rotation.
+         The agent will automatically replace those timestamp fields with the time of the file rotation. For example:
 
-        e.g.:
-
-          ```
+          ```yml
           log:
             level: info
             file: /var/log/newrelic-infra/newrelic-infra.log
@@ -2824,6 +2826,7 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
               </tr>
             </tbody>
           </table>
+
         </Collapser>
       </CollapserGroup>
 
@@ -2833,7 +2836,7 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
   </Collapser>
 </CollapserGroup>
 
-## Metrics variables
+## Metrics variables [#metrics]
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -2549,6 +2549,286 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
       </table>
     </Collapser>
 
+    <Collapser
+      className="freq-link"
+      id="rotate"
+      title="rotate"
+    >
+      Starting with version [v1.28.0](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes), You can use the built-in log rotation feature.
+      By default, log rotation is disabled and in order to enable it you have to specify the maximum size of the log file using `max_size_mb` option.
+      When infrastructure agent log file has reached that value, the current log file will be rotated into a new file.
+      
+      ```
+      log:
+        level: info
+        file: /var/log/newrelic-infra/newrelic-infra.log
+        rotate:
+          max_size_mb: 1000                        # Required
+          max_files: 5                             # Optional
+          compression_enabled: true                # Optional
+          file_pattern: "YYYY-MM-DD_hh-mm-ss".log  # Optional
+      ```
+      <CollapserGroup>
+        <Collapser
+          className="rotate-max_size_mb"
+          id="rotate-max_size_mb"
+          title="max_size_mb"
+        >
+        `max_size_mb` specifies the maximum size in MegaBytes of infrastructure agent log file. When the file has reached this value the current logs will be rotated into a new file. 
+        When the `max_size_mb` is `0` built-in log rotation is disabled.
+
+          <table>
+            <thead>
+              <tr>
+                <th style={{ width: "200px" }}>
+                  YML option name
+                </th>
+
+                <th style={{ width: "200px" }}>
+                  Environment variable
+                </th>
+
+                <th>
+                  Type
+                </th>
+
+                <th>
+                  Default
+                </th>
+
+                <th>
+                  Version
+                </th>
+              </tr>
+            </thead>
+
+            <tbody>
+              <tr>
+                <td>
+                  `max_size_mb`
+                </td>
+
+                <td>
+                  `NRIA_LOG_ROTATE_MAX_SIZE_MB`
+                </td>
+
+                <td>
+                  integer
+                </td>
+
+                <td>
+                  0 - Disabled
+                </td>
+
+                <td/>
+              </tr>
+            </tbody>
+          </table>
+        </Collapser>
+
+        <Collapser
+          className="rotate-max_files"
+          id="rotate-max_files"
+          title="max_files"
+        >
+
+          `max_files` defines how many archived log files will be keept. When this value is exceeded, older files will be removed.
+          When the `max_files` is `0` the limit for the number of files is disabled.
+
+          <table>
+            <thead>
+              <tr>
+                <th style={{ width: "200px" }}>
+                  YML option name
+                </th>
+
+                <th style={{ width: "200px" }}>
+                  Environment variable
+                </th>
+
+                <th>
+                  Type
+                </th>
+
+                <th>
+                  Default
+                </th>
+
+                <th>
+                  Version
+                </th>
+              </tr>
+            </thead>
+
+            <tbody>
+              <tr>
+                <td>
+                  `max_files`
+                </td>
+
+                <td>
+                  `NRIA_LOG_ROTATE_MAX_FILES`
+                </td>
+
+                <td>
+                  integer
+                </td>
+
+                <td>
+                  0
+                </td>
+
+                <td/>
+              </tr>
+            </tbody>
+          </table>
+        </Collapser>
+
+        <Collapser
+            className="rotate-compression_enabled"
+            id="rotate-compression_enabled"
+            title="compression_enabled"
+        >
+
+          You can enable compression for the log archives by setting `compression_enabled` to `true`. If compression is activated,
+          rotated files will have `gzip` format and will use less disk space.
+
+          <Callout variant="important">
+            During the log rotation, if compression is enabled, the agent CPU usage might increase, especially when `max_size_mb` value is greater than `1000`
+          </Callout>
+
+          <table>
+            <thead>
+              <tr>
+                <th style={{ width: "200px" }}>
+                  YML option name
+                </th>
+
+                <th style={{ width: "200px" }}>
+                  Environment variable
+                </th>
+
+                <th>
+                  Type
+                </th>
+
+                <th>
+                  Default
+                </th>
+
+                <th>
+                  Version
+                </th>
+              </tr>
+            </thead>
+
+            <tbody>
+              <tr>
+                <td>
+                  `compression_enabled`
+                </td>
+
+                <td>
+                  `NRIA_LOG_ROTATE_COMPRESSION_ENABLED`
+                </td>
+
+                <td>
+                  boolean
+                </td>
+
+                <td>
+                  false
+                </td>
+
+                <td/>
+              </tr>
+            </tbody>
+          </table>
+        </Collapser>
+
+        <Collapser
+          className="rotate-file_pattern"
+          id="rotate-file_pattern"
+          title="file_pattern"
+        >
+
+          `file_pattern` specifies the name format for the archived log files. By default the new file name will use the following
+          name pattern: `original-file_YYYY-MM-DD_hh-mm-ss.log`.
+
+          You can customize the file name pattern using the following timestamp fields:
+
+          * `YYYY`: Year
+          * `MM`: Month
+          * `DD`: Day
+          * `hh`: Hour
+          * `mm`: Minute
+          * `ss`: Secound
+
+         The agent will automatically replace those timestamp fields with the time of file rotation.
+
+        e.g.:
+
+          ```
+          log:
+            level: info
+            file: /var/log/newrelic-infra/newrelic-infra.log
+            rotate:
+              max_size_mb: 1000
+              file_pattern: "rotated.YYYY-MM-DD_hh-mm-ss".log
+          ```
+
+          <table>
+            <thead>
+              <tr>
+                <th style={{ width: "200px" }}>
+                  YML option name
+                </th>
+
+                <th style={{ width: "200px" }}>
+                  Environment variable
+                </th>
+
+                <th>
+                  Type
+                </th>
+
+                <th>
+                  Default
+                </th>
+
+                <th>
+                  Version
+                </th>
+              </tr>
+            </thead>
+
+            <tbody>
+              <tr>
+                <td>
+                  `file_pattern`
+                </td>
+
+                <td>
+                  `NRIA_LOG_ROTATE_FILE_PATTERN`
+                </td>
+
+                <td>
+                  string
+                </td>
+
+                <td>
+                  file_YYYY-MM-DD_hh-mm-ss.file_extension
+                </td>
+
+                <td/>
+              </tr>
+            </tbody>
+          </table>
+        </Collapser>
+      </CollapserGroup>
+
+    </Collapser>
+
   </CollapserGroup>
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -2574,7 +2574,7 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
           id="rotate-max_size_mb"
           title="max_size_mb"
         >
-        `max_size_mb` specifies the maximum size in MegaBytes of infrastructure agent log file. When the file has reached this value the current logs will be rotated into a new file. 
+        `max_size_mb` specifies the maximum size in MegaBytes of the infrastructure agent log file. When the file has reached this value the current logs will be rotated into a new file. 
         When the `max_size_mb` is `0` built-in log rotation is disabled.
 
           <table>
@@ -2764,7 +2764,7 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
           * `mm`: Minute
           * `ss`: Secound
 
-         The agent will automatically replace those timestamp fields with the time of file rotation.
+         The agent will automatically replace those timestamp fields with the time of the file rotation.
 
         e.g.:
 
@@ -2774,7 +2774,7 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
             file: /var/log/newrelic-infra/newrelic-infra.log
             rotate:
               max_size_mb: 1000
-              file_pattern: "rotated.YYYY-MM-DD_hh-mm-ss".log
+              file_pattern: rotated.YYYY-MM-DD_hh-mm-ss.log
           ```
 
           <table>


### PR DESCRIPTION
This PR will update infrastructure-agent documentation for log rotation:
- configure builtin log rotate mechanism