### PR TITLE
Update aws-rds-monitoring-integration.mdx

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-monitoring-integration.mdx
@@ -137,7 +137,7 @@ This integration collects Amazon RDS data for clusters and also for instances. S
 
     <tr>
       <td>
-        `cpuUtilization`
+        `CPUUtilization`
       </td>
 
       <td>


### PR DESCRIPTION
<fix>This metric name is `CPUUtilization` rather than `cpuUtilization`. There are various documentation from AWS showing the upper case 'CPU.' https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/cw-metrics-overview.html
Also was able to run queries with the uppercase 'CPUUtilization' successfully and returned no data on queries using the lowercase 'cpu'.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.