### PR TITLE
Fix(Go Agent): corrected names of functions, added multi-string usage for IgnoredPrefix

### DIFF
--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-code-level-metrics-config.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-code-level-metrics-config.mdx
@@ -91,25 +91,25 @@ There are additional configuration options you may wish to use to further refine
   By default, with code-level metrics enabled, the agent will ignore functions in the call stack which it believes to be internal
   to the agent itself, to ensure that the function reported is the one intended, even though functions inside the agent will have
   been called to get into the code-level metrics instrumentation code. By default, it does this by ignoring any functions whose
-  package name begins with `github.com/newrelic/go-agent/`. You can change this to any arbitrary name by setting your own
-  `IgnorePrefix` value.
+  package name begins with `github.com/newrelic/go-agent/`. You can change this to any arbitrary list of names by setting your own
+  `IgnoredPrefixes` value.
 
   To accomplish this, do one of the following:
 
-  * If configuring via the `NewApplication` function, add a `ConfigCodeLevelMetricsIgnorePrefix` option:
+  * If configuring via the `NewApplication` function, add a `ConfigCodeLevelMetricsIgnoredPrefix` option, passing any number of prefix strings as separate string arguments:
 
     ```go
     app, err := newrelic.NewApplication(
        newrelic.ConfigAppName("Your Application Name"),
        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
        newrelic.ConfigCodeLevelMetricsEnabled(true),
-       newrelic.ConfigCodeLevelMetricsIgnorePrefix("github.com/some/other/name/"),
+       newrelic.ConfigCodeLevelMetricsIgnoredPrefix("github.com/some/other/name/"),
     )
     ```
 
-  * If configuring via environment variables, set `NEW_RELIC_CODE_LEVEL_METRICS_IGNORE_PREFIX` to the desired prefix:
+  * If configuring via environment variables, set `NEW_RELIC_CODE_LEVEL_METRICS_IGNORED_PREFIX` to the desired prefix (or a comma-separated list of prefixes):
     ```
-    NEW_RELIC_CODE_LEVEL_METRICS_IGNORE_PREFIX="github.com/some/other/name/"
+    NEW_RELIC_CODE_LEVEL_METRICS_IGNORED_PREFIX="github.com/some/other/name/"
     ```
 
     Don't forget to also include the `newrelic.ConfigFromEnvironmet` option when setting up the application:
@@ -122,6 +122,9 @@ There are additional configuration options you may wish to use to further refine
        newrelic.ConfigFromEnvironment(),
     )
     ```
+
+  * It is also possible to directly set the `CodeLevelMetrics.IgnoredPrefixes` member of the `Config` struct (which is a `[]string` value), but we recommend using one of the above-mentioned methods instead of directly manipulating the `Config` structure.
+
   </Collapser>
   <Collapser
     id="go-clm-config-path-prefix"

--- a/src/content/docs/apm/agents/go-agent/instrumentation/go-agent-code-level-metrics-instrument.mdx
+++ b/src/content/docs/apm/agents/go-agent/instrumentation/go-agent-code-level-metrics-instrument.mdx
@@ -38,14 +38,22 @@ This means that, for this transaction only, a source file pathname of, for examp
 ### Adjusting the function recognition heuristic's ignore prefix [#instrument-transactions-ignore-prefix-clm]
 
 By default, the Go agent contains logic to skip over functions in the call stack which are internal to the agent itself, in order to arrive at the one you are instrumenting. The [configuration guide](/docs/apm/agents/go-agent/configuration/go-agent-code-level-metrics-config)
-has information about how you can globally change this heuristic via the `ConfigCodeLevelMetricsIgnorePrefix` setting, but you may wish to provide a custom namespace ignore prefix for a single transaction. You can do so by adding a `WithIgnorePrefix` option to the transaction:
+has information about how you can globally change this heuristic via the `ConfigCodeLevelMetricsIgnoredPrefix` setting, but you may wish to provide a custom namespace ignore prefix for a single transaction. You can do so by adding a `WithIgnoredPrefix` option to the transaction:
 
 ```go
-txn := app.StartTransaction("mytransaction", newrelic.WithIgnorePrefix("github.com/ignore/this/"))
+txn := app.StartTransaction("mytransaction", newrelic.WithIgnoredPrefix("github.com/ignore/this/"))
 defer txn.End()
 ```
 
-With this change, any functions from a package whose name begins with `github.com/ignore/this/` will be skipped over to find the function being instrumented.
+You can specify multiple string arguments to `WithIgnoredPrefix` if there are multiple packages whose functions should be ignored:
+
+```go
+txn := app.StartTransaction("mytransaction", newrelic.WithIgnoredPrefix("github.com/ignore/this/", "github.com/ignore/that/"))
+defer txn.End()
+```
+
+
+With this change, any functions from a package whose name begins with `github.com/ignore/this/` (or `github.com/ignore/that/` in the second example) will be skipped over to find the function being instrumented.
 
 ### Explicitly mark the code location [#instrument-transactions-this-location-clm]
 


### PR DESCRIPTION
* Existing version of the documentation misspelled `IgnoredPrefix` as `IgnorePrefix`. This corrects that typo.
* The upcoming release adds new functionality by allowing multiple string arguments to the `WithIgnoredPrefix` and `ConfigCodeLevelMetricsIgnoredPrefix` functions instead of just a single one as before. This is now documented.
* The `Config` structure's `IgnoredPrefix` member is now deprecated in favor of the new `IgnoredPrefixes` (the former being a single `string` value, the latter being `[]string` to allow multiple prefixes to be specified.