### PR TITLE
Updated cumulativetodelta/metrics

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
@@ -191,12 +191,14 @@ processors:
     spike_limit_mib: 200
   batch:
   cumulativetodelta:
-    metrics:
-      - system.network.io
-      - system.disk.operations
-      - system.network.dropped
-      - system.network.packets
-      - process.cpu.time
+    include:
+      metrics:
+        - system.network.io
+        - system.disk.operations
+        - system.network.dropped
+        - system.network.packets
+        - process.cpu.time
+      match_type: strict
   resource:
     attributes:
       - key: host.id


### PR DESCRIPTION
This configuration doesn't work with the new OpenTelemetry Collector v0.57.2 and up, and returns errors like `error reading processors configuration for "cumulativetodelta"` so `include` and `match_type` was added to work with newer releases of the collector.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.