### PR TITLE
Add link to logstash plugin in github

### DIFF
--- a/src/content/docs/logs/forward-logs/logstash-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/logstash-plugin-log-forwarding.mdx
@@ -34,7 +34,7 @@ To forward your logs from Logstash to New Relic:
 
 ## Install and configure the Logstash plugin [#logstash-plugin]
 
-To forward your logs to New Relic with our Logstash plugin:
+To forward your logs to [New Relic with our Logstash plugin](https://github.com/newrelic/logstash-output-plugin):
 
 1. Enter the following command into your terminal or command line interface:
    ```

--- a/src/content/docs/logs/forward-logs/logstash-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/logstash-plugin-log-forwarding.mdx
@@ -34,7 +34,7 @@ To forward your logs from Logstash to New Relic:
 
 ## Install and configure the Logstash plugin [#logstash-plugin]
 
-To forward your logs to [New Relic with our Logstash plugin](https://github.com/newrelic/logstash-output-plugin):
+To forward your logs to New Relic with our [Logstash plugin](https://github.com/newrelic/logstash-output-plugin):
 
 1. Enter the following command into your terminal or command line interface:
    ```


### PR DESCRIPTION
This PR just adds a link to the logstash plugin in the github repository to help the users to know which plugin are they going to use.