### PR TITLE
Move logs video 

### DIFF
--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -45,11 +45,6 @@ Forwarding your logs to New Relic will give you enhanced log management capabili
 
 You can use our guided install process to quickly and easily install log management and infrastructure monitoring together! To get learn how the guided install process works and how to use the logging data you see in New Relic, watch this Nerdlog video on YouTube (14:46 minutes):
 
-<Video
-  id="_II9Y-jOE7k"
-  type="youtube"
-/>
-
 To forward your logs through our infrastructure monitoring agent:
 
 1. If you haven't already, [create a New Relic account](https://newrelic.com/signup). It's free, forever.
@@ -59,6 +54,11 @@ To forward your logs through our infrastructure monitoring agent:
 5. [Configure](#parameters) your log sources and other parameters.
 6. Generate some traffic and wait a few minutes, then [check your account](#find-data) for data.
 7. [Explore your log data](#what-next) in the Logs UI and benefit from the log attributes automatically inserted by the infrastructure agent.
+
+<Video
+  id="_II9Y-jOE7k"
+  type="youtube"
+/>
 
 Here is an example of logs for your host's UI. You can see logs in context of events for the selected time period, and drill down into detailed data for any of the highlighted attributes. To examine even more detailed data, run a query, or click **Open in logs**.
 


### PR DESCRIPTION
A 14 minute long video makes the `basic process` seem very long and complex. This PR moves the video towards the bottom and surfaces the shorter 7 step action items.