### PR TITLE
Make minor Ruby agent 8.10.0 edits

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -2057,7 +2057,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Net::HTTP at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Net::HTTP at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-typhoeus" title="instrumentation.typhoeus">
@@ -2069,7 +2069,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Typhoeus at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Typhoeus at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-bunny" title="instrumentation.bunny">
@@ -2081,7 +2081,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of bunny at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of bunny at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-httprb" title="instrumentation.httprb">
@@ -2093,7 +2093,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of http.rb gem at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of http.rb gem at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-resque" title="instrumentation.resque">
@@ -2105,7 +2105,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of resque at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of resque at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-thread" title="instrumentation.thread">
@@ -2117,7 +2117,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of the Thread class at start up to allow the agent to correctly nest spans inside of an asyncronous transaction. This does not enable the agent to automatically trace all threads created (see `instrumentation.thread.tracing`). May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of the Thread class at start up to allow the agent to correctly nest spans inside of an asyncronous transaction. This does not enable the agent to automatically trace all threads created (see `instrumentation.thread.tracing`). May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-thread-tracing" title="instrumentation.thread.tracing">
@@ -2141,7 +2141,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Redis at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Redis at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-rake" title="instrumentation.rake">
@@ -2153,7 +2153,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of rake at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of rake at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-mongo" title="instrumentation.mongo">
@@ -2177,7 +2177,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Delayed Job at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Delayed Job at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-httpclient" title="instrumentation.httpclient">
@@ -2189,7 +2189,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of HTTPClient at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of HTTPClient at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-curb" title="instrumentation.curb">
@@ -2201,7 +2201,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Curb at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Curb at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-sinatra" title="instrumentation.sinatra">
@@ -2213,7 +2213,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Sinatra at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Sinatra at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-rack" title="instrumentation.rack">
@@ -2225,7 +2225,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Rack. When enabled, the agent hooks into the `to_app` method in Rack::Builder to find gems to instrument during application startup. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Rack. When enabled, the agent hooks into the `to_app` method in Rack::Builder to find gems to instrument during application startup. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-rack_urlmap" title="instrumentation.rack_urlmap">
@@ -2237,7 +2237,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Rack::URLMap at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Rack::URLMap at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-puma_rack" title="instrumentation.puma_rack">
@@ -2249,7 +2249,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Puma::Rack. When enabled, the agent hooks into the `to_app` method in Puma::Rack::Builder to find gems to instrument during application startup. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Puma::Rack. When enabled, the agent hooks into the `to_app` method in Puma::Rack::Builder to find gems to instrument during application startup. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-puma_rack_urlmap" title="instrumentation.puma_rack_urlmap">
@@ -2261,7 +2261,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Puma::Rack::URLMap at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Puma::Rack::URLMap at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-memcached" title="instrumentation.memcached">
@@ -2273,7 +2273,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of memcached gem for Memcache at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of memcached gem for Memcache at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-memcache_client" title="instrumentation.memcache_client">
@@ -2285,7 +2285,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of memcache-client gem for Memcache at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of memcache-client gem for Memcache at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-memcache" title="instrumentation.memcache">
@@ -2297,7 +2297,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of dalli gem for Memcache at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of dalli gem for Memcache at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-logger" title="instrumentation.logger">
@@ -2309,7 +2309,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Ruby standard library Logger at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Ruby standard library Logger at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-tilt" title="instrumentation.tilt">
@@ -2321,7 +2321,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of the Tilt template rendering library at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of the Tilt template rendering library at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-grpc_client" title="instrumentation.grpc_client">
@@ -2333,7 +2333,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of gRPC clients at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of gRPC clients at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-grpc-host_denylist" title="instrumentation.grpc.host_denylist">
@@ -2357,7 +2357,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of gRPC servers at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of gRPC servers at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-excon" title="instrumentation.excon">
@@ -2381,7 +2381,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of ActiveSupport::Logger at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of ActiveSupport::Logger at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-grape" title="instrumentation.grape">
@@ -2393,7 +2393,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Grape at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Grape at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
   </Collapser>
 
 </CollapserGroup>

--- a/src/content/docs/apm/agents/ruby-agent/instrumented-gems/grpc-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/instrumented-gems/grpc-instrumentation.mdx
@@ -24,26 +24,26 @@ See additional options and examples in the sections that follow.
 
 You can alter the behavior of the agent by modifying the New Relic config file or by setting environment variables. Here are the options that apply to both clients and servers:
 
