### PR TITLE
resolve-troubleshooting-typo

### DIFF
--- a/src/content/docs/infrastructure/prometheus-integrations/troubleshooting/no-data-appears-prometheus-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/troubleshooting/no-data-appears-prometheus-integration.mdx
@@ -79,7 +79,7 @@ Follow these troubleshooting tips for Docker or Kubernetes as applicable:
 
        If no data appears in New Relic's UI:
 
-    4. Run this NRQL query:
+    4. Inspect the logs for metric errors:
 
        ```
        kubectl logs deploy/nri-prometheus | grep "error emitting metrics"


### PR DESCRIPTION
This pr resolves a simple typo. Step 4 mentioned running a "nrql query" when referring to kubectl command.
