### PR TITLE
Update missing-trace-data.mdx

### DIFF
--- a/src/content/docs/distributed-tracing/troubleshooting/missing-trace-data.mdx
+++ b/src/content/docs/distributed-tracing/troubleshooting/missing-trace-data.mdx
@@ -196,9 +196,15 @@ Here are some causes and solutions when you have problems finding expected data 
     id="late-spans"
     title="Missing spans due to spans being sent late"
   >
-    Spans must be sent within the last sixty minutes to be captured in a trace index. If you send any spans older than sixty minutes but newer than a day, the span data will still be written. However, it won't be rolled into the trace index, which controls the trace list in the distributed tracing UI.
+    Spans must be sent within the last sixty minutes to be captured in a trace index. If you send any spans older than sixty minutes but newer than a day, the span data will still be written. However, it won't be rolled into the trace index, which controls the trace list in the distributed tracing UI. If a span has a timestamp older than a day, it will be dropped. This often occurs when there is clock skew (timing differences) between systems or long running background jobs.
 
-    If a span has a timestamp older than a day, it will be dropped. This often occurs when there is clock skew (timing differences) between systems or long running background jobs.
+    <Callout variant="important">
+      Any spans sent via the [OpenTelemetry Protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md) (OTLP for short) that are longer than sixty minutes will not be written to [NRDB](https://docs.newrelic.com/docs/data-apis/get-started/nrdb-horsepower-under-hood/), producing the following NrIntegrationError:
+      ```
+      The span timestamp cannot be older than 60 minutes.
+      ```
+    </Callout>
+
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
The timeframe listed for writing span data to NRDB only applies to spans sent via APM Agent. Spans sent via OTel that are older than an hour (even within the 24 hour window) will be dropped and cannot be accessed in NRDB.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.