### PR TITLE
fix(docs): Rename Baseline to Anomaly

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -686,7 +686,7 @@ When you create a NRQL alert, you can choose from different types of conditions:
     <tr>
       <td>
         [Anomaly](/docs/alerts/new-relic-alerts/defining-conditions/create-baseline-alert-conditions)
-        (Dynamic Baseline)
+        (Dynamic baseline)
       </td>
 
       <td>

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -685,8 +685,8 @@ When you create a NRQL alert, you can choose from different types of conditions:
 
     <tr>
       <td>
-        [Baseline](/docs/alerts/new-relic-alerts/defining-conditions/create-baseline-alert-conditions)
-        (Dynamic)
+        [Anomaly](/docs/alerts/new-relic-alerts/defining-conditions/create-baseline-alert-conditions)
+        (Dynamic Baseline)
       </td>
 
       <td>


### PR DESCRIPTION
Rename Baseline to Anomaly in create-nrql-alert-conditions.mdx. This matches the new terminology in the UI.

When you link to this page from the Create an alert condition page it is named differently in the docs and confusing. 

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.