### PR TITLE
docs: typo in C# code

### DIFF
--- a/src/content/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes.mdx
@@ -32,7 +32,7 @@ If you have [APM](/docs/apm/new-relic-apm/getting-started/introduction-new-relic
 
 New Relic agents send [event data](/docs/using-new-relic/data/understand-data/new-relic-data-types#event-data) to New Relic as part of the normal harvest cycle every five seconds for agent versions supporting [real time streaming](/docs/agents/manage-apm-agents/agent-data/real-time-streaming).
 
-Sending a lot of events can increase the memory overhead of the agent. New Relic enforces an upper limit of 833 custom events every 5 seconds. Additionally, posts greater than 1MB (10^6 bytes) in size will not be recorded, regardless of the custom event limit.
+Sending a lot of events can increase the memory overhead of the agent. New Relic enforces an upper limit of 833 custom events every 5 seconds. Additionally, posts greater than 1MB (10^6 bytes) in size will not be recorded, regardless of the custom event limit. 
 
 You can also send custom events using the [Event API](/docs/insights/insights-data-sources/custom-data/introduction-event-api) (without need for APM). However, be aware that custom events sent with the agent APIs are not compatible with [high security mode](/docs/accounts-partnerships/accounts/security/high-security).
 

--- a/src/content/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes.mdx
@@ -118,10 +118,10 @@ When creating your own custom events and attributes, follow data requirements fo
 
     ```cs
     var eventAttributes = new Dictionary<String, Object>();
-    NewRelic.Api.Agent.NewRelic.RecordCustomEvent('MyCustomEvent', eventAttributes);
+    NewRelic.Api.Agent.NewRelic.RecordCustomEvent("MyCustomEvent", eventAttributes);
     ```
 
-    The first argument defines the name of your event type, and the second argument is an IEnumerable with the attributes for your custom event. Ensure you limit the number of unique event type names that you create, and do not generate these names dynamically. For restrictions on event type names, see our documentation about [limits and restricted characters](/docs/telemetry-data-platform/custom-data/custom-events/data-requirements-limits-custom-event-data) and [NRQL reserved words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
+    The first argument defines the name of your event type, and the second argument is an `IEnumerable` with the attributes for your custom event. Ensure you limit the number of unique event type names that you create, and do not generate these names dynamically. For restrictions on event type names, see our documentation about [limits and restricted characters](/docs/telemetry-data-platform/custom-data/custom-events/data-requirements-limits-custom-event-data) and [NRQL reserved words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
 
     You can then add [custom attributes](/docs/agents/manage-apm-agents/agent-data/collect-custom-attributes#net-att) for your .NET app.
 
@@ -139,7 +139,7 @@ When creating your own custom events and attributes, follow data requirements fo
     recordCustomEvent(eventType, attributes)
     ```
 
-    Use recordCustomEvent to record an event-based metric, usually associated with a particular duration. The eventType must be an alphanumeric string less than 255 characters. The attributes must be an object of key and value pairs. The keys must be shorter than 255 characters, and the values must be string, number, or boolean. For restrictions on event type names, see our documentation about [limits and restricted characters](/docs/telemetry-data-platform/custom-data/custom-events/data-requirements-limits-custom-event-data) and [NRQL reserved words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
+    Use `recordCustomEvent()` to record an event-based metric, usually associated with a particular duration. The `eventType` must be an alphanumeric string less than 255 characters. The attributes must be an object of key and value pairs. The keys must be shorter than 255 characters, and the values must be string, number, or boolean. For restrictions on event type names, see our documentation about [limits and restricted characters](/docs/telemetry-data-platform/custom-data/custom-events/data-requirements-limits-custom-event-data) and [NRQL reserved words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
 
     You can then add [custom attributes](/docs/apm/other-features/attributes/collecting-custom-attributes#nodejs-att) for your Node.js app.
 


### PR DESCRIPTION
strings have to be in `"` not `'` or they cause an error in .NET. Also added some words in backticks since I was here

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.