### PR TITLE
fix(php-agent): Correct release note support statement

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-1000312.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-1000312.mdx
@@ -15,5 +15,5 @@ downloadLink: 'https://download.newrelic.com/php_agent/archive/10.0.0.312'
 * Additional fixes to significantly reduce the number of duplicated log messages in some situations where large log consumption had been observed in the past.
 
 ### Support statement ###
-* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [9.11.0.267](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9110267/).
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines please consult the following [document](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
 

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9200310.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9200310.mdx
@@ -21,4 +21,4 @@ downloadLink: 'https://download.newrelic.com/php_agent/archive/9.20.0.310'
 
 ### Support statement
 
-* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [9.7.0](docs/release-notes/agent-release-notes/php-release-notes/php-agent-970258.mdx).
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines please consult the following [document](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9210311.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9210311.mdx
@@ -17,5 +17,5 @@ downloadLink: 'https://download.newrelic.com/php_agent/archive/9.21.0.311'
 * Improved stability of using Laravel framework when using opcache with PHP 8.1.
 
 ### Support statement ###
-* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [9.7.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-970258/).
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines please consult the following [document](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
 


### PR DESCRIPTION
The product manager for the PHP agent team requested we put up-to-date information in the past few release notes on the policies regarding supported PHP agent versions and EOL information.  This PR changes the support information of these release notes.