### PR TITLE
Update docs to reflect Python Agent's deprecation of Python 3.6

### DIFF
--- a/src/content/docs/apm/agents/python-agent/installation/install-python-agent-docker.mdx
+++ b/src/content/docs/apm/agents/python-agent/installation/install-python-agent-docker.mdx
@@ -18,7 +18,7 @@ This Dockerfile provides a base for your Python Docker image by installing the P
 1. To get started, copy the code block below and save it as a new Dockerfile in your directory.
 
    ```
-   FROM python:3.6-alpine
+   FROM python:3.7-alpine
 
    RUN pip install --no-cache-dir newrelic
 

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/datastoretrace-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/datastoretrace-python-agent-api.mdx
@@ -23,7 +23,7 @@ Used to instrument calls to datastores.
 
 ## Description
 
-`datastore_trace` is used to add more detail to your [transaction traces](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) in the form of additional segments. Any calls reported with `datastore_trace` will appear on the [APM Databases page](/docs/apm/applications-menu/monitoring/databases-slow-queries-page). `datastore_trace` returns a [partial](https://docs.python.org/3.6/library/functools.html#functools.partial) of `DatastoreTraceWrapper` that can be used as a decorator for a function to time calls to your datastore.
+`datastore_trace` is used to add more detail to your [transaction traces](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) in the form of additional segments. Any calls reported with `datastore_trace` will appear on the [APM Databases page](/docs/apm/applications-menu/monitoring/databases-slow-queries-page). `datastore_trace` returns a [partial](https://docs.python.org/3.7/library/functools.html#functools.partial) of `DatastoreTraceWrapper` that can be used as a decorator for a function to time calls to your datastore.
 
 The `datastore_trace` decorator can be used on generators and coroutines with agent version 2.102.0.85 or higher. Timing of these objects begins when consumption starts, and ends when the object is exhausted or goes out of scope. This is a change from earlier versions where the metric represented the time taken to create the generator or coroutine object itself.
 

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/externaltrace-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/externaltrace-python-agent-api.mdx
@@ -22,7 +22,7 @@ Report calls to external services as transaction trace segments.
 
 ## Description
 
-`external_trace` is used to add more detail to your [transaction traces](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) in the form of additional segments. Any calls reported with `external_trace` will appear on the externals tab in APM. `external_trace` returns a [partial](https://docs.python.org/3.6/library/functools.html#functools.partial) of `ExternalTraceWrapper` that can be used as a decorator for a function that calls an external service.
+`external_trace` is used to add more detail to your [transaction traces](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) in the form of additional segments. Any calls reported with `external_trace` will appear on the externals tab in APM. `external_trace` returns a [partial](https://docs.python.org/3.7/library/functools.html#functools.partial) of `ExternalTraceWrapper` that can be used as a decorator for a function that calls an external service.
 
 The `external_trace` decorator can be used on generators and coroutines with agent version 2.102.0.85 or higher. Timing of these objects begins when consumption starts, and ends when the object is exhausted or goes out of scope. This is a change from earlier versions where the metric represented the time taken to create the generator or coroutine object itself.
 

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/messagetrace-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/messagetrace-python-agent-api.mdx
@@ -30,7 +30,7 @@ Agent version 2.88.0.72 or higher.
 
 ## Description
 
-[`message_transaction`](/docs/agents/python-agent/python-agent-api/message_transaction) (and its associated calls) report message functions as [transactions](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction). `message_trace` is used to add more detail to your [transaction traces](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) in the form of additional segments. `message_trace` returns a [partial](https://docs.python.org/3.6/library/functools.html#functools.partial) of `MessageTraceWrapper` that can be used as a decorator for a message function.
+[`message_transaction`](/docs/agents/python-agent/python-agent-api/message_transaction) (and its associated calls) report message functions as [transactions](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction). `message_trace` is used to add more detail to your [transaction traces](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) in the form of additional segments. `message_trace` returns a [partial](https://docs.python.org/3.7/library/functools.html#functools.partial) of `MessageTraceWrapper` that can be used as a decorator for a message function.
 
 The `message_trace` decorator can be used on generators and coroutines with agent version 2.102.0.85 or higher. Timing of these objects begins when consumption starts, and ends when the object is exhausted or goes out of scope. This is a change from earlier versions where the metric represented the time taken to create the generator or coroutine object itself.
 

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/messagetransaction-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/messagetransaction-python-agent-api.mdx
@@ -30,7 +30,7 @@ Agent version 2.88.0.72 or higher.
 
 ## Description
 
-This decorator returns a [partial](https://docs.python.org/3.6/library/functools.html#functools.partial) of `MessageTransactionWrapper` that can be used as a decorator for a messaging function. When used, the returned decorator records a message transaction and its message-related [attributes](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute).
+This decorator returns a [partial](https://docs.python.org/3.7/library/functools.html#functools.partial) of `MessageTransactionWrapper` that can be used as a decorator for a messaging function. When used, the returned decorator records a message transaction and its message-related [attributes](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute).
 
 If the decorator will not work in your application, you can use one of the following:
 

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/profiletrace-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/profiletrace-python-agent-api.mdx
@@ -23,7 +23,7 @@ Adds additional attributes to function trace names.
 
 ## Description
 
-`profile_trace` is used to add more detail to your [transaction traces](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) in the form of additional segments. Any calls reported with `profile_trace` will appear on the [APM Databases page](/docs/apm/applications-menu/monitoring/databases-slow-queries-page). `profile_trace` returns a [partial](https://docs.python.org/3.6/library/functools.html#functools.partial) of `ProfileTraceWrapper` that can be used as a decorator for a function to time calls to your profiler.
+`profile_trace` is used to add more detail to your [transaction traces](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) in the form of additional segments. Any calls reported with `profile_trace` will appear on the [APM Databases page](/docs/apm/applications-menu/monitoring/databases-slow-queries-page). `profile_trace` returns a [partial](https://docs.python.org/3.7/library/functools.html#functools.partial) of `ProfileTraceWrapper` that can be used as a decorator for a function to time calls to your profiler.
 
 If you cannot use the decorator in your application, you can use the following call format: The wrapper form is `ProfileTraceWrapper`. It can be used to return a wrapped function without the use of a decorator.
 

--- a/src/content/whats-new/2022/07/whats-new-07-15-July-2022-EOL-announcements.md
+++ b/src/content/whats-new/2022/07/whats-new-07-15-July-2022-EOL-announcements.md
@@ -7,7 +7,7 @@ learnMoreLink: 'https://discuss.newrelic.com/t/july-2022-end-of-life-announcemen
 
 This quarter we are discontinuing capabilities and features across the following products. If you have questions or concerns, please comment on [this Explorers Hub post](https://discuss.newrelic.com/t/july-2022-end-of-life-announcements/188318), or reach out to your account management team.
 
-**Support ending July 2022**
+**Support ending August 2022**
 
 **Python agent 3.6
 *PHP agent (certain versions, frameworks, platforms)*

--- a/src/i18n/content/jp/docs/apm/agents/python-agent/installation/install-python-agent-docker.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/python-agent/installation/install-python-agent-docker.mdx
@@ -16,7 +16,7 @@ Pythonエージェントを使って、Dockerコンテナにデプロイされ�
 1. はじめに、以下のコードブロックをコピーして、あなたのディレクトリに新しいDockerfileとして保存してください。
 
    ```
