### PR TITLE
Changes to .NET agent documentation for major version 10.0.0 release

### DIFF
--- a/src/content/docs/apm/agents/net-agent/custom-instrumentation/create-transactions-xml-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/custom-instrumentation/create-transactions-xml-net.mdx
@@ -60,7 +60,7 @@ To create a custom instrumentation file:
        <var>PATH_TO_AGENT_DIRECTORY</var>/Extensions
        ```
 
-       `PATH_TO_AGENT_DIRECTORY` will be the default `/usr/local/newrelic-netcore20-agent` or the directory chosen at installation.
+       `PATH_TO_AGENT_DIRECTORY` will be the default `/usr/local/newrelic-dotnet-agent` (agent version 10.0.0 and newer), `/usr/local/newrelic-netcore20-agent` (agent versions older than 10.0.0), or the directory chosen at installation.
      </Collapser>
 
      <Collapser

--- a/src/content/docs/apm/agents/net-agent/custom-instrumentation/create-transactions-xml-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/custom-instrumentation/create-transactions-xml-net.mdx
@@ -60,7 +60,7 @@ To create a custom instrumentation file:
        <var>PATH_TO_AGENT_DIRECTORY</var>/Extensions
        ```
 
-       `PATH_TO_AGENT_DIRECTORY` will be the default `/usr/local/newrelic-dotnet-agent` (agent version 10.0.0 and newer), `/usr/local/newrelic-netcore20-agent` (agent versions older than 10.0.0), or the directory chosen at installation.
+       `PATH_TO_AGENT_DIRECTORY` will be the default `/usr/local/newrelic-dotnet-agent` (agent versions 10.0.0 or higher), `/usr/local/newrelic-netcore20-agent` (agent versions 9.9.0 or lower), or the directory chosen at installation.
      </Collapser>
 
      <Collapser

--- a/src/content/docs/apm/agents/net-agent/installation/install-net-agent-linux.mdx
+++ b/src/content/docs/apm/agents/net-agent/installation/install-net-agent-linux.mdx
@@ -44,9 +44,11 @@ To install the .NET agent on a Linux system with a package manager:
 1. Install the agent. These details are the same for all installations using a package manager:
 
    * Install location:
-     * For agent versions 10.0.0 and newer: `/usr/local/newrelic-dotnet-agent`.
-     * For agent versions older than 10.0.0: `/usr/local/newrelic-netcore20-agent`.
-     * **Important**: the rest of this document will use the newer name where applicable; replace with the older name if you are using an older agent.
+     * For agent versions 10.0.0 or higher: `/usr/local/newrelic-dotnet-agent`.
+     * For agent versions 9.9.0 or lower: `/usr/local/newrelic-netcore20-agent`.
+       <Callout variant="important">
+          The rest of this document will use the newer name where applicable; replace with the older name if you are using an older agent.
+        </Callout>
    * The file `newrelic-dotnet-agent-path.sh` is placed in `/etc/profile.d`, and this will set the `CORECLR_NEWRELIC_HOME` environment variable on system start.
    * The path to `newrelic.config` file is `${CORECLR_NEWRELIC_HOME}/newrelic.config`.
 2. Follow the instructions for your package manager:

--- a/src/content/docs/apm/agents/net-agent/installation/install-net-agent-linux.mdx
+++ b/src/content/docs/apm/agents/net-agent/installation/install-net-agent-linux.mdx
@@ -43,8 +43,11 @@ To install the .NET agent on a Linux system with a package manager:
 
 1. Install the agent. These details are the same for all installations using a package manager:
 
-   * Install location: `/usr/local/newrelic-netcore20-agent`.
-   * The file `newrelic-netcore20-agent-path.sh` is placed in `/etc/profile.d`, and this will set the `CORECLR_NEWRELIC_HOME` environment variable on system start.
+   * Install location:
+     * For agent versions 10.0.0 and newer: `/usr/local/newrelic-dotnet-agent`.
+     * For agent versions older than 10.0.0: `/usr/local/newrelic-netcore20-agent`.
+     * **Important**: the rest of this document will use the newer name where applicable; replace with the older name if you are using an older agent.
+   * The file `newrelic-dotnet-agent-path.sh` is placed in `/etc/profile.d`, and this will set the `CORECLR_NEWRELIC_HOME` environment variable on system start.
    * The path to `newrelic.config` file is `${CORECLR_NEWRELIC_HOME}/newrelic.config`.
 2. Follow the instructions for your package manager:
 
