### PR TITLE
Change Ruby's link to distributed tracing to point to setup

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/introduction-new-relic-ruby.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/introduction-new-relic-ruby.mdx
@@ -32,7 +32,7 @@ The Ruby agent supports many of the most common [Ruby frameworks and platforms](
 * Monitor your app's [Apdex (user satisfaction)](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction).
 * Get a [high-level summary of your app](/docs/apm/applications-menu/monitoring/apm-overview-page).
 * Create [architectural maps](/docs/data-analysis/user-interface-functions/view-your-data/service-maps-visualize-monitor-apps-entire-architecture) of your app.
-* Enable [distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing) to understand activity in an environment that relies on many services.
+* Enable [distributed tracing](/docs/distributed-tracing/concepts/quick-start) to understand activity in an environment that relies on many services.
 * Install [New Relic Infrastructure](/docs/infrastructure) and view detailed host data for your app.
 
 **Find errors and problems quickly**

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/introduction-new-relic-ruby.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/introduction-new-relic-ruby.mdx
@@ -32,7 +32,7 @@ The Ruby agent supports many of the most common [Ruby frameworks and platforms](
 * Monitor your app's [Apdex (user satisfaction)](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction).
 * Get a [high-level summary of your app](/docs/apm/applications-menu/monitoring/apm-overview-page).
 * Create [architectural maps](/docs/data-analysis/user-interface-functions/view-your-data/service-maps-visualize-monitor-apps-entire-architecture) of your app.
-* Enable [distributed tracing](/docs/distributed-tracing/concepts/quick-start) to understand activity in an environment that relies on many services.
+* Enable [distributed tracing](/docs/apm/agents/ruby-agent/configuration/distributed-tracing-ruby-agent) to understand activity in an environment that relies on many services.
 * Install [New Relic Infrastructure](/docs/infrastructure) and view detailed host data for your app.
 
 **Find errors and problems quickly**

--- a/src/content/docs/distributed-tracing/concepts/introduction-distributed-tracing.mdx
+++ b/src/content/docs/distributed-tracing/concepts/introduction-distributed-tracing.mdx
@@ -28,7 +28,6 @@ redirects:
   - /docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing
   - /docs/distributed-tracing/get-started/introduction-distributed-tracing
   - /docs/distributed-tracing
-  - /docs/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing
 ---
 
 import introDt from 'images/intro-DT.png'


### PR DESCRIPTION
I changed the link in Ruby so it points to the distributed tracing setup page within the Ruby docs. Ruby users don't need to go to the general distributed tracing page (unless they click that link in the new DT instructions within Ruby). Also, I removed a duplicate redirect that was in the introduction to distributed tracing. That redirect was already over in the general distributed tracing setup page.