### PR TITLE
docs: add lang identifiers

### DIFF
--- a/src/content/docs/distributed-tracing/troubleshooting/missing-trace-data.mdx
+++ b/src/content/docs/distributed-tracing/troubleshooting/missing-trace-data.mdx
@@ -90,7 +90,7 @@ Here are some causes and solutions when you have problems finding expected data 
           </td>
 
           <td>
-            ```
+            ```xml
             <configuration . . . >
                <infiniteTracing>
                   <trace_observer>
@@ -136,7 +136,9 @@ Here are some causes and solutions when you have problems finding expected data 
           </td>
 
           <td>
+            ```ini
             infinite_tracing.span_queue_size = 100000
+            ```
           </td>
         </tr>
 
@@ -146,7 +148,9 @@ Here are some causes and solutions when you have problems finding expected data 
           </td>
 
           <td>
+            ```
             NEW_RELIC_INFINITE_TRACING_SPAN_QUEUE_SIZE = 100000
+            ```
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
I added the python code into a codeblock as well as language identifiers for it and the xml, because it looks nicer