@@ -71,7 +74,7 @@ To install the .NET agent on a Linux system with a package manager:
        4. Install the agent:
 
           ```
-          sudo apt-get install newrelic-netcore20-agent
+          sudo apt-get install newrelic-dotnet-agent
           ```
      </Collapser>
 
@@ -79,7 +82,7 @@ To install the .NET agent on a Linux system with a package manager:
        id="clamshell_debian_ubuntu_mint_dpkg"
        title="Install with dpkg (Debian, Linux Mint, or Ubuntu)"
      >
-       1. Go to **[download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release/)**, and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-netcore20-agent` .deb package.
+       1. Go to **[download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release/)**, and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-dotnet-agent` .deb package.
        2. Download the package with `wget`, replacing `https://LINK_TO_PACKAGE` with the full URL of the package:
 
           ```
@@ -88,7 +91,7 @@ To install the .NET agent on a Linux system with a package manager:
        3. Install the agent, replacing `VERSION` with the current version:
 
           ```
-          sudo dpkg -i newrelic-netcore20-agent_<var>VERSION</var>_<var>ARCHITECTURE</var>.deb
+          sudo dpkg -i newrelic-dotnet-agent_<var>VERSION</var>_<var>ARCHITECTURE</var>.deb
           ```
      </Collapser>
 
@@ -100,11 +103,16 @@ To install the .NET agent on a Linux system with a package manager:
          New Relic does not currently offer Linux rpm packages for ARM64. Instead, [leverage the tarball to install](#clamshell_tarball) on these platforms.
        </Callout>
 
-       1. Configure the New Relic yum repository:
+       1. Add New Relic's signing key to your system:
+          ```
+          TBD
+          ```
+
+       2. Configure the New Relic YUM repository:
 
           ```
-          cat << REPO | sudo tee "/etc/yum.repos.d/newrelic-netcore20-agent.repo"
-          [newrelic-netcore20-agent-repo]
+          cat << REPO | sudo tee "/etc/yum.repos.d/newrelic-dotnet-agent.repo"
+          [newrelic-dotnet-agent-repo]
           name=New Relic .NET Core packages for Enterprise Linux
           baseurl=https://yum.newrelic.com/pub/newrelic/el7/\$basearch
           enabled=1
@@ -112,10 +120,10 @@ To install the .NET agent on a Linux system with a package manager:
           gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic
           REPO
           ```
-       2. Install the agent:
+       3. Install the agent:
 
           ```
-          sudo yum install newrelic-netcore20-agent
+          sudo yum install newrelic-dotnet-agent
           ```
      </Collapser>
 
@@ -127,7 +135,7 @@ To install the .NET agent on a Linux system with a package manager:
          New Relic does not currently offer Linux rpm packages for ARM64. Instead, [leverage the tarball to install](#clamshell_tarball) on these platforms.
        </Callout>
 
-       1. Go to [download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release/), and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-netcore20-agent` .rpm package.
+       1. Go to [download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release/), and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-dotnet-agent` .rpm package.
        2. Download the package with `wget`, replacing `https://LINK_TO_PACKAGE` with the full URL of the package:
 
           ```
@@ -136,7 +144,7 @@ To install the .NET agent on a Linux system with a package manager:
        3. Install the agent, replacing `VERSION` with the current version:
 
           ```
