### PR TITLE
Docs: fix section link

### DIFF
--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -2989,7 +2989,7 @@ These properties are used for configuring the hostname displayed in the UI:
   </Collapser>
 
   <Collapser
-    id="ae-max_samples_stored"
+    id="ipv_preference"
     title="ipv_preference"
   >
     <table>


### PR DESCRIPTION
`ipv_preference` section link ID was `ae-max_samples_stored`, same as the transaction sections `max_samples_stored` ID so the link didn't work

