### PR TITLE
feat(custom headers): Added custom header option

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors.mdx
@@ -62,6 +62,7 @@ Keep in mind that the default timeout for a new monitor is 180 seconds.
          If a non-zero exit code is returned, the monitor will fail.
        * The **Bypass HEAD request** option is available for ping. This option skips the default `HEAD` request and instead uses the `GET` verb with a ping check.
        * **Redirect is Failure** is available for ping. If a redirect result occurs when Redirect is Failure is enabled, your synthetic monitor will categorize the result as a failure, rather than following the redirect and checking the resulting URL.
+       * **Custom Headers** can be added to ping and simple browser monitors. These headers will be added to requests submitted by the monitor.
     4. Select the [locations](#setting-location) from which you want your monitor to run.
     5. Choose a [frequency](#setting-frequency) to determine how often each location will run your monitor.
     6. Optional: Set up [alert notifications](/docs/synthetics/new-relic-synthetics/using-monitors/alerting-synthetics).


### PR DESCRIPTION
Added custom request headers to the advanced options for ping and simple browser monitors. This feature has been available in synthetics for a few months but was not added to the documentation when released.