### PR TITLE
Update dashboard example JSON

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/monitor-private-locations.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/monitor-private-locations.mdx
@@ -45,7 +45,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
       "pages": [
         {
           "name": "SyntheticsPrivateLocationStatus",
-          "description": "Private location queues.",
+          "description": null,
           "widgets": [
             {
               "title": "pending checks by location",
@@ -822,7 +822,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
               }
             },
             {
-              "title": "abnormal job duration by minion (s)",
+              "title": "abnormal job duration by minion",
               "layout": {
                 "column": 9,
                 "row": 1,
@@ -843,9 +843,15 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT stddev(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'abnormal job duration (s)' FACET minion WHERE location NOT LIKE 'AWS_%' LIMIT 20 TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT stddev(duration) AS 'abnormal job duration' FACET minion WHERE location NOT LIKE 'AWS_%' LIMIT 20 TIMESERIES AUTO"
                   }
-                ]
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
+                }
               }
             },
             {
@@ -944,7 +950,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
               }
             },
             {
-              "title": "abnormal job duration by monitor (s)",
+              "title": "abnormal job duration by monitor",
               "layout": {
                 "column": 9,
                 "row": 4,
@@ -965,11 +971,14 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT stddev(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'abnormal job duration (s)' FACET monitorId WHERE location NOT LIKE 'AWS_%' LIMIT 20 TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT stddev(duration) AS 'abnormal job duration' FACET monitorId WHERE location NOT LIKE 'AWS_%' LIMIT 20 TIMESERIES AUTO"
                   }
                 ],
                 "platformOptions": {
                   "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
                 }
               }
             },
@@ -1028,7 +1037,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
               }
             },
             {
-              "title": "job duration by location (s)",
+              "title": "job duration by location",
               "layout": {
                 "column": 7,
                 "row": 7,
@@ -1040,7 +1049,6 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "id": "viz.line"
               },
               "rawConfiguration": {
-                "dataFormatters": [],
                 "facet": {
                   "showOtherSeries": false
                 },
@@ -1050,16 +1058,22 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'avg job duration (s)' WHERE location NOT LIKE 'AWS_%' FACET locationLabel TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT average(duration) AS 'avg job duration' WHERE location NOT LIKE 'AWS_%' FACET locationLabel TIMESERIES AUTO"
                   }
                 ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
+                },
                 "yAxisLeft": {
                   "zero": true
                 }
               }
             },
             {
-              "title": "abnormal job duration by location (s)",
+              "title": "abnormal job duration by location",
               "layout": {
                 "column": 9,
                 "row": 7,
@@ -1080,16 +1094,19 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT stddev(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'abnormal job duration (s)' FACET locationLabel WHERE location NOT LIKE 'AWS_%' LIMIT 20 TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT stddev(duration) AS 'abnormal job duration' FACET locationLabel WHERE location NOT LIKE 'AWS_%' LIMIT 20 TIMESERIES AUTO"
                   }
                 ],
                 "platformOptions": {
                   "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
                 }
               }
             },
             {
-              "title": "monitors by runtime type version",
+              "title": "monitors by runtime type",
               "layout": {
                 "column": 1,
                 "row": 10,
@@ -1107,13 +1124,13 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT uniqueCount(monitorId) WHERE location NOT LIKE 'AWS_%' FACET runtimeTypeVersion"
+                    "query": "FROM SyntheticCheck SELECT uniqueCount(monitorId) WHERE location NOT LIKE 'AWS_%' FACET runtimeType"
                   }
                 ]
               }
             },
             {
-              "title": "monitors by runtime type version",
+              "title": "monitors by runtime type",
               "layout": {
                 "column": 5,
                 "row": 10,
@@ -1134,7 +1151,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT uniqueCount(monitorId) WHERE location NOT LIKE 'AWS_%' FACET runtimeTypeVersion TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT uniqueCount(monitorId) WHERE location NOT LIKE 'AWS_%' FACET runtimeType TIMESERIES AUTO"
                   }
                 ],
                 "yAxisLeft": {
@@ -1143,7 +1160,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
               }
             },
             {
-              "title": "job duration by runtime type version (s)",
+              "title": "job duration by runtime type",
               "layout": {
                 "column": 7,
                 "row": 10,
@@ -1155,7 +1172,6 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "id": "viz.line"
               },
               "rawConfiguration": {
-                "dataFormatters": [],
                 "facet": {
                   "showOtherSeries": false
                 },
@@ -1165,16 +1181,22 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'avg job duration (s)' WHERE location NOT LIKE 'AWS_%' FACET runtimeTypeVersion TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT average(duration) AS 'avg job duration' WHERE location NOT LIKE 'AWS_%' FACET runtimeType TIMESERIES AUTO"
                   }
                 ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
+                },
                 "yAxisLeft": {
                   "zero": true
                 }
               }
             },
             {
-              "title": "abnormal job duration by runtime type version (s)",
+              "title": "abnormal job duration by runtime type",
               "layout": {
                 "column": 9,
                 "row": 10,
@@ -1195,11 +1217,14 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT stddev(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'abnormal job duration (s)' FACET runtimeTypeVersion WHERE location NOT LIKE 'AWS_%' LIMIT 20 TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT stddev(duration) AS 'abnormal job duration' FACET runtimeType WHERE location NOT LIKE 'AWS_%' LIMIT 20 TIMESERIES AUTO"
                   }
                 ],
                 "platformOptions": {
                   "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
                 }
               }
             },
