### PR TITLE
[JULY 11TH; NOON] Add release notes for ruby agent 8.9.0

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-890.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-890.mdx
@@ -1,0 +1,25 @@
+---
+subject: Ruby agent
+releaseDate: '2022-07-11'
+version: 8.9.0
+downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.9.0.gem'
+---
+
+  ## v8.9.0
+  
+  * **Add support for Dalli 3.1.0 to Dalli 3.2.2**
+
+    Dalli versions 3.1.0 and above include breaking changes where the agent previously hooked into the gem. We have updated our instrumentation to correctly hook into Dalli 3.1.0 and above. At this time, 3.2.2 is the latest Dalli version and is confirmed to be supported.
+
+  * **Bugfix: Infinite Tracing hung on connection restart**
+
+    Previously, when using infinite tracing, the agent would intermittently encounter a deadlock when attempting to restart the infinite tracing connection. This bug would prevent the agent from sending all data types, including non-infinite-tracing-related data. This change reworks how we restart infinite tracing to prevent potential deadlocks.
+
+  * **Bugfix: Use read_nonblock instead of read on pipe**
+
+    Previously, our PipeChannelManager was using read which could cause resque jobs to get stuck in some versions. This change updates the PipeChannelManager to use read_nonblock instead to avoid this issue. 
+
+    
+## Support statement
+
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [6.5.0.357](https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-650357).


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
This pr adds the release notes for the ruby agent upcoming release 8.9.0. We will be releasing early next week
