### PR TITLE
Update compatibility requirements for Python Agent

### DIFF
--- a/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
@@ -50,14 +50,15 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
       </td>
 
       <td>
-        Python (CPython/PyPy) versions supported: 2.7, 3.6, 3.7, 3.8, 3.9, and 3.10.
+        Python (CPython/PyPy) versions supported: 2.7, 3.7, 3.8, 3.9, and 3.10.
 
-        **Recommendation:** Use Python version 3.6 or higher with our agent.
+        **Recommendation:** Use Python version 3.7 or higher with our agent.
 
         * Python versions 2.6 and 3.3 are supported only by Python agent versions 3.4.0.95 or lower.
         * Python version 3.4 is supported only by Python agent versions 4.20.0.120 or lower.
         * Python version 3.5 is supported only by Python agent versions 5.24.0.153 or lower.
-        * Python versions 2.7 and 3.6 follow our [end of life (EOL) support](#version) requirements.
+        * Python version 3.6 is supported only by Python agent versions 7.16.0.178 or lower.
+        * For Python version 2.7 follow our [end of life (EOL) support](#version) requirements.
       </td>
     </tr>
 
@@ -224,7 +225,7 @@ The following are proposed time ranges. The actual release date may vary.
       </td>
 
       <td>
-        Python agent versions released after March 2022 will not support Python 3.6. For more information, see our [Python agent release notes](/docs/release-notes/agent-release-notes/python-release-notes).
+        Python agent versions released after August 2022 will not support Python 3.6. For more information, see our [Python agent release notes](/docs/release-notes/agent-release-notes/python-release-notes).
       </td>
     </tr>
 


### PR DESCRIPTION
This PR updates the Compatibility Requirements page for the Python Agent to reflect the deprecation of Python 3.6.