### PR TITLE
chore(java): cap supported r2dbc-postrgres version

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -447,7 +447,7 @@ The agent automatically instruments these frameworks and libraries:
     * R2DBC MySQL 0.8.x to latest
     * R2DBC MSSQL 0.8.0 to latest
     * R2DBC Oracle 0.x to latest
-    * R2DBC Postgres 0.9.0 to latest
+    * R2DBC Postgres 0.9.0 to 0.9.1
     * Slick 3.0.0 to 3.3.x
     * Solr 4.0 to latest
     * Spymemcached 2.11 to latest


### PR DESCRIPTION
## Give us some context

We don't support yet the newly released r2dbc-postrgres.