### PR TITLE
Fix links in php-agent-configuration

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -803,7 +803,7 @@ For more information about ways to start the daemon and when to use an external 
   </Collapser>
 
   <Collapser
-    id="inivar-daemon-app_timeout"
+    id="inivar-daemon-app_connect_timeout"
     title="newrelic.daemon.app_connect_timeout"
   >
     <table>
@@ -1429,7 +1429,7 @@ For more information about ways to start the daemon and when to use an external 
   </Collapser>
 
   <Collapser
-    id="inivar-daemon-app_timeout"
+    id="inivar-daemon-start_timeout"
     title="newrelic.daemon.start_timeout"
   >
     <table>


### PR DESCRIPTION
Fixed a couple duplicate links so that they are unique and when linked will bring the user to the correct setting.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.