### PR TITLE
Update the rest of the Go docs with language identifiers

### DIFF
--- a/src/content/docs/apm/agents/go-agent/configuration/distributed-tracing-go-agent.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/distributed-tracing-go-agent.mdx
@@ -167,12 +167,12 @@ Infinite Tracing configuration settings include the standard distributed tracing
 
             * `newrelic.Config` structure:
 
-              ```
+              ```go
               app, err := newrelic.NewApplication(
-                  newrelic.ConfigAppName(<var>YOUR_APP_NAME</var>),
-                  newrelic.ConfigLicense(<var>YOUR_LICENSE_KEY</var>),
+                  newrelic.ConfigAppName(YOUR_APP_NAME),
+                  newrelic.ConfigLicense(YOUR_LICENSE_KEY),
                   func(cfg *newrelic.Config) {
-                      cfg.InfiniteTracing.TraceObserver.Host = <var>YOUR_TRACE_OBSERVER_HOST</var>
+                      cfg.InfiniteTracing.TraceObserver.Host = YOUR_TRACE_OBSERVER_HOST
                   },
               )
               ```
@@ -294,11 +294,11 @@ If you've been using an older agent without distributed tracing, before turning 
 
             * `ConfigOption` structure:
 
-              ```
+              ```go
               newrelic.NewApplication(
-                newrelic.ConfigAppName("Example App"),
-                newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
-                newrelic.ConfigDistributedTracerEnabled(true),
+                  newrelic.ConfigAppName("Example App"),
+                  newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+                  newrelic.ConfigDistributedTracerEnabled(true),
               )
               ```
             * Environment variable:
@@ -339,13 +339,13 @@ All installations of the Go agent and distributed tracing require some manual in
       >
         Here is an example of code before instrumentation:
 
-        ```
+        ```go
         http.HandleFunc("/users", usersHandler)
         ```
 
         And here is an example of that same code after instrumentation:
 
-        ```
+        ```go
         http.HandleFunc(newrelic.WrapHandleFunc(app, "/users", usersHandler))
         ```
       </Collapser>
@@ -362,7 +362,7 @@ All installations of the Go agent and distributed tracing require some manual in
 
     The easiest way to create an external segment for your outbound HTTP request is to use the `newrelic.NewRoundTripper` method. Here is an example of making a request to `http://api.example.com` that includes the outgoing distributed tracing headers:
 