-  - **auto:** The default that is enabled via automatic Ruby method behavior selection
-  - **disabled:** Instrumentation disabled
-  - **prepend:** Force the use of Ruby method prepending
-  - **chain:** Force the use of Ruby method chaining
+* `auto`: The default that is enabled via automatic Ruby method behavior selection
+* `disabled`: Instrumentation disabled
+* `prepend`: Force the use of Ruby method prepending
+* `chain`: Force the use of Ruby method chaining
 
-### gRPC client options
+### Client-specific options
 
 Use the following only for clients:
 
-  - config file parameter: `instrumentation.grpc_client`
-  - environment variable: `NEW_RELIC_INSTRUMENTATION_GRPC_CLIENT`
+* config file parameter: `instrumentation.grpc_client`
+* environment variable: `NEW_RELIC_INSTRUMENTATION_GRPC_CLIENT`
 
-### gRPC server options
+### Server-specific options
 
 Use the following only for servers:
 
-  - config file parameter: `instrumentation.grpc_server`
-  - environment variable: `NEW_RELIC_INSTRUMENTATION_GRPC_SERVER`
+* config file parameter: `instrumentation.grpc_server`
+* environment variable: `NEW_RELIC_INSTRUMENTATION_GRPC_SERVER`
 
-### Client and server gRPC configuration examples
+### Client and server configuration examples
 
 To disable gRPC server instrumentation via the config file:
 
@@ -84,7 +84,11 @@ The New Relic Ruby agent's gRPC instrumentation includes distributed tracing hea
 
 You can see the collected gRPC data in the New Relic UI on a number of pages. For example, on the [Summary page](/docs/apm/applications-menu/monitoring/apm-overview-page), gRPC client requests will appear as web transactions and contribute data to the **Web transactions time**, **Throughput**, and **Error rate** charts.
 
