### PR TITLE
Collapser fixes for java install docs

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,2 +1,3 @@
 export { default as onRouteUpdate } from './gatsby/on-route-update';
 export { default as wrapPageElement } from './gatsby/wrap-page-element';
+export { default as shouldUpdateScroll } from './gatsby/should-update-scroll';

--- a/gatsby/should-update-scroll.js
+++ b/gatsby/should-update-scroll.js
@@ -1,0 +1,16 @@
+const shouldUpdateScroll = ({
+  prevRouterProps,
+  routerProps: { location },
+  getSavedScrollPosition,
+}) => {
+  if (
+    location.pathname.includes('/install/') &&
+    location.pathname === prevRouterProps.location.pathname
+  ) {
+    return false;
+  }
+  const currentPosition = getSavedScrollPosition(location);
+  return currentPosition || [0, 0];
+};
+
+export default shouldUpdateScroll;

--- a/src/components/AppInfoConfig.js
+++ b/src/components/AppInfoConfig.js
@@ -25,6 +25,7 @@ const AppInfoConfig = ({ selectOptions, mdx, onChange, showGuided }) => {
             }
             label={select.label}
             placeholder={select.placeholder}
+            defaultOpen={!queryParams.has(select.optionType)}
           />
         );
       })}

--- a/src/components/AppInfoConfigOption.js
+++ b/src/components/AppInfoConfigOption.js
@@ -15,7 +15,7 @@ const AppInfoConfigOption = ({ optionType, selectOptions, mdx, onChange }) => {
     <div>
       <TileSelect
         label={select.label}
-        onChange={onChange}
+        onChange={(value) => onChange(value, select)}
         value={
           queryParams.has(select.optionType)
             ? queryParams.get(select.optionType)
@@ -23,6 +23,7 @@ const AppInfoConfigOption = ({ optionType, selectOptions, mdx, onChange }) => {
         }
         options={select.options}
         placeholder={select.placeholder}
+        defaultOpen={!queryParams.has(select.optionType)}
       />
 
       {body && <MDXContainer body={body} />}

--- a/src/components/TileSelect/TileOption.js
+++ b/src/components/TileSelect/TileOption.js
@@ -18,15 +18,15 @@ const TileOption = ({ displayName, value, logo, onChange, isSelected }) => {
         text-align: center;
         padding: 0.5rem;
         color: var(--system-text-primary-light);
-        border: 1px solid #3a444b;
+        border: ${isSelected
+          ? '1.25px solid var(--attention-notification-info)'
+          : ' 1px solid #3a444b'};
         background: var(--system-background-app-light);
 
         .light-mode & {
-          border: 1px solid var(--system-border-strong-light);
-
-          &:hover {
-            border-color: var(--border-hover-color);
-          }
+          border: ${isSelected
+            ? '1.25px solid var(--attention-notification-info)'
+            : '1px solid var(--system-border-strong-light)'};
         }
       `}
     >

--- a/src/components/TileSelect/TileSelect.js
+++ b/src/components/TileSelect/TileSelect.js
@@ -2,17 +2,18 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 
-// import logos from '../install/assets';
 import TileOption from './TileOption';
 import TileCollapser from './TileCollapser';
 
-const TileSelect = ({ options, onChange, value, label, placeholder }) => {
-  const [isOpen, setIsOpen] = useState(true);
-
-  const handleChange = (value) => {
-    onChange(value);
-    setIsOpen(false);
-  };
+const TileSelect = ({
+  options,
+  onChange,
+  value,
+  label,
+  placeholder,
+  defaultOpen = true,
+}) => {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
 
   const selectedOption =
     value && options.find((option) => option.value === value);
@@ -41,7 +42,10 @@ const TileSelect = ({ options, onChange, value, label, placeholder }) => {
           {options.map((optionProps) => (
             <TileOption
               key={`${label}-${optionProps.displayName}`}
-              onChange={handleChange}
+              onChange={(val) => {
+                onChange(val);
+                setIsOpen(false);
+              }}
               isSelected={value === optionProps.value}
               {...optionProps}
             />
@@ -53,11 +57,12 @@ const TileSelect = ({ options, onChange, value, label, placeholder }) => {
 };
 
 TileSelect.propTypes = {
-  options: PropTypes.object,
+  options: PropTypes.array,
   onSelect: PropTypes.func,
   value: PropTypes.string,
   label: PropTypes.string,
   placeholder: PropTypes.string,
+  defaultOpen: PropTypes.bool,
 };
 
 export default TileSelect;


### PR DESCRIPTION
* removes scrolling issue 
* if the optionType is used more than once, it will collapse all of them (for example the framework selection and the top and bottom collapse at the same time)