### PR TITLE
Fix typo in memory_limiter configuration stanza

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
@@ -114,7 +114,7 @@ Adapt the `config.yaml` with these recommended parameters:
 
     <tr>
       <td>
-        `processors::memory_limited`
+        `processors::memory_limiter`
       </td>
 
       <td>


### PR DESCRIPTION
The correct config stanza name appears in the sample code block elsewhere in this doc.