### PR TITLE
Document Historical Data Export max inspected limit

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-historical-data-export.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-historical-data-export.mdx
@@ -26,6 +26,7 @@ Here are some limits and restrictions on the feature:
 
 The following are the default usage limits for an export: 
 * Exports should be estimated to return fewer than 200 million events
+* Exports should be estimated to inspect fewer than 5 billion events
 * No more than two concurrent exports per account
 
 If you'd like higher limits, talk to your account representative. 


### PR DESCRIPTION
This PR updates the NerdGraph Historical Data Export page to include information on the maximum inspected count limit.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.