### PR TITLE
docs: add filetype to codeblock where it's missing

### DIFF
--- a/src/content/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic.mdx
+++ b/src/content/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic.mdx
@@ -215,7 +215,7 @@ To forward logs to New Relic with `syslog-ng`:
    ```
 5. Define the New Relic `syslog` format and add your [New Relic license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key):
 
-   ```
+   ```properties
    template NRFormat { template("YOUR_LICENSE_KEY <${PRI}>1 ${ISODATE} ${HOST:--} ${PROGRAM:--} ${PID:--} ${MSGID:--} ${SDATA:--} $MSG\n");
            template_escape(no);
    };


### PR DESCRIPTION
`properties` works on the docs site now, but one codeblock didn't have it

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.