### PR TITLE
docs: fix page header data

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags.mdx
@@ -1,4 +1,4 @@
-  ---
+---
 title: Android agent configuration and feature flags
 tags:
   - Mobile monitoring


### PR DESCRIPTION
The data info at the top of this file is appearing as plain text in the UI, and I think that might be why the website's search isn't finding this page either. I think some stray spaces are to blame

<img width="1311" alt="image" src="https://user-images.githubusercontent.com/48165493/181292416-ed78b169-2a83-4d6a-a21a-66852240e9a8.png">


<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.