### PR TITLE
docs: update confusing language

### DIFF
--- a/src/content/docs/apm/agents/net-agent/custom-instrumentation/create-transactions-xml-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/custom-instrumentation/create-transactions-xml-net.mdx
@@ -32,7 +32,7 @@ Some important rules to know before you create a custom transaction:
 * Database and external calls do not require custom instrumentation because they're automatically instrumented.
 * Ensure your XML file is in the correct path. To define its instrumentation set, the .NET agent reads every XML file in the `Extensions` directory.
 * If a method you attempt to instrument is already part of an existing transaction, it will be added as a segment to that transaction. No new transaction will be created. This will occur even if the parent method is instrumented using custom instrumentation.
-* Avoid instrumenting things like Main() as this method won't end until the application ends and data may not be sent to New Relic.
+* Avoid instrumenting things like `Main()` as this method won't end until the application ends and data may not be sent to New Relic.
 
 To create a custom instrumentation file:
 
@@ -82,18 +82,18 @@ To create a custom instrumentation file:
    </CollapserGroup>
 2. Copy this template into the file you created. This template defines two separate class and methods as transactions but more can be added:
 
-   ```
+   ```xml
    <?xml version="1.0" encoding="utf-8"?>
    <extension xmlns="urn:newrelic-extension">
      <instrumentation>
        <!-- Define the method which triggers the creation of a transaction. -->
-       <tracerFactory name="NewRelic.Agent.Core.Tracer.Factories.BackgroundThreadTracerFactory" metricName="<var>Name</var>">
+       <tracerFactory name="NewRelic.Agent.Core.Tracer.Factories.BackgroundThreadTracerFactory" metricName="<var>TransactionName</var>">
          <match assemblyName="<var>AssemblyName</var>" className="<var>NameSpace.ClassName</var>">
            <exactMethodMatcher methodName="<var>MethodName</var>" />
          </match>
        </tracerFactory>
        <!-- Define the method which triggers the creation of a transaction. -->
-       <tracerFactory name="NewRelic.Agent.Core.Tracer.Factories.BackgroundThreadTracerFactory" metricName="<var>Name2</var>">
+       <tracerFactory name="NewRelic.Agent.Core.Tracer.Factories.BackgroundThreadTracerFactory" metricName="<var>TransactionName2</var>">
          <match assemblyName="<var>AssemblyName</var>" className="<var>NameSpace.ClassName2</var>">
            <exactMethodMatcher methodName="<var>MethodName2</var>" />
          </match>
