### PR TITLE
Add detail to orgs/accounts section about adding accounts

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-structure/add-accounts.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-structure/add-accounts.mdx
@@ -1,5 +1,5 @@
 ---
-title: Add accounts
+title: Add an account in your New Relic organization
 translate:
   - jp
 metaDescription: How to add accounts to your New Relic organization. 
@@ -7,13 +7,13 @@ metaDescription: How to add accounts to your New Relic organization.
 
 Some New Relic organizations have the ability to add more accounts to their organization. 
 
-## Why add accounts? [#why-add-accounts]
+## Why add an account? [#why-add-accounts]
 
 You should try to minimize the number of accounts you have in your New Relic organization. For reasons to add accounts, see [Organization/account structure](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure). 
 
 ## Add accounts [#add-accounts]
 
-How you add accounts depends on which [user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-user-models) your users are on: 
+How you add an account depends on which [user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-user-models) your users are on: 
 
 * Our newer user model: 
   * To add an account from the UI: from the **Access management** UI page, click **Accounts**, and then click **Create account**. Learn more about [user management](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks#where).

--- a/src/content/docs/accounts/accounts-billing/account-structure/add-accounts.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-structure/add-accounts.mdx
@@ -5,9 +5,15 @@ translate:
 metaDescription: How to add accounts to your New Relic organization. 
 ---
 
-Some New Relic organizations have the ability to add more accounts to their organization. For why you'd want to do this, see [Organization structure](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure). 
+Some New Relic organizations have the ability to add more accounts to their organization. 
 
-How you add accounts to your New Relic organization depends on the type of [user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-user-models) your users are on: 
+## Why add accounts? [#why-add-accounts]
+
+You should try to minimize the number of accounts you have in your New Relic organization. For reasons to add accounts, see [Organization/account structure](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure). 
+
+## Add accounts [#add-accounts]
+
+How you add accounts depends on which [user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-user-models) your users are on: 
 
 * Our newer user model: 
   * To add an account from the UI: from the **Access management** UI page, click **Accounts**, and then click **Create account**. Learn more about [user management](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks#where).

--- a/src/content/docs/accounts/accounts-billing/account-structure/add-accounts.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-structure/add-accounts.mdx
@@ -1,5 +1,5 @@
 ---
-title: Add an account in your New Relic organization
+title: Add an account to your New Relic organization
 translate:
   - jp
 metaDescription: How to add accounts to your New Relic organization. 

--- a/src/content/docs/accounts/accounts-billing/account-structure/new-relic-account-structure.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-structure/new-relic-account-structure.mdx
@@ -9,24 +9,41 @@ redirects:
   - /docs/accounts/accounts-billing/new-relic-one-pricing-users/new-relic-account-structure 
 ---
 
-Depending on your [user model](/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models), you have different options for adding and managing accounts and assigning users to them. We have two user models:
+<Callout variant="tip">
+This doc is for organizations whose users are on our [newer user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-user-models). If your users are still on our original user model, see [Original user model account access](/docs/accounts/original-accounts-billing/original-users-roles/original-account-structure).
+</Callout>
 
-* [Our newer user model](#new-model)
-* [Our original user model](/docs/accounts/original-accounts-billing/original-users-roles/original-account-structure)
+Understanding the structure of New Relic organizations and accounts will help you with getting around New Relic and setting up user access. 
 
-## Our newer user model [#new-model]
+## Organizations and accounts [#organization-accounts]
 
-This section is for organizations whose users are on our [newer user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-user-models).
+At New Relic, an **organization** represents a New Relic customer. Your New Relic organization contains everything relevant to you and your team members: your organization's accounts, users, and data.
 
-At New Relic, an "organization" represents a New Relic customer. The organization contains everything relevant to a New Relic customer: its accounts, its users, and its data.
+When you sign up for New Relic, it creates an organization containing a single account. A Standard edition organization can only have a single account. Pro and Enterprise edition organizations can add more accounts. 
 
-When a New Relic organization is created, it contains a single account. A Standard edition organization can only have a single account, but Pro and Enterprise edition organizations can add more accounts. 
+An account can have many sources of data reporting to it. All data reported to New Relic requires an [account ID](/docs/accounts/accounts-billing/account-structure/account-id), which governs where that data goes and where it's stored. That ID is also used for some account-specific tasks, like making API calls. 
 
-Why an organization creates new accounts depends on their goals and structure. There's nothing preventing even quite large companies from having a single account, or a handful of accounts. The fewer accounts you have, the easier it is to see how all your monitored entities relate to each other using our platform. But there can be several reasons to add accounts, such as creating separate accounts for production and non-production environments, or if you want to establish firmer boundaries between different sets of data for any reason. If you're in doubt about why to create accounts, talk to your account representative.
+When you [set up user access](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#understand-concepts), you give users access to specific accounts. 
 
-Each account in an organization has its own [account ID](/docs/accounts/accounts-billing/account-setup/account-id), and that ID is used for some account-specific tasks, like making API calls.
+## Cross-account access [#cross-account-access]
 
-To add and rename accounts, see [Add accounts](/docs/accounts/accounts-billing/account-structure/add-accounts). 
+New Relic provides various cross-platform functionality that gives users access to data in multiple accounts. For example, you can assign users access to multiple accounts. And features like distributed tracing, custom dashboards, and workloads allow you to see data from entities monitored in other accounts, if you're assigned access to those accounts. 
+
+But there can be some cross-account obstacles. For example, when using the [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder) to query your data, that will only query inside of the account you're in (to be able to make queries across accounts, you can use [our NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial).) This is one reason to attempt to minimize the number of accounts you have. 
+
+## Reasons to add accounts [#add-accounts]
+
+Why you'd add more accounts depends on your goals and structure. There's nothing preventing even quite large organizations from having a single account, or only two or three accounts. 
+
+When planning out your accounts, you should try to minimize the number of accounts in your organization as much as you can. This is for two reasons: a) it makes it simpler to manage your [user access](#account-access), and b) it makes it a bit easier for your users to use New Relic (for example, they'll be able to [query cross-account data in the query builder](#cross-account-access)).
+
+Reasons to add accounts: 
+
+* To separate production and testing environments. For example, you might name one account `Invoice processing dev` and another `Invoice processing prod`.
+* To separate projects of any sort that involve fairly distinct datasets. 
+* To control user access to different projects or data sets. For example, you might want to set up an account for outside contractors that only contains data from certain entities, and creating a separate account is one way to do that. 
+
+For how to add and rename accounts, see [Add accounts](/docs/accounts/accounts-billing/account-structure/add-accounts). 
 
 ### How users access accounts [#account-access]
 
@@ -38,4 +55,5 @@ To learn more about access issues, see [Factors affecting access](/docs/accounts
 
 ## Original user model [#original-model]
 
-If your users are still on our original user model, see [Original user model account access](/docs/accounts/original-accounts-billing/original-users-roles/original-account-structure).
+If your users are still on our original user model, the account structure and access works differently: see [Original user model account access](/docs/accounts/original-accounts-billing/original-users-roles/original-account-structure).
+

--- a/src/content/docs/accounts/accounts-billing/account-structure/new-relic-account-structure.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-structure/new-relic-account-structure.mdx
@@ -10,10 +10,10 @@ redirects:
 ---
 
 <Callout variant="tip">
-This doc is for organizations whose users are on our [newer user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-user-models). If your users are still on our original user model, see [Original user model account access](/docs/accounts/original-accounts-billing/original-users-roles/original-account-structure).
+This doc is for organizations with users on our [newer user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-user-models). If your users are still on our original user model, see [Original account access](/docs/accounts/original-accounts-billing/original-users-roles/original-account-structure).
 </Callout>
 
-Understanding the structure of New Relic organizations and accounts will help you with getting around New Relic and setting up user access. 
+Understanding the structure of New Relic organizations and accounts will help you with finding data in New Relic and setting up user access. 
 
 ## Organizations and accounts [#organization-accounts]
 

--- a/src/content/docs/accounts/accounts-billing/account-structure/new-relic-account-structure.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-structure/new-relic-account-structure.mdx
@@ -23,7 +23,7 @@ When you sign up for New Relic, it creates an organization containing a single a
 
 An account can have many sources of data reporting to it. All data reported to New Relic requires an [account ID](/docs/accounts/accounts-billing/account-structure/account-id), which governs where that data goes and where it's stored. That ID is also used for some account-specific tasks, like making API calls. 
 
-When you [set up user access](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#understand-concepts), you give users access to specific accounts. 
+When you [set up user access](#account-access), you give users access to specific accounts. 
 
 ## Cross-account access [#cross-account-access]
 
@@ -45,7 +45,7 @@ Reasons to add accounts:
 
 For how to add and rename accounts, see [Add accounts](/docs/accounts/accounts-billing/account-structure/add-accounts). 
 
-### How users access accounts [#account-access]
+## How users access accounts [#account-access]
 
 In your organization, your New Relic users are granted access to specific accounts that are relevant to their duties and responsibilities. To manage users' access to accounts, you create [access grants](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts#understand-concepts), which assign a group of users to a specific role on a specific account. For example, you might assign a group the ability to manage billing on some accounts using the [**Billing manager** role](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts#standard-roles), and assign some users as non-admin full platform users on some accounts, and assign some users as basic users on some accounts. Our user management system allows you to create the user access you need, whether that's a relatively simple setup with just a few roles across a few accounts, or a complex one with many roles across many accounts. [Learn more about user management.](/docs/accounts/accounts-billing/new-relic-one-user-management/)
 

--- a/src/content/docs/accounts/accounts-billing/account-structure/new-relic-account-structure.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-structure/new-relic-account-structure.mdx
@@ -21,7 +21,7 @@ At New Relic, an **organization** represents a New Relic customer. Your New Reli
 
 When you sign up for New Relic, it creates an organization containing a single account. A Standard edition organization can only have a single account. Pro and Enterprise edition organizations can add more accounts. 
 
-An account can have many sources of data reporting to it. All data reported to New Relic requires an [account ID](/docs/accounts/accounts-billing/account-structure/account-id), which governs where that data goes and where it's stored. That ID is also used for some account-specific tasks, like making API calls. 
+An account can have many sources of data reporting to it. For example, a single account could have data reporting from our infrastructure agent, an APM agent, and other integrations. All data reported to New Relic requires an [account ID](/docs/accounts/accounts-billing/account-structure/account-id), which tells New Relic which account to put that data in. That ID is also used for some account-specific tasks, like making API calls. 
 
 When you [set up user access](#account-access), you give users access to specific accounts. 
 
@@ -29,15 +29,18 @@ When you [set up user access](#account-access), you give users access to specifi
 
 New Relic provides various cross-platform functionality that gives users access to data in multiple accounts. For example, you can assign users access to multiple accounts. And features like distributed tracing, custom dashboards, and workloads allow you to see data from entities monitored in other accounts, if you're assigned access to those accounts. 
 
-But there can be some cross-account obstacles. For example, when using the [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder) to query your data, that will only query inside of the account you're in (to be able to make queries across accounts, you can use [our NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial).) This is one reason to attempt to minimize the number of accounts you have. 
+But there can be some cross-account obstacles. For example, the [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder) only lets you query inside of the account you're currently in (to make a cross-account query, you'd have to use [our NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial)). That's one reason to try to minimize the number of accounts you have. 
 
 ## Reasons to add accounts [#add-accounts]
 
 Why you'd add more accounts depends on your goals and structure. There's nothing preventing even quite large organizations from having a single account, or only two or three accounts. 
 
-When planning out your accounts, you should try to minimize the number of accounts in your organization as much as you can. This is for two reasons: a) it makes it simpler to manage your [user access](#account-access), and b) it makes it a bit easier for your users to use New Relic (for example, they'll be able to [query cross-account data in the query builder](#cross-account-access)).
+When planning out your accounts, you should try to minimize the number of accounts in your organization as much as you can. This is for two reasons:
 
-Reasons to add accounts: 
+* It makes it simpler to plan and manage [the accounts your users have access to](#account-access), and
+* It makes it easier for your users to use some New Relic features (for example, having fewer [cross-account restraints in the query builder](#cross-account-access)).
+
+Some example reasons to add accounts: 
 
 * To separate production and testing environments. For example, you might name one account `Invoice processing dev` and another `Invoice processing prod`.
 * To separate projects of any sort that involve fairly distinct datasets. 


### PR DESCRIPTION
As part of onboarding/guide work, putting in updated info into 'account/orgs' section instead of in guide. 