### PR TITLE
Update to correct naming

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/aws-vpc-flow-log-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/aws-vpc-flow-log-monitoring.mdx
@@ -1,12 +1,12 @@
 ---
-title: Set up AWS VPC flow log monitoring
+title: Set up Amazon VPC Flow Logs monitoring
 tags:
   - Integrations
   - Network monitoring
   - Installation
   - Setup
   - AWS
-metaDescription: Set up AWS VPC flow log monitoring.
+metaDescription: Set up Amazon VPC Flow Logs monitoring.
 dataSource: aws-vpc-flow-logs
 redirects:
     - /docs/network-performance-monitoring/setup-performance-monitoring/aws-vpc-flow-monitoring/
@@ -25,10 +25,10 @@ import overviewCloudFlowLogs from 'images/npm-overview-cloud-flow-logs.png';
 
 Amazon Virtual Private Cloud Flow (VPC) Logs via Amazon Kinesis Data Firehose help you reduce the friction of sending logs to New Relic. With VPC flow logs from across your AWS estates, you can quickly understand key insights for performance analytics and troubleshooting network connectivity.
 
-<img title="AWS VPC flow logs overview" alt="AWS VPC flow logs overview" src={overviewCloudFlowLogs}/>
+<img title="Amazon VPC Flow Logs overview" alt="Amazon VPC Flow Logs overview" src={overviewCloudFlowLogs}/>
 
 <figcaption>