@@ -103,17 +103,17 @@ To create a custom instrumentation file:
    ```
 
 
-1. In the file you created, customize the attribute values `Name`, `AssemblyName`, `NameSpace.ClassName`, and `MethodName`. Customize these values for both the trigger method and for any methods called by the trigger method.
+1. In the file you created, customize the attribute values `TransactionName`, `AssemblyName`, `NameSpace.ClassName`, and `MethodName`. Customize these values for both the trigger method and for any methods called by the trigger method.
 
    <Callout variant="tip">
      These values are case sensitive.
    </Callout>
 
-   * `Name`: Defines the transaction name. The metricName attribute is optional. If omitted, the transaction name will be `NameSpace.ClassName`/`MethodName`. The transaction category will be "Custom". The resulting full metric name will be "OtherTransaction/Custom/`Name` . If you wish to change the transaction category from "Custom", use the [SetTransactionName](/docs/agents/net-agent/net-agent-api/settransactionname-net-agent-api) api call. The New Relic UI groups transactions under categories in the [transaction type field](#custom-txn-screen).
+   * `TransactionName`: Defines the transaction name. The `metricName` attribute is optional. If omitted, the transaction name will be `NameSpace.ClassName/MethodName`. The transaction category will be `Custom`. The resulting full metric name will be `OtherTransaction/Custom/TransactionName` . If you wish to change the transaction category from `Custom`, use the [SetTransactionName](/docs/agents/net-agent/net-agent-api/settransactionname-net-agent-api) api call. The New Relic UI groups transactions under categories in the [transaction type field](#custom-txn-screen).
    * `AssemblyName`: The assembly that contains the trigger method.
    * `NameSpace.ClassName`: The fully-qualified class name that contains the trigger method.
    * `MethodName`: The exact name of the trigger method.
-2. Adding additional methods must include the "NewRelic.Agent.Core.Tracer.Factories.BackgroundThreadTracerFactory" attribute to be defined as a transaction. Tags without this attribute will [add detail to existing](/docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net) transactions only.
+2. Adding additional methods must include the `"NewRelic.Agent.Core.Tracer.Factories.BackgroundThreadTracerFactory"` attribute to be defined as a transaction. Tags without this attribute will [add detail to existing transactions](/docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net) only.
 3. Optional: To check if the XML file is formatted correctly, you can check it against the XSD (located at `C:\ProgramData\New Relic\.NET Agent\Extensions\extension.xsd`) using any XSD validator.
 
 <Callout variant="important">
@@ -124,7 +124,7 @@ To create a custom instrumentation file:
 
 The custom transaction starts when the method specified by `methodName` is invoked in the assembly specified by `assemblyName`. The transaction ends when the method returns or throws an exception.
 
-You can view these metrics in the [**Transactions** page](/docs/applications-menu/transactions-dashboard#tx_viewing) and in [transaction traces](/docs/traces/viewing-transaction-traces). To view the transaction: Go to **[one.newrelic.com](https://one.newrelic.com)** **> APM > (select an app) > Monitor > Transactions > Type > (select a type)**. The type is defined by [`Category/Name`](#category-name).
+You can view these metrics in the [**Transactions** page](/docs/applications-menu/transactions-dashboard#tx_viewing) and in [transaction traces](/docs/traces/viewing-transaction-traces). To view the transaction: Go to **[one.newrelic.com](https://one.newrelic.com)** **> APM > (select an app) > Monitor > Transactions > Type > (select a type)**. The type will `Non-web/Custom` unless you [use the API to change the category](/docs/agents/net-agent/net-agent-api/settransactionname-net-agent-api).
 
 <img
   title="custom_transactions.png"
@@ -147,7 +147,7 @@ This example presents a simple implementation of creating transactions.
   >
     This custom instrumentation file defines the three methods to instrument. Only two are defined as transactions.
 
-    ```
+    ```xml
     <?xml version="1.0" encoding="utf-8"?>
     <extension xmlns="urn:newrelic-extension">
       <instrumentation>
@@ -175,7 +175,7 @@ This example presents a simple implementation of creating transactions.
   >
     This code contains the three methods, with comments explaining when each one will be instrumented by the agent:
 
-    ```
+    ```cs
     var bar = new Bar();
     bar.Bar1(); // Creates a transaction named Bars in the Custom category.
     bar.Bar2(); // Creates a transaction named Bars in the Custom category.
@@ -229,7 +229,7 @@ This simple console app demonstrates creating transactions. After running the ap
   >
     This custom instrumentation file defines two methods to instrument:
 
-    ```
+    ```xml
     <?xml version="1.0" encoding="utf-8"?>
     <extension xmlns="urn:newrelic-extension">
         <instrumentation>
@@ -256,7 +256,7 @@ This simple console app demonstrates creating transactions. After running the ap
   >
     This code contains the two methods specified by the custom instrumentation file:
 
-    ```
+    ```cs
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/src/content/docs/apm/agents/net-agent/custom-instrumentation/create-transactions-xml-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/custom-instrumentation/create-transactions-xml-net.mdx
@@ -109,7 +109,7 @@ To create a custom instrumentation file:
      These values are case sensitive.
    </Callout>
 
-   * `TransactionName`: Defines the transaction name. The `metricName` attribute is optional. If omitted, the transaction name will be `NameSpace.ClassName/MethodName`. The transaction category will be `Custom`. The resulting full metric name will be `OtherTransaction/Custom/TransactionName` . If you wish to change the transaction category from `Custom`, use the [SetTransactionName](/docs/agents/net-agent/net-agent-api/settransactionname-net-agent-api) api call. The New Relic UI groups transactions under categories in the [transaction type field](#custom-txn-screen).
+   * `TransactionName`: Defines the transaction name. The `metricName` attribute is optional. If omitted, the transaction name will be `NameSpace.ClassName/MethodName`. The transaction category will be `Custom`. The resulting full metric name will be `OtherTransaction/Custom/TransactionName` . If you wish to change the transaction category from `Custom`, use the [SetTransactionName](/docs/agents/net-agent/net-agent-api/settransactionname-net-agent-api) api call. The New Relic UI groups transactions under categories in the [transaction type field](docs/apm/transactions/intro-transactions/transactions-new-relic-apm/#agent-net).
    * `AssemblyName`: The assembly that contains the trigger method.
    * `NameSpace.ClassName`: The fully-qualified class name that contains the trigger method.
    * `MethodName`: The exact name of the trigger method.


### PR DESCRIPTION
This line of code has `name` and `Name` in it
```xml
<tracerFactory name="NewRelic.Agent.Core.Tracer.Factories.BackgroundThreadTracerFactory" metricName="Name">
```
It was difficult to understand which was referred to later when `Name` is referred to, so I made `Name` `TransactionName`. I also removed a dead link and updated the text to make more sense. Then I added language identifiers

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.