@@ -1258,7 +1283,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
               }
             },
             {
-              "title": "job duration by type (s)",
+              "title": "job duration by type",
               "layout": {
                 "column": 7,
                 "row": 13,
@@ -1270,7 +1295,6 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "id": "viz.line"
               },
               "rawConfiguration": {
-                "dataFormatters": [],
                 "facet": {
                   "showOtherSeries": false
                 },
@@ -1280,16 +1304,22 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'avg job duration (s)' WHERE location NOT LIKE 'AWS_%' FACET type TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT average(duration) AS 'avg job duration' WHERE location NOT LIKE 'AWS_%' FACET type TIMESERIES AUTO"
                   }
                 ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
+                },
                 "yAxisLeft": {
                   "zero": true
                 }
               }
             },
             {
-              "title": "abnormal job duration by type (s)",
+              "title": "abnormal job duration by type",
               "layout": {
                 "column": 9,
                 "row": 13,
@@ -1310,9 +1340,15 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT stddev(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'abnormal job duration (s)' FACET type WHERE location NOT LIKE 'AWS_%' TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT stddev(duration) AS 'abnormal job duration' FACET type WHERE location NOT LIKE 'AWS_%' TIMESERIES AUTO"
                   }
-                ]
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
+                }
               }
             },
             {
@@ -1370,7 +1406,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
               }
             },
             {
-              "title": "job duration by status (s)",
+              "title": "job duration by status",
               "layout": {
                 "column": 7,
                 "row": 16,
@@ -1382,7 +1418,6 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "id": "viz.line"
               },
               "rawConfiguration": {
-                "dataFormatters": [],
                 "facet": {
                   "showOtherSeries": false
                 },
@@ -1392,16 +1427,22 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'avg job duration (s)' WHERE location NOT LIKE 'AWS_%' FACET result TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT average(duration) AS 'avg job duration' WHERE location NOT LIKE 'AWS_%' FACET result TIMESERIES AUTO"
                   }
                 ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
+                },
                 "yAxisLeft": {
                   "zero": true
                 }
               }
             },
             {
-              "title": "abnormal job duration by status (s)",
+              "title": "abnormal job duration by status",
               "layout": {
                 "column": 9,
                 "row": 16,
@@ -1422,9 +1463,15 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT stddev(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'abnormal job duration (s)' FACET result WHERE location NOT LIKE 'AWS_%' TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT stddev(duration) AS 'abnormal job duration' FACET result WHERE location NOT LIKE 'AWS_%' TIMESERIES AUTO"
                   }
-                ]
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
+                }
               }
             },
             {
@@ -1482,7 +1529,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
               }
             },
             {
-              "title": "job duration for successes by type (s)",
+              "title": "job duration for successes by type",
               "layout": {
                 "column": 7,
                 "row": 19,
@@ -1494,7 +1541,6 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "id": "viz.line"
               },
               "rawConfiguration": {
-                "dataFormatters": [],
                 "facet": {
                   "showOtherSeries": false
                 },
@@ -1504,16 +1550,22 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'avg job duration (s)' WHERE location NOT LIKE 'AWS_%' AND result = 'SUCCESS' FACET type TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT average(duration) AS 'avg job duration' WHERE location NOT LIKE 'AWS_%' AND result = 'SUCCESS' FACET type TIMESERIES AUTO"
                   }
                 ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
+                },
                 "yAxisLeft": {
                   "zero": true
                 }
               }
             },
             {
-              "title": "abnormal job duration for successes by type (s)",
+              "title": "abnormal job duration for successes by type",
               "layout": {
                 "column": 9,
                 "row": 19,
@@ -1534,9 +1586,15 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT stddev(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'abnormal job duration (s)' FACET type WHERE location NOT LIKE 'AWS_%' AND result = 'SUCCESS' TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT stddev(duration) AS 'abnormal job duration' FACET type WHERE location NOT LIKE 'AWS_%' AND result = 'SUCCESS' TIMESERIES AUTO"
                   }
-                ]
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
+                }
               }
             },
             {
@@ -1594,7 +1652,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
               }
             },
             {
-              "title": "job duration for failures by type (s)",
+              "title": "job duration for failures by type",
               "layout": {
                 "column": 7,
                 "row": 22,
@@ -1606,7 +1664,6 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "id": "viz.line"
               },
               "rawConfiguration": {
-                "dataFormatters": [],
                 "facet": {
                   "showOtherSeries": false
                 },
@@ -1616,16 +1673,22 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'avg job duration (s)' WHERE location NOT LIKE 'AWS_%' AND result = 'FAILED' FACET type TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT average(duration) AS 'avg job duration' WHERE location NOT LIKE 'AWS_%' AND result = 'FAILED' FACET type TIMESERIES AUTO"
                   }
                 ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
+                },
                 "yAxisLeft": {
                   "zero": true
                 }
               }
             },
             {
-              "title": "abnormal job duration for failures by type (s)",
+              "title": "abnormal job duration for failures by type",
               "layout": {
                 "column": 9,
                 "row": 22,
@@ -1646,9 +1709,15 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT stddev(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'abnormal job duration (s)' FACET type WHERE location NOT LIKE 'AWS_%' AND result = 'FAILED' TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT stddev(duration) AS 'abnormal job duration' FACET type WHERE location NOT LIKE 'AWS_%' AND result = 'FAILED' TIMESERIES AUTO"
                   }
-                ]
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
+                }
               }
             },
             {
@@ -1671,7 +1740,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT uniqueCount(monitorId) AS 'monitors with results',uniqueCount(monitorId)/rate(uniqueCount(id), 1 minute) AS 'avg job frequency (m)',average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'avg duration (s)' WHERE location NOT LIKE 'AWS_%' AND type = 'SIMPLE' FACET locationLabel"
+                    "query": "FROM SyntheticCheck SELECT uniqueCount(monitorId) AS 'monitors with results',uniqueCount(monitorId)/rate(uniqueCount(id), 1 minute) AS 'avg job frequency (m)',average(duration) AS 'avg job duration' WHERE location NOT LIKE 'AWS_%' AND type = 'SIMPLE' FACET locationLabel"
                   }
                 ]
               }
