### PR TITLE
docs: move paragraph into code blocks

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/distributed-tracing-php-agent.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/distributed-tracing-php-agent.mdx
@@ -171,7 +171,7 @@ Infinite Tracing configuration settings include the standard distributed tracing
 
             * Configuration file (`newrelic.ini`):
 
-              ```
+              ```ini
               newrelic.distributed_tracing_enabled = true
               newrelic.span_events_enabled = true
               newrelic.infinite_tracing.trace_observer.host= "<var><a href="/docs/understand-dependencies/distributed-tracing/infinite-tracing/set-trace-observer#ui-endpoints">YOUR_TRACE_OBSERVER_HOST</a></var>"
@@ -287,30 +287,30 @@ If you've been using an older agent without distributed tracing, before turning 
 
             * Enable distributed tracing:
 
-              ```
+              ```ini
               newrelic.distributed_tracing_enabled = true
               ```
             * Set [transaction tracer](/docs/agents/php-agent/configuration/php-agent-configuration#inivar-tt-settings)
 
-              ```
+              ```ini
               newrelic.transaction_tracer.enabled = true
               ```
             * Set [transaction tracer threshold](/docs/agents/php-agent/configuration/php-agent-configuration#inivar-tt-threshold) to a suitable value:
               * If you want to make all transactions eligible for a distributed trace, set this value to `0` seconds.
               * If you are only interested in traces for longer running transactions, or if generating a trace for every transaction creates unacceptable application performance, set this value higher than `0` seconds.
 
-            ```
+            ```ini
             newrelic.transaction_tracer.threshold = 0
             ```
             * Optionally, if you only want W3C Trace Context tracing, you can disable the New Relic distributed tracing headers the `newrelic.distributed_tracing_exclude_newrelic_header` configuration option:
 
-            ```
+            ```ini
             newrelic.distributed_tracing_exclude_newrelic_header = 1
             ```
 
             * Enable spans with the configuration setting:
 
-            ```
+            ```ini
             newrelic.span_events_enabled = true
             ```
           </td>
@@ -343,11 +343,19 @@ If you find that there are too many unimportant spans being reported for PHP fun
 ## Manually instrument applications and services with PHP agent API [#manual]
 
 <Callout variant="important">
-  W3C Trace Context support was added in version 9.8. With this, the API for manually instrumenting applications has changed from the JSON payload related functions
+  W3C Trace Context support was added in version 9.8. With this, the API for manually instrumenting applications has changed from the JSON payload related functions:
+  
+  ```php
+  newrelic_create_distributed_trace_payload()
+  newrelic_accept_distributed_trace_payload($payload)
+  ```
 
-  `newrelic_create_distributed_trace_payload()` and `newrelic_accept_distributed_trace_payload($payload),`
-
-  to the header array forms `newrelic_insert_distributed_trace_headers($outbound_headers)` and `newrelic_accept_distributed_trace_headers($inbound_headers)`.
+  To the header array forms: 
+  
+  ```php
+  newrelic_insert_distributed_trace_headers($outbound_headers)
+  newrelic_accept_distributed_trace_headers($inbound_headers)
+  ```
 
   The JSON functions are now considered deprecated, and will be removed in a future release.
 </Callout>
@@ -374,7 +382,7 @@ For more information about using manual instrumentation to get more detail or to
   >
     Somewhere in your application you'll have code that looks or acts like the following:
 
-    ```
+    ```php
     // create a job object
     $job = new \Generic\Queue\Job;
 
@@ -387,7 +395,7 @@ For more information about using manual instrumentation to get more detail or to
 
     If you want this job to appear in a distributed trace, you need to insert distributed trace headers into an array by using `newrelic_insert_distributed_trace_headers`, and then add those headers to the job's data:
 
-    ```
+    ```php
     $outbound_headers = array();
     if (newrelic_insert_distributed_trace_headers($outbound_headers)) {
 
@@ -420,7 +428,7 @@ For more information about using manual instrumentation to get more detail or to
   >
     Next, somewhere in your application stack you'll have a queue runner that looks or acts like the following:
 
-    ```
+    ```php
     // create the job runner
     $jobRunner = \Generic\Queue\Runner;
 
@@ -433,7 +441,7 @@ For more information about using manual instrumentation to get more detail or to
 
     In order to accept distributed trace headers, use the `newrelic_accept_distributed_trace_headers` function
 
-    ```
+    ```php
     // create the job runner
     $jobRunner = \Generic\Queue\Runner;
 
@@ -457,7 +465,7 @@ For more information about using manual instrumentation to get more detail or to
   >
     Somewhere in your application you'll have code that looks or acts like the following:
 
-    ```
+    ```php
     // create a job object
     $job = new \Generic\Queue\Job;
 
@@ -470,7 +478,7 @@ For more information about using manual instrumentation to get more detail or to
 
     If you want this job to appear in a distributed trace, you need to create a distributed trace payload using `newrelic_create_distributed_trace_payload`, and then add that payload to the job's data:
 
-    ```
+    ```php
     $payload = newrelic_create_distributed_trace_payload();
 
     // create a job object
@@ -495,7 +503,7 @@ For more information about using manual instrumentation to get more detail or to
   >
     Next, somewhere in your application stack you'll have a queue runner that looks or acts like the following:
 
-    ```
+    ```php
     // create the job runner
     $jobRunner = \Generic\Queue\Runner;
 
@@ -508,7 +516,7 @@ For more information about using manual instrumentation to get more detail or to
 
     In order to accept a distributed trace payload, use the `newrelic_accept_distributed_trace_payload` function
 
-    ```
+    ```php
     // create the job runner
     $jobRunner = \Generic\Queue\Runner;
 
@@ -528,7 +536,7 @@ For more information about using manual instrumentation to get more detail or to
   >
     If you need to transport the payload via a mechanism that requires HTTP safe strings, (HTTP headers, URL query strings, POST fields, etc.), the API includes distributed tracing methods and functions that will create and accept HTTP safe versions of the strings.
 
-    ```
+    ```php
     // create the HTTP safe payload string 
     $payload = newrelic_create_distributed_trace_payload();
     $httpSafePayload = $payload->httpSafe();


### PR DESCRIPTION
The paragraph of code was hard to read, so I added codeblocks. I also added language identifiers to the page.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.