### PR TITLE
chore: Add section about upgrading from 7.x to 8.x

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/installation/update-ruby-agent.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/installation/update-ruby-agent.mdx
@@ -61,6 +61,22 @@ To update the Ruby agent:
 
   <tbody>
     <tr>
+      <td id="migration-7-8">
+        From version 7 to 8
+      </td>
+
+      <td>
+        Release notes: [Ruby agent 8.0.0](docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-800)
+
+        Please see our [Ruby Agent 7.x to 8.x migration guide](/docs/apm/agents/ruby-agent/getting-started/migration-8x-guide/) for helpful strategies and tips for migrating from earlier versions of the Ruby agent to 8.0.0. We cover new configuration defaults, changes to the `add_method_tracer` API and deprecated items and their replacements in this guide.
+
+        * Changes to the add_method_tracer API method
+        * Distributed Tracing is enabled by default
+        * Cross Application Tracing is deprecated
+        * Removed deprecated API methods and legacy instrumentation
+      </td>
+    </tr>
+    <tr>
       <td id="migration-6-7">
         From version 6 to 7
       </td>


### PR DESCRIPTION
## Give us some context

This document was missing a section about migrating to our latest major version. Thanks @angelatan2 for noticing this!