### PR TITLE
fix(Go): update configuration instructions

### DIFF
--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
@@ -613,6 +613,60 @@ In this and the following examples, `config` represents your New Relic config st
 
 If you're using New Relic APM and CodeStream, see [how to associate repositories](/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags](/docs/codestream/start-here/codestream-new-relic/#buildsha) with errors inbox.
 
+## Configuring from the Environment [#configuring-from-the-environment]
+For greater flexibility, you can set many configuration options by setting environment variables instead of hardcoding them into your application's
+source code. In order to use them, add a call to `ConfigFromEnvironment()` among your other configuration options:
+
+
+```go
+app, err := newrelic.NewApplication(
+   newrelic.ConfigAppName("Your Application Name"),
+   newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+   newrelic.ConfigFromEnvironment(),
+)
+```
+
+Note that the environment variables will be read, and their corresponding entries in the `newrelic.Config` struct will be updated, at the
+point in the list of options where `newrelic.ConfigFromEnvironment()` appears. If there are additional configuration options listed after
+`ConfigFromEnvironment`, they may override the values set by `ConfigFromEnvironment`.
+
+For example, if the following environment variables are set:
+```
+NEW_RELIC_LICENSE_KEY="your_license_key_here"
+NEW_RELIC_APP_NAME="Your Application Name"
+NEW_RELIC_CODE_LEVEL_METRICS_ENABLED="true"
+NEW_RELIC_CODE_LEVEL_METRICS_PATH_PREFIX="myproject/src"
+NEW_RELIC_LABELS="Env:Dev;Label2:label2;Label3:label3;Label4:label4"
+```
+then the following code:
+```go
+app, err := newrelic.NewApplication(
+   newrelic.ConfigFromEnvironment(),
+)
+```
+will accomplish the same result as the hard-coded equivalent:
+```go
+app, err := newrelic.NewApplication(
+   newrelic.ConfigAppName("Your Application Name"),
+   newrelic.ConfigLicense("your_license_key_here"),
+   newrelic.ConfigCodeLevelMetricsEnabled(true),
+   newrelic.ConfigCodeLevelMetricsPathPrefix("myproject/src"),
+   func(config *newrelic.Config) {
+	config.Labels = map[string]string{
+	    "Env":    "Dev",
+	    "Label2": "label2",
+	    "Label3": "label3",
+	    "Label4": "label4",
+	}
+    },
+)
+```
+
+<Callout variant="tip">
+   Environment variables must have a non-empty value in order to be read by `newrelic.ConfigFromEnvironment`.
+</Callout>
+
+
 ## Custom events configuration [#custom-insights-events-settings]
 
 You can create custom events and make them available for querying and analysis.

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
@@ -613,10 +613,10 @@ In this and the following examples, `config` represents your New Relic config st
 
 If you're using New Relic APM and CodeStream, see [how to associate repositories](/docs/codestream/start-here/codestream-new-relic/#repo-url) and [how to associate build SHAs or release tags](/docs/codestream/start-here/codestream-new-relic/#buildsha) with errors inbox.
 
-## Configuring from the Environment [#configuring-from-the-environment]
+## Configuring from the environment [#configuring-from-the-environment]
+
 For greater flexibility, you can set many configuration options by setting environment variables instead of hardcoding them into your application's
 source code. In order to use them, add a call to `ConfigFromEnvironment()` among your other configuration options:
-
 
 ```go
 app, err := newrelic.NewApplication(
@@ -638,13 +638,17 @@ NEW_RELIC_CODE_LEVEL_METRICS_ENABLED="true"
 NEW_RELIC_CODE_LEVEL_METRICS_PATH_PREFIX="myproject/src"
 NEW_RELIC_LABELS="Env:Dev;Label2:label2;Label3:label3;Label4:label4"
 ```
+
 then the following code:
+
 ```go
 app, err := newrelic.NewApplication(
    newrelic.ConfigFromEnvironment(),
 )
 ```
+
 will accomplish the same result as the hard-coded equivalent:
+
 ```go
 app, err := newrelic.NewApplication(
    newrelic.ConfigAppName("Your Application Name"),
@@ -665,7 +669,6 @@ app, err := newrelic.NewApplication(
 <Callout variant="tip">
    Environment variables must have a non-empty value in order to be read by `newrelic.ConfigFromEnvironment`.
 </Callout>
-
 
 ## Custom events configuration [#custom-insights-events-settings]
 

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
@@ -62,15 +62,16 @@ Here are detailed descriptions of each configuration method:
        ```go
        app, err := newrelic.NewApplication(
            newrelic.ConfigAppName("Your Application Name"),
-           newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+           newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
        )
        ```
+       Note the use of `os.Getenv` to read your license key from the environment rather than hard-coding it as a string literal value passed to `newrelic.ConfigLicense`. We recommend that you do not place license keys or other sensitive information in your source code, as that may result in them being stored in your SCM repository and possibly revealed to unauthorized parties.
     2. Update values on the `newrelic.Config` struct to configure your application using `newrelic.ConfigOption`s. These are functions that accept a pointer to the `newrelic.Config` struct. Add additional `newrelic.ConfigOption`s to further configure your application. For example, you can use one of the predefined options to do common configurations:
 
        ```go
        app, err := newrelic.NewApplication(
            newrelic.ConfigAppName("Your Application Name"),
-           newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+           newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
            // add debug level logging to stdout
            newrelic.ConfigDebugLogger(os.Stdout),
        )
