### PR TITLE
SLES 11.4 eol

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -151,7 +151,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        Versions 11.4, 12.1, 12.2, 12.3, 12.4, 12.5, 15, 15.1, 15.2, 15.3
+        Versions 12.1, 12.2, 12.3, 12.4, 12.5, 15, 15.1, 15.2, 15.3
       </td>
     </tr>
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -342,11 +342,6 @@ To install infrastructure in Linux, follow these instructions:
        id="amazon-linux-repository"
        title={<><img src={suseIcon} title="suse icon" alt="suse icon" style={{ height: '32px', width: '32px', verticalAlign: 'middle' }}/> SLES</>}
      >
-       **SLES 11.4 (x86)**
-
-       ```
-       sudo curl -o /etc/zypp/repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/zypp/sles/11.4/x86_64/newrelic-infra.repo
-       ```
 
        **SLES 12.1 (x86)**
 

--- a/src/i18n/content/jp/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/i18n/content/jp/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -301,11 +301,6 @@ InfrastructureをLinuxでインストールするには、次の指示に従っ�
        id="amazon-linux-repository"
        title={<><img src={suseIcon} title="suse icon" alt="suse icon" style={{ height: '32px', width: '32px', verticalAlign: 'middle' }}/>SLES</>}
      >
-       **SLES 11.4（x86）**
-
-       ```
-       sudo curl -o /etc/zypp/repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/zypp/sles/11.4/x86_64/newrelic-infra.repo
-       ```
 
        **SLES 12.1（x86）**
 

--- a/src/i18n/content/kr/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/i18n/content/kr/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -301,11 +301,6 @@ Linux에 인프라를 설치하려면 다음 지침을 따르십시오.
        id="amazon-linux-repository"
        title={<><img src={suseIcon} title="suse icon" alt="suse icon" style={{ height: '32px', width: '32px', verticalAlign: 'middle' }}/>SLES</>}
      >
-       **SLES 11.4(x86)**
-
-       ```
-       sudo curl -o /etc/zypp/repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/zypp/sles/11.4/x86_64/newrelic-infra.repo
-       ```
 
        **SLES 12.1(x86)**
 


### PR DESCRIPTION
## Give us some context

* SUSE Enterprise Server (SLES) version 11.4 reached end of life March 2022. Updating docs to highlight this is no longer officially supported.