@@ -1696,13 +1765,13 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT count(*),latest(monitorId) AS 'latest monitor id',latest(type),average((nr.internalQueueDuration+nr.executionDuration)/1e3) AS 'avg job duration (s)',max(timestamp) AS 'last occurred' WHERE type = 'SIMPLE' AND result = 'FAILED' AND location NOT LIKE 'AWS_%' FACET error LIMIT 5"
+                    "query": "FROM SyntheticCheck SELECT count(*),latest(monitorId) AS 'latest monitor id',latest(type),average(duration) AS 'avg job duration',max(timestamp) AS 'last occurred' WHERE type = 'SIMPLE' AND result = 'FAILED' AND location NOT LIKE 'AWS_%' FACET error LIMIT 5"
                   }
                 ]
               }
             },
             {
-              "title": "ping duration with monitor count (s)",
+              "title": "ping duration with monitor count",
               "layout": {
                 "column": 5,
                 "row": 28,
@@ -1714,15 +1783,24 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "id": "viz.line"
               },
               "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
                 "legend": {
                   "enabled": true
                 },
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'avg job duration (s)',uniqueCount(monitorId) AS 'monitor count' WHERE type = 'SIMPLE' AND location NOT LIKE 'AWS_%' TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT average(duration) AS 'avg job duration',uniqueCount(monitorId) AS 'monitor count' WHERE type = 'SIMPLE' AND location NOT LIKE 'AWS_%' TIMESERIES AUTO"
                   }
                 ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
