### PR TITLE
nri-f5: add info commonname deprecation

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/f5-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/f5-monitoring-integration.mdx
@@ -109,6 +109,13 @@ If you're still using our legacy configuration/definition files, see [on-host in
 
 Specific settings related to F5 are defined using the `env` section of the configuration file. These settings control the connection to your F5 instance, as well as other security settings and features.
 
+<Callout variant="tip">
+  After version 2.6.0 the integration is built leveraging golang 1.18.0. The HTTP client [no longer rely on CommonName](https://go.dev/doc/go1.15#commonname) to validate the certificate.
+  > The deprecated, legacy behavior of treating the CommonName field on X.509 certificates as a host name when no Subject Alternative Names are present is now disabled by default.
+  To overcome this issue the user should update the certificate relying on `Subject Alternative Name`. 
+  While the certificate is not updated, certificate validation could be disabled setting `--tls_insecure_skip_verify` to true.
+</Callout>
+
 ## F5 instance settings [#instance-settings]
 
 The F5 integration collects both metrics(**M**) and inventory(**I**) information. In the table, use the **Applies To** column for the settings available to each collection:
@@ -327,6 +334,28 @@ The F5 integration collects both metrics(**M**) and inventory(**I**) information
 
       <td style={{ 'text-align': 'center' }}>
         M
+      </td>
+    </tr>
+
+    {
+      ' '
+    }
+
+    <tr>
+      <td>
+        **TLS_INSECURE_SKIP_VERIFY**
+      </td>
+
+      <td>
+        Skip verification of the certificate sent by the host.
+      </td>
+
+      <td>
+        false
+      </td>
+
+      <td style={{ 'text-align': 'center' }}>
+        M/I
       </td>
     </tr>
 


### PR DESCRIPTION
In particular in the new golang version the CommonName is no longer taken into consideration while validating certificates.

>The deprecated, legacy behavior of treating the CommonName field on X.509 certificates as a host name when no Subject Alternative Names are present is now disabled by default.

This could be an issue for users still relying on legacy commonName and not on Subject Alternative Name. In that case they would see an error message like:

```
[ERR] Encountered fatal error: Post [...] x509:  certificate relies on legacy Common Name field, use SANs instead
```

To overcome this issue the user should update the certificate relying on Subject Alternative Name.
In the meanwhile as a workaround they could also pass the new argument --ssl_insecure_skip_verify to skip the certificate validation.