### PR TITLE
Align helm release name with guided install

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
@@ -112,7 +112,7 @@ ksm:
 4. Make sure everything is configured properly in the chart by running the following command. Notice that we are specifying `--dry-run` and `--debug`, so nothing will be installed in this step:
 
 ```shell
-helm upgrade --install newrelic newrelic/nri-bundle \
+helm upgrade --install newrelic-bundle newrelic/nri-bundle \
 --namespace newrelic --create-namespace \
 -f values-newrelic.yaml \
 --dry-run \
@@ -132,7 +132,7 @@ Our Kubernetes charts have a comprehensive set of flags and tunables that can be
 5. Install the Kubernetes integration by running the command without `--debug` and `--dry-run`:
 
 ```shell
-helm upgrade --install newrelic newrelic/nri-bundle \
+helm upgrade --install newrelic-bundle newrelic/nri-bundle \
 --namespace newrelic --create-namespace \
 -f values-newrelic.yaml \
 ```
@@ -182,7 +182,7 @@ You should see:
     3. Make sure everything is configured properly in the chart by running the following command. This step uses the `--dry-run` and `--debug` switches and therefore the agent is not installed.
 
        ```shell
-       helm upgrade --install newrelic newrelic/nri-bundle \
+       helm upgrade --install newrelic-bundle newrelic/nri-bundle \
        --version 3.2.11 \
        --dry-run \
        --debug \
@@ -200,7 +200,7 @@ You should see:
     4. Install the New Relic Kubernetes integration by running the same command without `--dry-run` and `--debug`
 
        ```shell
-       helm upgrade --install newrelic newrelic/nri-bundle \
+       helm upgrade --install newrelic-bundle newrelic/nri-bundle \
        --version 3.2.11 \
        --namespace newrelic \
        --set global.licenseKey=_YOUR_NEW_RELIC_LICENSE_KEY_ \
@@ -288,7 +288,7 @@ To update your Kubernetes integration installed via Helm:
 2. Update the release by running again the appropriate `helm upgrade --install ...` command in the section above
 
    ```shell
-   helm upgrade --install newrelic newrelic/nri-bundle \
+   helm upgrade --install newrelic-bundle newrelic/nri-bundle \
    --namespace newrelic --create-namespace \
    -f values-newrelic.yaml
    ```
@@ -413,5 +413,5 @@ The default settings for these parameters and others can be found in the [newrel
 To uninstall the Kubernetes integration using Helm, run the following command:
 
 ```shell
-helm uninstall newrelic -n newrelic
+helm uninstall newrelic-bundle -n newrelic
 ```


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?

If a customer installed New Relic's Kubernetes integration with the Guided Install, the Helm release name did not match the instructions in these docs.  I've changed the `newrelic` release name to `newrelic-bundle` to align with the Guided Install default name.
