### PR TITLE
Fix(Go Agent): Added notes about compatibility with legacy code

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-18-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-18-0.mdx
@@ -19,6 +19,15 @@ downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.18.0'
 ### Fixed
  * Fixed issue with custom event limits and number of distributed tracing spans to more accurately follow configured limits.
 
+### Compatibility Notice
+This release extends the API by allowing custom options to be added to calls to the `Application.StartTransaction` method and the `WrapHandle` and `WrapHandleFunc` functions. They are implemented as variadic functions such that the new option parameters are optional (i.e., zero or more options may be added to the end of the function calls) to be backward-compatible with pre-3.18.0 usage of those functions.
+This prevents the changes from breaking existing code for typical usage of the agent. However, it does mean those functions' call signatures have changed:
+ * `StartTransaction(string)` -> `StartTransaction(string, ...TraceOption)`
+ * `WrapHandle(*Application, string, http.Handler)` -> `WrapHandle(*Application, string, http.Handler, ...TraceOption)`
+ * `WrapHandleFunc(*Application, string, func(http.ResponseWriter, *http.Request))` -> `WrapHandleFunc(*Application, string, func(http.ResponseWriter, *http.Request), ...TraceOption)`
+
+If, for example, you created your own custom interface type which includes the `StartTransaction` method or something that depends on these functions' exact call semantics, that code will need to be updated accordingly before using version 3.18.0 of the Go Agent.
+
 ### Support Statement
 New Relic recommends that you upgrade the agent regularly to ensure that you’re getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach end-of-life.
 * Note that the oldest supported version of the Go agent is 2.11.0.


### PR DESCRIPTION
Release 3.18.0 introduced API changes in a backwards-compatible manner to prevent this from being a breaking change for users of the Go Agent. While this is the case for what we believe to be typical usage of the agent, there is a possible edge case where a change to customer code is necessary if they wrote their own custom code around the agent.

This PR adds a notice to the release notes for 3.18.0 to point this out to users so they are fully informed of the issue.