### PR TITLE
fix(docs): Fixes step two of React Native setup

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-monitoring-react-native/monitor-your-react-native-application.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-monitoring-react-native/monitor-your-react-native-application.mdx
@@ -1,5 +1,5 @@
 ---
-title: Monitor your React Native application 
+title: Monitor your React Native application
 tags:
   - Mobile monitoring
   - New Relic Mobile
@@ -46,7 +46,7 @@ Please be sure to enter your proper application tokens. `appToken` is platform-s
 
 ```js
 import NewRelic from 'newrelic-react-native-agent';
-import * as appVesrion from './package.json';
+import {name, version} from './package.json';
 import {Platform} from 'react-native';
 
     let appToken;
@@ -59,8 +59,8 @@ import {Platform} from 'react-native';
 
 
 NewRelic.startAgent(appToken);
-NewRelic.setJSAppVersion(appVesrion.version);
-AppRegistry.registerComponent(appName, () => App);
+NewRelic.setJSAppVersion(version);
+AppRegistry.registerComponent(name, () => App);
 ```
 
 ### Step three: Android setup [#step-three-android-setup]


### PR DESCRIPTION
Following the Mobile Monitoring configuration tutorial, I noticed a typo in the documentation (step two).

```javascript
import * as appVesrion from './package.json';
```

Taking advantage... I used a destructuring assignment task in the import.

```javascript
import {name, version} from './package.json';
```
