### PR TITLE
fix(node agent): document the new grpc.record_errors configuration option

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -3470,6 +3470,54 @@ For more information about setting up distributed tracing, see [Enable distribut
   </Collapser>
 </CollapserGroup>
 
+## gRPC server instrumentation [#grpc_server]
+
+The `grpc` section controls the behavior of how the gRPC server is instrumented.
+
+
+<CollapserGroup>
+  <Collapser
+    id="record_errors"
+    title="record_errors"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_GRPC_RECORD_ERRORS`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When enabled, the agent will send all error gRPC status codes to New Relic, that is, nonzero status codes. If disabled, the server instrumentation will not send any nonzero status codes to New Relic.
+  </Collapser>
+</CollapserGroup>
+
+
 ## Span events
 
 [Span data](/docs/apm/distributed-tracing/ui-data/span-event) is reported for [distributed tracing](#distributed-tracing). Distributed tracing must be enabled to report spans. Span configuration is set in the `span_events` stanza. Options include:


### PR DESCRIPTION
This was introduced [in version 8.17.0 of the Node.js agent](https://github.com/newrelic/node-newrelic/pull/1291/files).
