### PR TITLE
fix(node agent): update compatibility requirements with newer features

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -327,7 +327,9 @@ For other message queue libraries, use [custom instrumentation](/docs/agents/nod
 
 ## HTTP/1.1
 
-The Node.js agent instruments the native `http` module. In addition, the popular [undici](https://www.npmjs.com/package/undici) client also has experimental support.
+The Node.js agent instruments the native `http` module. 
+
+In addition, the popular [undici](https://www.npmjs.com/package/undici) client has experimental support as well. To use undici, be sure to set `feature_flag.undici_instrumentation = true` in the `newrelic.js` [configuration file](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#methods-and-precedence).
 
 ## gRPC
 

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -327,7 +327,7 @@ For other message queue libraries, use [custom instrumentation](/docs/agents/nod
 
 ## HTTP/1.1
 
-The Node.js agent instruments the native `http` module. In addition, the popular [undici](https://www.npmjs.com/package/undici) client is also supported.
+The Node.js agent instruments the native `http` module. In addition, the popular [undici](https://www.npmjs.com/package/undici) client also has experimental support.
 
 ## gRPC
 

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -158,12 +158,12 @@ Errors resulting in unhandled rejections are not scoped to the transaction that 
 * [Hapi](https://www.npmjs.com/package/hapi)
 * [Koa](https://www.npmjs.com/package/koa) 2.0.0 or higher ([external module](https://github.com/newrelic/node-newrelic-koa) loaded with the agent)
 * [Fastify](https://www.npmjs.com/package/fastify)
-* [Next.js](https://www.npmjs.com/package/next) 12.0.9 or higher
+* [Next.js](https://www.npmjs.com/package/next) 12.0.9 or higher (12.2.0 or higher required for middleware instrumentation)
 
 If you are using a supported framework with default routers, the Node.js agent can read these frameworks' route names as is. However, if you want more specific names than are provided by your framework, you may want to use one or more of the tools New Relic provides with the [Node.js transaction naming API](/docs/nodejs/nodejs-transaction-naming-api).
 
 <Callout title="EOL NOTICE">
-  We're discontinuing support for several capabilities in November 2021. This includes the Oracle Driver Package and Hapi versions prior to Hapi 19.2 for our Node.js agent. For more details, including how you can easily prepare for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-and-support-across-node-agents-suggested-pagerduty-responders-incident-workflows-and-kubernetes-instrumentation/164481?u=dholloran).
+  We have discontinued support for several capabilities in November 2021. This includes the Oracle Driver Package and Hapi versions prior to Hapi 19.2 for our Node.js agent. For more details, including how you can easily prepare for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-and-support-across-node-agents-suggested-pagerduty-responders-incident-workflows-and-kubernetes-instrumentation/164481?u=dholloran).
 </Callout>
 
 ## Processors [#processors]
@@ -324,6 +324,21 @@ For other message queue libraries, use [custom instrumentation](/docs/agents/nod
 * AWS EC2
 * [Microsoft Azure](/docs/nodejs/nodejs-agent-on-microsoft-azure)
 * [Heroku](/docs/nodejs/nodejs-agent-on-heroku)
+
+## HTTP/1.1
+
+The Node.js agent instruments the native `http` module. In addition, the popular [undici](https://www.npmjs.com/package/undici) client is also supported.
+
+## gRPC
+
+* The [grpc-js](https://www.npmjs.com/package/@grpc/grpc-js) library is supported for unary, streaming, or bidirectional client calls.
+
+## Logging libraries
+
+In order to support [APM logs in context](/docs/apm/new-relic-apm/getting-started/get-started-logs-context), the Node.js agent instruments the following libraries:
+
+* [winston](https://www.npmjs.com/package/winston)
+* [pino](https://www.npmjs.com/package/pino)
 
 ## Process managers
 


### PR DESCRIPTION
This closes [#1254 of the node-newrelic repo](https://github.com/newrelic/node-newrelic/issues/1254)

A couple of other updates are also included for other instrumented libraries.