-The gRPC data is also available through the [Distributed tracing page](/docs/apm/agents/ruby-agent/configuration/distributed-tracing-ruby-agent/):
+The gRPC data is also available on the distributed tracing page of the UI:
+
+<Callout variant="tip">
+Distributed tracing is turned on by default in new Ruby agents, but if you have questions about it, see [Distributed tracing for your Ruby services](/docs/apm/agents/ruby-agent/configuration/distributed-tracing-ruby-agent/).
+</Callout>
 
 1. Go to **[one.newrelic.com](https://one.newrelic.com/)**.
 2. In the left pane, click **APM &amp; services**.
@@ -109,13 +113,13 @@ In the event of a gRPC-based Ruby exception, information about the exception wil
 
 When contacting New Relic for support and/or feedback related to the New Relic Ruby agent's gRPC instrumentation, please try to have answers to the following questions:
 
-- What version of the `grpc` gem are you using?
-- Do you use New Relic Infinite Tracing?
-- How would you describe your application's environment? (Framework, Ruby version, other key technologies used)
-- What do you use gRPC for?
-- Do you use Ruby for gRPC clients?
-- Do you use a different language for gRPC clients?
-- Do you use Ruby for gRPC servers?
-- Do you use a different language for gRPC servers?
-- Where are you calling your gRPC client code? (from a controller, a background job, etc.)
-- What strategy/strategies are you using to send your data? (unary, bidirectional, client-streaming, server-streaming)
+* What version of the `grpc` gem are you using?
+* Do you use New Relic Infinite Tracing?
+* How would you describe your application's environment? (Framework, Ruby version, other key technologies used)
+* What do you use gRPC for?
+* Do you use Ruby for gRPC clients?
+* Do you use a different language for gRPC clients?
+* Do you use Ruby for gRPC servers?
+* Do you use a different language for gRPC servers?
+* Where are you calling your gRPC client code? (from a controller, a background job, etc.)
+* What strategy/strategies are you using to send your data? (unary, bidirectional, client-streaming, server-streaming)

--- a/src/content/docs/apm/agents/ruby-agent/instrumented-gems/grpc-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/instrumented-gems/grpc-instrumentation.mdx
@@ -14,13 +14,13 @@ The [New Relic Ruby agent](/docs/agents/ruby-agent/getting-started/new-relic-rub
 </Callout>
 
 
-## Configuration (all settings are optional)
+## Configuration (all settings are optional) [#config-overview]
 
 You can configure the instrumentation of gRPC clients and servers separately. By default, both configuration options are set to `auto`, which is short for `automatic`. The agent's automatic behavior for each is to enable the instrumentation by attempting to leverage Ruby module prepend behavior at first and falling back on Ruby method chaining behavior if known compatibility issues are encountered.
 
 See additional options and examples in the sections that follow.
 
-### Client and server options
+### Client and server options [#combined-options]
 
 You can alter the behavior of the agent by modifying the New Relic config file or by setting environment variables. Here are the options that apply to both clients and servers:
 
@@ -29,21 +29,21 @@ You can alter the behavior of the agent by modifying the New Relic config file o
 * `prepend`: Force the use of Ruby method prepending
 * `chain`: Force the use of Ruby method chaining
 
-### Client-specific options
+### Client-specific options [#client-specific]
 
 Use the following only for clients:
 
 * config file parameter: `instrumentation.grpc_client`
 * environment variable: `NEW_RELIC_INSTRUMENTATION_GRPC_CLIENT`
 
-### Server-specific options
+### Server-specific options [#server-specific]
 
 Use the following only for servers:
 
 * config file parameter: `instrumentation.grpc_server`
 * environment variable: `NEW_RELIC_INSTRUMENTATION_GRPC_SERVER`
 
-### Client and server configuration examples
+### Examples of client and server configuration [#combined-examples]
 
 To disable gRPC server instrumentation via the config file:
 
@@ -67,7 +67,7 @@ INFO : Installing New Relic supported gRPC_Client instrumentation using Prepend
 INFO : Installing New Relic supported gRPC_Server instrumentation using Prepend
 ```
 
-## Usage
+## Usage [#usage]
 
 As long as the instrumentation is working properly (see [Verification](#verification) above to confirm this), all instrumentation performed by the New Relic Ruby agent should be fully automatic and not require any modifications to any of your existing gRPC client and/or server code.
 
@@ -80,15 +80,21 @@ The New Relic Ruby agent's gRPC instrumentation includes distributed tracing hea
 </Callout>
 
 
-## Viewing data
+## View data [#view-data]
 
-You can see the collected gRPC data in the New Relic UI on a number of pages. For example, on the [Summary page](/docs/apm/applications-menu/monitoring/apm-overview-page), gRPC client requests will appear as web transactions and contribute data to the **Web transactions time**, **Throughput**, and **Error rate** charts.
+You can see the collected gRPC data on a number of pages in the New Relic UI.
 
-The gRPC data is also available on the distributed tracing page of the UI:
+### Summary page [#summary]
+
+On the UI [Summary page](/docs/apm/applications-menu/monitoring/apm-overview-page), gRPC client requests appear as web transactions and contribute data to the following charts: **Web transactions time**, **Throughput**, and **Error rate**.
+
+### Distributed tracing page [#distributed-tracing-page]
 
 <Callout variant="tip">
-Distributed tracing is turned on by default in new Ruby agents, but if you have questions about it, see [Distributed tracing for your Ruby services](/docs/apm/agents/ruby-agent/configuration/distributed-tracing-ruby-agent/).
+Distributed tracing is turned on by default in new Ruby agents, but if you have questions, see [Distributed tracing for your Ruby services](/docs/apm/agents/ruby-agent/configuration/distributed-tracing-ruby-agent/).
 </Callout>
+
+Check out gRPC data on the distributed tracing page of the UI:
 
 1. Go to **[one.newrelic.com](https://one.newrelic.com/)**.
 2. In the left pane, click **APM &amp; services**.
@@ -104,12 +110,12 @@ Distributed tracing is turned on by default in new Ruby agents, but if you have 
 
 As long as both the client and server applications are being monitored by a New Relic agent with support for gRPC (in Ruby or another language), the distributed tracing map should do the following:
 
-* Display both the client and server applications.
-* Report on how many distinct call types were performed between them.
+  * Display both the client and server applications.
+  * Report on how many distinct call types were performed between them.
 
 In the event of a gRPC-based Ruby exception, information about the exception will appear on the **Events &gt; Errors** page.
 
-## Support and feedback
+## Support and feedback [#support-feedback]
 
 When contacting New Relic for support and/or feedback related to the New Relic Ruby agent's gRPC instrumentation, please try to have answers to the following questions:
 


### PR DESCRIPTION
This is a follow-up to the Ruby agent 8.10.0 release. This PR has some minor tweaks based on team feedback.