### PR TITLE
Fix(Go agent): corrected EOL version in release notes

### DIFF
--- a/src/content/docs/apm/agents/go-agent/get-started/go-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/go-agent/get-started/go-agent-eol-policy.mdx
@@ -29,6 +29,20 @@ Any versions not listed in the following table are no longer supported. Please [
   <tbody>
     <tr>
       <td>
+        v3.18.0
+      </td>
+
+      <td>
+        Aug 1, 2022
+      </td>
+
+      <td>
+        Aug 1, 2023
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         v3.17.0
       </td>
 

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-17-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-17-0.mdx
@@ -27,4 +27,4 @@ downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.17.0'
 
 ### Support Statement
 New Relic recommends that you upgrade the agent regularly to ensure that you’re getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach end-of-life.
-* Note that the oldest supported version of the Go Agent is 3.6.0.
+* Note that the oldest supported version of the Go Agent is 2.11.0.

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-18-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-18-0.mdx
@@ -21,4 +21,4 @@ downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.18.0'
 
 ### Support Statement
 New Relic recommends that you upgrade the agent regularly to ensure that you’re getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach end-of-life.
-* Note that the oldest supported version of the Go agent is 3.6.0.
+* Note that the oldest supported version of the Go agent is 2.11.0.


### PR DESCRIPTION
The last two release notes for the Go agent reflect an incorrectly-calculated oldest supported agent version. This PR corrects them.
It also adds the latest release to the EOL version table.