### PR TITLE
set active state on hover and focus for walkthrough steps / start instrumentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "^2.0.0-next.8",
     "@mdx-js/react": "^2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "6.9.2",
+    "@newrelic/gatsby-theme-newrelic": "6.10.0",
     "@splitsoftware/splitio-react": "^1.2.4",
     "cockatiel": "^3.0.0-beta.0",
     "common-tags": "^1.8.0",

--- a/src/components/AgentConfig.js
+++ b/src/components/AgentConfig.js
@@ -8,9 +8,18 @@ import {
 } from '@newrelic/gatsby-theme-newrelic';
 import MDXContainer from './MDXContainer';
 
-const AgentConfig = ({ inputOptions, config, tipMdx }) => {
+const AgentConfig = ({ inputOptions, config, tipMdx, onChange }) => {
   const [state, setState] = useState([...inputOptions]);
   const { body } = tipMdx;
+
+  const handleChange = (value, idx, name) => {
+    setState([
+      ...state.slice(0, idx),
+      { ...state[idx], value },
+      ...state.slice(idx + 1),
+    ]);
+    onChange({ name, value });
+  };
 
   return (
     <div
@@ -42,13 +51,7 @@ const AgentConfig = ({ inputOptions, config, tipMdx }) => {
               defaultValue={defaultValue}
               value={state[idx].value}
               url={url}
-              onChange={(e) =>
-                setState([
-                  ...state.slice(0, idx),
-                  { ...state[idx], value: e.target.value },
-                  ...state.slice(idx + 1),
-                ])
-              }
+              onChange={(e) => handleChange(e.target.value, idx, name)}
               toolTip={toolTip}
               css={css`
                 margin-bottom: 1.5rem;
@@ -104,6 +107,7 @@ AgentConfig.propTypes = {
   ),
   config: PropTypes.string,
   tipMdx: PropTypes.node,
+  onChange: PropTypes.func,
 };
 
 export default AgentConfig;

--- a/src/pages/install/{installConfig.agentName}.js
+++ b/src/pages/install/{installConfig.agentName}.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { graphql } from 'gatsby';
 import { css } from '@emotion/react';
 import { Walkthrough, Layout } from '@newrelic/gatsby-theme-newrelic';
@@ -29,6 +29,12 @@ const InstallPage = ({ data }) => {
   const [pageState, setPageState] = useState({
     selectOptions: defaultAppInfoState(appInfo),
   });
+
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const handleSelectIndex = useCallback((idx) => {
+    setSelectedIndex(idx);
+  }, []);
 
   const renderStep = (step) => {
     const { overrides } = step;
@@ -108,30 +114,31 @@ const InstallPage = ({ data }) => {
           <MDXContainer body={intro.mdx?.body} />
         </div>
         <div>
-          <Walkthrough
-            css={css`
-              max-width: 900px;
-            `}
-            r
-          >
+          <Walkthrough>
             {walkthroughSteps.map(({ content, step: { mdx } }, index) => {
               const { descriptionText, headingText } = mdx?.frontmatter;
               return (
                 <Walkthrough.Step
-                  key={index}
-                  number={index}
+                  number={index + 1}
                   title={headingText}
+                  active={selectedIndex === index}
+                  key={index}
                 >
-                  {descriptionText && (
-                    <p
-                      css={css`
-                        margin-bottom: 2rem;
-                      `}
-                    >
-                      {descriptionText}
-                    </p>
-                  )}
-                  {content}
+                  <div
+                    onMouseOver={() => handleSelectIndex(index)}
+                    onFocus={() => handleSelectIndex(index)}
+                  >
+                    {descriptionText && (
+                      <p
+                        css={css`
+                          margin-bottom: 2rem;
+                        `}
+                      >
+                        {descriptionText}
+                      </p>
+                    )}
+                    {content}
+                  </div>
                 </Walkthrough.Step>
               );
             })}

--- a/src/pages/install/{installConfig.agentName}.js
+++ b/src/pages/install/{installConfig.agentName}.js
@@ -1,10 +1,11 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState } from 'react';
 import { graphql } from 'gatsby';
 import { css } from '@emotion/react';
 import {
   Walkthrough,
   useQueryParams,
   Layout,
+  useTessen,
 } from '@newrelic/gatsby-theme-newrelic';
 import PageTitle from '../../components/PageTitle';
 import MDXContainer from '../../components/MDXContainer';
@@ -22,10 +23,14 @@ const InstallPage = ({ data }) => {
     appInfo,
     agentConfigFile,
     whatsNext,
+    agentName,
   } = installConfig;
 
   const { queryParams, setQueryParam, deleteQueryParam } = useQueryParams();
   const [showGuided, setShowGuided] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const tessen = useTessen();
 
   const handleChange = (value, select) => {
     if (value !== null || value !== undefined) {
@@ -34,16 +39,39 @@ const InstallPage = ({ data }) => {
         (option) => option.value === value && option.recommendedGuided === true
       );
       setShowGuided(recommendedGuided);
+      tessen.track({
+        eventName: 'appInfoOptionSelected',
+        category: `${select.optionType}AppInfoOptionSelect`,
+        value,
+        path: location.pathname,
+        agentName,
+        recommendedGuided,
+      });
     } else {
       deleteQueryParam(select.optionType, value);
     }
   };
 
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const handleAgentConfigChange = ({ name, value }) => {
+    tessen.track({
+      eventName: 'agentConfigFileUpdated',
+      category: `${name}AgentConfigFileUpdated`,
+      key: name,
+      value,
+      path: location.pathname,
+      agentName,
+    });
+  };
 
-  const handleSelectIndex = useCallback((idx) => {
-    setSelectedIndex(idx);
-  }, []);
+  const handleSelectIndex = (index) => {
+    setSelectedIndex(index);
+    tessen.track({
+      eventName: 'activeStepUpdated',
+      activeStep: index + 1,
+      path: location.pathname,
+      agentName,
+    });
+  };
 
   const renderStep = (step) => {
     const { overrides } = step;
@@ -78,6 +106,7 @@ const InstallPage = ({ data }) => {
           config={agentConfigFile?.internal?.content}
           inputOptions={inputOptions}
           tipMdx={mdx}
+          onChange={handleAgentConfigChange}
         />
       );
     } else if (componentType === 'appInfoConfig') {
@@ -131,22 +160,19 @@ const InstallPage = ({ data }) => {
                   title={headingText}
                   active={selectedIndex === index}
                   key={index}
+                  onMouseOver={() => handleSelectIndex(index)}
+                  onFocus={() => handleSelectIndex(index)}
                 >
-                  <div
-                    onMouseOver={() => handleSelectIndex(index)}
-                    onFocus={() => handleSelectIndex(index)}
-                  >
-                    {descriptionText && (
-                      <p
-                        css={css`
-                          margin-bottom: 2rem;
-                        `}
-                      >
-                        {descriptionText}
-                      </p>
-                    )}
-                    {content}
-                  </div>
+                  {descriptionText && (
+                    <p
+                      css={css`
+                        margin-bottom: 2rem;
+                      `}
+                    >
+                      {descriptionText}
+                    </p>
+                  )}
+                  {content}
                 </Walkthrough.Step>
               );
             })}
@@ -190,6 +216,7 @@ export const pageQuery = graphql`
     ...MainLayout_query
     installConfig(agentName: { eq: $agentName }) {
       id
+      agentName
       title
       intro {
         filePath

--- a/yarn.lock
+++ b/yarn.lock
@@ -3270,10 +3270,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@6.9.2":
-  version "6.9.2"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.9.2.tgz#e1bea9c8e823ee7c9680997ffe063a1d122f29b8"
-  integrity sha512-jzO3tIVz+GQkgvPURkdhTlyR/EFlUlYXFc8qtJG7h76k7aQcLEWm57dnH2ARim5u74zAkyUShfB/oeyK99Cp2g==
+"@newrelic/gatsby-theme-newrelic@6.10.0":
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.10.0.tgz#37eadf240e6b0b4ae070a8b0aa7b2db9b03ad24e"
+  integrity sha512-3ls5zA6WHHlTG6CyaDKu/7Z4Rha4ikDrhGhQDkge9MS0JMsMGNrR+yRWvCGFwrVcwAcJWLHcpqdWjTsUqvd+AA==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
## https://issues.newrelic.com/browse/NR-42029
- [x] Pass `active` prop to `WalkthroughStep` if the item is focused on or if the item is hovered on
- [x] Ensure that only one step is highlighted at a time

## https://issues.newrelic.com/browse/NR-37499
Added instrumentation to begin doing this ticket ^ 

- [x] App config options select (e.g. deployment method selected and framework selected) 
- [x] Usage of agent config component 
- [x] Step is active
- [x] ~clicks on download / copy YAML config file~ this is already handled in the `CodeBlock` component in the theme: https://github.com/newrelic/gatsby-theme-newrelic/blob/34f45f1416b48897618d62df4f92f17bfc20cf9e/packages/gatsby-theme-newrelic/src/components/CodeBlock.js#L99-L109