### PR TITLE
Fix two anchors

### DIFF
--- a/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
+++ b/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
@@ -21,9 +21,9 @@ New Relic customers must meet all of the following requirements for our FedRAMP 
 
 2. **Subscription level**: Customer must have a current and valid subscription for our Enterprise edition with the [Data Plus option](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing#data-plus), or have an alternative New Relic-approved subscription.
 
-3. **Authorized New Relic endpoints**: Customer must send their data only to our [FedRAMP-designated endpoints](#endpoints).
+3. **Authorized New Relic endpoints**: Customer must send their data only to our [FedRAMP-designated endpoints](#overview).
 
-4. **Authorized services and features**: Customer must use only FedRAMP audited and authorized New Relic [services and features](#endpoints).
+4. **Authorized services and features**: Customer must use only FedRAMP audited and authorized New Relic [services and features](#overview).
 
 ## FedRAMP inheritance [#inheritance]
 


### PR DESCRIPTION
Update two document anchors. I think these were supposed to point to the next section called FedRAMP-compliant endpoints.