### PR TITLE
Update google-memorystore-memcached.mdx

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-memorystore-memcached.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-memorystore-memcached.mdx
@@ -139,7 +139,7 @@ This integration collects GCP Memcache data for MemcacheNode.
       </td>
 
       <td>
-        Percent
+        Double
       </td>
 
       <td>
@@ -167,11 +167,11 @@ This integration collects GCP Memcache data for MemcacheNode.
       </td>
 
       <td>
-        Percent
+        Double
       </td>
 
       <td>
-        Hit ratio, expressed as a percentage of the total cache requests excluding set operations. Values are numbers between 0.0 and 1.0, charts display the values as a percentage between 0% and 100%.
+        Hit ratio, expressed as a percentage of the total cache requests excluding set operations. Values are numbers between 0.0 and 1.0.
       </td>
     </tr>
 


### PR DESCRIPTION
Original descriptions are what the google charts show, not new relic charts. 

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Mismatch between what our docs say vs what our dashboards, and metrics show.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

Confirmed with engineering that both metrics are reported as they are collected from GCP as doubles: https://cloud.google.com/monitoring/api/metrics_gcp, and would require conversion in the New Relic charts to display as percent.
