### PR TITLE
Update New Relic/OpenTelemetry comparison doc

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-comparison.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-comparison.mdx
@@ -273,8 +273,6 @@ New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: 🟡 Limi
 
 The **Summary** page offers an overview of a service’s health, charting golden signals about your entity: response time, throughput, and error rate. These are also broken down by service instance ID (OpenTelemetry) or hostname (New Relic agent).
 
-OpenTelemetry services use spans to create golden signals, whereas New Relic agent services use metrics.
-
 <CollapserGroup>
   <Collapser
     className="freq-link"
@@ -341,7 +339,7 @@ Distributed tracing is supported today by our agents and OpenTelemetry. Both pro
 
     Additionally, OpenTelemetry offers a standalone service called a collector, a configurable telemetry-processing system. This means you can configure a custom sampling strategy (or strategies) that makes the most sense for your observability needs. However, configuring and operating collectors can be complex.
 
-    Another option for tail-based sampling with OpenTelemetry is for you to use New Relic’s Infinite Tracing with OTLP. There is a tail-based sampling processor available today for the collector, but it is in the process of being deprecated in favor of a more native solution.
+    To use tail sampling and OpenTelemetry, you can use the [tail sampling processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor) in the collector, or New Relic Infinite Tracing with OTLP.
   </Collapser>
   <Collapser
     className="freq-link"
@@ -555,7 +553,9 @@ For OpenTelemetry services, you can use this page to explore data about the span
 
 New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic:  🟡 Limited support
 
-The APM view shows response time, throughput, error rate, end user response time, and PageView rates. The OpenTelemetry view only shows the first three metrics.
+Services instrumented with New Relic and services instrumented with OpenTelemetry appear in different sections.
+
+OpenTelemetry services use spans to create golden signals, whereas New Relic agent services use metrics.
 
 ## Lookout [#lookout]
 
@@ -563,9 +563,13 @@ New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic:  🟡 Lim
 
 For OpenTelemetry services, only other OpenTelemetry-instrumented services are shown in this view.
 
+OpenTelemetry services use spans to create golden signals, whereas New Relic agent services use metrics.
+
 ## Navigator [#navigator]
 
 New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: ✅
+
+OpenTelemetry services use spans to create golden signals, whereas New Relic agent services use metrics.
 
 ## Apdex [#apdex]
 
@@ -855,7 +859,7 @@ Service deployments, related deployments, and Java agent circuit breaker events 
 
 ## Faster time-to-glass [#to-glass]
 
-New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic:  🟡 Limited support
+New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: ✅
 
 New Relic agents send events on a 15s interval and metrics on a 1m interval, although you can configure it to be faster or slower.
 


### PR DESCRIPTION
Here are some updates for September 2022.

* Move golden metrics statement from Summary page to each of these sections: Explorer , Navigator, and Lookout.
* Turn Time to glass section to green for OTel.
* Add new comment under Explorer explaining that OTel and New Relic are in different sections.
* Revamp the tail-based sampling with new info from @reese-lee 