### PR TITLE
fix: remove invalid double quotes in yaml value

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -2568,7 +2568,7 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
           max_size_mb: 1000                        # Required
           max_files: 5                             # Optional
           compression_enabled: true                # Optional
-          file_pattern: "YYYY-MM-DD_hh-mm-ss".log  # Optional
+          file_pattern: YYYY-MM-DD_hh-mm-ss.log  # Optional
       ```
 
       <CollapserGroup>


### PR DESCRIPTION
Double quotes are not allowed in YAML. The current configuration example makes the infra-agent crash.

Merge asap. Thanks