-   FROM python:3.6-alpine
+   FROM python:3.7-alpine
 
    RUN pip install --no-cache-dir newrelic
 

--- a/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/datastoretrace-python-agent-api.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/datastoretrace-python-agent-api.mdx
@@ -20,7 +20,7 @@ newrelic.agent.datastore_trace(product, target, operation)
 
 ## 説明
 
-`datastore_trace` は、 [トランザクショントレース](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) に、追加セグメントの形で詳細を追加するために使用されます。 `datastore_trace` で報告されたすべてのコールは、 [APM Databases ページ](/docs/apm/applications-menu/monitoring/databases-slow-queries-page) に表示されます。 `datastore_trace` は、 `DatastoreTraceWrapper` の [部分的な](https://docs.python.org/3.6/library/functools.html#functools.partial) を返します。これは、あなたのデータストアへのコールを計時する関数のデコレーターとして使用できます。
+`datastore_trace` は、 [トランザクショントレース](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) に、追加セグメントの形で詳細を追加するために使用されます。 `datastore_trace` で報告されたすべてのコールは、 [APM Databases ページ](/docs/apm/applications-menu/monitoring/databases-slow-queries-page) に表示されます。 `datastore_trace` は、 `DatastoreTraceWrapper` の [部分的な](https://docs.python.org/3.7/library/functools.html#functools.partial) を返します。これは、あなたのデータストアへのコールを計時する関数のデコレーターとして使用できます。
 
 `datastore_trace` デコレータは、エージェントのバージョン 2.102.0.85 以降のジェネレータおよびコルーチンで使用できます。これらのオブジェクトのタイミングは、消費が開始されたときに始まり、オブジェクトが使い果たされたときやスコープ外になったときに終了します。これは、以前のバージョンでは、ジェネレータまたはコルーチンオブジェクト自体の作成にかかった時間を表す指標だったのが、変更されたものです。
 

--- a/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/externaltrace-python-agent-api.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/externaltrace-python-agent-api.mdx
@@ -20,7 +20,7 @@ newrelic.agent.external_trace(library, url, method=None)
 
 ## 説明
 
-`external_trace` は、追加セグメントの形で [トランザクショントレース](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) に詳細を追加するために使用されます。 `external_trace` で報告されたすべてのコールは、APM の「externals」タブに表示されます。 `external_trace` は、外部サービスを呼び出す関数のデコレーターとして使用できる `ExternalTraceWrapper` の [部分的な](https://docs.python.org/3.6/library/functools.html#functools.partial) を返します。
+`external_trace` は、追加セグメントの形で [トランザクショントレース](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) に詳細を追加するために使用されます。 `external_trace` で報告されたすべてのコールは、APM の「externals」タブに表示されます。 `external_trace` は、外部サービスを呼び出す関数のデコレーターとして使用できる `ExternalTraceWrapper` の [部分的な](https://docs.python.org/3.7/library/functools.html#functools.partial) を返します。
 
 `external_trace` デコレータは、エージェントバージョン 2.102.0.85 以降のジェネレータおよびコルーチンで使用できます。これらのオブジェクトのタイミングは、消費が開始されたときに始まり、オブジェクトが使い果たされたときやスコープ外に出たときに終了します。これは、以前のバージョンでは、ジェネレータまたはコルーチンオブジェクト自体の作成にかかった時間を表す指標だったのが、変更されたものです。
 

--- a/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/messagetransaction-python-agent-api.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/messagetransaction-python-agent-api.mdx
@@ -24,7 +24,7 @@ newrelic.agent.message_transaction(library, destination_type, destination_name, 
 
 ## 説明
 
-このデコレーターは、メッセージング機能のデコレーターとして使用できる `MessageTransactionWrapper` の [部分的な](https://docs.python.org/3.6/library/functools.html#functools.partial) を返します。使用されると、返されたデコレーターは、メッセージ・トランザクションとそのメッセージ関連の [属性を記録します](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) 。
+このデコレーターは、メッセージング機能のデコレーターとして使用できる `MessageTransactionWrapper` の [部分的な](https://docs.python.org/3.7/library/functools.html#functools.partial) を返します。使用されると、返されたデコレーターは、メッセージ・トランザクションとそのメッセージ関連の [属性を記録します](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) 。
 
 デコレーターがアプリケーションで動作しない場合は、以下のいずれかを使用することができます。
 

--- a/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/profiletrace-python-agent-api.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/profiletrace-python-agent-api.mdx
@@ -20,7 +20,7 @@ newrelic.agent.profile_trace(name=None, group=None, label=None, params=None, dep
 
 ## 説明
 
-`profile_trace` は、追加セグメントの形で [トランザクショントレース](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) に詳細を追加するために使用されます。 `profile_trace` で報告されたすべてのコールは、 [APM Databases ページ](/docs/apm/applications-menu/monitoring/databases-slow-queries-page) に表示されます。 `profile_trace` は、 `ProfileTraceWrapper` の [部分的な](https://docs.python.org/3.6/library/functools.html#functools.partial) を返します。これは、プロファイラーへのコールの時間を計る関数のデコレーターとして使用できます。
+`profile_trace` は、追加セグメントの形で [トランザクショントレース](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) に詳細を追加するために使用されます。 `profile_trace` で報告されたすべてのコールは、 [APM Databases ページ](/docs/apm/applications-menu/monitoring/databases-slow-queries-page) に表示されます。 `profile_trace` は、 `ProfileTraceWrapper` の [部分的な](https://docs.python.org/3.7/library/functools.html#functools.partial) を返します。これは、プロファイラーへのコールの時間を計る関数のデコレーターとして使用できます。
 
 アプリケーションでデコレーターを使用できない場合は、以下の呼び出し形式を使用することができます。ラッパー形式は， `ProfileTraceWrapper` ．デコレーターを使わずにラップされた関数を返すのに使えます．
 

--- a/src/i18n/content/kr/docs/apm/agents/python-agent/installation/install-python-agent-docker.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/python-agent/installation/install-python-agent-docker.mdx
@@ -16,7 +16,7 @@ Python 에이전트를 사용하여 Docker 컨테이너에 배포된 Python 애�
 1. 시작하려면 아래 코드 블록을 복사하여 디렉터리에 새 Dockerfile로 저장합니다.
 
    ```
-   FROM python:3.6-alpine
+   FROM python:3.7-alpine
 
    RUN pip install --no-cache-dir newrelic
 

--- a/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/datastoretrace-python-agent-api.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/datastoretrace-python-agent-api.mdx
@@ -20,7 +20,7 @@ newrelic.agent.datastore_trace(product, target, operation)
 
 ## 설명
 
-`datastore_trace` 추가 세그먼트의 형태로 [트랜잭션 추적](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) 에 세부 정보를 추가하는 데 사용됩니다. `datastore_trace` 으로 보고된 모든 호출은 [APM 데이터베이스 페이지](/docs/apm/applications-menu/monitoring/databases-slow-queries-page) 에 나타납니다. `datastore_trace` 은 데이터 저장소에 대한 호출 시간을 지정하는 함수의 데코레이터로 사용할 수 있는 `DatastoreTraceWrapper` 의 [일부](https://docs.python.org/3.6/library/functools.html#functools.partial) 를 반환합니다.
+`datastore_trace` 추가 세그먼트의 형태로 [트랜잭션 추적](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) 에 세부 정보를 추가하는 데 사용됩니다. `datastore_trace` 으로 보고된 모든 호출은 [APM 데이터베이스 페이지](/docs/apm/applications-menu/monitoring/databases-slow-queries-page) 에 나타납니다. `datastore_trace` 은 데이터 저장소에 대한 호출 시간을 지정하는 함수의 데코레이터로 사용할 수 있는 `DatastoreTraceWrapper` 의 [일부](https://docs.python.org/3.7/library/functools.html#functools.partial) 를 반환합니다.
 
 `datastore_trace` 데코레이터는 에이전트 버전이 2.102.0.85 이상인 생성기 및 코루틴에서 사용할 수 있습니다. 이러한 개체의 타이밍은 소비가 시작될 때 시작되고 개체가 소진되거나 범위를 벗어날 때 끝납니다. 이는 메트릭이 생성기 또는 코루틴 개체 자체를 생성하는 데 걸린 시간을 나타내는 이전 버전에서 변경된 사항입니다.
 

--- a/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/externaltrace-python-agent-api.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/externaltrace-python-agent-api.mdx
@@ -20,7 +20,7 @@ newrelic.agent.external_trace(library, url, method=None)
 
 ## 설명
 
-`external_trace` 추가 세그먼트의 형태로 [트랜잭션 추적](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) 에 세부 정보를 추가하는 데 사용됩니다. `external_trace` 으로 보고된 모든 통화는 APM의 외부 탭에 표시됩니다. `external_trace` 은 외부 서비스를 호출하는 함수의 데코레이터로 사용할 수 있는 `ExternalTraceWrapper` 의 [일부](https://docs.python.org/3.6/library/functools.html#functools.partial) 를 반환합니다.
+`external_trace` 추가 세그먼트의 형태로 [트랜잭션 추적](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) 에 세부 정보를 추가하는 데 사용됩니다. `external_trace` 으로 보고된 모든 통화는 APM의 외부 탭에 표시됩니다. `external_trace` 은 외부 서비스를 호출하는 함수의 데코레이터로 사용할 수 있는 `ExternalTraceWrapper` 의 [일부](https://docs.python.org/3.7/library/functools.html#functools.partial) 를 반환합니다.
 
 `external_trace` 데코레이터는 에이전트 버전이 2.102.0.85 이상인 생성기 및 코루틴에서 사용할 수 있습니다. 이러한 개체의 타이밍은 소비가 시작될 때 시작되고 개체가 소진되거나 범위를 벗어날 때 끝납니다. 이는 메트릭이 생성기 또는 코루틴 개체 자체를 생성하는 데 걸린 시간을 나타내는 이전 버전에서 변경된 사항입니다.
 

--- a/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/messagetrace-python-agent-api.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/messagetrace-python-agent-api.mdx
@@ -24,7 +24,7 @@ newrelic.agent.message_trace(library, operation, destination_type, destination_n
 
 ## 설명
 
-[`message_transaction`](/docs/agents/python-agent/python-agent-api/message_transaction) (및 관련 호출)은 메시지 기능을 [트랜잭션](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction) 으로 보고합니다. `message_trace` 은 추가 세그먼트 형태로 [트랜잭션 추적](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) 에 세부정보를 추가하는 데 사용됩니다. `message_trace` 는 메시지 함수의 데코레이터로 사용할 수 있는 `MessageTraceWrapper` 의 [일부](https://docs.python.org/3.6/library/functools.html#functools.partial) 를 반환합니다.
+[`message_transaction`](/docs/agents/python-agent/python-agent-api/message_transaction) (및 관련 호출)은 메시지 기능을 [트랜잭션](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction) 으로 보고합니다. `message_trace` 은 추가 세그먼트 형태로 [트랜잭션 추적](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) 에 세부정보를 추가하는 데 사용됩니다. `message_trace` 는 메시지 함수의 데코레이터로 사용할 수 있는 `MessageTraceWrapper` 의 [일부](https://docs.python.org/3.7/library/functools.html#functools.partial) 를 반환합니다.
 
 `message_trace` 데코레이터는 에이전트 버전이 2.102.0.85 이상인 생성기 및 코루틴에서 사용할 수 있습니다. 이러한 개체의 타이밍은 소비가 시작될 때 시작되고 개체가 소진되거나 범위를 벗어날 때 끝납니다. 이는 메트릭이 생성기 또는 코루틴 개체 자체를 생성하는 데 걸린 시간을 나타내는 이전 버전에서 변경된 사항입니다.
 

--- a/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/messagetransaction-python-agent-api.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/messagetransaction-python-agent-api.mdx
@@ -24,7 +24,7 @@ newrelic.agent.message_transaction(library, destination_type, destination_name, 
 
 ## 설명
 
-이 데코레이터는 메시징 기능의 데코레이터로 사용할 수 있는 `MessageTransactionWrapper` 의 [일부](https://docs.python.org/3.6/library/functools.html#functools.partial) 를 반환합니다. 사용되는 경우 반환된 데코레이터는 메시지 트랜잭션 및 해당 메시지 관련 [속성](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) 을 기록합니다.
+이 데코레이터는 메시징 기능의 데코레이터로 사용할 수 있는 `MessageTransactionWrapper` 의 [일부](https://docs.python.org/3.7/library/functools.html#functools.partial) 를 반환합니다. 사용되는 경우 반환된 데코레이터는 메시지 트랜잭션 및 해당 메시지 관련 [속성](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) 을 기록합니다.
 
 데코레이터가 애플리케이션에서 작동하지 않으면 다음 중 하나를 사용할 수 있습니다.
 

--- a/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/profiletrace-python-agent-api.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/profiletrace-python-agent-api.mdx
@@ -20,7 +20,7 @@ newrelic.agent.profile_trace(name=None, group=None, label=None, params=None, dep
 
 ## 설명
 
-`profile_trace` 추가 세그먼트의 형태로 [트랜잭션 추적](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) 에 세부 정보를 추가하는 데 사용됩니다. `profile_trace` 으로 보고된 모든 호출은 [APM 데이터베이스 페이지](/docs/apm/applications-menu/monitoring/databases-slow-queries-page) 에 나타납니다. `profile_trace` 은 프로파일러에 대한 호출 시간을 지정하는 함수의 데코레이터로 사용할 수 있는 `ProfileTraceWrapper` 의 [일부](https://docs.python.org/3.6/library/functools.html#functools.partial) 를 반환합니다.
+`profile_trace` 추가 세그먼트의 형태로 [트랜잭션 추적](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) 에 세부 정보를 추가하는 데 사용됩니다. `profile_trace` 으로 보고된 모든 호출은 [APM 데이터베이스 페이지](/docs/apm/applications-menu/monitoring/databases-slow-queries-page) 에 나타납니다. `profile_trace` 은 프로파일러에 대한 호출 시간을 지정하는 함수의 데코레이터로 사용할 수 있는 `ProfileTraceWrapper` 의 [일부](https://docs.python.org/3.7/library/functools.html#functools.partial) 를 반환합니다.
 
 애플리케이션에서 데코레이터를 사용할 수 없는 경우 다음 호출 형식을 사용할 수 있습니다. 래퍼 형식은 `ProfileTraceWrapper` 입니다. 데코레이터를 사용하지 않고 래핑된 함수를 반환하는 데 사용할 수 있습니다.
 


### PR DESCRIPTION
Update New Relic docs to reflect Python Agent's deprecation of Python 3.6.

There are documents in various languages that I was not able to modify to reflect this (since I do not speak the languages), but the ones in English or with links to pages I was able to update.