### PR TITLE
chore(Java): Code level metrics and release fix

### DIFF
--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -2102,6 +2102,45 @@ The agent collects utilization information and sends it to the New Relic service
   </Collapser>
 </CollapserGroup>
 
+## Code-level metrics
+
+Code-level metrics give you detailed insight into how your code is performing at the method level. For each method automatically instrumented or instrumented by the @Trace annotation, you'll see response time, throughput, and error rate  for the last 30 minutes. For more information on code-level metrics, see [Performance monitoring with CodeStream](/docs/codestream/how-use-codestream/performance-monitoring).
+
+The code-level metrics options are set in the `code_level_metrics` stanza and can be [overridden](#System_Properties) by using a `newrelic.config.code_level_metrics` prefixed system property.
+
+<CollapserGroup>
+  <Collapser
+    id="clm-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+      <tr>
+        <th>
+          Type
+        </th>
+
+        <td>
+          Boolean
+        </td>
+      </tr>
+
+      <tr>
+        <th>
+          Default
+        </th>
+
+        <td>
+          `false`
+        </td>
+      </tr>
+      </tbody>
+    </table>
+
+    [Code-level metrics](/docs/codestream/how-use-codestream/performance-monitoring/#code-level) is disabled by default. Set this to true to turn it on.
+  </Collapser>
+</CollapserGroup>
+
 ## Cross application tracer [#Cross_Application_Tracer]
 
 <Callout variant="important">

--- a/src/content/docs/apm/agents/java-agent/features/java-codestream-integration.mdx
+++ b/src/content/docs/apm/agents/java-agent/features/java-codestream-integration.mdx
@@ -1,0 +1,75 @@
+---
+title: New Relic CodeStream integration
+tags:
+ - Agents
+ - Java agent
+ - Features
+metaDescription: The Java agent can be integrated with New Relic CodeStream to provide code-level metrics.
+---
+
+Display context-sensitive APM data directly in your IDE by integrating [New Relic CodeStream](/docs/codestream/how-use-codestream/performance-monitoring#code-level) with the Java agent. Visualize code-level production telemetry in your editor as your write and review code with this integration.
+
+## Getting started
+
+First, [install](/docs/codestream/start-here/install-codestream) the New Relic CodeStream extension into your supported IDE of choice and log in.
+
+<Callout variant="important">
+  The New Relic CodeStream integration is available in Java agent version 7.10.0 and higher. To enable the integration, either set `code_level_metrics.enabled: true` in `newrelic.yml`, or `NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=true` as an environment variable, or `-Dnewrelic.config.code-level-metrics.enabled=true` as a system property.
+</Callout>
+
+## Agent attributes
+
+The Java agent reports and attaches the following attributes to spans produced by your application:
+
+<table>
+  <thead>
+  <tr>
+    <th style={{ width: "200px" }}>
+      **Name**
+    </th>
+
+    <th>
+      **Description**
+    </th>
+
+    <th>
+      **Example**
+    </th>
+  </tr>
+  </thead>
+
+  <tbody>
+  <tr>
+    <td>
+      `code.function`
+    </td>
+
+    <td>
+      The name of the instrumented function (Java method).
+    </td>
+
+    <td>
+      retrieveData
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      `code.namespace`
+    </td>
+
+    <td>
+      The namespace (fully qualified class name) in which `code.function` is defined
+    </td>
+
+    <td>
+      com.example.MyService
+    </td>
+  </tr>
+  </tbody>
+</table>
+
+<Callout variant="important">
+  Spans created using the API method `NewRelic.getAgent().getTransaction().startSegment()` will not contain these attributes. To create a span that contain these attributes annotate a method with `@Trace` or use XML instrumentation.
+</Callout>
+

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-7100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-7100.mdx
@@ -1,3 +1,10 @@
+---
+subject:  Java agent
+releaseDate:  '2022-09-15'
+version:  7.10.0
+downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/7.10.0/'
+---
+
 ## New features and improvements
 
 ### Added the following Jakarta EE 9/9.1 compatible instrumentation:
@@ -17,7 +24,7 @@
 
 ### Code level metrics
 
-For traced methods in automatic instrumentation or from @Trace annotations, the agent is now capable of reporting metrics with method-level granularity. When the new functionality is enabled, the agent will associate source-code-related metadata with some metrics. Then, when the corresponding Java class file that defines the methods is loaded up in a [New Relic CodeStream](https://www.codestream.com/)-powered IDE, [the four golden signals](https://sre.google/sre-book/monitoring-distributed-systems) for each method will be presented to the developer directly.
+For traced methods in automatic instrumentation or from @Trace annotations, the agent is now capable of reporting metrics with method-level granularity. When the new functionality [is enabled](/docs/apm/agents/java-agent/features/java-codestream-integration), the agent will associate source-code-related metadata with some metrics. Then, when the corresponding Java class file that defines the methods is loaded up in a [New Relic CodeStream](https://www.codestream.com/)-powered IDE, [the four golden signals](https://sre.google/sre-book/monitoring-distributed-systems#xref_monitoring_golden-signals) for each method will be presented to the developer directly.
 
 ### Agent log forwarding now adds the following attributes to log events for the log4j2 and logback1.2 frameworks:
 

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -218,6 +218,8 @@ pages:
           - title: Features
             path: /docs/apm/agents/java-agent/features
             pages:
+              - title: CodeStream integration
+                path: /docs/apm/agents/java-agent/features/java-codestream-integration
               - title: JVM metrics page (Java)
                 path: /docs/apm/agents/java-agent/features/jvms-page-java-view-app-server-metrics-jmx
               - title: Real-time profiling for Java


### PR DESCRIPTION
## Give us some context

Some content related to the 7.10 release didn't go with the main PR.

Also the release notes were missing the metadata.