### PR TITLE
Infra Agent tar.gz package signature process link

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-assisted-install-infrastructure-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-assisted-install-infrastructure-agent-linux.mdx
@@ -26,11 +26,12 @@ To install the agent:
 
 1. Download the [packaged agent file](https://download.newrelic.com/infrastructure_agent/binaries/linux/) or use the following command that automatically fetches a specific version of the agent, its checksum and verifies it after download. Replace `ARCH=amd64` with desired architecture (amd64, 386, arm64, arm) and `V=1.27.4` with [latest or specific version](https://github.com/newrelic/infrastructure-agent/releases/latest).
 
-   ```
+   ```shell
    V=1.27.4 ARCH=amd64; echo "https://download.newrelic.com/infrastructure_agent/binaries/linux/${ARCH}/newrelic-infra_linux_${V}_amd64.tar.gz" | { read    url; wget "${url}"{,.sum}; shasum -a 256 --check ${url##*/}.sum; }
    ```
-   Since version `1.27.4` we provide the `tar.gz` package GPG signature. You can check the signature procedure and instructions for
-   verification in the [infra-agent repository on GitHub](https://github.com/newrelic/infrastructure-agent/blob/master/docs/pgp-signed-release.md)
+
+   From version `1.27.4` on, we provide the `tar.gz` package GPG signature. You can check the signature procedure and instructions for
+   verification in the [infra-agent repository on GitHub](https://github.com/newrelic/infrastructure-agent/blob/master/docs/pgp-signed-release.md).
 
 2. Unpack the file.
 3. Make sure the file unpacks with the following structure:

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-assisted-install-infrastructure-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-assisted-install-infrastructure-agent-linux.mdx
@@ -29,6 +29,9 @@ To install the agent:
    ```
    V=1.27.4 ARCH=amd64; echo "https://download.newrelic.com/infrastructure_agent/binaries/linux/${ARCH}/newrelic-infra_linux_${V}_amd64.tar.gz" | { read    url; wget "${url}"{,.sum}; shasum -a 256 --check ${url##*/}.sum; }
    ```
+   Since version `1.27.4` we provide the `tar.gz` package GPG signature. You can check the signature procedure and instructions for
+   verification in the [infra-agent repository on GitHub](https://github.com/newrelic/infrastructure-agent/blob/master/docs/pgp-signed-release.md)
+
 2. Unpack the file.
 3. Make sure the file unpacks with the following structure:
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-manual-install-infrastructure-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-manual-install-infrastructure-agent-linux.mdx
@@ -62,11 +62,12 @@ To install the agent:
 
 1. Download the [packaged agent file](https://download.newrelic.com/infrastructure_agent/binaries/linux/) or use the following command that automatically fetches a specific version of the agent, its checksum and verifies it after download. Replace `ARCH=amd64` with desired architecture (amd64, 386, arm64, arm) and `V=1.27.4` with [latest or specific version](https://github.com/newrelic/infrastructure-agent/releases/latest).
 
-   ```
+   ```shell
    V=1.27.4 ARCH=amd64; echo "https://download.newrelic.com/infrastructure_agent/binaries/linux/${ARCH}/newrelic-infra_linux_${V}_amd64.tar.gz" | { read    url; wget "${url}"{,.sum}; shasum -a 256 --check ${url##*/}.sum; }
    ```
-   Since version `1.27.4` we provide the `tar.gz` package GPG signature. You can check the signature procedure and instructions for
-   verification in the [infra-agent repository on GitHub](https://github.com/newrelic/infrastructure-agent/blob/master/docs/pgp-signed-release.md)
+
+   From version `1.27.4` on, we provide the `tar.gz` package GPG signature. You can check the signature procedure and instructions for
+   verification in the [infra-agent repository on GitHub](https://github.com/newrelic/infrastructure-agent/blob/master/docs/pgp-signed-release.md).
 2. Unpack the file.
 3. Make sure the file unpacks with the following structure:
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-manual-install-infrastructure-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-manual-install-infrastructure-agent-linux.mdx
@@ -65,6 +65,8 @@ To install the agent:
    ```
    V=1.27.4 ARCH=amd64; echo "https://download.newrelic.com/infrastructure_agent/binaries/linux/${ARCH}/newrelic-infra_linux_${V}_amd64.tar.gz" | { read    url; wget "${url}"{,.sum}; shasum -a 256 --check ${url##*/}.sum; }
    ```
+   Since version `1.27.4` we provide the `tar.gz` package GPG signature. You can check the signature procedure and instructions for
+   verification in the [infra-agent repository on GitHub](https://github.com/newrelic/infrastructure-agent/blob/master/docs/pgp-signed-release.md)
 2. Unpack the file.
 3. Make sure the file unpacks with the following structure:
 


### PR DESCRIPTION
Added link to infra-agent instructions for tar.gz package signature verification. 