### PR TITLE
Updating requirements information for Partner accounts with V2 user model

### DIFF
--- a/src/content/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models.mdx
+++ b/src/content/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models.mdx
@@ -67,7 +67,7 @@ Here are factors governing which organizations have users on the newer model:
 
 * All New Relic organizations that signed up after July 30, 2020 have users on this model (and also have the [newer pricing model](#pricing-plans)).
 * Some older New Relic organizations have had their users migrated to the new model by New Relic or by using the [user migration procedure](/docs/accounts/original-accounts-billing/original-users-roles/user-migration).
-* Partner accounts (resellers, managed service providers), and organizations using the [partnership account structure](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions), previously couldn't migrate their users to the new model. However, in 2022, these accounts can now complete this migration.
+* Some New Relic partners (for example, resellers, managed service providers) have had their users migrated to the new model. (If you're a New Relic organization with users on the original model and you require multi-tenancy, contact your account representative for more information.)
 
 ## Feature impacts of user model [#limitations]
 

--- a/src/content/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models.mdx
+++ b/src/content/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models.mdx
@@ -67,7 +67,7 @@ Here are factors governing which organizations have users on the newer model:
 
 * All New Relic organizations that signed up after July 30, 2020 have users on this model (and also have the [newer pricing model](#pricing-plans)).
 * Some older New Relic organizations have had their users migrated to the new model by New Relic or by using the [user migration procedure](/docs/accounts/original-accounts-billing/original-users-roles/user-migration).
-* Partner accounts (resellers, managed service providers), and organizations using the [partnership account structure](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions), cannot yet migrate their users to the new model.
+* Partner accounts (resellers, managed service providers), and organizations using the [partnership account structure](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partnership-accounts-users-subscriptions), previously couldn't migrate their users to the new model. However, in 2022, these accounts can now complete this migration.
 
 ## Feature impacts of user model [#limitations]
 


### PR DESCRIPTION
_What problems does this PR solve?_

We are working through the V2 user model requirements, and we are under the impression that New Relic supports V2 for Partner accounts. In this document, it appears they are not supported; however, that contradicts information we have received from New Relic (as we are a partner that has been notified in moving to V2).