### PR TITLE
SEO component in install pages

### DIFF
--- a/plugins/gatsby-source-install-config/gatsby-node.js
+++ b/plugins/gatsby-source-install-config/gatsby-node.js
@@ -30,7 +30,13 @@ exports.sourceNodes = ({
       whatsNext: {
         filePath: whatsNextFilePath,
       },
-      ...pick(configYamlNode, ['title', 'agentName', 'agentType', 'appInfo']),
+      ...pick(configYamlNode, [
+        'title',
+        'agentName',
+        'agentType',
+        'appInfo',
+        'metaDescription',
+      ]),
     };
 
     createNode({
@@ -54,6 +60,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       agentName: String!
       agentType: String!
       title: String!
+      metaDescription: String
       intro: MDXConfig
       appInfo: [AppInfoOption!]!
       steps: [InstallStep]

--- a/src/install/config/java.yaml
+++ b/src/install/config/java.yaml
@@ -1,6 +1,7 @@
 agentName: java
 agentType: APM
 title: 'Monitor your java app'
+metaDescription: 'New Relic supports the most popular Java app servers, frameworks, virtual machines, and tools. Once installed, the APM agent monitors your app’s performance and gives you insight into that performance.'
 introFilePath: 'src/install/java/intro.mdx'
 agentConfigFilePath: 'src/install/config/agent-config/java-newrelic.yml'
 appInfo:

--- a/src/pages/install/{installConfig.agentName}.js
+++ b/src/pages/install/{installConfig.agentName}.js
@@ -13,8 +13,10 @@ import AgentConfig from '../../components/AgentConfig';
 import AppInfoConfig from '../../components/AppInfoConfig';
 import AppInfoConfigOption from '../../components/AppInfoConfigOption';
 import InstallNextSteps from '../../components/InstallNextSteps';
+import SEO from '../../components/SEO';
+import { TYPES } from '../../utils/constants';
 
-const InstallPage = ({ data }) => {
+const InstallPage = ({ data, location }) => {
   const { installConfig = {} } = data;
   const {
     title,
@@ -24,6 +26,7 @@ const InstallPage = ({ data }) => {
     agentConfigFile,
     whatsNext,
     agentName,
+    metaDescription,
   } = installConfig;
 
   const { queryParams, setQueryParam, deleteQueryParam } = useQueryParams();
@@ -144,47 +147,55 @@ const InstallPage = ({ data }) => {
     .filter(({ content }) => content !== null);
 
   return (
-    <Layout.Main>
-      <Layout.Content>
-        <PageTitle>{title}</PageTitle>
-        <div
-          css={css`
-            margin-bottom: 2rem;
-          `}
-        >
-          <MDXContainer body={intro.mdx?.body} />
-        </div>
-        <div>
-          <Walkthrough>
-            {walkthroughSteps.map(({ content, step: { mdx } }, index) => {
-              const { descriptionText, headingText } = mdx?.frontmatter;
-              return (
-                <Walkthrough.Step
-                  number={index + 1}
-                  title={headingText}
-                  active={selectedIndex === index}
-                  key={index}
-                  onMouseOver={() => handleSelectIndex(index)}
-                  onFocus={() => handleSelectIndex(index)}
-                >
-                  {descriptionText && (
-                    <p
-                      css={css`
-                        margin-bottom: 2rem;
-                      `}
-                    >
-                      {descriptionText}
-                    </p>
-                  )}
-                  {content}
-                </Walkthrough.Step>
-              );
-            })}
-          </Walkthrough>
-        </div>
-        <InstallNextSteps mdx={whatsNext.mdx} />
-      </Layout.Content>
-    </Layout.Main>
+    <>
+      <SEO
+        location={location}
+        title={title}
+        description={metaDescription}
+        type={TYPES.INTERACTIVE_INSTALL_PAGE}
+      />
+      <Layout.Main>
+        <Layout.Content>
+          <PageTitle>{title}</PageTitle>
+          <div
+            css={css`
+              margin-bottom: 2rem;
+            `}
+          >
+            <MDXContainer body={intro.mdx?.body} />
+          </div>
+          <div>
+            <Walkthrough>
+              {walkthroughSteps.map(({ content, step: { mdx } }, index) => {
+                const { descriptionText, headingText } = mdx?.frontmatter;
+                return (
+                  <Walkthrough.Step
+                    number={index + 1}
+                    title={headingText}
+                    active={selectedIndex === index}
+                    key={index}
+                    onMouseOver={() => handleSelectIndex(index)}
+                    onFocus={() => handleSelectIndex(index)}
+                  >
+                    {descriptionText && (
+                      <p
+                        css={css`
+                          margin-bottom: 2rem;
+                        `}
+                      >
+                        {descriptionText}
+                      </p>
+                    )}
+                    {content}
+                  </Walkthrough.Step>
+                );
+              })}
+            </Walkthrough>
+          </div>
+          <InstallNextSteps mdx={whatsNext.mdx} />
+        </Layout.Content>
+      </Layout.Main>
+    </>
   );
 };
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -13,4 +13,5 @@ export const TYPES = {
   TABLE_OF_CONTENTS: 'views_page_menu',
   AUTO_INDEX_PAGE: 'views_page_menu',
   WHATS_NEW_PAGE: 'views_page_content',
+  INTERACTIVE_INSTALL_PAGE: 'interactive_install_page',
 };


### PR DESCRIPTION
### https://issues.newrelic.com/browse/NR-44952
- [x] Add SEO component with relevant props / surface any additional props needed in the {agentName.yml} file
- [x] Add a `document_type` for these pages
- [x] Use title, description text all from the {agentName}.yml file (config) 
- [ ] Sync with Austin and Clinton on any other relevant data that needs to be collected or presented through SEO component 
-  [x] ~Ensure these pages will surface in site search results (one record per agent without query params)~ rule added in swiftype
- [x] ~Ensure these pages will not surface in nr1-help-xp (may be separate chunk of work for Docs Library Service) (similar to what we do with attribute dictionary)~ PR open in docs library service