### PR TITLE
docs: `message` is a property

### DIFF
--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -133,7 +133,7 @@ You have three options to configure APM logs in context to send your app's logs 
   ```
   Note: The environment variable value, if present, takes precedence over the config file value.
 
-  Our decorator adds five attributes to every log message: `entity.guid`, `entity.name`, `hostname`, `trace.id`, and  `span.id`. Example:
+  Our decorator adds five attributes to every log `message`: `entity.guid`, `entity.name`, `hostname`, `trace.id`, and  `span.id`. Example:
 
   ```log
   This is my log message. NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}


### PR DESCRIPTION
Very minor edit, but I'm just trying to clarify that the this sentence is specifically speaking about the property named `message` on the log, the data will look something like this

```json
{
    "Timestamp": "2022-06-24T09:05:51.6760737+00:00",
    "message": "Writing data to file 'some_file_location' NR-LINKING|MzM5MTg5M3xBUE|af960d|12|34|example-app|"
} 
```

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.