### PR TITLE
Update firewall rule list for Pixie

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -497,6 +497,7 @@ The [Pixie integration](https://github.com/newrelic/newrelic-pixie-integration) 
 The Pixie integration requires outbound network access to the following:
 
 * work.withpixie.ai:443
+* withpixie.ai:443
 * otlp.nr-data.net:4317 (US region accounts)
 * otlp.eu01.nr-data.net:4317 (EU region accounts)
 


### PR DESCRIPTION
Add ```withpixie.ai:443``` to the Pixie firewall list in addition to ```work.withpixie.ai:443```. not adding this will result 'pl-cluster-secrets can not find' error

This was tested with AKS and Azure Firewall