### PR TITLE
docs: Add parsing JSON mixed-up with plain text log message

### DIFF
--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -305,7 +305,7 @@ Watch our YouTube video (approx. 6 minutes) to learn how to use a Grok debugger 
     id="parsing-json"
     title="Parsing JSON mixed-up with plain text"
   >
-    We parse you log JSON messages but default but sometimes you've JSON log messages mixed up with plain text and in that case you also want to be able to parse them and then be able to filter using the JSON attributes.
+    New Relic logs pipeline parses your log JSON messages by default but sometimes you've JSON log messages that are mixed up with plain text and in that case you also want to be able to parse them and then be able to filter using the JSON attributes.
 
     If thats the case you can use the `json` [grok type](#grok-syntax) that will do exactly that, parse the JSON extracted by the grok pattern.
 

--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -305,23 +305,22 @@ Watch our YouTube video (approx. 6 minutes) to learn how to use a Grok debugger 
     id="parsing-json"
     title="Parsing JSON mixed-up with plain text"
   >
-    New Relic logs pipeline parses your log JSON messages by default but sometimes you've JSON log messages that are mixed up with plain text and in that case you also want to be able to parse them and then be able to filter using the JSON attributes.
+    The New Relic logs pipeline parses your log JSON messages by default, but sometimes you hve JSON log messages that are mixed with plain text. In this situation, you also want to be able to parse them and then be able to filter using the JSON attributes.
 
-    If that is the case, you can use the `json` [grok type](#grok-syntax), which will parse the JSON captured by the grok pattern.
-
-    Using the `json` [grok type](#grok-syntax), you can extract and parse JSON from logs that are not properly formatted, e.g, your logs are prefixed with a date time string:
+    If that is the case, you can use the `json` [grok type](#grok-syntax), which will parse the JSON captured by the grok pattern. Using the `json` [grok type](#grok-syntax), you can extract and parse JSON from logs that are not properly formatted; for example, if your logs are prefixed with a date/time string:
 
     ```
     2015-05-13T23:39:43.945958Z {"event": "TestRequest", "status": 200, "response": {"headers": {"X-Custom": "foo"}, "request": {"headers": {"X-Custom": "bar"}}}}
     ```
 
-    In order to extract and parse the JSON data from this log format, you would create the following Grok expression:
+    In order to extract and parse the JSON data from this log format, create the following Grok expression:
 
     ```
     %{TIMESTAMP_ISO8601:containerTimestamp} %{GREEDYDATA:log:json}
     ```
 
-    The resulting log would be:
+    The resulting log is:
+    
     ```
     containerTimestamp: "2015-05-13T23:39:43.945958Z"
     log.event: "TestRequest"
@@ -332,7 +331,7 @@ Watch our YouTube video (approx. 6 minutes) to learn how to use a Grok debugger 
 
     Optionally, you can configure the `json` [grok type](#grok-syntax) using `:json(_CONFIG_)`:
 
-    - `json({"dropOriginal": true})`: Drop the original attribute. When set to `true` (default value), the Parsing rule will drop the original JSON attribute.
+    - `json({"dropOriginal": true})`: Drop the original attribute. When set to `true` (default value), the parsing rule will drop the original JSON attribute.
     - `json({"depth": 62})`: Levels of depth you want to parse the JSON value (defaulted to 62).
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -307,7 +307,7 @@ Watch our YouTube video (approx. 6 minutes) to learn how to use a Grok debugger 
   >
     New Relic logs pipeline parses your log JSON messages by default but sometimes you've JSON log messages that are mixed up with plain text and in that case you also want to be able to parse them and then be able to filter using the JSON attributes.
 
-    If thats the case you can use the `json` [grok type](#grok-syntax) that will do exactly that, parse the JSON extracted by the grok pattern.
+    If that is the case, you can use the `json` [grok type](#grok-syntax), which will parse the JSON captured by the grok pattern.
 
     As an example, imagine your logs are JSON logs but prefixed with a date time string:
 

--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -309,19 +309,19 @@ Watch our YouTube video (approx. 6 minutes) to learn how to use a Grok debugger 
 
     If that is the case, you can use the `json` [grok type](#grok-syntax), which will parse the JSON captured by the grok pattern.
 
-    As an example, imagine your logs are JSON logs but prefixed with a date time string:
+    Using the `json` [grok type](#grok-syntax), you can extract and parse JSON from logs that are not properly formatted, e.g, your logs are prefixed with a date time string:
 
     ```
     2015-05-13T23:39:43.945958Z {"event": "TestRequest", "status": 200, "response": {"headers": {"X-Custom": "foo"}, "request": {"headers": {"X-Custom": "bar"}}}}
     ```
 
-    For parsing that we can create a Parsing Rule with the following Grok:
+    In order to extract and parse the JSON data from this log format, you would create the following Grok expression:
 
     ```
     %{TIMESTAMP_ISO8601:containerTimestamp} %{GREEDYDATA:log:json}
     ```
 
-    And the log will result as:
+    The resulting log would be:
     ```
     containerTimestamp: "2015-05-13T23:39:43.945958Z"
     log.event: "TestRequest"
@@ -330,10 +330,10 @@ Watch our YouTube video (approx. 6 minutes) to learn how to use a Grok debugger 
     log.request.headers.X-Custom: "bar"
     ```
 
-    It is possible to configure some JSON parser behaviors using `:json(_CONFIG_)`:
+    Optionally, you can configure the `json` [grok type](#grok-syntax) using `:json(_CONFIG_)`:
 
-    - `json({"dropOriginal": true})`: Drop original field, this defaults to true and means that will drop the JSON string attribute after parsing it.
-    - `json({"depth": 62})`: Allows to control how much levels you want to parse from your JSON (It defaults to its max that is 62).
+    - `json({"dropOriginal": true})`: Drop the original attribute. When set to `true` (default value), the Parsing rule will drop the original JSON attribute.
+    - `json({"depth": 62})`: Levels of depth you want to parse the JSON value (defaulted to 62).
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -289,8 +289,51 @@ Watch our YouTube video (approx. 6 minutes) to learn how to use a Grok debugger 
               ISO 8601 time as a `long`
             </td>
           </tr>
+
+          <tr>
+            <td>
+              `json`
+            </td>
+            <td>
+              JSON structured data, take a look to [Parsing JSON mixed-up with plain text](#parsing-json) for more information
+            </td>
+          </tr>
         </tbody>
       </table>
+  </Collapser>
+  <Collapser
+    id="parsing-json"
+    title="Parsing JSON mixed-up with plain text"
+  >
+    We parse you log JSON messages but default but sometimes you've JSON log messages mixed up with plain text and in that case you also want to be able to parse them and then be able to filter using the JSON attributes.
+
+    If thats the case you can use the `json` [grok type](#grok-syntax) that will do exactly that, parse the JSON extracted by the grok pattern.
+
+    As an example, imagine your logs are JSON logs but prefixed with a date time string:
+
+    ```
+    2015-05-13T23:39:43.945958Z {"event": "TestRequest", "status": 200, "response": {"headers": {"X-Custom": "foo"}, "request": {"headers": {"X-Custom": "bar"}}}}
+    ```
+
+    For parsing that we can create a Parsing Rule with the following Grok:
+
+    ```
+    %{TIMESTAMP_ISO8601:containerTimestamp} %{GREEDYDATA:log:json}
+    ```
+
+    And the log will result as:
+    ```
+    containerTimestamp: "2015-05-13T23:39:43.945958Z"
+    log.event: "TestRequest"
+    log.status: 200
+    log.response.headers.X-Custom: "foo"
+    log.request.headers.X-Custom: "bar"
+    ```
+
+    It is possible to configure some JSON parser behaviors using `:json(_CONFIG_)`:
+
+    - `json({"dropOriginal": true})`: Drop original field, this defaults to true and means that will drop the JSON string attribute after parsing it.
+    - `json({"depth": 62})`: Allows to control how much levels you want to parse from your JSON (It defaults to its max that is 62).
   </Collapser>
 </CollapserGroup>
 
@@ -627,7 +670,7 @@ Here are some examples of how to add `logtype` to logs sent by some of our [supp
       - name: file-simple
         file: /path/to/file
         attributes:
-          logtype: fileRaw  
+          logtype: fileRaw
       - name: nginx-example
         file: /var/log/nginx.log
         attributes:


### PR DESCRIPTION
* What problems does this PR solve?
- We're adding a new feature to logs parsing that allow to parse grok matches to JSON, here we try to explain how to do it and the configurations available.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
Added section is in a Collapser because it's related to the other ones from the collapser. The `json` type is added as well to the grok-types table because it's not a type as that, but the way to use those "actions" is the same as for types in Grok, and also, it could be understandable as a "type casting" as the others, you're casting your "text" into a "structured json" type.

* If your issue relates to an existing GitHub issue, please link to it.
No