### PR TITLE
fix: Basic User NerdGraph access docs

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -302,7 +302,14 @@ Here's a detailed comparison of capabilities by user type. For tips on why you'd
         [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) (our GraphQL API)
       </td>
 
-      <td style="text-align:center"/>
+      <td style="text-align:center">
+        <Icon
+          style={{color: '#328787'}}
+          name="fe-check"
+        />
+
+        (for permitted features)
+      </td>
 
       <td style="text-align:center">
         <Icon


### PR DESCRIPTION
I'm a New Relic employee (epoley@newrelic.com). My team owns NerdGraph.

To the best of our understanding, there is a mistake in this user types comparison chart. Basic Users should be able to access NerdGraph in general (though of course some specific APIs may be restricted.)

Read this complete internal Slack discussion for more context: https://newrelic.slack.com/archives/CBHJRSPSA/p1635878905246100

If you'd like to discuss this further in a non-public setting, feel free to contact us in #help-unified-api