### PR TITLE
Added missing full stops for consistency

### DIFF
--- a/src/content/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic.mdx
+++ b/src/content/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic.mdx
@@ -76,11 +76,11 @@ Here’s a quick guide to writing our voice traits:
       </td>
 
       <td>
-        Truthful, authentic, transparent, frank, transparent, approachable
+        Truthful, authentic, transparent, frank, transparent, approachable.
       </td>
         
       <td>
-        Abrupt, boastful, complicated, curt, chatty, arrogant
+        Abrupt, boastful, complicated, curt, chatty, arrogant.
       </td>
       </tr>
 
@@ -94,11 +94,11 @@ Here’s a quick guide to writing our voice traits:
       </td>
 
       <td>
-        Uplifting, inspiring, optimistic, supportive
+        Uplifting, inspiring, optimistic, supportive.
       </td>
 
       <td>
-        Arrogant, presumptuous, overconfident, pushy
+        Arrogant, presumptuous, overconfident, pushy.
       </td>
     </tr>
 
@@ -112,11 +112,11 @@ Here’s a quick guide to writing our voice traits:
       </td>
 
       <td>
-         Smart, intuitive, innovative, magical, intellectually bold    
+         Smart, intuitive, innovative, magical, intellectually bold.
       </td>
 
       <td>
-        Know-it-all, trendy, miraculous, aggressive
+        Know-it-all, trendy, miraculous, aggressive.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Added missing full stops for consistency under the "Strategies for being honest, empowering, and ingenious" table.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
I could not attend to the Rookie Relic docs session, but I am checking the slides.
When learning how to edit this page, I found some missing full stops (".") in the "Strategies for being honest, empowering, and ingenious". 
I added the missing full stops to have consistency.