### PR TITLE
Updates for Pending Java Agent 7.10 release

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -310,16 +310,16 @@ The agent automatically instruments these frameworks and libraries:
     The agent automatically instruments the following app/web servers. To install the Java agent on supported app/web servers, see [Install the Java agent](/docs/agents/java-agent/installation/java-agent-manual-installation).
 
     * ColdFusion 10
-    * Glassfish 3.0 to 6.x
+    * Glassfish 3.0 to latest
     * JBoss 7.0 to latest
     * JBoss EAP 6.0 to 7.3
-    * Jetty 7.0.0.M3 to 11.x
+    * Jetty 7.0.0.M3 to latest
     * Mule ESB 3.4 to 3.8.x
     * Netty 3.3.0.Alpha1 to 5.0.0.Alpha1
     * Resin 3.1.9 to 4.0.x
     * Spray-can 1.3.1 to latest
-    * Tomcat 7.0.0 to 10.0.x
-    * TomEE 1.5 to 8.0.x
+    * Tomcat 7.0.0 to latest
+    * TomEE 1.5 to latest
     * WebLogic 12.1.2.1 to 12.2.x
     * [WebSphere 8.5.x to 9.x](/docs/agents/java-agent/additional-installation/websphere-application-server)
     * WebSphere Liberty Profile 8.5 to latest

--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -256,11 +256,11 @@ Before you install the Java agent, ensure your system meets these requirements:
     * Eclipse OpenJ9 versions 8 to 13 for Linux, Windows, and macOS
     * OpenJDK versions 8 to 18 for Linux, Windows, and macOS
     * AdoptOpenJDK versions 8 to 16 for Linux, Windows, and macOS
-    * Temurin version 17 for Linux, Windows, and macOS
+    * Temurin version 17 and 18 for Linux, Windows, and macOS
     * Oracle Hotspot JVM versions 8 to 16 for Linux, Solaris, Windows, and macOS
     * Azul Zing JVM versions 8 and 11 for Linux, Windows, and macOS
-    * Azul Zulu JVM versions 8 to 17 for Linux, Windows, and macOS
-    * Amazon Corretto JVM versions 8, 11, and 17 for Linux, Windows, and macOS
+    * Azul Zulu JVM versions 8 to 18 for Linux, Windows, and macOS
+    * Amazon Corretto JVM versions 8, 11, 17, and 18 for Linux, Windows, and macOS
     * Alibaba Dragonwell JVM versions 8 and 11 for Linux, Windows, and macOS
 
     (Java 1.7) Compatible only with [Java agent 6.5.x](https://download.newrelic.com/newrelic/java-agent/newrelic-agent/6.5.3/newrelic-java-6.5.3.zip) \[ZIP | 16.8 MB] legacy agent:
@@ -310,15 +310,15 @@ The agent automatically instruments these frameworks and libraries:
     The agent automatically instruments the following app/web servers. To install the Java agent on supported app/web servers, see [Install the Java agent](/docs/agents/java-agent/installation/java-agent-manual-installation).
 
     * ColdFusion 10
-    * Glassfish 3.0 to 5.x
+    * Glassfish 3.0 to 6.x
     * JBoss 7.0 to latest
     * JBoss EAP 6.0 to 7.3
-    * Jetty 7.0.0.M3 to 10.x
+    * Jetty 7.0.0.M3 to 11.x
     * Mule ESB 3.4 to 3.8.x
     * Netty 3.3.0.Alpha1 to 5.0.0.Alpha1
     * Resin 3.1.9 to 4.0.x
     * Spray-can 1.3.1 to latest
-    * Tomcat 7.0.0 to 9.0.x
+    * Tomcat 7.0.0 to 10.0.x
     * TomEE 1.5 to 8.0.x
     * WebLogic 12.1.2.1 to 12.2.x
     * [WebSphere 8.5.x to 9.x](/docs/agents/java-agent/additional-installation/websphere-application-server)
@@ -348,9 +348,10 @@ The agent automatically instruments these frameworks and libraries:
     * GraphQL 17.0 to latest
     * Hibernate 3.3.0.CR1 to 6.0.0.Alpha2
     * Hystrix 1.3.15 to latest
+    * Jakarta RESTful WS API 2.1.x to 3.1.x
     * JAX-RS 1.0 to 2.0
     * [JCache API](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-3200) 1.0.0 to latest
-    * Jersey 1.0.1 to 2.x
+    * Jersey 1.0.1 to latest
     * JSF (Java Server Faces)
     * Log4j 2 2.6 to latest (for our [logs in context](/docs/logs/logs-context/java-configure-logs-context-all/) feature)
     * Logback 1.1 to latest (for our [logs in context](/docs/logs/logs-context/java-configure-logs-context-all/) feature)
@@ -500,7 +501,7 @@ The agent automatically instruments these frameworks and libraries:
   >
     * EJB Session Beans 3.0 or higher
     * JMX
-    * JSP (Java Server Pages) 2.0 to 2.2
+    * JSP (Java Server Pages) 2.0 to 3.0
     * [Scala](/docs/agents/java-agent/frameworks/scala-installation-java) 2.9.3 to 2.13.x
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
HOLD THIS AS A DRAFT FOR NOW.

These changes update compatibility and requirements docs' page to reflect changes in the agent version 7.10
