### PR TITLE
feat: added node v9 to the update node.js agent page, provided a spec…

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -4,7 +4,7 @@ tags:
   - Agents
   - Nodejs agent
   - Getting started
-translate:
+translate: 
   - jp
 metaDescription: 'The New Relic Node.js agent supports these frameworks, architectures, and operating systems.'
 redirects:

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -2,7 +2,7 @@
 title: Compatibility and requirements for the Node.js agent
 tags:
   - Agents
-  - Nodejs agent
+  - Nodejs agent 
   - Getting started
 translate: 
   - jp

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -56,7 +56,7 @@ The following are proposed time ranges. The actual release date may vary.
       </td>
 
       <td>
-        April-October 2022
+        August 3, 2022 with Node.js agent v9.0.0
       </td>
     </tr>
 
@@ -124,7 +124,7 @@ The following are proposed time ranges. The actual release date may vary.
       </td>
 
       <td>
-        April-October 2022
+        As of August 3, 2022, we have discontinued support for Node.js 12 with v9 of the Node.js agent.
       </td>
     </tr>
 
@@ -327,7 +327,7 @@ For other message queue libraries, use [custom instrumentation](/docs/agents/nod
 
 ## HTTP/1.1
 
-The Node.js agent instruments the native `http` module. 
+The Node.js agent instruments the native `http` module.
 
 In addition, the popular [undici](https://www.npmjs.com/package/undici) client has experimental support as well. To use undici, be sure to set `feature_flag.undici_instrumentation = true` in the `newrelic.js` [configuration file](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#methods-and-precedence).
 

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
@@ -111,18 +111,18 @@ Before upgrading to Node.js version 9, review this information for major changes
 
     <tr>
       <td>
-        **BREAKING**: Updated the minimum supported version of hapi to be >= v20.0.0.
+        **BREAKING**: Updated the minimum supported version of hapi to be v20.0.0.
 
       </td>
 
       <td>
-        * All versions < v20.0.0 are deprecated by hapi for security reasons, see their [support policy](https://hapi.dev/policies/support/).
+        * All versions lower than v20.0.0 are deprecated by hapi for security reasons. See [their support policy](https://hapi.dev/policies/support/).
       </td>
     </tr>
 
     <tr>
       <td>
-        Update New Relic Dependencies to versions with updated Node version support
+        Update New Relic dependencies to versions with updated Node version support
       </td>
 
       <td>

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
@@ -19,6 +19,134 @@ To take full advantage of New Relic's latest features, enhancements, and importa
 
 **Recommendation:** Test your updated version before moving it into production. If you have problems, follow the Node.js agent [troubleshooting procedures](/docs/agents/nodejs-agent/troubleshooting/troubleshooting-your-nodejs-installation).
 
+## Upgrade to Node.js agent version 9 [#node-agent-v9]
+
+Before upgrading to Node.js version 9, review this information for major changes.
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "250px" }}>
+        **Major changes with Node.js agent v9**
+      </th>
+
+      <th>
+        **Comments**
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        Added official parity support for Node 18.
+      </td>
+
+      <td/>
+    </tr>
+
+    <tr>
+      <td>
+        **BREAKING**: Dropped Node 12 support.
+      </td>
+
+      <td>
+        * For further information see our [support policy](/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        **BREAKING**: The agent no-longer includes the New Relic certificate bundle automatically when using the 'certificates' configuration (commonly with proxies).
+      </td>
+
+      <td>
+        * The agent no-longer includes the New Relic certificate bundle when using the 'certificates' configuration (commonly with proxies). If you find this breaking your current environment, we recommend getting a CA bundle such as the one from Mozilla.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        **BREAKING**: The agent now excludes port when making external HTTPS requests to port 443 to be in compliance with the spec and other agents
+      </td>
+
+      <td>
+        * Previous external segments would be named `External/example.com:443` when using default HTTPS port.
+      </td>
+      <td>
+        * The external segment will now be named `External/example.com`.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        **BREAKING**: Removed ability to disable async hooks based promise context tracking via the `await_support` feature flag. This also removes the legacy Promise instrumentation.
+      </td>
+
+      <td>
+        *  Released the `await_support` feature flag. The agent now relies on async_hooks to track async promise propagation.  The net result is the if you had `feature_flag.await_support` set to false, the legacy instrumentation tracked every function in a promise chain as a separate segment.
+
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        **BREAKING**: Removed instrumentation for the obsolete [oracle](https://www.npmjs.com/package/oracle) npm package.
+      </td>
+
+      <td>
+
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        **BREAKING**: Updated the minimum version of `pg` to be 8.2.x.  This is the earliest support version that runs on Node 14+.
+      </td>
+
+      <td>
+
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        **BREAKING**: Updated the minimum supported version of hapi to be >= v20.0.0.
+
+      </td>
+
+      <td>
+        * All versions < v20.0.0 are deprecated by hapi for security reasons, see their [support policy](https://hapi.dev/policies/support/).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Update New Relic Dependencies to versions with updated Node version support
+      </td>
+
+      <td>
+        * @newrelic/aws-sdk v5.0.0
+        * @newrelic/koa v7.0.0
+        * @newrelic/native-metrics v9.0.0
+        * @newrelic/superagent v6.0.0
+        * @newrelic/test-utilities v7.0.0
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Node version support [#node-support-v9]
+
+Node 14 is the earliest version supported by the New Relic Node.js v9 agent. Node 12 and 13 are not supported by v9. Customers running Node 13 and earlier have two options:
+
+* Upgrade to a supported version of Node and take advantage of the New Relic Node.js v9 agent's new features.
+* Remain on New Relic Node.js v8 agent without the ability to use new features only available with update agent versions.
+
+<Callout variant="tip">
+  Upgrade to a newer version of Node as soon as possible. The next major version of the New Relic Node.js agent will likely remove support for Node 14.
+</Callout>
+
 ## Upgrade to Node.js agent version 8 [#node-agent-v8]
 
 Before upgrading to Node.js version 8, review this information for major changes.


### PR DESCRIPTION
Updated relevant pages calling out the v9.0.0 release.  I saw two other pages that I'm unsure who's responsible for updating as I noticed they are new and already out of date: https://docs.newrelic.com/docs/apm/agents/nodejs-agent/getting-started/nodejs-agent-eol-policy/ and https://docs.newrelic.com/docs/release-notes/agent-release-notes/nodejs-release-notes/current