### PR TITLE
fix 8.0.0 changelog link on Ruby agent update page

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/installation/update-ruby-agent.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/installation/update-ruby-agent.mdx
@@ -66,7 +66,7 @@ To update the Ruby agent:
       </td>
 
       <td>
-        Release notes: [Ruby agent 8.0.0](docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-800)
+        Release notes: [Ruby agent 8.0.0](/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-800)
 
         Please see our [Ruby Agent 7.x to 8.x migration guide](/docs/apm/agents/ruby-agent/getting-started/migration-8x-guide/) for helpful strategies and tips for migrating from earlier versions of the Ruby agent to 8.0.0. We cover new configuration defaults, changes to the `add_method_tracer` API and deprecated items and their replacements in this guide.
 


### PR DESCRIPTION
Fix the v8.0.0 changelog link (by adding a leading slash to convert the relative link into an absolute one) on the Ruby agent update instructions page.