+                },
                 "yAxisLeft": {
                   "zero": true
                 }
@@ -1750,9 +1828,15 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT average((nr.internalQueueDuration+nr.executionDuration)/1e3) WHERE type = 'SIMPLE' AND location NOT LIKE 'AWS_%' AND result = 'FAILED' FACET cases(WHERE error NOT LIKE '%timeout%' AS 'other error duration (s)', WHERE error LIKE '%timeout%' AS 'timeout duration (s)') TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT average(duration) WHERE type = 'SIMPLE' AND location NOT LIKE 'AWS_%' AND result = 'FAILED' FACET cases(WHERE error NOT LIKE '%timeout%' AS 'other error duration', WHERE error LIKE '%timeout%' AS 'timeout duration') TIMESERIES AUTO"
                   }
                 ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
+                },
                 "yAxisLeft": {
                   "zero": true
                 }
@@ -1838,9 +1922,12 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT uniqueCount(monitorId) AS 'monitors with results',uniqueCount(monitorId)/rate(uniqueCount(id), 1 minute) AS 'avg job frequency (m)',average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'avg duration (s)' WHERE location NOT LIKE 'AWS_%' AND type != 'SIMPLE' FACET locationLabel"
+                    "query": "FROM SyntheticCheck SELECT uniqueCount(monitorId) AS 'monitors with results',uniqueCount(monitorId)/rate(uniqueCount(id), 1 minute) AS 'avg job frequency (m)',average(duration) AS 'avg job duration' WHERE location NOT LIKE 'AWS_%' AND type != 'SIMPLE' FACET locationLabel"
                   }
-                ]
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                }
               }
             },
             {
@@ -1863,13 +1950,13 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT count(*),latest(monitorId) AS 'latest monitor id',latest(type),average((nr.internalQueueDuration+nr.executionDuration)/1e3) AS 'avg job duration (s)',max(timestamp) AS 'last occurred' WHERE type != 'SIMPLE' AND result = 'FAILED' AND location NOT LIKE 'AWS_%' FACET error LIMIT 5"
+                    "query": "FROM SyntheticCheck SELECT count(*),latest(monitorId) AS 'latest monitor id',latest(type),average(duration) AS 'avg job duration',max(timestamp) AS 'last occurred' WHERE type != 'SIMPLE' AND result = 'FAILED' AND location NOT LIKE 'AWS_%' FACET error LIMIT 5"
                   }
                 ]
               }
             },
             {
-              "title": "non-ping duration with monitor count (s)",
+              "title": "non-ping duration with monitor count",
               "layout": {
                 "column": 5,
                 "row": 34,
@@ -1881,15 +1968,24 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "id": "viz.line"
               },
               "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
                 "legend": {
                   "enabled": true
                 },
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'avg job duration (s)',uniqueCount(monitorId) AS 'monitor count' WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT average(duration) AS 'avg job duration',uniqueCount(monitorId) AS 'monitor count' WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' TIMESERIES AUTO"
                   }
                 ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
