### PR TITLE
fix: missing escaped characters on manual install

### DIFF
--- a/src/content/docs/infrastructure/elastic-container-service-integration/installation/install-ecs-integration.mdx
+++ b/src/content/docs/infrastructure/elastic-container-service-integration/installation/install-ecs-integration.mdx
@@ -191,7 +191,7 @@ One [install option](#install-overview) is to manually do the steps that are don
    ```
    aws iam create-policy \
    	--policy-name "NewRelicSSMLicenseKeyReadAccess" \
-   	--policy-document "{"Version"\"2012-10-17","Statement":[{"Effect":"Allow","Action":["ssm:GetParameters"],"Resource":["<var>ARN_OF_LICENSE_KEY_PARAMETER</var>"]}]}"
+    --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"ssm:GetParameters\"],\"Resource\":[\"<var>ARN_OF_LICENSE_KEY_PARAMETER</var>\"]}]}" \
    	--description "Provides read access to the New Relic SSM license key parameter"
    ```
 4. Create an IAM role to be used as the task execution role:


### PR DESCRIPTION
Fixed a broken command on the manual installation part on install-ecs-integration.mdx, added missing escaped characters