### PR TITLE
Typo on Program Benefits Table Heading: "Standard"

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/eligibility-guidelines-new-relic-nonprofit-program.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/eligibility-guidelines-new-relic-nonprofit-program.mdx
@@ -164,7 +164,7 @@ To learn more or to sign up as a new or existing New Relic customer, go to [newr
     <tr>
         <th>Monthly Benefits</th>
         <th>Free Trial</th>
-        <th>O4G Standar</th>
+        <th>O4G Standard</th>
         <th>O4G Pro</th>
     </tr>
     <tr>


### PR DESCRIPTION
The table heading for the table in the Program Benefits section for standard edition had a typo, it said "Standar" instead of "Standard" -- this update adds the "d" to correct the typo in the table heading. Thank you.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.