### PR TITLE
docs: update instructions

### DIFF
--- a/src/content/docs/errors-inbox/error-external-services.mdx
+++ b/src/content/docs/errors-inbox/error-external-services.mdx
@@ -18,7 +18,7 @@ To connect an inbox to Slack either follow the steps below or follow along with 
 <Video id="HEbX0dgeGGw" type="youtube" />
 
 1. If your Slack workspace does not have the [New Relic app](https://newrelic.slack.com/apps/AP92KQJS3-new-relic?tab=more_info) installed, do that first.
-2. Open one of your New Relic error inboxes, select the **Inbox Settings** icon (looks like a gear) in the top right corner.
+2. Open one of your New Relic error inboxes, select the **Notification Settings** icon (looks like a bell) in the top right corner.
 3. Toggle the Slack button to **on** if it is **off**.
 4. If no workspaces are available, click the <Icon name="fe-plus" /> plus button to enable Slack with a one click Slack authentication.
 5. Once authenticated, you will be able to select a Workspace and specific Channel to send notifications to.


### PR DESCRIPTION
Step two said:
> Open one of your New Relic error inboxes, select the Inbox Settings icon (looks like a gear) in the top right corner.

I assume these are just out of date, currently (as the video shows too) this is **Notification Settings** with a bell icon, not a gear

<img width="320" alt="image (12)" src="https://user-images.githubusercontent.com/48165493/190699276-aaf8cd02-8939-4294-89dd-e4fc8ef8bf86.png">
