### PR TITLE
docs: add json identifier to code example

### DIFF
--- a/src/content/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits.mdx
+++ b/src/content/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits.mdx
@@ -275,7 +275,7 @@ The following table shows the required request metadata for all trace data forma
 
 A response for successfully sending trace data will include a `requestId`. For example:
 
-```
+```json
 {"requestId":"c1bb62fc-001a-b000-0000-016bb152e1bb"}
 ```
 

--- a/src/content/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits.mdx
+++ b/src/content/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits.mdx
@@ -11,7 +11,7 @@ redirects:
   - /docs/understand-dependencies/distributed-tracing/trace-api/trace-api-general-requirements-limits
 ---
 
-Information about [Trace API](/docs/apm/distributed-tracing/trace-api/introduction-new-relic-trace-api) data requirements, including:
+Information about [Trace API](/docs/apm/distributed-tracing/trace-api/introduction-new-relic-trace-api) data requirements, including: 
 
 * Data specifications and max limits
 * Required metadata (headers, query parameters)


### PR DESCRIPTION
I just prettied up the example json