### PR TITLE
chore: add cf parameters to aws metric stream

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
@@ -64,7 +64,8 @@ This table outlines the various parameters required for the CloudFormation templ
         Description
       </th>
     </tr>
-
+    
+    <tr>
       <th>
         Constraints
       </th>

--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
@@ -63,9 +63,7 @@ This table outlines the various parameters required for the CloudFormation templ
       <th>
         Description
       </th>
-    </tr>
-    
-    <tr>
+      
       <th>
         Constraints
       </th>

--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
@@ -49,6 +49,129 @@ First, you need to link each of your AWS accounts with your New Relic account. T
 
 Next, set up the metric stream using the [CloudFormation template](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?templateURL=https://nr-downloads-main.s3.amazonaws.com/cloud_integrations/aws/cloudformation/MetricStreams_CloudFormation.yml&stackName=NewRelic-Metric-Stream&param_NewRelicDatacenter=US) we provide in the last step of our UI. This template is provided as a base to set up the integration on a single region. You can customize and extend it to meet your requirements.
 
+### CloudFormation Template Parameters
+
+This table outlines the various parameters required for the CloudFormation template. *Note that the template will create new resources in your AWS account and it is not recommended to provided the names of existing AWS resources here.*
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: '100px' }}>
+        Name
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+
+      <th>
+        Constraints
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        New Relic Ingest License Key
+      </td>
+
+      <td>
+        The license key associated with the account you wish to export metrics to ([Direct Link](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher))
+      </td>
+
+      <td>
+        40-character hexadecimal string
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        New Relic Datacenter
+      </td>
+
+      <td>
+        Identification of the New Relic datacenter to export your metrics to. (EU datacenter accounts have license keys prefixed with `eu0x`)
+      </td>
+
+      <td>
+        Allowed values: `US`, `EU`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        CloudWatch Metric Stream name
+      </td>
+
+      <td>
+        Name of new CloudWatch Metric Stream (must be unique per AWS account in the same AWS Region)
+      </td>
+
+      <td>
+        Must only container letters (uppercase and lowercase), numbers, and characters '_', and '-' with max length of 255 total characters
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Kinesis Data Firehose name
+      </td>
+
+      <td>
+        Name of new Kinesis Firehose Delivery Stream (must be unique per AWS account in the same AWS Region)
+      </td>
+
+      <td>
+        Must only container letters (uppercase and lowercase), numbers, and characters '.', '_', and '-' with max length of 64 total characters
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Firehose S3 backup bucket name
+      </td>
+
+      <td>
+        Name of new S3 Bucket Destination for failed events (must be globally unique across all AWS accounts in all AWS Regions within a partition)
+      </td>
+
+      <td>
+        Must adhere to the [S3 bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Enrich metrics with resource metadata from AWS Config?
+      </td>
+
+      <td>
+        Enable and configure AWS Config to track resource changes
+      </td>
+
+      <td>
+        Allowed values: `true`, `false`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Config S3 backup bucket name
+      </td>
+
+      <td>
+        Name of new S3 Bucket Destination for delivery channel configuration (must be globally unique across all AWS accounts in all AWS Regions within a partition)
+      </td>
+
+      <td>
+        Must adhere to the [S3 bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 <Callout variant="tip">
   The provided CloudFormation template does not include any inclusion nor exclusion namespace filter in CloudWatch metric streams. Consider adapting the base template based on your business requirements.
 </Callout>

--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
@@ -51,12 +51,12 @@ Next, set up the metric stream using the [CloudFormation template](https://conso
 
 ### CloudFormation Template Parameters
 
-This table outlines the various parameters required for the CloudFormation template. *Note that the template will create new resources in your AWS account and it is not recommended to provided the names of existing AWS resources here.*
+This table outlines the various parameters required for the CloudFormation template. Since the template will create new resources in your AWS account, we don't providing names of existing AWS resources here.
 
 <table>
   <thead>
     <tr>
-      <th style={{ width: '100px' }}>
+      <th style={{ width: '200px' }}>
         Name
       </th>
 

--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
@@ -77,7 +77,7 @@ This table outlines the various parameters required for the CloudFormation templ
       </td>
 
       <td>
-        The license key associated with the account you wish to export metrics to ([Direct Link](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher))
+        The [license key](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher) associated with the account you wish to export metrics to.
       </td>
 
       <td>
@@ -91,7 +91,7 @@ This table outlines the various parameters required for the CloudFormation templ
       </td>
 
       <td>
-        Identification of the New Relic datacenter to export your metrics to. (EU datacenter accounts have license keys prefixed with `eu0x`)
+        Identification of the New Relic datacenter your metrics are exported to. (EU datacenter accounts have license keys prefixed with `eu0x`)
       </td>
 
       <td>


### PR DESCRIPTION
this PR adds details to the 7 parameters required by the CloudFormation template used to implement AWS CloudWatch Metric Streams.