### PR TITLE
fix: Remove upgrade to Java 11 from 3.0.66 Notes

### DIFF
--- a/src/content/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3066.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3066.mdx
@@ -6,6 +6,5 @@ version: 3.0.66
 
 ### Fixes
 
-* Upgraded to Java 11
 * Added Private Minion network cleanup to address NEWRELIC-2759
 * Updated the version of thrift to address minion runner 2.0.0 build errors


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Need to remove this from the release notes as we had to revert that change.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.