### PR TITLE
fix(syntheticIPs): Clarified IP docs

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/administration/new-synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/new-synthetic-public-minion-ips.mdx
@@ -9,11 +9,11 @@ translate:
 metaDescription: 'New runtime capabilities for synthetic monitoring may require you update your firewall allow list to accept network requests from new IP address ranges'
 ---
 
-Additional [source IP address ranges](#us_new_ip) will be added on October 3, 2022 to support the continued growth of synthetics. As a result, you may need to reconfigure your firewall's allow list, bot detection software, and other related applications to accept network requests from additional IP address ranges. Please ensure your configurations include these [new IP ranges](#us_new_ip) in addition to the IP and IP range JSON listings in our [synthetic monitor public minion IP documentation](/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips/)
+Additional [source IP address ranges](#us_new_ip) will be used starting on October 3, 2022 to support the continued growth of synthetics. As a result, you may need to reconfigure your firewall's allow list, bot detection software, and other related applications to accept network requests from additional IP address ranges. Please ensure your configurations include these [new IP ranges](#us_new_ip). These IP ranges have been added to the IP range JSON file in our [synthetic monitor public minion IP documentation](/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips/)
 
 ## New IP address ranges for public minions [#us_new_ip]
 
-Additional IP address ranges will be added on October 3, 2022. These ranges cover both US and EU data centers. These are in addition to the existing [IP range JSON listing](/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips/#dynamic-ip-addresses). The JSON list will be updated to include these additional IP ranges before they are used.
+Additional IP address ranges will be used starting on October 3, 2022. These ranges cover both US and EU data centers. These are in addition to and not replacing our existing published IP ranges. These IP ranges have been proactively added to the IP range JSON file IP range JSON file in our [synthetic monitor public minion IP documentation](/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips/) even though they will not be used until October 3, 2022.
 
 <table class="alternate">
   <thead>

--- a/src/content/docs/synthetics/synthetic-monitoring/administration/new-synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/new-synthetic-public-minion-ips.mdx
@@ -9,7 +9,7 @@ translate:
 metaDescription: 'New runtime capabilities for synthetic monitoring may require you update your firewall allow list to accept network requests from new IP address ranges'
 ---
 
-Additional [source IP address ranges](#us_new_ip) will be used starting on October 3, 2022 to support the continued growth of synthetics. As a result, you may need to reconfigure your firewall's allow list, bot detection software, and other related applications to accept network requests from additional IP address ranges. Please ensure your configurations include these [new IP ranges](#us_new_ip). These IP ranges have been added to the IP range JSON file in our [synthetic monitor public minion IP documentation](/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips/)
+To support continued growth for synthetics, we'll begin using additional [source IP address ranges](#us_new_ip) on October 3, 2022.  As a result, you may need to reconfigure your firewall's allow list, bot detection software, and other related applications to accept network requests from additional IP address ranges. Please ensure your configurations include these [new IP ranges](#us_new_ip). These IP ranges have been added to the IP range JSON file in our [synthetic monitor public minion IP documentation](/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips/)
 
 ## New IP address ranges for public minions [#us_new_ip]
 

--- a/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
@@ -19,7 +19,7 @@ New Relic uses public minions to execute your [synthetic monitors](/docs/synthet
 Because of this, ensure your firewall allows synthetics network requests. Minion IP addresses are publicly available in JSON format, so you can easily read and parse them.
 
 <Callout variant="important">
-  Please ensure your allow list or related configurations include *both* the [IP and IP range lists](#dynamic-ip-addresses) as requests could be sent from either environment.
+  Please ensure your allow list or related configurations include *both* the [IP and IP range lists](#dynamic-ip-addresses) as requests could be sent from either environment. The IPs contained in the IP-only, DNS name-only, and IP and DNS name list files have been added to the IP range list as /32 addresses to make allow list configurations easier. **These /32 addresses are not new.**
 </Callout>
 
 **Optional steps**:
@@ -37,7 +37,7 @@ Minions are deployed on servers, and the agents are activated using non-personal
 IP addresses for released locations are subject to change. If a change is needed, we'll attempt to proactively notify customers prior to any changes via e-mail. You can also check the [Explorers Hub](https://discuss.newrelic.com/) for updates.
 
 <Callout variant="important">
-  [Additional IP address ranges](/docs/synthetics/synthetic-monitoring/administration/new-synthetic-public-minion-ips/#us_new_ip) will be added on October 3, 2022. Some customers may need to update firewall, bot detection, or related configurations to allow this traffic.
+  [Additional IP address ranges](/docs/synthetics/synthetic-monitoring/administration/new-synthetic-public-minion-ips/#us_new_ip) will be added on October 3, 2022. Some customers may need to update firewall, bot detection, or related configurations to allow this traffic. These have been added to the IP range list, but will not be used until October 3, 2022.
 </Callout>
 
 <table style={{ width: "300px" }}>

--- a/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
@@ -19,7 +19,7 @@ New Relic uses public minions to execute your [synthetic monitors](/docs/synthet
 Because of this, ensure your firewall allows synthetics network requests. Minion IP addresses are publicly available in JSON format, so you can easily read and parse them.
 
 <Callout variant="important">
-  Please ensure your allow list or related configurations include *both* the [IP and IP range lists](#dynamic-ip-addresses) as requests could be sent from either environment. The IPs contained in the IP-only, DNS name-only, and IP and DNS name list files have been added to the IP range list as /32 addresses to make allow list configurations easier. **These /32 addresses are not new.**
+  Please ensure your allow list or related configurations include both the [IP and IP range lists](#dynamic-ip-addresses) as requests could be sent from either environment. The IPs contained in the IP-only, DNS name-only, and IP and DNS name list files have been added to the IP range list as /32 addresses to make allow list configurations easier. **These /32 addresses are not new.**
 </Callout>
 
 **Optional steps**:


### PR DESCRIPTION
Clarified a few sections of the synthetics IP and new synthetics IP documentation. I also updated this to indicate that the new IP ranges are now included in the IP range JSON files.