### PR TITLE
fix(amazon-integrations): remove outdated permissions

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/get-started/integrations-managed-policies.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/get-started/integrations-managed-policies.mdx
@@ -91,8 +91,6 @@ A user different than `root` can be used in the managed policy.
                       - 'elasticloadbalancing:DescribeLoadBalancerPolicies'
                       - 'elasticloadbalancing:DescribeLoadBalancerPolicyTypes'
                       - 'apigateway:GET'
-                      - 'apigateway:HEAD'
-                      - 'apigateway:OPTIONS'
                       - 'autoscaling:DescribeLaunchConfigurations'
                       - 'autoscaling:DescribeAutoScalingGroups'
                       - 'autoscaling:DescribePolicies'
@@ -185,7 +183,6 @@ A user different than `root` can be used in the managed policy.
                       - 's3:GetBucketRequestPayment'
                       - 's3:GetEncryptionConfiguration'
                       - 's3:GetInventoryConfiguration'
-                      - 's3:GetIpConfiguration'
                       - 'ses:ListConfigurationSets'
                       - 'ses:GetSendQuota'
                       - 'ses:DescribeConfigurationSet'
@@ -321,8 +318,6 @@ The following permissions are used by New Relic to retrieve data for specific AW
     Additional [API Gateway](/docs/infrastructure/amazon-integrations/amazon-integrations/aws-api-gateway-monitoring-integration) permissions:
 
     * `apigateway:GET`
-    * `apigateway:HEAD`
-    * `apigateway:OPTIONS`
   </Collapser>
 
   <Collapser
@@ -610,7 +605,6 @@ The following permissions are used by New Relic to retrieve data for specific AW
     * `s3:GetBucketRequestPayment`
     * `s3:GetEncryptionConfiguration`
     * `s3:GetInventoryConfiguration`
-    * `s3:GetIpConfiguration`
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
Removed permissions that no longer exist from the Cloud Integrations documentation. 
These permissions are no longer part of the recommended managed policy `ReadOnlyAccess` either. 
