### PR TITLE
fix: link to "harvest cycle"

### DIFF
--- a/src/content/docs/apm/transactions/transaction-traces/introduction-transaction-traces.mdx
+++ b/src/content/docs/apm/transactions/transaction-traces/introduction-transaction-traces.mdx
@@ -54,7 +54,7 @@ In APM, a transaction trace records the segments that make up a [transaction](/d
 
 Here are the default rules that govern which transactions a New Relic agent traces:
 
-* Over the minute-long [harvest cycle](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#harvest-cycle), all transactions that violate the threshold (either four times your [Apdex T value](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction) or a specific number of seconds) are added to a pool of transactions.
+* Over the minute-long [harvest cycle](/docs/new-relic-solutions/get-started/glossary/#harvest-cycle), all transactions that violate the threshold (either four times your [Apdex T value](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction) or a specific number of seconds) are added to a pool of transactions.
 * At the end of that minute, the New Relic agent selects the slowest transaction in that pool and performs a transaction trace on it.
 
 These are the general rules, but there are some agent-specific differences. For example:


### PR DESCRIPTION
Link to "harvest cycle" in glossary was broken. https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/getting-started/glossary#harvest-cycle redirects to https://docs.newrelic.com/docs/new-relic-solutions/get-started/glossary/ The anchor is lost in the redirect, so there'a probably a bunch of similar broken links.