-          sudo rpm -i newrelic-netcore20-agent_<var>VERSION</var>.x86_64.rpm
+          sudo rpm -i newrelic-dotnet-agent_<var>VERSION</var>.x86_64.rpm
           ```
      </Collapser>
 
@@ -144,7 +152,7 @@ To install the .NET agent on a Linux system with a package manager:
        id="clamshell_tarball"
        title="Install with tarball"
      >
-       1. Go to **[download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release)**, and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-netcore20-agent-VERSION.tar.gz` package.
+       1. Go to **[download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release)**, and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-dotnet-agent-VERSION.tar.gz` package.
        2. Download the package with wget, replacing `https://LINK_TO_PACKAGE` with the full URL of the package:
 
           ```
@@ -155,11 +163,11 @@ To install the .NET agent on a Linux system with a package manager:
           ```
           tar xzf newrelic*.tar.gz
           ```
-       4. Move the `newrelic-netcore20-agent` directory to `/usr/local` or your preferred install location.
-       5. Verify that the environment variable `CORECLR_NEWRELIC_HOME` points to the `newrelic-netcore20-agent` directory and that the directory is readable by monitored .NET processes.
+       4. Move the `newrelic-dotnet-agent` directory to `/usr/local` or your preferred install location.
+       5. Verify that the environment variable `CORECLR_NEWRELIC_HOME` points to the `newrelic-dotnet-agent` directory and that the directory is readable by monitored .NET processes.
 
           <Callout variant="important">
-            If `CORECLR_NEWRELIC_HOME` does not exist, create it and point it to the `newrelic-netcore20-agent` directory.
+            If `CORECLR_NEWRELIC_HOME` does not exist, create it and point it to the `newrelic-dotnet-agent` directory.
           </Callout>
        6. Verify that the `logs` directory in the agent home directory is writeable by monitored .NET processes.
      </Collapser>
@@ -225,7 +233,7 @@ Use one of the following methods to set the environment variables that enable th
     id="clamshell_env_setenv"
     title="Use setenv.sh"
   >
-    Except for `CORECLR_NEWRELIC_HOME`, the `source /usr/local/newrelic-netcore20-agent/setenv.sh` script included with the .NET agent configures the environment variables automatically.
+    Except for `CORECLR_NEWRELIC_HOME`, the `source /usr/local/newrelic-dotnet-agent/setenv.sh` script included with the .NET agent configures the environment variables automatically.
 
     <Callout variant="tip">
       Set these environment variables before running any apps that you want instrumented. This sets the environment variables only for the current shell and any child processes of that shell.

--- a/src/content/docs/apm/agents/net-agent/installation/install-net-agent-linux.mdx
+++ b/src/content/docs/apm/agents/net-agent/installation/install-net-agent-linux.mdx
@@ -105,7 +105,8 @@ To install the .NET agent on a Linux system with a package manager:
 
        1. Add New Relic's signing key to your system:
           ```
-          TBD
+          sudo wget https://download.newrelic.com/548C16BF.gpg -O /etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic
+          sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic
           ```
 
        2. Configure the New Relic YUM repository:

--- a/src/content/docs/apm/agents/net-agent/installation/uninstall-net-agent.mdx
+++ b/src/content/docs/apm/agents/net-agent/installation/uninstall-net-agent.mdx
@@ -44,6 +44,11 @@ After uninstalling the agent, you may want to remove all agent-related files. Be
 To uninstall the .NET agent on Linux, use your package management tool.
 
 <Callout variant="important">
+  For .NET agent versions 10.0 and higher, the name of the package is `newrelic-dotnet-agent`.  For .NET agent versions 9.x and earlier, the name of the package is `newrelic-netcore20-agent`.
+  The rest of this document will refer to `newrelic-dotnet-agent`; replace this with the older name if you have an older agent version installed.
+</Callout>
+
+<Callout variant="important">
   You must restart your application once the uninstall is finished.
 </Callout>
 
@@ -52,10 +57,10 @@ To uninstall the .NET agent on Linux, use your package management tool.
     id="apt-uninstall"
     title="Uninstall with apt (Debian, Ubuntu, and Linux Mint)"
   >
-    Execute the following command as root:
+    Execute the following command as root (or using sudo):
 
     ```
-    sudo apt-get remove newrelic-netcore20-agent
+    apt-get remove newrelic-dotnet-agent
     ```
   </Collapser>
 
@@ -63,10 +68,10 @@ To uninstall the .NET agent on Linux, use your package management tool.
     id="dpkg-uninstall"
     title="Uninstall with dpkg (Debian, Ubuntu, and Linux Mint)"
   >
-    Execute the following command as root:
+    Execute the following command as root (or using sudo):
 
     ```
-    sudo dpkg --remove newrelic-netcore20-agent
+    dpkg --remove newrelic-dotnet-agent
     ```
   </Collapser>
 
@@ -74,10 +79,10 @@ To uninstall the .NET agent on Linux, use your package management tool.
     id="yum-uninstall"
     title="Uninstall with yum (CentOS, Red Hat Enterprise Linux, Oracle Linux)"
   >
-    Execute the following command as root:
+    Execute the following command as root (or using sudo):
 
     ```
-    sudo yum remove newrelic-netcore20-agent
+    yum remove newrelic-dotnet-agent
     ```
   </Collapser>
 
@@ -85,10 +90,10 @@ To uninstall the .NET agent on Linux, use your package management tool.
     id="rpm-uninstall"
     title="Uninstall with rpm (CentOS, Red Hat Enterprise Linux, Oracle Linux)"
   >
-    Execute the following command as root:
+    Execute the following command as root (or using sudo):
 
     ```
