### PR TITLE
fix: lower case the d in Docs on home page

### DIFF
--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -33,13 +33,7 @@
     },
     "search": {
       "popularSearches": {
-        "options": [
-          "NRQL",
-          "logs",
-          "alert",
-          "best practices",
-          "Kubernetes"
-        ],
+        "options": ["NRQL", "logs", "alert", "best practices", "Kubernetes"],
         "title": "Popular searches"
       },
       "placeholder": "What are you looking for?"
@@ -56,7 +50,7 @@
         "title": "Forward logs using infrastructure agent"
       }
     },
-    "pageTitle": "Welcome to New Relic Docs!",
+    "pageTitle": "Welcome to New Relic docs!",
     "whatsNew": {
       "title": "What's new"
     }


### PR DESCRIPTION
Lower case the `D` in home page title