### PR TITLE
docs: +lang identifiers

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -455,6 +455,7 @@ module.exports = {
             'mustache',
             'powershell',
             'promql',
+            'properties',
             'protobuf',
             'puppet',
             'jsx',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -442,6 +442,7 @@ module.exports = {
             'elixir',
             'erlang',
             'gettext',
+            'ini',
             'pascal',
             'parser',
             'nginx',

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -52,7 +52,7 @@ If you are unsure which file to edit:
 * From the command line, review the output of `php -i`.
 * In a browser, review the output of a page containing the script:
 
-  ```
+  ```php
   <?php phpinfo(); ?>
   ```
 * If the `newrelic.ini` file appears, use it.
@@ -695,7 +695,7 @@ These settings are available in the `newrelic.ini` file.
 
     **Example tags**
 
-    ```
+    ```ini
     "Server:One;Data Center:Primary"
     ```
   </Collapser>
@@ -1488,7 +1488,7 @@ Changing these settings in your local agent configuration file (`newrelic.ini`) 
 
 An example configuration that enabled logs in context with logging metrics and agent log forwarding would be:
 
-```
+```ini
 newrelic.application_logging.enabled = true
 newrelic.application_logging.metrics.enabled = true
 newrelic.application_logging.forwarding.enabled = true
@@ -1636,7 +1636,7 @@ If you're using a [supported logging framework](/docs/logs/logs-context/configur
           </th>
 
           <td>
-            10000
+            `10000`
           </td>
         </tr>
 
@@ -1646,7 +1646,7 @@ If you're using a [supported logging framework](/docs/logs/logs-context/configur
           </th>
 
           <td>
-            20000
+            `20000`
           </td>
         </tr>        
       </tbody>
@@ -1711,14 +1711,14 @@ If you're using a [supported logging framework](/docs/logs/logs-context/configur
 
 It is possible to control the log level of messages forwarded by the agent.  The log levels recognized follow the [PSR-3](https://www.php-fig.org/psr/psr-3/) specification and are as follows (from highest to lowest severity):
 
-* EMERGENCY
-* ALERT
-* CRITICAL
-* ERROR
-* WARNING
-* NOTICE
-* INFO
-* DEBUG
+* `EMERGENCY`
+* `ALERT`
+* `CRITICAL`
+* `ERROR`
+* `WARNING`
+* `NOTICE`
+* `INFO`
+* `DEBUG`
 
 When a log level is specifed for the agent then all messages of this log level or of higher severity will be reported.
 
@@ -2460,7 +2460,7 @@ The values of these settings are used to control various tracer features.
 
     Enable or disable [distributed tracing](/docs/apm/agents/php-agent/configuration/distributed-tracing-php-agent). It is turned on by default in PHP agents 9.21.0 and higher. When the agent's transaction tracer and distributed tracing features are enabled, the agent will insert headers into outbound requests, and scan incoming requests for distributed tracing headers.
 
-    ```
+    ```ini
     newrelic.transaction_tracer.enabled = true
     newrelic.distributed_tracing_enabled = true
     ```
@@ -3336,7 +3336,7 @@ This section lists the settings that affect attribute collection and reporting.
           </th>
 
           <td>
-            True, except for browser_monitoring.attributes.enabled
+            `true`, except for `browser_monitoring.attributes.enabled`
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
I'm not sure if we recognize `.ini` file types in markdown, but I added them just in case

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.