### PR TITLE
Chore/update snmp traps

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -464,7 +464,7 @@ Our network monitoring container supports all major versions of SNMP (v1, v2c, a
 
 ### Collection of SNMP traps
 
-By default the agent will listen for incoming SNMP traps on UDP port 1620 and it is not necessary to run a dedicated agents for trap collection as all SNMP polling agents will run this passive listener.
+By default the agent will listen for incoming SNMP traps on UDP port 1620 and it is not necessary to run a dedicated agent for trap collection as all SNMP polling agents will run this passive listener.
 
 If you need to use the standard port of UDP 162 for your SNMP traps, the following steps will need to be followed for your container.
 

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -187,7 +187,7 @@ Configured network devices for SNMP polling from the **ktranslate** docker conta
           </td>
 
           <td>
-            162 (default)
+            1620 (default)
           </td>
 
           <td>

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -461,3 +461,34 @@ Our network monitoring container supports all major versions of SNMP (v1, v2c, a
     8. [Visualize your network performance data in New Relic](/docs/network-performance-monitoring/monitoring-network-data/visualize-network-data).
   </Collapser>
 </CollapserGroup>
+
+### Collection of SNMP traps
+
+By default the agent will listen for incoming SNMP traps on UDP port 1620 and it is not necessary to run a dedicated agents for trap collection as all SNMP polling agents will run this passive listener.
+
+If you need to use the standard port of UDP 162 for your SNMP traps, the following steps will need to be followed for your container.
+
+1. Update your `snmp-base.yaml` config file to change the listening IP from `127.0.0.1` to `0.0.0.0`. *(This allows the Docker container to listen on the `docker0` interface for external packets.)*
+
+```yaml
+trap:
+  listen: 0.0.0.0:1620
+  community: hello
+  version: ""
+  transport: ""
+```
+
+2. Enable port forwarding during your `docker run...` command to redirect packets sent to UDP 162 on the host into UDP 1620 on the container:
+
+```shell
+docker run -d --name ktranslate-snmp --restart unless-stopped -p 162:1620/udp \
+  -v `pwd`/snmp-base.yaml:/snmp-base.yaml \
+  -e NEW_RELIC_API_KEY=$YOUR_NR_LICENSE_KEY  \
+kentik/ktranslate:v2 \
+  -snmp /snmp-base.yaml \
+  -nr_account_id=$YOUR_NR_ACCOUNT_ID \
+  -metrics=jchf \
+  -tee_logs=true \
+  -service_name=snmp \
+  nr1.snmp
+```

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -47,7 +47,6 @@ Set up your network devices so they send network data to New Relic.
 Configured network devices for SNMP polling from the **ktranslate** docker container. Some samples of basic SNMP configurations can be found here:
 * Cisco
   * [IOS](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/snmp/configuration/xe-16/snmp-xe-16-book/nm-snmp-cfg-snmp-support.html#GUID-98F0633A-F3BA-4C59-B886-F523099D3AE5)
-  * [Meraki](https://documentation.meraki.com/General_Administration/Monitoring_and_Reporting/SNMP_Overview_and_Configuration)
   * [NX-OS](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/sw/4_2/nx-os/system_management/configuration/guide/sm_nx_os_cli/sm_9snmp.html#wp1056898)
 * Juniper
   * [Junos OS](https://www.juniper.net/documentation/us/en/software/junos/network-mgmt/topics/topic-map/configuring-basic-snmp.html)


### PR DESCRIPTION
* removing Meraki from SNMP samples because we don't recommend monitoring Meraki via SNMP due to various issues with the vendor
* adding notes on SNMP trap collection to reflect [recent bug fix](https://discuss.newrelic.com/t/snmp-traps-on-docker-host/184124/27?u=zackm)
