### PR TITLE
Remove section about curated dashboards

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
@@ -313,23 +313,6 @@ As with the EC2 API polling integration, when the infrastructure agent is instal
 
 The following attributes will decorate infrastructure samples. Some of these may not be applicable on all environments: `awsAvailabilityZone`, `ec2InstanceId`, `ec2PublicDnsName`, `ec2State`, `ec2EbsOptimized`, `ec2PublicIpAddress`, `ec2PrivateIpAddress`, `ec2VpcId`, `ec2AmiId`, `ec2PrivateDnsName`, `ec2KeyName`, `ec2SubnetId`, `ec2InstanceType`, `ec2Hypervisor`, `ec2Architecture`, `ec2RootDeviceType`, `ec2RootDeviceName`, `ec2VirtualizationType`, `ec2PlacementGroupName`, `ec2PlacementGroupTenancy`.
 
-## Curated dashboards [#curated-dashboards]
-
-A set of dashboards for the most popular AWS Services are available in New Relic [Instant Observability](/docs/using-new-relic/welcome-new-relic/get-started/new-relic-quickstarts-overview/).
-
-### How to import dashboards [#import-dashboards]
-
-Follow these steps in order to browse and import dashboards:
-
-1. Click **Instant Observability** from the top bar of the New Relic UI.
-2. Search for any AWS service name, such as **AWS SQS**, **AWS RDS**, **AWS ELB**, or **AWS EC2**.
-3. Access the AWS service tile.
-4. Click **Install this quickstarts** and select your account.
-5. Click **Done** to confirm that AWS metric stream is already configured.
-6. Browse and adapt the dashboard according to your needs.
-
-Have an interesting dashboard to share with the community? See [contribution guidelines](https://github.com/newrelic/newrelic-quickstarts#getting-started) in the Instant Observability GitHub repository.
-
 ## Custom metrics and percentiles [#custom-metrics-percentiles]
 
 The CloudWatch metric stream integration automatically ingests new metrics configured in the stream, including custom metrics and percentiles.


### PR DESCRIPTION
Since we had a broken link in the "Curated dashboards" section, we looked at the section more closely and realized that we don't actually have a quickstart with a dashboard for Metric Streams. So, we are removing this section.