### PR TITLE
Fix mysql TLS setting

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mySQL/mysql-config.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mySQL/mysql-config.mdx
@@ -148,7 +148,7 @@ The MySQL integration collects both Metrics and Inventory information. In the ta
 
     <tr>
       <td>
-        `USE_TLS`
+        `ENABLE_TLS`
       </td>
 
       <td>
@@ -331,7 +331,7 @@ The values for these settings can be defined in several ways:
 - Adding the value directly in the config file. This is the most common way.
 - Replacing the values from environment variables using the `{{ }}` notation. Read more about [using environment variable passthroughs with on-host integrations](/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/#passthrough) or see the example for [environment variables replacement](/docs/infrastructure/host-integrations/host-integrations-list/elasticsearch/elasticsearch-integration#envvar-replacement).
 <Callout variant="important">
-  This requires infrastructure agent v1.14.0+. 
+  This requires infrastructure agent v1.14.0+.
 </Callout>
 
 - Using secrets management. Use this to protect sensitive information, such as passwords that would be exposed in plain text on the configuration file. For more information, see [secrets management](/docs/integrations/host-integrations/installation/secrets-management).

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mySQL/mysql-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mySQL/mysql-integration.mdx
@@ -252,7 +252,7 @@ There are several ways to configure the integration, depending on how it was ins
           PORT: 3306
           USERNAME: mysql_user
           PASSWORD: mysql_password
-          USE_TLS: true
+          ENABLE_TLS: true
           REMOTE_MONITORING: true
         interval: 30s
         labels:


### PR DESCRIPTION
This PR is to fix a small discrepancy we have in our mysql settings and example docs

The correct syntax to enable TLS support is `ENABLE_TLS`
https://github.com/newrelic/nri-mysql/blob/master/mysql-config.yml.sample#L6