### PR TITLE
docs: fix code examples & links, etc

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
@@ -262,15 +262,15 @@ While you can assume that all calls to an application are needed to support the 
 
 ### Custom attributes
 
-Any [custom attributes](/docs/data-apis/custom-data/custom-events/collect-custom-attributes/) added using a call to an APM API [addCustomParameter](https://developer.newrelic.com/collect-data/custom-attributes/) will add an additional attribute to the transaction payload. These are often useful, but as application logic and priorities change the data can become less valuable or even obsolete.
+Any [custom attributes](/docs/data-apis/custom-data/custom-events/collect-custom-attributes/) added using a call to an APM API [`addCustomParameter`](https://developer.newrelic.com/collect-data/custom-attributes/) will add an additional attribute to the transaction payload. These are often useful, but as application logic and priorities change the data can become less valuable or even obsolete.
 
-The Java agent captures the following request.headers by default:
+The Java agent captures the following `request.headers` by default:
 
-* request.headers.referer
-* request.headers.accept
-* request.headers.contentLength
-* request.headers.host
-* request.headers.userAgent
+* `request.headers.referer`
+* `request.headers.accept`
+* `request.headers.contentLength`
+* `request.headers.host`
+* `request.headers.userAgent`
 
 Developers might also use `addCustomParameter` to capture additional information (potentially more verbose headers).
 
@@ -309,7 +309,7 @@ Events that are capped and subject to sampling include:
 * `Transaction`
 * `TransactionError`
 
-Most agents have configuration options for changing the event limit on sampled transactions. For example, the Java agent uses [max_samples_stored](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#ae-max_samples_stored). The default value for `max_samples_stored` is `2000` and the max is `10000`. This value governs how many sampled events can be reported every 60 seconds from an agent instance.
+Most agents have configuration options for changing the event limit on sampled transactions. For example, the Java agent uses [`max_samples_stored`](/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file/#ae-max_samples_stored). The default value for `max_samples_stored` is `2000` and the max is `10000`. This value governs how many sampled events can be reported every 60 seconds from an agent instance.
 
 For a full explanation of event sampling limits, see [Event limits](/docs/using-new-relic/data/understand-data/new-relic-event-limits-sampling).
 
@@ -355,14 +355,14 @@ Distributed tracing configuration has some language-specific differences.
 
 Distributed tracing can be disabled as needed. This is an example for Java agent `newrelic.yml`:
 
-```
+```yml
 distributed_tracing:
     enabled: false
 ```
 
 This is a node.js example for `newrelic.js`
 
-```
+```js
 distributed_tracing: {
   enabled: false
 }
@@ -397,12 +397,12 @@ For [browser agent version 1211](/docs/release-notes/new-relic-browser-release-n
 
 Requests can be blocked in three ways:
 
-* To block recording of all `AjaxRequest` events, add an asterisk \* as a wildcard.
+* To block recording of all `AjaxRequest` events, add an asterisk `*` as a wildcard.
 * To block recording of `AjaxRequest` events to a domain, enter just the domain name. Example: `example.com`
 * To block recording of `AjaxRequest` events to a specific domain and path, enter the domain and path. Example: `example.com/path`
 * The protocol, port, search and hash of a URL are ignored by the deny list.
 
-To validate whether the filters you have added work as expected, run a NRQL query for AjaxRequest events matching your filter.
+To validate whether the filters you have added work as expected, run a NRQL query for `AjaxRequest` events matching your filter.
 
 ### Accessing the deny list
 
@@ -417,7 +417,7 @@ To update the deny list of URLs your application will filter from creating event
 
 ### Validating
 
-```
+```sql
 FROM AjaxRequest SELECT * WHERE requestUrl LIKE `%example.com%`
 ```
   </Collapser>
@@ -439,10 +439,10 @@ FROM AjaxRequest SELECT * WHERE requestUrl LIKE `%example.com%`
 
 All settings, including the call to invoke the agent, are called in the `onCreate` method of the `MainActivity` class. To change settings, call the setting in one of two ways (if the setting supports it):
 
-```
+```java
 NewRelic.disableFeature(FeatureFlag.DefaultInteractions);
 NewRelic.enableFeature(FeatureFlag.CrashReporting);
-NewRelic.withApplicationToken(<var>NEW_RELIC_TOKEN</var>).start(this.getApplication());
+NewRelic.withApplicationToken(NEW_RELIC_TOKEN).start(this.getApplication());
 ```
 
 [Analytics settings](/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags#analytics-settings) enable or disable collection of event data. These events are reported to New Relic and used in the **Crash analysis** page.
@@ -457,27 +457,27 @@ The following feature flags can be configured:
 
 #### Crash and error reporting
 
-* NRFeatureFlag_CrashReporting
-* NRFeatureFlag_HandleExceptionEvents
-* NRFeatureFlag_CrashReporting
+* `NRFeatureFlag_CrashReporting`
+* `NRFeatureFlag_HandleExceptionEvents`
+* `NRFeatureFlag_CrashReporting`
 
 #### Distributed tracing
 
-* NRFeatureFlag_DistributedTracing
+* `NRFeatureFlag_DistributedTracing`
 
 #### Interactions
 
-* NRFeatureFlag_DefaultInteractions
-* NRFeatureFlag_InteractionTracing
-* NRFeatureFlag_SwiftInteractionTracing
+* `NRFeatureFlag_DefaultInteractions`
+* `NRFeatureFlag_InteractionTracing`
+* `NRFeatureFlag_SwiftInteractionTracing`
 
 #### Network feature flags
 
-* NRFeatureFlag_ExperimentalNetworkInstrumentation
-* NRFeatureFlag_NSURLSessionInstrumentation
-* NRFeatureFlag_NetworkRequestEvents
-* NRFeatureFlag_RequestErrorEvents
-* NRFeatureFlag_HttpResponseBodyCapture
+* `NRFeatureFlag_ExperimentalNetworkInstrumentation`
+* `NRFeatureFlag_NSURLSessionInstrumentation`
+* `NRFeatureFlag_NetworkRequestEvents`
+* `NRFeatureFlag_RequestErrorEvents`
+* `NRFeatureFlag_HttpResponseBodyCapture`
 
 For more details, see [Feature flags](/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/ios-agent-configuration-feature-flags).
   </Collapser>
@@ -498,51 +498,51 @@ For more details, see [Feature flags](/docs/mobile-monitoring/new-relic-mobile-i
   * Log forwarding configuration
 </Callout>
 
-New Relic's [infrastructure agent configuration file](/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings) contains a couple of powerful ways to control ingest volume. The most important ingest control is configuring sampling rates. There are several distinct sampling rate configurations that can be adjusted.  In addition it's possible to create regular expressions to control what gets collected from certain collectors such as for *ProcessSample* and *NetworkSample*.
+New Relic's [infrastructure agent configuration file](/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings) contains a couple of powerful ways to control ingest volume. The most important ingest control is configuring sampling rates. There are several distinct sampling rate configurations that can be adjusted.  In addition it's possible to create regular expressions to control what gets collected from certain collectors such as for `ProcessSample` and `NetworkSample`.
 
 ### Configurable Sampling rates
 
 There are a number of sampling rates that can be configured in infrastructure, but these are the most commonly used.
 
-| Parameter                   | Default | Disable |
-| --------------------------- | ------- | ------- |
-| metrics_storage_sample_rate | 5       | -1      |
-| metrics_process_sample_rate | 20      | -1      |
-| metrics_network_sample_rate | 10      | -1      |
-| metrics_system_sample_rate  | 5       | -1      |
-| metrics_nfs_sample_rate     | 5       | -1      |
+| Parameter                     | Default | Disable |
+| ---------------------------   | ------- | ------- |
+| `metrics_storage_sample_rate` | 5       | -1      |
+| `metrics_process_sample_rate` | 20      | -1      |
+| `metrics_network_sample_rate` | 10      | -1      |
+| `metrics_system_sample_rate`  | 5       | -1      |
+| `metrics_nfs_sample_rate`     | 5       | -1      |
 
 ### Process samples
 
 Process samples can be the single most high volume source of data from the infrastructure agent.  This is because it will send information about any running process on a host. They're disabled by default but they can be enabled as follows:
 
-```
+```yaml
 enable_process_metrics: true
 ```
 
-This has the same effect as setting `metrics_process_sample_rate` to -1.
+This has the same effect as setting `metrics_process_sample_rate` to `-1`.
 
 By default, processes using low memory are excluded from being sampled. For more information, see `disable-zero-mem-process-filter`.
 
 You can control how much data is sent to New Relic by configuring `include_matching_metrics`, which allows you to restrict the transmission of metric data based on the values of metric [attributes](/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/query-infrastructure-dimensional-metrics-nrql#naming-conventions).
 
-You include metric data by defining literal or partial values for any of the attributes of the metric. For example, you can choose to send the `host.process.cpuPercent` of all processes whose `process.name` matches the ^java regular expression.
+You include metric data by defining literal or partial values for any of the attributes of the metric. For example, you can choose to send the `host.process.cpuPercent` of all processes whose `process.name` matches the `^java` regular expression.
 
 In this example, we include process metrics using executable files and names:
 
-```
-include_matching_metrics: # You can combine attributes from different metrics
+```yaml
+  include_matching_metrics:             # You can combine attributes from different metrics
     process.name:
-      - regex “^java”    # Include all processes starting with "java"
+      - regex "^java"                   # Include all processes starting with "java"
     process.executable:
-      - “/usr/bin/python2”              # Include the Python 2.x executable
-      - regex “\\System32\\svchost”     # Include all svchost executables
+      - "/usr/bin/python2"              # Include the Python 2.x executable
+      - regex "\\System32\\svchost"     # Include all svchost executables
 ```
 
 You can also use this filter for the Kubernetes integration:
 
-```
-env:
+```yaml
+  env:
     - name: NRIA_INCLUDE_MATCHING_METRICS
       value: |
         process.name:
@@ -565,7 +565,7 @@ The configuration uses a simple pattern-matching mechanism that can look for int
 * `{name}[other characters]`
 * `[number]{name}[other characters]`, where you specify the name using the `index-1` option
 
-```
+```yaml
 network_interface_filters:
   prefix:
     - dummy
@@ -583,7 +583,7 @@ Default network interface filters for Windows:
 
 To override defaults include your own filter in the config file:
 
-```
+```yaml
 network_interface_filters:
   prefix:
     - dummy
@@ -598,7 +598,7 @@ network_interface_filters:
 
 Example of custom attributes from `newrelic.yml`
 
-```
+```yaml
 custom_attributes:
   environment: production
   service: billing
@@ -670,46 +670,46 @@ You may consider disabling some of the following:
         #- --collectors=replicasets
         #- --collectors=services
         #- --collectors=statefulsets
-    ```
+```
 
         _Example of updating state metrics in manifest (ClusterRole)_
 
     ```shell
-[rules]
-# - apiGroups: ["extensions", "apps"]
-#   resources:
-#   - daemonsets
-#   verbs: ["list", "watch"]
+    [rules]
+    # - apiGroups: ["extensions", "apps"]
+    #   resources:
+    #   - daemonsets
+    #   verbs: ["list", "watch"]
 
-# - apiGroups: ["extensions", "apps"]
-#   resources:
-#   - deployments
-#   verbs: ["list", "watch"]
+    # - apiGroups: ["extensions", "apps"]
+    #   resources:
+    #   - deployments
+    #   verbs: ["list", "watch"]
 
-# - apiGroups: [""]
-#   resources:
-#   - endpoints
-#   verbs: ["list", "watch"]
+    # - apiGroups: [""]
+    #   resources:
+    #   - endpoints
+    #   verbs: ["list", "watch"]
 
-# - apiGroups: [""]
-#   resources:
-#   - namespaces
-#   verbs: ["list", "watch"]
+    # - apiGroups: [""]
+    #   resources:
+    #   - namespaces
+    #   verbs: ["list", "watch"]
 
-# - apiGroups: ["extensions", "apps"]
-#   resources:
-#   - replicasets
-#   verbs: ["list", "watch"]
+    # - apiGroups: ["extensions", "apps"]
+    #   resources:
+    #   - replicasets
+    #   verbs: ["list", "watch"]
 
-# - apiGroups: [""]
-#   resources:
-#   - services
-#   verbs: ["list", "watch"]
+    # - apiGroups: [""]
+    #   resources:
+    #   - services
+    #   verbs: ["list", "watch"]
 
-# - apiGroups: ["apps"]
-#   resources:
-#   - statefulsets
-#   verbs: ["list", "watch"]
+    # - apiGroups: ["apps"]
+    #   resources:
+    #   - statefulsets
+    #   verbs: ["list", "watch"]
     ```
 
 ### Config `lowDataMode` in `nri-bundle` chart
@@ -748,18 +748,18 @@ We'll use a few examples to demonstrate.
 </Callout>
 
 The PostgreSQL on-host integration configuration provides these adjustable settings that can help manage data volume:
-* interval: Default is 15s
-* COLLECTION_LIST: list of tables to monitor (use ALL to monitor ALL)
-* COLLECT_DB_LOCK_METRICS: Collect `dblock` metrics
-* PGBOUNCER: Collect `pgbouncer` metrics
-* COLLECT_BLOAT_METRICS: Collect bloat metrics
-* METRICS: Set to `true` to collect only metrics
-* INVENTORY: Set to `true` to enable only inventory collection
-* CUSTOM_METRICS_CONFIG: Config file containing custom collection queries
+* `interval`: Default is 15s
+* `COLLECTION_LIST`: list of tables to monitor (use ALL to monitor ALL)
+* `COLLECT_DB_LOCK_METRICS`: Collect `dblock` metrics
+* `PGBOUNCER`: Collect `pgbouncer` metrics
+* `COLLECT_BLOAT_METRICS`: Collect bloat metrics
+* `METRICS`: Set to `true` to collect only metrics
+* `INVENTORY`: Set to `true` to enable only inventory collection
+* `CUSTOM_METRICS_CONFIG`: Config file containing custom collection queries
 
 **Sample config:**
 
-```
+```yaml
 integrations:
   - name: nri-postgresql
     env:
@@ -768,7 +768,6 @@ integrations:
       HOSTNAME: psql-sample.localnet
       PORT: 6432
       DATABASE: postgres
-
       COLLECT_DB_LOCK_METRICS: false
       COLLECTION_LIST: '{"postgres":{"public":{"pg_table1":["pg_index1","pg_index2"],"pg_table2":[]}}}'
       TIMEOUT:  10
@@ -790,13 +789,13 @@ integrations:
 </Callout>
 
 The Kafka on-host integration configuration provides these adjustable settings that can help manage data volume:
-* interval: Default is 15s
-* TOPIC_MODE: Determines how many topics we collect. Options are `all`, `none`, `list`, or `regex`.
-* METRICS: Set to `true` to collect only metrics
-* INVENTORY: Set to `true` to enable only inventory collection
-* TOPIC_LIST: JSON array of topic names to monitor. Only in effect if topic_mode is set to list.
-* COLLECT_TOPIC_SIZE: Collect the metric Topic size. Options are `true` or `false`, defaults to `false`.
-* COLLECT_TOPIC_OFFSET:Collect the metric Topic offset. Options are `true` or `false`, defaults to `false`.
+* `interval`: Default is 15s
+* `TOPIC_MODE`: Determines how many topics we collect. Options are `all`, `none`, `list`, or `regex`.
+* `METRICS`: Set to `true` to collect only metrics
+* `INVENTORY`: Set to `true` to enable only inventory collection
+* `TOPIC_LIST`: JSON array of topic names to monitor. Only in effect if topic_mode is set to list.
+* `COLLECT_TOPIC_SIZE`: Collect the metric Topic size. Options are `true` or `false`, defaults to `false`.
+* `COLLECT_TOPIC_OFFSET`:Collect the metric Topic offset. Options are `true` or `false`, defaults to `false`.
 
 It should be noted that collection of topic level metrics especially offsets can be resource intensive to collect and can have an impact on data volume. It's very possible that a cluster's ingest can increase by an order of magnitude simply by the addition of new Kafka topics to the cluster.
 
@@ -810,16 +809,16 @@ It should be noted that collection of topic level metrics especially offsets can
 </Callout>
 
 The MongoDB integration provides these adjustable settings that can help manage data volume:
-* interval: Default is 15s
-* METRICS: Set to `true` to collect only metrics
-* INVENTORY: Set to `true` to enable only inventory collection
-* FILTERS: A JSON map of database names to an array of collection names. If empty, it defaults to all databases and collections.
+* `interval`: Default is 15s
+* `METRICS`: Set to `true` to collect only metrics
+* `INVENTORY`: Set to `true` to enable only inventory collection
+* `FILTERS`: A JSON map of database names to an array of collection names. If empty, it defaults to all databases and collections.
 
 For any on-host integration you use it's important to be aware of parameters like `FILTERS` where the default is to collect metrics from all databases. This is an area where you can use your monitoring priorities to streamline collected data.
 
 **Example configuration with different intervals for METRIC and INVENTORY:**
 
-```
+```yaml
 integrations:
   - name: nri-mongodb
     env:
@@ -858,17 +857,17 @@ integrations:
 </Callout>
 
 The Elasticsearch integration provides these adjustable settings that can help manage data volume:
-* interval: Default is 15s
-* METRICS: Set to `true` to collect only metrics
-* INVENTORY: Set to `true` to enable only inventory collection
-* COLLECT_INDICES: Signals whether to collect indices metrics or not.
-* COLLECT_PRIMARIES: Signals whether to collect primary metrics or not.
-* INDICES_REGEX: Filter which indices are collected.
-* MASTER_ONLY: Collect cluster metrics on the elected master only.
+* `interval`: Default is 15s
+* `METRICS`: Set to `true` to collect only metrics
+* `INVENTORY`: Set to `true` to enable only inventory collection
+* `COLLECT_INDICES`: Signals whether to collect indices metrics or not.
+* `COLLECT_PRIMARIES`: Signals whether to collect primary metrics or not.
+* `INDICES_REGEX`: Filter which indices are collected.
+* `MASTER_ONLY`: Collect cluster metrics on the elected master only.
 
-**Example configuration with different intervals for METRIC and INVENTORY:**
+**Example configuration with different intervals for `METRICS` and `INVENTORY`:**
 
-```
+```yaml
 integrations:
   - name: nri-elasticsearch
     env:
@@ -902,40 +901,40 @@ integrations:
   variant="IMPORTANT"
   title="Growth drivers"
 >
-  * Metrics listed in COLLECTION_CONFIGS
+  * Metrics listed in `COLLECTION_CONFIG`
 </Callout>
 
 The JMX integration is inherently generic. It allows us to scrape metrics from any JMX instance. We have a good amount of control over what gets collected by this integration. In some enterprise New Relic environments JMX metrics reprepresent a relatively high proportion of all data collected.
 
 The JMX integration provides these adjustable settings that can help manage data volume:
-* interval: Default is 15s
-* METRICS: Set to `true` to collect only metrics
-* INVENTORY: Set to `true` to enable only inventory collection
-* METRIC_LIMIT: Number of metrics that can be collected per entity. If this limit is exceeded the entity will not be reported. A limit of 0 implies no limit.
-* LOCAL_ENTITY: Collect all metrics on the local entity. Only used when monitoring localhost.
-* COLLECTION_FILES: A comma-separated list of full file paths to the metric collection definition files. For on-host install, the default JVM metrics collection file is at /etc/newrelic-infra/integrations.d/jvm-metrics.yml.
-* COLLECTION_CONFIG: Configuration of the metrics collection as a JSON.
+* `interval`: Default is 15s
+* `METRICS`: Set to `true` to collect only metrics
+* `INVENTORY`: Set to `true` to enable only inventory collection
+* `METRIC_LIMIT`: Number of metrics that can be collected per entity. If this limit is exceeded the entity will not be reported. A limit of 0 implies no limit.
+* `LOCAL_ENTITY`: Collect all metrics on the local entity. Only used when monitoring localhost.
+* `COLLECTION_FILES`: A comma-separated list of full file paths to the metric collection definition files. For on-host install, the default JVM metrics collection file is at `/etc/newrelic-infra/integrations.d/jvm-metrics.yml`.
+* `COLLECTION_CONFIG`: Configuration of the metrics collection as a JSON.
 
-It's the COLLECTION_CONFIG entries that most govern the amount of data ingested.  Understanding the JMX model you are scraping will help you optimize.
+It's the `COLLECTION_CONFIG` entries that most govern the amount of data ingested.  Understanding the JMX model you are scraping will help you optimize.
 
-_COLLECTION_CONFIG example for JVM metrics_
+_`COLLECTION_CONFIG` example for JVM metrics_
 
-```
+```java
 COLLECTION_CONFIG='{"collect":[{"domain":"java.lang","event_type":"JVMSample","beans":[{"query":"type=GarbageCollector,name=*","attributes":["CollectionCount","CollectionTime"]},{"query":"type=Memory","attributes":["HeapMemoryUsage.Committed","HeapMemoryUsage.Init","HeapMemoryUsage.Max","HeapMemoryUsage.Used","NonHeapMemoryUsage.Committed","NonHeapMemoryUsage.Init","NonHeapMemoryUsage.Max","NonHeapMemoryUsage.Used"]},{"query":"type=Threading","attributes":["ThreadCount","TotalStartedThreadCount"]},{"query":"type=ClassLoading","attributes":["LoadedClassCount"]},{"query":"type=Compilation","attributes":["TotalCompilationTime"]}]}]}'
 ```
 
 Omitting any one entry from that config such as `NonHeapMemoryUsage.Init` will have a tangible impact on the overall data volume collected.
 
-_COLLECTION_CONFIG example for Tomcat metrics_
+_`COLLECTION_CONFIG` example for Tomcat metrics_
 
-```
+```java
 COLLECTION_CONFIG={"collect":[{"domain":"Catalina","event_type":"TomcatSample","beans":[{"query":"type=UtilityExecutor","attributes":["completedTaskCount"]}]}]}
 ```
 
 ### Other on-host integrations
 
 There are many other on-host integrations with configuration options that will help you optimize collection. Some commonly used ones are:
-* [NGINX](/docs/infrastructure/host-integrations/host-integrations-list/nginx/nginx-advanced-config)
+* [NGINX](/docs/infrastructure/host-integrations/host-integrations-list/nginx/nginx-integration/)
 * [MySQL](/docs/infrastructure/host-integrations/host-integrations-list/mySQL/mysql-integration)
 * [Redis](/docs/infrastructure/host-integrations/host-integrations-list/redis-monitoring-integration)
 * [Apache](/docs/infrastructure/host-integrations/host-integrations-list/apache-monitoring-integration)
@@ -959,15 +958,15 @@ Monitored devices driven by:
 </Callout>
 
 This section focuses on New Relic's network performance monitoring which relies on the `ktranslate` agent from Kentik.  This agent is quite sophisticated and it's important to fully understand the [advanced configuration docs](/docs/network-performance-monitoring/advanced/advanced-config) before major optimization efforts. Configuration options include:
-* mibs_enabled: Array of all active MIBs the ktranslate docker image will poll. This list is automatically generated during discovery if the discovery_add_mibs attribute is true. MIBs not listed here will not be polled on any device in the configuration file. You can specify a SNMP table directly in a MIB file using MIB-NAME.tableName syntax. Ex: HOST-RESOURCES-MIB.hrProcessorTable.
-* user_tags: key:value pair attributes to give more context to the device. Tags at this level will be applied to all devices in the configuration file.
-* devices: Section listing devices to be monitored for flow
-* traps: configures IP and ports to be monitored with SNMP traps (default is 127.0.0.1:1162)
-* discovery: configures how endpoints can be discovered. Under this section the following parameters will do the most to increase or decrease scope:
-  * cidrs: Array of target IP ranges in [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation).
-  * ports: Array of target ports to scan during SNMP polling.
-  * debug: Indicates whether to enable debug level logging during discovery. By default, it's set to `false`
-  * default_communities: Array of SNMPv1/v2c community strings to scan during SNMP polling. This array is evaluated in order and discovery accepts the first passing community.
+* `mibs_enabled`: Array of all active MIBs the ktranslate docker image will poll. This list is automatically generated during discovery if the `discovery_add_mibs` attribute is `true`. MIBs not listed here will not be polled on any device in the configuration file. You can specify a SNMP table directly in a MIB file using `MIB-NAME.tableName` syntax. Ex: `HOST-RESOURCES-MIB.hrProcessorTable`.
+* `user_tags`: key:value pair attributes to give more context to the device. Tags at this level will be applied to all devices in the configuration file.
+* `devices`: Section listing devices to be monitored for flow
+* `traps`: configures IP and ports to be monitored with SNMP traps (default is `127.0.0.1:1162`)
+* `discovery`: configures how endpoints can be discovered. Under this section the following parameters will do the most to increase or decrease scope:
+  * `cidrs`: Array of target IP ranges in [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation).
+  * `ports`: Array of target ports to scan during SNMP polling.
+  * `debug`: Indicates whether to enable debug level logging during discovery. By default, it's set to `false`
+  * `default_communities`: Array of SNMPv1/v2c community strings to scan during SNMP polling. This array is evaluated in order and discovery accepts the first passing community.
 
 To support filtering of data that does not create value for your observability needs, you can set the `global.match_attributes.{}` and/or `devices.<deviceName>.match_attributes.{}` attribute map.
 
@@ -1009,14 +1008,13 @@ The queue for logs sorts based on the priority and when the log arrives. Higher 
 
 Most general forwarders provide a fairly complete [routing workflow](https://docs.fluentd.org/configuration/routing-examples) that includes filtering, and transformation.
 New Relic's infrastructure agent provides some very simple patterns for filtering unwanted logs.
-Regular expression for filtering records. Only supported for the tail, systemd, syslog, and tcp (only with format none) sources.
-This field works in a way similar to grep -E in Unix systems. For example, for a given file being captured, you can filter for records containing either `WARN` or `ERROR` using:
+Regular expression for filtering records. Only supported for the `tail`, `systemd`, `syslog`, and `tcp` (only with format none) sources.
+This field works in a way similar to `grep -E` in Unix systems. For example, for a given file being captured, you can filter for records containing either `WARN` or `ERROR` using:
   
-```
+```yaml
   - name: only-records-with-warn-and-error
     file: /var/log/logFile.log
     pattern: WARN|ERROR
-
 ```
 
 If you have pre-written Fluentd configurations for Fluentbit that do valuable filtering or parsing, you can import them into our New Relic logging config. To do this, use the `config_file` and `parsers` parameters in any `.yaml` file in your `logging.d` folder: 
@@ -1065,7 +1063,7 @@ New Relic provides two primary options for sending Prometheus metrics to New Rel
 
 ### Option 1: [Prometheus remote write integration](/docs/integrations/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration)
 
-For Prometheus server scrape config options, see [the Prometheus config docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config). These scrape configs determine which metrics are collected by Prometheus server. By configuring the [remote_write](/docs/integrations/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration) parameter, the collected metrics can be written to the New Relic database (NRDB) via the New Relic Metric API.
+For Prometheus server scrape config options, see [the Prometheus config docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config). These scrape configs determine which metrics are collected by Prometheus server. By configuring the [`remote_write`](/docs/integrations/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration) parameter, the collected metrics can be written to the New Relic database (NRDB) via the New Relic Metric API.
 
 ### Option 2: [Prometheus OpenMetrics integration (POMI)](/docs/integrations/prometheus-integrations/install-configure-openmetrics/install-update-or-uninstall-your-prometheus-openmetrics-integration)
 
@@ -1081,10 +1079,10 @@ For the latest reference config, see [nri-prometheus-latest.yaml](https://downlo
 
 **POMI config parameter:**
 
-```
+```yaml
 # Label used to identify scrapable targets. 
 # Defaults to "prometheus.io/scrape"
-    scrape_enabled_label: "prometheus.io/scrape"
+  scrape_enabled_label: "prometheus.io/scrape"
 ```
 
 POMI will discover any Prometheus endpoint exposed at the node-level by default. This typically includes metrics coming from Kubelet and cAdvisor.
@@ -1097,13 +1095,13 @@ For the endpoints targeted by the New Relic Kubernetes Daemonset, see [our Kuber
 
 POMI will discover any Prometheus endpoint exposed at the node-level by default. This typically includes metrics coming from Kubelet and cAdvisor.
 
-If you're running the New Relic Kubernetes Daemonset, it's important that you set require_scrape_enabled_label_for_nodes: true so that POMI doesn't collect duplicate metrics. 
+If you're running the New Relic Kubernetes Daemonset, it's important that you set `require_scrape_enabled_label_for_nodes: true` so that POMI doesn't collect duplicate metrics. 
 
 For the endpoints targeted by the New Relic Kubernetes Daemonset, see [our Kubernetes README on GitHub](https://github.com/newrelic/nri-kubernetes/blob/main/README.md).
 
 _POMI config parameters_
 
-```
+```yaml
 # Whether k8s nodes need to be labeled to be scraped or not. 
 # Defaults to false.
   require_scrape_enabled_label_for_nodes: false
@@ -1119,8 +1117,8 @@ It's also very important to set `require_scrape_enabled_label_for_node: true` so
 
 **POMI config parameters:**
 
-```
-transformations:
+```yaml
+  transformations:
     - description: "Uncomment if running New Relic Kubernetes integration"
       ignore_metrics:
         - prefixes:
@@ -1148,9 +1146,7 @@ The resource request for CPU and memory should be set at something reasonable so
 
 **POMI config parameter:**
 
-```
-…
-
+```yaml
 spec:
   serviceAccountName: nri-prometheus
   containers:
@@ -1163,8 +1159,6 @@ spec:
       limits:
         memory: 1G
         cpu: 1000m
-
-…
 ```
 
 ### POMI: estimating DPM and cardinality
@@ -1179,11 +1173,13 @@ If you're already running Prometheus Server, you can run DPM and cardinality est
 
 **Data points per minute (DPM):**
 
-rate(prometheus_tsdb_head_samples_appended_total[10m]) \* 60
-
+```promql
+rate(prometheus_tsdb_head_samples_appended_total[10m]) * 60
+```
+    
 **Top 20 metrics (highest cardinality):**
 
-```
+```promql
 topk(20, count by (**name**, job)({__name__=~".+"}))
 ```
   </Collapser>
@@ -1230,7 +1226,7 @@ For example in AWS it's possible to use condition keys to [limit access to Cloud
 
 The following policy limits the user to publishing metrics only in the namespace named `MyCustomNamespace`:
 
-```
+```json
 {
     "Version": "2012-10-17",
     "Statement": {
@@ -1246,9 +1242,9 @@ The following policy limits the user to publishing metrics only in the namespace
 }
 ```
 
-The following policy allows the user to publish metrics in any namespace except for CustomNamespace2:
+The following policy allows the user to publish metrics in any namespace except for `CustomNamespace2`:
 
-```
+```json
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -1310,14 +1306,17 @@ Omit debug logs (knowing they can be turned on if there is an issue) (saves 5%)
 
 #### Method 2: [Our NerdGraph API](/docs/data-apis/manage-data/drop-data-using-nerdgraph/)
 
-* Create the relevant NRQL query: `SELECT count(*) FROM Log WHERE `level` = 'DEBUG'`.
+* Create the relevant NRQL query: 
+  ```sql
+  SELECT count(*) FROM Log WHERE `level` = 'DEBUG'
+  ```
 * Make sure it finds the logs we want to drop.
-* Check variations on the attribute name and value (Debug vs DEBUG).
+* Check variations on the attribute name and value (`Debug` vs `DEBUG`).
 * Execute the following NerdGraph statement and make sure it works:
 
-```
+```graphql
 mutation {
-    nrqlDropRulesCreate(accountId: <var>YOUR_ACCOUNT_ID</var>, rules: [
+    nrqlDropRulesCreate(accountId: YOUR_ACCOUNT_ID, rules: [
         {
             action: DROP_DATA
             nrql: "SELECT * FROM Log WHERE `level` = 'DEBUG'"
@@ -1341,13 +1340,16 @@ mutation {
   >
   Let's implement the recommendation: `Drop process sample data in DEV environments`.
 
-  * Create the relevant query: 'SELECT \* FROM ProcessSample WHERE `env` = 'DEV''
+  * Create the relevant query: 
+    ```sql
+    SELECT * FROM ProcessSample WHERE `env` = 'DEV'
+    ```
   * Make sure it finds the process samples we want to drop
   * Check for other variations on `env` such as `ENV` and `Environment`
   * Check for various of `DEV` such as `Dev` and `Development`
   * Use our NerdGraph API to execute the following statement and make sure it works:
 
-    ```
+    ```graphql
     mutation {
         nrqlDropRulesCreate(accountId: YOUR_ACCOUNT_ID, rules: [
             {
@@ -1371,24 +1373,27 @@ mutation {
     id="cloud-metrics"
     title="Cloud metrics"
   >
-  In some cases we can economize on data where we have redundant coverage. For example: in an environment where you have the AWS RDS integration running as well as one of the New Relic on-host integrations that monitor SQL databases such as nri-mysql or nri-postgresql you may be able to discard some overlapping metrics.
+  In some cases we can economize on data where we have redundant coverage. For example: in an environment where you have the AWS RDS integration running as well as one of the New Relic on-host integrations that monitor SQL databases such as `nri-mysql` or `nri-postgresql` you may be able to discard some overlapping metrics.
 
   For quick exploration we can run a query like this:
 
-  ```
+  ```sql
   FROM Metric select count(*) where metricName like 'aws.rds%' facet metricName limit max
   ```
 
   That will show us all `metricName` values matching the pattern.
 
   We see from the results there's a high volume of metrics of the pattern `aws.rds.cpu%`. Let's drop those because we have other instrumentation for those: 
-  * Create the relevant query: 'FROM Metric select \* where metricName like 'aws.rds.cpu%' facet metricName limit max since 1 day ago'
+  * Create the relevant query: 
+    ```sql
+    FROM Metric select * where metricName like 'aws.rds.cpu%' facet metricName limit max since 1 day ago
+    ```
   * Make sure it finds the process samples we want to drop.
   * Use the NerdGraph API to execute the following statement and make sure it works:
 
-  ```
+  ```graphql
   mutation {
-      nrqlDropRulesCreate(accountId: <var>YOUR_ACCOUNT_ID</var>, rules: [
+      nrqlDropRulesCreate(accountId: YOUR_ACCOUNT_ID, rules: [
           {
               action: DROP_DATA
               nrql: "FROM Metric select * where metricName like 'aws.rds.cpu%' facet metricName limit max since 1 day ago"
@@ -1414,9 +1419,9 @@ mutation {
 
   To set these drop rules, change the `action` field to `DROP_ATTRIBUTES` instead of `DROP_DATA`.
 
-  ```
+  ```graphql
   mutation {
-      nrqlDropRulesCreate(accountId: <var>YOUR_ACCOUNT_ID</var>, rules: [
+      nrqlDropRulesCreate(accountId: YOUR_ACCOUNT_ID, rules: [
           {
               action: DROP_ATTRIBUTES
               nrql: "SELECT stack_trace, json_data FROM Log where appName='myApp'"
@@ -1446,7 +1451,7 @@ mutation {
 
   The following example could drop about 25% of spans:
 
-  ```
+  ```sql
   SELECT * FROM Span WHERE trace.id rlike r'.*[0-3]' and appName = 'myApp'
   ```
 
@@ -1458,9 +1463,9 @@ mutation {
 
   Here's an example of a full mutation:
 
-  ```
+  ```graphql
   mutation {
-      nrqlDropRulesCreate(accountId: <var>YOUR_ACCOUNT_ID</var>, rules: [
+      nrqlDropRulesCreate(accountId: YOUR_ACCOUNT_ID, rules: [
           {
               action: DROP_ATTRIBUTES
               nrql: "SELECT * FROM Span WHERE trace.id rlike r'.*[0-3]' and appName = 'myApp'"


### PR DESCRIPTION
- The cmd SELECT count(*) FROM Log WHERE `level` = 'DEBUG' was rendering wrong because of the internal backtick. 
- The link to the Java config was broken too so fixed that. 
- Fixed some incorrect chars, `“` for `"`
- Fixed link to NGINX
- promql probably isn't recognized by our docs site
- I suspect this code block has leftover markdown for the `**name**` part, but I don't know promql so I can't say if that's valid or not
 
  ```promql
  topk(20, count by (**name**, job)({__name__=~".+"}))
  ```
- I did a bunch of general cleaning up too and added lang identifiers to the code

The bottom of this page also has a broken link I can't make sense of: https://docs.newrelic.com/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide/#conclusion



<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.