### PR TITLE
Update manage-monitor-runtimes.mdx

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/manage-monitor-runtimes.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/manage-monitor-runtimes.mdx
@@ -472,7 +472,7 @@ Here are monitor version details for all [monitor types](/docs/synthetics/new-re
 <CollapserGroup>
   <Collapser
     id="v06"
-    title={<>Version 0.6.x (<strong>Latest</strong>)</>}
+    title={<>Version 0.6.x</>}
   >
     Synthetic monitor version 0.6.x details:
 


### PR DESCRIPTION
0.6.x is not the latest.

## Give us some context

* Clarification of the manage runtime docs - the latest runtime is not 0.6.x (chrome 72). The latest is Chrome 100. 