### PR TITLE
chore: updates Node agent log forwarding configuration to be enabled by default

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -3837,7 +3837,7 @@ To turn on Infinite Tracing, enable distributed tracing (set `distributed_tracin
           </th>
 
           <td>
-            `false`
+            `true`
           </td>
         </tr>
 


### PR DESCRIPTION
Updating the Node.js agent configuration docs to reflect that log forwarding is now enabled by default.