-**Add [AWS VPC flow logs to your New Relic account](https://one.newrelic.com/nr1-core?&state=bd947742-3034-63b7-7196-8baaf36dd8d9)**.
+**Add [Amazon VPC Flow Logs to your New Relic account](https://one.newrelic.com/nr1-core?&state=bd947742-3034-63b7-7196-8baaf36dd8d9)**.
 </figcaption>
 
 Amazon Virtual Private Cloud (VPC) enables you to launch AWS resources into an isolated and secure virtual network with the benefits of using scalable AWS infrastructure.  
@@ -39,7 +39,7 @@ Amazon Virtual Private Cloud (VPC) enables you to launch AWS resources into an i
   to="https://one.newrelic.com/nr1-core?&state=bd947742-3034-63b7-7196-8baaf36dd8d9"
   variant="primary"
 >
-  Add AWS VPC flow logs
+  Add Amazon VPC Flow Logs
 </ButtonLink>
 
 ## Prerequisites [#prerequisites]
@@ -51,12 +51,12 @@ Amazon Virtual Private Cloud (VPC) enables you to launch AWS resources into an i
 ### AWS prerequisites [#prerequisites-aws]
 
 <Callout variant="important">
-    AWS VPC Flow Logs via Kinesis Data Firehose isn't supported for FedRAMP customers yet. In the meantime, you can use [our FedRAMP ingest APIs](/docs/security/security-privacy/compliance/fedramp-compliant-endpoints#data-ingest-apis).
+    Amazon VPC Flow Logs via Kinesis Data Firehose isn't supported for FedRAMP customers yet. In the meantime, you can use [our FedRAMP ingest APIs](/docs/security/security-privacy/compliance/fedramp-compliant-endpoints#data-ingest-apis).
 </Callout>
 
 * Environment:
     * [AWS CLI (v 1.9.15+) installed](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html).
-    * A list of AWS regions where you collect AWS VPC flow logs.
+    * A list of AWS regions where you collect Amazon VPC Flow Logs.
 * Permissions:
     * An AWS user with [permissions to create VPC flow logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html#flow-logs-s3-iam).
     * Amazon S3 log file permissions to [read and write for the log delivery owner](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html#flow-logs-file-permissions).
@@ -67,7 +67,7 @@ Amazon Virtual Private Cloud (VPC) enables you to launch AWS resources into an i
     * [VPC IDs](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/describe-vpcs.html) that will be configured to ship VPC flow logs. If you want more granular control, specify the [subnet IDs](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/describe-subnets.html) instead of the VPC IDs.
     * ARN for the [Kinesis Data Firehose with S3 bucket access](https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3).
     <Callout variant="tip">
-        We recommend you create a new data firehose with our guided install the first time you configure VPC Flow Logs for a specific region. For subsequent VPCs and subnets in the same region, you can reuse the existing data firehose.
+        We recommend you create a new data firehose with our guided install the first time you configure VPC flow logs for a specific region. For subsequent VPCs and subnets in the same region, you can reuse the existing data firehose.
     </Callout>
 
 ### IAM roles [#iam-roles]
@@ -169,30 +169,30 @@ ${version} ${account-id} ${region} ${az-id} ${sublocation-type} ${vpc-id} ${subn
 
 You must use a [log partition](https://docs.newrelic.com/docs/logs/ui-data/data-partitions/) for VPC flow logs named `Log_VPC_Flows_AWS`. If you use the [guided install](https://one.newrelic.com/nr1-core?&state=bd947742-3034-63b7-7196-8baaf36dd8d9), this is handled automatically.
 
-## Set up AWS VPC flow logs monitoring in New Relic [#setup-aws-vpc-flow-logs]
+## Set up Amazon VPC Flow Logs monitoring in New Relic [#setup-aws-vpc-flow-logs]
 
-You can set up your AWS VPC flow logs by installing a bundle that includes a dashboard designed for AWS VPC flow logs.
+You can set up your Amazon VPC Flow Logs by installing a bundle that includes a dashboard designed for Amazon VPC Flow Logs.
 
-1. Go to New Relic Instant Observability page for [AWS VPC flow logs](https://newrelic.com/instant-observability/aws-vpc-flow-logs/61d2ff67-f519-492c-a8de-6019b47d5bb2).
-    <img title="AWS VPC flow logs I/O page" alt="AWS VPC flow logs instant observability page" src={awsVPCflowLogsIO}/>
+1. Go to New Relic Instant Observability page for [Amazon VPC Flow Logs](https://newrelic.com/instant-observability/aws-vpc-flow-logs/61d2ff67-f519-492c-a8de-6019b47d5bb2).
+    <img title="Amazon VPC Flow Logs I/O page" alt="Amazon VPC Flow Logs instant observability page" src={awsVPCflowLogsIO}/>
 
     <figcaption>
-    **[New Relic Instant Observability](https://newrelic.com/instant-observability/aws-vpc-flow-logs/61d2ff67-f519-492c-a8de-6019b47d5bb2)** to set up AWS VPC flow logs monitoring.
+    **[New Relic Instant Observability](https://newrelic.com/instant-observability/aws-vpc-flow-logs/61d2ff67-f519-492c-a8de-6019b47d5bb2)** to set up Amazon VPC Flow Logs monitoring.
     </figcaption>
 
 2. Click **Install now** to get directed to your New Relic account, and follow the guided install process.
 3. [Visualize your network performance data in New Relic](/docs/network-performance-monitoring/monitoring-network-data/visualize-network-data).
 
-## Send additional AWS VPC flow logs [#additional-aws-vpc-flow-logs]
+## Send additional Amazon VPC Flow Logs [#additional-aws-vpc-flow-logs]
 
-Additionally, if you need to install more AWS VPC flow logs or you don't want to install the bundle with a custom dashboard, follow these steps:
+Additionally, if you need to install more Amazon VPC Flow Logs or you don't want to install the bundle with a custom dashboard, follow these steps:
 
 1. Start the **[guided install process](https://one.newrelic.com/nr1-core?&state=bd947742-3034-63b7-7196-8baaf36dd8d9)**.
-2. From the **Select an account** dropdown, choose the account you want to send AWS VPC flow logs to and click **Continue**.
-3. In the **Select your data** section, choose **AWS VPC flow logs** and click **Continue**.
+2. From the **Select an account** dropdown, choose the account you want to send Amazon VPC Flow Logs to and click **Continue**.
+3. In the **Select your data** section, choose **Amazon VPC Flow Logs** and click **Continue**.
 4. In the **Select your install method** section, continue with **CLI** and click **Continue**.
 
-After these steps, a new wizard pops-up to help you set up the sending of AWS VPC flow logs to New Relic through the AWS Kinesis Firehose service.
+After these steps, a new wizard pops-up to help you set up the sending of Amazon VPC Flow Logs to New Relic through the AWS Kinesis Firehose service.
 
 1. In the **Choose Setup Options** section:
     - Verify your setup method is correct.
@@ -204,7 +204,7 @@ After these steps, a new wizard pops-up to help you set up the sending of AWS VP
     - In the **Firehose Backup Bucket** field, enter the [ARN of the S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-arn-format.html) to be used to store messages that fail delivery. The ARN must follow this format: `arn:my_string`.
     - In the **Firehose IAM Role** field, enter the [ARN of the IAM role](https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#firehose-assume-role) to be used by Kinesis Data Firehose. The ARN must follow this format: `arn:my_string`.
     - Click **Continue**.
-    - Optionally, if you want to sample VPC Flow Logs, select the **Use Sampling** checkbox and:
+    - Optionally, if you want to sample VPC flow logs, select the **Use Sampling** checkbox and:
 
 <CollapserGroup>
     <Collapser
@@ -249,9 +249,9 @@ Generate Kinesis Firehose step in the guided install.
 
 4. In the **Define Flow Logs** section, do the following:
 - From the **Traffic Type** dropdown, select whether to send only accepted, only rejected, or all flow log entries.
-- In the **Flow Source ID** field, enter the VPC ID (`vpc-MY_STRING`) or the subnet ID (`subnet-MY_STRING`) for which AWS VPC flow logs should be created.
+- In the **Flow Source ID** field, enter the VPC ID (`vpc-MY_STRING`) or the subnet ID (`subnet-MY_STRING`) for which Amazon VPC Flow Logs should be created.
 - The **Flow Source Type** field will be automatically populated, so click **Continue**.
 
 5. In the **Create Flow Logs** section, click **Generate CLI Command** and copy the contents of the syntax block. Then, run it in the AWS CLI to begin generating flow logs for the specified resources.
-6. Click **Continue** to start exploring AWS VPC flow logs in the network monitoring section of New Relic.
+6. Click **Continue** to start exploring Amazon VPC Flow Logs in the network monitoring section of New Relic.
 7. [Visualize your network performance data in New Relic](/docs/network-performance-monitoring/monitoring-network-data/visualize-network-data).


### PR DESCRIPTION
This is Kevin Downs, Infrastructure PMM at New Relic.  I updated this doc to correct the name.
Incorrect: "AWS VPC flow logs" or "AWS VPC Flow Logs"
Correct: "Amazon VPC Flow Logs"
Note: "VPC flow logs" without "Amazon" *is* correct.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.