### PR TITLE
Update use-tags-help-organize-find-your-data.mdx

### DIFF
--- a/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data.mdx
@@ -159,12 +159,12 @@ Follow these best practices to get the most out of your tags.
     title="Keep tags simple"
   >
 
-  - Start by adding only tags you know you'll definitely use. Unused tags create noise and may add confusion.
-  - Try to use short tags. Shorter tags are easier to parse, and also the UI may sometimes truncate longer tags. (See [character limits](#formatting).)
-  - When possible, use keys and values that are human-readable (for example, `region: EMEA` is better than `Param8323 : 1229072`).
-  - Avoid including several values like `regions: EMEA | US | LATAM` in a single tag. We recommend using three different tags for that, like `region: emea`, `region: us`, and `region: latam`. If you want to match multiple tags, you can do that using the advanced options in the filter UI.
-However, Alert Incidents only support one instance of a key name.  So, if you do include `region: EMEA` and `regiion:US`, only one of those tags will be added to an Alert Incident, and which tag is added is relatively indeterminant. 
-    
+Some tips on keeping tags simple:
+* Start by adding only tags you know you'll definitely use. Unused tags create noise and may add confusion.
+* Try to use short tags. Shorter tags are easier to parse, and also the UI may sometimes truncate longer tags. (See [character limits](#formatting).)
+* When possible, use keys and values that are human-readable (for example, `region: EMEA` is better than `Param8323 : 1229072`).
+* Avoid including several values like `regions: EMEA | US | LATAM` in a single tag. We recommend using three different tags for that, like `region: emea`, `region: us`, and `region: latam`. If you want to match multiple tags, you can do that using the advanced options in the filter UI. 
+  * A caveat for [alert incidents](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/basic-alerting-concepts): these only support one key name instance. If you do use multiple key names, one will be randomly selected to be added to that incident.  
   </Collapser>
 
   <Collapser

--- a/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data.mdx
@@ -163,6 +163,7 @@ Follow these best practices to get the most out of your tags.
   - Try to use short tags. Shorter tags are easier to parse, and also the UI may sometimes truncate longer tags. (See [character limits](#formatting).)
   - When possible, use keys and values that are human-readable (for example, `region: EMEA` is better than `Param8323 : 1229072`).
   - Avoid including several values like `regions: EMEA | US | LATAM` in a single tag. We recommend using three different tags for that, like `region: emea`, `region: us`, and `region: latam`. If you want to match multiple tags, you can do that using the advanced options in the filter UI.
+However, Alert Incidents only support one instance of a key name.  So, if you do include `region: EMEA` and `regiion:US`, only one of those tags will be added to an Alert Incident, and which tag is added is relatively indeterminant. 
     
   </Collapser>
 


### PR DESCRIPTION
added :
"However, Alert Incidents only support one instance of a key name.  So, if you do include `region: EMEA` and `regiion:US`, only one of those tags will be added to an Alert Incident, and which tag is added is relatively indeterminant. "
to the section : "Keep tags simple"

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.