### PR TITLE
Fix link to Metric Streams NerdGraph mutation

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
@@ -45,7 +45,7 @@ The New Relic UI currently recommends the `ReadOnlyAccess` policy over these ind
 First, you need to link each of your AWS accounts with your New Relic account. To do so, use either of these options:
 
 * Go to **[one.newrelic.com](https://one.newrelic.com/) > Infrastructure > AWS**, click on **Add an AWS account**, then on **Use metric streams**, and follow the steps.
-* [Automate this step with NerdGraph](/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial/#link-aws).
+* [Automate this step with NerdGraph](/docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial/#link-aws-cloudwatch).
 
 Next, set up the metric stream using the [CloudFormation template](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https://nr-downloads-main.s3.amazonaws.com/cloud_integrations/aws/cloudformation/MetricStreams_CloudFormation.yml&stackName=NewRelic-Metric-Stream&param_NewRelicDatacenter=US) we provide in the last step of our UI. This template is provided as a base to set up the integration on a single region. You can customize and extend it to meet your requirements.
 


### PR DESCRIPTION
The link to the NerdGraph information for linking AWS accounts to New Relic for Metric Streams was pointing to the section for API Polling integrations. This change fixes it to point to the Metric Streams version of the mutation.