### PR TITLE
Add linux messages built in parsing rule

### DIFF
--- a/src/content/docs/logs/ui-data/built-log-parsing-rules.mdx
+++ b/src/content/docs/logs/ui-data/built-log-parsing-rules.mdx
@@ -1304,6 +1304,27 @@ New Relic can parse common log formats according to built-in rules, so that you 
   </Collapser>
 
   <Collapser
+    id="linux_messages"
+    title="Linux Messages (/var/log/messages)"
+  >
+    **Source:** `logtype = 'linux_messages'`
+
+    **Grok:**
+
+    ```grok
+    %{SYSLOGTIMESTAMP:linux_messages.timestamp} %{NOTSPACE:linux_messages.hostname} %{DATA:linux_messages.process}(\[%{NUMBER:linux_messages.pid:integer}\])?: %{GREEDYDATA:linux_messages.message}
+    ```
+
+    **Results:**
+
+    * `linux_messages.timestamp`: The time of the log
+    * `linux_messages.hostname`: The linux server hostname
+    * `linux_messages.process`: The linux process name
+    * `linux_messages.pid`: The linux PID (process identifier)
+    * `linux_messages.message`: The log message
+  </Collapser>
+
+  <Collapser
     id="iis"
     title="Microsoft IIS"
   >

--- a/src/content/docs/logs/ui-data/built-log-parsing-rules.mdx
+++ b/src/content/docs/logs/ui-data/built-log-parsing-rules.mdx
@@ -1304,6 +1304,28 @@ New Relic can parse common log formats according to built-in rules, so that you 
   </Collapser>
 
   <Collapser
+    id="linux_cron"
+    title="Linux Cron (/var/log/cron)"
+  >
+    **Source:** `logtype = 'linux_cron'`
+
+    **Grok:**
+
+    ```grok
+    %{SYSLOGTIMESTAMP:linux_cron.timestamp} %{NOTSPACE:linux_cron.hostname} %{DATA:linux_cron.process}(\[%{NUMBER:linux_cron.pid:integer}\])?: (\(%{DATA:linux_cron.user}\))?%{GREEDYDATA:linux_cron.message}
+    ```
+
+    **Results:**
+
+    * `linux_cron.timestamp`: The time of the log
+    * `linux_cron.hostname`: The linux server hostname
+    * `linux_cron.process`: The linux cron process name
+    * `linux_cron.pid`: The linux cron PID (process identifier)
+    * `linux_cron.user`: The linux user that executed the cron
+    * `linux_cron.message`: The log message
+  </Collapser>
+
+  <Collapser
     id="linux_messages"
     title="Linux Messages (/var/log/messages)"
   >

--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -478,6 +478,34 @@ To learn what fields are parsed for each rule, see our documentation about [buil
 
     <tr>
       <td>
+        [`linux_cron`](/docs/logs/ui-data/built-log-parsing-rules/#linux_cron)
+      </td>
+
+      <td>
+        Linux Cron
+      </td>
+
+      <td>
+        `logtype:"linux_cron"`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [`linux_messages`](/docs/logs/ui-data/built-log-parsing-rules/#linux_messages)
+      </td>
+
+      <td>
+        Linux Messages
+      </td>
+
+      <td>
+        `logtype:"linux_messages"`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         [`iis_w3c`](/docs/logs/ui-data/built-log-parsing-rules/#iis)
       </td>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Update docs for 2 new built-in parsing rules
Linux Cron (/var/log/cron), logtype=linux_cron
Linux Messages (/var/log/messages), logtype=linux_messages

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.