### PR TITLE
Change units from GiB to GB

### DIFF
--- a/src/data-dictionary/events/NrConsumption/GigabytesIngested.md
+++ b/src/data-dictionary/events/NrConsumption/GigabytesIngested.md
@@ -1,7 +1,7 @@
 ---
 name: GigabytesIngested
 type: attribute
-units: gibibyte (Gib)
+units: gigabyte (GB)
 events:
   - NrConsumption
   - NrMTDConsumption


### PR DESCRIPTION
Change units for GigabytesIngested from GiB to GB

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

This PR changes units for GigabytesIngested from GiB to GB.  This is important because NrUsage and NrConsumption metrics in New Relic are tracked via GBs, not GiBs.  There is a difference in GBs and GiBs: https://en.wikipedia.org/wiki/Gigabyte