### PR TITLE
chore(.GITHUB): Remove Recharge Week info

### DIFF
--- a/.github/workflows/auto-comment.yml
+++ b/.github/workflows/auto-comment.yml
@@ -9,12 +9,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pullRequestOpened: |
             Hi @{{ author }} 👋
-            Thanks for your pull request! New Relic is on a company-wide vacation the week of August 8 through August 12. We'll take a look as soon as we're back August 15.
+            
+            Thanks for your pull request! Your PR is in a queue, and a writer will take a look soon. We generally publish small edits within one business day, and larger edits within three days.
             
             Gatsby Cloud will automatically generate a preview of your request, and will comment with a link when the preview is ready (usually 20 to 30 minutes).
 
           issuesOpened: |
             Hi @{{ author }} 👋
-            Thank you for filing an issue! New Relic is on a company-wide vacation the week of August 8 through August 12. We'll take a look as soon as we're back August 15. Or, if your issue is urgent, you can reach out to our support team at support.newrelic.com. 
-            
-            We'll triage your issue and let you know if we have questions, and then route it to the appropriate team so we can get it solved.
+
+            Thank you for filing an issue! We'll triage your issue and let you know if we have questions, and then route it to the appropriate team so we can get it solved.


### PR DESCRIPTION
Remove Recharge Week verbiage from PR and issue auto-replies

See also #8804 