-    sudo rpm -e newrelic-netcore20-agent
+    sudo rpm -e newrelic-dotnet-agent
     ```
   </Collapser>
 

--- a/src/content/docs/apm/agents/net-agent/installation/uninstall-net-agent.mdx
+++ b/src/content/docs/apm/agents/net-agent/installation/uninstall-net-agent.mdx
@@ -44,7 +44,7 @@ After uninstalling the agent, you may want to remove all agent-related files. Be
 To uninstall the .NET agent on Linux, use your package management tool.
 
 <Callout variant="important">
-  For .NET agent versions 10.0 and higher, the name of the package is `newrelic-dotnet-agent`.  For .NET agent versions 9.x and earlier, the name of the package is `newrelic-netcore20-agent`.
+  For .NET agent versions 10.0.0 or higher, the name of the package is `newrelic-dotnet-agent`. For .NET agent versions 9.9.0 or lower, the name of the package is `newrelic-netcore20-agent`.
   The rest of this document will refer to `newrelic-dotnet-agent`; replace this with the older name if you have an older agent version installed.
 </Callout>
 

--- a/src/content/docs/apm/agents/net-agent/installation/update-net-agent.mdx
+++ b/src/content/docs/apm/agents/net-agent/installation/update-net-agent.mdx
@@ -59,7 +59,7 @@ How to update the APM .NET agent.
 ## Update the .NET agent (Linux) [#updating_net_core]
 
 <Callout variant="important">
-  For .NET agent versions 10.0 and higher, the name of the package is `newrelic-dotnet-agent`.  For .NET agent versions 9.x and earlier, the name of the package is `newrelic-netcore20-agent`.
+  For .NET agent versions 10.0.0 or higher, the name of the package is `newrelic-dotnet-agent`. For .NET agent versions 9.9.0 or lower, the name of the package is `newrelic-netcore20-agent`.
   The rest of this document will refer to `newrelic-dotnet-agent`; replace this with the older name if you have an older agent version installed.
 </Callout>
 

--- a/src/content/docs/apm/agents/net-agent/installation/update-net-agent.mdx
+++ b/src/content/docs/apm/agents/net-agent/installation/update-net-agent.mdx
@@ -58,6 +58,11 @@ How to update the APM .NET agent.
 
 ## Update the .NET agent (Linux) [#updating_net_core]
 
+<Callout variant="important">
+  For .NET agent versions 10.0 and higher, the name of the package is `newrelic-dotnet-agent`.  For .NET agent versions 9.x and earlier, the name of the package is `newrelic-netcore20-agent`.
+  The rest of this document will refer to `newrelic-dotnet-agent`; replace this with the older name if you have an older agent version installed.
+</Callout>
+
 Use one of the following methods to update to the latest version of New Relic's .NET agent:
 
 <CollapserGroup>
@@ -79,7 +84,7 @@ Use one of the following methods to update to the latest version of New Relic's 
     2. Use the following to update the agent:
 
        ```bash
-       sudo yum update newrelic-netcore20-agent
+       sudo yum update newrelic-dotnet-agent
        ```
   </Collapser>
 
@@ -91,7 +96,7 @@ Use one of the following methods to update to the latest version of New Relic's 
     2. Use the following to get a list of available updates and install them:
 
        ```bash
-       sudo apt-get update && sudo apt-get install --only-upgrade newrelic-netcore20-agent
+       sudo apt-get update && sudo apt-get install --only-upgrade newrelic-dotnet-agent
        ```
   </Collapser>
 

--- a/src/content/docs/apm/agents/net-agent/other-installation/install-net-agent-docker-container.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/install-net-agent-docker-container.mdx
@@ -31,6 +31,11 @@ Requirements include:
 
 ## Install for Linux Docker containers [#linux]
 
+<Callout variant="important">
+  For .NET agent versions 10.0 and higher, the name of the package is `newrelic-dotnet-agent`.  For .NET agent versions 9.x and earlier, the name of the package is `newrelic-netcore20-agent`.
+  The rest of this document will refer to `newrelic-dotnet-agent`; replace this with the older name if you need to use an older agent version.
+</Callout>
+
 ### Example Linux Dockerfile
 
 ```
@@ -46,14 +51,14 @@ RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
 && wget https://download.newrelic.com/548C16BF.gpg \
 && apt-key add 548C16BF.gpg \
 && apt-get update \
