### PR TITLE
Add ruby agent 8.10.1 release notes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8101.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8101.mdx
@@ -1,0 +1,26 @@
+---
+subject: Ruby agent
+releaseDate: '2022-11-13'
+version: 8.10.1
+downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.10.1.gem'
+---
+
+  ## v8.10.1
+
+  * **Bugfix: Missing unscoped metrics when instrumentation.thread.tracing is enabled**
+    
+    Previously, when `instrumentation.thread.tracing` was set to true, some puma applications encountered a bug where a varying number of unscoped metrics would be missing. The agent now will correctly store and send all unscoped metrics.
+    
+    Thank you to @texpert for providing details of their situation to help resolve the issue.
+  
+  
+  * **Bugfix: gRPC instrumentation causes ArgumentError when other Google gems are present**
+
+    Previously, when the agent had gRPC instrumentation enabled in an application using other gems (such as google-ads-googleads), the instrumentation could cause the error `ArgumentError: wrong number of arguments (given 3, expected 2)`. The gRPC instrumentation has been updated to prevent this issue from occurring in the future. 
+
+    Thank you to @FeminismIsAwesome for bringing this issue to our attention.
+
+
+## Support statement
+
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [6.5.0.357](https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-650357).


### PR DESCRIPTION

## Give us some context
This PR adds the release notes for the upcoming release of 8.10.1 of the ruby agent. 
