### PR TITLE
docs: fix chars used for double quotes

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/8x-to-9x-agent-migration-guide.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/8x-to-9x-agent-migration-guide.mdx
@@ -23,9 +23,9 @@ Main changes include:
 
 [Distributed tracing](/docs/distributed-tracing/) is a feature that has existed in the .NET agent since July 2018. It replaces cross-application tracing (CAT) as the best way to quickly understand what happens to requests as they travel through various services in a distributed application architecture. CAT will be deprecated in the .NET agent as of version 9.0, and will be removed in a future major release.
 
-In 8.x versions of the .NET agent, the default `newrelic.config` file installed on a host by any .NET agent installer would have the `crossApplicationTracer` element present and set `enabled=”true”`. The `distributedTracing` element was not present by default.
+In 8.x versions of the .NET agent, the default `newrelic.config` file installed on a host by any .NET agent installer would have the `crossApplicationTracer` element present and set `enabled="true"`. The `distributedTracing` element was not present by default.
 
-In 9.x, this will be reversed: `crossApplicationTracer` will not be present by default, and `distributedTracing` will be present with the default value of `enabled=”true”`. However, the agent installers do not overwrite an existing `newrelic.config` file when upgrading from one version to another. Therefore, if you are upgrading the agent from 8.x to 9.x on a given host, the agent’s behavior on that host will not change.
+In 9.x, this will be reversed: `crossApplicationTracer` will not be present by default, and `distributedTracing` will be present with the default value of `enabled="true"`. However, the agent installers do not overwrite an existing `newrelic.config` file when upgrading from one version to another. Therefore, if you are upgrading the agent from 8.x to 9.x on a given host, the agent’s behavior on that host will not change.
 
 <Callout variant="tip">
   If you wish to adopt the new default tracing behavior when upgrading from 8.x to 9.x, you will need to modify your agent configuration to enable distributed tracing. New installations of the 9.x agent on a host will have distributed tracing enabled by default.
@@ -132,11 +132,15 @@ replace it with this:
 // Create an external web request to another instrumented service
 HttpWebRequest requestMessage = (HttpWebRequest)WebRequest.Create("https://remote-address");
 
-// Insert the distributed trace headers to the message. The “setter” // action tells the API how to add headers to the “carrier”, which 
+// Insert the distributed trace headers to the message. The "setter"
+// action tells the API how to add headers to the "carrier", which
 // is the HttpWebRequest message in this example
 IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
 ITransaction currentTransaction = agent.CurrentTransaction;
-var setter = new Action<HttpWebRequest, string, string>((carrier, key, value) =>  { carrier.Headers?.Set(key, value); });
+var setter = new Action<HttpWebRequest, string, string>((carrier, key, value) =>
+{
+    carrier.Headers?.Set(key, value);
+});
 currentTransaction.InsertDistributedTraceHeaders(requestMessage, setter);
 ```
 
@@ -147,11 +151,12 @@ If you previously had code that looked like this:
 ```cs
 // Obtain the payload from the upstream request object
 HttpContext httpContext = HttpContext.Current;
-string payload = httpContext.Request.Headers[NewRelic.Api.Agent.Constants.DistributedTracePayloadKey)];
+string payload = httpContext.Request.Headers[NewRelic.Api.Agent.Constants.DistributedTracePayloadKey];
 
 // Accept the payload
 IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
-ITransaction transaction = agent.CurrentTransaction; transaction.AcceptDistributedTracePayload(payload, TransportType.HTTP);
+ITransaction transaction = agent.CurrentTransaction;
+transaction.AcceptDistributedTracePayload(payload, TransportType.HTTP);
 ```
 
 replace it with this:
@@ -161,7 +166,7 @@ HttpContext httpContext = HttpContext.Current;
 IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
 ITransaction currentTransaction = agent.CurrentTransaction;
 
-// The “Getter” method defines how to get headers from the carrier, 
+// The "Getter" method defines how to get headers from the carrier, 
 // which is the HttpContext in this example 
 IEnumerable<string> Getter(HttpContext carrier, string key)
 {
@@ -180,7 +185,7 @@ If you previously had code that looked like this:
 ```cs
 // Called in code that runs inside a transaction created by the
 // agent, for example an ASP.NET WebApi endpoint
-NewRelic.Api.Agent.NewRelic.AddCustomParameter(“myCustomParameter”, “myValue”);
+NewRelic.Api.Agent.NewRelic.AddCustomParameter("myCustomParameter", "myValue");
 ```
 
 replace it with this:
@@ -191,7 +196,7 @@ IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
 ITransaction currentTransaction = agent.CurrentTransaction;
 
 // Add the custom attribute to the current transaction
-currentTransaction.AddCustomAttribute(“myCustomParameter”, “myValue”);
+currentTransaction.AddCustomAttribute("myCustomParameter", "myValue");
 ```
 
 ## Removal of deprecated agent configuration settings
@@ -359,7 +364,7 @@ Most of the configuration options being removed relate to capture or exclusion o
 
     <tr>
       <td>
-        ` analyticsEvents.*`
+        `analyticsEvents.*`
       </td>
 
       <td>


### PR DESCRIPTION
A lot of this code used the wrong unicode double quotes. `”` is not the same as `"` and  `”` is an invalid char in c#, so that code was broken.  
I also fixed some other code wonkyness like a stray `)` breaking a line of code and some lines mashed together on a single line which were tougher to read.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.