### PR TITLE
Added iOS XCFramework Agent version 7.3.8 release notes

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/upload-dsyms-bitcode-apps.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/upload-dsyms-bitcode-apps.mdx
@@ -13,7 +13,7 @@ import screenShot20140923At113035Am0 from 'images/Screen-Shot-2014-09-23-at-11.3
 
 Your app's dSYM files are stored in Xcode's dSYM archive path folder. This is the folder where the iOS agent gets the dSYM files that are used to symbolicate your crash reports.
 
-New Relic provides a post-build script as part of the [iOS agent's install process](/docs/mobile-monitoring/mobile-monitoring-installation/getting-started/ios-installation-configuration) and the [tvOS agent's install process](/docs/mobile-monitoring/new-relic-mobile-ios/get-started/tvos-installation-configuration). This script automatically uploads your app's dSYM files.
+New Relic provides a post-build script as part of the [iOS agent's install process](/docs/mobile-monitoring/mobile-monitoring-installation/getting-started/ios-installation-configuration). This script automatically converts your dSYM to the New Relic map file format and uploads the files needed for crash symbolication to New Relic.
 
 ## Automatic script [#Automatic]
 
@@ -21,7 +21,7 @@ The script automatically uploads dSYM files **only for release builds**. Non-rel
 
 If you see unreadable machine code in the [**Crashes** page](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/mobile-apps-crashes-dashboard), your dSYM files may not be uploaded correctly. In some cases, you may need to [manually upload dSYM files](#manual-dsym).
 
-The automatic script uses Python 2. As of October 2019 with [macOS 10.15 (Catalina)](https://developer.apple.com/documentation/macos_release_notes/macos_catalina_10_15_beta_10_release_notes#3318248), Python won't be installed by default. If you're using the automatic script (recommended), you may need to manually install [Python 2](https://www.python.org/downloads/mac-osx/). If you're using Homebrew, see [Python on Homebrew](https://docs.brew.sh/Homebrew-and-Python).
+As of New Relic iOS Agent version 7.3.8 the automatic script uses Python 3. As of macOS 12.3 [macOS 12.3 (Monterey)](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes) Python 3 will be installed by default with Xcode. If you're using the automatic script (recommended) on macOS 12.2 or before, you may need to manually install [Python 3](https://www.python.org/downloads/mac-osx/).
 
 ## Identify missing dSYMs [#IdentifyingMissingdSYMs]
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/ios-agent-configuration-feature-flags.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/ios-agent-configuration-feature-flags.mdx
@@ -302,6 +302,38 @@ If used, be sure to call the feature flag before the New Relic iOS agent start c
       </tbody>
     </table>
   </Collapser>
+
+  <Collapser
+    id="webViewInstrumentation"
+    title="NRFeatureFlag_WebViewInstrumentation"
+  >
+
+    Enable (default) or disable automatic WKWebView instrumentation.
+
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
 </CollapserGroup>
 
 ## Networking feature flags [#networking]

--- a/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-738.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-738.mdx
@@ -1,0 +1,20 @@
+---
+subject: XCFramework agent
+releaseDate: '2022-08-24'
+version: 7.3.8
+downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.3.8.zip'
+---
+
+## Fixed in this release
+
+* Automatic dSYM file upload script updated to use Python 3.
+* Fix for custom event memory leak.
+
+### Other notes
+
+* This artifact was built using Xcode 13.4.1 with a minimum deployment target of iOS version 9.0. Compatible with CocoaPods 1.10 or higher and Swift Package Manager.
+* For Mac Catalyst, the zip file installation may integrate more easily than using CocoaPods.
+
+### Support statement
+
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. The iOS and tvOS agents were deprecated with the release of version 7.2.1 of the [XCFramework](https://docs.newrelic.com/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-700) agent. As of this release, the oldest supported version is 7.0.0 of the [XCFramework](https://docs.newrelic.com/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-700)


### PR DESCRIPTION
XCFramework 7.3.8 Release notes added @ `xcframework-agent-738.mdx` go live 08/24/22.

Updated `upload-dsyms-bitcode-apps.mdx` to reflect changes.
Add additional ff to `ios-agent-configuration-feature-flags.mdx`.