### PR TITLE
framework updates 

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -13,7 +13,7 @@ redirects:
   - /docs/agents/net-agent/getting-started/compatibility-requirements-net-framework-agent
 ---
 
-Our .NET agent supports both .NET Framework and .NET Core. Here we describe the compatibility and support for .NET Framework applications. For .NET Core, see [Compatibility and requirements for .NET Core](/docs/agents/net-agent/installation/compatibility-requirements-net-core-agent).
+Our .NET agent supports both .NET Framework and .NET Core. Here we describe the compatibility and support for .NET Framework applications. For .NET Core, see [Compatibility and requirements for .NET Core](/docs/agents/net-agent/installation/compatibility-requirements-net-core-agent). 
 
 The agent includes built-in instrumentation for some of the most popular parts of the .NET Framework ecosystem, including frameworks, databases, and message queuing systems. After you [download and install](/docs/agents/net-agent/installation/introduction-net-agent-install) the agent, it runs within the monitored process. The agent does not create a separate process or service.
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -760,6 +760,16 @@ The .NET agent does not directly monitor datastore processes. Also, by default t
     </table>
   </Collapser>
   <Collapser
+      id="technologies"
+      title="Supported .NET technologies and languages"
+  >
+  You can automatically instrument the follow .NET technologies and language:
+  
+  * C# applications
+  * ADO.NET
+  
+  </Collapser>
+  <Collapser
     className="freq-link"
     id="logging-frameworks"
     title="Logging Frameworks"

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -73,29 +73,10 @@ Before you [install New Relic's .NET agent](/docs/agents/net-agent/installation/
   >
     The use of [Code Access Security](https://docs.microsoft.com/en-us/dotnet/framework/misc/code-access-security) is compatible with the .NET agent only when Full Trust is provided. The agent is not compatible with more restrictive trust levels.
 </Collapser>
-
 <Collapser
-    className="freq-link"
-    id="operating-system"
-    title="Operating system"
->
-    The agent requires one of these operating systems:
-
-    * Windows Server 2008
-    * Windows Server 2008 R2
-    * Windows Server 2012
-    * Windows Server 2012 R2
-    * Windows Server 2016
-    * Windows Server 2019
-    * Windows 10
-    * Windows Azure (OS Family 1, 2, and 3)
-    * Windows containers running on Windows 2016 (NanoServer based images are not supported)
-</Collapser>
-
-  <Collapser
     id="azure"
     title="Microsoft Azure"
-  >
+>
     For Azure-specific installation instructions, see:
 
     * [Install on Azure Cloud Services](/docs/agents/net-agent/azure-installation/install-app-azure-cloud-services)
@@ -194,7 +175,23 @@ Before you [install New Relic's .NET agent](/docs/agents/net-agent/installation/
   <Collapser title="Network requirements">
     The agent requires your firewall to allow outgoing connections to specific [networks and ports](/docs/apm/new-relic-apm/getting-started/networks).
 </Collapser>
+<Collapser
+    className="freq-link"
+    id="operating-system"
+    title="Operating system"
+>
+    The agent requires one of these operating systems:
 
+    * Windows Server 2008
+    * Windows Server 2008 R2
+    * Windows Server 2012
+    * Windows Server 2012 R2
+    * Windows Server 2016
+    * Windows Server 2019
+    * Windows 10
+    * Windows Azure (OS Family 1, 2, and 3)
+    * Windows containers running on Windows 2016 (NanoServer based images are not supported)
+</Collapser>
 <Collapser
     className="freq-link"
     id="user-rights"
@@ -247,11 +244,11 @@ If your application is hosted in ASP.NET or another [fully supported framework](
 The .NET agent does not directly monitor datastore processes. Also, by default the .NET SQL parameter capture in a query trace does not list parameters for a parameterized query or a stored procedure. Collection of the SQL query parameters can be enabled in the agent [configuration](/docs/agents/net-agent/configuration/net-agent-configuration#datastore-tracer-query-parameters).
 
 <CollapserGroup>
-  <Collapser
+<Collapser
     className="freq-link"
     id="app-frameworks"
     title="App frameworks"
-  >
+>
     The agent automatically instruments some application frameworks; we refer to these frameworks as **fully supported**.
 
     <table>
@@ -439,13 +436,13 @@ The .NET agent does not directly monitor datastore processes. Also, by default t
         </tr>
       </tbody>
     </table>
-  </Collapser>
+</Collapser>
 
-  <Collapser
+<Collapser
     className="freq-link"
     id="database"
     title="Datastores"
-  >
+>
     Collecting [instance details](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues) for supported datastores requires .NET agent version 6.5.29.0 or higher and is enabled by default. To request instance-level information from datastores not currently listed, get support at [support.newrelic.com](https://support.newrelic.com).
 
     In order to automatically instrument the performance of .NET Framework application calls to these datastores, make sure you have the [.NET agent version 8.14 or higher](/docs/release-notes/agent-release-notes/net-release-notes):
@@ -641,52 +638,21 @@ The .NET agent does not directly monitor datastore processes. Also, by default t
         </tr>
       </tbody>
     </table>
-  </Collapser>
+</Collapser>
 
-  <Collapser
-    className="freq-link"
-    id="messaging"
-    title="Messaging"
-  >
-    The agent automatically instruments these message systems:
-
-    MSMQ:
-
-      * Puts and takes on messages.
-
-    NServiceBus 5.0 or higher:
-
-      * Puts and takes on messages and [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing).
-
-    RabbitMQ 3.5 or higher:
-
-      * Puts and takes on messages and queue purge.
-
-      * When receiving messages using an `IBasicConsumer`, the `EventingBasicConsumer` is the only implementation that is instrumented by the .NET agent.
-
-      * `BasicGet` is instrumented, but the agent does not support [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) for `BasicGet`.
-
-      * The following methods are instrumented:
-        * `IModel.BasicGet`
-        * `IModel.BasicPublish`
-        * `IModel.BasicComsume`
-        * `IModel.QueuePurge`
-        * `EventingBasicConsumer.HandleBasicDeliver`
-  </Collapser>
-
-  <Collapser
+<Collapser
     className="freq-link"
     id="cms"
     title="CMS"
-  >
+>
     The agent automatically instruments the **EPiServer** content management system.
-  </Collapser>
+</Collapser>
 
-  <Collapser
+<Collapser
     className="freq-link"
     id="additional-frameworks"
     title="External call libraries"
-  >
+>
     The agent automatically instruments these external call libraries :
 
     <table>
@@ -753,22 +719,13 @@ The .NET agent does not directly monitor datastore processes. Also, by default t
         </tr>
       </tbody>
     </table>
-  </Collapser>
-  <Collapser
-      id="technologies"
-      title="Supported .NET technologies and languages"
-  >
-  You can automatically instrument the follow .NET technologies and language:
-  
-  * C# applications
-  * ADO.NET
-  
-  </Collapser>
-  <Collapser
+</Collapser>
+
+<Collapser
     className="freq-link"
     id="logging-frameworks"
     title="Logging Frameworks"
-  >
+>
     The .NET agent [can be configured](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#application_logging) to automatically instrument these logging frameworks for automatic logs-in-context with [agent forwarding](/docs/logs/logs-context/net-configure-logs-context-all#1-agent) and [local log decoration](/docs/logs/logs-context/net-configure-logs-context-all#2-decorate):
 
     <table>
@@ -811,7 +768,47 @@ The .NET agent does not directly monitor datastore processes. Also, by default t
         </tr>
       </tbody>
     </table>
-  </Collapser>
+</Collapser>
+
+<Collapser
+    className="freq-link"
+    id="messaging"
+    title="Messaging"
+>
+    The agent automatically instruments these message systems:
+
+    MSMQ:
+
+      * Puts and takes on messages.
+
+    NServiceBus 5.0 or higher:
+
+      * Puts and takes on messages and [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing).
+
+    RabbitMQ 3.5 or higher:
+
+      * Puts and takes on messages and queue purge.
+
+      * When receiving messages using an `IBasicConsumer`, the `EventingBasicConsumer` is the only implementation that is instrumented by the .NET agent.
+
+      * `BasicGet` is instrumented, but the agent does not support [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) for `BasicGet`.
+
+      * The following methods are instrumented:
+        * `IModel.BasicGet`
+        * `IModel.BasicPublish`
+        * `IModel.BasicComsume`
+        * `IModel.QueuePurge`
+        * `EventingBasicConsumer.HandleBasicDeliver`
+</Collapser>
+<Collapser
+      id="technologies"
+      title="Supported .NET languages and technologies"
+>
+  You can automatically instrument the following .NET languages and technologies:
+  
+  * ADO.NET
+  * C# applications
+</Collapser>
 </CollapserGroup>
 
 ## Connect the agent to other New Relic products [#digital-intelligence-platform]

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -26,7 +26,84 @@ Want to try out New Relic's .NET agent? [Create a New Relic account](https://new
 Before you [install New Relic's .NET agent](/docs/agents/net-agent/installation/install-net-agent-windows), make sure your system meets these requirements:
 
 <CollapserGroup>
+<Collapser
+    id="lifespan"
+    title="Application lifespan"
+  >
+    The .NET agent uploads data at the end of each [harvest cycle](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#harvest-cycle) (once per minute). If your .NET app doesn't run that long, you can set the `service element`'s `sendDataOnExit` attribute to `true` in the `newrelic.config` file.
+</Collapser>
+<Collapser
+    className="freq-link"
+    id="app-web-servers"
+    title="App/web servers"
+>
+    You must use one of these app/web servers:
+
+    * IIS
+    * Self-hosted OWIN
+    * Self-hosted WCF
+    * Kestrel
+    * Kestrel with IIS reverse proxy via AspNetCoreModule
+    * Kestrel with IIS reverse proxy via AspNetCoreModuleV2
+
+      The agent automatically creates transactions for apps hosted in IIS. If you self-host with WCF and OWIN version 3 or higher, the agent also automatically creates transactions. For other self-hosted services, you will need to [create transactions via custom instrumentation](/docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation#new-existing).
+</Collapser>
   <Collapser
+    id="aws-elastic-beanstalk"
+    title="AWS Elastic Beanstalk"
+  >
+  <Callout
+    variant="important"
+  >
+    AWS [Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk) is not a supported .NET environment.
+  </Callout>  
+  </Collapser>
+
+<Collapser
+    className="freq-link"
+    id="clrs"
+    title="CLRs"
+  >
+    The agent requires CLR version 4.0. Legacy applications running on CLR 2.0 can be instrumented with agent versions earlier than 7.0.
+</Collapser>
+  <Collapser
+    className="freq-link"
+    id="code-access"
+    title="Code Access Security"
+  >
+    The use of [Code Access Security](https://docs.microsoft.com/en-us/dotnet/framework/misc/code-access-security) is compatible with the .NET agent only when Full Trust is provided. The agent is not compatible with more restrictive trust levels.
+</Collapser>
+
+<Collapser
+    className="freq-link"
+    id="operating-system"
+    title="Operating system"
+>
+    The agent requires one of these operating systems:
+
+    * Windows Server 2008
+    * Windows Server 2008 R2
+    * Windows Server 2012
+    * Windows Server 2012 R2
+    * Windows Server 2016
+    * Windows Server 2019
+    * Windows 10
+    * Windows Azure (OS Family 1, 2, and 3)
+    * Windows containers running on Windows 2016 (NanoServer based images are not supported)
+</Collapser>
+
+  <Collapser
+    id="azure"
+    title="Microsoft Azure"
+  >
+    For Azure-specific installation instructions, see:
+
+    * [Install on Azure Cloud Services](/docs/agents/net-agent/azure-installation/install-app-azure-cloud-services)
+    * [Install on Azure Service Fabric](/docs/agents/net-agent/azure-installation/install-net-agent-azure-service-fabric)
+    * [Install on Azure Web Apps](/docs/agents/net-agent/azure-installation/install-app-azure-web-apps)
+  </Collapser>
+
+<Collapser
     className="freq-link"
     id="net-version"
     title=".NET Framework version"
@@ -113,93 +190,16 @@ Before you [install New Relic's .NET agent](/docs/agents/net-agent/installation/
       </tbody>
     </table>
 
-  </Collapser>
+</Collapser>
+  <Collapser title="Network requirements">
+    The agent requires your firewall to allow outgoing connections to specific [networks and ports](/docs/apm/new-relic-apm/getting-started/networks).
+</Collapser>
 
-  <Collapser
-    className="freq-link"
-    id="app-web-servers"
-    title="App/web servers"
-  >
-    You must use one of these app/web servers:
-
-    * IIS
-    * Self-hosted OWIN
-    * Self-hosted WCF
-    * Kestrel
-    * Kestrel with IIS reverse proxy via AspNetCoreModule
-    * Kestrel with IIS reverse proxy via AspNetCoreModuleV2
-
-      The agent automatically creates transactions for apps hosted in IIS. If you self-host with WCF and OWIN version 3 or higher, the agent also automatically creates transactions. For other self-hosted services, you will need to [create transactions via custom instrumentation](/docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation#new-existing).
-  </Collapser>
-
-  <Collapser
-    className="freq-link"
-    id="clrs"
-    title="CLRs"
-  >
-    The agent requires CLR version 4.0. Legacy applications running on CLR 2.0 can be instrumented with agent versions earlier than 7.0.
-  </Collapser>
-
-  <Collapser
-    className="freq-link"
-    id="operating-system"
-    title="Operating system"
-  >
-    The agent requires one of these operating systems:
-
-    * Windows Server 2008
-    * Windows Server 2008 R2
-    * Windows Server 2012
-    * Windows Server 2012 R2
-    * Windows Server 2016
-    * Windows Server 2019
-    * Windows 10
-    * Windows Azure (OS Family 1, 2, and 3)
-    * Windows containers running on Windows 2016 (NanoServer based images are not supported)
-  </Collapser>
-
-  <Collapser
-    id="other-apm"
-    title="Use of other monitoring software"
-  >
-    The .NET Common Language Runtime (CLR) only allows one profiler to access the profiling API of a process at any given time. Running our .NET agent alongside other monitoring software will result in a [profiler conflict](/docs/agents/net-agent/troubleshooting/profiler-conflicts). For more information, see [Errors while using other APM software](/docs/apm/new-relic-apm/troubleshooting/errors-while-using-other-apm-software).
-  </Collapser>
-
-  <Collapser
-    id="azure"
-    title="Microsoft Azure"
-  >
-    For Azure-specific installation instructions, see:
-
-    * [Install on Azure Cloud Services](/docs/agents/net-agent/azure-installation/install-app-azure-cloud-services)
-    * [Install on Azure Service Fabric](/docs/agents/net-agent/azure-installation/install-net-agent-azure-service-fabric)
-    * [Install on Azure Web Apps](/docs/agents/net-agent/azure-installation/install-app-azure-web-apps)
-  </Collapser>
-  
-  <Collapser
-    id="aws-elastic-beanstalk"
-    title="AWS Elastic Beanstalk"
-  >
-  <Callout
-    variant="important"
-  >
-    AWS [Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk) is not a supported .NET environment.
-  </Callout>  
-  </Collapser>
-  
-  <Collapser
-    className="freq-link"
-    id="architecture"
-    title="Processor architectures"
-  >
-    The agent is available in both a 32-bit and 64-bit version. On 64-bit systems, the 64-bit agent can instrument both 32-bit and 64-bit applications.
-  </Collapser>
-
-  <Collapser
+<Collapser
     className="freq-link"
     id="user-rights"
     title="Permissions"
-  >
+>
     Installation requires elevated privileges (Administrator). For example, you can:
 
     * Be logged in as an administrator user.
@@ -215,34 +215,29 @@ Before you [install New Relic's .NET agent](/docs/agents/net-agent/installation/
     * Restrict permissions for the `newrelic.config` file and give read/write access only to the owner of the monitored process.
 
     * Review permissions for the logs created by the agent to minimize the number of users with access and their privileges.
-  </Collapser>
+</Collapser>
 
+<Collapser
+    className="freq-link"
+    id="architecture"
+    title="Processor architectures"
+  >
+    The agent is available in both a 32-bit and 64-bit version. On 64-bit systems, the 64-bit agent can instrument both 32-bit and 64-bit applications.
+</Collapser>
   <Collapser
     className="freq-link"
     id="security-requirements"
     title="Security requirements"
   >
     As a standard [security measure for data collection](/docs/accounts-partnerships/accounts/security/data-security), your app server must support SHA-2 (256-bit). SHA-1 is not supported.
-  </Collapser>
+</Collapser>
 
-  <Collapser
-    className="freq-link"
-    id="code-access"
-    title="Code Access Security"
+<Collapser
+    id="other-apm"
+    title="Use of other monitoring software"
   >
-    The use of [Code Access Security](https://docs.microsoft.com/en-us/dotnet/framework/misc/code-access-security) is compatible with the .NET agent only when Full Trust is provided. The agent is not compatible with more restrictive trust levels.
-  </Collapser>
-
-  <Collapser title="Network requirements">
-    The agent requires your firewall to allow outgoing connections to specific [networks and ports](/docs/apm/new-relic-apm/getting-started/networks).
-  </Collapser>
-
-  <Collapser
-    id="lifespan"
-    title="Application lifespan"
-  >
-    The .NET agent uploads data at the end of each [harvest cycle](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#harvest-cycle) (once per minute). If your .NET app doesn't run that long, you can set the `service element`'s `sendDataOnExit` attribute to `true` in the `newrelic.config` file.
-  </Collapser>
+    The .NET Common Language Runtime (CLR) only allows one profiler to access the profiling API of a process at any given time. Running our .NET agent alongside other monitoring software will result in a [profiler conflict](/docs/agents/net-agent/troubleshooting/profiler-conflicts). For more information, see [Errors while using other APM software](/docs/apm/new-relic-apm/troubleshooting/errors-while-using-other-apm-software).
+</Collapser>
 </CollapserGroup>
 
 ## Automatic instrumentation [#instrumented-features]

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -11,26 +11,23 @@ redirects:
   - /docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent
 ---
 
-Our Node.js agent is publicly available on [GitHub](https://github.com/newrelic/node-newrelic) and the [Node Package Manager (npm) repository](https://npmjs.org/package/newrelic). 
+Our Node.js agent includes built-in instrumentation of the most popular Node frameworks, app servers, databases, and message queuing systems. For frameworks and libraries that are not instrumented out of the box, you can extend the agent with our [Node agent API](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/).
 
-If you haven't already, [create a New Relic account](https://newrelic.com/signup). It's free, forever. 
-
-<Callout variant="tip">
-  For best performance, use the latest active long term support (LTS) version of Node.js.  
-</Callout>
+Ready to try out New Relic's Node.js agent? [Create a New Relic account](https://newrelic.com/signup)!
 
 ## Requirements to install the agent
 
-Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent), check that your system meets these minimum requirements: 
-
+Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent), check that your system meets its minimum requirements. For best performance, use the latest active long term support (LTS) version of Node.js. 
+ 
 <CollapserGroup>
 <Collapser
     id="system"
     title="System requirements"
 >
-We will support the [latest even versions of Node.js releases](https://nodejs.org/en/about/releases/) by the beginning of the following active long term support schedule. The version support policy does not replace our [general end-of-life (EOL) policy](/docs/agents/manage-apm-agents/maintenance/new-relic-agent-plugin-end-life-policy).
 
-The following are proposed time ranges. The actual release date may vary.
+For all latest [even versions of Node.js releases](https://nodejs.org/en/about/releases/), expect active support by the following active long term support schedule, we will add support to. The version support policy does not replace our [general end-of-life (EOL) policy](/docs/agents/manage-apm-agents/maintenance/new-relic-agent-plugin-end-life-policy).
+
+The following are proposed time ranges for Node version support, but the actual release date may vary.
 
 <table>
   <thead>
@@ -97,17 +94,6 @@ The following are proposed time ranges. The actual release date may vary.
 
 When support for a new long term support agent version is made available, support for the Node.js agent version that reaches end-of-life during the same time period will simultaneously drop.
 
-The Node agent is compatible with the following operating systems:
-
-* Linux
-* SmartOS
-* macOS 10.7 and higher
-* Windows Server 2008 and higher
-</Collapser>
-<Collapser
-    id="eol"
-    title="Node.js releases reaching EOL"
->
 The following are proposed time ranges. The actual release date may vary.
 
 <table>
@@ -158,10 +144,21 @@ The following are proposed time ranges. The actual release date may vary.
   </tbody>
 </table>
 
-For Node.js 12, the following change affects the Node.js agent:
+In Node.js 12, errors resulting in unhandled rejections are not scoped to the transaction that was active when the rejected promise was created. This is because the promise responsible for triggering the init async hook is no longer passed through on the promise wrap instance. This breaks the linkage that associates a given promise rejection with the transaction it was scheduled in.
 
-Errors resulting in unhandled rejections are not scoped to the transaction that was active when the rejected promise was created. This is because the promise responsible for triggering the init async hook is no longer passed through on the promise wrap instance. This breaks the linkage that associates a given promise rejection with the transaction it was scheduled in.
+</Collapser>
+<Collapser
+    id="operating systems"
+    title="Compatible operating systems"
+>
 
+The Node agent is compatible with the following operating systems:
+
+* Linux
+* SmartOS
+* macOS 10.7 and higher
+* Windows Server 2008 and higher 
+The following are proposed time ranges. The actual release date may vary.
 </Collapser>
 <Collapser
     id="host"
@@ -190,6 +187,10 @@ As a standard [security measure for data collection](/docs/accounts-partnerships
 
 ## Instrument with Node [#instrument]
 
+After installation, the agent automatically instruments with our catalog of supported Node libraries and frameworks. This gives you immediate access to granular information specific to your web apps and servers. 
+
+For unsupported frameworks or libraries, you'll need to instrument the agent yourself using the [Node.js agent API](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api). 
+
 <CollapserGroup>
   <Collapser
     id="support"
@@ -203,13 +204,18 @@ As a standard [security measure for data collection](/docs/accounts-partnerships
 * [Koa](https://www.npmjs.com/package/koa) 2.0.0 or higher ([external module](https://github.com/newrelic/node-newrelic-koa) loaded with the agent)
 * [Fastify](https://www.npmjs.com/package/fastify)
 * [Next.js](https://www.npmjs.com/package/next) 12.0.9 or higher (12.2.0 or higher required for middleware instrumentation)
-* [TypeScript](https://www.npmjs.com/package/typescript)
 
 If you are using a supported framework with default routers, the Node.js agent can read these frameworks' route names as is. However, if you want more specific names than are provided by your framework, you may want to use one or more of the tools New Relic provides with the [Node.js transaction naming API](/docs/nodejs/nodejs-transaction-naming-api).
 
 <Callout title="EOL NOTICE">
   We have discontinued support for several capabilities in November 2021. This includes the Oracle Driver Package and Hapi versions prior to Hapi 19.2 for our Node.js agent. For more details, including how you can easily prepare for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-and-support-across-node-agents-suggested-pagerduty-responders-incident-workflows-and-kubernetes-instrumentation/164481?u=dholloran).
 </Callout>
+</Collapser>
+<Collapser
+    id=""
+    title="Typerscript"
+>
+
 </Collapser>
 <Collapser
     id="Datastores"
@@ -260,11 +266,10 @@ In order to support [APM logs in context](/docs/apm/new-relic-apm/getting-starte
 * [winston](https://www.npmjs.com/package/winston)
 * [pino](https://www.npmjs.com/package/pino)
 </Collapser>
-</CollapserGroup>
-
-
-## Instance details
-
+<Collapser
+    id=""
+    title=""
+>
 We collect [instance details for a variety of databases and database drivers](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues). The ability to view specific instances and the types of database information in APM depends on your agent version.
 
 New Relic's Node.js agent [version 1.31.0](/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1310) or higher supports the following:
@@ -349,7 +354,7 @@ New Relic's Node.js agent [version 1.31.0](/docs/release-notes/agent-release-not
       <td>
         [MySQL](http://www.mysql.com/)
       </td>
-
+ 
       <td>
         [mysql](https://www.npmjs.com/package/mysql)
       </td>
@@ -384,6 +389,8 @@ New Relic's Node.js agent [version 1.31.0](/docs/release-notes/agent-release-not
 </table>
 
 To request instance-level information from datastores currently not listed for your New Relic agent, get support at [support.newrelic.com](https://support.newrelic.com).
+</Collapser>
+</CollapserGroup>
 
 ## Connect the agent to other New Relic features [#digital-intelligence-platform]
 

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -154,6 +154,7 @@ For Node.js 12, the following change affects the Node.js agent:
 
 Errors resulting in unhandled rejections are not scoped to the transaction that was active when the rejected promise was created. This is because the promise responsible for triggering the init async hook is no longer passed through on the promise wrap instance. This breaks the linkage that associates a given promise rejection with the transaction it was scheduled in.
 </Collapser>
+</CollapserGroup>
 
 ## System compatibility
 

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -11,16 +11,23 @@ redirects:
   - /docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent
 ---
 
-Our Node.js agent is publicly available on the [Node Package Manager (npm) repository](https://npmjs.org/package/newrelic) as well as on [GitHub](https://github.com/newrelic/node-newrelic). Before you install the Node.js agent, make sure your application meets the following system requirements.
+Our Node.js agent is publicly available on [GitHub](https://github.com/newrelic/node-newrelic) and the [Node Package Manager (npm) repository](https://npmjs.org/package/newrelic). 
 
 If you haven't already, [create a New Relic account](https://newrelic.com/signup). It's free, forever. 
-
-## Support for new Node.js versions [#version]
 
 <Callout variant="tip">
   For best performance, use the latest active long term support (LTS) version of Node.js.  
 </Callout>
 
+## Requirements to install the agent
+
+Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent), check that your system meets these minimum requirements: 
+
+<CollapserGroup>
+<Collapser
+    id="system"
+    title="System requirements"
+>
 We will support the [latest even versions of Node.js releases](https://nodejs.org/en/about/releases/) by the beginning of the following active long term support schedule. The version support policy does not replace our [general end-of-life (EOL) policy](/docs/agents/manage-apm-agents/maintenance/new-relic-agent-plugin-end-life-policy).
 
 The following are proposed time ranges. The actual release date may vary.
@@ -90,7 +97,13 @@ The following are proposed time ranges. The actual release date may vary.
 
 When support for a new long term support agent version is made available, support for the Node.js agent version that reaches end-of-life during the same time period will simultaneously drop.
 
-<CollapserGroup>
+The Node agent is compatible with the following operating systems:
+
+* Linux
+* SmartOS
+* macOS 10.7 and higher
+* Windows Server 2008 and higher
+</Collapser>
 <Collapser
     id="eol"
     title="Node.js releases reaching EOL"
@@ -144,55 +157,28 @@ The following are proposed time ranges. The actual release date may vary.
     </tr>
   </tbody>
 </table>
-</Collapser>
-<Collapser
-    id="12error"
-    title="Node.js 12 errors"
->
 
 For Node.js 12, the following change affects the Node.js agent:
 
 Errors resulting in unhandled rejections are not scoped to the transaction that was active when the rejected promise was created. This is because the promise responsible for triggering the init async hook is no longer passed through on the promise wrap instance. This breaks the linkage that associates a given promise rejection with the transaction it was scheduled in.
+
 </Collapser>
-</CollapserGroup>
-
-## System compatibility
-
-<CollapserGroup>
 <Collapser
-    id="processors]"
+    id="host"
+    title="Hosting services"
+>
+It's also compatible with these hosting services:
+
+* [Google App Engine (GAE) flexible environment](/docs/agents/nodejs-agent/hosting-services/install-new-relic-nodejs-agent-gae-flexible-environment)
+* AWS EC2
+* [Microsoft Azure](/docs/nodejs/nodejs-agent-on-microsoft-azure)
+* [Heroku](/docs/nodejs/nodejs-agent-on-heroku)
+</Collapser>
+<Collapser
+    id="processor"
     title="Processors"
 >
-* The Node.js agent is built to run on most processors including being tested and validated to work on AWS Graviton2
-
-</Collapser>
-<Collapser
-    id="OS"
-    title="Operating systems"
->
-* Linux
-* SmartOS
-* macOS 10.7 and higher
-* Windows Server 2008 and higher
-
-</Collapser>
-<Collapser
-    id ="messages"
-    title="Messages queues"
->
-
-[Message queue instrumentation](/docs/agents/nodejs-agent/troubleshooting/troubleshoot-message-consumers) is only available with the [New Relic Node.js agent v2 or higher](/docs/release-notes/agent-release-notes/nodejs-release-notes). Currently supported message queue instrumentation:
-
-* `amqplib`
-
-For other message queue libraries, use [custom instrumentation](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation#message-client).
-
-</Collapser> 
-<Collapser
-    id="process-managers"
-    title="Process managers"
->
-In general, process managers that handle starting, stopping, and restarting of Node.js (like [Forever](https://www.npmjs.com/package/forever)) should be compatible with the Node.js agent. If you are using [PM2](https://www.npmjs.com/package/pm2), the minimum supported version of PM2 is 2.0.
+The Node.js agent runs on most processors, including AWS Graviton2. In general, process managers that handle starting, stopping, and restarting of Node.js (like [Forever](https://www.npmjs.com/package/forever)) should be compatible with the Node.js agent. If you are using [PM2](https://www.npmjs.com/package/pm2), the minimum supported version of PM2 is 2.0.
 </Collapser>
 <Collapser
     id="security"
@@ -202,7 +188,7 @@ As a standard [security measure for data collection](/docs/accounts-partnerships
 </Collapser>
 </CollapserGroup> 
 
-## Libraries and frameworks
+## Instrument with Node [#instrument]
 
 <CollapserGroup>
   <Collapser
@@ -240,13 +226,16 @@ The Node.js agent monitors the performance of Node.js application calls to these
 * [Postgres](https://www.npmjs.com/package/pg) (including the [native](https://www.npmjs.com/package/pg-native) and [pure JavaScript](https://www.npmjs.com/package/pg-js) packages)
 </Collapser>
 <Collapser
-    id="hosting"
-    title="Hosting services"
+    id ="messages"
+    title="Messages queues"
 >
-* [Google App Engine (GAE) flexible environment](/docs/agents/nodejs-agent/hosting-services/install-new-relic-nodejs-agent-gae-flexible-environment)
-* AWS EC2
-* [Microsoft Azure](/docs/nodejs/nodejs-agent-on-microsoft-azure)
-* [Heroku](/docs/nodejs/nodejs-agent-on-heroku)
+
+[Message queue instrumentation](/docs/agents/nodejs-agent/troubleshooting/troubleshoot-message-consumers) is only available with the [New Relic Node.js agent v2 or higher](/docs/release-notes/agent-release-notes/nodejs-release-notes). Currently supported message queue instrumentation:
+
+* `amqplib`
+
+For other message queue libraries, use [custom instrumentation](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation#message-client).
+
 </Collapser>
 <Collapser
     id="http"

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -150,6 +150,54 @@ For Node.js 12, the following change affects the Node.js agent:
 
 Errors resulting in unhandled rejections are not scoped to the transaction that was active when the rejected promise was created. This is because the promise responsible for triggering the init async hook is no longer passed through on the promise wrap instance. This breaks the linkage that associates a given promise rejection with the transaction it was scheduled in.
 
+## Requirements
+
+<CollapserGroup>
+<Collapser
+    id="processors]"
+    title="Processors"
+>
+* The New Relic Node Agent is built to run on most processors including being tested and validated to work on AWS Graviton2
+
+</Collapser>
+<Collapser
+    id="OS"
+    title="Operating systems"
+>
+* Linux
+* SmartOS
+* macOS 10.7 and higher
+* Windows Server 2008 and higher
+
+</Collapser>
+<Collapser
+    id ="messages"
+    title="Messages queues"
+>
+
+[Message queue instrumentation](/docs/agents/nodejs-agent/troubleshooting/troubleshoot-message-consumers) is only available with the [New Relic Node.js agent v2 or higher](/docs/release-notes/agent-release-notes/nodejs-release-notes). Currently supported message queue instrumentation:
+
+* `amqplib`
+
+For other message queue libraries, use [custom instrumentation](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation#message-client).
+
+</Collapser> 
+<Collapser
+    id="process-managers"
+    title="Process managers"
+>
+In general, process managers that handle starting, stopping, and restarting of Node.js (like [Forever](https://www.npmjs.com/package/forever)) should be compatible with the Node.js agent. If you are using [PM2](https://www.npmjs.com/package/pm2), the minimum supported version of PM2 is 2.0.
+</Collapser>
+<Collapser
+    id="security"
+    title="Security requirements"
+>
+As a standard [security measure for data collection](/docs/accounts-partnerships/accounts/security/data-security), your app server must support SHA-2 (256-bit). SHA-1 is not supported.
+</Collapser>
+</CollapserGroup> 
+
+## Libraries and frameworks
+
 <CollapserGroup>
   <Collapser
     id="support"
@@ -172,24 +220,6 @@ If you are using a supported framework with default routers, the Node.js agent c
 </Callout>
 </Collapser>
 <Collapser
-    id="processors]"
-    title="Processors"
->
-
-* The New Relic Node Agent is built to run on most processors including being tested and validated to work on AWS Graviton2
-
-</Collapser>
-<Collapser
-    id="OS"
-    title="Operating systems"
->
-
-* Linux
-* SmartOS
-* macOS 10.7 and higher
-* Windows Server 2008 and higher
-</Collapser>
-<Collapser
     id="Datastores"
     title="Datastores"
 >
@@ -202,8 +232,41 @@ The Node.js agent monitors the performance of Node.js application calls to these
 * MySQL (via [mysql](https://www.npmjs.com/package/mysql) and [mysql2](https://www.npmjs.com/package/mysql2) packages)
 * [Redis](https://www.npmjs.com/package/redis)
 * [Postgres](https://www.npmjs.com/package/pg) (including the [native](https://www.npmjs.com/package/pg-native) and [pure JavaScript](https://www.npmjs.com/package/pg-js) packages)
-</Collapser> 
+</Collapser>
+<Collapser
+    id="hosting"
+    title="Hosting services"
+>
+* [Google App Engine (GAE) flexible environment](/docs/agents/nodejs-agent/hosting-services/install-new-relic-nodejs-agent-gae-flexible-environment)
+* AWS EC2
+* [Microsoft Azure](/docs/nodejs/nodejs-agent-on-microsoft-azure)
+* [Heroku](/docs/nodejs/nodejs-agent-on-heroku)
+</Collapser>
+<Collapser
+    id="http"
+    title="HTTP/1.1"
+>
+The Node.js agent instruments the native `http` module.
+
+In addition, the popular [undici](https://www.npmjs.com/package/undici) client has experimental support as well. To use undici, be sure to set `feature_flag.undici_instrumentation = true` in the `newrelic.js` [configuration file](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#methods-and-precedence).
+</Collapser>
+<Collapser
+    id="gRPC"
+    title="gRPC"
+>
+* The [grpc-js](https://www.npmjs.com/package/@grpc/grpc-js) library is supported for unary, streaming, or bidirectional client calls.
+</Collapser>
+<Collapser 
+    id="logging"
+    title="Logging libraries"
+>
+In order to support [APM logs in context](/docs/apm/new-relic-apm/getting-started/get-started-logs-context), the Node.js agent instruments the following libraries:
+
+* [winston](https://www.npmjs.com/package/winston)
+* [pino](https://www.npmjs.com/package/pino)
+</Collapser>
 </CollapserGroup>
+
 
 ## Instance details
 
@@ -326,46 +389,6 @@ New Relic's Node.js agent [version 1.31.0](/docs/release-notes/agent-release-not
 </table>
 
 To request instance-level information from datastores currently not listed for your New Relic agent, get support at [support.newrelic.com](https://support.newrelic.com).
-
-## Messages queues [#message-queues]
-
-[Message queue instrumentation](/docs/agents/nodejs-agent/troubleshooting/troubleshoot-message-consumers) is only available with the [New Relic Node.js agent v2 or higher](/docs/release-notes/agent-release-notes/nodejs-release-notes). Currently supported message queue instrumentation:
-
-* `amqplib`
-
-For other message queue libraries, use [custom instrumentation](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation#message-client).
-
-## Hosting services
-
-* [Google App Engine (GAE) flexible environment](/docs/agents/nodejs-agent/hosting-services/install-new-relic-nodejs-agent-gae-flexible-environment)
-* AWS EC2
-* [Microsoft Azure](/docs/nodejs/nodejs-agent-on-microsoft-azure)
-* [Heroku](/docs/nodejs/nodejs-agent-on-heroku)
-
-## HTTP/1.1
-
-The Node.js agent instruments the native `http` module.
-
-In addition, the popular [undici](https://www.npmjs.com/package/undici) client has experimental support as well. To use undici, be sure to set `feature_flag.undici_instrumentation = true` in the `newrelic.js` [configuration file](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#methods-and-precedence).
-
-## gRPC
-
-* The [grpc-js](https://www.npmjs.com/package/@grpc/grpc-js) library is supported for unary, streaming, or bidirectional client calls.
-
-## Logging libraries
-
-In order to support [APM logs in context](/docs/apm/new-relic-apm/getting-started/get-started-logs-context), the Node.js agent instruments the following libraries:
-
-* [winston](https://www.npmjs.com/package/winston)
-* [pino](https://www.npmjs.com/package/pino)
-
-## Process managers
-
-In general, process managers that handle starting, stopping, and restarting of Node.js (like [Forever](https://www.npmjs.com/package/forever)) should be compatible with the Node.js agent. If you are using [PM2](https://www.npmjs.com/package/pm2), the minimum supported version of PM2 is 2.0.
-
-## Security requirements
-
-As a standard [security measure for data collection](/docs/accounts-partnerships/accounts/security/data-security), your app server must support SHA-2 (256-bit). SHA-1 is not supported.
 
 ## Connect the agent to other New Relic features [#digital-intelligence-platform]
 

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -15,13 +15,11 @@ Our Node.js agent is publicly available on the [Node Package Manager (npm) repos
 
 If you haven't already, [create a New Relic account](https://newrelic.com/signup). It's free, forever. 
 
-## Node.js version support [#version]
+## Support for new Node.js versions [#version]
 
 <Callout variant="tip">
   For best performance, use the latest active long term support (LTS) version of Node.js.  
 </Callout>
-
-### Support for new Node.js releases [#support-new]
 
 We will support the [latest even versions of Node.js releases](https://nodejs.org/en/about/releases/) by the beginning of the following active long term support schedule. The version support policy does not replace our [general end-of-life (EOL) policy](/docs/agents/manage-apm-agents/maintenance/new-relic-agent-plugin-end-life-policy).
 
@@ -90,10 +88,13 @@ The following are proposed time ranges. The actual release date may vary.
   </tbody>
 </table>
 
-### End of support for Node.js releases reaching EOL [#support-end]
-
 When support for a new long term support agent version is made available, support for the Node.js agent version that reaches end-of-life during the same time period will simultaneously drop.
 
+<CollapserGroup>
+<Collapser
+    id="eol"
+    title="Node.js releases reaching EOL"
+>
 The following are proposed time ranges. The actual release date may vary.
 
 <table>
@@ -143,21 +144,25 @@ The following are proposed time ranges. The actual release date may vary.
     </tr>
   </tbody>
 </table>
-
-## Node.js 12 errors [#node12-errors]
+</Collapser>
+<Collapser
+    id="12error"
+    title="Node.js 12 errors"
+>
 
 For Node.js 12, the following change affects the Node.js agent:
 
 Errors resulting in unhandled rejections are not scoped to the transaction that was active when the rejected promise was created. This is because the promise responsible for triggering the init async hook is no longer passed through on the promise wrap instance. This breaks the linkage that associates a given promise rejection with the transaction it was scheduled in.
+</Collapser>
 
-## Requirements
+## System compatibility
 
 <CollapserGroup>
 <Collapser
     id="processors]"
     title="Processors"
 >
-* The New Relic Node Agent is built to run on most processors including being tested and validated to work on AWS Graviton2
+* The Node.js agent is built to run on most processors including being tested and validated to work on AWS Graviton2
 
 </Collapser>
 <Collapser

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -358,6 +358,12 @@ In order to support [APM logs in context](/docs/apm/new-relic-apm/getting-starte
 For other message queue libraries, use [custom instrumentation](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation#message-client).
 
 </Collapser>
+<Collapser
+    id="langtech"
+    title="Supported languages and technologies"
+>
+[TypeScript](https://www.npmjs.com/package/typescript) is a programming language that can compile to JavaScript. After installation, the Node.js agent automatically instruments your TypeScript apps, giving you immediate access to performance data right out of the box. 
+</Collapser>
 
 <Collapser
     id="support"
@@ -377,12 +383,6 @@ If you are using a supported framework with default routers, the Node.js agent c
 <Callout title="EOL NOTICE">
   We have discontinued support for several capabilities in November 2021. This includes the Oracle Driver Package and Hapi versions prior to Hapi 19.2 for our Node.js agent. For more details, including how you can easily prepare for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-and-support-across-node-agents-suggested-pagerduty-responders-incident-workflows-and-kubernetes-instrumentation/164481?u=dholloran).
 </Callout>
-</Collapser>
-<Collapser
-    id="langtech"
-    title="Supported languages and technologies"
->
-[TypeScript](https://www.npmjs.com/package/typescript) is a programming language that can compile to JavaScript. After installation, the Node.js agent automatically instruments your TypeScript apps, giving you immediate access to performance data right out of the box. 
 </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -211,7 +211,7 @@ If you are using a supported framework with default routers, the Node.js agent c
 </Collapser>
 <Collapser
     id="typescript"
-    title="TyperScript"
+    title="TypeScript"
 >
 [TypeScript](https://www.npmjs.com/package/typescript) is a programming language that can compile to JavaScript. After installation, the the Node.js agent automatically instruments your TypeScript apps, giving you immediate access to performance data right out of the box. 
 </Collapser>

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -11,15 +11,46 @@ redirects:
   - /docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent
 ---
 
-Our Node.js agent includes built-in instrumentation of the most popular Node frameworks, app servers, databases, and message queuing systems. For frameworks and libraries that are not instrumented out of the box, you can extend the agent with our [Node agent API](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/).
+Our Node.js agent includes built-in instrumentation of the most popular Node frameworks, app servers, databases, and message queuing systems. For frameworks and libraries that aren't instrumented out of the box, you can extend the agent with our [Node agent API](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/).
 
-Ready to try out New Relic's Node.js agent? [Create a New Relic account](https://newrelic.com/signup)!
+Our Node.js agent is publicly available on the [Node Package Manager (npm) repository](https://npmjs.org/package/newrelic) as well as on [GitHub](https://github.com/newrelic/node-newrelic). Ready to try out New Relic's Node.js agent? [Create a New Relic account](https://newrelic.com/signup)!
 
 ## Requirements to install the agent
 
 Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent), check that your system meets its minimum requirements. For best performance, use the latest active long term support (LTS) version of Node.js. 
  
 <CollapserGroup>
+<Collapser
+    id="operating systems"
+    title="Compatible operating systems"
+>
+
+The Node agent is compatible with the following operating systems:
+
+* Linux
+* SmartOS
+* macOS 10.7 and higher
+* Windows Server 2008 and higher 
+The following are proposed time ranges. The actual release date may vary.
+</Collapser>
+<Collapser
+    id="host"
+    title="Hosting services"
+>
+It's also compatible with these hosting services:
+
+* [Google App Engine (GAE) flexible environment](/docs/agents/nodejs-agent/hosting-services/install-new-relic-nodejs-agent-gae-flexible-environment)
+* AWS EC2
+* [Microsoft Azure](/docs/nodejs/nodejs-agent-on-microsoft-azure)
+* [Heroku](/docs/nodejs/nodejs-agent-on-heroku)
+</Collapser>
+
+<Collapser
+    id="security"
+    title="Security requirements"
+>
+As a standard [security measure for data collection](/docs/accounts-partnerships/accounts/security/data-security), your app server must support SHA-2 (256-bit). SHA-1 is not supported.
+</Collapser>
 <Collapser
     id="system"
     title="System requirements"
@@ -141,80 +172,16 @@ The following are proposed time ranges for EOL on older Node.js versions. The ac
     </tr>
   </tbody>
 </table>
-
-In Node.js 12, errors resulting in unhandled rejections are not scoped to the transaction that was active when the rejected promise was created. This is because the promise responsible for triggering the init async hook is no longer passed through on the promise wrap instance. This breaks the linkage that associates a given promise rejection with the transaction it was scheduled in.
-
-</Collapser>
-<Collapser
-    id="operating systems"
-    title="Compatible operating systems"
->
-
-The Node agent is compatible with the following operating systems:
-
-* Linux
-* SmartOS
-* macOS 10.7 and higher
-* Windows Server 2008 and higher 
-The following are proposed time ranges. The actual release date may vary.
-</Collapser>
-<Collapser
-    id="host"
-    title="Hosting services"
->
-It's also compatible with these hosting services:
-
-* [Google App Engine (GAE) flexible environment](/docs/agents/nodejs-agent/hosting-services/install-new-relic-nodejs-agent-gae-flexible-environment)
-* AWS EC2
-* [Microsoft Azure](/docs/nodejs/nodejs-agent-on-microsoft-azure)
-* [Heroku](/docs/nodejs/nodejs-agent-on-heroku)
-</Collapser>
-<Collapser
-    id="processor"
-    title="Processors"
->
-The Node.js agent runs on most processors, including AWS Graviton2. In general, process managers that handle starting, stopping, and restarting of Node.js (like [Forever](https://www.npmjs.com/package/forever)) should be compatible with the Node.js agent. If you are using [PM2](https://www.npmjs.com/package/pm2), the minimum supported version of PM2 is 2.0.
-</Collapser>
-<Collapser
-    id="security"
-    title="Security requirements"
->
-As a standard [security measure for data collection](/docs/accounts-partnerships/accounts/security/data-security), your app server must support SHA-2 (256-bit). SHA-1 is not supported.
 </Collapser>
 </CollapserGroup> 
 
-## Instrument with Node [#instrument]
+## Instrument with Node.js [#instrument]
 
-After installation, the agent automatically instruments with our catalog of supported Node libraries and frameworks. This gives you immediate access to granular information specific to your web apps and servers. 
+After installation, the agent automatically instruments with our catalog of supported Node.js libraries and frameworks. This gives you immediate access to granular information specific to your web apps and servers. 
 
 For unsupported frameworks or libraries, you'll need to instrument the agent yourself using the [Node.js agent API](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api). 
 
 <CollapserGroup>
-  <Collapser
-    id="support"
-    title="Supported Node.js frameworks"
-  >
-
-* [Express](https://www.npmjs.com/package/express) 4.6.0 or higher
-* [Restify](https://www.npmjs.com/package/restify)
-* [Connect](https://www.npmjs.com/package/connect)
-* [Hapi](https://www.npmjs.com/package/hapi)
-* [Koa](https://www.npmjs.com/package/koa) 2.0.0 or higher ([external module](https://github.com/newrelic/node-newrelic-koa) loaded with the agent)
-* [Fastify](https://www.npmjs.com/package/fastify)
-* [Next.js](https://www.npmjs.com/package/next) 12.0.9 or higher (12.2.0 or higher required for middleware instrumentation)
-
-If you are using a supported framework with default routers, the Node.js agent can read these frameworks' route names as is. However, if you want more specific names than are provided by your framework, you may want to use one or more of the tools New Relic provides with the [Node.js transaction naming API](/docs/nodejs/nodejs-transaction-naming-api).
-
-<Callout title="EOL NOTICE">
-  We have discontinued support for several capabilities in November 2021. This includes the Oracle Driver Package and Hapi versions prior to Hapi 19.2 for our Node.js agent. For more details, including how you can easily prepare for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-and-support-across-node-agents-suggested-pagerduty-responders-incident-workflows-and-kubernetes-instrumentation/164481?u=dholloran).
-</Callout>
-</Collapser>
-<Collapser
-    id="typescript"
-    title="TypeScript"
->
-[TypeScript](https://www.npmjs.com/package/typescript) is a programming language that can compile to JavaScript. After installation, the the Node.js agent automatically instruments your TypeScript apps, giving you immediate access to performance data right out of the box. 
-</Collapser>
 <Collapser
     id="Datastores"
     title="Datastores"
@@ -229,18 +196,14 @@ The Node.js agent monitors the performance of Node.js application calls to these
 * [Redis](https://www.npmjs.com/package/redis)
 * [Postgres](https://www.npmjs.com/package/pg) (including the [native](https://www.npmjs.com/package/pg-native) and [pure JavaScript](https://www.npmjs.com/package/pg-js) packages)
 </Collapser>
+
 <Collapser
-    id ="messages"
-    title="Messages queues"
+    id="gRPC"
+    title="gRPC"
 >
-
-[Message queue instrumentation](/docs/agents/nodejs-agent/troubleshooting/troubleshoot-message-consumers) is only available with the [New Relic Node.js agent v2 or higher](/docs/release-notes/agent-release-notes/nodejs-release-notes). Currently supported message queue instrumentation:
-
-* `amqplib`
-
-For other message queue libraries, use [custom instrumentation](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation#message-client).
-
+* The [grpc-js](https://www.npmjs.com/package/@grpc/grpc-js) library is supported for unary, streaming, or bidirectional client calls.
 </Collapser>
+
 <Collapser
     id="http"
     title="HTTP/1.1"
@@ -249,21 +212,7 @@ The Node.js agent instruments the native `http` module.
 
 In addition, the popular [undici](https://www.npmjs.com/package/undici) client has experimental support as well. To use undici, be sure to set `feature_flag.undici_instrumentation = true` in the `newrelic.js` [configuration file](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#methods-and-precedence).
 </Collapser>
-<Collapser
-    id="gRPC"
-    title="gRPC"
->
-* The [grpc-js](https://www.npmjs.com/package/@grpc/grpc-js) library is supported for unary, streaming, or bidirectional client calls.
-</Collapser>
-<Collapser 
-    id="logging"
-    title="Logging libraries"
->
-In order to support [APM logs in context](/docs/apm/new-relic-apm/getting-started/get-started-logs-context), the Node.js agent instruments the following libraries:
 
-* [winston](https://www.npmjs.com/package/winston)
-* [pino](https://www.npmjs.com/package/pino)
-</Collapser>
 <Collapser
     id="instance"
     title="Instance details"
@@ -387,6 +336,53 @@ New Relic's Node.js agent [version 1.31.0](/docs/release-notes/agent-release-not
 </table>
 
 To request instance-level information from datastores currently not listed for your New Relic agent, get support at [support.newrelic.com](https://support.newrelic.com).
+</Collapser>
+<Collapser 
+    id="logging"
+    title="Logging libraries"
+>
+In order to support [APM logs in context](/docs/apm/new-relic-apm/getting-started/get-started-logs-context), the Node.js agent instruments the following libraries:
+
+* [winston](https://www.npmjs.com/package/winston)
+* [pino](https://www.npmjs.com/package/pino)
+</Collapser>
+
+
+<Collapser
+    id ="messages"
+    title="Messages queue"
+>
+
+[Message queue instrumentation](/docs/agents/nodejs-agent/troubleshooting/troubleshoot-message-consumers) is only available with the [New Relic Node.js agent v2 or higher](/docs/release-notes/agent-release-notes/nodejs-release-notes). Currently supported message queue instrumentation: `amqplib`. 
+
+For other message queue libraries, use [custom instrumentation](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation#message-client).
+
+</Collapser>
+
+<Collapser
+    id="support"
+    title="Supported Node.js frameworks"
+  >
+
+* [Express](https://www.npmjs.com/package/express) 4.6.0 or higher
+* [Restify](https://www.npmjs.com/package/restify)
+* [Connect](https://www.npmjs.com/package/connect)
+* [Hapi](https://www.npmjs.com/package/hapi)
+* [Koa](https://www.npmjs.com/package/koa) 2.0.0 or higher ([external module](https://github.com/newrelic/node-newrelic-koa) loaded with the agent)
+* [Fastify](https://www.npmjs.com/package/fastify)
+* [Next.js](https://www.npmjs.com/package/next) 12.0.9 or higher (12.2.0 or higher required for middleware instrumentation)
+
+If you are using a supported framework with default routers, the Node.js agent can read these frameworks' route names as is. However, if you want more specific names than are provided by your framework, you may want to use one or more of the tools New Relic provides with the [Node.js transaction naming API](/docs/nodejs/nodejs-transaction-naming-api).
+
+<Callout title="EOL NOTICE">
+  We have discontinued support for several capabilities in November 2021. This includes the Oracle Driver Package and Hapi versions prior to Hapi 19.2 for our Node.js agent. For more details, including how you can easily prepare for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-and-support-across-node-agents-suggested-pagerduty-responders-incident-workflows-and-kubernetes-instrumentation/164481?u=dholloran).
+</Callout>
+</Collapser>
+<Collapser
+    id="langtech"
+    title="Supported languages and technologies"
+>
+[TypeScript](https://www.npmjs.com/package/typescript) is a programming language that can compile to JavaScript. After installation, the Node.js agent automatically instruments your TypeScript apps, giving you immediate access to performance data right out of the box. 
 </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -13,7 +13,7 @@ redirects:
 
 Our Node.js agent is publicly available on the [Node Package Manager (npm) repository](https://npmjs.org/package/newrelic) as well as on [GitHub](https://github.com/newrelic/node-newrelic). Before you install the Node.js agent, make sure your application meets the following system requirements.
 
-If you haven't already, [create a New Relic account](https://newrelic.com/signup). It's free, forever.
+If you haven't already, [create a New Relic account](https://newrelic.com/signup). It's free, forever. 
 
 ## Node.js version support [#version]
 
@@ -150,7 +150,11 @@ For Node.js 12, the following change affects the Node.js agent:
 
 Errors resulting in unhandled rejections are not scoped to the transaction that was active when the rejected promise was created. This is because the promise responsible for triggering the init async hook is no longer passed through on the promise wrap instance. This breaks the linkage that associates a given promise rejection with the transaction it was scheduled in.
 
-## Supported Node.js frameworks [#supported-frameworks]
+<CollapserGroup>
+  <Collapser
+    id="support"
+    title="Supported Node.js frameworks"
+  >
 
 * [Express](https://www.npmjs.com/package/express) 4.6.0 or higher
 * [Restify](https://www.npmjs.com/package/restify)
@@ -159,25 +163,36 @@ Errors resulting in unhandled rejections are not scoped to the transaction that 
 * [Koa](https://www.npmjs.com/package/koa) 2.0.0 or higher ([external module](https://github.com/newrelic/node-newrelic-koa) loaded with the agent)
 * [Fastify](https://www.npmjs.com/package/fastify)
 * [Next.js](https://www.npmjs.com/package/next) 12.0.9 or higher (12.2.0 or higher required for middleware instrumentation)
+* [TypeScript](https://www.npmjs.com/package/typescript)
 
 If you are using a supported framework with default routers, the Node.js agent can read these frameworks' route names as is. However, if you want more specific names than are provided by your framework, you may want to use one or more of the tools New Relic provides with the [Node.js transaction naming API](/docs/nodejs/nodejs-transaction-naming-api).
 
 <Callout title="EOL NOTICE">
   We have discontinued support for several capabilities in November 2021. This includes the Oracle Driver Package and Hapi versions prior to Hapi 19.2 for our Node.js agent. For more details, including how you can easily prepare for this transition, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-and-support-across-node-agents-suggested-pagerduty-responders-incident-workflows-and-kubernetes-instrumentation/164481?u=dholloran).
 </Callout>
-
-## Processors [#processors]
+</Collapser>
+<Collapser
+    id="processors]"
+    title="Processors"
+>
 
 * The New Relic Node Agent is built to run on most processors including being tested and validated to work on AWS Graviton2
 
-## Operating systems [#operating-system]
+</Collapser>
+<Collapser
+    id="OS"
+    title="Operating systems"
+>
 
 * Linux
 * SmartOS
 * macOS 10.7 and higher
 * Windows Server 2008 and higher
-
-## Datastores [#database]
+</Collapser>
+<Collapser
+    id="Datastores"
+    title="Datastores"
+>
 
 The Node.js agent monitors the performance of Node.js application calls to these datastores:
 
@@ -187,6 +202,8 @@ The Node.js agent monitors the performance of Node.js application calls to these
 * MySQL (via [mysql](https://www.npmjs.com/package/mysql) and [mysql2](https://www.npmjs.com/package/mysql2) packages)
 * [Redis](https://www.npmjs.com/package/redis)
 * [Postgres](https://www.npmjs.com/package/pg) (including the [native](https://www.npmjs.com/package/pg-native) and [pure JavaScript](https://www.npmjs.com/package/pg-js) packages)
+</Collapser> 
+</CollapserGroup>
 
 ## Instance details
 

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -25,9 +25,9 @@ Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configu
     title="System requirements"
 >
 
-For all latest [even versions of Node.js releases](https://nodejs.org/en/about/releases/), expect active support by the following active long term support schedule, we will add support to. The version support policy does not replace our [general end-of-life (EOL) policy](/docs/agents/manage-apm-agents/maintenance/new-relic-agent-plugin-end-life-policy).
+We will support the [latest even versions of Node.js releases](https://nodejs.org/en/about/releases/) by the beginning of the following active long term support schedule. The version support policy does not replace our general end-of-life (EOL) policy.
 
-The following are proposed time ranges for Node version support, but the actual release date may vary.
+The following are proposed time ranges. The actual release date may vary.
 
 <table>
   <thead>
@@ -92,9 +92,7 @@ The following are proposed time ranges for Node version support, but the actual 
   </tbody>
 </table>
 
-When support for a new long term support agent version is made available, support for the Node.js agent version that reaches end-of-life during the same time period will simultaneously drop.
-
-The following are proposed time ranges. The actual release date may vary.
+The following are proposed time ranges for EOL on older Node.js versions. The actual release date may vary.
 
 <table>
   <thead>
@@ -212,10 +210,10 @@ If you are using a supported framework with default routers, the Node.js agent c
 </Callout>
 </Collapser>
 <Collapser
-    id=""
-    title="Typerscript"
+    id="typescript"
+    title="TyperScript"
 >
-
+[TypeScript](https://www.npmjs.com/package/typescript) is a programming language that can compile to JavaScript. After installation, the the Node.js agent automatically instruments your TypeScript apps, giving you immediate access to performance data right out of the box. 
 </Collapser>
 <Collapser
     id="Datastores"
@@ -267,8 +265,8 @@ In order to support [APM logs in context](/docs/apm/new-relic-apm/getting-starte
 * [pino](https://www.npmjs.com/package/pino)
 </Collapser>
 <Collapser
-    id=""
-    title=""
+    id="instance"
+    title="Instance details"
 >
 We collect [instance details for a variety of databases and database drivers](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues). The ability to view specific instances and the types of database information in APM depends on your agent version.
 

--- a/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
@@ -107,6 +107,7 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
       <td>
         NumPy
       </td>
+    </tr>
       
     <tr>
       <td>

--- a/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
@@ -12,7 +12,7 @@ redirects:
   - /docs/agents/python-agent/getting-started/status-python-agent
 ---
 
-Before you install New Relic's Python agent, make sure your system meets these requirements.
+Before you install New Relic's Python agent, make sure your system meets these requirements. 
 
 ## Basic requirements [#basic]
 
@@ -84,6 +84,7 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
         * Starlette
         * Tornado 6
         * Web2Py
+        * NumPy
       </td>
     </tr>
 

--- a/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
@@ -84,7 +84,6 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
         * Starlette
         * Tornado 6
         * Web2Py
-        * NumPy
       </td>
     </tr>
 
@@ -100,6 +99,15 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
       </td>
     </tr>
 
+    <tr id="libraries">
+      <td>
+      Supported libraries
+      </td>
+
+      <td>
+        NumPy
+      </td>
+      
     <tr>
       <td>
         Hosting


### PR DESCRIPTION
Made changes to Compatibility/Requirements docs for Python, Node.js, and .NET.

- For the Node.js doc, I restructured the page for readability. Because TypeScript is a JavaScript "dialect" / programming language, it was ~suggested that I not add it to the existing framework collapser. I decided to give it its own collapser as a band-aid solution
- For the Python doc, I added a line in the table for Python libraries for NumPy (the Frameworks row was just for frameworks)
- For .NET, I created a miscellaneous collapser for C# and ADO.NET. I can create a follow up ticket to tease this out a little bit more, but for the purposes of these tickets, this seemed like an ok solution. 