### PR TITLE
Fix monitoring for i18n github actions by adding required field

### DIFF
--- a/scripts/actions/check-job-progress.js
+++ b/scripts/actions/check-job-progress.js
@@ -20,6 +20,7 @@ const {
 const PROJECT_ID = configuration.TRANSLATION.VENDOR_PROJECT;
 
 const defaultTrackingMetadata = {
+  eventType: 'GithubActionsI18n',
   projectId: PROJECT_ID,
   workflow: 'checkAndDeserialize',
 };


### PR DESCRIPTION
## Description

Adds the required `eventType` field to the JSON body to name the event for querying and such.

I was able to successfully send a custom event locally. I _did_ use the `ingest - license` key. Not sure what `NEW_RELIC_LICENSE_KEY` is set to, but if it doesn't work after merging, that would be a good next step.

## Related info
- Related to https://issues.newrelic.com/browse/NR-11123 
- https://docs.newrelic.com/docs/data-apis/ingest-apis/event-api/introduction-event-api/#json-guidelines