+                },
                 "yAxisLeft": {
                   "zero": true
                 }
@@ -1917,9 +2013,15 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT average((nr.internalQueueDuration+nr.executionDuration)/1e3) WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' AND result = 'FAILED' FACET cases(WHERE error NOT LIKE '%timeout%' AS 'other error duration (s)', WHERE error LIKE '%timeout%' AS 'timeout duration (s)') TIMESERIES AUTO"
+                    "query": "FROM SyntheticCheck SELECT average(duration) WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' AND result = 'FAILED' FACET cases(WHERE error NOT LIKE '%timeout%' AS 'other error duration', WHERE error LIKE '%timeout%' AS 'timeout duration') TIMESERIES AUTO"
                   }
                 ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
+                "units": {
+                  "unit": "MS"
+                },
                 "yAxisLeft": {
                   "zero": true
                 }
@@ -2126,7 +2228,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT uniqueCount(id) AS 'results',uniqueCount(location)/rate(uniqueCount(id), 1 minute) AS 'avg job frequency (m)',average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'avg duration (s)' WHERE location NOT LIKE 'AWS_%' FACET monitorId,type,apiVersion,runtimeTypeVersion LIMIT 50"
+                    "query": "FROM SyntheticCheck SELECT uniqueCount(id) AS 'results',uniqueCount(location)/rate(uniqueCount(id), 1 minute) AS 'avg job frequency (m)',average(duration) AS 'avg job duration' WHERE location NOT LIKE 'AWS_%' FACET monitorId,type,apiVersion,runtimeType LIMIT 50"
                   }
                 ]
               }
@@ -2467,7 +2569,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticRequest SELECT percentage(uniqueCount(id),WHERE domComplete IS NULL) AS 'percent incomplete',uniqueCount(id) AS 'jobs' WHERE isNavigationRoot IS true AND location NOT LIKE 'AWS_%' FACET monitorName,monitorId,runtimeTypeVersion LIMIT 20"
+                    "query": "FROM SyntheticRequest SELECT percentage(uniqueCount(id),WHERE domComplete IS NULL) AS 'percent incomplete',uniqueCount(id) AS 'jobs' WHERE isNavigationRoot IS true AND location NOT LIKE 'AWS_%' FACET monitorName,monitorId,runtimeType LIMIT 20"
                   }
                 ]
               }
