### PR TITLE
Fix warning and critical behavior explanation

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/specify-when-alerts-create-incidents.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/specify-when-alerts-create-incidents.mdx
@@ -44,7 +44,7 @@ Choose from two threshold types when a policy condition is met:
 * Critical (red)
 * Warning (yellow)
 
-When a policy condition violates a critical threshold, an issue record can be created with detailed information to help you respond efficiently. The issue record will also include any warning incidents occurred after the opening critical threshold incident.
+When a policy condition violates a threshold, an issue record can be created with detailed information to help you respond efficiently. The issue record may also include any other incidents occurring after the opening incident.
 
 Notifications are sent to every notification channel on the policy as well as all destinations on any workflow that is properly configured when an issue opens, if and when an issue is acknowledged, and when an issue closes.
 


### PR DESCRIPTION
Warning and Critical thresholds are treated identically now. Warning incidents can open their own issues, and users can be notified on them the same as critical. The only difference now is the label ("Critical" vs. "Warning").

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.