### PR TITLE
fix: Add NetworkSample to list of event types

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-baseline-ingest-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-baseline-ingest-guide.mdx
@@ -128,7 +128,7 @@ Below is a breakdown of the different `usageMetric` types, the constituent event
       </td>
 
       <td>
-        `SystemSample`, `StorageSample`, `InfrastructureEvent`
+        `SystemSample`, `StorageSample`, `InfrastructureEvent`, `NetworkSample`
       </td>
 
       <td>


### PR DESCRIPTION
NetworkSample was a critical omission from the list of event types that are covered under infra host bytes.  This PR adds it.