### PR TITLE
Correct command to check for environment variables

### DIFF
--- a/src/content/docs/apm/agents/net-agent/troubleshooting/debugging-net-core-agent-linux.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/debugging-net-core-agent-linux.mdx
@@ -56,7 +56,7 @@ Based on the output, here's what you need to do:
 Execute the following, replacing `PID` with your process ID.
 
 ```
-args --null --max-args=1 < /proc/<var>PID</var>/environ | grep "CORECLR_"
+xargs --null --max-args=1 < /proc/<var>PID</var>/environ | grep "CORECLR_"
 ```
 
 Based on the output, here's what you need to do:


### PR DESCRIPTION
Command should be:

xargs --null --max-args=1 < /proc/<var>PID</var>/environ | grep "CORECLR_"

per our post here: https://discuss.newrelic.com/t/relic-solution-net-core-agent-installation-troubleshooting-in-linux/69965

When running just args, I get a command not found message. The command works when using xargs.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.