### PR TITLE
Remove un-used timingPrecision config attribute from .NET docs

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -269,8 +269,7 @@ The root element of the configuration document is a `configuration` element.
 ```xml
 <configuration xmlns="urn:newrelic-config"
   agentEnabled="true"
-  maxStackTraceLines="50"
-  timingPrecision="low">
+  maxStackTraceLines="50">
 ```
 
 The `configuration` element supports the following attributes:
@@ -336,37 +335,6 @@ The `configuration` element supports the following attributes:
     </table>
 
     The maximum number of stack frames to trace in any stack dump.
-  </Collapser>
-
-  <Collapser
-    id="config-timingPrecision"
-    title="timingPrecision"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            String
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `low`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Controls the precision of the timers. High precision will provide better data, but at a lower execution speed. Possible values are `high` and `low`.
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
We received a customer question about the the `timingPrecision` configuration attribute and realized it doesn't actually do anything after reviewing code. To minimize customer confusion, we should remove this from our published docs.