### PR TITLE
Unsupported mysql TLS bellow 1.2 in nri-mysql

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/microsoft-sql/microsoft-sql-server-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/microsoft-sql/microsoft-sql-server-integration.mdx
@@ -33,6 +33,10 @@ To install the Microsoft SQL Server integration, you must run through the follow
 
 Our integration is compatible with Microsoft SQL Server 2008 R2 SP3 or higher.
 
+### TLS Support [#supported-tls]
+
+We require TLS authentication to be a minimum version of TLS 1.2.
+
 ### Supported operating systems [#supported-os]
 
 - Windows <img style={{ width: '32px', height: '32px'}} class="inline" title="Windows" alt="Windows" src={windows}/>
@@ -55,7 +59,7 @@ To install the Microsoft SQL Server integration:
   - [32-bit Windows](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-mssql/386/nri-mssql-386.msi)
   - [64-bit Windows](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-mssql/nri-mssql-amd64.msi)
 2. In an administrator account, run the install script using an absolute path. Use the corresponding example for your environment:
-  
+
   <CollapserGroup>
     <Collapser
       id="32-bit-path"
@@ -171,7 +175,7 @@ Create a new login and to grant `CONNECT` and `VIEW SERVER STATE` permissions by
         CLOSE db_cursor
         DEALLOCATE db_cursor
     ```
-    
+
   </Collapser>
 </CollapserGroup>
 
@@ -422,7 +426,7 @@ The configuration file has common settings applicable to all integrations like `
         # Example for stored procedure 'exec dbo.sp_server_info @attribute_id = 2'
       - query: dbo.sp_server_info @attribute_id = 2
     ```
-    
+
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mySQL/mysql-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mySQL/mysql-integration.mdx
@@ -45,6 +45,10 @@ Our integration is compatible with MySQL version 5.6 or higher.
   For MySQL v8.0 and higher we do not support the following metrics: `db.qCacheFreeMemoryBytes`, `db.qCacheHitRatio`, and `db.qCacheNotCachedPerSecond`.
 </Callout>
 
+### TLS Support [#supported-tls]
+
+We require TLS authentication to be a minimum version of TLS 1.2.
+
 ### Supported operating systems [#supported-os]
 
 * Windows <img style={{ width: '32px', height: '32px'}} class="inline" title="Windows" alt="Windows" src={windows}/>


### PR DESCRIPTION
- Adds TLS Support section to nri-mysql integration docs to clarify that since version 2.8.2 TLS under 1.2 is unsupported.