### PR TITLE
Remove semicolon from C# Serilog code example

### DIFF
--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -217,7 +217,7 @@ You have three options to configure APM logs in context to send your app's logs 
   Log.Logger = new LoggerConfiguration()
       .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
       .Enrich.FromLogContext()
-      .WriteTo.Console(new JsonFormatter());
+      .WriteTo.Console(new JsonFormatter())
       .CreateLogger();
   ```
 


### PR DESCRIPTION
Removed the semicolon found after the `.WriteTo.Console(new JsonFormatter());` line which causes a syntax error when copying the code.

[Link to issue](https://docs.newrelic.com/docs/logs/logs-context/net-configure-logs-context-all#2-decorate), incorrect code found in the code sample within:
### Serilog Configuration
#### JSON Formatter with automatic property output
```csharp
Log.Logger = new LoggerConfiguration()
    .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
    .Enrich.FromLogContext()
    .WriteTo.Console(new JsonFormatter());
    .CreateLogger();
```