### PR TITLE
Remove trailing slash

### DIFF
--- a/src/nav/logs.yml
+++ b/src/nav/logs.yml
@@ -22,7 +22,7 @@ pages:
       - title: AWS Lambda for CloudWatch logs
         path: /docs/logs/forward-logs/aws-lambda-sending-cloudwatch-logs
       - title: CircleCI logs
-        path: /docs/logs/forward-logs/circleci-logs/
+        path: /docs/logs/forward-logs/circleci-logs
       - title: Cloudflare Logpush 
         path: /docs/logs/forward-logs/cloudflare-logpush-forwarding
       - title: Fluentd plugin


### PR DESCRIPTION
Removes a trailing slash in the logs nav file that was causing a weird left nav interaction. 