### PR TITLE
Fix - Added quotations to password value

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/redis/redis-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/redis/redis-integration.mdx
@@ -627,7 +627,7 @@ Even though our default sample configuration file includes examples of labels, t
           METRICS: true
           HOSTNAME: localhost
           PORT: 6379
-          PASSWORD: my_password
+          PASSWORD: "my_password"
           REMOTE_MONITORING: true
         interval: 15s
         labels:
@@ -638,7 +638,7 @@ Even though our default sample configuration file includes examples of labels, t
           INVENTORY: true
           HOSTNAME: localhost
           PORT: 6379
-          PASSWORD: my_password
+          PASSWORD: "my_password"
           REMOTE_MONITORING: true
         interval: 60s
         labels:
@@ -661,7 +661,7 @@ Even though our default sample configuration file includes examples of labels, t
           HOSTNAME: localhost
           PORT: 6379
           USERNAME: my_user
-          PASSWORD: my_password
+          PASSWORD: "my_password"
           REMOTE_MONITORING: true
         interval: 15s
         labels:
@@ -673,7 +673,7 @@ Even though our default sample configuration file includes examples of labels, t
           HOSTNAME: localhost
           PORT: 6379
           USERNAME: my_user
-          PASSWORD: my_password
+          PASSWORD: "my_password"
           REMOTE_MONITORING: true
         interval: 60s
         labels:


### PR DESCRIPTION
Strings with special characters need to be surrounded by quotes in YAML:
https://yaml.org/spec/1.2.2/#53-indicator-characters

* What problems does this PR solve?
Improvement to documentation

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
Many passwords use special characters, and not including the quotations in the documentation may cause confusion