### PR TITLE
fix(docs): replace mark with var

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
@@ -105,7 +105,7 @@ If you have an EU region account, use the appropriate endpoints to access the fo
 
       <td>
         ```
-        sourcemaps.service.<mark>eu</mark>.newrelic.com
+        sourcemaps.service.<var>eu</var>.newrelic.com
         ```
       </td>
     </tr>
@@ -117,7 +117,7 @@ If you have an EU region account, use the appropriate endpoints to access the fo
 
       <td>
         ```
-        infra-api.<mark>eu</mark>.newrelic.com
+        infra-api.<var>eu</var>.newrelic.com
         ```
       </td>
     </tr>
@@ -129,7 +129,7 @@ If you have an EU region account, use the appropriate endpoints to access the fo
 
       <td>
         ```
-        rpm.<mark>eu</mark>.newrelic.com/mobile
+        rpm.<var>eu</var>.newrelic.com/mobile
         ```
       </td>
     </tr>
@@ -141,7 +141,7 @@ If you have an EU region account, use the appropriate endpoints to access the fo
 
       <td>
         ```
-        api.<mark>eu</mark>.newrelic.com/graphiql
+        api.<var>eu</var>.newrelic.com/graphiql
         ```
       </td>
     </tr>
@@ -167,7 +167,7 @@ If you have an EU region account, use the appropriate endpoints to access the fo
 
       <td>
         ```
-        api.<mark>eu</mark>.newrelic.com
+        api.<var>eu</var>.newrelic.com
         ```
       </td>
     </tr>
@@ -179,7 +179,7 @@ If you have an EU region account, use the appropriate endpoints to access the fo
 
       <td>
         ```
-        synthetics.<mark>eu</mark>.newrelic.com/synthetics/api
+        synthetics.<var>eu</var>.newrelic.com/synthetics/api
         ```
       </td>
     </tr>
@@ -191,7 +191,7 @@ If you have an EU region account, use the appropriate endpoints to access the fo
 
       <td>
         ```
-        trace-api.<mark>eu</mark>.newrelic.com/trace/v1
+        trace-api.<var>eu</var>.newrelic.com/trace/v1
         ```
       </td>
     </tr>
@@ -203,7 +203,7 @@ If you have an EU region account, use the appropriate endpoints to access the fo
 
       <td>
         ```
-        metric-api.<mark>eu</mark>.newrelic.com/metric/v1
+        metric-api.<var>eu</var>.newrelic.com/metric/v1
         ```
       </td>
     </tr>
@@ -215,7 +215,7 @@ If you have an EU region account, use the appropriate endpoints to access the fo
 
       <td>
         ```
-        log-api.<mark>eu</mark>.newrelic.com/log/v1
+        log-api.<var>eu</var>.newrelic.com/log/v1
         ```
       </td>
     </tr>
@@ -227,7 +227,7 @@ If you have an EU region account, use the appropriate endpoints to access the fo
 
       <td>
         ```
-        insights-collector.<mark>eu01</mark>.nr-data.net
+        insights-collector.<var>eu01</var>.nr-data.net
         ```
       </td>
     </tr>
@@ -239,7 +239,7 @@ If you have an EU region account, use the appropriate endpoints to access the fo
 
       <td>
         ```
-        insights-api.<mark>eu</mark>.newrelic.com
+        insights-api.<var>eu</var>.newrelic.com
         ```
       </td>
     </tr>

--- a/src/content/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api.mdx
@@ -59,7 +59,7 @@ Edit the returned link to change the format of your export (PDF or PNG), or resi
 For example, if you obtain the link:
 
 ```
-https://gorgon.nr-assets.net/image/e0c22263-2d88-40bc-940a-b885dbc1d98d?format=<mark>PDF</mark>&<mark>width=2000&height=2000</mark>
+https://gorgon.nr-assets.net/image/e0c22263-2d88-40bc-940a-b885dbc1d98d?format=<var>PDF</var>&<var>width=2000&height=2000</var>
 ```
 
 You could:

