### PR TITLE
chore: replaces spelling of 'acount' with 'account'.

### DIFF
--- a/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
+++ b/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
@@ -375,7 +375,7 @@ The headers also contain information that helps us link the spans together later
 
     <tr>
       <td>
-        Trusted acount key
+        Trusted account key
       </td>
 
       <td>

--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-baseline-ingest-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-baseline-ingest-guide.mdx
@@ -892,7 +892,7 @@ SELECT rate(sum(GigabytesIngested), 1 day) AS avgGbIngest FROM NrConsumption WHE
             We can use Lookout to find anomalies in our ingest by **usageMetric**.
         </figcaption>
 
-Change the facet field to `consumingAcountName` to get this view:
+Change the facet field to `consumingAccountName` to get this view:
 
         <img
             src={lookoutviewconsumingaccont}

--- a/src/i18n/content/kr/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-baseline-ingest-guide.mdx
+++ b/src/i18n/content/kr/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-baseline-ingest-guide.mdx
@@ -902,7 +902,7 @@ SELECT rate(sum(GigabytesIngested), 1 day) AS avgGbIngest FROM NrConsumption WHE
   Lookout을 사용하여 사용 **메트릭** 으로 수집에서 이상을 찾을 수 있습니다.
 </figcaption>
 
-이 보기를 얻으려면 패싯 필드를 `consumingAcountName` 으로 변경합니다.
+이 보기를 얻으려면 패싯 필드를 `consumingAccountName` 으로 변경합니다.
 
 <img
   src={lookoutviewconsumingaccont}


### PR DESCRIPTION
Fixes spelling of "account" in a few places a found "acount" was used. 