### PR TITLE
add commonJS support note

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -57,7 +57,9 @@ Here are detailed descriptions of each configuration method:
     id="config_file"
     title="Agent configuration file"
   >
-    The config file (`newrelic.js`) contains every Node.js agent setting. When you [install the Node.js agent](/docs/agents/nodejs-agent/installation-configuration/installing-maintaining-nodejs#installing), you must copy `newrelic.js` into your app's root directory. Most settings are empty by default; they inherit their values from `config/default.js`. If your application is running on CommonJS, simply change the configuration file type to (`newrelic.cjs`), this filetype is supported as of [v7.5.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-5-0/) of the Node Agent.
+    The config file (`newrelic.js`) contains every Node.js agent setting. When you [install the Node.js agent](/docs/agents/nodejs-agent/installation-configuration/installing-maintaining-nodejs#installing), you must copy `newrelic.js` into your app's root directory. Most settings are empty by default; they inherit their values from `config/default.js`.
+    
+    If your application is running on CommonJS, simply change the configuration file type to (`newrelic.cjs`). This filetype is supported as of [v7.5.0](/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-5-0/) of the Node.js agent.
   </Collapser>
 
   <Collapser
@@ -69,7 +71,7 @@ Here are detailed descriptions of each configuration method:
 
     Where available, these environment variables are documented below under individual config options as the **Environ variable**. There are also two rarely used settings that can [only be configured via environment variables](#environment-variable-overrides).
 
-    If you're using New Relic CodeStream to monitor performance from your IDE you may also want to [associate repositories with your services](/docs/codestream/how-use-codestream/performance-monitoring#repo-association) and [associate build SHAs or release tags with errors](/docs/codestream/how-use-codestream/performance-monitoring#buildsha).
+    If you're using New Relic CodeStream to monitor performance from your IDE, you may also want to [associate repositories with your services](/docs/codestream/how-use-codestream/performance-monitoring#repo-association) and [associate build SHAs or release tags with errors](/docs/codestream/how-use-codestream/performance-monitoring#buildsha).
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -57,7 +57,7 @@ Here are detailed descriptions of each configuration method:
     id="config_file"
     title="Agent configuration file"
   >
-    The config file (`newrelic.js`) contains every Node.js agent setting. When you [install the Node.js agent](/docs/agents/nodejs-agent/installation-configuration/installing-maintaining-nodejs#installing), you must copy `newrelic.js` into your app's root directory. Most settings are empty by default; they inherit their values from `config/default.js`.
+    The config file (`newrelic.js`) contains every Node.js agent setting. When you [install the Node.js agent](/docs/agents/nodejs-agent/installation-configuration/installing-maintaining-nodejs#installing), you must copy `newrelic.js` into your app's root directory. Most settings are empty by default; they inherit their values from `config/default.js`. If your application is running on CommonJS, simply change the configuration file type to (`newrelic.cjs`), this filetype is supported as of [v7.5.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-5-0/) of the Node Agent.
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
We support .cjs file types for Node Agent configuration as of v7.5.0 and it was not listed in our docs.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.