### PR TITLE
fix(k8s): replacing w/ guided install links

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration.mdx
@@ -69,7 +69,7 @@ Our automated installer will generate either a helm command or a set of plain ma
   <ButtonLink
     data-tessen="stitchedPathLinkClick"
     role="button"
-    to="https://one.newrelic.com/launcher/k8s-cluster-explorer-nerdlet.cluster-explorer-launcher?pane=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsInBhdGgiOiJndWlkZWQiLCJlbnYiOiJrdWJlcm5ldGVzIiwiaW5pdGlhbEFjdGlvbkluZGV4IjpudWxsLCJhY3Rpb25JbmRleCI6MX0="
+    to="https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5saXN0aW5nIn0=&cards[0]=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsImFjdGl2ZUNvbXBvbmVudCI6IlZUU09FbnZpcm9ubWVudCIsInBhdGgiOiJndWlkZWQifQ=="
     variant="primary"
   >
     Start the installer
@@ -77,7 +77,7 @@ Our automated installer will generate either a helm command or a set of plain ma
 </ButtonGroup>
 
 <Callout variant="tip">
-  If your New Relic account [is in the EU region](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers), access the automated installer from [one.eu.newrelic.com](http://one.eu.newrelic.com/launcher/k8s-cluster-explorer-nerdlet.cluster-explorer-launcher?pane=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsInBhdGgiOiJndWlkZWQiLCJlbnYiOiJrdWJlcm5ldGVzIiwiaW5pdGlhbEFjdGlvbkluZGV4IjpudWxsLCJhY3Rpb25JbmRleCI6MX0=).
+  If your New Relic account [is in the EU region](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers), access the automated installer from [one.eu.newrelic.com](http://one.eu.newrelic.com/launcher/nr1-core.explorer?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5saXN0aW5nIn0=&cards[0]=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsImFjdGl2ZUNvbXBvbmVudCI6IlZUU09FbnZpcm9ubWVudCIsInBhdGgiOiJndWlkZWQifQ==).
 </Callout>
 
 ## Why it matters [#features]

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure.mdx
@@ -58,7 +58,7 @@ If your New Relic account [is in the EU region](/docs/using-new-relic/welcome-ne
 
   <ButtonLink
     role="button"
-    to="https://one.newrelic.com/launcher/k8s-cluster-explorer-nerdlet.cluster-explorer-launcher?pane=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsInBhdGgiOiJndWlkZWQiLCJlbnYiOiJrdWJlcm5ldGVzIiwiaW5pdGlhbEFjdGlvbkluZGV4IjpudWxsLCJhY3Rpb25JbmRleCI6MX0="
+    to="http://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5saXN0aW5nIn0=&cards[0]=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsImFjdGl2ZUNvbXBvbmVudCI6IlZUU09FbnZpcm9ubWVudCIsInBhdGgiOiJndWlkZWQifQ=="
     variant="primary"
   >
     Start the installer
@@ -66,7 +66,7 @@ If your New Relic account [is in the EU region](/docs/using-new-relic/welcome-ne
 
   <ButtonLink
     role="button"
-    to="http://one.eu.newrelic.com/launcher/k8s-cluster-explorer-nerdlet.cluster-explorer-launcher?pane=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsInBhdGgiOiJndWlkZWQiLCJlbnYiOiJrdWJlcm5ldGVzIiwiaW5pdGlhbEFjdGlvbkluZGV4IjpudWxsLCJhY3Rpb25JbmRleCI6MX0="
+    to="http://one.eu.newrelic.com/launcher/nr1-core.explorer?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5saXN0aW5nIn0=&cards[0]=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsImFjdGl2ZUNvbXBvbmVudCI6IlZUU09FbnZpcm9ubWVudCIsInBhdGgiOiJndWlkZWQifQ=="
     variant="primary"
   >
     Eu guided install


### PR DESCRIPTION
Was told that these links were bad. Replaced with general guided install links, because in my understanding that is the path they need and the guided install uses the k8s integration.