### PR TITLE
docs: add info about new env var

### DIFF
--- a/src/content/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
+++ b/src/content/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
@@ -2,7 +2,7 @@
 title: Install the .NET agent on Azure Web Apps
 tags:
   - Agents
-  - NET agent
+  - NET agent 
   - Azure installation
 metaDescription: 'Microsoft Azure Marketplace customers: How to install the New Relic .NET agent (Framework and Core) for Azure Web Apps.'
 redirects:

--- a/src/content/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
+++ b/src/content/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
@@ -11,7 +11,7 @@ redirects:
   - /docs/agents/net-agent/azure-installation/install-net-core
   - /docs/agents/net-agent/azure-installation/install-app-azure-web-apps
   - /docs/agents/net-agent/azure-installation
-  - /docs/apm/agents/net-agent/azure-installation/install-azure-marketplace-app-new-relic/
+  - /docs/apm/agents/net-agent/azure-installation/install-azure-marketplace-app-new-relic
   - /docs/agents/net-agent/azure-installation/install-azure-marketplace-app-new-relic
 ---
 
@@ -49,16 +49,9 @@ To install the .NET agent for an Azure Web App using the New Relic Azure Site Ex
 
 1. Shut down your web application before installing the [New Relic Azure Site Extension](https://www.nuget.org/packages/NewRelic.Azure.WebSites.Extension).
 2. Add the site extension: Navigate to `http://[yoursitename].scm.azurewebsites.net`, then select **Site extensions > Gallery**.
-3. Select the plus <Icon name="fe-plus"/>
-   icon next to the New Relic site extension.
-4. In the Azure portal, add New Relic [app settings](#web-app-agent-settings) to your Azure App Service.
-    <Callout variant="important">
-      The Azure extension will install the latest version of the agent by default, beginning with the [v10.x the agent dropped support for .NET Framework 4.6.1 and lower and .NET Core 3.0 and lower](/docs/apm/agents/net-agent/getting-started/9x-to-10x-agent-migration-guide). To use the extension with one of these out-of-support versions of .NET, use the env var `NEWRELIC_AGENT_VERSION_OVERRIDE`. For example:
-      ```
-      NEWRELIC_AGENT_VERSION_OVERRIDE=9.9.0
-      ```
-    </Callout>  
-6. Restart your web app to use the new version of the agent.
+3. Select the plus <Icon name="fe-plus"/> icon next to the New Relic site extension.
+4. In the Azure portal, add New Relic [app settings](#web-app-agent-settings) to your Azure App Service. This installs the latest .NET agent version. With version 10.x, we dropped support for .NET Framework 4.6.1 and lower and .NET Core 3.0 and lower (see [the migration guide](/docs/apm/agents/net-agent/getting-started/9x-to-10x-agent-migration-guide)). If you need a lower agent version, use the `NEWRELIC_AGENT_VERSION_OVERRIDE` environment variable. For example: `NEWRELIC_AGENT_VERSION_OVERRIDE=9.9.0`.
+5. Restart your web app.
 
 <Callout variant="important">
 If you need to add a custom instrumentation XML, or modify the base `newrelic.config` file, you'll find the .NET Framework agent at `%HOME%\NewRelicAgent\Framework`, and the .NET Core agent at`%HOME%\NewRelicAgent\Core`.
@@ -358,7 +351,7 @@ To add your app settings:
          </td>
 
          <td>
-           `YOUR_LICENSE_KEY`
+           `<var>YOUR_LICENSE_KEY</var>`
          </td>
        </tr>
 
@@ -368,14 +361,14 @@ To add your app settings:
          </td>
 
          <td>
-           `YOUR_APP_NAME`
+           `<var>YOUR_APP_NAME</var>`
          </td>
        </tr>
      </tbody>
    </table>
    
    
-   **Note**: There is an optional key/value pair you can add [if you need to use a previous version of the .NET agent with your app](/docs/apm/agents/net-agent/getting-started/9x-to-10x-agent-migration-guide/#the-net-agent-no-longer-supports-frameworks-designated-as-end-of-life):
+   If you need to [use a previous .NET agent version](/docs/apm/agents/net-agent/getting-started/9x-to-10x-agent-migration-guide/#the-net-agent-no-longer-supports-frameworks-designated-as-end-of-life), use this key/value pair: 
 
    <table>
      <thead>
@@ -397,7 +390,7 @@ To add your app settings:
          </td>
 
          <td>
-           `AGENT_VERSION_NUMBER`
+           `<var>DESIRED_AGENT_VERSION_NUMBER</var>`
          </td>
        </tr>
 

--- a/src/content/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
+++ b/src/content/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
@@ -52,7 +52,13 @@ To install the .NET agent for an Azure Web App using the New Relic Azure Site Ex
 3. Select the plus <Icon name="fe-plus"/>
    icon next to the New Relic site extension.
 4. In the Azure portal, add New Relic [app settings](#web-app-agent-settings) to your Azure App Service.
-5. Restart your web app to use the new version of the agent.
+    <Callout variant="important">
+      The Azure Extension will install the latest version of the agent by defualt, beginning with the [v10.x the agent dropped support for .NET Framework 4.6.1 and lower and .NET Core 3.0 and lower](/docs/apm/agents/net-agent/getting-started/9x-to-10x-agent-migration-guide). To use the extension with one of these out of support versions of .NET use the env var `NEWRELIC_AGENT_VERSION_OVERRIDE`. For example:
+      ```
+      NEWRELIC_AGENT_VERSION_OVERRIDE=9.9.0
+      ```
+    </Callout>  
+6. Restart your web app to use the new version of the agent.
 
 <Callout variant="important">
 If you need to add a custom instrumentation XML, or modify the base `newrelic.config` file, you'll find the .NET Framework agent at `%HOME%\NewRelicAgent\Framework`, and the .NET Core agent at`%HOME%\NewRelicAgent\Core`.
@@ -365,6 +371,36 @@ To add your app settings:
            `YOUR_APP_NAME`
          </td>
        </tr>
+     </tbody>
+   </table>
+   
+   
+   **Note**: There is an optional key/value pair you can add [if you need to use a previous version of the .NET agent with your app](/docs/apm/agents/net-agent/getting-started/9x-to-10x-agent-migration-guide/#the-net-agent-no-longer-supports-frameworks-designated-as-end-of-life):
+
+   <table>
+     <thead>
+       <tr>
+         <th width={300}>
+           Key
+         </th>
+
+         <th>
+           Value
+         </th>
+       </tr>
+     </thead>
+
+     <tbody>
+       <tr>
+         <td>
+           `NEWRELIC_AGENT_VERSION_OVERRIDE`
+         </td>
+
+         <td>
+           `AGENT_VERSION_NUMBER`
+         </td>
+       </tr>
+
      </tbody>
    </table>
 4. Save and restart your web app.

--- a/src/content/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
+++ b/src/content/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
@@ -53,7 +53,7 @@ To install the .NET agent for an Azure Web App using the New Relic Azure Site Ex
    icon next to the New Relic site extension.
 4. In the Azure portal, add New Relic [app settings](#web-app-agent-settings) to your Azure App Service.
     <Callout variant="important">
-      The Azure Extension will install the latest version of the agent by defualt, beginning with the [v10.x the agent dropped support for .NET Framework 4.6.1 and lower and .NET Core 3.0 and lower](/docs/apm/agents/net-agent/getting-started/9x-to-10x-agent-migration-guide). To use the extension with one of these out of support versions of .NET use the env var `NEWRELIC_AGENT_VERSION_OVERRIDE`. For example:
+      The Azure extension will install the latest version of the agent by default, beginning with the [v10.x the agent dropped support for .NET Framework 4.6.1 and lower and .NET Core 3.0 and lower](/docs/apm/agents/net-agent/getting-started/9x-to-10x-agent-migration-guide). To use the extension with one of these out-of-support versions of .NET, use the env var `NEWRELIC_AGENT_VERSION_OVERRIDE`. For example:
       ```
       NEWRELIC_AGENT_VERSION_OVERRIDE=9.9.0
       ```


### PR DESCRIPTION
@vuqtran88 asked that I try to add this new info about an optional env var to target older agents. Now that the agent 10x is not supporting .NET versions 9x did support this is probably going to be important info to release. I'm waiting for a build to see if my links and formatting all worked, I'm not sure this is merge-able yet.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.