### PR TITLE
docs: add language identifiers to the shell command

### DIFF
--- a/src/content/docs/apm/agents/net-agent/troubleshooting/resolve-net-scom-conflicts.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/resolve-net-scom-conflicts.mdx
@@ -29,7 +29,7 @@ To resolve SCOM profiler conflicts:
 1. Remove the SCOM profiler: Uninstall SCOM, or re-install SCOM and disable the `APM` portion in the install wizard.
 2. To resolve the SCOM conflict, restore the registry settings using PowerShell:
 
-   ```
+   ```shell
    $HKLM = 2147483650 #HKEY_LOCAL_MACHINE
    $reg = [wmiclass]"\\.\root\default:StdRegprov"
    $key = "SYSTEM\CurrentControlSet\Services\W3SVC"
@@ -43,7 +43,7 @@ To resolve SCOM profiler conflicts:
    iisreset
    ```
 3. Run these commands **each** time you restart your server, or create a startup script to restore these settings.
-4. Recycle your app pool, or from a command prompt, run **IISRESET**.
+4. Recycle your app pool, or from a command prompt, run **`IISRESET`**.
 
 <Callout variant="important">
   You must repair your installation each time you restart your server.

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/resolve-net-scom-conflicts.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/resolve-net-scom-conflicts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Resolve .NET and SCOM conflicts
-type: troubleshooting
+type: troubleshooting 
 tags:
   - Agents
   - NET agent


### PR DESCRIPTION
~~I think this command is actually broken, as you can see when it's colorized, I'm reaching out to the .NET team to see if I can get some confirmation on how to properly write it. The issue being I think these `\` are accidentally escaping the following `"`~~

I tested out the command and I was incorrect, it is working as expected, adding escape chars breaks it

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.