### PR TITLE
Corrected required resource attribute

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-troubleshooting.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-troubleshooting.mdx
@@ -56,7 +56,7 @@ Various parts of the New Relic UI rely on the presence of specific attributes to
 
 ### Problem
 
-You've correlated your logs with your service using `service.id`([OpenTelemetry logs: Best practices](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs)) so you can see logs associated with traces, but you don't see any logs in the New Relic UI. In this scenario, the log data has made it to New Relic, but isn't showing up in the distributed trace UI with corresponding spans.
+You've correlated your logs with your service using `service.name`([OpenTelemetry logs: Best practices](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs)) so you can see logs associated with traces, but you don't see any logs in the New Relic UI. In this scenario, the log data has made it to New Relic, but isn't showing up in the distributed trace UI with corresponding spans.
 
 ### Solution
 


### PR DESCRIPTION
* What problems does this PR solve?

The original copy says that `service.id` is required for log correlation; it is `service.name`.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

The doc that this one links to has the correct attribute, `service.name`. 

* If your issue relates to an existing GitHub issue, please link to it.

N/A