### PR TITLE
Add Python agent release notes and config updates for logging on by default. (Publish on 07/21/2022)

### DIFF
--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -3884,7 +3884,7 @@ The following settings are available for configuration of application logging in
           </th>
 
           <td>
-            `false`
+            `true`
           </td>
         </tr>
 
@@ -3910,7 +3910,11 @@ The following settings are available for configuration of application logging in
       </tbody>
     </table>
 
-  If `true`, the agent captures log records emitted by your application and forwards them to New Relic. `application_logging.enabled` must also be `true` for this setting to take effect.
+    If `true`, the agent captures log records emitted by your application and forwards them to New Relic. `application_logging.enabled` must also be `true` for this setting to take effect.
+
+    <Callout variant="caution">
+      If you are already sending your application's logs to New Relic using an existing log forwarding solution, be sure to disable that before enabling log forwarding in the agent, in order to prevent being billed for duplicate log data.
+    </Callout>
   </Collapser>
 
    <Collapser

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-71600178.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-71600178.mdx
@@ -1,0 +1,25 @@
+---
+subject: Python agent
+releaseDate: '2022-07-21'
+version: 7.16.0.178
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+---
+
+## Notes
+
+This release of the Python agent enables log forwarding to New Relic by default.
+
+Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the New Relic [download site](http://download.newrelic.com/python_agent/release).
+
+## New features
+
+* **APM logs in context**
+
+Automatic application log forwarding is now enabled by default. This version of the agent will automatically send enriched application logs to New Relic. To learn more about about this feature, see the [APM logs in context documentation](https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/get-started-logs-context/). For additional configuration options, see the [Python logs in context documentation](https://docs.newrelic.com/docs/logs/logs-context/configure-logs-context-python/). To learn about how to toggle log ingestion on or off by account, see our documentation to [disable automatic logging](https://docs.newrelic.com/docs/logs/logs-context/disable-automatic-logging) via the UI or API.
+
+
+## Support statement
+
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.14.1.144](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5141144/).
+
+


### PR DESCRIPTION
To be merged on 7/21 in line with the Python agent v7.16.0.178 release.