### PR TITLE
Adding firehose endpoints for US and EU

### DIFF
--- a/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
+++ b/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
@@ -43,9 +43,7 @@ To forward your logs from Kinesis Data Firehose to New Relic:
      src={img0ThirdPartyPartnerAwsKinesisFirehose}
    />
 
-6. Under **HTTP endpoint URL**, select **New Relic logs - US** from the dropdown.
-
-   **Note**: To send your logs to the EU, complete the remaining steps in this section, then proceed to the [configuration procedures for EU accounts](#configure-eu-stream).
+6. Under **HTTP endpoint URL**, select **New Relic logs - US**. This is the US endpoint (https://aws-api.newrelic.com/firehose/v1). To use the EU endpoint, complete the remaining steps in this procedure, then go to [EU account configuration](#configure-eu-stream).
 
 7. Paste your [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key) in the **API key** field.
 
@@ -55,15 +53,8 @@ To forward your logs from Kinesis Data Firehose to New Relic:
 
 10. Configure and review the remaining metadata settings.
 
-Any optional key/value pairs you add in the AWS Management Console will result in attribute/value pairs you can use in New Relic.
+Any optional key/value pairs you add in the AWS Management Console will result in attribute/value pairs you can use in New Relic. Kinesis Data Firehose includes these key-value pairs in each HTTP call. These [Kinesis Firehose parameters](https://docs.aws.amazon.com/firehose/latest/dev/create-destination.html#create-destination-new-relic) can help you identify and organize your destinations.
 
-Kinesis Data Firehose includes these key-value pairs in each HTTP call. These [Kinesis Firehose Parameters](https://docs.aws.amazon.com/firehose/latest/dev/create-destination.html#create-destination-new-relic) can help you identify and organize your destinations.
-
-<Callout variant="important">
-  Please note that the endpoint for firehose are: 
-   US Endpoint : https://aws-api.newrelic.com/firehose/v1
-   EU Endpoint : https://aws-api.eu.newrelic.com/firehose/v1
-</Callout>
 
 ## Configure buffer size and interval [#buffer-settings]
 

--- a/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
+++ b/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
@@ -59,6 +59,12 @@ Any optional key/value pairs you add in the AWS Management Console will result i
 
 Kinesis Data Firehose includes these key-value pairs in each HTTP call. These [Kinesis Firehose Parameters](https://docs.aws.amazon.com/firehose/latest/dev/create-destination.html#create-destination-new-relic) can help you identify and organize your destinations.
 
+<Callout variant="important">
+  Please note that the endpoint for firehose are: 
+   US Endpoint : https://aws-api.newrelic.com/firehose/v1
+   EU Endpoint : https://aws-api.eu.newrelic.com/firehose/v1
+</Callout>
+
 ## Configure buffer size and interval [#buffer-settings]
 
 When selecting our Kinesis Firehose integration for logs in AWS, the wizard hides a small section called `Buffer hints` at the bottom of the screen. This section contains two very important configuration options: `Buffer size` and `Buffer interval`.


### PR DESCRIPTION
Adding firehose endpoints for US and EU

* The endpoint for firehose is not mentioned in the docs due to which customer is using wrong endpoints leading to an intermittent invalid response. 
* This issue is related the to https://issues.newrelic.com/browse/NR-24671 