-&& apt-get install -y newrelic-netcore20-agent \
+&& apt-get install -y newrelic-dotnet-agent \
 && rm -rf /var/lib/apt/lists/*
 
 # Enable the agent
 ENV CORECLR_ENABLE_PROFILING=1 \
 CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A} \
-CORECLR_NEWRELIC_HOME=/usr/local/newrelic-netcore20-agent \
-CORECLR_PROFILER_PATH=/usr/local/newrelic-netcore20-agent/libNewRelicProfiler.so \
+CORECLR_NEWRELIC_HOME=/usr/local/newrelic-dotnet-agent \
+CORECLR_PROFILER_PATH=/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so \
 NEW_RELIC_LICENSE_KEY=<var>YOUR_LICENSE_KEY</var> \
 NEW_RELIC_APP_NAME=<var>YOUR_APP_NAME</var>
 
@@ -82,13 +87,13 @@ RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
 && wget https://download.newrelic.com/548C16BF.gpg \
 && apt-key add 548C16BF.gpg \
 && apt-get update \
-&& apt-get install -y newrelic-netcore20-agent
+&& apt-get install -y newrelic-dotnet-agent
 
 # Enable the agent
 ENV CORECLR_ENABLE_PROFILING=1 \
 CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A} \
-CORECLR_NEWRELIC_HOME=/usr/local/newrelic-netcore20-agent \
-CORECLR_PROFILER_PATH=/usr/local/newrelic-netcore20-agent/libNewRelicProfiler.so \
+CORECLR_NEWRELIC_HOME=/usr/local/newrelic-dotnet-agent \
+CORECLR_PROFILER_PATH=/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so \
 NEW_RELIC_LICENSE_KEY=<var>YOUR_LICENSE_KEY</var> \
 NEW_RELIC_APP_NAME=<var>YOUR_APP_NAME</var>
 

--- a/src/content/docs/apm/agents/net-agent/other-installation/install-net-agent-docker-container.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/install-net-agent-docker-container.mdx
@@ -32,7 +32,7 @@ Requirements include:
 ## Install for Linux Docker containers [#linux]
 
 <Callout variant="important">
-  For .NET agent versions 10.0 and higher, the name of the package is `newrelic-dotnet-agent`.  For .NET agent versions 9.x and earlier, the name of the package is `newrelic-netcore20-agent`.
+  For .NET agent versions 10.0.0 or higher, the name of the package is `newrelic-dotnet-agent`. For .NET agent versions 9.9.0 or lower, the name of the package is `newrelic-netcore20-agent`.
   The rest of this document will refer to `newrelic-dotnet-agent`; replace this with the older name if you need to use an older agent version.
 </Callout>
 

--- a/src/content/docs/apm/agents/net-agent/other-installation/net-agent-install-resources.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/net-agent-install-resources.mdx
@@ -114,7 +114,7 @@ The scriptable installers are ZIP archives containing a PowerShell script for in
 </Callout>
 
 <Callout variant="important">
-  As of .NET agent version 10.0, the scriptable installers are no longer available.  This documentation remains for customers who wish to use the scriptable installer for an older version.
+  As of .NET agent version 10.0.0, the scriptable installers are no longer available.  This documentation remains for customers who wish to use the scriptable installer for an older version.
 </Callout>
 
 <CollapserGroup>

--- a/src/content/docs/apm/agents/net-agent/other-installation/net-agent-install-resources.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/net-agent-install-resources.mdx
@@ -115,6 +115,10 @@ The scriptable installers are ZIP archives containing a PowerShell script for in
   We recommend using the MSI installer over the scriptable installer. If you want to automate your install, consider running the MSI installer from the command line.
 </Callout>
 
+<Callout variant="important">
+  As of .NET agent version 10.0, the scriptable installers are no longer available.  This documentation remains for customers who wish to use the scriptable installer for an older version.
+</Callout>
+
 <CollapserGroup>
   <Collapser
     id="framework-installer-options"

--- a/src/content/docs/apm/agents/net-agent/other-installation/net-agent-install-resources.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/net-agent-install-resources.mdx
@@ -32,11 +32,9 @@ The New Relic .NET agent [download library](https://download.newrelic.com/dot_ne
 
 To manually install the agent using a ZIP file, choose the correct file for the application you wish to monitor:
 
-1. Go to the [.NET agent download site](http://download.newrelic.com/dot_net_agent/latest_release/ "Link opens in a new window.") and get the file matching your application's runtime and architecture:
-   * .NET Framework (32-bit): `newrelic-agent-win-x86-VERSION.zip`
-   * .NET Framework (64-bit): `newrelic-agent-win-x64-VERSION.zip`
-   * .NET Core (32-bit): `newrelic-netcore20-agent-win-x86-VERSION.zip`
-   * .NET Core (64-bit): `newrelic-netcore20-agent-win-x64-VERSION.zip`
+1. Go to the [.NET agent download site](http://download.newrelic.com/dot_net_agent/latest_release/ "Link opens in a new window.") and get the file matching your application's architecture (64-bit or 32-bit):
+   * .NET Framework or .NET Core/.NET 5+ (32-bit): `NewRelicDotNetAgent_VERSION_x86.zip`
+   * .NET Framework or .NET Core/.NET 5+ (64-bit): `NewRelicDotNetAgent_VERSION_x64.zip`
 2. Unzip the agent folder in the desired location.
 3. Set environment variables for the process you wish to monitor.
 
@@ -54,22 +52,22 @@ To manually install the agent using a ZIP file, choose the correct file for the 
        ```
        COR_ENABLE_PROFILING=1
          COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
-         NEWRELIC_HOME=<var>path\to\agent\directory</var>
-         COR_PROFILER_PATH=<var>path\to\agent\directory</var>\NewRelic.Profiler.dll
+         NEWRELIC_HOME=<var>path\to\agent\directory\netframework</var>
+         COR_PROFILER_PATH=<var>path\to\agent\directory\netframework</var>\NewRelic.Profiler.dll
        ```
      </Collapser>
 
      <Collapser
        id="net-core-env-variables"
-       title=".NET Core environment variables for manual install"
+       title=".NET Core/.NET 5+ environment variables for manual install"
      >
-       For .NET Core, the following variables are required:
+       For .NET Core/.NET 5+, the following variables are required:
 
        ```
        CORECLR_ENABLE_PROFILING=1
          CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
-         CORECLR_NEWRELIC_HOME=<var>path\to\agent\directory</var>
-         CORECLR_PROFILER_PATH=<var>path\to\agent\directory</var>\NewRelic.Profiler.dll
+         CORECLR_NEWRELIC_HOME=<var>path\to\agent\directory\netcore</var>
+         CORECLR_PROFILER_PATH=<var>path\to\agent\directory\netcore</var>\NewRelic.Profiler.dll
        ```
      </Collapser>
    </CollapserGroup>

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/debugging-net-core-agent-linux.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/debugging-net-core-agent-linux.mdx
@@ -26,7 +26,7 @@ After installing New Relic's .NET agent in Linux, you don't see any data, notice
 
 <Callout variant="tip">
   * If you installed the .NET Core agent, or installed either agent with the `NewRelic.Agent` NuGet package, you’ll find a `logs` folder in the directory where the agent was extracted on your system.
-  * In some installation methods in linux, it defaults to `/usr/local/newrelic-netcore20-agent`
+  * In some installation methods in linux, it defaults to `/usr/local/newrelic-dotnet-agent` (agent version 10.0.0 and newer) or `/usr/local/newrelic-netcore20-agent` (agent versions older than 10.0.0).
 </Callout>
 
 1. Make sure you’re looking at current data. Delete or move any existing files in the logs directory so that you’re sure the logs you generate reflect the current state of your system.

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/debugging-net-core-agent-linux.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/debugging-net-core-agent-linux.mdx
@@ -26,7 +26,7 @@ After installing New Relic's .NET agent in Linux, you don't see any data, notice
 
 <Callout variant="tip">
   * If you installed the .NET Core agent, or installed either agent with the `NewRelic.Agent` NuGet package, you’ll find a `logs` folder in the directory where the agent was extracted on your system.
-  * In some installation methods in linux, it defaults to `/usr/local/newrelic-dotnet-agent` (agent version 10.0.0 and newer) or `/usr/local/newrelic-netcore20-agent` (agent versions older than 10.0.0).
+  * In some installation methods in linux, it defaults to `/usr/local/newrelic-dotnet-agent` (agent versions 10.0.0 or higher) or `/usr/local/newrelic-netcore20-agent` (agent versions 9.9.0 or lower).
 </Callout>
 
 1. Make sure you’re looking at current data. Delete or move any existing files in the logs directory so that you’re sure the logs you generate reflect the current state of your system.


### PR DESCRIPTION
This PR has changes to a bunch of the .NET agent documentation to support our upcoming major version release (10.0.0), mostly caused by the fact that the name (and install path) of our Linux agent installation packages is changing from `newrelic-netcore20-agent` to `newrelic-dotnet-agent`.

We have release agent version 10.0.0 as of 7/19/2022 so this should be merged as soon as practicable.
