### PR TITLE
Update .NET Agent Package Name

### DIFF
--- a/src/content/docs/apm/agents/net-agent/installation/install-net-agent-linux.mdx
+++ b/src/content/docs/apm/agents/net-agent/installation/install-net-agent-linux.mdx
@@ -13,6 +13,10 @@ redirects:
 
 This document explains how to install and enable New Relic's [.NET agent](/docs/agents/net-agent) on Linux for application performance monitoring.
 
+<Callout variant="caution">
+  **Note:** As of version 10.x of the .NET agent the agent install packages are now known as `newrelic-dotnet-agent` and no longer as `newrelic-netcore20-agent`. For more information please see [the 9.x to 10.x migration guide](https://docs.newrelic.com/docs/apm/agents/net-agent/getting-started/9x-to-10x-agent-migration-guide/)
+</Callout>
+
 ## Install overview [#getting-started]
 
 The instructions in this document are for a standard .NET agent installation on Linux. However, some setups have specific install documentation that you should read first:
@@ -43,8 +47,8 @@ To install the .NET agent on a Linux system with a package manager:
 
 1. Install the agent. These details are the same for all installations using a package manager:
 
-   * Install location: `/usr/local/newrelic-netcore20-agent`.
-   * The file `newrelic-netcore20-agent-path.sh` is placed in `/etc/profile.d`, and this will set the `CORECLR_NEWRELIC_HOME` environment variable on system start.
+   * Install location: `/usr/local/newrelic-dotnet-agent`.
+   * The file `newrelic-dotnet-agent-path.sh` is placed in `/etc/profile.d`, and this will set the `CORECLR_NEWRELIC_HOME` environment variable on system start.
    * The path to `newrelic.config` file is `${CORECLR_NEWRELIC_HOME}/newrelic.config`.
 2. Follow the instructions for your package manager:
 
@@ -71,7 +75,7 @@ To install the .NET agent on a Linux system with a package manager:
        4. Install the agent:
 
           ```
-          sudo apt-get install newrelic-netcore20-agent
+          sudo apt-get install newrelic-dotnet-agent
           ```
      </Collapser>
 
@@ -79,7 +83,7 @@ To install the .NET agent on a Linux system with a package manager:
        id="clamshell_debian_ubuntu_mint_dpkg"
        title="Install with dpkg (Debian, Linux Mint, or Ubuntu)"
      >
-       1. Go to **[download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release/)**, and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-netcore20-agent` .deb package.
+       1. Go to **[download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release/)**, and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `nnewrelic-dotnet-agent` .deb package.
        2. Download the package with `wget`, replacing `https://LINK_TO_PACKAGE` with the full URL of the package:
 
           ```
@@ -88,7 +92,7 @@ To install the .NET agent on a Linux system with a package manager:
        3. Install the agent, replacing `VERSION` with the current version:
 
           ```
-          sudo dpkg -i newrelic-netcore20-agent_<var>VERSION</var>_<var>ARCHITECTURE</var>.deb
+          sudo dpkg -i newrelic-dotnet-agent_<var>VERSION</var>_<var>ARCHITECTURE</var>.deb
           ```
      </Collapser>
 
@@ -103,8 +107,8 @@ To install the .NET agent on a Linux system with a package manager:
        1. Configure the New Relic yum repository:
 
           ```
-          cat << REPO | sudo tee "/etc/yum.repos.d/newrelic-netcore20-agent.repo"
-          [newrelic-netcore20-agent-repo]
+          cat << REPO | sudo tee "/etc/yum.repos.d/newrelic-dotnet-agent.repo"
+          [newrelic-dotnet-agent-repo]
           name=New Relic .NET Core packages for Enterprise Linux
           baseurl=https://yum.newrelic.com/pub/newrelic/el7/\$basearch
           enabled=1
@@ -115,7 +119,7 @@ To install the .NET agent on a Linux system with a package manager:
        2. Install the agent:
 
           ```
-          sudo yum install newrelic-netcore20-agent
+          sudo yum install newrelic-dotnet-agent
           ```
      </Collapser>
 
@@ -127,7 +131,7 @@ To install the .NET agent on a Linux system with a package manager:
          New Relic does not currently offer Linux rpm packages for ARM64. Instead, [leverage the tarball to install](#clamshell_tarball) on these platforms.
        </Callout>
 
-       1. Go to [download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release/), and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-netcore20-agent` .rpm package.
+       1. Go to [download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release/), and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-dotnet-agent` .rpm package.
        2. Download the package with `wget`, replacing `https://LINK_TO_PACKAGE` with the full URL of the package:
 
           ```
@@ -136,7 +140,7 @@ To install the .NET agent on a Linux system with a package manager:
        3. Install the agent, replacing `VERSION` with the current version:
 
           ```
-          sudo rpm -i newrelic-netcore20-agent_<var>VERSION</var>.x86_64.rpm
+          sudo rpm -i newrelic-dotnet-agent_<var>VERSION</var>.x86_64.rpm
           ```
      </Collapser>
 
@@ -144,7 +148,7 @@ To install the .NET agent on a Linux system with a package manager:
        id="clamshell_tarball"
        title="Install with tarball"
      >
-       1. Go to **[download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release)**, and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-netcore20-agent-VERSION.tar.gz` package.
+       1. Go to **[download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release)**, and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-dotnet-agent-VERSION.tar.gz` package.
        2. Download the package with wget, replacing `https://LINK_TO_PACKAGE` with the full URL of the package:
 
           ```
@@ -155,11 +159,11 @@ To install the .NET agent on a Linux system with a package manager:
           ```
           tar xzf newrelic*.tar.gz
           ```
-       4. Move the `newrelic-netcore20-agent` directory to `/usr/local` or your preferred install location.
-       5. Verify that the environment variable `CORECLR_NEWRELIC_HOME` points to the `newrelic-netcore20-agent` directory and that the directory is readable by monitored .NET processes.
+       4. Move the `newrelic-dotnet-agent` directory to `/usr/local` or your preferred install location.
+       5. Verify that the environment variable `CORECLR_NEWRELIC_HOME` points to the `newrelic-dotnet-agent` directory and that the directory is readable by monitored .NET processes.
 
           <Callout variant="important">
-            If `CORECLR_NEWRELIC_HOME` does not exist, create it and point it to the `newrelic-netcore20-agent` directory.
+            If `CORECLR_NEWRELIC_HOME` does not exist, create it and point it to the `newrelic-dotnet-agent` directory.
           </Callout>
        6. Verify that the `logs` directory in the agent home directory is writeable by monitored .NET processes.
      </Collapser>
@@ -225,7 +229,7 @@ Use one of the following methods to set the environment variables that enable th
     id="clamshell_env_setenv"
     title="Use setenv.sh"
   >
-    Except for `CORECLR_NEWRELIC_HOME`, the `source /usr/local/newrelic-netcore20-agent/setenv.sh` script included with the .NET agent configures the environment variables automatically.
+    Except for `CORECLR_NEWRELIC_HOME`, the `source /usr/local/newrelic-dotnet-agent/setenv.sh` script included with the .NET agent configures the environment variables automatically.
 
     <Callout variant="tip">
       Set these environment variables before running any apps that you want instrumented. This sets the environment variables only for the current shell and any child processes of that shell.

--- a/src/content/docs/apm/agents/net-agent/installation/install-net-agent-linux.mdx
+++ b/src/content/docs/apm/agents/net-agent/installation/install-net-agent-linux.mdx
@@ -83,7 +83,7 @@ To install the .NET agent on a Linux system with a package manager:
        id="clamshell_debian_ubuntu_mint_dpkg"
        title="Install with dpkg (Debian, Linux Mint, or Ubuntu)"
      >
-       1. Go to **[download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release/)**, and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `nnewrelic-dotnet-agent` .deb package.
+       1. Go to **[download.newrelic.com/dot_net_agent/latest_release](https://download.newrelic.com/dot_net_agent/latest_release/)**, and copy the URL that corresponds to your [architecture](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#architecture) and to the latest `newrelic-dotnet-agent` .deb package.
        2. Download the package with `wget`, replacing `https://LINK_TO_PACKAGE` with the full URL of the package:
 
           ```


### PR DESCRIPTION
* Updates package name references with the new package names for the v10.x agent via a `sed s/newrelic-netcore20-agent/newrelic-dotnet-agent/` 
* Adds a notation about the agent name change for customers who might not have noticed the package change

Closes https://github.com/newrelic/docs-website/issues/8542 but will need validation from the .NET agent support team before this is published for customers. I've only validated the tarball install.