### PR TITLE
Update InfiniteTracing proxy documentation for .NET Agent

### DIFF
--- a/src/content/docs/distributed-tracing/infinite-tracing/infinite-tracing-configure-proxy-support.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/infinite-tracing-configure-proxy-support.mdx
@@ -33,7 +33,7 @@ If your application is already using a proxy, these properties may already be se
 
 ## .NET [#dot-net]
 
-.Net is not supported.
+The proxy address can be specified by the `GRPC_PROXY` environment variable.
 
 ## Node.js, PHP, Python, and Ruby [#node-php-python-ruby]
 


### PR DESCRIPTION
Adds instructions on how to specify the Infinite Tracing proxy configuration for the .NET agent.