### PR TITLE
Fix configure-prometheus-openmetrics-integrations-large-kubernetes…

### DIFF
--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-openmetrics/configure-prometheus-openmetrics-integrations-large-kubernetes-environments.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-openmetrics/configure-prometheus-openmetrics-integrations-large-kubernetes-environments.mdx
@@ -17,13 +17,13 @@ CPU and memory limits and requests can vary according to the number of targets m
 To estimate the size of the environment you are monitoring, run the following query to see how many targets are being scraped:
 
 ```
-SELECT latest(nr_stats_targets) FROM Metric where clusterName=’clusterName’ SINCE 30 MINUTES AGO TIMESERIES
+SELECT latest(nr_stats_targets) FROM Metric WHERE clusterName = 'clustername' SINCE 30 MINUTES AGO TIMESERIES
 ```
 
 In huge environments with hundreds of targets to be scraped, the latency on the `/metrics` endpoints must be below 1 second. Run this query to check the latency of the different targets. This query retrieves the data exposed by the [Prometheus OpenMetrics integration](/docs/integrations/prometheus-integrations/install-configure-openmetrics/install-update-or-uninstall-your-prometheus-openmetrics-integration), and shows the time required to fetch each endpoint.
 
 ```
-SELECT average(nr_stats_integration_fetch_target_duration_seconds) FROM Metric where clusterName=’clustername' SINCE 30 MINUTES AGO FACET target LIMIT 30
+SELECT average(nr_stats_integration_fetch_target_duration_seconds) FROM Metric WHERE clusterName = 'clustername' SINCE 30 MINUTES AGO FACET target LIMIT 30
 ```
 
 In order to keep the time needed to scrape all the targets below 30 seconds, use the following configurations:


### PR DESCRIPTION
Replace smart quotes in NRQL with single quotes, other standardization to NRQL syntax

The existing versions with smart quotes do not run as-is on NR