### PR TITLE
Chore: fix indentation in autodiscovery config

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/monitor-services/monitor-services-running-kubernetes.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/monitor-services/monitor-services-running-kubernetes.mdx
@@ -106,9 +106,9 @@ redis-sampleapp.yaml:
       # --tls: Use tls for connecting to the kubelet
       # --port: Port used to connect to the kubelet. Defaults to 10255.
       exec: /var/db/newrelic-infra/nri-discovery-kubernetes --tls --port 10250
-    # Monitor pods which have a `app=sampleapp` label
-    match:
-      label.app: sampleapp
+      # Monitor pods which have a `app=sampleapp` label
+      match:
+        label.app: sampleapp
 
   # Integrations section contains the integration configs.
   # ${placeholders} will be replaced with the specified attributes for each pod that is discovered
@@ -140,8 +140,8 @@ newrelic-infrastructure:
           # --port: Port used to connect to the kubelet. Default is 10255
           # --tls: Use secure (TLS) connection
           exec: /var/db/newrelic-infra/nri-discovery-kubernetes --tls --port 10250
-        match:
-          label.app: sampleapp
+          match:
+            label.app: sampleapp
 
       integrations:
         - name: nri-redis


### PR DESCRIPTION
* What problems does this PR solve?
Fix indentation on YAML.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
See example at https://github.com/newrelic/nri-kubernetes/blob/37e7255299d4ae79403a1d2042a74207bb9bb19d/charts/newrelic-infrastructure/tests/configmap_integrations_test.yaml

* If your issue relates to an existing GitHub issue, please link to it.