### PR TITLE
Add documentation about new environment variables in .NET Agent

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -245,6 +245,8 @@ NEW_RELIC_UTILIZATION_DETECT_DOCKER=<var>true|false</var>
 NEW_RELIC_UTILIZATION_DETECT_KUBERNETES=<var>true|false</var>
 NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD=<var>true|false</var>
 NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=<var>true|false</var>
+NEW_RELIC_SEND_DATA_ON_EXIT=<var>true|false</var>
+NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS=<var>2000</var>
 ```
 
 If you're using New Relic CodeStream to monitor performance from your IDE you may also want to [associate repositories with your services](/docs/codestream/how-use-codestream/performance-monitoring#repo-association) and [associate build SHAs or release tags with errors](/docs/codestream/how-use-codestream/performance-monitoring#buildsha).
@@ -482,6 +484,12 @@ The `service` element supports the following attributes:
     </table>
 
     Block application shutdown while the agent initiates a final harvest cycle and sends all data to New Relic.
+  
+    Alternatively, set the `NEW_RELIC_SEND_DATA_ON_EXIT` environment variable in the application's environment.
+
+    ```
+    NEW_RELIC_SEND_DATA_ON_EXIT=<var>true|false</var>
+    ```
   </Collapser>
 
   <Collapser
@@ -523,6 +531,12 @@ The `service` element supports the following attributes:
     </table>
 
     The minimum amount of time the process must run before the agent blocks it from shutting down. This setting only applies when [`sendDataOnExit`](#service-sendDataOnExit) is `true`.
+  
+    Alternatively, set the `NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS` environment variable in the application's environment.
+
+    ```
+    NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS=<var>2000</var>
+    ```
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
We are adding a few new environment variables to the .NET agent to control if and when data is sent during shutdown.