### PR TITLE
Correct version that ZTS builds were deprecated in the PHP agent

### DIFF
--- a/src/content/docs/apm/agents/php-agent/advanced-installation/php-agent-installation-non-standard-php-advanced.mdx
+++ b/src/content/docs/apm/agents/php-agent/advanced-installation/php-agent-installation-non-standard-php-advanced.mdx
@@ -129,7 +129,7 @@ If this process doesn't work for you, you can get the correct information from y
       </td>
 
       <td>
-        ZTS options apply only to [PHP agent versions 9.17 and earlier](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9170300/). ZTS is not available for PHP versions 9.18 or higher.
+        ZTS options apply only to [PHP agent versions 9.19.0.309 and earlier](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9200310/). ZTS is not available for PHP agent versions 9.20.0.310 or higher.
 
         To determine whether ZTS is compiled in, look for the `Thread Safety` setting at the top of the `phpinfo()` output.
 


### PR DESCRIPTION
ZTS builds were deprecated as of version 9.19 and not version 9.17.

Slack conversation with ENG to confirm: https://newrelic.slack.com/archives/C05112CNH/p1657224263652059?thread_ts=1657220579.996889&cid=C05112CNH

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.