### PR TITLE
Fix constant typo

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/background-jobs/monitor-ruby-background-processes.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/background-jobs/monitor-ruby-background-processes.mdx
@@ -102,7 +102,7 @@ NewRelic::Agent.manual_start(:sync_startup => true)
 
 Using `require 'new_relic/agent'` will require the agent's code, and it will make sure the agent doesn't run until you manually start it.
 
-If the process is shorter than the agent [harvest cycle](/docs/using-new-relic/welcome-new-relic/get-started/glossary#harvest-cycle), you need to manually shut down the agent with [`::NewRelic::Agents.shutdown`](https://www.rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent:shutdown) to ensure all queued data is sent.
+If the process is shorter than the agent [harvest cycle](/docs/using-new-relic/welcome-new-relic/get-started/glossary#harvest-cycle), you need to manually shut down the agent with [`::NewRelic::Agent.shutdown`](https://www.rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent:shutdown) to ensure all queued data is sent.
 
 ## Configure newrelic.yml for background processes [#config_file]
 
@@ -171,7 +171,7 @@ For more information, see the documentation about [controlling agent startup](/d
 
 ## Monitor scripts [#monitoring_scripts]
 
-The [agent startup instructions](#start_agent) apply when running background jobs in a daemon. If a script executes a single background task and exits, manually shut down the agent with `::NewRelic::Agents.shutdown` when the script finishes. This ensures the New Relic collector receives the data. For example:
+The [agent startup instructions](#start_agent) apply when running background jobs in a daemon. If a script executes a single background task and exits, manually shut down the agent with `::NewRelic::Agent.shutdown` when the script finishes. This ensures the New Relic collector receives the data. For example:
 
 ```
 require 'newrelic_rpm'


### PR DESCRIPTION
`NewRelic::Agents.shutdown` produces an error because the constant is actually `NewRelic::Agent.shutdown` (without an `s`).

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.