### PR TITLE
Align Api-Key header example with error response

### DIFF
--- a/src/content/docs/apis/nerdgraph/get-started/nerdgraph-explorer.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/nerdgraph-explorer.mdx
@@ -138,7 +138,7 @@ Let's say that you've built a NerdGraph query you're happy with and you want to 
 # curl version
 curl https://api.newrelic.com/graphql \
   -H 'Content-Type: application/json' \
-  -H 'API-Key: API_KEY_REDACTED' \
+  -H 'Api-Key: API_KEY_REDACTED' \
   --data-binary '{"query":"{\n  actor {\n    user {\n      name\n      email\n    }\n    account(id: 12345678)\n  }\n}\n", "variables":""}'
 
 # New Relic CLI version


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?

Aligns the curl example with an error response people may see.

The error is:

```
Please provide an API key via the `Api-Key` header
```

So folks may be lead to believe the `API-Key` is incorrect in the example code, when in fact they need to create a `user` API key.

