### PR TITLE
Doc: Add documentation about new `SetName()` on the agent API

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/ispan.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/ispan.mdx
@@ -51,6 +51,15 @@ This section contains descriptions and parameters of `ISpan` methods:
         Add contextual information from your application to the current span in form of attributes.
       </td>
     </tr>
+    <tr>
+      <td>
+        [SetName](#setname)
+      </td>
+
+      <td>
+        Changes the name of the current span/segment/metrics that will be reported to New Relic.
+      </td>
+    </tr>
   </tbody>
 </table>
 
@@ -130,4 +139,63 @@ currentSpan
     .AddCustomAttribute("currentAge",31)
     .AddCustomAttribute("birthday", new DateTime(2000, 02, 14))
     .AddCustomAttribute("waitTime", TimeSpan.FromMilliseconds(93842));
+```
+
+## SetName [#setname]
+
+Changes the name of the current segment/span that will be reported to New Relic. For segments/spans resulting from custom instrumentation, the metric name reported to New Relic will be altered as well. 
+
+This method requires .NET agent version and .NET agent API version 10.1.0 or higher.
+
+### Syntax
+
+```cs
+ISpan SetName(string name)
+```
+
+### Parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        Parameter
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `name`
+
+        _string_
+      </td>
+
+      <td>
+        The new name for the span/segment.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### Returns
+
+A reference to the current span.
+
+## Examples
+
+```cs
+
+[Trace]
+public void MyTracedMethod()
+{
+    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
+    ISpan currentSpan = agent.CurrentSpan; 
+
+    currentSpan.SetName("MyCustomName");
 ```


### PR DESCRIPTION
## Give us some context

Version 10.1.0 of the .NET Agent (as yet unreleased) introduces is a new method to the `ISpan` API. These changes provide documentation about how to use this API.

Please check with our team before merging this as we would like to synchronize it with the Agent Release.