### PR TITLE
Add links to README.md and THIRD_PARTY_NOTICES.md

### DIFF
--- a/src/content/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent.mdx
+++ b/src/content/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent.mdx
@@ -50,6 +50,8 @@ It may take several minutes after enabling the browser monitoring agent before y
 
 No matter which option you use to deploy browser monitoring, the end result is the same: the browser monitoring JavaScript snippet (also referred to as the "agent") is inserted into your app pages. The method you select depends on your preferences and business needs.
 
+To learn more about the scripts used to install the agent, check out the browser agent's [Read me](https://github.com/newrelic/newrelic-browser-agent) file in our GitHub repo. You can also learn about the third party libraries called during installation in the [Third party notices](https://github.com/newrelic/newrelic-browser-agent/blob/main/THIRD_PARTY_NOTICES.md) file. 
+
 ### Enable an APM-monitored app [#select-apm-app]
 
 When [enabling browser monitoring](#enable), you can use an APM agent to automatically inject the browser monitoring JavaScript snippet for you. This is the easiest way to install the agent for an app that's already being monitored by APM.


### PR DESCRIPTION
Addressing [this GitHub issue](https://github.com/newrelic/docs-website/issues/8384). Added links to the relevant files in the "Deployment options" H2. Wanted to give customers the option to read about what they're installing before installing the agent. 