### PR TITLE
fix(node agent): add compressed_content_encoding configuration setting

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -263,6 +263,47 @@ This section defines the Node.js agent variables in the order they typically app
   </Collapser>
 
   <Collapser
+    id="compressed_content_encoding"
+    title="compressed_content_encoding"
+  >
+  If the data compression threshold is reached in the payload, the agent compresses data, using gzip compression by default. The config option `compressed_content_encoding` can be set to `deflate` to use deflate compression.
+
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `gzip`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_COMPRESSED_CONTENT_ENCODING`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
+
+<Collapser
     id="apdex"
     title="apdex_t (DEPRECATED)"
   >


### PR DESCRIPTION
This has been added in the following PR:

https://github.com/newrelic/node-newrelic/pull/1326
