### PR TITLE
Add links to sample instrumentation in setup

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup.mdx
@@ -21,13 +21,13 @@ import nativeOtlpWithCollector from 'images/native_otlp_with_collector.png'
 OpenTelemetry is a flexible toolkit that you can implement in a variety of ways for services. If you are planning to gather telemetry about hosts, skip to our [collector instructions](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro).
 
 <Callout variant="tip">
-If you prefer to practice with a sample service first, get started right away with these options:
+If you prefer to practice with a sample first, run a sample service in your own development environment with one of these options:
 
 * [OpenTelemetry masterclass](https://developer.newrelic.com/opentelemetry-masterclass): Learn about OpenTelemetry and try a hands-on tutorial for .NET or Python
 * [New Relic OpenTelemetry examples](https://github.com/newrelic/newrelic-opentelemetry-examples): Try out instrumentation with sample programs in .NET, Go, Java, or Python
 </Callout>
 
-The following five steps will help you instrument your own services:
+The following five steps will help you instrument your own services with OpenTelemetry:
 
 1. [Prerequisites](#prereqs)
 2. [Instrument your service with OpenTelemetry](#instrument)

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup.mdx
@@ -21,13 +21,13 @@ import nativeOtlpWithCollector from 'images/native_otlp_with_collector.png'
 OpenTelemetry is a flexible toolkit that you can implement in a variety of ways for services. If you are planning to gather telemetry about hosts, skip to our [collector instructions](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro).
 
 <Callout variant="tip">
-These instructions will help you instrument your own services. If you prefer to instrument a sample service, see these options:
+If you prefer to practice with a sample service first, get started right away with these options:
 
-* [OpenTelemetry masterclass](https://developer.newrelic.com/opentelemetry-masterclass): Provides some background about OpenTelemetry and hands-on tutorials for .NET and Python
-* [New Relic OpenTelemetry examples](https://github.com/newrelic/newrelic-opentelemetry-examples): A repository with a range of language projects
+* [OpenTelemetry masterclass](https://developer.newrelic.com/opentelemetry-masterclass): Learn about OpenTelemetry and try a hands-on tutorial for .NET or Python
+* [New Relic OpenTelemetry examples](https://github.com/newrelic/newrelic-opentelemetry-examples): Try out instrumentation with sample programs in .NET, Go, Java, or Python
 </Callout>
 
-To gather telemetry from services, we recommend a basic five-step approach:
+The following five steps will help you instrument your own services:
 
 1. [Prerequisites](#prereqs)
 2. [Instrument your service with OpenTelemetry](#instrument)

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup.mdx
@@ -20,6 +20,13 @@ import nativeOtlpWithCollector from 'images/native_otlp_with_collector.png'
 
 OpenTelemetry is a flexible toolkit that you can implement in a variety of ways for services. If you are planning to gather telemetry about hosts, skip to our [collector instructions](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro).
 
+<Callout variant="tip">
+These instructions will help you instrument your own services. If you prefer to instrument a sample service, see these options:
+
+* [OpenTelemetry masterclass](https://developer.newrelic.com/opentelemetry-masterclass): Provides some background about OpenTelemetry and hands-on tutorials for .NET and Python
+* [New Relic OpenTelemetry examples](https://github.com/newrelic/newrelic-opentelemetry-examples): A repository with a range of language projects
+</Callout>
+
 To gather telemetry from services, we recommend a basic five-step approach:
 
 1. [Prerequisites](#prereqs)


### PR DESCRIPTION
Since our setup guide targets users who want to instrument their own services right away, I thought we should offer an alternative track for people who want to instrument a sample service before working on their own.