@@ -2979,8 +3081,8 @@ The following Private Minion dashboard example JSON can be imported to your acco
           ]
         },
         {
-          "name": "Performance Analysis",
-          "description": "Assess how the minion is performing given the current job demand. Should we scale up by adding more heavy workers and a bigger VM,or should we scale out by adding more VMs?",
+          "name": "CPM Performance Analysis",
+          "description": null,
           "widgets": [
             {
               "title": "",
@@ -3006,7 +3108,9 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "width": 4,
                 "height": 3
               },
-              "linkedEntityGuids": null,
+              "linkedEntityGuids": [
+                "MzI1NjA5M3xWSVp8REFTSEJPQVJEfDU3MjU1Mjk"
+              ],
               "visualization": {
                 "id": "viz.table"
               },
@@ -3026,7 +3130,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
               }
             },
             {
-              "title": "number of minions (1 per host)",
+              "title": "number of minions (1 per host or node)",
               "layout": {
                 "column": 9,
                 "row": 1,
@@ -3098,7 +3202,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT rate(uniqueCount(id), 1 minute) AS 'jobs per minute' WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' FACET locationLabel SINCE 2 days ago"
+                    "query": "FROM SyntheticCheck SELECT rate(uniqueCount(id), 1 minute) AS 'jobs per minute' WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' FACET locationLabel SINCE 1 hour ago"
                   }
                 ],
                 "platformOptions": {
@@ -3125,7 +3229,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'avg success duration (s)' WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' AND result = 'SUCCESS' FACET locationLabel SINCE 2 days ago"
+                    "query": "FROM SyntheticCheck SELECT average(duration) AS 'avg success duration' WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' AND result = 'SUCCESS' FACET locationLabel SINCE 1 hour ago"
                   }
                 ],
                 "platformOptions": {
@@ -3134,7 +3238,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
               }
             },
             {
-              "title": "non-ping avg timeout duration",
+              "title": "non-ping avg failure duration",
               "layout": {
                 "column": 1,
                 "row": 7,
@@ -3152,7 +3256,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT average(nr.internalQueueDuration+nr.executionDuration)/1e3 AS 'error duration (s)' WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' AND result = 'FAILED' FACET cases(WHERE error NOT LIKE '%timeout%' AS 'other error duration (s), just FYI', WHERE error LIKE '%timeout%' AS 'avg timeout duration (s)')"
+                    "query": "FROM SyntheticCheck SELECT average(duration) AS 'failure duration' WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' AND result = 'FAILED' FACET locationLabel SINCE 1 hour ago"
                   }
                 ],
                 "platformOptions": {
@@ -3161,7 +3265,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
               }
             },
             {
-              "title": "non-ping job timeout rate",
+              "title": "non-ping job failure rate",
               "layout": {
                 "column": 5,
                 "row": 7,
@@ -3180,7 +3284,254 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticCheck SELECT percentage(count(*), WHERE error LIKE '%timeout%' OR error LIKE '%timed-out%') WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' FACET locationLabel SINCE 2 days ago"
+                    "query": "FROM SyntheticCheck SELECT percentage(count(*), WHERE result = 'FAILED') WHERE type != 'SIMPLE' AND location NOT LIKE 'AWS_%' FACET locationLabel SINCE 1 hour ago"
+                  }
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "SJM Performance Analysis",
+          "description": null,
+          "widgets": [
+            {
+              "title": "",
+              "layout": {
+                "column": 1,
+                "row": 1,
+                "width": 4,
+                "height": 3
+              },
+              "linkedEntityGuids": null,
+              "visualization": {
+                "id": "viz.markdown"
+              },
+              "rawConfiguration": {
+                "text": "See [this Google sheet](https://docs.google.com/spreadsheets/d/1Se-xAuZd8TJitNMNviiEUHTG08rKDc0O4Hkl63DgDvE/edit?usp=sharing) to assist in calculating values for Parallelism and Completions on node-api-runtime and node-browser-runtime pods.\n\nFor more info:  \nhttps://discuss.newrelic.com/t/relic-solution-scaling-and-rightsizing-for-the-cpm/123999"
+              }
+            },
+            {
+              "title": "minionIds and cpu cores",
+              "layout": {
+                "column": 5,
+                "row": 1,
+                "width": 4,
+                "height": 3
+              },
+              "linkedEntityGuids": [
+                "MzI1NjA5M3xWSVp8REFTSEJPQVJEfDU3MjU1Mzc"
+              ],
+              "visualization": {
+                "id": "viz.table"
+              },
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 0,
+                    "query": "FROM SyntheticsPrivateMinion SELECT latest(minionProcessors),latest(timestamp) FACET minionId,minionLocation WHERE minionLocation NOT LIKE 'AWS_%' SINCE 5 minutes ago"
+                  }
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                }
+              }
+            },
+            {
+              "title": "number of job managers (1 per host or node)",
+              "layout": {
+                "column": 9,
+                "row": 1,
+                "width": 4,
+                "height": 3
+              },
+              "linkedEntityGuids": null,
+              "visualization": {
+                "id": "viz.billboard"
+              },
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 0,
+                    "query": "FROM SyntheticsPrivateMinion SELECT uniqueCount(minionId) AS 'number of job managers' FACET minionLocation WHERE minionLocation NOT LIKE 'AWS_%' SINCE 5 minutes ago"
+                  }
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                }
+              }
+            },
+            {
+              "title": "jobs per minute",
+              "layout": {
+                "column": 1,
+                "row": 4,
+                "width": 4,
+                "height": 3
+              },
+              "linkedEntityGuids": null,
+              "visualization": {
+                "id": "viz.billboard"
+              },
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 0,
+                    "query": "FROM SyntheticCheck SELECT rate(uniqueCount(id), 1 minute) WHERE runtimeType IS NOT NULL AND location NOT LIKE 'AWS_%' FACET runtimeType SINCE 1 hour ago"
+                  }
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                }
+              }
+            },
+            {
+              "title": "queue growth per minute",
+              "layout": {
+                "column": 5,
+                "row": 4,
+                "width": 4,
+                "height": 3
+              },
+              "linkedEntityGuids": null,
+              "visualization": {
+                "id": "viz.line"
+              },
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "legend": {
+                  "enabled": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 0,
+                    "query": "FROM SyntheticsPrivateLocationStatus SELECT clamp_min(derivative(checksPending,1 minute),0) FACET name TIMESERIES 3 hours SLIDE BY 1 hour SINCE 1 week ago"
+                  }
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
+                "yAxisLeft": {
+                  "zero": true
+                }
+              }
+            },
+            {
+              "title": "avg success duration",
+              "layout": {
+                "column": 9,
+                "row": 4,
+                "width": 4,
+                "height": 3
+              },
+              "linkedEntityGuids": null,
+              "visualization": {
+                "id": "viz.billboard"
+              },
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 0,
+                    "query": "FROM SyntheticCheck SELECT average(duration) WHERE runtimeType IS NOT NULL AND location NOT LIKE 'AWS_%' AND result = 'SUCCESS' FACET runtimeType SINCE 1 hour ago"
+                  }
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                }
+              }
+            },
+            {
+              "title": "avg failure duration",
+              "layout": {
+                "column": 1,
+                "row": 7,
+                "width": 4,
+                "height": 3
+              },
+              "linkedEntityGuids": null,
+              "visualization": {
+                "id": "viz.billboard"
+              },
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": true
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 0,
+                    "query": "FROM SyntheticCheck SELECT average(duration) WHERE runtimeType AND location NOT LIKE 'AWS_%' AND result = 'FAILED' FACET runtimeType SINCE 1 hour ago"
+                  }
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                }
+              }
+            },
+            {
+              "title": "job failure rate",
+              "layout": {
+                "column": 5,
+                "row": 7,
+                "width": 4,
+                "height": 3
+              },
+              "linkedEntityGuids": null,
+              "visualization": {
+                "id": "viz.billboard"
+              },
+              "rawConfiguration": {
+                "dataFormatters": [],
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 0,
+                    "query": "FROM SyntheticCheck SELECT percentage(count(*), WHERE result = 'FAILED') WHERE runtimeType IS NOT NULL AND location NOT LIKE 'AWS_%' FACET runtimeType SINCE 1 hour ago"
+                  }
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                }
+              }
+            },
+            {
+              "title": "number of monitors",
+              "layout": {
+                "column": 9,
+                "row": 7,
+                "width": 4,
+                "height": 3
+              },
+              "linkedEntityGuids": null,
+              "visualization": {
+                "id": "viz.billboard"
+              },
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 0,
+                    "query": "FROM SyntheticCheck SELECT uniqueCount(monitorId) WHERE runtimeType IS NOT NULL AND location NOT LIKE 'AWS_%' FACET runtimeType SINCE 2 days ago"
                   }
                 ],
                 "platformOptions": {


### PR DESCRIPTION
- add charts for the new Synthetics Job Manager (SJM)
- add link to new performance analysis spreadsheet for SJM
- change `nr.internalQueueDuration+nr.executionDuration` to `duration` to more closely match results in Synthetics UI.