### PR TITLE
Chore(Go Agent): update EOL table for agent versions

### DIFF
--- a/src/content/docs/apm/agents/go-agent/get-started/go-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/go-agent/get-started/go-agent-eol-policy.mdx
@@ -29,6 +29,20 @@ Any versions not listed in the following table are no longer supported. Please [
     <tbody>
     <tr>
       <td>
+        v3.19.2
+      </td>
+
+      <td>
+        Sept 21, 2022
+      </td>
+
+      <td>
+        Sept 21, 2023
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         v3.19.1
       </td>
 
@@ -253,76 +267,6 @@ Any versions not listed in the following table are no longer supported. Please [
     
     <tr>
       <td>
-        v3.9.0
-      </td>
-
-      <td>
-        Sep 3, 2020
-      </td>
-
-      <td>
-        Sep 3, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v3.8.1
-      </td>
-
-      <td>
-        Jul 15, 2020
-      </td>
-
-      <td>
-        Jul 15, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v3.8.0
-      </td>
-
-      <td>
-        Jul 1, 2020
-      </td>
-
-      <td>
-        Jul 1, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v3.7.0
-      </td>
-
-      <td>
-        Jun 18, 2020
-      </td>
-
-      <td>
-        Jun 18, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v3.6.0
-      </td>
-
-      <td>
-        Jun 9, 2020
-      </td>
-
-      <td>
-        Jun 9, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
         v3.5.0
       </td>
 
@@ -514,34 +458,6 @@ Any versions not listed in the following table are no longer supported. Please [
 
       <td>
         Sep 23, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v2.12.0
-      </td>
-
-      <td>
-        Sep 17, 2019
-      </td>
-
-      <td>
-        Sep 17, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v2.11.0
-      </td>
-
-      <td>
-        Aug 22, 2019
-      </td>
-
-      <td>
-        Aug 22, 2022
       </td>
     </tr>
     


### PR DESCRIPTION
Removes versions no longer supported, adds new 3.19.2 version