### PR TITLE
"Whats New": Data Plus - Longer Running Queries

### DIFF
--- a/src/content/whats-new/2022/08/whats-new-8-25-longer-running-queries.md
+++ b/src/content/whats-new/2022/08/whats-new-8-25-longer-running-queries.md
@@ -1,7 +1,7 @@
 ---
 title: 'New Relic Data Plus provides more powerful queries through increased query durations and limits.’
 releaseDate: '2022-08-25' 
-getStartedLink:'https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial/'
+getStartedLink: 'https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial/'
 ---
 # Analyze larger volumes of data with longer running queries
 

--- a/src/content/whats-new/2022/08/whats-new-8-25-longer-running-queries.md
+++ b/src/content/whats-new/2022/08/whats-new-8-25-longer-running-queries.md
@@ -1,14 +1,13 @@
 ---
 title: 'New Relic Data Plus provides more powerful queries through increased query durations and limits.’
-releaseDate: '2022-08-25'
-learnMoreLink: 
+releaseDate: '2022-08-25' 
 getStartedLink: 'https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial/'
 ---
-# Longer running queries allow you to analyze larger volumes of data
+# Analyze larger volumes of data with longer running queries
 
-After the launch of [Data Plus](https://docs.newrelic.com/whats-new/2022/06/whats-new-6-1-data-plus-available) in June, we are continuing to support and help your teams scale their observability practices. Today, Data Plus customers now can utilize longer running queries (up to 10x the the previous maximum duration) to analyze larger data volumes.  Data Plus customers get a max query duration of up to 10 minutes via asynchronous queries and up to 2 minutes via regular NRQL queries compared to 60 seconds for the existing data option. Learn how to run [asynchronous queries](https://docs.newrelic.com/docs/apis/nerdgraph/examples/async-queries-nrql-tutorial/) via our [NerdGraph] (https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/) API.
+After the launch of [Data Plus](https://docs.newrelic.com/whats-new/2022/06/whats-new-6-1-data-plus-available) in June, we are continuing to support and help your teams scale their observability practices. Today, Data Plus customers now can utilize longer running queries (up to 10x the the previous maximum duration) to analyze larger data volumes.  Data Plus customers get a max query duration of up to 10 minutes via asynchronous queries and up to two minutes via regular NRQL queries,c compared to 60 seconds for the existing data option. Learn how to run [asynchronous queries](https://newrelic.com/blog/nerdlog/data-plus-pricing) via our [NerdGraph] (https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/) API.
 
-In addition to more powerful and 10x maximum duration longer running queries, Data Plus also includes:
+In addition to more powerful and 10x longer-running queries, Data Plus also includes:
 
 * Up to 90 days of data retention 
 * FedRAMP and HIPAA compliance (Pro and Enterprise customers only) 
@@ -19,11 +18,7 @@ In addition to more powerful and 10x maximum duration longer running queries, Da
 
 [Read more here](https://newrelic.com/blog/nerdlog/data-plus-pricing)
 
-# How to Sign up for Data Plus
+# How to Sign up for [Data Plus](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing)
 1. Understand the new pricing mode and [upgrade to Data Plus here](https://newrelic.com/blog/nerdlog/data-plus-pricing) at a promotional pricing model of $.50/GB.
 
 2. Learn more about asynchronous queries with [asynchronous queries tutorial](https://docs.newrelic.com/docs/apis/nerdgraph/examples/async-queries-nrql-tutorial/) or get started [querying your data using NRQL](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial/).
-
-
-# Next Steps
-[Sign up today for a free New Relic account](https://newrelic.com/signup) to take advantage of the 100 GB/month of data ingest, one full-platform user, and unlimited basic users offering to get started with network monitoring as part of the observability journey.

--- a/src/content/whats-new/2022/08/whats-new-8-25-longer-running-queries.md
+++ b/src/content/whats-new/2022/08/whats-new-8-25-longer-running-queries.md
@@ -1,7 +1,7 @@
 ---
 title: 'New Relic Data Plus provides more powerful queries through increased query durations and limits.’
 releaseDate: '2022-08-25' 
-getStartedLink: 'https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial/
+getStartedLink:'https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial/'
 ---
 # Analyze larger volumes of data with longer running queries
 

--- a/src/content/whats-new/2022/08/whats-new-8-25-longer-running-queries.md
+++ b/src/content/whats-new/2022/08/whats-new-8-25-longer-running-queries.md
@@ -1,7 +1,7 @@
 ---
 title: 'New Relic Data Plus provides more powerful queries through increased query durations and limits.’
 releaseDate: '2022-08-25' 
-getStartedLink: 'https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial/'
+getStartedLink: 'https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial/
 ---
 # Analyze larger volumes of data with longer running queries
 

--- a/src/content/whats-new/2022/08/whats-new-8-25-longer-running-queries.md
+++ b/src/content/whats-new/2022/08/whats-new-8-25-longer-running-queries.md
@@ -1,8 +1,9 @@
 ---
-title: 'New Relic Data Plus provides more powerful queries through increased query durations and limits.’
+title: 'New Relic Data Plus provides more powerful queries through increased query durations and limits.'
 releaseDate: '2022-08-25' 
 getStartedLink: 'https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial/'
 ---
+
 # Analyze larger volumes of data with longer running queries
 
 After the launch of [Data Plus](https://docs.newrelic.com/whats-new/2022/06/whats-new-6-1-data-plus-available) in June, we are continuing to support and help your teams scale their observability practices. Today, Data Plus customers now can utilize longer running queries (up to 10x the the previous maximum duration) to analyze larger data volumes.  Data Plus customers get a max query duration of up to 10 minutes via asynchronous queries and up to two minutes via regular NRQL queries,c compared to 60 seconds for the existing data option. Learn how to run [asynchronous queries](https://newrelic.com/blog/nerdlog/data-plus-pricing) via our [NerdGraph] (https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/) API.

--- a/src/content/whats-new/2022/08/whats-new-8-25-longer-running-queries.md
+++ b/src/content/whats-new/2022/08/whats-new-8-25-longer-running-queries.md
@@ -1,12 +1,12 @@
 ---
-title: 'New Relic Data Plus provides more powerful queries through increased query durations and limits.'
+title: 'New Relic Data Plus now allows you to analyze larger data volumes through long running queries.'
 releaseDate: '2022-08-25' 
 getStartedLink: 'https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial/'
 ---
 
-# Analyze larger volumes of data with longer running queries
+# Analyze larger volumes of data with long running queries
 
-After the launch of [Data Plus](https://docs.newrelic.com/whats-new/2022/06/whats-new-6-1-data-plus-available) in June, we are continuing to support and help your teams scale their observability practices. Today, Data Plus customers now can utilize longer running queries (up to 10x the the previous maximum duration) to analyze larger data volumes.  Data Plus customers get a max query duration of up to 10 minutes via asynchronous queries and up to two minutes via regular NRQL queries,c compared to 60 seconds for the existing data option. Learn how to run [asynchronous queries](https://newrelic.com/blog/nerdlog/data-plus-pricing) via our [NerdGraph] (https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/) API.
+After the launch of [Data Plus](https://docs.newrelic.com/whats-new/2022/06/whats-new-6-1-data-plus-available) in June, we are continuing to support and help your teams scale their observability practices. Many organizations pull in large amounts of events and data from their systems which can too much data to efficiently run queries for troubleshooting. Today, Data Plus customers can utilize longer running queries (up to 10x the the previous maximum duration) to analyze larger data volumes efficiently.  Data Plus customers get a max query duration of up to 10 minutes via NerdGraph (New Relic's GraphQL API) and up to two minutes via regular NRQL query builder, compared to 60 seconds for the existing data option. Learn how to run queries via our [NerdGraph](https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/) API.
 
 In addition to more powerful and 10x longer-running queries, Data Plus also includes:
 
@@ -14,7 +14,7 @@ In addition to more powerful and 10x longer-running queries, Data Plus also incl
 * FedRAMP and HIPAA compliance (Pro and Enterprise customers only) 
 * Logs obfuscation
 * Cloud provider choice (coming soon)
-* Enhanced streaming and historical data export (coming soon) 
+* Enhanced streaming and historical data export (coming September) 
 * Vulnerability management (coming soon)
 
 [Read more here](https://newrelic.com/blog/nerdlog/data-plus-pricing)
@@ -22,4 +22,4 @@ In addition to more powerful and 10x longer-running queries, Data Plus also incl
 # How to Sign up for [Data Plus](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing)
 1. Understand the new pricing mode and [upgrade to Data Plus here](https://newrelic.com/blog/nerdlog/data-plus-pricing) at a promotional pricing model of $.50/GB.
 
-2. Learn more about asynchronous queries with [asynchronous queries tutorial](https://docs.newrelic.com/docs/apis/nerdgraph/examples/async-queries-nrql-tutorial/) or get started [querying your data using NRQL](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial/).
+2. Learn more about about longer running queries on our [GraphQL API](https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/) or get started [querying your data using NRQL](https://docs.newrelic.com/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder/).

--- a/src/content/whats-new/2022/08/whats-new-8-25-longer-running-queries.md
+++ b/src/content/whats-new/2022/08/whats-new-8-25-longer-running-queries.md
@@ -1,0 +1,29 @@
+---
+title: 'New Relic Data Plus provides more powerful queries through increased query durations and limits.’
+releaseDate: '2022-08-25'
+learnMoreLink: 
+getStartedLink: 'https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial/'
+---
+# Longer running queries allow you to analyze larger volumes of data
+
+After the launch of [Data Plus](https://docs.newrelic.com/whats-new/2022/06/whats-new-6-1-data-plus-available) in June, we are continuing to support and help your teams scale their observability practices. Today, Data Plus customers now can utilize longer running queries (up to 10x the the previous maximum duration) to analyze larger data volumes.  Data Plus customers get a max query duration of up to 10 minutes via asynchronous queries and up to 2 minutes via regular NRQL queries compared to 60 seconds for the existing data option. Learn how to run [asynchronous queries](https://docs.newrelic.com/docs/apis/nerdgraph/examples/async-queries-nrql-tutorial/) via our [NerdGraph] (https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/) API.
+
+In addition to more powerful and 10x maximum duration longer running queries, Data Plus also includes:
+
+* Up to 90 days of data retention 
+* FedRAMP and HIPAA compliance (Pro and Enterprise customers only) 
+* Logs obfuscation
+* Cloud provider choice (coming soon)
+* Enhanced streaming and historical data export (coming soon) 
+* Vulnerability management (coming soon)
+
+[Read more here](https://newrelic.com/blog/nerdlog/data-plus-pricing)
+
+# How to Sign up for Data Plus
+1. Understand the new pricing mode and [upgrade to Data Plus here](https://newrelic.com/blog/nerdlog/data-plus-pricing) at a promotional pricing model of $.50/GB.
+
+2. Learn more about asynchronous queries with [asynchronous queries tutorial](https://docs.newrelic.com/docs/apis/nerdgraph/examples/async-queries-nrql-tutorial/) or get started [querying your data using NRQL](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial/).
+
+
+# Next Steps
+[Sign up today for a free New Relic account](https://newrelic.com/signup) to take advantage of the 100 GB/month of data ingest, one full-platform user, and unlimited basic users offering to get started with network monitoring as part of the observability journey.


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

* This help improve querying of large data volumes from large enterprises or customers that want to query older events
* Longer running queries is released on 08-25-2022 for Data Plus customers.
* The longer running queries extends query durations up 2x (2minutes) for normal NRQL queries and 10x (10 minutes) for New Relic's GraphQL API (NerdGraph) queries
* If your issue relates to an existing GitHub issue, please link to it.