### PR TITLE
New 'quick launch guide'

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
@@ -1,5 +1,5 @@
 ---
-title: Downgrade or cancel account/organization 
+title: Downgrade or cancel account/organization
 tags:
   - Accounts
   - Accounts and billing

--- a/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
@@ -1,5 +1,5 @@
 ---
-title: Downgrade or cancel account/organization
+title: Downgrade or cancel account/organization 
 tags:
   - Accounts
   - Accounts and billing

--- a/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
@@ -26,7 +26,7 @@ For how to manage data ingest, see [Manage your data](/docs/telemetry-data-platf
 To uninstall agents or integrations, here are some recommended procedures:
 * [Remove APM, browser, and mobile apps](/docs/apm/new-relic-apm/maintenance/remove-applications-new-relic/)
 * [Remove infrastructure agent](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/uninstall-infrastructure-agent/)
-* For how to disable other New Relic tools, see their specific docs. You can [search New Relic quickstarts here](https://newrelic.com/instant-observability/).
+* For how to disable other New Relic tools, see their specific docs. You can [search New Relic solutions here](https://newrelic.com/instant-observability/).
 
 ## Downgrade organization [#downgrading]
 

--- a/src/content/docs/logs/forward-logs/circleci-logs.mdx
+++ b/src/content/docs/logs/forward-logs/circleci-logs.mdx
@@ -41,7 +41,7 @@ Complete these steps to set up a CircleCI webhook to forward your logs to New Re
 
 ## What's next [#next]
 
-* Go to the [CircleCI quickstart](https://newrelic.com/instant-observability/circleci/39109d3d-b1d8-4366-8ca9-b8925005f727) in New Relic Instant Observability, and click **+ Install quickstart**.
+* Go to the [CircleCI quickstart](https://newrelic.com/instant-observability/circleci/39109d3d-b1d8-4366-8ca9-b8925005f727) in New Relic Instant Observability, and click **+ Install now**.
 * Learn more about the integration in this blog post: [Integrations for CI-CD Analytics](https://newrelic.com/blog/nerdlog/integrations-for-ci-cd-analytics)
 * Explore logging data across your platform with our [Logs UI](/docs/logs/log-management/ui-data/use-logs-ui/).
 * Get deeper visibility into both your application and your platform performance data by forwarding your logs with our [logs in context](/docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-apm-agents/) capabilities.

--- a/src/content/docs/logs/forward-logs/cloudflare-logpush-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/cloudflare-logpush-forwarding.mdx
@@ -164,7 +164,7 @@ Get started in minutes with a pre-built dashboard to see key metrics from your C
   Our Instant Observability quickstart for Cloudflare network logs includes a pre-built dashboard.
 </figcaption>
 
-* Go the [Cloudflare Network Logs quickstart](https://newrelic.com/instant-observability/cloudflare/fc2bb0ac-6622-43c6-8c1f-6a4c26ab5434) in New Relic Instant Observability, and click **+ Install quickstart**.
+* Go the [Cloudflare Network Logs quickstart](https://newrelic.com/instant-observability/cloudflare/fc2bb0ac-6622-43c6-8c1f-6a4c26ab5434) in New Relic Instant Observability, and click **+ Install now**.
 
 * Learn more about the integration by reading the blog post: [A faster and cheaper way to send log insights to New Relic with the Cloudflare Logpush integration](https://newrelic.com/blog/how-to-relic/cloudflare-log-integration)
 

--- a/src/content/docs/logs/troubleshooting/no-log-data-appears-ui.mdx
+++ b/src/content/docs/logs/troubleshooting/no-log-data-appears-ui.mdx
@@ -14,9 +14,20 @@ redirects:
 
 ## Problem
 
-After enabling log management capabilities in New Relic, no data appears in your Logs UI after about five minutes.
+You're not seeing expected log data in the New Relic UI after ten minutes of installing the infrastructure agent, the APM agent, or setting up log forwarding.
 
-## Solution
+## Solutions
+
+### APM and infrastructure [#agents]
+
+Our APM agents and infrastructure agent are designed to automatically report log data. This is referred to as [logs-in-context](/docs/logs/logs-context/logs-in-context) because it appears in context of various New Relic UI experiences. 
+
+If you don't see that data, or want to add more log data, here are some options: 
+
+* APM: [manual processes for setting up log reporting](/docs/logs/logs-context/logs-in-context/#enable-logs)
+* Infrastructure agent: [logging config options](/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#logging-variables)
+
+### Log forwarding [#log-forwarding]
 
 If no data appears after you send some log payloads and wait about five minutes, try the following:
 
@@ -36,11 +47,23 @@ If no data appears after you send some log payloads and wait about five minutes,
   <tbody>
     <tr>
       <td>
+        Infrastructure and APM agents
+      </td>
+
+      <td>
+These agents are designed to automatically report log data. This is referred to as [logs-in-context](/docs/logs/logs-context/logs-in-context). If you don't see that data, or want to do additional configuration, some options: 
+
+* APM: [manual processes for setting up log reporting](/docs/logs/logs-context/logs-in-context/#enable-logs)
+* Infrastructure agent: [logging config options](/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#logging-variables)
+      </td>
+    </tr>
+    <tr>
+      <td>
         Access to data
       </td>
 
       <td>
-        See [Factors affecting access to features and data](/docs/accounts/accounts-billing/account-structure/factors-affecting-access-features-data/).
+        It's possible you may not have the right permissions or account access. See [Factors affecting access to features and data](/docs/accounts/accounts-billing/account-structure/factors-affecting-access-features-data/).
       </td>
     </tr>
 
@@ -50,7 +73,7 @@ If no data appears after you send some log payloads and wait about five minutes,
       </td>
 
       <td>
-        Make sure you've installed a [compatible log forwarder](/docs/logs/forward-logs/).
+        If you've set up log forwarding, ensure you've installed a [compatible log forwarder](/docs/logs/forward-logs/).
       </td>
     </tr>
 
@@ -98,12 +121,9 @@ If no data appears after you send some log payloads and wait about five minutes,
         SELECT * FROM Log
         ```
 
-        If no data appears in the query builder, then no data will appear in the Logs UI. For more information, see our documentation about [data query options](/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data/) in New Relic.
+        If no data appears in the query builder, then no data will appear in the **Logs** UI. For more information, see [our docs about data query options](/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data).
       </td>
     </tr>
   </tbody>
 </table>
 
-## Other factors affecting access [#more-info]
-
-Learn more about [factors affecting your access to New Relic](/docs/accounts/accounts-billing/general-account-settings/factors-affecting-access-features-data).

--- a/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
@@ -52,13 +52,13 @@ With New Relic, you can:
 
 ## Get started with New Relic [#get-started-now]
 
-Here's how you can quickly get started capturing and analyzing your data:
+Here's how you can quickly get started:
 
 1. If you don't have a New Relic account, sign up at [newrelic.com/signup](https://newrelic.com/signup). It's free, forever!
-2. Follow the steps in our [Add your data](https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJ0dWNzb24ucGxnLWluc3RydW1lbnQtZXZlcnl0aGluZyJ9) UI page to get data flowing in. For your first install, we recommend the **Guided install** option, which will set up many integrations with a single command.
+2. For a recommended path on how to set up New Relic, see [our quick launch guide](/docs/new-relic-solutions/get-started/quick-launch-guide). If you'd prefer to add monitoring for some specific entities and services, use the [Add your data](https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJ0dWNzb24ucGxnLWluc3RydW1lbnQtZXZlcnl0aGluZyJ9) UI page. 
 3. Once you have data coming into New Relic, learn more about the [New Relic UI](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one) or [set up alerts](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-alerts/).
 
-Want to first estimate costs? See our [cost estimate resource](/docs/data-apis/manage-data/calculate-data-ingest). 
+Want to estimate costs? See [our blog post on estimating costs](https://newrelic.com/blog/nerdlog/estimate-data-cost). 
 
 ## All the answers in one place [#answers-in-one-place]
 

--- a/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
@@ -82,7 +82,7 @@ Main options:
         **Step 3. Check out some dashboards**
       </td>      
       <td>
-Now that you've got some data coming in, it's time to explore your environment in real time with some out-of-the-box UI views. You should see data in the **Infrastructure**, **APM**, and **Logs** UI pages (if you don't see that, consider revisiting the install instructions). 
+Now that you've got some data coming in, it's time to explore your environment in real time with some out-of-the-box UI views. You should see data in the **Infrastructure**, **APM**, and **Logs** UI pages. If you don't see that, revisit the install instructions or see [Not seeing data](/docs/new-relic-solutions/solve-common-issues/troubleshooting/not-seeing-data). 
 
 Some tips on understanding those UI pages and more: 
 * Video: [An introduction to the platform](https://www.youtube.com/watch?v=3ZCUujeAkMA) 

--- a/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
@@ -71,9 +71,6 @@ Our main options for instrumenting applications:
 
 </Collapser>
 </CollapserGroup>
-
-      Not seeing data? [Get help.](/docs/new-relic-solutions/solve-common-issues/troubleshooting/not-seeing-data)
-
       </td>      
       </tr>
       <tr>

--- a/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
@@ -14,7 +14,7 @@ Some important points before you start:
 
 * There are many ways to set up New Relic, depending on your system and your goals. This guide walks you through a quick setup that many customers find useful. 
 * This guide will tend to be most useful for smaller organizations, or for anyone who wants to test out New Relic before doing a more in-depth, at-scale rollout.
-* If you'd like to instead start adding tools for some specific technologies, see [Install New Relic](/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic). You can also add more of those after you complete this guide. 
+* If you'd like to instead start adding tools for some specific technologies, see [Install New Relic](/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic#what). You can also add some after you complete this guide. 
 
 ## Quick launch instructions [#quick-launch-steps]
 

--- a/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
@@ -10,7 +10,7 @@ This guide walks you through a recommend path for setting up New Relic quickly.
 
 ## Before you start [#before-start]
 
-Some important things to know before you start: 
+Some important points before you start: 
 
 * There are many ways to set up New Relic, depending on your system and your goals. This guide walks you through a quick setup that many customers find useful. 
 * This guide will tend to be most useful for smaller organizations, or for anyone who wants to test out New Relic before doing a more in-depth, at-scale rollout. If you'd like to instead add monitoring for some specific technologies, see [Install New Relic](/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic). 
@@ -36,16 +36,16 @@ Some important things to know before you start:
         **Step 2. Ingest some data**
       </td>      
       <td>
-        Our [guided install](https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5saXN0aW5nIn0=&cards[0]=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsImFjdGl2ZUNvbXBvbmVudCI6IlZUU09FbnZpcm9ubWVudCIsInBhdGgiOiJndWlkZWQifQ==) auto-discovers infrastructure and app components, and gets some data flowing quickly. If you prefer a more manual approach (for example, if you need to deploy at scale), see the  options directly below. 
+        Our [guided install](https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5saXN0aW5nIn0=&cards[0]=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsImFjdGl2ZUNvbXBvbmVudCI6IlZUU09FbnZpcm9ubWVudCIsInBhdGgiOiJndWlkZWQifQ==) auto-discovers infrastructure and app components, and gets some data flowing quickly. If you prefer a more manual approach (for example, if you need to deploy at scale), see the options directly below. Note that enabling infrastructure monitoring and APM will get you some log data reporting out-of-the-box.
 
         <CollapserGroup>
           <Collapser
             id="manual-install"
             title="Manual install"
           >
-Below are some manual install procedures for some of our most popular tools. If your goal is simply to test out and learn about New Relic, you might consider using the [guided install](https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5saXN0aW5nIn0=&cards[0]=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsImFjdGl2ZUNvbXBvbmVudCI6IlZUU09FbnZpcm9ubWVudCIsInBhdGgiOiJndWlkZWQifQ==) as a first step, followed by some of the manual installation procedures.
+Below are some manual install procedures for some of our most popular tools. 
 
-Install instructions: 
+Manual install docs: 
 
 * Infrastructure: 
   * [Install infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent/#install) 
@@ -53,7 +53,7 @@ Install instructions:
   * Install cloud platforms: [AWS](/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations), [Azure](/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations), [GCP](/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations)
   * [Other infrastructure integrations](https://newrelic.com/instant-observability/?category=infrastructure-and-os)
 * Application data: 
-  * [Install APM agent](https://newrelic.com/instant-observability/?category=application-monitoring&search=apm)
+  * [Install APM agent](/docs/apm/new-relic-apm/getting-started/introduction-apm)
   * [OpenTelemetry](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction)
 </Collapser>
 </CollapserGroup>
@@ -114,13 +114,11 @@ You're now ready to add the rest of your team to New Relic. Use the [**User mana
 
 ## Next steps [#next-steps]
 
-Some ideas for next steps: 
-* [Instrument more systems and services.](https://newrelic.com/instant-observability)
-* [Learn about deploying New Relic at scale](/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic#at-scale)
-* See [our Nerd Bytes YouTube channel](https://www.youtube.com/playlist?list=PLmhYj7Jl81JEV-llIDkCVC05tD7fbOv_b) for helpful how-to videos.
-* See [New Relic University](https://learn.newrelic.com) for in-depth training.
-* Go to [our community forum](https://discuss.newrelic.com) to ask questions and read answers from the community.
-* [Learn about how billing works](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing)
+Some common next steps:
+* For large organizations: [learn about deploying New Relic at scale](/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic#at-scale)
+* [Instrument more systems and services.](https://newrelic.com/instant-observability) Common tools added include: [browser monitoring](/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring), [mobile monitoring](/docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring), and [synthetic monitoring](/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring).
 * To troubleshoot common install and configuration options, see [New Relic Diagnostics](/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics).
+* [Learn about how billing works](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing)
+* Learn more about how to use New Relic. Besides the docs site, we've got [our Nerd Bytes YouTube channel](https://www.youtube.com/playlist?list=PLmhYj7Jl81JEV-llIDkCVC05tD7fbOv_b) for helpful how-to videos and [New Relic University](https://learn.newrelic.com) for in-depth training.
 
-If you're on Standard edition, you don't have technical support. To get 24-7 technical support, [upgrade to Pro or Enterprise edition](https://one.newrelic.com/nr1-core/plan-management/home?account=2816530&state=a7c193fe-1301-9e85-85c8-472b6a1d05ba).
+If you're on Standard edition, you don't have technical support. To get 24-7 technical support, [upgrade to Pro or Enterprise edition](https://one.newrelic.com/nr1-core/plan-management/home?account=2816530&state=a7c193fe-1301-9e85-85c8-472b6a1d05ba). If you don't have support, use [our community forum](https://discuss.newrelic.com) to ask questions and read answers from the community.

--- a/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
@@ -4,19 +4,18 @@ tags:
   - New Relic solutions
   - Best practices guides
 metaDescription: "A guide for how to quickly set up New Relic to get some important telemetry data reporting."
-redirects:
 ---
 
-This is a guide that walks you through a recommend path for setting up New Relic quickly. 
+This guide walks you through a recommend path for setting up New Relic quickly. 
 
 ## Before you start [#before-start]
 
 Some important things to know before you start: 
 
-* There are many ways to set up and use New Relic, depending on your systems and your goals. This guide walks you through a setup procedure that many customers find useful. 
-* This guide can be useful for smaller organizations, or for any organization who wants to test out New Relic before doing a more in-depth, at-scale rollout. If you'd like to instead add monitoring for a few specific systems and services, see [Install New Relic](/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic). 
+* There are many ways to set up New Relic, depending on your system and your goals. This guide walks you through a quick setup that many customers find useful. 
+* This guide will tend to be most useful for smaller organizations, or for anyone who wants to test out New Relic before doing a more in-depth, at-scale rollout. If you'd like to instead add monitoring for some specific technologies, see [Install New Relic](/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic). 
 * When you're done with this guide, you can complete your setup by adding more data and doing additional configuration. 
-* If you get stuck, see [the docs site](https://docs.newrelic.com) for a specific feature. Or check [our Nerd Bytes YouTube channel](https://www.youtube.com/playlist?list=PLmhYj7Jl81JEV-llIDkCVC05tD7fbOv_b) for helpful how-to videos or [New Relic University](https://learn.newrelic.com) for in-depth training.
+* If you get stuck, see [the docs site](https://docs.newrelic.com) for docs for a specific feature. Or check [our Nerd Bytes YouTube channel](https://www.youtube.com/playlist?list=PLmhYj7Jl81JEV-llIDkCVC05tD7fbOv_b) for helpful how-to videos or [New Relic University](https://learn.newrelic.com) for in-depth training.
 
 ## Quick launch instructions [#quick-launch-steps]
 

--- a/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
@@ -13,8 +13,8 @@ This guide walks you through a recommended path for setting up New Relic quickly
 Some important points before you start: 
 
 * There are many ways to set up New Relic, depending on your system and your goals. This guide walks you through a quick setup that many customers find useful. 
-* This guide will tend to be most useful for smaller organizations, or for anyone who wants to test out New Relic before doing a more in-depth, at-scale rollout. If you'd like to instead add monitoring for some specific technologies, see [Install New Relic](/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic). 
-* When you're done with this guide, you can complete your setup by adding more data and doing additional configuration. 
+* This guide will tend to be most useful for smaller organizations, or for anyone who wants to test out New Relic before doing a more in-depth, at-scale rollout.
+* If you'd like to instead start adding tools for some specific technologies, see [Install New Relic](/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic). You can also add more of those after you complete this guide. 
 
 ## Quick launch instructions [#quick-launch-steps]
 
@@ -25,7 +25,7 @@ Some important points before you start:
         **Step 1. Sign up for New Relic**
       </td>      
       <td>
-        If your organization doesn't yet have New Relic, [sign up here](https://newrelic.com/signup). No credit card needed and you get 100 GBs of data per month for free. [Learn more about estimating costs.](https://newrelic.com/blog/nerdlog/estimate-data-cost) 
+        If your organization doesn't already have a New Relic account, [sign up here](https://newrelic.com/signup). No credit card needed and you get 100 GBs of data per month for free. [Learn more about estimating costs.](https://newrelic.com/blog/nerdlog/estimate-data-cost) 
 
         Does your organization already have New Relic but you're just adding a new team or project? See [Add a new account](/docs/accounts/accounts-billing/account-structure/add-accounts). 
       </td>
@@ -35,16 +35,15 @@ Some important points before you start:
         **Step 2. Ingest some data**
       </td>      
       <td>
-        Our [guided install](https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5saXN0aW5nIn0=&cards[0]=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsImFjdGl2ZUNvbXBvbmVudCI6IlZUU09FbnZpcm9ubWVudCIsInBhdGgiOiJndWlkZWQifQ==) auto-discovers infrastructure and app components, and gets some data flowing quickly. If you prefer a more manual approach (for example, if you need to deploy at scale), see the options directly below. Note that enabling infrastructure monitoring and APM will get you some log data reporting out-of-the-box.
+        Our [guided install](https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5saXN0aW5nIn0=&cards[0]=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsImFjdGl2ZUNvbXBvbmVudCI6IlZUU09FbnZpcm9ubWVudCIsInBhdGgiOiJndWlkZWQifQ==) auto-discovers your environment, and walks you through a recommended setup. When the infrastructure agent and APM agent are installed, log data is usually also reported (although sometimes manual configuration is necessary). 
+        
+        If you prefer or require a more manual approach (for example, if you need to deploy at scale), see the options below. 
 
         <CollapserGroup>
           <Collapser
             id="manual-install"
             title="Manual install"
           >
-Below are some manual install procedures for some of our most popular tools. 
-
-### Infrastructure 
 
 **Infrastructure agent**
 
@@ -64,9 +63,9 @@ Connect your cloud platforms to get data from your cloud services:
 
 Install [on-host integrations](https://newrelic.com/instant-observability/?category=infrastructure-and-os) for popular infrastructure-related services like MySQL, Apache, Cassandra, NGINX, Kafka, and more. 
 
-### Application data
+**Application data** 
 
-Main options:
+Our main options for instrumenting applications: 
 * [Install a language-specific APM agent](/docs/apm/new-relic-apm/getting-started/introduction-apm)
 * [OpenTelemetry](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction)
 
@@ -85,14 +84,14 @@ Main options:
 Now that you've got some data coming in, it's time to explore your environment in real time with some out-of-the-box UI views. You should see data in the **Infrastructure**, **APM**, and **Logs** UI pages. If you don't see that, revisit the install instructions or see [Not seeing data](/docs/new-relic-solutions/solve-common-issues/troubleshooting/not-seeing-data). 
 
 Some tips on understanding those UI pages and more: 
-* Video: [An introduction to the platform](https://www.youtube.com/watch?v=3ZCUujeAkMA) 
-* [APM UI docs](/docs/apm/apm-ui-pages/monitoring/apm-summary-page-view-transaction-apdex-usage-data)
-* [Infrastructure UI docs](/docs/infrastructure/infrastructure-ui-pages/infrastructure-ui-entities)
-* [Logs UI docs](/docs/logs/ui-data/use-logs-ui)
-* [Distributed tracing UI docs](/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui) 
+* Video: [An intro to the platform](https://www.youtube.com/watch?v=3ZCUujeAkMA) (2:20)
+* [APM UI](/docs/apm/apm-ui-pages/monitoring/apm-summary-page-view-transaction-apdex-usage-data)
+* [Infrastructure UI](/docs/infrastructure/infrastructure-ui-pages/infrastructure-ui-entities)
+* [Logs UI](/docs/logs/ui-data/use-logs-ui)
+* [Distributed tracing UI](/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui) 
 * [Service maps](/docs/new-relic-solutions/new-relic-one/ui-data/service-maps/introduction-service-maps)
 
-Want to build your own custom dashboards? Learn how to [explore your data](/docs/query-your-data/explore-query-data/browse-data/introduction-data-explorer) and [query your data](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder). 
+Want to build your own dashboards? To build charts, you'll need to learn to [query your data](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder). 
 
       </td>
       </tr>
@@ -113,7 +112,7 @@ Want to get notifications for issues?
 * [Set up your first alert.](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition)
 * [Learn about important alerting concepts](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/basic-alerting-concepts)
 
-Note: Some of the [quickstarts](https://newrelic.com/instant-observability) come with pre-configured alerts.
+Note that some of the [quickstarts](https://newrelic.com/instant-observability) come with alerts already set up.
       </td>
       </tr>
       <tr>

--- a/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
@@ -6,7 +6,7 @@ tags:
 metaDescription: "A guide for how to quickly set up New Relic to get some important telemetry data reporting."
 ---
 
-This guide walks you through a recommend path for setting up New Relic quickly. 
+This guide walks you through a recommended path for setting up New Relic quickly. 
 
 ## Before you start [#before-start]
 
@@ -15,7 +15,6 @@ Some important points before you start:
 * There are many ways to set up New Relic, depending on your system and your goals. This guide walks you through a quick setup that many customers find useful. 
 * This guide will tend to be most useful for smaller organizations, or for anyone who wants to test out New Relic before doing a more in-depth, at-scale rollout. If you'd like to instead add monitoring for some specific technologies, see [Install New Relic](/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic). 
 * When you're done with this guide, you can complete your setup by adding more data and doing additional configuration. 
-* If you get stuck, see [the docs site](https://docs.newrelic.com) for docs for a specific feature. Or check [our Nerd Bytes YouTube channel](https://www.youtube.com/playlist?list=PLmhYj7Jl81JEV-llIDkCVC05tD7fbOv_b) for helpful how-to videos or [New Relic University](https://learn.newrelic.com) for in-depth training.
 
 ## Quick launch instructions [#quick-launch-steps]
 
@@ -45,16 +44,32 @@ Some important points before you start:
           >
 Below are some manual install procedures for some of our most popular tools. 
 
-Manual install docs: 
+### Infrastructure 
 
-* Infrastructure: 
-  * [Install infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent/#install) 
-  * [Install Kubernetes integration](/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm)  
-  * Install cloud platforms: [AWS](/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations), [Azure](/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations), [GCP](/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations)
-  * [Other infrastructure integrations](https://newrelic.com/instant-observability/?category=infrastructure-and-os)
-* Application data: 
-  * [Install APM agent](/docs/apm/new-relic-apm/getting-started/introduction-apm)
-  * [OpenTelemetry](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction)
+**Infrastructure agent**
+
+Install the infrastructure agent to get host data. Choose the most relevant option:
+  * Docker: [Install on a Docker container](/docs/infrastructure/install-infrastructure-agent/linux-installation/docker-instrumentation-infrastructure-monitoring)
+  * Kubernetes: 
+    * [Install agent via Kubernetes](/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm)
+    * [Use our Pixie integration](/docs/kubernetes-pixie/auto-telemetry-pixie/get-started-auto-telemetry-pixie) to get telemetry data and dashboards
+  * Otherwise: [Install the agent on a host](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent/#install) 
+
+**Cloud platforms**
+Connect your cloud platforms to get data from your cloud services:
+
+* Install cloud platforms: [AWS](/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations), [Azure](/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations), [GCP](/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations)
+
+**Infrastructure services**
+
+Install [on-host integrations](https://newrelic.com/instant-observability/?category=infrastructure-and-os) for popular infrastructure-related services like MySQL, Apache, Cassandra, NGINX, Kafka, and more. 
+
+### Application data
+
+Main options:
+* [Install a language-specific APM agent](/docs/apm/new-relic-apm/getting-started/introduction-apm)
+* [OpenTelemetry](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction)
+
 </Collapser>
 </CollapserGroup>
 
@@ -86,7 +101,7 @@ Want to build your own custom dashboards? Learn how to [explore your data](/docs
         **Step 4. Add more data**
       </td>   
       <td>
-If you need data from other sources, choose from among [our hundreds of quickstart integrations](https://newrelic.com/instant-observability). 
+If you need data from other sources, choose from [our hundreds of integrations](https://newrelic.com/instant-observability). 
       </td>
       </tr>
       <tr>
@@ -95,10 +110,10 @@ If you need data from other sources, choose from among [our hundreds of quicksta
       </td>      
       <td>
 Want to get notifications for issues?
-* [Watch a video about creating an alert condition](https://www.youtube.com/watch?v=ViBvw6xfGzc) and [read the alerting docs](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition).
-* Set up [notification destinations](/docs/alerts-applied-intelligence/notifications/notification-integrations) 
+* [Set up your first alert.](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition)
+* [Learn about important alerting concepts](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/basic-alerting-concepts)
 
-Note: Some of the quickstart integrations come with pre-configured alerts.
+Note: Some of the [quickstarts](https://newrelic.com/instant-observability) come with pre-configured alerts.
       </td>
       </tr>
       <tr>
@@ -116,9 +131,15 @@ You're now ready to add the rest of your team to New Relic. Use the [**User mana
 
 Some common next steps:
 * For large organizations: [learn about deploying New Relic at scale](/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic#at-scale)
-* [Instrument more systems and services.](https://newrelic.com/instant-observability) Common tools added include: [browser monitoring](/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring), [mobile monitoring](/docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring), and [synthetic monitoring](/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring).
-* To troubleshoot common install and configuration options, see [New Relic Diagnostics](/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics).
+* To troubleshoot common install issues, see [New Relic Diagnostics](/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics).
+* [Instrument more systems and services.](https://newrelic.com/instant-observability) Popular tools include: 
+  * [Browser monitoring](/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring)
+  * [Mobile monitoring](/docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring)
+  * [Synthetic monitors](/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring)
 * [Learn about how billing works](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing)
-* Learn more about how to use New Relic. Besides the docs site, we've got [our Nerd Bytes YouTube channel](https://www.youtube.com/playlist?list=PLmhYj7Jl81JEV-llIDkCVC05tD7fbOv_b) for helpful how-to videos and [New Relic University](https://learn.newrelic.com) for in-depth training.
+* Learn more about how to use New Relic: 
+  * Docs site
+  * [Our Nerd Bytes YouTube channel](https://www.youtube.com/playlist?list=PLmhYj7Jl81JEV-llIDkCVC05tD7fbOv_b) for helpful how-to videos
+  * [New Relic University](https://learn.newrelic.com) for in-depth training
 
-If you're on Standard edition, you don't have technical support. To get 24-7 technical support, [upgrade to Pro or Enterprise edition](https://one.newrelic.com/nr1-core/plan-management/home?account=2816530&state=a7c193fe-1301-9e85-85c8-472b6a1d05ba). If you don't have support, use [our community forum](https://discuss.newrelic.com) to ask questions and read answers from the community.
+If you're on Standard edition, you may not have access to our global technical support service. To get 24-7 support, [upgrade to Pro or Enterprise edition](https://one.newrelic.com/nr1-core/plan-management/home?account=2816530&state=a7c193fe-1301-9e85-85c8-472b6a1d05ba). Alternatively, use [our community forum](https://discuss.newrelic.com) to ask questions and see answers.

--- a/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
@@ -3,22 +3,22 @@ title: "New Relic quick launch guide"
 tags:
   - New Relic solutions
   - Best practices guides
-metaDescription: "A guide for how to quickly set up New Relic to get some key data reporting."
+metaDescription: "A guide for how to quickly set up New Relic to get some important telemetry data reporting."
 redirects:
 ---
 
-This is a guide giving one recommended path for setting up New Relic quickly. 
+This is a guide that walks you through a recommend path for setting up New Relic quickly. 
 
 ## Before you start [#before-start]
 
 Some important things to know before you start: 
 
-* There are many ways to set up and use New Relic, depending on your systems and your goals. This guide walks you through a setup procedure that many of our customers find useful. 
-* This guide is useful for smaller, simpler organizations, or for any organization who wants to test out New Relic before doing a more in-depth, at-scale rollout. 
+* There are many ways to set up and use New Relic, depending on your systems and your goals. This guide walks you through a setup procedure that many customers find useful. 
+* This guide can be useful for smaller organizations, or for any organization who wants to test out New Relic before doing a more in-depth, at-scale rollout. If you'd like to instead add monitoring for a few specific systems and services, see [Install New Relic](/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic). 
 * When you're done with this guide, you can complete your setup by adding more data and doing additional configuration. 
 * If you get stuck, see [the docs site](https://docs.newrelic.com) for a specific feature. Or check [our Nerd Bytes YouTube channel](https://www.youtube.com/playlist?list=PLmhYj7Jl81JEV-llIDkCVC05tD7fbOv_b) for helpful how-to videos or [New Relic University](https://learn.newrelic.com) for in-depth training.
 
-## Quick launch [#quick-launch-steps]
+## Quick launch instructions [#quick-launch-steps]
 
 <table>
   <tbody>
@@ -29,7 +29,7 @@ Some important things to know before you start:
       <td>
         If your organization doesn't yet have New Relic, [sign up here](https://newrelic.com/signup). No credit card needed and you get 100 GBs of data per month for free. [Learn more about estimating costs.](https://newrelic.com/blog/nerdlog/estimate-data-cost) 
 
-        Already have a New Relic organization but you're adding a new team or project? Consider [adding a new account in your organization](/docs/accounts/accounts-billing/account-structure/add-accounts). 
+        Does your organization already have New Relic but you're just adding a new team or project? See [Add a new account](/docs/accounts/accounts-billing/account-structure/add-accounts). 
       </td>
 </tr>
 <tr>
@@ -44,7 +44,7 @@ Some important things to know before you start:
             id="manual-install"
             title="Manual install"
           >
-Below are some manual install procedures for some of the most popular tools. If your goal is simply to test out and learn about New Relic, you might consider using the [guided install](https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5saXN0aW5nIn0=&cards[0]=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsImFjdGl2ZUNvbXBvbmVudCI6IlZUU09FbnZpcm9ubWVudCIsInBhdGgiOiJndWlkZWQifQ==) as a first step, followed by the more manual installation procedures.
+Below are some manual install procedures for some of our most popular tools. If your goal is simply to test out and learn about New Relic, you might consider using the [guided install](https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5saXN0aW5nIn0=&cards[0]=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsImFjdGl2ZUNvbXBvbmVudCI6IlZUU09FbnZpcm9ubWVudCIsInBhdGgiOiJndWlkZWQifQ==) as a first step, followed by some of the manual installation procedures.
 
 Install instructions: 
 
@@ -68,7 +68,7 @@ Install instructions:
         **Step 3. Check out some dashboards**
       </td>      
       <td>
-Now that you've got some data coming in, it's time to explore your environment in real time with some out-of-the-box dashboards. You should see data in the **Infrastructure**, **APM**, and **Logs** UI pages (if you don't see that, consider revisiting the install instructions). 
+Now that you've got some data coming in, it's time to explore your environment in real time with some out-of-the-box UI views. You should see data in the **Infrastructure**, **APM**, and **Logs** UI pages (if you don't see that, consider revisiting the install instructions). 
 
 Some tips on understanding those UI pages and more: 
 * Video: [An introduction to the platform](https://www.youtube.com/watch?v=3ZCUujeAkMA) 
@@ -76,6 +76,7 @@ Some tips on understanding those UI pages and more:
 * [Infrastructure UI docs](/docs/infrastructure/infrastructure-ui-pages/infrastructure-ui-entities)
 * [Logs UI docs](/docs/logs/ui-data/use-logs-ui)
 * [Distributed tracing UI docs](/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui) 
+* [Service maps](/docs/new-relic-solutions/new-relic-one/ui-data/service-maps/introduction-service-maps)
 
 Want to build your own custom dashboards? Learn how to [explore your data](/docs/query-your-data/explore-query-data/browse-data/introduction-data-explorer) and [query your data](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder). 
 
@@ -106,7 +107,7 @@ Note: Some of the quickstart integrations come with pre-configured alerts.
         **Step 6. Add users**
       </td>      
       <td>
-You're now ready to add the rest of your team to New Relic. Use the [**User management** UI](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks#where) to add users. To learn about the different types of users, see [User type](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type). See [our tutorial on adding accounts and users](/docs/accounts/accounts-billing/new-relic-one-user-management/account-user-mgmt-tutorial). 
+You're now ready to add the rest of your team to New Relic. Use the [**User management** UI](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks#where) to add users. To learn about the different types of users, see [User type](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type). See [our tutorial on adding users and managing user access](/docs/accounts/accounts-billing/new-relic-one-user-management/account-user-mgmt-tutorial). 
       </td>
       </tr>
   </tbody>
@@ -115,6 +116,8 @@ You're now ready to add the rest of your team to New Relic. Use the [**User mana
 ## Next steps [#next-steps]
 
 Some ideas for next steps: 
+* [Instrument more systems and services.](https://newrelic.com/instant-observability)
+* [Learn about deploying New Relic at scale](/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic#at-scale)
 * See [our Nerd Bytes YouTube channel](https://www.youtube.com/playlist?list=PLmhYj7Jl81JEV-llIDkCVC05tD7fbOv_b) for helpful how-to videos.
 * See [New Relic University](https://learn.newrelic.com) for in-depth training.
 * Go to [our community forum](https://discuss.newrelic.com) to ask questions and read answers from the community.

--- a/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
@@ -1,0 +1,124 @@
+---
+title: "New Relic quick launch guide"
+tags:
+  - New Relic solutions
+  - Best practices guides
+metaDescription: "A guide for how to quickly set up New Relic to get some key data reporting."
+redirects:
+---
+
+This is a guide giving one recommended path for setting up New Relic quickly. 
+
+## Before you start [#before-start]
+
+Some important things to know before you start: 
+
+* There are many ways to set up and use New Relic, depending on your systems and your goals. This guide walks you through a setup procedure that many of our customers find useful. 
+* This guide is useful for smaller, simpler organizations, or for any organization who wants to test out New Relic before doing a more in-depth, at-scale rollout. 
+* When you're done with this guide, you can complete your setup by adding more data and doing additional configuration. 
+* If you get stuck, see [the docs site](https://docs.newrelic.com) for a specific feature. Or check [our Nerd Bytes YouTube channel](https://www.youtube.com/playlist?list=PLmhYj7Jl81JEV-llIDkCVC05tD7fbOv_b) for helpful how-to videos or [New Relic University](https://learn.newrelic.com) for in-depth training.
+
+## Quick launch [#quick-launch-steps]
+
+<table>
+  <tbody>
+    <tr>
+      <td style={{ width: "190px" }}>
+        **Step 1. Sign up for New Relic**
+      </td>      
+      <td>
+        If your organization doesn't yet have New Relic, [sign up here](https://newrelic.com/signup). No credit card needed and you get 100 GBs of data per month for free. [Learn more about estimating costs.](https://newrelic.com/blog/nerdlog/estimate-data-cost) 
+
+        Already have a New Relic organization but you're adding a new team or project? Consider [adding a new account in your organization](/docs/accounts/accounts-billing/account-structure/add-accounts). 
+      </td>
+</tr>
+<tr>
+      <td>
+        **Step 2. Ingest some data**
+      </td>      
+      <td>
+        Our [guided install](https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5saXN0aW5nIn0=&cards[0]=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsImFjdGl2ZUNvbXBvbmVudCI6IlZUU09FbnZpcm9ubWVudCIsInBhdGgiOiJndWlkZWQifQ==) auto-discovers infrastructure and app components, and gets some data flowing quickly. If you prefer a more manual approach (for example, if you need to deploy at scale), see the  options directly below. 
+
+        <CollapserGroup>
+          <Collapser
+            id="manual-install"
+            title="Manual install"
+          >
+Below are some manual install procedures for some of the most popular tools. If your goal is simply to test out and learn about New Relic, you might consider using the [guided install](https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5saXN0aW5nIn0=&cards[0]=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsImFjdGl2ZUNvbXBvbmVudCI6IlZUU09FbnZpcm9ubWVudCIsInBhdGgiOiJndWlkZWQifQ==) as a first step, followed by the more manual installation procedures.
+
+Install instructions: 
+
+* Infrastructure: 
+  * [Install infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent/#install) 
+  * [Install Kubernetes integration](/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm)  
+  * Install cloud platforms: [AWS](/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations), [Azure](/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations), [GCP](/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations)
+  * [Other infrastructure integrations](https://newrelic.com/instant-observability/?category=infrastructure-and-os)
+* Application data: 
+  * [Install APM agent](https://newrelic.com/instant-observability/?category=application-monitoring&search=apm)
+  * [OpenTelemetry](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction)
+</Collapser>
+</CollapserGroup>
+
+      Not seeing data? [Get help.](/docs/new-relic-solutions/solve-common-issues/troubleshooting/not-seeing-data)
+
+      </td>      
+      </tr>
+      <tr>
+      <td>
+        **Step 3. Check out some dashboards**
+      </td>      
+      <td>
+Now that you've got some data coming in, it's time to explore your environment in real time with some out-of-the-box dashboards. You should see data in the **Infrastructure**, **APM**, and **Logs** UI pages (if you don't see that, consider revisiting the install instructions). 
+
+Some tips on understanding those UI pages and more: 
+* Video: [An introduction to the platform](https://www.youtube.com/watch?v=3ZCUujeAkMA) 
+* [APM UI docs](/docs/apm/apm-ui-pages/monitoring/apm-summary-page-view-transaction-apdex-usage-data)
+* [Infrastructure UI docs](/docs/infrastructure/infrastructure-ui-pages/infrastructure-ui-entities)
+* [Logs UI docs](/docs/logs/ui-data/use-logs-ui)
+* [Distributed tracing UI docs](/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui) 
+
+Want to build your own custom dashboards? Learn how to [explore your data](/docs/query-your-data/explore-query-data/browse-data/introduction-data-explorer) and [query your data](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder). 
+
+      </td>
+      </tr>
+      <tr>
+      <td>
+        **Step 4. Add more data**
+      </td>   
+      <td>
+If you need data from other sources, choose from among [our hundreds of quickstart integrations](https://newrelic.com/instant-observability). 
+      </td>
+      </tr>
+      <tr>
+      <td>
+        **Step 5. Set up alerting**
+      </td>      
+      <td>
+Want to get notifications for issues?
+* [Watch a video about creating an alert condition](https://www.youtube.com/watch?v=ViBvw6xfGzc) and [read the alerting docs](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition).
+* Set up [notification destinations](/docs/alerts-applied-intelligence/notifications/notification-integrations) 
+
+Note: Some of the quickstart integrations come with pre-configured alerts.
+      </td>
+      </tr>
+      <tr>
+      <td>
+        **Step 6. Add users**
+      </td>      
+      <td>
+You're now ready to add the rest of your team to New Relic. Use the [**User management** UI](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks#where) to add users. To learn about the different types of users, see [User type](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type). See [our tutorial on adding accounts and users](/docs/accounts/accounts-billing/new-relic-one-user-management/account-user-mgmt-tutorial). 
+      </td>
+      </tr>
+  </tbody>
+</table>
+
+## Next steps [#next-steps]
+
+Some ideas for next steps: 
+* See [our Nerd Bytes YouTube channel](https://www.youtube.com/playlist?list=PLmhYj7Jl81JEV-llIDkCVC05tD7fbOv_b) for helpful how-to videos.
+* See [New Relic University](https://learn.newrelic.com) for in-depth training.
+* Go to [our community forum](https://discuss.newrelic.com) to ask questions and read answers from the community.
+* [Learn about how billing works](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing)
+* To troubleshoot common install and configuration options, see [New Relic Diagnostics](/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics).
+
+If you're on Standard edition, you don't have technical support. To get 24-7 technical support, [upgrade to Pro or Enterprise edition](https://one.newrelic.com/nr1-core/plan-management/home?account=2816530&state=a7c193fe-1301-9e85-85c8-472b6a1d05ba).

--- a/src/content/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic.mdx
@@ -193,7 +193,7 @@ If you're on our EU data center, [start here](https://one.eu.newrelic.com/market
   src={installNrQuick}
 />
 
-Our [integrations catalog](https://newrelic.com/instant-observability/) showcases everything you can monitor with New Relic. Not only that, click **+Install quickstart** anywhere to be funneled into the right installation flow, once you've [signed up for a free New Relic account](https://newrelic.com/signup).
+Our [integrations catalog](https://newrelic.com/instant-observability/) showcases everything you can monitor with New Relic. If you've already [signed up for a free New Relic account](https://newrelic.com/signup), you can click **+Install now** anywhere you see that to be funneled into the installation flow. 
 
 ## Need to deploy at scale? [#at-scale]
 

--- a/src/content/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic.mdx
@@ -37,9 +37,13 @@ import prometheuslogo from 'images/prometheus-logo.png'
 
 Welcome to New Relic! Want to get started? You're in the right place.
 
+## Want a guide for how to set up New Relic? [#quick-launch]
+
+Would you like a guide for how to set up New Relic? See our [Quick launch guide](/docs/new-relic-solutions/get-started/quick-launch-guide). If you'd prefer to add monitoring for some specific technologies, keep reading.
+
 ## What do you want to monitor? [#what]
 
-See something you want to monitor? Click a logo to get started. Don't have an account? You'll be asked to [sign up for a free New Relic account](https://newrelic.com/signup). Once you've signed up, the UI guides you into the installation flow that's right for you.
+See something below that you want to monitor? Click a logo to get started. Don't have an account? You'll be asked to [sign up for a free New Relic account](https://newrelic.com/signup). Once you've signed up, the UI gives you suggestions for what to monitor.
 
 <Callout variant="important">
 If you're on our EU data center, [start here](https://one.eu.newrelic.com/marketplace).
@@ -191,9 +195,16 @@ If you're on our EU data center, [start here](https://one.eu.newrelic.com/market
 
 Our [integrations catalog](https://newrelic.com/instant-observability/) showcases everything you can monitor with New Relic. Not only that, click **+Install quickstart** anywhere to be funneled into the right installation flow, once you've [signed up for a free New Relic account](https://newrelic.com/signup).
 
+## Need to deploy at scale? [#at-scale]
+
+Here are some resources for deploying New Relic at scale: 
+* [Docs on automating workflows](https://developer.newrelic.com/automate-workflows)
+* [Configuration management for infrastructure monitoring](/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent#config-mgmt)
+* [Our in-depth observability-as-code guide](/docs/new-relic-solutions/observability-maturity/operational-efficiency/observability-as-code-guide)
+
 ## Want to dig deep? Explore our manual installation paths [#manual-install]
 
-Want more info before getting started? We've got extensive docs on anything you might be into: 
+Here are in-depth install and configuration procedures for our agents and integrations: 
 
 <CollapserGroup>
   <Collapser
@@ -201,8 +212,6 @@ Want more info before getting started? We've got extensive docs on anything you 
     id="apm-install"
     title="Install an APM agent"
   >
-
-
 Use our application performance monitoring (APM) monitoring to learn about your web or non-web application's performance. We support apps for several programming languages:
 
 * [C](/docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code)

--- a/src/content/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic.mdx
@@ -37,9 +37,9 @@ import prometheuslogo from 'images/prometheus-logo.png'
 
 Welcome to New Relic! Want to get started? You're in the right place.
 
-## Want a guide for how to set up New Relic? [#quick-launch]
+## Want recommendations for setting up New Relic? [#quick-launch]
 
-Would you like a guide for how to set up New Relic? See our [Quick launch guide](/docs/new-relic-solutions/get-started/quick-launch-guide). If you'd prefer to add monitoring for some specific technologies, keep reading.
+Would you like a recommended path for how to set things up? See our [Quick launch guide](/docs/new-relic-solutions/get-started/quick-launch-guide). If you'd prefer to add monitoring for some specific technologies, keep reading.
 
 ## What do you want to monitor? [#what]
 

--- a/src/content/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic.mdx
@@ -198,9 +198,9 @@ Our [integrations catalog](https://newrelic.com/instant-observability/) showcase
 ## Need to deploy at scale? [#at-scale]
 
 Here are some resources for deploying New Relic at scale: 
-* [Docs on automating workflows](https://developer.newrelic.com/automate-workflows)
-* [Configuration management for infrastructure monitoring](/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent#config-mgmt)
-* [Our in-depth observability-as-code guide](/docs/new-relic-solutions/observability-maturity/operational-efficiency/observability-as-code-guide)
+* [Configuration management options for infrastructure monitoring](/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent#config-mgmt)
+* [Docs on automating New Relic deployment](https://developer.newrelic.com/automate-workflows)
+* [Our in-depth guide to automating your New Relic depoyment](/docs/new-relic-solutions/observability-maturity/operational-efficiency/observability-as-code-guide)
 
 ## Want to dig deep? Explore our manual installation paths [#manual-install]
 

--- a/src/content/docs/new-relic-solutions/observability-maturity/innovation-growth/development-release-quality-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/innovation-growth/development-release-quality-guide.mdx
@@ -5,7 +5,7 @@ tags:
   - Innovation and growth
   - Release quality
   - Implementation guide
-metaDescription: The goal of the release quality guide is to reduce the size and scope of releases, while increasing release frequency, thus increasing the rate of innovation while also reducing the blast radius of failed production deployments.
+metaDescription: "Our release quality guide helps you use New Relic to improve and optimize the quality and cadence of your code deployments."
 redirects: 
   - /docs/new-relic-solutions/observability-maturity/innovation-growth/release-quality-implementation-guide
 ---

--- a/src/content/docs/new-relic-solutions/observability-maturity/innovation-growth/improving-development-quality-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/innovation-growth/improving-development-quality-guide.mdx
@@ -5,7 +5,7 @@ tags:
   - Innovation and growth
   - Development quality
   - Implementation guide
-metaDescription: Development quality's overall goal is to ensure that fewer defects are introduced into the code base, thus increasing stability.
+metaDescription: "Our development quality guide helps increase stability by using New Relic to ensure that fewer defects are introduced into the code base."
 redirects: 
   - /docs/new-relic-solutions/observability-maturity/innovation-growth/development-quality-implementation-guide
 ---

--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/observability-as-code-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/observability-as-code-guide.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Observability-as-code: automating your observability configuration to drive value"
+metaDescription: "Our observability-as-code guide gives you best practices for automating your New Relic installation and configuration."
 tags:
   - Observability as Code
   - Automation

--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/service-characterization-optimize-telemetry-data-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/service-characterization-optimize-telemetry-data-guide.mdx
@@ -5,7 +5,7 @@ tags:
   - Operational efficiency 
   - Service characterization
   - Implementation guide
-metaDescription: The goal of the service characterization guide is to ensure you have the best telemetry possible to describe the runtime operation of your services.
+metaDescription: "Our service characterization guide helps you set up the best telemetry possible to describe the runtime operation of your services."
 redirects:
   - /docs/agents/manage-apm-agents/agent-data/custom-instrumentation
   - /docs/new-relic-solutions/observability-maturity/operational-efficiency/sc-implementation-guide

--- a/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/not-seeing-data.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/not-seeing-data.mdx
@@ -71,6 +71,14 @@ In addition, you can try these troubleshooting steps that apply to all APM agent
 
 See [Troubleshooting browser monitoring installation](/docs/browser/new-relic-browser/troubleshooting/troubleshooting-browser-monitoring-installation).
 
+## Logs [#logs]
+
+Our APM agents and infrastructure agent are designed to automatically report log data. This is referred to as [logs-in-context](/docs/logs/logs-context/logs-in-context) because it appears in context of various New Relic UI experiences. If you don't see that data, or want to add more log data, here are some options: 
+
+* APM: [manual processes for setting up log reporting](/docs/logs/logs-context/logs-in-context/#enable-logs)
+* Infrastructure agent: [logging config options](/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#logging-variables)
+* [Forward logs from your logging system](/docs/logs/forward-logs/enable-log-management-new-relic)
+
 ### Infrastructure monitoring [#infrastructure-agents]
 
 Follow the troubleshooting procedures for your infrastructure agent:

--- a/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/not-seeing-data.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/not-seeing-data.mdx
@@ -73,11 +73,7 @@ See [Troubleshooting browser monitoring installation](/docs/browser/new-relic-br
 
 ## Logs [#logs]
 
-Our APM agents and infrastructure agent are designed to automatically report log data. This is referred to as [logs-in-context](/docs/logs/logs-context/logs-in-context) because it appears in context of various New Relic UI experiences. If you don't see that data, or want to add more log data, here are some options: 
-
-* APM: [manual processes for setting up log reporting](/docs/logs/logs-context/logs-in-context/#enable-logs)
-* Infrastructure agent: [logging config options](/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#logging-variables)
-* [Forward logs from your logging system](/docs/logs/forward-logs/enable-log-management-new-relic)
+See [Not seeing logs](/docs/logs/troubleshooting/no-log-data-appears-ui).
 
 ### Infrastructure monitoring [#infrastructure-agents]
 

--- a/src/nav/new-relic-solutions.yml
+++ b/src/nav/new-relic-solutions.yml
@@ -81,6 +81,8 @@ pages:
         path: /docs/new-relic-solutions/overview
       - title: New Relic glossary
         path: /docs/new-relic-solutions/get-started/glossary
+      - title: Quick launch guide
+        path: /docs/new-relic-solutions/get-started/quick-launch-guide
       - title: Observability maturity guides
         pages:
           - title: Introduction

--- a/src/nav/new-relic-solutions.yml
+++ b/src/nav/new-relic-solutions.yml
@@ -1,7 +1,7 @@
 title: Guides and solutions
 path: /docs/new-relic-solutions
 pages:
-  - title: Introduction to New Relic 
+  - title: Welcome to New Relic 
     path: /docs/new-relic-solutions/get-started/intro-new-relic
   - title: Install New Relic
     path: /docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic
@@ -9,7 +9,7 @@ pages:
     pages:
       - title: Introduction to the platform
         path: /docs/new-relic-solutions/new-relic-one/introduction-new-relic-one
-      - title: New navigation transition guide 
+      - title: New navigation UI transition guide 
         path: /docs/new-relic-solutions/new-relic-one/new-navigation-transition-guide
       - title: 'Platform basics: search, share, and more'
         path: /docs/new-relic-solutions/new-relic-one/ui-data/basic-ui-features


### PR DESCRIPTION
Changes: 
Added new 'quick launch guide'
Added references to this from related intro/welcome docs
Assorted changes as noticed 

Things to review: 
- the 'quick launch guide' itself (which has been on beta site for a while and gotten significant review already)
- The references to it in the 'Welcome' and 'Install' docs
- The location of the guide. 