### PR TITLE
fix: remove bold styling in link

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/quick-launch-guide.mdx
@@ -120,7 +120,7 @@ Note that some of the [quickstarts](https://newrelic.com/instant-observability) 
         **Step 6. Add users**
       </td>      
       <td>
-You're now ready to add the rest of your team to New Relic. Use the [**User management** UI](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks#where) to add users. To learn about the different types of users, see [User type](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type). See [our tutorial on adding users and managing user access](/docs/accounts/accounts-billing/new-relic-one-user-management/account-user-mgmt-tutorial). 
+You're now ready to add the rest of your team to New Relic. Use the [User management UI](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks#where) to add users. To learn about the different types of users, see [User type](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type). See [our tutorial on adding users and managing user access](/docs/accounts/accounts-billing/new-relic-one-user-management/account-user-mgmt-tutorial). 
       </td>
       </tr>
   </tbody>


### PR DESCRIPTION
Although it technically follows our style guide, the bold styling in the link distracts more than it adds. 