### PR TITLE
Fix broken MELT link

### DIFF
--- a/src/content/docs/data-apis/understand-data/new-relic-data-types.mdx
+++ b/src/content/docs/data-apis/understand-data/new-relic-data-types.mdx
@@ -778,4 +778,4 @@ To report custom distributed tracing data, see the [Trace API](/docs/apm/distrib
 Understanding New Relic data types can help you:
 
 * [Query data in New Relic](/docs/query-new-relic-data)
-* [Send data to New Relic](https://developer.newrelic.com/use-cases/collect-data-from-any-source)
+* [Send data to New Relic](/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic)


### PR DESCRIPTION
Out team moved some use-case docs around on the developer site, which affected a link on our MELT page. This PR replaces that link.