### PR TITLE
fix: clarified the supported libraries for Node.js automatic log forw…

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs.mdx
@@ -17,7 +17,7 @@ redirects:
   - /docs/agents/nodejs-agent
 ---
 
-Pinpoint and solve issues down to the line of code with Node.js monitoring from New Relic. With features like [service maps](/docs/data-analysis/service-maps/get-started/introduction-service-maps), [errors inbox](/docs/errors-inbox/errors-inbox), [logs in context](/docs/apm/new-relic-apm/getting-started/get-started-logs-context), and more, our Node.js agent helps you get the full picture of your app environment.  
+Pinpoint and solve issues down to the line of code with Node.js monitoring from New Relic. With features like [service maps](/docs/data-analysis/service-maps/get-started/introduction-service-maps), [errors inbox](/docs/errors-inbox/errors-inbox), [logs in context](/docs/apm/new-relic-apm/getting-started/get-started-logs-context), and more, our Node.js agent helps you get the full picture of your app environment.
 
 ## Why it matters [#why]
 
@@ -83,8 +83,7 @@ After installing the Node.js agent, extend your instrumentation:
       </td>
 
       <td>
-        * To enrich [Winston](https://github.com/winstonjs/winston) log data, use our [automatic logs in context](/docs/logs/logs-context/configure-logs-context-nodejs) solution for Node.js.
-        * To enrich [Pino](https://github.com/pinojs/pino) log data, use our [Pino log enricher](/docs/logs/logs-context/configure-logs-context-nodejs/#nodejs-pino).
+        * To enrich [Winston](https://github.com/winstonjs/winston) or [Pino](https://github.com/pinojs/pino) log data, use our [automatic logs in context](/docs/logs/logs-context/configure-logs-context-nodejs) solution for Node.js.
       </td>
     </tr>
 

--- a/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
@@ -42,7 +42,7 @@ Supported frameworks for automatic logs in context include:
   <Callout variant="important">
     Agent releases 8.16.0 and higher have this feature enabled in the agent configuration file by default.
 
-    Agent log forwarding will cause an increase in the consumption of data when a [supported framework](/docs/logs/logs-context/node-configure-logs-context-all#automatic) is detected. The amount depends on the application and amount of logs it produces. This feature can be disabled. See [Disable automatic logging](https://docs.newrelic.com/docs/logs/logs-context/disable-automatic-logging/) for more information about your options.
+    Agent log forwarding will cause an increase in the consumption of data when a [supported framework](/docs/logs/logs-context/node-configure-logs-context-all#automatic) is detected. The amount depends on the application and amount of logs it produces. This feature can be disabled. See [Disable automatic logging](/docs/logs/logs-context/disable-automatic-logging/) for more information about your options.
 
     If you already have a log forwarding solution in place, you should disable this feature.
   </Callout>

--- a/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
@@ -33,7 +33,20 @@ For more information, including examples, learn how to get started with [APM log
 
 With application logging, your APM agent automatically collects and contextualizes your logs.
 
-You have three options to configure APM logs in context to send your app's logs and linking metadata automatically to New Relic.
+If you are using a supported framework, you have three options to configure APM logs in context to send your app's logs and linking metadata automatically to New Relic.
+
+Supported frameworks for automatic logs in context include:
+ * [Winston](https://github.com/winstonjs/winston) 3.0.0 or higher.
+ * [Pino](https://github.com/pinojs/pino) 7.0.0 or higher.
+
+  <Callout variant="important">
+    Agent releases 8.16.0 and higher have this feature enabled in the agent configuration file by default.
+
+    Agent log forwarding will cause an increase in the consumption of data when a [supported framework](/docs/logs/logs-context/node-configure-logs-context-all#automatic) is detected. The amount depends on the application and amount of logs it produces. This feature can be disabled. See [Disable automatic logging](https://docs.newrelic.com/docs/logs/logs-context/disable-automatic-logging/) for more information about your options.
+
+    If you already have a log forwarding solution in place, you should disable this feature.
+  </Callout>
+
 
 <CollapserGroup>
   <Collapser


### PR DESCRIPTION
Updated the Node.js docs to call out which libraries are supported for automatic log fowarding.  I also added a note, similar to java agent as to when log forwarding is on by default.