### PR TITLE
Correct two broken links

### DIFF
--- a/src/content/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models.mdx
+++ b/src/content/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models.mdx
@@ -46,7 +46,7 @@ When you log in to New Relic, the user record associated with that login is on e
 
 To determine if you can manage users who are on our newer user model, see [Manage users](/docs/accounts/accounts-billing/new-relic-one-pricing-users/add-manage-users-groups-roles#where).
 
-The user model is independent of your pricing model. For how user model relates to pricing, see the [Pricing and user model table](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-pricing-models/#pricing-user-table).
+The user model is independent of your pricing model. For how user model relates to pricing, see the [Pricing and user model table](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-pricing-models#pricing-user-table).
 
 ## User model comparison [#differences]
 

--- a/src/content/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models.mdx
+++ b/src/content/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models.mdx
@@ -46,7 +46,7 @@ When you log in to New Relic, the user record associated with that login is on e
 
 To determine if you can manage users who are on our newer user model, see [Manage users](/docs/accounts/accounts-billing/new-relic-one-pricing-users/add-manage-users-groups-roles#where).
 
-The user model is independent of your pricing model. For how user model relates to pricing, see the [Pricing and user model table](#pricing-user-table).
+The user model is independent of your pricing model. For how user model relates to pricing, see the [Pricing and user model table](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-pricing-models/#pricing-user-table).
 
 ## User model comparison [#differences]
 
@@ -79,4 +79,4 @@ The new user model offers [many benefits](https://newrelic.com/blog/how-to-relic
 
 ## Relation between user model and pricing model [#relation-to-pricing]
 
-The user model isn't directly related to our two pricing models. For information about how these relate, see [Pricing model and user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-pricing-models/#pricing-user-table).
+The user model isn't directly related to our two pricing models. For information about how these relate, see [Pricing model and user model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-pricing-models#pricing-user-table).


### PR DESCRIPTION
We had two links to the same doc, each with their own syntax issues. This should correct the two issues.

This closed GitHub issue #8993