### PR TITLE
docs: fix deprecaded link +lang identifiers

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/settransactionname-net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/settransactionname-net-agent-api.mdx
@@ -15,7 +15,7 @@ redirects:
 
 ## Syntax
 
-```
+```cs
 NewRelic.Api.Agent.NewRelic.SetTransactionName(string $category, string $name)
 ```
 
@@ -37,7 +37,7 @@ If you use this call multiple times within the same transaction, each call overw
   Do not use brackets `[suffix]` at the end of your transaction name. New Relic automatically strips brackets from the name. Instead, use parentheses `(suffix)` or other symbols if needed.
 </Callout>
 
-Unique values like URLs, page titles, hex values, session IDs, and uniquely identifiable values should not be used in naming your transactions. Instead, add that data to the transaction as a custom parameter with the [`AddCustomParameter()`](/docs/agents/net-agent/net-agent-api/add-custom-parameter) call.
+Unique values like URLs, page titles, hex values, session IDs, and uniquely identifiable values should not be used in naming your transactions. Instead, add that data to the transaction as a custom parameter with the [`AddCustomAttribute()`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute) call.
 
 <Callout variant="important">
   Do not create more than 1000 unique transaction names (for example, avoid naming by URL if possible). This will make your charts less useful, and you may run into limits New Relic sets on the number of unique transaction names per account. It also can slow down the performance of your application.
@@ -67,7 +67,7 @@ Unique values like URLs, page titles, hex values, session IDs, and uniquely iden
       </td>
 
       <td>
-        Required. The category of this transaction, which you can use to distinguish different types of transactions. Defaults to **Custom**. Only the first 255 characters are retained.
+        Required. The category of this transaction, which you can use to distinguish different types of transactions. Defaults to **`Custom`**. Only the first 255 characters are retained.
       </td>
     </tr>
 
@@ -87,6 +87,6 @@ Unique values like URLs, page titles, hex values, session IDs, and uniquely iden
 
 ## Examples
 
-```
+```cs
 NewRelic.Api.Agent.NewRelic.SetTransactionName("Other", "MyTransaction");
 ```


### PR DESCRIPTION
the customer parameters method doesn't exist anymore replaced with this:

/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.