@@ -80,7 +81,7 @@ Here are detailed descriptions of each configuration method:
        ```go
        app, err := newrelic.NewApplication(
            newrelic.ConfigAppName("Your Application Name"),
-           newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+           newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
            newrelic.ConfigDebugLogger(os.Stdout),
            func(config *newrelic.Config) {
            	// add more specific configuration of the agent within a custom ConfigOption
@@ -99,7 +100,7 @@ To make Go agent configuration changes, set the values in the `newrelic.Config` 
 ```go
 app, err := newrelic.NewApplication(
     newrelic.ConfigAppName("Your Application Name"),
-    newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+    newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
     func(config *newrelic.Config) {
     	config.Enabled = false
     },
@@ -197,7 +198,7 @@ In this and the following examples, `config` represents your New Relic config st
     ```go
     app, err := newrelic.NewApplication(
         newrelic.ConfigAppName("YOUR_APP_NAME;APP_GROUP_1;ALL_APPS"),
-        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
     )
     ```
   </Collapser>
@@ -249,10 +250,19 @@ In this and the following examples, `config` represents your New Relic config st
     ```go
     app, err := newrelic.NewApplication(
         newrelic.ConfigAppName("Your Application Name"),
-        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
         func(config *newrelic.Config) {
         	config.Enabled = false
         },
+    )
+    ```
+    
+    You may make use of the `ConfigEnabled` option to make this easier:
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigAppName("Your Application Name"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+	newrelic.ConfigEnabled(false),
     )
     ```
 
@@ -313,7 +323,7 @@ In this and the following examples, `config` represents your New Relic config st
         ```go
         app, err := newrelic.NewApplication(
             newrelic.ConfigAppName("Your Application Name"),
-            newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+            newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
             func(config *newrelic.Config) {
                 config.Labels = map[string]string{
                     "Env":    "Dev",
@@ -422,7 +432,7 @@ In this and the following examples, `config` represents your New Relic config st
       ```go
       app, err := newrelic.NewApplication(
           newrelic.ConfigAppName("Your Application Name"),
-          newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+          newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
           func(config *newrelic.Config) {
               config.HighSecurity = true
           },
@@ -653,7 +663,7 @@ You can create custom events and make them available for querying and analysis.
     ```go
     app, err := newrelic.NewApplication(
         newrelic.ConfigAppName("Your Application Name"),
-        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
         func(config *newrelic.Config) {
             config.CustomInsightsEvents.Enabled = false
         },
@@ -761,7 +771,7 @@ Transaction events are used in collecting events corresponding to web requests a
     ```go
     app, err := newrelic.NewApplication(
         newrelic.ConfigAppName("Your Application Name"),
-        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
         func(config *newrelic.Config) {
             config.TransactionEvents.Attributes.Exclude = allAgentAttributeNames
         },
@@ -990,7 +1000,7 @@ The following settings are used to configure the error collector:
         ```go
         app, err := newrelic.NewApplication(
             newrelic.ConfigAppName("Your Application Name"),
-            newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+           newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
             func(config *newrelic.Config) {
                 config.ErrorCollector.IgnoreStatusCodes = []int{0, 5, 404, 418}
             },
@@ -1053,7 +1063,7 @@ The following settings are used to configure the error collector:
     ```go
     app, err := newrelic.NewApplication(
         newrelic.ConfigAppName("Your Application Name"),
-        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
         func(config *newrelic.Config) {
             config.ErrorCollector.Attributes.Exclude = allAgentAttributeNames
         },
@@ -1321,7 +1331,7 @@ Here are settings for changing transaction tracer configuration. For more inform
     ```go
     app, err := newrelic.NewApplication(
         newrelic.ConfigAppName("Your Application Name"),
-        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
         func(config *newrelic.Config) {
             config.TransactionTracer.Segments.Attributes.Exclude = allSegmentAttributeNames
         },
@@ -1437,7 +1447,7 @@ Here are settings for changing transaction tracer configuration. For more inform
     ```go
     app, err := newrelic.NewApplication(
         newrelic.ConfigAppName("Your Application Name"),
-        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
         func(config *newrelic.Config) {
             config.TransactionTracer.Attributes.Exclude = allAgentAttributeNames
         },
@@ -1919,7 +1929,7 @@ When distributed tracing is enabled, you can collect [span events](/docs/apm/dis
     ```go
     app, err := newrelic.NewApplication(
         newrelic.ConfigAppName("Your Application Name"),
-        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
         func(config *newrelic.Config) {
             config.TransactionTracer.Segments.Attributes.Exclude = allSpanAttributeNames
         },


### PR DESCRIPTION
## Fixed
 * Agent configuration instructions showed examples with hard-coded license key embedded in the project source code. This is not recommended for security and privacy reasons. This was updated to explain the risk and to show how to get that value from the runtime environment instead.
 * Added additional instructions to show how one may configure a wide variety of agent parameters from the environment.
