### PR TITLE
GROK parsing variable name restrictions

### DIFF
--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -107,6 +107,8 @@ Grok is a superset of regular expressions that adds built-in named patterns to b
 
 You can always use a mix of regular expressions and Grok pattern names in your matching string. For more information, see our list of [Grok syntax and supported types](#grok-syntax).
 
+Variable names must be explicitely set and be lowercase like `%{URI:uri}`. Expressions such as `%{URI}` or `%{URI:URI}` would not work.
+
 Watch our YouTube video (approx. 6 minutes) to learn how to use a Grok debugger when you create Grok parsing rule patterns:
 
 <Video


### PR DESCRIPTION
  - Add pharagraph defining naming restrictions for GROK variables