### PR TITLE
Add an example POD/container restart NRQL Alerts

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-recommended-alert-policy.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-recommended-alert-policy.mdx
@@ -226,7 +226,7 @@ While we try to tackle the most common use cases across all the environments, th
           </td>
 
           <td>
-            `from K8sContainerSample select latest(restartCount) - earliest(restartCount) where clusterName = '<YOUR CLUSTER NAME>' facet containerName, podName, reason`
+            `from K8sContainerSample select latest(restartCount) - earliest(restartCount) where clusterName = '<YOUR CLUSTER NAME>' facet containerName, podName`
           </td>
         </tr>
 
@@ -236,7 +236,7 @@ While we try to tackle the most common use cases across all the environments, th
           </td>
 
           <td>
-            `Statis`
+            `Static`
           </td>
         </tr>
 

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-recommended-alert-policy.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-recommended-alert-policy.mdx
@@ -200,4 +200,64 @@ While we try to tackle the most common use cases across all the environments, th
       </tbody>
     </table>
   </Collapser>
+  
+  <Collapser
+    className="freq-link"
+    id="pod-restart"
+    title="Alert when container restarts"
+  >
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: "180px" }}>
+            Setting
+          </th>
+
+          <th>
+            Value
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            **NRQL**
+          </td>
+
+          <td>
+            `from K8sContainerSample select latest(restartCount) - earliest(restartCount) where clusterName = '<YOUR CLUSTER NAME>' facet containerName, podName, reason`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            **Threshold**
+          </td>
+
+          <td>
+            `Statis`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            **Warning threshold**
+          </td>
+
+          <td/>
+        </tr>
+
+        <tr>
+          <td>
+            **Critical threshold**
+          </td>
+
+          <td>
+            `Open violation when the query returns a value > 1 at least once in 1 minute`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
Could we add an example POD restart NRQL based Alert ? 
Alert when container restarts:
NRQL: ` from K8sContainerSample select latest(restartCount) - earliest(restartCount) where clusterName = '<YOUR CLUSTER NAME>' facet containerName, podName, reason` 

Threshold: Static
Open violation when the query returns a value > 1 at least once in 1 minute
Advanced signal settings:
- Window Duration: 1 minute
- Streaming method: Event flow
- Delay: 1 minute
- Gap-filling strategy: Last known value

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.