### PR TITLE
Add datasource resolution

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -294,6 +294,7 @@ exports.createSchemaCustomization = ({ actions }) => {
   type Frontmatter {
     isFeatured: Boolean
     translationType: String
+    dataSource: String
   }
   `;
 
@@ -327,6 +328,10 @@ exports.createResolvers = ({ createResolvers }) => {
           hasOwnProperty(source, 'translationType')
             ? source.translationType
             : null,
+      },
+      dataSource: {
+        resolve: (source) =>
+          hasOwnProperty(source, 'dataSource') ? source.dataSource : null,
       },
     },
   });


### PR DESCRIPTION
This forces datasource to resolve to something (null) even if it doesn't exist on a doc. it should get rid of the error when building a folder of docs with no datasource frontmatter