-    ```
+    ```go
     func useNewRoundTripper(txn *newrelic.Transaction) (*http.Response, error) {
         client := &http.Client{}
         client.Transport = newrelic.NewRoundTripper(client.Transport)
@@ -374,7 +374,7 @@ All installations of the Go agent and distributed tracing require some manual in
 
     If you have a more complex request that uses the Go standard library's `http.Request`, use the `newrelic.StartExternalSegment` method to ensure your outbound request is eligible for distributed tracing:
 
-    ```
+    ```go
     func external(txn *newrelic.Transaction, req *http.Request) (*http.Response, error) { 
         s := newrelic.StartExternalSegment(txn, req) 
         response, err := http.DefaultClient.Do(req) 
@@ -386,7 +386,7 @@ All installations of the Go agent and distributed tracing require some manual in
 
     An `ExternalSegment` created with a struct literal cannot be used for distributed tracing. Because of this, New Relic recommends using [`newrelic.NewRoundTripper` or `newrelic.StartExternalSegment`](/docs/agents/go-agent/get-started/instrument-go-segments#go-external-segments).
 
-    ```
+    ```go
     func noGoodForDt(txn *newrelic.Transaction, url string) (*http.Response, error) {
         // Distributed tracing headers are not added to the outgoing request.
         // Use newrelic.NewRoundTripper or newrelicc.StartExternalSegment instead.
@@ -428,7 +428,7 @@ All installations of the Go agent and distributed tracing require some manual in
           </td>
 
           <td>
-            ```
+            ```go
             <a href="https://godoc.org/github.com/newrelic/go-agent/v3/newrelic#Transaction.InsertDistributedTraceHeaders">InsertDistributedTraceHeaders(h http.Header)</a>
             ```
           </td>
@@ -440,7 +440,7 @@ All installations of the Go agent and distributed tracing require some manual in
           </td>
 
           <td>
-            ```
+            ```go
             <a href="https://godoc.org/github.com/newrelic/go-agent/v3/newrelic#Transaction.AcceptDistributedTraceHeaders">AcceptDistributedTraceHeaders(h http.Header)</a>
             ```
           </td>

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
@@ -643,7 +643,7 @@ then the following code:
 
 ```go
 app, err := newrelic.NewApplication(
-   newrelic.ConfigFromEnvironment(),
+    newrelic.ConfigFromEnvironment(),
 )
 ```
 
@@ -651,17 +651,17 @@ will accomplish the same result as the hard-coded equivalent:
 
 ```go
 app, err := newrelic.NewApplication(
-   newrelic.ConfigAppName("Your Application Name"),
-   newrelic.ConfigLicense("your_license_key_here"),
-   newrelic.ConfigCodeLevelMetricsEnabled(true),
-   newrelic.ConfigCodeLevelMetricsPathPrefix("myproject/src"),
-   func(config *newrelic.Config) {
-	config.Labels = map[string]string{
-	    "Env":    "Dev",
-	    "Label2": "label2",
-	    "Label3": "label3",
-	    "Label4": "label4",
-	}
+    newrelic.ConfigAppName("Your Application Name"),
+    newrelic.ConfigLicense("your_license_key_here"),
+    newrelic.ConfigCodeLevelMetricsEnabled(true),
+    newrelic.ConfigCodeLevelMetricsPathPrefix("myproject/src"),
+    func(config *newrelic.Config) {
+        config.Labels = map[string]string{
+            "Env":    "Dev",
+            "Label2": "label2",
+            "Label3": "label3",
+            "Label4": "label4",
+        }
     },
 )
 ```
@@ -2091,12 +2091,12 @@ The following settings are available for configuration of application logging in
     </table>
     If `true`, enables the collection of log events and logging metrics if these sub-feature configurations are also enabled.  If `false`, no logging instrumentation features are enabled.
 
-    Configure ApplicationLogging by calling ConfigAppLogEnabled().
+    Configure ApplicationLogging by calling `ConfigAppLogEnabled()`.
 
     ```go
-      app, err := newrelic.NewApplication(
+    app, err := newrelic.NewApplication(
         newrelic.ConfigAppLogEnabled(true),
-      )
+    )
     ```
   </Collapser>
 
@@ -2139,12 +2139,12 @@ The following settings are available for configuration of application logging in
 
   If `true`, the agent captures log records emitted by your application and forwards them to New Relic. `ApplicationLogging.Enabled` must also be `true` for this setting to take effect.
   
-  Enable log forwarding by calling ConfigAppLogForwardingEnabled().
+  Enable log forwarding by calling `ConfigAppLogForwardingEnabled()`.
 
   ```go
-    app, err := newrelic.NewApplication(
+  app, err := newrelic.NewApplication(
       newrelic.ConfigAppLogForwardingEnabled(true),
-    )
+  )
   ```
   </Collapser>
 
@@ -2191,9 +2191,9 @@ The following settings are available for configuration of application logging in
     Configure `ApplicationLogging.Forwarding.MaxSamplesStored` by calling `ConfigAppLogForwardingMaxSamplesStored()`.
 
     ```go
-      app, err := newrelic.NewApplication(
-      newrelic.ConfigAppLogForwardingMaxSamplesStored(1000),
-      )
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigAppLogForwardingMaxSamplesStored(1000),
+    )
     ```
 
     Set this to a lower value to reduce the amount of log lines sent (may cause log sampling). Set this to a higher value to send more log lines.
@@ -2242,12 +2242,12 @@ The following settings are available for configuration of application logging in
 
   If `true`, the agent captures metrics related to the log lines being sent up by your application. `ApplicationLogging.Enabled` must also be `true` for this setting to take effect.
 
-  Configure ApplicationLogging.Metrics.Enabled by calling ConfigAppLogMetricsEnabled().
+  Configure ApplicationLogging.Metrics.Enabled by calling `ConfigAppLogMetricsEnabled()`.
 
   ```go
-    app, err := newrelic.NewApplication(
+  app, err := newrelic.NewApplication(
       newrelic.ConfigAppLogConfigAppLogMetricsEnabled(true),
-    )
+  )
   ```
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/apm/agents/go-agent/features/add-browser-monitoring-your-go-apps.mdx
+++ b/src/content/docs/apm/agents/go-agent/features/add-browser-monitoring-your-go-apps.mdx
@@ -20,7 +20,7 @@ Include the byte slice returned by `Transaction.BrowserTimingHeader().WithTags()
 
 The JavaScript returned from `Transaction.BrowserTimingHeader` is request-specific. That is why it must be called on each request.
 
-```
+```go
 func indexHandler(w http.ResponseWriter, req *http.Request) {
     io.WriteString(w, "<html><head>")
 

--- a/src/content/docs/apm/agents/go-agent/features/create-custom-events-go.mdx
+++ b/src/content/docs/apm/agents/go-agent/features/create-custom-events-go.mdx
@@ -16,7 +16,7 @@ Custom events are useful to explore data for a single event you are interested i
 
 To add `RecordCustomEvent` to your Go app, use this format:
 
-```
+```go
 RecordCustomEvent(eventType string, params map[string]interface{})
 ```
 
@@ -72,15 +72,15 @@ RecordCustomEvent(eventType string, params map[string]interface{})
 
 Here is an example of a custom event for a Go app:
 
-```
+```go
 func customEvent(w http.ResponseWriter, r *http.Request) {
     io.WriteString(w, "recording a custom event")
 
-    app.RecordCustomEvent("<var>my_event_type</var>", map[string]interface{}{
-        "myString": "<var>hello</var>",
-        "myFloat":   <var>0.603</var>,
-        "myInt":     <var>123</var>,
-        "myBool":    <var>true</var>,
+    app.RecordCustomEvent("my_event_type", map[string]interface{}{
+        "myString":  "hello",
+        "myFloat":   0.603,
+        "myInt":     123,
+        "myBool":    true,
     })
 }
 ```

--- a/src/content/docs/apm/agents/go-agent/features/cross-application-tracing-go.mdx
+++ b/src/content/docs/apm/agents/go-agent/features/cross-application-tracing-go.mdx
@@ -30,9 +30,9 @@ Even with cross application tracing enabled, you'll need to make sure your appli
   >
     If you're using Go's [`http.ServeMux`](https://golang.org/pkg/net/http/#ServeMux) and want CAT support, you'll need to use the agent's `WrapHandle` and `WrapHandleFunc` wrappers. These wrappers automatically start and end transactions with the request and response writer, which will [automatically add the correct CAT headers](/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces#security). Your code should look similar to the following:
 
-    ```
+    ```go
     http.HandleFunc("/users", usersHandler)
-        http.HandleFunc(newrelic.WrapHandleFunc(app, "/users", usersHandler))
+    http.HandleFunc(newrelic.WrapHandleFunc(app, "/users", usersHandler))
     ```
 
     You can read more about these wrappers in [Instrument Go transactions](/docs/agents/go-agent/get-started/instrument-go-transactions#http-handler-txns).
@@ -44,8 +44,8 @@ Even with cross application tracing enabled, you'll need to make sure your appli
   >
     When creating your own transactions with `app.StartTransaction`, ensure that you also call `Transaction.SetWebRequest` and `Transaction.SetWebResponse`. For example, a transaction started with the following code will have CAT enabled:
 
-    ```
-    txn := app.StartTransaction("<var>transactionName</var>")
+    ```go
+    txn := app.StartTransaction("transactionName")
     // req is a *http.Request, this marks the transaction as a web transaction
     txn.SetWebRequestHTTP(req)
 
@@ -58,20 +58,20 @@ Even with cross application tracing enabled, you'll need to make sure your appli
 
     However, a transaction started without the calls to `Transaction.SetWebRequest` and `Transaction.SetWebResponse` **will not** have CAT enabled:
 
-    ```
+    ```go
     // Cross application tracing not enabled
-    txn := app.StartTransaction("<var>transactionName</var>")
+    txn := app.StartTransaction("transactionName")
     defer txn.End()
     ```
 
     Additionally, if you're setting HTTP response codes, use the Go agent's `txn.WriteHeader` method rather than the standard library's [`http.ResponseWriter.WriteHeader`](https://golang.org/pkg/net/http/#ResponseWriter) method.
 
-    ```
+    ```go
     // old code
     // writer.WriteHeader(http.StatusInternalServerError)
 
     // replace with this
-    txn := app.StartTransaction("<var>transactionName</var>")
+    txn := app.StartTransaction("transactionName")
     txn.SetWebRequest(req)
     writer = txn.SetWebResponse(writer)
     writer.WriteHeader(http.StatusInternalServerError)
@@ -86,11 +86,11 @@ Even with cross application tracing enabled, you'll need to make sure your appli
 
     The easiest way to create an external segment for your outbound HTTP(s) request is to use the `newrelic.NewRoundTripper` method. For example, this code will make a request to `http://api.example.com/` that includes the outgoing CAT headers.
 
-    ```
+    ```go
     func useNewRoundTripper(txn *newrelic.Transaction) (*http.Response, error) {
         client := &http.Client{}
         client.Transport = newrelic.NewRoundTripper(client.Transport)
-        req, _ := http.NewRequest("GET", "<var>http://api.example.com/</var>", nil)
+        req, _ := http.NewRequest("GET", "http://api.example.com/", nil)
         req = newrelic.RequestWithTransactionContext(req, txn)
         return client.Do(req)
     }
@@ -98,7 +98,7 @@ Even with cross application tracing enabled, you'll need to make sure your appli
 
     If you have a more complex request that uses the Go standard library's `http.Request`, you'll need to use the `newrelic.StartExternalSegment` method to ensure your outbound request is eligible for CAT.
 
-    ```
+    ```go
     func external(txn *newrelic.Transaction, req *http.Request) (*http.Response, error) {
         s := newrelic.StartExternalSegment(txn, req)
         response, err := http.DefaultClient.Do(req)
@@ -110,7 +110,7 @@ Even with cross application tracing enabled, you'll need to make sure your appli
 
     While it's also possible to create an `ExternalSegment` via a struct literal, this segment **will not** be eligible for CAT. Because of this, New Relic recommends using [`newrelic.NewRoundTripper` or `newrelic.ExternalSegment`](/docs/agents/go-agent/get-started/instrument-go-segments#go-external-segments).
 
-    ```
+    ```go
     func noGoodForCat(txn *newrelic.Transaction, url string) (*http.Response, error) {
         // CAT headers not inserted
         defer newrelic.ExternalSegment{

--- a/src/content/docs/apm/agents/go-agent/features/trace-asynchronous-applications.mdx
+++ b/src/content/docs/apm/agents/go-agent/features/trace-asynchronous-applications.mdx
@@ -22,7 +22,7 @@ All `Transaction` methods can be used in any `Transaction` reference. The `Trans
 
 Example passing a new `Transaction` reference directly to another goroutine:
 
-```
+```go
 go func(txn *newrelic.Transaction) {
     defer txn.StartSegment("async").End()
     time.Sleep(100 * time.Millisecond)
@@ -31,7 +31,7 @@ go func(txn *newrelic.Transaction) {
 
 Example passing a new `Transaction` reference on a channel to another goroutine:
 
-```
+```go
 ch := make(chan *newrelic.Transaction)
 go func() {
     txn := <-ch

--- a/src/content/docs/apm/agents/go-agent/installation/install-go-agent-gae-flexible-environment.mdx
+++ b/src/content/docs/apm/agents/go-agent/installation/install-go-agent-gae-flexible-environment.mdx
@@ -45,7 +45,7 @@ For more information about deploying and configuring your Go app in the GAE flex
   >
     The `app.yaml` configuration file is required for a GAE flexible environment app with a custom runtime. At a minimum, make sure it contains:
 
-    ```
+    ```yaml
     runtime: custom
     env: flex
     ```
@@ -57,8 +57,8 @@ For more information about deploying and configuring your Go app in the GAE flex
   >
     The [Dockerfile](http://docs.docker.com/engine/reference/builder/) defines the Docker image to be built and is required for a GAE flexible environment app. The following Dockerfile example code defines the golang version used.
 
-    ```
-    FROM golang:<var>1.8-onbuild</var>
+    ```dockerfile
+    FROM golang:1.8-onbuild
     CMD go run main.go
     ```
   </Collapser>
@@ -69,8 +69,8 @@ For more information about deploying and configuring your Go app in the GAE flex
   >
     To build the Docker image, run the following command. Be sure to include the period at the end of the code, to indicate the current directory contains the build files.
 
-    ```
-    docker build --rm -t <var>Docker-image-name</var> .
+    ```bash
+    docker build --rm -t Docker-image-name .
     ```
   </Collapser>
 
@@ -80,8 +80,8 @@ For more information about deploying and configuring your Go app in the GAE flex
   >
     1. To deploy your Docker image to your [initialized GAE flexible environment](https://cloud.google.com/sdk/docs/initializing), run the following command:
 
-       ```
-       gcloud --project <var>go-app-name</var> app deploy
+       ```bash
+       gcloud --project go-app-name app deploy
        ```
     2. Wait until the deployment completes.
     3. To view your GAE flex app data in New Relic, go to the [APM **Summary** page](/docs/apm/applications-menu/monitoring/apm-overview-page).
@@ -96,7 +96,7 @@ If you create a custom runtime, your app must be able to handle a large number o
 
 **Recommendation:** Configure your `app.yaml` to disable health checks by adding:
 
-```
+```yaml
 health_check:
   enable_health_check: False
 ```
@@ -108,6 +108,6 @@ Use these resources to troubleshoot your GAE flex environment app:
 * To connect to the GAE instance and start a shell in the Docker container running your code, see [GAE's documentation for debugging an instance](https://cloud.google.com/appengine/docs/flexible/go/debugging-an-instance).
 * To redirect New Relic Go agent logs to [Stackdriver](http://cloud.google.com/logging/docs/view/logs_viewer_v2) in the [Cloud Platform Console](https://cloud.google.com/compute/docs/console), change the `newrelic.yml` file to:
 
-  ```
+  ```yaml
   log_file_name: STDOUT
   ```

--- a/src/content/docs/apm/agents/go-agent/installation/update-go-agent.mdx
+++ b/src/content/docs/apm/agents/go-agent/installation/update-go-agent.mdx
@@ -17,7 +17,7 @@ To update the Go agent, follow your standard procedures to run the following pro
 
 1. From [http://github.com/newrelic/go-agent](http://github.com/newrelic/go-agent), use this process:
 
-   ```
+   ```bash
    go get -u github.com/newrelic/go-agent/v3/newrelic
    ```
 2. Compile and deploy your application.

--- a/src/content/docs/apm/agents/go-agent/instrumentation/create-custom-metrics-go.mdx
+++ b/src/content/docs/apm/agents/go-agent/instrumentation/create-custom-metrics-go.mdx
@@ -23,21 +23,21 @@ redirects:
 
 1. Instantiate your application by running the following:
 
-   ```
+   ```go
    app, err := newrelic.NewApplication(
-     newrelic.ConfigAppName("<var>Your Application Name</var>"),
-     newrelic.ConfigLicense("<var>NEW_RELIC_LICENSE_KEY</var>"),
+     newrelic.ConfigAppName("Your Application Name"),
+     newrelic.ConfigLicense("NEW_RELIC_LICENSE_KEY"),
      newrelic.ConfigDebugLogger(os.Stdout),
    )
    ```
 
 2. After instantiating your app, create a custom metric with the following code:
 
-   ```
+   ```go
    app.RecordCustomMetric(
-           "CustomMetricName",         //name of your metric
-           132,                         //time in ms
-       );
+       "CustomMetricName",         //name of your metric
+       132,                         //time in ms
+   );
    ```
 
    * `RecordCustomMetric`'s first parameter is a string that names your custom metric.

--- a/src/content/docs/apm/agents/go-agent/instrumentation/go-agent-attributes.mdx
+++ b/src/content/docs/apm/agents/go-agent/instrumentation/go-agent-attributes.mdx
@@ -37,7 +37,7 @@ The Go agent receives the following [default attributes](/docs/agents/manage-apm
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.AttributeHostDisplayName)
       ```
   </Collapser>
@@ -56,7 +56,7 @@ The Go agent receives the following [default attributes](/docs/agents/manage-apm
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.AttributeResponseCodeDeprecated)
       ```
   </Collapser>
@@ -81,7 +81,7 @@ The Go agent receives the following [default attributes](/docs/agents/manage-apm
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.AttributeRequestAccept)
       ```
   </Collapser>
@@ -100,7 +100,7 @@ The Go agent receives the following [default attributes](/docs/agents/manage-apm
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.AttributeRequestContentLength)
       ```
   </Collapser>
@@ -119,7 +119,7 @@ The Go agent receives the following [default attributes](/docs/agents/manage-apm
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.AttributeRequestContentType)
       ```
   </Collapser>
@@ -138,7 +138,7 @@ The Go agent receives the following [default attributes](/docs/agents/manage-apm
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.AttributeRequestHost)
       ```
   </Collapser>
@@ -157,7 +157,7 @@ The Go agent receives the following [default attributes](/docs/agents/manage-apm
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.AttributeRequestReferer)
       ```
   </Collapser>
@@ -176,7 +176,7 @@ The Go agent receives the following [default attributes](/docs/agents/manage-apm
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.AttributeRequestUserAgentDeprecated)
       ```
 
@@ -199,14 +199,14 @@ The Go agent receives the following [default attributes](/docs/agents/manage-apm
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.AttributeRequestUserAgent)
       ```
 
       <Callout variant="important">
         This attribute was added in v3.0.0 of the agent and the original `request.headers.User-Agent` will eventually be removed. Therefore the v3.x agents will produce two attributes representing the the contents of the User-Agent HTTP header. To completely exclude the attribute when using the v3.x agent, you must include both the old and new attributes. For example:
 
-        ```
+        ```go
         config.Attributes.Exclude = append(config.Attributes.Exclude,
             newrelic.AttributeRequestUserAgent,
             newrelic.AttributeRequestUserAgentDeprecated,
@@ -229,7 +229,7 @@ The Go agent receives the following [default attributes](/docs/agents/manage-apm
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.AttributeRequestMethod)
       ```
   </Collapser>
@@ -248,7 +248,7 @@ The Go agent receives the following [default attributes](/docs/agents/manage-apm
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.AttributeResponseContentLength)
       ```
   </Collapser>
@@ -267,7 +267,7 @@ The Go agent receives the following [default attributes](/docs/agents/manage-apm
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.AttributeResponseContentType)
       ```
   </Collapser>
@@ -286,14 +286,14 @@ The Go agent receives the following [default attributes](/docs/agents/manage-apm
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.AttributeResponseCode)
       ```
 
       <Callout variant="important">
         This attribute was added in v3.0.0 of the agent and the original `httpResponseCode` will eventually be removed. Therefore the v3.x agents will produce two attributes representing the response status code for a web request. To completely exclude the attribute when using the v3.x agent, you must include both the old and new attributes. For example:
 
-        ```
+        ```go
         config.Attributes.Exclude = append(config.Attributes.Exclude,
             newrelic.AttributeResponseCode,
             newrelic.AttributeResponseCodeDeprecated,
@@ -321,7 +321,7 @@ If you have [Go agent v2.6.0 or higher](/docs/release-notes/agent-release-notes/
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.SpanAttributeDBCollection)
       ```
   </Collapser>
@@ -339,7 +339,7 @@ If you have [Go agent v2.6.0 or higher](/docs/release-notes/agent-release-notes/
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.SpanAttributeDBInstance)
       ```
   </Collapser>
@@ -357,7 +357,7 @@ If you have [Go agent v2.6.0 or higher](/docs/release-notes/agent-release-notes/
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.SpanAttributeDBStatement)
       ```
   </Collapser>
@@ -375,7 +375,7 @@ If you have [Go agent v2.6.0 or higher](/docs/release-notes/agent-release-notes/
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.SpanAttributeHTTPMethod)
       ```
   </Collapser>
@@ -393,7 +393,7 @@ If you have [Go agent v2.6.0 or higher](/docs/release-notes/agent-release-notes/
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.SpanAttributeHTTPURL)
       ```
   </Collapser>
@@ -411,7 +411,7 @@ If you have [Go agent v2.6.0 or higher](/docs/release-notes/agent-release-notes/
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.SpanAttributePeerAddress)
       ```
   </Collapser>
@@ -429,7 +429,7 @@ If you have [Go agent v2.6.0 or higher](/docs/release-notes/agent-release-notes/
 
       Example of excluding this attribute:
 
-      ```
+      ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.SpanAttributePeerHostname)
       ```
   </Collapser>
@@ -448,7 +448,7 @@ Use these options to change attribute destinations:
 
     For example, to turn off APM error collection: After the [config](https://github.com/newrelic/go-agent/blob/master/GUIDE.md#config-and-application), add:
 
-    ```
+    ```go
     config.ErrorCollector.Attributes.Enabled = false
     ```
   </Collapser>
@@ -461,7 +461,7 @@ Use these options to change attribute destinations:
 
     For example, to disable `AttributeResponseCode`: After the [config](https://github.com/newrelic/go-agent/blob/master/GUIDE.md#config-and-application), add:
 
-    ```
+    ```go
     config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.AttributeResponseCode)
     ```
   </Collapser>
@@ -471,13 +471,13 @@ Use these options to change attribute destinations:
 
 Add custom attributes by using this method in a transaction:
 
-```
-txn.AddAttribute("<var>key</var>", "<var>value</var>")
+```go
+txn.AddAttribute("key", "value")
 ```
 
 The `txn` variable is the one [instrumented for the Go transaction](/docs/agents/go-agent/get-started/instrument-go-transactions#go-txn). For example:
 
-```
+```go
 txn.AddAttribute("product", "widget")
 txn.AddAttribute("price", 19.99)
 txn.AddAttribute("importantCustomer", true)

--- a/src/content/docs/apm/agents/go-agent/instrumentation/instrument-go-segments.mdx
+++ b/src/content/docs/apm/agents/go-agent/instrumentation/instrument-go-segments.mdx
@@ -27,7 +27,7 @@ To instrument an arbitrary block of code as a segment, use the following pattern
 
 ```go
 segment := newrelic.Segment{}
-segment.Name = "<var>mySegmentName</var>"
+segment.Name = "mySegmentName"
 segment.StartTime = txn.StartSegmentNow()
 // ... code you want to time here ...
 segment.End()
@@ -36,7 +36,7 @@ segment.End()
 `StartSegment` is a convenient helper. It creates a segment and starts it:
 
 ```go
-segment := txn.StartSegment("<var>mySegmentName</var>")
+segment := txn.StartSegment("mySegmentName")
 // ... code you want to time here ...
 segment.End()
 ```
@@ -48,7 +48,7 @@ Instrumenting a function as a segment is essentially the same as instrumenting a
 To instrument a function as a segment, add the following code at the start of the function, and include [`txn`](/docs/agents/go-agent/get-started/instrument-go-transactions) as the variable name set for the transaction:
 
 ```go
-defer txn.StartSegment("<var>mySegmentName</var>").End()
+defer txn.StartSegment("mySegmentName").End()
 ```
 
 ## Nest segments [#go-nesting-segments]
@@ -58,8 +58,8 @@ Segments can be nested. The segment being ended must be the most recently starte
 Here's an example of a segment starting and ending inside another segment:
 
 ```go
-s1 := txn.StartSegment("<var>outerSegment</var>")
-s2 := txn.StartSegment("<var>innerSegment</var>")
+s1 := txn.StartSegment("outerSegment")
+s2 := txn.StartSegment("innerSegment")
 // s2 must end before s1
 s2.End()
 s1.End()


### PR DESCRIPTION
Update the rest of the Go docs with language identifiers and fix various code indentation issues.

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.