### PR TITLE
docs: Update ios-application-licenses.mdx

### DIFF
--- a/src/content/docs/licenses/product-or-service-licenses/mobile-app-licenses/ios-application-licenses.mdx
+++ b/src/content/docs/licenses/product-or-service-licenses/mobile-app-licenses/ios-application-licenses.mdx
@@ -32,21 +32,7 @@ We love open-source software, and use the following in the New Relic iOS app. Th
   <tbody>
     <tr>
       <td>
-        [AFNetworking](https://github.com/AFNetworking/AFNetworking)
-      </td>
-
-      <td>
-        [MIT](https://github.com/AFNetworking/AFNetworking/blob/master/LICENSE)
-      </td>
-
-      <td>
-        Copyright © 2011-2020 Alamofire Software Foundation [http://alamofire.org/](http://alamofire.org/)
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [Ace](https://github.com/ajaxorg/ace)
+        [ace](https://github.com/ajaxorg/ace)
       </td>
 
       <td>
@@ -60,7 +46,7 @@ We love open-source software, and use the following in the New Relic iOS app. Th
 
     <tr>
       <td>
-        [ActiveLabel](https://github.com/optonaut/ActiveLabel.swift)
+        [ActiveLabel.swift](https://github.com/optonaut/ActiveLabel.swift.git)
       </td>
 
       <td>
@@ -74,7 +60,21 @@ We love open-source software, and use the following in the New Relic iOS app. Th
 
     <tr>
       <td>
-        [Alamofire](https://github.com/Alamofire/Alamofire)
+        [AFNetworking](https://github.com/AFNetworking/AFNetworking)
+      </td>
+
+      <td>
+        [MIT](https://github.com/AFNetworking/AFNetworking/blob/master/LICENSE)
+      </td>
+
+      <td>
+        Copyright © 2011-2020 [Alamofire Software Foundation](http://alamofire.org/)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [Alamofire](https://github.com/Alamofire/Alamofire.git)
       </td>
 
       <td>
@@ -82,21 +82,21 @@ We love open-source software, and use the following in the New Relic iOS app. Th
       </td>
 
       <td>
-        Copyright © 2014-2021 [Alamofire Software Foundation](http://alamofire.org/)
+        Copyright © 2014-2022 [Alamofire Software Foundation](http://alamofire.org/)
       </td>
     </tr>
 
     <tr>
       <td>
-        [Analytics](http://segment.com/)
+        [analytics-swift](https://github.com/segmentio/analytics-swift.git)
       </td>
 
       <td>
-        [MIT](https://github.com/segmentio/analytics-ios/blob/master/LICENSE)
+        [MIT](https://github.com/segmentio/analytics-swift/blob/main/LICENSE)
       </td>
 
       <td>
-        Copyright © 2016 Segment.io, Inc.
+        Copyright © 2021 Segment
       </td>
     </tr>
 
@@ -116,21 +116,7 @@ We love open-source software, and use the following in the New Relic iOS app. Th
 
     <tr>
       <td>
-        [BigNumber](https://github.com/mkrd/Swift-Big-Integer)
-      </td>
-
-      <td>
-        [MIT](https://github.com/mkrd/Swift-Big-Integer/blob/master/LICENSE)
-      </td>
-
-      <td>
-        Copyright © 2019 mkrd
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [CDMarkdownKit](https://github.com/chrisdhaan/CDMarkdownKit)
+        [CDMarkdownKit](https://github.com/chrisdhaan/CDMarkdownKit.git)
       </td>
 
       <td>
@@ -138,17 +124,17 @@ We love open-source software, and use the following in the New Relic iOS app. Th
       </td>
 
       <td>
-        Copyright © 2016-2017 Christopher de Haan `contact@christopherdehaan.me`
+        Copyright © 2016-2022 Christopher de Haan `contact@christopherdehaan.me`
       </td>
     </tr>
 
     <tr>
       <td>
-        [Charts](https://github.com/danielgindi/Charts)
+        [Charts](https://github.com/danielgindi/Charts.git)
       </td>
 
       <td>
-        [Apache License, Version 2.0](https://github.com/danielgindi/Charts/blob/master/LICENSE)
+        [APACHE-2.0](https://github.com/danielgindi/Charts/blob/master/LICENSE)
       </td>
 
       <td>
@@ -158,21 +144,63 @@ We love open-source software, and use the following in the New Relic iOS app. Th
 
     <tr>
       <td>
-        [ECSlidingViewController](https://github.com/edgecase/ecslidingviewcontroller)
+        [ECSlidingViewController](https://github.com/ECSlidingViewController/ECSlidingViewController)
       </td>
 
       <td>
-        [MIT](https://github.com/edgecase/ECSlidingViewController#mit-license)
+        [MIT](https://github.com/ECSlidingViewController/ECSlidingViewController/blob/master/LICENSE)
       </td>
 
       <td>
-        Copyright © 2013 EdgeCase
+        Copyright © 2013 Mike Enriquez `mike@enriquez.me`
       </td>
     </tr>
 
     <tr>
       <td>
-        LoginManagerSDK
+        [jstimezonedetect](https://bitbucket.org/pellepim/jstimezonedetect)
+      </td>
+
+      <td>
+        [MIT](https://bitbucket.org/pellepim/jstimezonedetect/src/default/LICENCE.txt)
+      </td>
+
+      <td>
+        Copyright © 2012 Jon Nylander, project maintained at [bitbucket.org](bitbucket.org)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [KeychainAccess](https://github.com/kishikawakatsumi/KeychainAccess.git)
+      </td>
+
+      <td>
+        [MIT](https://github.com/kishikawakatsumi/KeychainAccess/blob/master/LICENSE)
+      </td>
+
+      <td>
+        Copyright © 2014 kishikawa katsumi
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [lodash](https://github.com/lodash/lodash)
+      </td>
+
+      <td>
+        [MIT](https://github.com/lodash/lodash/blob/master/LICENSE)
+      </td>
+
+      <td>
+        Copyright © JS Foundation and other contributors [js.foundation](https://js.foundation/)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        login_manager_sdk
       </td>
 
       <td>
@@ -180,17 +208,17 @@ We love open-source software, and use the following in the New Relic iOS app. Th
       </td>
 
       <td>
-        Copyright © 2010-2021 New Relic, Inc. All rights reserved.
+        Copyright © 2010-2022 New Relic, Inc. All rights reserved.
       </td>
     </tr>
 
     <tr>
       <td>
-        [Mantle](https://github.com/Mantle/Mantle)
+        [Mantle](https://github.com/Mantle/Mantle.git)
       </td>
 
       <td>
-        [MIT](https://github.com/Mantle/Mantle/blob/master/LICENSE.md)
+        [MIT](https://github.com/github/Mantle/blob/master/LICENSE.md)
       </td>
 
       <td>
@@ -200,7 +228,7 @@ We love open-source software, and use the following in the New Relic iOS app. Th
 
     <tr>
       <td>
-        MetricMetadata
+        metric_metadata
       </td>
 
       <td>
@@ -208,13 +236,27 @@ We love open-source software, and use the following in the New Relic iOS app. Th
       </td>
 
       <td>
-        Copyright © 2010-2021 New Relic, Inc. All rights reserved.
+        Copyright © 2010-2022 New Relic, Inc. All rights reserved.
       </td>
     </tr>
 
     <tr>
       <td>
-        NRCharts
+        [newrelic-ios-agent-spm](https://github.com/newrelic/newrelic-ios-agent-spm.git)
+      </td>
+
+      <td>
+        [APACHE-2.0](https://github.com/newrelic/newrelic-ios-agent-spm/blob/main/LICENSE)
+      </td>
+
+      <td>
+        Copyright © 2010-2022 New Relic, Inc. All rights reserved.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        nr_ios_chart
       </td>
 
       <td>
@@ -222,13 +264,13 @@ We love open-source software, and use the following in the New Relic iOS app. Th
       </td>
 
       <td>
-        Copyright © 2010-2021 New Relic, Inc. All rights reserved.
+        Copyright © 2010-2022 New Relic, Inc. All rights reserved.
       </td>
     </tr>
 
     <tr>
       <td>
-        [NVActivityIndicatorView](https://github.com/ninjaprox/NVActivityIndicatorView)
+        [NVActivityIndicatorView](https://github.com/ninjaprox/NVActivityIndicatorView.git)
       </td>
 
       <td>
@@ -237,20 +279,6 @@ We love open-source software, and use the following in the New Relic iOS app. Th
 
       <td>
         Copyright © 2016 Vinh Nguyen
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        NewRelicAgent
-      </td>
-
-      <td>
-        [New Relic License](https://newrelic.com/terms)
-      </td>
-
-      <td>
-        Copyright © 2010-2021 New Relic, Inc. All rights reserved.
       </td>
     </tr>
 
@@ -270,7 +298,7 @@ We love open-source software, and use the following in the New Relic iOS app. Th
 
     <tr>
       <td>
-        RadarKit
+        radarkit
       </td>
 
       <td>
@@ -278,41 +306,69 @@ We love open-source software, and use the following in the New Relic iOS app. Th
       </td>
 
       <td>
-        © 2010-2021 New Relic, Inc. All rights reserved.
+        Copyright © 2010-2022 New Relic, Inc. All rights reserved.
       </td>
     </tr>
 
     <tr>
       <td>
-        [SSPullToRefresh](https://github.com/soffes/sspulltorefresh)
+        [Sovran-Swift](https://github.com/segmentio/Sovran-Swift.git)
       </td>
 
       <td>
-        [MIT](https://github.com/soffes/sspulltorefresh/blob/master/LICENSE)
+        [MIT](https://github.com/segmentio/Sovran-Swift/blob/main/LICENSE)
       </td>
 
       <td>
-        Copyright © 2012-2014 Sam Soffes, [http://soff.es](http://soff.es)
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [UICKeyChainStore](https://github.com/kishikawakatsumi/UICKeyChainStore)
-      </td>
-
-      <td>
-        [MIT](https://github.com/kishikawakatsumi/UICKeyChainStore/blob/master/LICENSE)
-      </td>
-
-      <td>
-        Copyright © 2011 kishikawa katsumi
+        Copyright © 2021 Segment
       </td>
     </tr>
 
     <tr>
       <td>
-        WidgetLibrary
+        [swift-algorithms](https://github.com/apple/swift-algorithms)
+      </td>
+
+      <td>
+        [APACHE-2.0](https://github.com/apple/swift-algorithms/blob/main/LICENSE.txt)
+      </td>
+
+      <td>
+        Copyright © 2020 Apple Inc
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [Swift-Big-Integer](https://github.com/mkrd/Swift-Big-Integer.git)
+      </td>
+
+      <td>
+        [MIT](https://github.com/mkrd/Swift-BigInt/blob/master/LICENSE)
+      </td>
+
+      <td>
+        Copyright © 2019 mkrd
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [swift-numerics](https://github.com/apple/swift-numerics)
+      </td>
+
+      <td>
+        [APACHE-2.0](https://github.com/apple/swift-numerics/blob/main/LICENSE.txt)
+      </td>
+
+      <td>
+        Copyright © 2020 Apple Inc
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        widget_ios
       </td>
 
       <td>
@@ -320,63 +376,21 @@ We love open-source software, and use the following in the New Relic iOS app. Th
       </td>
 
       <td>
-        © 2010-2021 New Relic, Inc. All rights reserved.
+        Copyright © 2010-2022 New Relic, Inc. All rights reserved.
       </td>
     </tr>
 
     <tr>
       <td>
-        [XYPieChart](https://github.com/xyfeng/XYPieChart)
+        [Yams](https://github.com/jpsim/Yams.git)
       </td>
 
       <td>
-        [MIT](https://github.com/xyfeng/XYPieChart/blob/master/LICENSE.txt)
-      </td>
-
-      <td>
-        Copyright © 2012 Xiaoyang Feng, XYStudio.cc
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [Yams](https://github.com/jpsim/Yams)
-      </td>
-
-      <td>
-        [MIT](https://github.com/jpsim/Yams/blob/master/LICENSE)
+        [MIT](https://github.com/jpsim/Yams/blob/main/LICENSE)
       </td>
 
       <td>
         Copyright © 2016 JP Simard.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [jsTimezoneDetect](https://bitbucket.org/pellepim/jstimezonedetect)
-      </td>
-
-      <td>
-        [MIT](https://bitbucket.org/pellepim/jstimezonedetect/src/default/LICENCE.txt)
-      </td>
-
-      <td>
-        Copyright © 2012 Jon Nylander, project maintained at [bitbucket.org](https://bitbucket.org/pellepim/jstimezonedetect)
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [lodash](https://github.com/lodash/lodash)
-      </td>
-
-      <td>
-        [MIT](https://github.com/lodash/lodash/blob/master/LICENSE)
-      </td>
-
-      <td>
-        Copyright © JS Foundation and other contributors [js.foundation](https://js.foundation/)
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Updates licenses used in the iOS mobile app.

We have changed to using swift package manager, and as a result have changed around some of the packages we are using. This updates to our latest set of external packages and licenses they have.