### PR TITLE
Chore: Update network port behaviors to match changes in guided install

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -564,7 +564,7 @@ global:
           </td>
 
           <td>
-            Listening IP port for receiving SNMP traps. By default it's set to `0.0.0.1:1620` and we use a redirect in your `docker run ...` command to redirect the more common UDP 162 on the host to UDP 1620 in the container.  The redirect is done with this flag `-p 162:1620/udp`
+            Listening IP port for receiving SNMP traps. By default it's set to `0.0.0.0:1620` and we use a redirect in your `docker run ...` command to redirect the more common UDP 162 on the host to UDP 1620 in the container.  The redirect is done with this flag `-p 162:1620/udp`
           </td>
         </tr>
 

--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -123,7 +123,7 @@ devices:
         transport: https
         port: 443
 trap:
-  listen: 127.0.0.1:1620
+  listen: 0.0.0.0:1620
   community: public
   version: ""
   transport: ""
@@ -564,7 +564,7 @@ global:
           </td>
 
           <td>
-            Listening IP port for receiving SNMP traps. By default it's set to `127.0.0.1:1620`. Using the SNMP Trap default of `162` requires replacing `--net=host` in your run command with `-p 162:1620/udp`.
+            Listening IP port for receiving SNMP traps. By default it's set to `0.0.0.1:1620` and we use a redirect in your `docker run ...` command to redirect the more common UDP 162 on the host to UDP 1620 in the container.  The redirect is done with this flag `-p 162:1620/udp`
           </td>
         </tr>
 
@@ -576,7 +576,7 @@ global:
           <td/>
 
           <td>
-            SNMPv1/v2c community string for receiving SNMP traps.
+            SNMPv1/v2c community string for receiving SNMP traps.  By default we still process incoming traps even if they do not match this community.
           </td>
         </tr>
 

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-syslog-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-syslog-monitoring.mdx
@@ -148,7 +148,7 @@ Set up your network devices so they send syslog data to New Relic.
       </td>
 
       <td>
-        5143 (default)
+        514 (default)
       </td>
 
       <td>
@@ -159,7 +159,7 @@ Set up your network devices so they send syslog data to New Relic.
 </table>
 
 <Callout variant="tip">
-The default listening port for **ktranslate** is `5143 (TCP/UDP)`. If you need to use the default syslog port of `514`, you can do so by removing `--net=host` from your run command, replacing it with `-p 514:5143/udp`. To bind the listener to a port above `1024`, add `-syslog.source="0.0.0.0:<port>"` to the end of the run command instead.
+The default listening port for **ktranslate** listens is port `5143 (TCP/UDP)`. To use the default syslog port of `514`, our guided install redirects traffic into the Docker container with the flag`-p 514:5143/udp`. To bind the listener to a port above `1024`, add `-syslog.source="0.0.0.0:<port>"` to the end of the run command instead.
 </Callout>
 
 ## Set up network syslog monitoring in New Relic [#setup-network-syslog-monitoring]
@@ -222,7 +222,7 @@ If you prefer to do the setup manually, see the instructions below.
 
     4. Run `ktranslate` to listen for network syslog by running:
        ```shell
-         docker run -d --name ktranslate-syslog --restart unless-stopped --net=host \
+         docker run -d --name ktranslate-syslog --restart unless-stopped -p 514:5143/udp \
          -v `pwd`/snmp-base.yaml:/snmp-base.yaml \
          -e NEW_RELIC_API_KEY=$YOUR_NR_LICENSE_KEY \
          kentik/ktranslate:v2 \

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-syslog-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-syslog-monitoring.mdx
@@ -159,7 +159,7 @@ Set up your network devices so they send syslog data to New Relic.
 </table>
 
 <Callout variant="tip">
-The default listening port for **ktranslate** listens is port `5143 (TCP/UDP)`. To use the default syslog port of `514`, our guided install redirects traffic into the Docker container with the flag`-p 514:5143/udp`. To bind the listener to a port above `1024`, add `-syslog.source="0.0.0.0:<port>"` to the end of the run command instead.
+The default listening port for **ktranslate** is port `5143 (TCP/UDP)`. To use the more common syslog port of `514`, our guided install redirects traffic into the Docker container with the flag`-p 514:5143/udp`. To bind the listener to a port above `1024`, add `-syslog.source="0.0.0.0:<port>"` to the end of the run command instead.
 </Callout>
 
 ## Set up network syslog monitoring in New Relic [#setup-network-syslog-monitoring]

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -211,7 +211,7 @@ Configured network devices for SNMP polling from the **ktranslate** docker conta
           </td>
 
           <td>
-            1620 (default)
+            162 (default)
           </td>
 
           <td>
@@ -437,6 +437,7 @@ Our network monitoring container supports all major versions of SNMP (v1, v2c, a
 
        <Callout variant="tip">
          We recommend to set `discovery.add_mibs: true` to automate the addition of all discovered MIBs into the `global.mibs_enabled` attribute.
+         If you intend to collect SNMP traps we also recommend changing the default value of `listener: 127.0.0.1:1620` to `listener: 0.0.0.0:1620`
        </Callout>
 
     4. Launch a short-lived container to execute discovery by running
@@ -488,21 +489,9 @@ Our network monitoring container supports all major versions of SNMP (v1, v2c, a
 
 ### Collection of SNMP traps
 
-By default the agent will listen for incoming SNMP traps on UDP port 1620 and it is not necessary to run a dedicated agent for trap collection as all SNMP polling agents will run this passive listener.
+It is not necessary to run a dedicated agent for trap collection as all SNMP polling agents will run this passive listener.
 
-If you need to use the standard port of UDP 162 for your SNMP traps, the following steps will need to be followed for your container.
-
-1. Update your `snmp-base.yaml` config file to change the listening IP from `127.0.0.1` to `0.0.0.0`. *(This allows the Docker container to listen on the `docker0` interface for external packets.)*
-
-```yaml
-trap:
-  listen: 0.0.0.0:1620
-  community: hello
-  version: ""
-  transport: ""
-```
-
-2. Enable port forwarding during your `docker run...` command to redirect packets sent to UDP 162 on the host into UDP 1620 on the container:
+Ktranslate listens for incoming SNMP traps on UDP port 1620, but you can use a port redirect in your `docker run...` command to redirect packets sent to UDP 162 on the host into UDP 1620 on the container
 
 ```shell
 docker run -d --name ktranslate-snmp --restart unless-stopped -p 162:1620/udp \


### PR DESCRIPTION

## Give us some context

Product team is updating the guided install to make it so that some steps we previously called out as optional are now the default setup.