### PR TITLE
fix(link fixes and apdex removal): Adjustments

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors.mdx
@@ -48,11 +48,11 @@ Keep in mind that the default timeout for a new monitor is 180 seconds.
     id="simple"
     title="Add a ping or simple browser monitor"
   >
-    1. Go to [**one.newrelic.com**](http://one.newrelic.com/), then select **Synthetics**. Click <Icon name="fe-plus-circle"/> [**Create monitor**](https://one.newrelic.com/synthetics-nerdlets/monitor-create?account=3501165&state=81b68a54-0e7f-46ac-d519-09477745afee) in the far right of the Explorer nav.
+    1. Go to [**one.newrelic.com**](http://one.newrelic.com/), then select **Synthetics**. Click <Icon name="fe-plus-circle"/> [**Create monitor**](https://one.newrelic.com/synthetics-nerdlets/monitor-create) in the far right of the Explorer nav.
     2. Specify a [monitor type](#setting-type), [name](#setting-name), and URL (may be any valid HTTP or HTTPS URL).
     3. Optional: Add a **validation string** or **Advanced options**:
 
-       * A **validation string** is available for ping and simple browser. This option enables substring monitoring for [response validation](/docs/synthetics/new-relic-synthetics/using-monitors/add-edit-monitors#response-validation).
+       * A **validation string** is available for ping and simple browser. This option enables substring monitoring for [response validation](#response-validation).
        * **Verify SSL** is available for ping and simple browser. This option verifies the validity of the SSL certificate chain. It can be duplicated by running the following syntax:
 
          ```
@@ -75,7 +75,7 @@ Keep in mind that the default timeout for a new monitor is 180 seconds.
     id="complex"
     title="Add a scripted browser or API test monitor"
   >
-    1. Go to [**one.newrelic.com**](http://one.newrelic.com/), then select **Synthetics**. Click <Icon name="fe-plus-circle"/> [**Create monitor**](https://one.newrelic.com/synthetics-nerdlets/monitor-create?account=3501165&state=81b68a54-0e7f-46ac-d519-09477745afee) in the far right of the Explorer nav.
+    1. Go to [**one.newrelic.com**](http://one.newrelic.com/), then select **Synthetics**. Click <Icon name="fe-plus-circle"/> [**Create monitor**](https://one.newrelic.com/synthetics-nerdlets/monitor-create) in the far right of the Explorer nav.
     2. Specify a [monitor type](#setting-type) and [name](#setting-name).
     3. Select the [locations](#setting-location) from which you want your monitor to run.
     4. Choose a [frequency](#setting-frequency) to determine how often each location will run your monitor.
@@ -94,7 +94,7 @@ Keep in mind that the default timeout for a new monitor is 180 seconds.
     id="stepmonitor"
     title="Add a step monitor"
   >
-    1. Go to [**one.newrelic.com**](http://one.newrelic.com/), then select **Synthetics**. Click <Icon name="fe-plus-circle"/> [**Create monitor**](https://one.newrelic.com/synthetics-nerdlets/monitor-create?account=3501165&state=81b68a54-0e7f-46ac-d519-09477745afee) located on the far right of the Explorer nav.
+    1. Go to [**one.newrelic.com**](http://one.newrelic.com/), then select **Synthetics**. Click <Icon name="fe-plus-circle"/> [**Create monitor**](https://one.newrelic.com/synthetics-nerdlets/monitor-create) located on the far right of the Explorer nav.
     2. Select step monitor as the [monitor type](#setting-type).
     3. Specify a [name](#setting-name) and choose a [frequency](#setting-frequency) to determine how often each location will run your monitor.
     4. Select the [locations](#setting-location) from which you want your monitor to run.
@@ -118,7 +118,7 @@ Keep in mind that the default timeout for a new monitor is 180 seconds.
     id="certificate"
     title="Add a certificate check monitor"
   >
-    1. Go to [**one.newrelic.com**](http://one.newrelic.com/), then select **Synthetics**. Click <Icon name="fe-plus-circle"/> [**Create monitor**](https://one.newrelic.com/synthetics-nerdlets/monitor-create?account=3501165&state=81b68a54-0e7f-46ac-d519-09477745afee) in the far right of the Explorer nav.
+    1. Go to [**one.newrelic.com**](http://one.newrelic.com/), then select **Synthetics**. Click <Icon name="fe-plus-circle"/> [**Create monitor**](https://one.newrelic.com/synthetics-nerdlets/monitor-create) in the far right of the Explorer nav.
     2. Select the certificate check monitor type.
     3. Specify a [name](#setting-name) and enter the domain you'd like to monitor.
     4. Enter the number of days it takes for your certificate to expire.
@@ -134,7 +134,7 @@ Keep in mind that the default timeout for a new monitor is 180 seconds.
     id="broken-links"
     title="Add a broken links monitor"
   >
-    1. Go to [**one.newrelic.com**](http://one.newrelic.com/), then select **Synthetics**. Click <Icon name="fe-plus-circle"/> [**Create monitor**](https://one.newrelic.com/synthetics-nerdlets/monitor-create?account=3501165&state=81b68a54-0e7f-46ac-d519-09477745afee) in the far right of the Explorer nav.
+    1. Go to [**one.newrelic.com**](http://one.newrelic.com/), then select **Synthetics**. Click <Icon name="fe-plus-circle"/> [**Create monitor**](https://one.newrelic.com/synthetics-nerdlets/monitor-create) in the far right of the Explorer nav.
     2. Select the broken links check monitor type.
     3. Specify a [name](#setting-name) and enter the URL you'd like to monitor (may be any valid HTTP or HTTPS URL).
     4. Select the period to determine your monitor's [frequency](#setting-frequency).
@@ -165,7 +165,7 @@ You cannot change a monitor's [type](#setting-type) after the monitor is created
 1. From the **Monitors** tab in [**one.newrelic.com**](http://one.newrelic.com/) **> Synthetics**, select the monitor you want to edit.
 2. In the side menu, select a link to change the following [settings](#settings):
 
-   * Select **Settings > General** to edit [name](#setting-name), [Apdex T](#setting-apdex), URL, [locations](#setting-location), [frequency](#setting-frequency), and advanced options.
+   * Select **Settings > General** to edit [name](#setting-name), URL, [locations](#setting-location), [frequency](#setting-frequency), and advanced options.
    * For **Scripted browser** and **API test** monitors, select **Settings > Script** to edit your monitor script.
    * For synthetic monitoring alerts, click **Manage alerts**.
 3. Select **Save changes** to confirm.
@@ -207,7 +207,7 @@ When configuring monitors, the following settings are available:
     Select the type of monitor you want to create. A monitor's [type](/docs/synthetics/new-relic-synthetics/getting-started/types-synthetics-monitors#types-monitors) can't be changed after the monitor is created.
 
     * **Ping**: Specify a single URL to monitor for availability. New Relic will check this URL via HEAD or GET requests. The non-configurable [timeout](/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers#waiting-elements) for this monitor is 60 seconds.
-    * **Simple browser**: Specify a single URL to monitor via real browser. Once each [frequency interval](#setting-frequency), New Relic will check this URL via a Selenium-powered Google Chrome browser. The non-configurable [timeout](/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers#waiting-elements) for this monitor is 60 seconds.
+    * **Simple browser**: Specify a single URL to monitor via real browser. Once each [frequency interval](#setting-frequency), New Relic will check this URL via a Selenium-powered Google Chrome browser. The non-configurable [timeout](/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers/#waiting-elements) for this monitor is 60 seconds.
     * **Scripted browser**: [Create a script](/docs/synthetics/new-relic-synthetics/scripting-monitors/writing-synthetic-scripts) to drive a Selenium-powered Google Chrome browser. The browser follows each step in the script to verify that complex behavior is working as expected (for example, searching a website, then clicking one of the search results). The non-configurable [timeout](/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers#waiting-elements) for this monitor is 180 seconds.
     * **API test**: Create an API script to ensure your API endpoint is working correctly. For more information, see [Write API tests](/docs/synthetics/new-relic-synthetics/scripting-monitors/writing-api-tests). The non-configurable timeout for this monitor is 180 seconds.
   </Collapser>
@@ -243,17 +243,10 @@ When configuring monitors, the following settings are available:
   </Collapser>
 
   <Collapser
-    id="setting-apdex"
-    title="Apdex T"
-  >
-    Customize the [Apdex T](/docs/apm/new-relic-apm/getting-started/glossary#apdex_t) for this monitor. This setting is only available when editing the settings for an existing monitor, not when creating a new monitor. Change the Apdex T from the default 7 seconds for more accurate Apdex scores [in your SLA reports](/docs/synthetics/new-relic-synthetics/dashboards/synthetics-sla-report-dashboard-aggregate-metrics-all-monitors). For example, if you have a very long [scripted browser](/docs/synthetics/new-relic-synthetics/scripting-monitors/writing-scripted-browsers), you might adjust the Apdex T to 15 seconds to more closely reflect the usual completion time. Similarly, a good Apdex T for a simple browser check might be only 2 seconds.
-  </Collapser>
-
-  <Collapser
     id="response-validation"
     title="Response Validation (optional)"
   >
-    Specify text to search for on the page DOM. When using simple browser or ping [monitor types](/docs/synthetics/new-relic-synthetics/getting-started/types-synthetics-monitors#types-monitors), there is a 1MB (10^6 bytes) limit on the page load.
+    Specify text to search for on the page DOM. When using simple browser or ping [monitor types](/docs/synthetics/synthetic-monitoring/getting-started/types-synthetic-monitors/#types-monitors), there is a 1MB (10^6 bytes) limit on the page load.
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
- Fixed multiple broken create monitor links
- Fixed link to additional response validation details
- Fixed link to monitor types in the response validation section
- Removed references to Apdex. The Apdex T value can no longer be set in the synthetics UI.