### PR TITLE
[NR-39298] AGP 7.2.1 breaks transform API, fixed in 7.2.2

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
@@ -72,7 +72,7 @@ Make sure your Android app meets these requirements:
           </Callout>
 
           <Callout variant="important">
-            As of May 2022, Android Gradle Plugin 7.2.1 release breaks transform API when used along with ASM API, which has impacted New Relic android agent functionalities. This issue has been fixed in Android Gradle Plugin [7.2.2](https://developer.android.com/studio/releases/gradle-plugin#7-2-0)
+            As of May, 2022, Android Gradle plugin version 7.2.1 release breaks the transform API when used along with ASM API, and this has impacted New Relic Android agent functionalities. This issue has been fixed in [Android Gradle plugin version 7.2.2](https://developer.android.com/studio/releases/gradle-plugin#7-2-0)
           </Callout>
 
           Upgrade to the most recent version before installing the Android agent.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
@@ -71,6 +71,10 @@ Make sure your Android app meets these requirements:
             As of January 2021, our Android agent discontinued support for Android Gradle Plugin version 2. For more information, see our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-across-browser-php-python-mobile-and-android-agents/123951).
           </Callout>
 
+          <Callout variant="important">
+            As of May 2022, Android Gradle Plugin 7.2.1 release breaks transform API when used along with ASM API, which has impacted New Relic android agent functionalities. This issue has been fixed in Android Gradle Plugin [7.2.2](https://developer.android.com/studio/releases/gradle-plugin#7-2-0)
+          </Callout>
+
           Upgrade to the most recent version before installing the Android agent.
       </td>
     </tr>


### PR DESCRIPTION
* What problems does this PR solve? - We've identified one of the version of an essential library breaks our agent functionality