### PR TITLE
fix(php-agent):Update PHP compatibility specs

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -26,11 +26,7 @@ New Relic supports PHP versions 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, and 8.1.
 </Callout>
 
 * We recommend using a [supported release](http://php.net/supported-versions.php) of PHP, especially 7.4, 8.0, and 8.1.
-* PHP 5.1 support was deprecated in release 4.0 of the agent, and removed in release 4.5.
-* PHP 5.2 support was deprecated in release 6.8 of the agent, and removed in release 7.0.
-* PHP 5.3 and PHP 5.4 support was deprecated in release [9.15](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293) of the agent, and removed in release [9.17](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9170300/).
-* 32-bit support for PHP versions 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4 was deprecated in release [9.19](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9190309).
-* Release [9.19](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9190309) is the last release to support ZTS builds. In the future, ZTS builds may not be provided and support may be completely pulled from the codebase.
+* Release [9.19](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9190309) was the last release to support ZTS builds.
 
 ## Permissions [#permissions]
 
@@ -47,10 +43,6 @@ For any installation, you will need your New Relic [license key](/docs/subscript
 * ARM64
 
 ## Operating systems [#operating-systems]
-
-<Callout variant="important">
-  The Windows operating system is not supported.
-</Callout>
 
 <table>
   <thead>
@@ -70,13 +62,9 @@ For any installation, you will need your New Relic [license key](/docs/subscript
       <td>
         Linux (x86_64)
 
-        Linux (x86) **DEPRECATED**
       </td>
 
       <td>
-        <Callout variant="important">
-          As of June 2022, we're discontinuing support for x86 architecture. For more information, see our [PHP agent release notes v9.19.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9190309).
-        </Callout>
 
         * Amazon Linux 2
 
@@ -86,18 +74,10 @@ For any installation, you will need your New Relic [license key](/docs/subscript
             As of March 2022, we deprecated support for Red Hat Enterprise Linux (RHEL) 6. For more information, see our [PHP agent release notes v9.20.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9200310).  It will no longer be supported starting June, 2022.
           </Callout>
 
-          <Callout variant="important">
-            As of January 2021, we discontinued support for Red Hat Enterprise Linux (RHEL) 5. For more information, see our [PHP agent release notes v9.15.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293) and our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-across-browser-php-python-mobile-and-android-agents/123951).
-          </Callout>
-
         * CentOS 6 or higher
 
           <Callout variant="important">
             As of March 2022, we deprecated support for Centos 6. For more information, see our [PHP agent release notes v9.20.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9200310).  It will no longer be supported starting June, 2022.
-          </Callout>
-
-          <Callout variant="important">
-            As of January 2021, we discontinued support for CentOS 5. For more information, see our [PHP agent release notes v9.15.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293) and our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-across-browser-php-python-mobile-and-android-agents/123951).
           </Callout>
 
         * Debian 7.0 ("wheezy") or higher
@@ -131,33 +111,6 @@ For any installation, you will need your New Relic [license key](/docs/subscript
       </td>
     </tr>
 
-    <tr>
-      <td>
-        macOS (x86_64 only) ** UNSUPPORTED **
-      </td>
-
-      <td>
-        <Callout variant="important">
-          As of January 2021, we're discontinuing support for macOS. For more information, see our [PHP agent release notes v9.15.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9150293) and our [Explorers Hub post](https://discuss.newrelic.com/t/important-upcoming-changes-to-capabilities-across-browser-php-python-mobile-and-android-agents/123951).
-        </Callout>
-
-        macOS 10.6 or higher. Because modern versions of macOS can't run 32-bit applications, New Relic removed support for 32-bit macOS with PHP agent release 4.6.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        FreeBSD (x64) **DEPRECATED**
-      </td>
-
-      <td>
-        <Callout variant="important">
-          As of June, 2022, we're discontinuing support for FreeBSD. For more information, see our [PHP agent release notes v9.19.0](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9190309).
-        </Callout>
-
-        The latest agent supports the latest production release.
-      </td>
-    </tr>
   </tbody>
 </table>
 
@@ -207,31 +160,24 @@ Supported PHP frameworks include:
       <td>
         [Drupal 6.x, 7.x, 8.x, and 9.x](/docs/agents/php-agent/frameworks-libraries/drupal-specific-functionality)
       </td>
+      <td>
+        Slim 2.x, 3.x, and 4.x
+      </td>      
     </tr>
 
     <tr>
       <td>
         Joomla 3.x
       </td>
-
       <td>
-        Slim 2.x, 3.x, and 4.x
+        Symfony 3.x, 4.x, and 5.x
       </td>
+
     </tr>
 
     <tr>
       <td>
         Kohana 3.2 and 3.3
-      </td>
-
-      <td>
-        Symfony 3.x, 4.x, 5.x
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Laminas 3.x
       </td>
 
       <td>
@@ -241,7 +187,7 @@ Supported PHP frameworks include:
 
     <tr>
       <td>
-        Laravel 4.x, 5.x, 6.x, and 7.x
+        Laminas 3.x
       </td>
 
       <td>
@@ -251,25 +197,31 @@ Supported PHP frameworks include:
 
     <tr>
       <td>
-        Laravel Lumen 6.x, 7.x, and 8.x
+        Laravel 4.x, 5.x, 6.x, and 7.x
       </td>
 
       <td>
         Zend Framework 1.x, 2.x, and 3.x
       </td>
     </tr>
+
+    <tr>
+      <td>
+        Laravel Lumen 6.x, 7.x, and 8.x
+      </td>
+
+
+    </tr>
   </tbody>
 </table>
 
-<Callout variant="important">
-  Joomla 3.x is not supported on PHP 8.x
-</Callout>
 
 <Callout variant="important">
   As of PHP agent version 9.17, the following frameworks or framework versions
-  are no longer supported and may be removed from future agent builds: _ Cake
-  PHP 1.x _ Joomla 1.5, 1.6, and 2.x _ Kohana _ Silex 1.x and 2.x \* Symfony 1.x
-  and 2.x
+  are no longer supported: Cake PHP 1.x; Joomla 1.5, 1.6, and 2.x; Silex 1.x and 2.x; 
+  Symfony 1.x and 2.x.
+
+  Joomla 3.x is not supported on PHP 8.x
 </Callout>
 
 The PHP agent's list of frameworks continues to grow. Even if the framework you are using is not listed here, the PHP agent may be able to provide you with useful information about your app.
@@ -381,9 +333,7 @@ If your application uses other application performance monitoring (APM) software
 
 ## Instance details
 
-New Relic collects [instance details for a variety of databases and database drivers](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues). The ability to view specific instances and the types of database information in APM depends on your New Relic agent version.
-
-New Relic's PHP agent [version 6.8 or higher](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-680177) supports instance details for the following:
+New Relic collects [instance details for a variety of databases and database drivers](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues). The ability to view specific instances and the types of database information in APM is available for the following:
 
 <table>
   <thead>
@@ -394,10 +344,6 @@ New Relic's PHP agent [version 6.8 or higher](/docs/release-notes/agent-release-
 
       <th>
         Extension
-      </th>
-
-      <th>
-        Minimum agent version
       </th>
     </tr>
   </thead>
@@ -411,10 +357,6 @@ New Relic's PHP agent [version 6.8 or higher](/docs/release-notes/agent-release-
       <td>
         [mongodb](https://github.com/mongodb/mongo-php-library)
       </td>
-
-      <td>
-        7.1
-      </td>
     </tr>
 
     <tr>
@@ -424,10 +366,6 @@ New Relic's PHP agent [version 6.8 or higher](/docs/release-notes/agent-release-
 
       <td>
         [mysql](http://php.net/manual/en/book.mysql.php)
-      </td>
-
-      <td>
-        6.8
       </td>
     </tr>
 
@@ -439,10 +377,6 @@ New Relic's PHP agent [version 6.8 or higher](/docs/release-notes/agent-release-
       <td>
         [mysqli](http://php.net/manual/en/book.mysqli.php)
       </td>
-
-      <td>
-        6.8
-      </td>
     </tr>
 
     <tr>
@@ -452,10 +386,6 @@ New Relic's PHP agent [version 6.8 or higher](/docs/release-notes/agent-release-
 
       <td>
         [pdo_mysql](http://php.net/manual/en/ref.pdo-mysql.php)
-      </td>
-
-      <td>
-        6.8
       </td>
     </tr>
 
@@ -467,10 +397,6 @@ New Relic's PHP agent [version 6.8 or higher](/docs/release-notes/agent-release-
       <td>
         [pgsql](http://php.net/manual/en/book.pgsql.php)
       </td>
-
-      <td>
-        6.9
-      </td>
     </tr>
 
     <tr>
@@ -480,10 +406,6 @@ New Relic's PHP agent [version 6.8 or higher](/docs/release-notes/agent-release-
 
       <td>
         [pdo_pgsql](http://php.net/manual/en/ref.pdo-pgsql.php)
-      </td>
-
-      <td>
-        6.9
       </td>
     </tr>
 
@@ -495,10 +417,6 @@ New Relic's PHP agent [version 6.8 or higher](/docs/release-notes/agent-release-
       <td>
         [predis](https://github.com/nrk/predis)
       </td>
-
-      <td>
-        7.1
-      </td>
     </tr>
 
     <tr>
@@ -508,10 +426,6 @@ New Relic's PHP agent [version 6.8 or higher](/docs/release-notes/agent-release-
 
       <td>
         [redis](https://pecl.php.net/package/redis)
-      </td>
-
-      <td>
-        7.1
       </td>
     </tr>
   </tbody>
@@ -527,7 +441,7 @@ To request instance-level information from datastores currently not listed for y
 ## Message queuing [#queuing]
 
 * HTTP
-* Laravel Queuing, available as an experimental feature in the [PHP Agent 6.6.0.169 release](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-660169), enabled by default since [PHP Agent 8.0.0.204](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-800204).
+* Laravel Queuing
 
 ## Security requirements [#security]
 


### PR DESCRIPTION
This PR contains changes to the compatibility specification page for the PHP agent requested by the PM.

These changes can go live when they have been approved, there is no need to sit on them.

Thanks!