### PR TITLE
fix: add Lambda note to Node 12 deprecation doc

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -166,6 +166,9 @@ If you are using a supported framework with default routers, the Node.js agent c
   We have discontinued support for several capabilities in November 2021. This includes the Oracle Driver Package and Hapi versions prior to Hapi 19.2 for our Node.js agent. For more details, including how you can easily prepare for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-and-support-across-node-agents-suggested-pagerduty-responders-incident-workflows-and-kubernetes-instrumentation/164481?u=dholloran).
 </Callout>
 
+## Lambda [#lambda]
+While agent version 9.0.0 drops support for Node 12, that version of Node is currently still a valid runtime in AWS Lambda. One version of the Node 12 Lambda layer was published containing the v9.0.0 agent. For customers running Node 12 Lambda functions, we recommend reverting to a Lambda Layer version prior to the latest one. Alternatively, we recommend updating those functions to Node 14.x or Node 16.x runtimes. 
+
 ## Processors [#processors]
 
 * The New Relic Node Agent is built to run on most processors including being tested and validated to work on AWS Graviton2

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -167,7 +167,8 @@ If you are using a supported framework with default routers, the Node.js agent c
 </Callout>
 
 ## Lambda [#lambda]
-While agent version 9.0.0 drops support for Node 12, that version of Node is currently still a valid runtime in AWS Lambda. One version of the Node 12 Lambda layer was published containing the v9.0.0 agent. For customers running Node 12 Lambda functions, we recommend reverting to a Lambda Layer version prior to the latest one. Alternatively, we recommend updating those functions to Node 14.x or Node 16.x runtimes. 
+
+Node.js agent version 9.0.0 dropped support for Node 12, but Node 12 is currently still a valid runtime in AWS Lambda. One version of the Node 12 Lambda layer was published containing the v9.0.0 agent. If you run Node 12 Lambda functions, we recommend reverting to a Lambda layer version lower than the current one. Alternatively, we recommend updating those functions to Node 14.x or Node 16.x runtimes. 
 
 ## Processors [#processors]
 


### PR DESCRIPTION
One version of our Node 12 Lambda Layer was released with the Node agent v9.0.0...which doesn't support Node 12. This note adds a recommendation to revert one layer version or update the function runtime.