### PR TITLE
Add react logo

### DIFF
--- a/src/@newrelic/gatsby-theme-newrelic/icons/logo.js
+++ b/src/@newrelic/gatsby-theme-newrelic/icons/logo.js
@@ -30,6 +30,7 @@ import php from './logo/php';
 import postgresql from './logo/postgresql';
 import prometheus from './logo/prometheus';
 import python from './logo/python';
+import react from './logo/react';
 import redis from './logo/redis';
 import ruby from './logo/ruby';
 import statsd from './logo/statsd';
@@ -70,6 +71,7 @@ export default {
   python,
   redis,
   ruby,
+  react,
   statsd,
   windows,
 };

--- a/src/@newrelic/gatsby-theme-newrelic/icons/logo/react.js
+++ b/src/@newrelic/gatsby-theme-newrelic/icons/logo/react.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import SVG from '@newrelic/gatsby-theme-newrelic/src/components/SVG';
+
+const ReactIcon = (props) => {
+  return (
+    <SVG {...props} viewBox="-11.5 -10.23174 23 20.46348">
+      <circle cx="0" cy="0" r="2.05" fill="#61dafb" />
+      <g stroke="#61dafb" strokeWidth="1" fill="none">
+        <ellipse rx="11" ry="4.2" />
+        <ellipse rx="11" ry="4.2" transform="rotate(60)" />
+        <ellipse rx="11" ry="4.2" transform="rotate(120)" />
+      </g>
+    </SVG>
+  );
+};
+
+export default ReactIcon;

--- a/src/content/docs/apm/new-relic-apm/getting-started/introduction-apm.mdx
+++ b/src/content/docs/apm/new-relic-apm/getting-started/introduction-apm.mdx
@@ -19,22 +19,6 @@ redirects:
 
 import apmOverview from 'images/apm-intro-overview.png'
 
-import clogo from 'images/clogo.png'
-
-import gologo from 'images/gologo.png'
-
-import javalogo from 'images/javalogo.png'
-
-import dotnetlogo from 'images/dotnetlogo.png'
-
-import nodejslogo from 'images/nodejslogo.png'
-
-import pythonlogo from 'images/pythonlogo.png'
-
-import phplogo from 'images/phplogo.png'
-
-import rubylogo from 'images/rubylogo.png'
-
 Our application performance monitoring (APM) provides a unified monitoring service for all your apps and microservices. Monitor everything from the hundreds of dependencies of a modern stack down to simple web-transaction times and throughput of an app. Keep track of your app's health in real-time by monitoring your metrics, events, logs, and transactions (MELT) through pre-built and custom dashboards. 
 
 Our APM service provides the flexibility to monitor the exact things you need from your app by automatically instrumenting your code when you install one of our agents. 


### PR DESCRIPTION
Can be used in techtiles as 'logo-react'

I also deleted some image imports in the apm intro since they weren't being used