### PR TITLE
Remove standalone signup and link to storefront signup

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -175,15 +175,6 @@ module.exports = {
             }),
           },
         },
-        signup: {
-          environment: process.env.ENVIRONMENT || 'staging',
-          signupUrl:
-            process.env.SIGNUP_URL ||
-            'https://signup-receiver.staging-service.newrelic.com',
-          reCaptchaToken:
-            process.env.RECAPTCHA_TOKEN ||
-            '6LdMFd8UAAAAAApWFzm8YCyuGCUfg57U1WvqVYqC',
-        },
       },
     },
     {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "6.9.3",
+    "@newrelic/gatsby-theme-newrelic": "6.11.0",
     "@splitsoftware/splitio-react": "^1.2.4",
     "cockatiel": "^3.0.0-beta.0",
     "common-tags": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "6.11.0",
+    "@newrelic/gatsby-theme-newrelic": "6.11.1",
     "@splitsoftware/splitio-react": "^1.2.4",
     "cockatiel": "^3.0.0-beta.0",
     "common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2885,10 +2885,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.11.0.tgz#b562ef0de7291efa29c62f30803e8de3f431a3ed"
-  integrity sha512-OIHkUYWOEe5lB82UR1spybUJqU3I9qQvjpWG4hRaVycGtJHvyXWiIrfrClYSDWdeG3OuG4LmYG0mEb1Sw8sFdw==
+"@newrelic/gatsby-theme-newrelic@6.11.1":
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.11.1.tgz#bf0d8f92d99785bbc69aa0c2b64d907a0f0620b8"
+  integrity sha512-zC1pa2PyB0Oj6EKRdO6tmpjMERIIp+EdOda3vAWHaPN5TcvavC9e2qWQ5SZIyRyNKOGitSexRCwQFyhCE9se9g==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2885,10 +2885,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@6.9.3":
-  version "6.9.3"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.9.3.tgz#bb80efc06f0b2d56397fb2df1748254f606b94b2"
-  integrity sha512-qGQYn+0TNlHblg5T1Y7Z7vT51ujtAsAiL0YKq9eal84bEHGRu8Nzkjd2Q8UrRAFAIdeM6/pPow3gb2moCKIzZQ==
+"@newrelic/gatsby-theme-newrelic@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.11.0.tgz#b562ef0de7291efa29c62f30803e8de3f431a3ed"
+  integrity sha512-OIHkUYWOEe5lB82UR1spybUJqU3I9qQvjpWG4hRaVycGtJHvyXWiIrfrClYSDWdeG3OuG4LmYG0mEb1Sw8sFdw==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
Switches `Start now` to link to newrelic.com/signup instead of standalone signup modal.

signup config removed for now to remove recaptcha

looks like feedback work deployed in 6.10 may affect current form