--- a/src/content/docs/apis/nerdgraph/examples/export-import-dashboards-using-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/export-import-dashboards-using-api.mdx
@@ -53,7 +53,7 @@ Use the following query to export, then extract the dashboard's entity informati
 ```
 {
   actor {
-    entity(guid: "<mark>your_guid_xxxxxxx</mark>") {
+    entity(guid: "<var>your_guid_xxxxxxx</var>") {
       ... on DashboardEntity {
         name
         permissions
@@ -86,7 +86,7 @@ Use the following mutation to import the dashboard into another account:
 
 ```
 mutation create($dashboard: DashboardInput!) {
-  dashboardCreate(accountId: <mark>your_new_AccountID</mark>, dashboard: $dashboard) {
+  dashboardCreate(accountId: <var>your_new_AccountID</var>, dashboard: $dashboard) {
     entityResult {
       guid
       name

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-api-loss-signal-gap-filling.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-api-loss-signal-gap-filling.mdx
@@ -56,9 +56,9 @@ Existing NRQL conditions may have their loss of signal settings already configur
               query
             }
             expiration {
-              <mark>closeViolationsOnExpiration</mark>
-              <mark>expirationDuration</mark>
-              <mark>openViolationOnExpiration</mark>
+              <var>closeViolationsOnExpiration</var>
+              <var>expirationDuration</var>
+              <var>openViolationOnExpiration</var>
             }
           }
         }
@@ -78,9 +78,9 @@ You should see a result like this:
         "alerts": {
           "nrqlCondition": {
             "expiration": {
-              "<mark>closeViolationsOnExpiration</mark>": false,
-              "<mark>expirationDuration</mark>": 300,
-              "<mark>openViolationOnExpiration</mark>": true
+              "<var>closeViolationsOnExpiration</var>": false,
+              "<var>expirationDuration</var>": 300,
+              "<var>openViolationOnExpiration</var>": true
             },
             "id": "<var>YOUR_ACCOUNT_ID</var>",
             "name": "Any less than - Extrapolation",
@@ -123,9 +123,9 @@ mutation {
       }]
       valueFunction: SINGLE_VALUE
       violationTimeLimitSeconds: 86400
-      <mark>expiration</mark>: {
-        <mark>expirationDuration</mark>: 120
-        <mark>openViolationOnExpiration</mark>: <var>true</var>
+      <var>expiration</var>: {
+        <var>expirationDuration</var>: 120
+        <var>openViolationOnExpiration</var>: <var>true</var>
       }
     }
   ) {
@@ -146,9 +146,9 @@ mutation {
     id: <var>YOUR_STATIC_CONDITION_ID</var>
     condition: {
       expiration: {
-        <mark>closeViolationsOnExpiration</mark>: <var>BOOLEAN</var>
-        <mark>expirationDuration</mark>: <var>DURATION_IN_SECONDS</var>
-        <mark>openViolationOnExpiration</mark>: <var>BOOLEAN</var>
+        <var>closeViolationsOnExpiration</var>: <var>BOOLEAN</var>
+        <var>expirationDuration</var>: <var>DURATION_IN_SECONDS</var>
+        <var>openViolationOnExpiration</var>: <var>BOOLEAN</var>
       }
     }
   ) {
@@ -202,8 +202,8 @@ mutation {
         aggregationWindow: 60,
         aggregationMethod: EVENT_FLOW,
         aggregationDelay: 120,
-        <mark>fillOption: STATIC,</mark>
-        <mark>fillValue: 1</mark>
+        <var>fillOption: STATIC,</var>
+        <var>fillValue: 1</var>
       }
     }
   ) {

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial.mdx
@@ -862,7 +862,7 @@ This example uses an [AWS SQS](/docs/integrations/amazon-integrations/aws-integr
         integrations: {
           aws : {
             sqs: [
-              { linkedAccountId: <<var>LINKED_CLOUD_ACCOUNT_ID</var>>, <mark>metricsPollingInterval: 300</mark> }
+              { linkedAccountId: <<var>LINKED_CLOUD_ACCOUNT_ID</var>>, <var>metricsPollingInterval: 300</var> }
             ]
           }
         }
@@ -874,7 +874,7 @@ This example uses an [AWS SQS](/docs/integrations/amazon-integrations/aws-integr
             id
             slug
           }
-          ... on <mark>SqsIntegration</mark> {
+          ... on <var>SqsIntegration</var> {
             metricsPollingInterval
           }
         }
@@ -901,11 +901,11 @@ This example uses an [AWS SQS](/docs/integrations/amazon-integrations/aws-integr
 
     ```
     mutation {
-      <mark>cloudDisableIntegration</mark> (
+      <var>cloudDisableIntegration</var> (
         accountId: <<var>NR_ACCOUNT_ID</var>>,
         integrations: {
           aws: {
-            <mark>sqs</mark>: [
+            <var>sqs</var>: [
               { linkedAccountId: <<var>LINKED_CLOUD_ACCOUNT_ID</var>> }
             ]
           }

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
@@ -79,7 +79,7 @@ The `queryBuilder` argument is useful to construct simple queries. It allows you
 ```
     {
       actor {
-        entitySearch(<mark>queryBuilder</mark>: {domain: APM, type: APPLICATION}) {
+        entitySearch(<var>queryBuilder</var>: {domain: APM, type: APPLICATION}) {
           query
           results {
             entities {
@@ -101,7 +101,7 @@ This is useful to craft more complex queries.
 2. Run a basic query to find entities that match your search criteria. For example:
 
 ```
-    query($query: <mark>String!</mark>) {
+    query($query: <var>String!</var>) {
       actor {
         entitySearch(query: $query) {
           count
@@ -207,7 +207,7 @@ Entities in NerdGraph rely on [GraphQL interfaces](/docs/apis/graphql-api/gettin
       ```
       {
         actor {
-          entitySearch(<mark>queryBuilder</mark>: {domain: APM, type: APPLICATION}) {
+          entitySearch(<var>queryBuilder</var>: {domain: APM, type: APPLICATION}) {
             query
             results {
               entities {
@@ -236,7 +236,7 @@ Entities in NerdGraph rely on [GraphQL interfaces](/docs/apis/graphql-api/gettin
       ```
       {
         actor {
-          entitySearch(queryBuilder: {<mark>infrastructureIntegrationType</mark>: F5_NODE}) {
+          entitySearch(queryBuilder: {<var>infrastructureIntegrationType</var>: F5_NODE}) {
             query
             results {
               entities {
@@ -360,9 +360,9 @@ Entities in NerdGraph rely on [GraphQL interfaces](/docs/apis/graphql-api/gettin
           results {
             entities {
               name
-              <mark>tags</mark> {
-                <mark>key</mark>
-                <mark>values</mark>
+              <var>tags</var> {
+                <var>key</var>
+                <var>values</var>
               }
             }
           }
@@ -466,7 +466,7 @@ Entities in NerdGraph rely on [GraphQL interfaces](/docs/apis/graphql-api/gettin
         actor {
           entitySearch(query: "name like '<var>nerd-graph</var>'") {
             results {
-              <mark>nextCursor</mark>
+              <var>nextCursor</var>
               entities {
                 name
               }
@@ -483,7 +483,7 @@ Entities in NerdGraph rely on [GraphQL interfaces](/docs/apis/graphql-api/gettin
         actor {
           entitySearch(query: "name like 'nerd-graph'") {
             results(cursor: "<var>next_cursor_value</var>") {
-              <mark>nextCursor</mark>
+              <var>nextCursor</var>
               entities {
                 name
               }

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial.mdx
@@ -49,7 +49,7 @@ This NerdGraph query example returns the following results:
             "nrql": {
                "results": [
                  {
-                  "count": <mark>1000</mark>
+                  "count": <var>1000</var>
                  }
                 ]
             }
@@ -70,7 +70,7 @@ In addition to returning raw data, you can fetch embeddable chart links for the 
    actor {
       account(id: <var>YOUR_ACCOUNT_ID)</var> {
          nrql(query: "<a href="/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions#state-select">SELECT</a> count(*) from <a href="/docs/insights/insights-data-sources/default-data/apm-default-event-attributes-insights#transaction-event">Transaction</a> <a href="/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions#sel-timeseries">TIMESERIES</a>") {
-            <mark>embeddedChartUrl</mark>
+            <var>embeddedChartUrl</var>
          }
       }
    }
@@ -85,7 +85,7 @@ This NerdGraph query example returns the URL for the chart in the following resp
       "actor": {
          "account": {
             "nrql": {
-               "<mark>embeddedChartUrl</mark>": "https://chart-embed.service.newrelic.com/charts/<var>EMBEDDABLE-CHART-ID</var>"
+               "<var>embeddedChartUrl</var>": "https://chart-embed.service.newrelic.com/charts/<var>EMBEDDABLE-CHART-ID</var>"
             }
          }
       }
@@ -126,7 +126,7 @@ When using NerdGraph to explore your data, you can use the `suggestedFacets` fie
        actor {
           account(id: <var>YOUR_ACCOUNT_ID</var>) {
              nrql(query: "<a href="/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions#state-select">SELECT</a> count(*) from <a href="https://docs.newrelic.com/docs/insights/insights-data-sources/default-data/apm-default-event-attributes-insights#transaction-event">Transaction</a> <a href="/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions#sel-timeseries">TIMESERIES</a>") {
-                <mark>suggestedFacets</mark> {
+                <var>suggestedFacets</var> {
                    attributes
                 }
              }
@@ -143,7 +143,7 @@ When using NerdGraph to explore your data, you can use the `suggestedFacets` fie
           "actor": {
              "account": {
                 "nrql": {
-                   "<mark>suggestedFacets</mark>": [
+                   "<var>suggestedFacets</var>": [
            	          "attributes": ["host"]
                    ]
                 }

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial.mdx
@@ -33,7 +33,7 @@ In this example, our entity is a browser app called `Cookie Checkout`:
 ```
 {
   actor {
-    <mark>entitySearch</mark>(query: "name like '<var>Cookie Checkout</var>'") {
+    <var>entitySearch</var>(query: "name like '<var>Cookie Checkout</var>'") {
       results {
         entities {
           tags {
@@ -62,7 +62,7 @@ In this example, we have a browser application called `Cookie Checkout` owned by
 
 ```
 mutation {
-    <mark>taggingAddTagsToEntity</mark>(
+    <var>taggingAddTagsToEntity</var>(
         guid: "<var>ENTITY_GUID</var>",
         tags: { key: "<var>team</var>", values: ["<var>ui</var>"]}) {
             errors {
@@ -85,7 +85,7 @@ The following example mutation removes the `team` tag from an entity:
 
 ```
 mutation {
-    <mark>taggingDeleteTagFromEntity</mark>(
+    <var>taggingDeleteTagFromEntity</var>(
         guid: "<var>ENTITY_GUID</var>",
         tagKeys: ["<var>team</var>"]) {
             errors {
@@ -107,9 +107,9 @@ The following example mutation deletes the `ui` value from the `tag` key:
 
 ```
 mutation {
-    <mark>taggingDeleteTagValuesFromEntity</mark>(
+    <var>taggingDeleteTagValuesFromEntity</var>(
         guid: "<var>ENTITY_GUID</var>",
-        <mark>tagValues</mark>: [{key: "<var>team</var>" value: "<var>ui</var>"}]) {
+        <var>tagValues</var>: [{key: "<var>team</var>" value: "<var>ui</var>"}]) {
             errors {
                 message
             }
@@ -131,7 +131,7 @@ In this example, the `Cookie Checkout` browser application was transferred from 
 
 ```
 mutation {
-    <mark>taggingReplaceTagsOnEntity</mark>(
+    <var>taggingReplaceTagsOnEntity</var>(
         guid: "<var>ENTITY_GUID</var>",
         <var>tags</var>: {key: "<var>team</var>" values: ["<var>cookie-dev</var>"]}) {
             errors {

--- a/src/content/docs/apis/rest-api-v2/basic-functions/specify-time-range-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/basic-functions/specify-time-range-v2.mdx
@@ -52,7 +52,7 @@ By default the API time input uses Universal Time Coordinated (UTC). To offset t
     ```
     curl -X GET "https://api.newrelic.com/v2/applications/<var>$APP_ID</var>/metrics/data.json" \
          -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>" -i \
-         -d 'names[]=Agent/MetricsReported/count&from=2014-08-11T14:42:00<mark>-02:00</mark>&to=2014-08-11T15:12:00<mark>-02:00</mark>'
+         -d 'names[]=Agent/MetricsReported/count&from=2014-08-11T14:42:00<var>-02:00</var>&to=2014-08-11T15:12:00<var>-02:00</var>'
     ```
   </Collapser>
 
@@ -63,7 +63,7 @@ By default the API time input uses Universal Time Coordinated (UTC). To offset t
     ```
     curl -X GET "https://api.newrelic.com/v2/applications/<var>$APP_ID</var>/metrics/data.json" \
          -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>" -i \
-         -d 'names[]=Agent/MetricsReported/count&from=2014-08-11T14:42:00<mark>%2B08:00</mark>&to=2014-08-11T15:12:00<mark>%2B08:00</mark>
+         -d 'names[]=Agent/MetricsReported/count&from=2014-08-11T14:42:00<var>%2B08:00</var>&to=2014-08-11T15:12:00<var>%2B08:00</var>
     ```
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/apis/rest-api-v2/get-started/introduction-new-relic-rest-api-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/get-started/introduction-new-relic-rest-api-v2.mdx
@@ -54,7 +54,7 @@ The <var>[$APPID](/docs/apis/rest-api-v2/requirements/finding-product-id)</var> 
 If you have an [EU region account](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center), the URL is:
 
 ```
-api.<mark>eu</mark>.newrelic.com/v2/applications/<var>$APP_ID</var>/<var>metrics/data.json</var>
+api.<var>eu</var>.newrelic.com/v2/applications/<var>$APP_ID</var>/<var>metrics/data.json</var>
 ```
 
 <Callout variant="tip">

--- a/src/content/docs/apm/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications.mdx
+++ b/src/content/docs/apm/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications.mdx
@@ -47,15 +47,15 @@ To use tokens, you first need to create the token, then link another call to the
     * Example showing multi-threaded implementation of requesting data using a parallel {@link Stream}.
     */
     @RequestMapping("parallel_stream")
-    <mark>@Trace(dispatcher = true)</mark> // starts a transaction
+    <var>@Trace(dispatcher = true)</var> // starts a transaction
     public ResponseEntity<String> parallelStream(@RequestParam("ids") List<Long> ids) {
-       final Token token = NewRelic.getAgent().getTransaction().<mark>getToken()</mark>;
+       final Token token = NewRelic.getAgent().getTransaction().<var>getToken()</var>;
        List<item> results = ids
                .parallelStream()
                .map(id -> requestItemAsync(id, token)) // requestItemAsync represents an example of work being passed to another thread. The token is passed along to allow linking the work on the new thread back to the thread that the token was originally created on.
                .filter(item -> item != null)
                .collect(Collectors.toList());
-       <mark>token.expire()</mark>;
+       <var>token.expire()</var>;
        return formattedResponse("parallel_stream", results);
     }
     ```
@@ -76,9 +76,9 @@ To use tokens, you first need to create the token, then link another call to the
     After `parallelStream()` collects all results, the token is expired. This is important because it makes sure the transaction doesn't stay open after `parallelStream()` completes.
 
     ```
-    <mark>@Trace(async = true)</mark>
+    <var>@Trace(async = true)</var>
     private Item requestItemAsync(long id, Token token) {
-       <mark>token.link()</mark>;
+       <var>token.link()</var>;
        return requestItem(id);
     }
     ```
@@ -135,7 +135,7 @@ Segments are used to measure an arbitrary piece of asynchronous application code
     * Example showing single threaded implementation of inserting data into a datasource.
     */
     @RequestMapping("insert")
-    <mark>@Trace(dispatcher = true)</mark> //starts a transaction
+    <var>@Trace(dispatcher = true)</var> //starts a transaction
     public ResponseEntity insert(@RequestParam("id") Long id) {
        if (id != null) {
            storeItem(id);
@@ -161,9 +161,9 @@ Segments are used to measure an arbitrary piece of asynchronous application code
 
     ```
     private void storeItem(long id) {
-       Segment segment = NewRelic.getAgent().getTransaction().<mark>startSegment("storeItem")</mark>;
+       Segment segment = NewRelic.getAgent().getTransaction().<var>startSegment("storeItem")</var>;
 
-       segment.<mark>reportAsExternal</mark>(DatastoreParameters
+       segment.<var>reportAsExternal</var>(DatastoreParameters
                .product("H2")
                .collection(null)
                .operation("insert")
@@ -173,7 +173,7 @@ Segments are used to measure an arbitrary piece of asynchronous application code
 
        // fire and forget
        DB_POOL.submit(() -> {
-           <mark>segment.end();</mark>
+           <var>segment.end();</var>
            insertData(id);
        });
     }

--- a/src/content/docs/apm/agents/java-agent/instrumentation/instrument-browser-monitoring-java-agent-api.mdx
+++ b/src/content/docs/apm/agents/java-agent/instrumentation/instrument-browser-monitoring-java-agent-api.mdx
@@ -79,11 +79,11 @@ If your framework does not allow you to enable browser monitoring from our UI, w
        <head><title>EXAMPLE</title>
        <meta charset="utf-8">
        <meta name="description" content="Example header and footer call">;
-       <mark><%= com.newrelic.api.agent.NewRelic.getBrowserTimingHeader() %>
-       </mark></head>​
+       <var><%= com.newrelic.api.agent.NewRelic.getBrowserTimingHeader() %>
+       </var></head>​
        <body>
 
-       <mark><%= com.newrelic.api.agent.NewRelic.getBrowserTimingFooter() %></mark>
+       <var><%= com.newrelic.api.agent.NewRelic.getBrowserTimingFooter() %></var>
        </body>
        </html>
        ```

--- a/src/content/docs/apm/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net.mdx
@@ -24,7 +24,7 @@ Extension files define a number of tracer factories in an instrumentation elemen
 1. Create a new `.xml` file in the extensions directory used by the .NET agent to read every XML file and define its instrumentation set. For the .NET Framework agent, use the following location:
 
    ```
-   C:\<mark>ProgramData</mark>\New Relic\.NET Agent\Extensions
+   C:\<var>ProgramData</var>\New Relic\.NET Agent\Extensions
    ```
 
    <Callout variant="important">
@@ -80,7 +80,7 @@ To ignore a transaction:
 2. Add a `tracerFactory` whose name is `NewRelic.Agent.Core.Tracer.Factories.IgnoreTransactionTracerFactory`:
 
 ```
-<tracerFactory name="<mark>NewRelic.Agent.Core.Tracer.Factories.IgnoreTransactionTracerFactory</mark>">
+<tracerFactory name="<var>NewRelic.Agent.Core.Tracer.Factories.IgnoreTransactionTracerFactory</var>">
   <match assemblyName="System.Web.Extensions" className="System.Web.Handlers.ScriptResourceHandler">
    <exactMethodMatcher methodName="Throw404" />
   </match>
@@ -92,7 +92,7 @@ To ignore a transaction:
 In some cases, asynchronous work can be tracked as a separate transaction by applying the `AsyncForceNewTransactionWrapper` instrumentation:
 
 ```
-<tracerFactory name="<mark>AsyncForceNewTransactionWrapper</mark>">
+<tracerFactory name="<var>AsyncForceNewTransactionWrapper</var>">
   <match assemblyName="<var>AssemblyName</var>" className="<var>Namespace.ClassName</var>">
     <exactMethodMatcher methodName="<var>MethodName</var>" />
   </match>
@@ -170,16 +170,16 @@ In some cases, asynchronous work can be tracked as a separate transaction by app
     The following methods **cannot** be instrumented using the `AsyncForceNewTransactionWrapper` custom instrumentation:
 
     ```
-    private <mark>async void</mark> AsyncMethod_Void()
+    private <var>async void</var> AsyncMethod_Void()
     {
     }
 
-    <mark>[Transaction]</mark>
+    <var>[Transaction]</var>
     private void TransactionAttributedMethod()
     {
     }
 
-    <mark>[Trace]</mark>
+    <var>[Trace]</var>
     private void TracedAttributedMethod()
     {
     }

--- a/src/content/docs/apm/agents/net-agent/custom-instrumentation/create-transactions-xml-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/custom-instrumentation/create-transactions-xml-net.mdx
@@ -44,7 +44,7 @@ To create a custom instrumentation file:
        title="For the .NET Framework or Core agent on Windows"
      >
        ```
-       C:\<mark>ProgramData</mark>\New Relic\.NET Agent\Extensions
+       C:\<var>ProgramData</var>\New Relic\.NET Agent\Extensions
        ```
 
        <Callout variant="important">

--- a/src/content/docs/apm/agents/net-agent/installation/install-net-agent-windows.mdx
+++ b/src/content/docs/apm/agents/net-agent/installation/install-net-agent-windows.mdx
@@ -202,8 +202,8 @@ Enable the agent for your application with one of the following methods:
     <?xml version="1.0" encoding="utf-8"?>
     <configuration>
       <appSettings>
-        <mark><add key="NewRelic.AgentEnabled" value="true" /></mark>
-        <mark><add key="NewRelic.AppName" value="DataServices" /></mark>
+        <var><add key="NewRelic.AgentEnabled" value="true" /></var>
+        <var><add key="NewRelic.AppName" value="DataServices" /></var>
       </appSettings>
     ```
   </Collapser>
@@ -239,7 +239,7 @@ Enable the agent for your application with one of the following methods:
 
       ```
       <configuration xmlns="urn:newrelic-config"
-        <mark>agentEnabled="true"></mark>
+        <var>agentEnabled="true"></var>
       ```
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-docker.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-docker.mdx
@@ -49,7 +49,7 @@ In addition to setting your application name or license key, you can set [other 
 ```
 $ docker run -e NEW_RELIC_LICENSE_KEY=<var>YOUR_LICENSE_KEY</var> \
         -e NEW_RELIC_APP_NAME="<var>Your Application Name</var>" \
-        <mark>-e NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true</mark> \
+        <var>-e NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true</var> \
         <var>your_image_name:latest</var>
 ```
 

--- a/src/content/docs/apm/agents/ruby-agent/attributes/enable-disable-attributes-ruby.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/attributes/enable-disable-attributes-ruby.mdx
@@ -1086,7 +1086,7 @@ New Relic recommends having these URIs reported, as they can contain useful debu
 For example, if you adding the following key to your configuration file will stop the agent from reporting any of the URI-related properties:
 
 ```
-attributes.exclude: <mark>uri</mark>
+attributes.exclude: <var>uri</var>
 ```
 
 ## Deprecated properties [#deprecated]

--- a/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
+++ b/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
@@ -347,7 +347,7 @@ Here are some sample queries for the event data to help you get started.
     Show the 95th percentile of first paint and first contentful paint over a time series:
 
     ```
-    SELECT FILTER(percentile(firstPaint, 95), where(timingName = '<mark>firstPaint</mark>')) as 'fp', FILTER(percentile(<mark>firstContentfulPaint</mark>, 95), where(timingName = 'firstContentfulPaint')) as 'fcp' FROM PageViewTiming TIMESERIES 1 minute SINCE 1 hour ago
+    SELECT FILTER(percentile(firstPaint, 95), where(timingName = '<var>firstPaint</var>')) as 'fp', FILTER(percentile(<var>firstContentfulPaint</var>, 95), where(timingName = 'firstContentfulPaint')) as 'fcp' FROM PageViewTiming TIMESERIES 1 minute SINCE 1 hour ago
     ```
   </Collapser>
 
@@ -358,7 +358,7 @@ Here are some sample queries for the event data to help you get started.
     Show the 95th percentile of first input delay over a time series, faceted by transaction name and interaction type:
 
     ```
-    SELECT percentile(<mark>firstInputDelay</mark>, 95) as 'fid' FROM PageViewTiming WHERE timingName = 'firstInteraction' TIMESERIES 1 minute FACET browserTransactionName, interactionType SINCE 3 hours ago
+    SELECT percentile(<var>firstInputDelay</var>, 95) as 'fid' FROM PageViewTiming WHERE timingName = 'firstInteraction' TIMESERIES 1 minute FACET browserTransactionName, interactionType SINCE 3 hours ago
     ```
   </Collapser>
 
@@ -369,7 +369,7 @@ Here are some sample queries for the event data to help you get started.
     Show a histogram of first input delay timings faceted by first interaction time ranges:
 
     ```
-    FROM PageViewTiming SELECT histogram(<mark>firstInputDelay</mark>, 1000, 10) SINCE 3 hours ago WHERE timingName = 'firstInteraction' FACET CASES (WHERE firstInteraction < 1, WHERE firstInteraction >= 1 AND firstInteraction < 5, WHERE firstInteraction >= 5)
+    FROM PageViewTiming SELECT histogram(<var>firstInputDelay</var>, 1000, 10) SINCE 3 hours ago WHERE timingName = 'firstInteraction' FACET CASES (WHERE firstInteraction < 1, WHERE firstInteraction >= 1 AND firstInteraction < 5, WHERE firstInteraction >= 5)
     ```
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/data-apis/convert-to-metrics/create-metrics-other-data-types.mdx
+++ b/src/content/docs/data-apis/convert-to-metrics/create-metrics-other-data-types.mdx
@@ -47,7 +47,7 @@ The most important part of [creating a metrics rule](#overview-process) is const
      This example query uses `average`, so use `summary`:
 
      ```
-     FROM ProcessSample SELECT <mark>summary</mark>(ioTotalReadBytes) 
+     FROM ProcessSample SELECT <var>summary</var>(ioTotalReadBytes) 
      WHERE nr.entityType = 'HOST'
      ```
 
@@ -61,7 +61,7 @@ The most important part of [creating a metrics rule](#overview-process) is const
      For `summary` on a non-numeric field use `summary(1)`:
 
      ```
-     FROM ProcessSample SELECT <mark>summary(1)</mark> 
+     FROM ProcessSample SELECT <var>summary(1)</var> 
      WHERE hostname LIKE '%prod%'
      ```
 
@@ -85,7 +85,7 @@ The most important part of [creating a metrics rule](#overview-process) is const
    ```
    FROM ProcessSample
    SELECT summary(ioTotalReadBytes) WHERE nr.entityType = 'HOST' 
-   <mark>FACET awsRegion, awsAvailabilityZone, commandName</mark>
+   <var>FACET awsRegion, awsAvailabilityZone, commandName</var>
    ```
 
 5. Set the [name of the metric](#naming) using the `AS` function. For example:

--- a/src/content/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes.mdx
@@ -413,14 +413,14 @@ Additional restrictions include:
           {
             "metrics": [
               {
-                "name": <mark>"service.errors.all"</mark>,
+                "name": <var>"service.errors.all"</var>,
                 "type": "count",
                 "value": 15,
                 "timestamp": 1531414060739,
                 "interval.ms": 10000,
                 "attributes": {
                   "service.response.statuscode": "400",
-                  <mark>"service.errors.all"</mark>: "test",
+                  <var>"service.errors.all"</var>: "test",
                   "service.name": "foo"
                 }
               }

--- a/src/content/docs/data-apis/understand-data/metric-data/query-metric-data-type.mdx
+++ b/src/content/docs/data-apis/understand-data/metric-data/query-metric-data-type.mdx
@@ -31,7 +31,7 @@ You can use [NRQL](/docs/query-data/nrql-new-relic-query-language/getting-starte
 To query a metric, use the following query format:
 
 ```
-FROM <mark>Metric</mark> SELECT <var>function</var>(<var>metric_name</var>) WHERE <var>attribute</var>=<var>value</var> FACET <var>attribute</var> TIMESERIES
+FROM <var>Metric</var> SELECT <var>function</var>(<var>metric_name</var>) WHERE <var>attribute</var>=<var>value</var> FACET <var>attribute</var> TIMESERIES
 ```
 
 Below are the functions supported for each [metric type](/docs/report-metrics-metric-api#payload-metrics):
@@ -177,7 +177,7 @@ The previous examples demonstrate basic forms of metric queries, but NRQL can al
     This example shows how to list the last 20 data points received for a particular metric:
 
     ```
-    FROM Metric SELECT * WHERE metricName = 'container_fs_usage_bytes' LIMIT 20 <mark>RAW</mark>
+    FROM Metric SELECT * WHERE metricName = 'container_fs_usage_bytes' LIMIT 20 <var>RAW</var>
     ```
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
@@ -532,7 +532,7 @@ You can add tags to your data, which we save as [attributes](/docs/using-new-rel
       -h $(hostname) \
       -e NR_ACCOUNT_ID=<var>YOUR_ACCOUNT_ID</var> \
       -e NR_API_KEY=<var>NEW_RELIC_LICENSE_KEY</var> \
-    <mark>  -e TAGS="environment:production region:us" \ </mark>
+    <var>  -e TAGS="environment:production region:us" \ </var>
       -p 8125:8125/udp \
       newrelic/nri-statsd:latest
     ```

--- a/src/content/docs/infrastructure/host-integrations/installation/container-auto-discovery-host-integrations.mdx
+++ b/src/content/docs/infrastructure/host-integrations/installation/container-auto-discovery-host-integrations.mdx
@@ -79,7 +79,7 @@ These examples (for Docker-only environments and for Kubernetes) show how to con
           ---
           discovery:
             command:
-              # Run discovery for Kubernetes. Use the following <mark>optional arguments</mark>:
+              # Run discovery for Kubernetes. Use the following <var>optional arguments</var>:
               # --namespaces: Comma separated list of namespaces to discover pods on
               # --tls: Use secure (TLS) connection
               # --port: Port used to connect to the kubelet.

--- a/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations.mdx
@@ -51,11 +51,11 @@ The response should look similar to the response below. The subscription `id` an
 @Azure:~$ az account show
 {
   "environmentName": "AzureCloud",
-  "id": <mark>"9ffe9512-f4a2-42dd-1230-518aec34be21"</mark>,
+  "id": <var>"9ffe9512-f4a2-42dd-1230-518aec34be21"</var>,
   "isDefault": true,
   "name": "Beyond Team Sandbox",
   "state": "Enabled",
-  "tenantId": <mark>"ac6692da-1231-422f-22a8-9eed6dbe83f1"</mark>,
+  "tenantId": <var>"ac6692da-1231-422f-22a8-9eed6dbe83f1"</var>,
   "user": {
     "name": "youremail@domain",
     "type": "user"

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-openmetrics/install-update-or-uninstall-your-prometheus-openmetrics-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-openmetrics/install-update-or-uninstall-your-prometheus-openmetrics-integration.mdx
@@ -80,7 +80,7 @@ docker logs nri-prometheus 2>&1 | grep "Integration version"
 Example output:
 
 ```
-time="2019-02-26T09:21:21Z" level=info msg="Starting New Relic's Prometheus OpenMetrics Integration version <mark>1.0.0</mark>"
+time="2019-02-26T09:21:21Z" level=info msg="Starting New Relic's Prometheus OpenMetrics Integration version <var>1.0.0</var>"
 ```
 
 ### Uninstall [#docker-uninstall]

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-apm-applications-kubernetes.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-apm-applications-kubernetes.mdx
@@ -46,7 +46,7 @@ kubectl auth can-i create mutatingwebhookconfigurations.admissionregistration.k8
 The output for the command above should be something similar to:
 
 ```
-<mark>yes</mark>
+<var>yes</var>
 ```
 
 If you see a different result, follow the Kubernetes documentation to [enable admission control in your cluster](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#how-do-i-turn-on-an-admission-controller).
@@ -189,11 +189,11 @@ openssl x509 -in <var>CA_BUNDLE_FILENAME</var> -outform PEM -out <var>BUNDLE_FIL
 Create the TLS secret with the signed certificate/key pair, and patch the mutating webhook configuration with the CA using the following commands:
 
 ```
-kubectl create secret tls <mark>newrelic-metadata-injection-admission</mark> \
+kubectl create secret tls <var>newrelic-metadata-injection-admission</var> \
 --key=<var>PEM_ENCODED_SERVER_KEY</var> \
 --cert=<var>PEM_ENCODED_CERTIFICATE</var> \
 --dry-run -o yaml |
-kubectl -n <mark>newrelic</mark> apply -f -
+kubectl -n <var>newrelic</var> apply -f -
 
 caBundle=$(cat <var>PEM_ENCODED_CA_BUNDLE</var> | base64 | td -d $'\n')
 kubectl patch mutatingwebhookconfiguration newrelic-metadata-injection-cfg --type='json' -p "[{'op': 'replace', 'path': '/webhooks/0/clientConfig/caBundle', 'value':'${caBundle}'}]"

--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -737,7 +737,7 @@ The following configuration parameters are not required but are still recommende
     ```
     - name: only-records-with-warn-and-error
       file: /var/log/logFile.log
-      <mark>pattern: WARN|ERROR</mark>
+      <var>pattern: WARN|ERROR</var>
     ```
 
     No filtering is applied by default.
@@ -805,16 +805,16 @@ Here is an example of a `logging.d/` configuration file in YAML format. For more
       # TCP network socket
       - name: syslog-tcp-test
         syslog:
-          uri: tcp://0.0.0.0:5140 # Use the <mark>tcp://LISTEN_ADDRESS:PORT</mark> format
+          uri: tcp://0.0.0.0:5140 # Use the <var>tcp://LISTEN_ADDRESS:PORT</var> format
           parser: rfc5424 # Default syslog parser is rfc3164
       # UDP network socket
       - name: syslog-udp-test
         syslog:
-          uri: udp://0.0.0.0:6140 # Use the <mark>udp://LISTEN_ADDRESS:PORT</mark> format
+          uri: udp://0.0.0.0:6140 # Use the <var>udp://LISTEN_ADDRESS:PORT</var> format
         max_line_kb: 35
 
       # Paths for Unix sockets are defined by combining protocol and path:
-      # unix_udp:// + /path/socket - for example, <mark>unix_udp:///tmp/socket</mark>
+      # unix_udp:// + /path/socket - for example, <var>unix_udp:///tmp/socket</var>
       # Unix TCP domain socket
       - name: syslog-unix-tcp-test
         syslog:
@@ -829,7 +829,7 @@ Here is an example of a `logging.d/` configuration file in YAML format. For more
       # Examples of 'tcp' source for formats 'none' and 'json'
       - name: tcp-simple-test
         tcp:
-          uri: tcp://0.0.0.0:1234 # Use the <mark>tcp://LISTEN_ADDRESS:PORT</mark> format
+          uri: tcp://0.0.0.0:1234 # Use the <var>tcp://LISTEN_ADDRESS:PORT</var> format
           format: none # Raw text - this is default for 'tcp'
           separator: \t # String for separating raw text entries
         attributes: # You can add custom attributes to any source of logs
@@ -838,7 +838,7 @@ Here is an example of a `logging.d/` configuration file in YAML format. For more
         max_line_kb: 32
       - name: tcp-json-test
         tcp:
-          uri: tcp://0.0.0.0:2345 # Use the <mark>tcp://LISTEN_ADDRESS:PORT</mark> format
+          uri: tcp://0.0.0.0:2345 # Use the <var>tcp://LISTEN_ADDRESS:PORT</var> format
           format: json
         attributes:
           tcpFormat: json
@@ -1057,7 +1057,7 @@ If you encounter problems with configuring your log forwarder, try these trouble
     One of the following error messages may appear when enabling log forwarding on Windows:
 
     ```
-    The code execution cannot proceed because <mark>VCRUNTIME140.dll</mark> was not found.
+    The code execution cannot proceed because <var>VCRUNTIME140.dll</var> was not found.
     ```
 
     OR

--- a/src/content/docs/logs/logs-context/java-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/java-configure-logs-context-all.mdx
@@ -141,7 +141,7 @@ If you are using a different logging framework, our [manual logs in context](#en
       enabled: true
       forwarding:
         enabled: true
-          <mark>max_samples_stored: 10000</mark>
+          <var>max_samples_stored: 10000</var>
       local_decorating: 
         enabled: false
     ```
@@ -151,7 +151,7 @@ If you are using a different logging framework, our [manual logs in context](#en
     ```
     NEW_RELIC_APPLICATION_LOGGING_ENABLED=true
     NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=true
-    <mark>NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED=10000</mark>
+    <var>NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED=10000</var>
     NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED=false
     ```
 
@@ -160,7 +160,7 @@ If you are using a different logging framework, our [manual logs in context](#en
     ```
     -Dnewrelic.config.application_logging.enabled=true
     -Dnewrelic.config.application_logging.forwarding.enabled=true
-    <mark>-Dnewrelic.config.application_logging.forwarding.max_samples_stored=10000</mark>
+    <var>-Dnewrelic.config.application_logging.forwarding.max_samples_stored=10000</var>
     -Dnewrelic.config.application_logging.local_decorating.enabled=false
     ```
 
@@ -449,19 +449,19 @@ If you need to use the manual process to set up logs in context for Java, follow
     4. In your logging configuration XML file, update your `<appender>` element with a `NewRelicLayout`, adding `<layout class="com.newrelic.logging.log4j1.NewRelicLayout"/>`:
 
        ```
-       <appender name="<mark>TypicalFile</mark>" class="org.apache.log4j.FileAppender">
+       <appender name="<var>TypicalFile</var>" class="org.apache.log4j.FileAppender">
          <param name="file" value="logs/log4j1-app.log"/>
          <param name="append" value="false"/>
-         <layout class="<mark>com.newrelic.logging.log4j1.NewRelicLayout</mark>"/> <!-- only this line needs to be added -->
+         <layout class="<var>com.newrelic.logging.log4j1.NewRelicLayout</var>"/> <!-- only this line needs to be added -->
        </appender>
        ```
 
     5. Use `NewRelicAsyncAppender` to wrap any appenders that will target New Relic's log forwarder. For example:
 
        ```
-       <appender name="<mark>NewRelicFile</mark>" 
+       <appender name="<var>NewRelicFile</var>" 
                  class="com.newrelic.logging.log4j1.NewRelicAsyncAppender">
-         <appender-ref ref="<mark>TypicalFile</mark>" />
+         <appender-ref ref="<var>TypicalFile</var>" />
        </appender>
        ```
 
@@ -469,7 +469,7 @@ If you need to use the manual process to set up logs in context for Java, follow
 
        ```
        <root>
-           <appender-ref ref="<mark>NewRelicFile</mark>" />
+           <appender-ref ref="<var>NewRelicFile</var>" />
        </root>
        ```
 
@@ -482,15 +482,15 @@ If you need to use the manual process to set up logs in context for Java, follow
          <appender name="TypicalFile" class="org.apache.log4j.FileAppender">
              <param name="file" value="logs/log4j1-app.log"/>
              <param name="append" value="false"/>
-             <mark><!-- layout has been replaced --></mark>
-             <mark><layout class="com.newrelic.logging.log4j1.NewRelicLayout"/></mark>
+             <var><!-- layout has been replaced --></var>
+             <var><layout class="com.newrelic.logging.log4j1.NewRelicLayout"/></var>
          </appender>
 
-       <mark>    <!-- this appender was added -->
+       <var>    <!-- this appender was added -->
          <appender name="NewRelicFile" 
                    class="com.newrelic.logging.log4j1.NewRelicAsyncAppender">
              <appender-ref ref="TypicalFile" />
-         </appender></mark>
+         </appender></var>
 
          <appender name="TypicalConsole" class="org.apache.log4j.ConsoleAppender">
            <layout class="org.apache.log4j.PatternLayout"> 
@@ -499,8 +499,8 @@ If you need to use the manual process to set up logs in context for Java, follow
          </appender>
 
          <root>        ​
-             <mark><!-- the new appender was used here -->​​</mark>
-             <mark><appender-ref ref="NewRelicFile" /></mark>
+             <var><!-- the new appender was used here -->​​</var>
+             <var><appender-ref ref="NewRelicFile" /></var>
              <appender-ref ref="TypicalConsole" />
          </root>
 
@@ -530,7 +530,7 @@ If you need to use the manual process to set up logs in context for Java, follow
 
        ```
        dependencies {
-           <mark>implementation("com.newrelic.logging:log4j2:2.0")</mark>
+           <var>implementation("com.newrelic.logging:log4j2:2.0")</var>
        }
        ```
 
@@ -538,11 +538,11 @@ If you need to use the manual process to set up logs in context for Java, follow
 
        ```
        <dependencies>
-       <mark>  <dependency>
+       <var>  <dependency>
                  <groupId>com.newrelic.logging</groupId>
                  <artifactId>log4j2</artifactId>
                  <version>2.0</version>
-               </dependency></mark>
+               </dependency></var>
        </dependencies>
        ```
 
@@ -550,7 +550,7 @@ If you need to use the manual process to set up logs in context for Java, follow
 
        ```
        <Configuration xmlns="http://logging.apache.org/log4j/2.0/config"
-             <mark>packages="com.newrelic.logging.log4j2"</mark>
+             <var>packages="com.newrelic.logging.log4j2"</var>
        >
        ```
 
@@ -560,7 +560,7 @@ If you need to use the manual process to set up logs in context for Java, follow
 
        ```
        <File name="MyFile" fileName="logs/app-log-file.log">
-           <mark><NewRelicLayout/></mark>
+           <var><NewRelicLayout/></var>
        </File>
        ```
 
@@ -569,14 +569,14 @@ If you need to use the manual process to set up logs in context for Java, follow
        ```
        appender.console.type = Console
        appender.console.name = STDOUT
-       <mark>appender.console.layout.type = NewRelicLayout</mark>
+       <var>appender.console.layout.type = NewRelicLayout</var>
        ```
 
     6. If you only modified an existing appender, skip this step. If you added a new appender, add `<AppenderRef/>` within `<Root>` to use this appender. Use the `ref` attribute to refer to appender `name` you created in the previous step. For example:
 
        ```
        <Root level="info">
-           <mark><AppenderRef ref="MyFile"/></mark>
+           <var><AppenderRef ref="MyFile"/></var>
 
        </Root>
        ```
@@ -585,7 +585,7 @@ If you need to use the manual process to set up logs in context for Java, follow
 
        ```
        rootLogger.level = info
-           <mark>rootLogger.appenderRef.stdout.ref = STDOUT</mark>
+           <var>rootLogger.appenderRef.stdout.ref = STDOUT</var>
        ​​​​​
        ```
   </Collapser>
@@ -612,7 +612,7 @@ If you need to use the manual process to set up logs in context for Java, follow
 
        ```
        dependencies {
-           <mark>implementation("com.newrelic.logging:logback:2.0")</mark>
+           <var>implementation("com.newrelic.logging:logback:2.0")</var>
        }
        ```
 
@@ -620,11 +620,11 @@ If you need to use the manual process to set up logs in context for Java, follow
 
        ```
        <dependencies>
-       <mark>  <dependency>
+       <var>  <dependency>
                  <groupId>com.newrelic.logging</groupId>
                  <artifactId>logback</artifactId>
                  <version>2.0</version>
-               </dependency></mark>
+               </dependency></var>
        </dependencies>
        ```
 

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/find-build-uuids-unsymbolicated-crashes.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/find-build-uuids-unsymbolicated-crashes.mdx
@@ -42,7 +42,7 @@ In this example, the main application is `New Relic`. Its Build UUID is `117667e
 
 ```
 Binary Images:
-0xb1000 - 0x30d000 <mark>New Relic</mark> armv7 <<mark>117667e7b8d230cb8a908906c64e0227</mark>> /var/containers/Bundle/Application/New Relic.app/New Relic
+0xb1000 - 0x30d000 <var>New Relic</var> armv7 <<var>117667e7b8d230cb8a908906c64e0227</var>> /var/containers/Bundle/Application/New Relic.app/New Relic
 0x22290000 - 0x22292000 libSystem.B.dylib armv7 <39d6d6f7c2ac3de8bb29c40a1b66368a> /usr/lib/libSystem.B.dylib
 0x22292000 - 0x222de000 libc++.1.dylib armv7 <017dba6c16b63f9ebecb9ddd0d0a4520> /usr/lib/libc++.1.dylib
 0x222de000 - 0x222f9000 libc++abi.dylib armv7 <d32373f6c2153a509f6603750d213ffb> /usr/lib/libc++abi.dylib

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags.mdx
@@ -20,8 +20,8 @@ All settings, including the call to invoke the agent, are called in the `onCreat
 * Change the setting on its own line for each specific condition:
 
   ```
-  NewRelic.<mark>disableFeature(FeatureFlag.DefaultInteractions)</mark>;
-  NewRelic.<mark>enableFeature(FeatureFlag.CrashReporting)</mark>;
+  NewRelic.<var>disableFeature(FeatureFlag.DefaultInteractions)</var>;
+  NewRelic.<var>enableFeature(FeatureFlag.CrashReporting)</var>;
   NewRelic.withApplicationToken(<NEW_RELIC_TOKEN>).start(this.getApplication());
   ```
 
@@ -30,8 +30,8 @@ All settings, including the call to invoke the agent, are called in the `onCreat
 
   ```
   NewRelic.withApplicationToken(<NEW_RELIC_TOKEN>)
-          <mark>.withDefaultInteractions(false)</mark>
-          <mark>.withCrashReportingEnabled(true)</mark>
+          <var>.withDefaultInteractions(false)</var>
+          <var>.withCrashReportingEnabled(true)</var>
           .start(this.getApplication());
   ```
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-device-id-obfuscation.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-device-id-obfuscation.mdx
@@ -35,11 +35,11 @@ This can be added in your `AppDelegate.h` after `#include <NewRelic/NewRelic.h>`
 
 #import "AppDelegate.h"
 #import <NewRelic/NewRelic.h>
-<mark>
+<var>
 @interface NewRelic (salt) 
   + (void) saltDeviceUUID:(BOOL)enabled;
 @end
-</mark>
+</var>
 @implementation AppDelegate
 // code 
 @end
@@ -66,7 +66,7 @@ Next, call `[NewRelic saltDeviceUUID:YES];` before your `[NewRelic startWithAppl
 
 @implementation AppDelegate
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-  <mark>[NewRelic saltDeviceUUID:YES];</mark>
+  <var>[NewRelic saltDeviceUUID:YES];</var>
   [NewRelic startWithApplicationToken:@"MY_TOKEN"];
 
   ...

--- a/src/content/docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-java.mdx
+++ b/src/content/docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-java.mdx
@@ -32,7 +32,7 @@ The New Relic Java agent only auto-instruments pages compiled with the Apache Ja
 <html>
 <head>
 <meta charset="utf-8">
-<mark><%= com.newrelic.api.agent.NewRelic.getBrowserTimingHeader() %></mark>
+<var><%= com.newrelic.api.agent.NewRelic.getBrowserTimingHeader() %></var>
  . . .
 </head>
 ```
@@ -44,7 +44,7 @@ The `X-UA-Compatible` meta tag should be within the meta tags immediately after 
 <html>
 <head>
 <meta http-equiv="X-UA-Compatible" content="IE=9">
-<mark><%= com.newrelic.api.agent.NewRelic.getBrowserTimingHeader() %></mark>
+<var><%= com.newrelic.api.agent.NewRelic.getBrowserTimingHeader() %></var>
  . . .
 </head>
 ```

--- a/src/content/docs/style-guide/formatting/code-examples.mdx
+++ b/src/content/docs/style-guide/formatting/code-examples.mdx
@@ -183,44 +183,10 @@ Follow these guidelines when you use `<var>` tags:
 * Use all caps and underscores `_` to separate words (also known as [SCREAMING_SNAKE_CASE](https://github.com/rubocop-hq/ruby-style-guide#screaming-snake-case)).
 * Don't combine them with other punctuation to indicate variables (such as wrapping the text in angle brackets or curly braces).
 * Don't overuse them. For example, if you're showing a complete config file where the user is expected to customize many values, a `<var>` tag on each configurable value is overkill.
-
-Do **not** use a `<var>` tag for:
-
-* Example code: If the code is meant to be an example, to show the format of the code, and there is not an actual procedure the customer is following, var tags are not needed. A couple reasons for this: 1) The important part of showing an example config file is to show the overall structure of the file, 2) Usually the number of config options present in a file will vary based on whatever the customer wishes to use, so using `<var>` tags can actually be confusing as it implies that these values must be present. Examples:
-  * [Example configuration file](/docs/integrations/host-integrations/host-integrations-list/oracledb-monitoring-integration#example-config) (or this [Java agent config template](/docs/agents/java-agent/configuration/java-agent-config-file-template)): if you are showing an example config file that isn't part of a procedure, you shouldn't use the `<var>` tag.
-  * [Instrumentation procedure](/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-new-relic-monitoring-aws-lambda#java) (at bottom of the Java section): the var tag wouldn't be necessary because it's an example, not part of a procedure, and the main goal is seeing the general structure. Also, because it's an example of app code, the concept of user-specific values doesn't have much meaning, because the entire code will vary dependent on how the customer has written their code. (If anything, this would be a potential for using [`<var>` format](#highlighting) to emphasize the New Relic functions.)
-* Response/output code: If the code is meant to show an expected return, and is not related to a procedure, then var tags shouldn't be used. Here's [a doc section](/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api#get-all-monitors) (the returned JSON) where var tags are not needed.
-
-For some use cases, [highlighting](#annotate-mark) may be a better choice than a `var` tag.
-
-<CollapserGroup>
-  <Collapser
-    id="var-tag-examples"
-    title="Examples of `<var>` tag use"
-  >
-    Below are some general style recommendations for formatting user-specific `<var>` values. `<var>` tag formatting may vary based on language- or system-specific expectations, so be sure check the style used in the documentation section in question, and to ask relevant SMEs what they think of the style.
-
-    * Account IDs and other IDs/#s: `<var>YOUR_ACCOUNT_ID</var>`, `<var>YOUR_API_KEY</var>`, etc. **This should be the general style used.**
-    * URLs: [example.com](https://example.com), or maybe <var>`YOUR_URL`</var>
-    * Paths: `<var>PATH/TO/SOMETHING.exe</var>` or maybe `<var>PATH_TO_FILE</var>`
-    * Emails: [datanerd@example.com](mailto:datanerd@example.com) or maybe `<var>YOUR_EMAIL</var>`
-    * Bash variables for REST API code: Some `<var>` tagged code values on the docs site have the form $&#x7B;API_KEY}. This is a format used for variables in bash scripts, where users assign values to specific variable names and then call those variables later in the script by using the $VARIABLE_NAME. For more info, see this [explanation of bash variables](http://tldp.org/HOWTO/Bash-Prog-Intro-HOWTO-5.html).
-
-      <Callout variant="important">
-        The bash variable style is currently used in the REST API docs, and in some Synthetics docs. However, going forward we should use the general variable style, without the $ and `&lt;` >.
-      </Callout>
-  </Collapser>
-</CollapserGroup>
-
-## Highlight a code section with `<var>` [#annotate-mark]
-
-Use the `<var>` tag to highlight areas of a code block that are particularly important but not directly procedural-related. Most commonly, `<var>` is used to highlight New Relic API methods in sample code that contains a lot of "other logic." They're also handy when you want to indicate a bit of code that will be referenced later in a procedure or doc.
-
-Here are two examples of highlighting:
-
-* Highlighting values in code response that are meant for later use: [Activate Azure integrations doc](/docs/infrastructure/microsoft-azure-integrations/getting-started/activate-azure-integrations#get-ids).
-* Highlighting the commands in a large code block example that are New Relic-specific commands, with explanations below: [Java API doc](/docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications#use-gettoken).
-
+* Highlight areas of a code block that are particularly important but not directly procedural-related. Most commonly, `<var>` is used to highlight New Relic API methods in sample code that contains a lot of "other logic." They're also handy when you want to indicate a bit of code that will be referenced later in a procedure or doc. Examples:
+    * Highlighting values in code response that are meant for later use: [Activate Azure integrations doc](/docs/infrastructure/microsoft-azure-integrations/getting-started/activate-azure-integrations#get-ids).
+    * Highlighting the commands in a large code block example that are New Relic-specific commands, with explanations below: [Java API doc](/docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications#use-gettoken).
+    
 When you use `<var>`, you should usually follow the code block with a list of bullets that explain what each API call is doing and link to method syntax.
 
 <CollapserGroup>
@@ -253,5 +219,33 @@ When you use `<var>`, you should usually follow the code block with a list of bu
     * `startSegment(...)`: Begins the segment that will time the code. For method syntax, see the [Javadoc](https://example.com).
     * `reportAsExternal(DatastoreParameters())`: Associates the time with a datastore external call This will show up in APM with [datastore data](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues). For more information, see [reportAsExternal API](http://newrelic.github.io/java-agent-api/javadoc/index.html?com/newrelic/api/agent/TracedMethod.html). For method syntax, see the [Javadoc](https://example.com).
     * `segment.end()`: Stops timing this segment. For method syntax, see the [Javadoc](https://example.com).
+  </Collapser>
+</CollapserGroup>
+
+Do **not** use a `<var>` tag for:
+
+* Example code: If the code is meant to be an example, to show the format of the code, and there is not an actual procedure the customer is following, var tags are not needed. A couple reasons for this: 1) The important part of showing an example config file is to show the overall structure of the file, 2) Usually the number of config options present in a file will vary based on whatever the customer wishes to use, so using `<var>` tags can actually be confusing as it implies that these values must be present. Examples:
+  * [Example configuration file](/docs/integrations/host-integrations/host-integrations-list/oracledb-monitoring-integration#example-config) (or this [Java agent config template](/docs/agents/java-agent/configuration/java-agent-config-file-template)): if you are showing an example config file that isn't part of a procedure, you shouldn't use the `<var>` tag.
+  * [Instrumentation procedure](/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-new-relic-monitoring-aws-lambda#java) (at bottom of the Java section): the var tag wouldn't be necessary because it's an example, not part of a procedure, and the main goal is seeing the general structure. Also, because it's an example of app code, the concept of user-specific values doesn't have much meaning, because the entire code will vary dependent on how the customer has written their code. (If anything, this would be a potential for using [`<var>` format](#highlighting) to emphasize the New Relic functions.)
+* Response/output code: If the code is meant to show an expected return, and is not related to a procedure, then var tags shouldn't be used. Here's [a doc section](/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api#get-all-monitors) (the returned JSON) where var tags are not needed.
+
+For some use cases, [highlighting](#annotate-mark) may be a better choice than a `var` tag.
+
+<CollapserGroup>
+  <Collapser
+    id="var-tag-examples"
+    title="Examples of `<var>` tag use"
+  >
+    Below are some general style recommendations for formatting user-specific `<var>` values. `<var>` tag formatting may vary based on language- or system-specific expectations, so be sure check the style used in the documentation section in question, and to ask relevant SMEs what they think of the style.
+
+    * Account IDs and other IDs/#s: `<var>YOUR_ACCOUNT_ID</var>`, `<var>YOUR_API_KEY</var>`, etc. **This should be the general style used.**
+    * URLs: [example.com](https://example.com), or maybe <var>`YOUR_URL`</var>
+    * Paths: `<var>PATH/TO/SOMETHING.exe</var>` or maybe `<var>PATH_TO_FILE</var>`
+    * Emails: [datanerd@example.com](mailto:datanerd@example.com) or maybe `<var>YOUR_EMAIL</var>`
+    * Bash variables for REST API code: Some `<var>` tagged code values on the docs site have the form $&#x7B;API_KEY}. This is a format used for variables in bash scripts, where users assign values to specific variable names and then call those variables later in the script by using the $VARIABLE_NAME. For more info, see this [explanation of bash variables](http://tldp.org/HOWTO/Bash-Prog-Intro-HOWTO-5.html).
+
+      <Callout variant="important">
+        The bash variable style is currently used in the REST API docs, and in some Synthetics docs. However, going forward we should use the general variable style, without the $ and `&lt;` >.
+      </Callout>
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/style-guide/formatting/code-examples.mdx
+++ b/src/content/docs/style-guide/formatting/code-examples.mdx
@@ -188,7 +188,7 @@ Do **not** use a `<var>` tag for:
 
 * Example code: If the code is meant to be an example, to show the format of the code, and there is not an actual procedure the customer is following, var tags are not needed. A couple reasons for this: 1) The important part of showing an example config file is to show the overall structure of the file, 2) Usually the number of config options present in a file will vary based on whatever the customer wishes to use, so using `<var>` tags can actually be confusing as it implies that these values must be present. Examples:
   * [Example configuration file](/docs/integrations/host-integrations/host-integrations-list/oracledb-monitoring-integration#example-config) (or this [Java agent config template](/docs/agents/java-agent/configuration/java-agent-config-file-template)): if you are showing an example config file that isn't part of a procedure, you shouldn't use the `<var>` tag.
-  * [Instrumentation procedure](/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-new-relic-monitoring-aws-lambda#java) (at bottom of the Java section): the var tag wouldn't be necessary because it's an example, not part of a procedure, and the main goal is seeing the general structure. Also, because it's an example of app code, the concept of user-specific values doesn't have much meaning, because the entire code will vary dependent on how the customer has written their code. (If anything, this would be a potential for using [`<mark>` format](#highlighting) to emphasize the New Relic functions.)
+  * [Instrumentation procedure](/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-new-relic-monitoring-aws-lambda#java) (at bottom of the Java section): the var tag wouldn't be necessary because it's an example, not part of a procedure, and the main goal is seeing the general structure. Also, because it's an example of app code, the concept of user-specific values doesn't have much meaning, because the entire code will vary dependent on how the customer has written their code. (If anything, this would be a potential for using [`<var>` format](#highlighting) to emphasize the New Relic functions.)
 * Response/output code: If the code is meant to show an expected return, and is not related to a procedure, then var tags shouldn't be used. Here's [a doc section](/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api#get-all-monitors) (the returned JSON) where var tags are not needed.
 
 For some use cases, [highlighting](#annotate-mark) may be a better choice than a `var` tag.
@@ -212,37 +212,37 @@ For some use cases, [highlighting](#annotate-mark) may be a better choice than a
   </Collapser>
 </CollapserGroup>
 
-## Highlight a code section with `<mark>` [#annotate-mark]
+## Highlight a code section with `<var>` [#annotate-mark]
 
-Use the `<mark>` tag to highlight areas of a code block that are particularly important but not directly procedural-related. Most commonly, `<mark>` is used to highlight New Relic API methods in sample code that contains a lot of "other logic." They're also handy when you want to indicate a bit of code that will be referenced later in a procedure or doc.
+Use the `<var>` tag to highlight areas of a code block that are particularly important but not directly procedural-related. Most commonly, `<var>` is used to highlight New Relic API methods in sample code that contains a lot of "other logic." They're also handy when you want to indicate a bit of code that will be referenced later in a procedure or doc.
 
 Here are two examples of highlighting:
 
 * Highlighting values in code response that are meant for later use: [Activate Azure integrations doc](/docs/infrastructure/microsoft-azure-integrations/getting-started/activate-azure-integrations#get-ids).
 * Highlighting the commands in a large code block example that are New Relic-specific commands, with explanations below: [Java API doc](/docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications#use-gettoken).
 
-When you use `<mark>`, you should usually follow the code block with a list of bullets that explain what each API call is doing and link to method syntax.
+When you use `<var>`, you should usually follow the code block with a list of bullets that explain what each API call is doing and link to method syntax.
 
 <CollapserGroup>
   <Collapser
     id="mark-tag-example"
-    title="Example of using the <mark> tag"
+    title="Example of using the <var> tag"
   >
     ```
     private void storeItem(long id) {
-        Segment segment = NewRelic.getAgent().getTransaction(). <mark>startSegment("storeItem")</mark>;
+        Segment segment = NewRelic.getAgent().getTransaction(). <var>startSegment("storeItem")</var>;
 
-          segment.<mark>reportAsExternal(DatastoreParameters
+          segment.<var>reportAsExternal(DatastoreParameters
                   .product("H2")
                   .collection(null)
                   .operation("insert")
                   .instance("localhost", 8080)
                   .databaseName("test")
-                  .build())</mark>;
+                  .build())</var>;
 
           // fire and forget
           DB_POOL.submit(() -> {
-              <mark>segment.end()</mark>;
+              <var>segment.end()</var>;
               insertData(id);
           });
       }

--- a/src/content/docs/style-guide/writing-docs/article-templates/api-tutorial-template.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/api-tutorial-template.mdx
@@ -78,9 +78,9 @@ If you think a large app code example would be useful, place it here. Within any
 
     ```
     private void storeItem(long id) {
-       Segment segment = NewRelic.getAgent().getTransaction().<mark>startSegment("storeItem")</mark>;
+       Segment segment = NewRelic.getAgent().getTransaction().<var>startSegment("storeItem")</var>;
 
-       segment.<mark>reportAsExternal</mark>(DatastoreParameters
+       segment.<var>reportAsExternal</var>(DatastoreParameters
                .product("H2")
                .collection(null)
                .operation("insert")
@@ -90,7 +90,7 @@ If you think a large app code example would be useful, place it here. Within any
 
        // fire and forget
        DB_POOL.submit(() -> {
-           <mark>segment.end();</mark>
+           <var>segment.end();</var>
            insertData(id);
        });
     }

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
@@ -59,7 +59,7 @@ To set up the modules:
              ├── counter
              │   ├── index.js
              │   └── package.json
-             └── package.json            <mark>⇦ the only mandatory file</mark>
+             └── package.json            <var>⇦ the only mandatory file</var>
        ```
 
        The `package.json` defines `dependencies` as both a local module (for example, `counter`) and an npm hosted modules (for example, `async` version `^2.6.1`):
@@ -67,11 +67,11 @@ To set up the modules:
        ```
        {
              "name": "custom-modules",
-             "version": "1.0.0",           <mark>⇦ optional</mark>
-             "description": "example custom modules directory", <mark>⇦ optional</mark>
+             "version": "1.0.0",           <var>⇦ optional</var>
+             "description": "example custom modules directory", <var>⇦ optional</var>
              "dependencies": {
-               "async": "^2.6.1",          <mark>⇦ npm hosted module</mark>
-               "counter": "file:./counter" <mark>⇦ Local module</mark>
+               "async": "^2.6.1",          <var>⇦ npm hosted module</var>
+               "counter": "file:./counter" <var>⇦ Local module</var>
              }
            }
        ```
@@ -87,14 +87,14 @@ To set up the modules:
 
        ```
        /example-custom-modules-dir/
-             ├── 6.11.2            <mark>⇦ optional Node specific directory</mark>
+             ├── 6.11.2            <var>⇦ optional Node specific directory</var>
              │   └── package.json
-             └── 10.15.0           <mark>⇦ optional Node specific directory</mark>
+             └── 10.15.0           <var>⇦ optional Node specific directory</var>
              │   └── package.json
              ├── counter
              │   ├── index.js
              │   └── package.json
-             └── package.json      <mark>⇦ the only mandatory file</mark>
+             └── package.json      <var>⇦ the only mandatory file</var>
          ​
        ```
      </Collapser>

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-maintenance-monitoring.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-maintenance-monitoring.mdx
@@ -59,7 +59,7 @@ You can monitor your minion's health by looking at CPM container logs.
       2018-10-10 11:33:43,723 - Configured 2 heavy worker threads, and 50 light worker threads
       2018-10-10 11:33:43,796 -
       2018-10-10 11:33:43,796 - **************************************************************************
-      2018-10-10 11:33:43,796 - * <mark>Synthetics Minion is ready and servicing location</mark> '<var>example_private_location</var>'
+      2018-10-10 11:33:43,796 - * <var>Synthetics Minion is ready and servicing location</var> '<var>example_private_location</var>'
       2018-10-10 11:33:43,796 - **************************************************************************
       ... logging continues ...
     ```


### PR DESCRIPTION
Replaced the `mark` tags with `var` tags
Updated the [Code references](https://docs.newrelic.com/docs/style-guide/formatting/code-examples/) page on the Style Guide