### PR TITLE
fix: Temporarily ignore missing file

### DIFF
--- a/scripts/actions/fetch-and-deserialize.js
+++ b/scripts/actions/fetch-and-deserialize.js
@@ -86,6 +86,9 @@ const fetchTranslatedFilesZip = (locale) => {
    * @returns {Promise<AdmZip|null>}
    */
   return async ({ fileUris }) => {
+    fileUris = fileUris.filter(
+      (uri) => uri !== 'src/announcements/q2-survey.mdx'
+    );
     const fileUriStr = fileUris.reduce((str, uri) => {
       return str.concat(`&fileUris[]=${encodeURIComponent(uri)}`);
     }, '');


### PR DESCRIPTION
Even though I deleted this file in the DB and the translation vendor UI it still shows up in the api call. this will temporarily ignore the file until we get through these stalled jobs