### PR TITLE
Fix i18n workflow bug when marking a translation as completed in translation database

### DIFF
--- a/scripts/actions/__tests__/check-job-progress.test.js
+++ b/scripts/actions/__tests__/check-job-progress.test.js
@@ -16,6 +16,8 @@ jest.mock('../utils/vendor-request');
 jest.mock('../fetch-and-deserialize');
 jest.mock('../configuration');
 
+const PROJECT_ID = '7470e5b60';
+
 describe('check-jobs-progress tests', () => {
   beforeEach(() => {
     jest.resetAllMocks();
@@ -89,13 +91,14 @@ describe('check-jobs-progress tests', () => {
 
       const slugStatus = { ok: false, slug: 'failure.txt', locale: 'ja-JP' };
 
-      await updateTranslationRecords([slugStatus]);
+      await updateTranslationRecords(PROJECT_ID, [slugStatus]);
 
       expect(updateTranslations.mock.calls.length).toBe(1);
       expect(updateTranslations.mock.calls[0][0]).toStrictEqual({
         slug: 'failure.txt',
         status: 'IN_PROGRESS',
         locale: 'ja-JP',
+        project_id: '7470e5b60',
       });
       expect(updateTranslations.mock.calls[0][1]).toStrictEqual({
         status: 'COMPLETED',
@@ -107,13 +110,14 @@ describe('check-jobs-progress tests', () => {
 
       const slugStatus = { ok: true, slug: 'success.txt', locale: 'ja-JP' };
 
-      await updateTranslationRecords([slugStatus]);
+      await updateTranslationRecords(PROJECT_ID, [slugStatus]);
 
       expect(updateTranslations.mock.calls.length).toBe(1);
       expect(updateTranslations.mock.calls[0][0]).toStrictEqual({
         slug: 'success.txt',
         status: 'IN_PROGRESS',
         locale: 'ja-JP',
+        project_id: '7470e5b60',
       });
       expect(updateTranslations.mock.calls[0][1]).toStrictEqual({
         status: 'COMPLETED',
@@ -128,13 +132,14 @@ describe('check-jobs-progress tests', () => {
         { ok: true, slug: 'fake_slug_3.txt', locale: 'ko-KR' },
       ];
 
-      await updateTranslationRecords(slugStatuses);
+      await updateTranslationRecords(PROJECT_ID, slugStatuses);
 
       expect(updateTranslations.mock.calls.length).toBe(3);
       expect(updateTranslations.mock.calls[0][0]).toStrictEqual({
         slug: 'fake_slug.txt',
         status: 'IN_PROGRESS',
         locale: 'ja-JP',
+        project_id: '7470e5b60',
       });
       expect(updateTranslations.mock.calls[0][1]).toStrictEqual({
         status: 'COMPLETED',
@@ -143,6 +148,7 @@ describe('check-jobs-progress tests', () => {
         slug: 'fake_slug_2.txt',
         status: 'IN_PROGRESS',
         locale: 'ko-KR',
+        project_id: '7470e5b60',
       });
       expect(updateTranslations.mock.calls[1][1]).toStrictEqual({
         status: 'COMPLETED',
@@ -151,6 +157,7 @@ describe('check-jobs-progress tests', () => {
         slug: 'fake_slug_3.txt',
         status: 'IN_PROGRESS',
         locale: 'ko-KR',
+        project_id: '7470e5b60',
       });
       expect(updateTranslations.mock.calls[2][1]).toStrictEqual({
         status: 'COMPLETED',

--- a/scripts/actions/check-job-progress.js
+++ b/scripts/actions/check-job-progress.js
@@ -195,13 +195,11 @@ const aggregateStatuses = (slugStatuses) => {
  * @param {SlugStatus[]} slugStatuses
  * @returns {Promise<void>}
  */
-const updateTranslationRecords = async (slugStatuses) => {
-  // TODO: need to update this when we implement multiple locales. This only works for one locale.
-
+const updateTranslationRecords = async (project_id, slugStatuses) => {
   await Promise.all(
     slugStatuses.map(async ({ locale, slug }) => {
       const records = await updateTranslations(
-        { slug, status: StatusEnum.IN_PROGRESS, locale },
+        { slug, status: StatusEnum.IN_PROGRESS, locale, project_id },
         { status: StatusEnum.COMPLETED }
       );
 
@@ -284,7 +282,8 @@ const main = async () => {
     const erroredStatuses = slugStatuses.filter(({ ok }) => !ok);
 
     logErroredStatuses(erroredStatuses);
-    await updateTranslationRecords(slugStatuses);
+
+    await updateTranslationRecords(PROJECT_ID, slugStatuses);
 
     const results = aggregateStatuses(slugStatuses);
 


### PR DESCRIPTION
# Summary
When downloading and deserialization was successful, we update the translation database to mark a file as COMPLETED before we then clean up and delete all completed files and jobs from database.

in rare circumstances the same file URI could be IN_PROGRESS for the same locale at the same time in two different projects. if so, we only want to delete the record for the project at hand (human or machine). otherwise both records are deleted and one of the workflows will start to fail when it can't find the relevant record for a given file for a given locale.

# Related info
See jira for full details https://issues.newrelic.com/browse/NR-39576