### PR TITLE
Fix typo in default value of max_segments_cli in configuration file

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -2042,7 +2042,7 @@ The values of these settings are used to control transaction traces.
 
     Specifies the maximum number of segments the PHP agent shall record for CLI transactions. Once that maximum is reached sampling will occur.
 
-    The PHP agent reports transaction traces and distributed traces as a collection of segments. Each segment represents a method or a function call in a transaction trace. The default value for this configuration is `0`, indicating that the PHP agent shall capture all segments during a web transaction. At the end of a transaction, it assembles the highest priority segments to report in a transaction trace.
+    The PHP agent reports transaction traces and distributed traces as a collection of segments. Each segment represents a method or a function call in a transaction trace. The default value for this configuration is `100000`, indicating that the PHP agent shall capture all segments during a web transaction. At the end of a transaction, it assembles the highest priority segments to report in a transaction trace.
 
     For long-running PHP processes with hundreds of thousands or millions of function calls, setting this to a value greater than `1` prevents the PHP agent from exhausting system memory when recording segments.
 


### PR DESCRIPTION
This closes #8526. 