### PR TITLE
feat(request module): Request module compatibility details

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests.mdx
@@ -21,7 +21,9 @@ import apiTestSnap0 from 'images/api-test-snap_0.png'
 
 Use synthetic monitoring's [API tests](/docs/synthetics/new-relic-synthetics/getting-started/types-synthetics-monitors) to monitor your API endpoint to ensure it is functioning correctly. New Relic uses the [got module](https://github.com/sindresorhus/got) internally to make HTTP calls to your endpoint and validate the results.
 
-Here we present some example functions showing how to use the `$http` object to submit your request. For detailed documentation on the options available for this object, see the [got module readme](https://github.com/sindresorhus/got). The `got` module documentation includes [a migration guide](https://github.com/sindresorhus/got/blob/main/documentation/migration-guides/request.md) highlighting changes to expect from the `request` module used in previous scripted API runtimes. 
+Here we present some example functions showing how to use the `$http` object to submit your request. The `$http` object provides a custom `request`-like experience while being powered by `got` to provide backward compatibility for basic use cases while avoiding the use of the deprecated `request` module. Not all advanced use cases of `request` are or will be supported by this backward compatibility. For detailed documentation on the options available for this object, see the [got module readme](https://github.com/sindresorhus/got). The `got` module documentation includes [a migration guide](https://github.com/sindresorhus/got/blob/main/documentation/migration-guides/request.md) highlighting changes to expect from the `request` module used in previous scripted API runtimes. 
+
+The `request`-like experience provided by the `$http` object will also be returned for any customers attempting to use `request` directly in Node 16 and newer scripted API runtimes.
 
 <Callout variant="tip">
   To view and share other API test examples, visit the [synthetics scripts](https://discuss.newrelic.com/tags/c/full-stack-observability/synthetic/81/script) section in Explorers Hub or the [Synthetic Monitoring Quickstarts Library](https://newrelic.github.io/quickstarts-synthetics-library/#/).
@@ -29,7 +31,7 @@ Here we present some example functions showing how to use the `$http` object to 
 
 ## Use API got module [#overview]
 
-API tests are powered by the [got module](https://github.com/sindresorhus/got), which is available through the `$http` object. Once each frequency interval, New Relic queries your endpoint from each of your selected locations. For instructions on creating a monitor, see [Adding monitors](/docs/synthetics/new-relic-synthetics/using-monitors/adding-editing-monitors#adding-monitors).
+API tests are powered by the [got module](https://github.com/sindresorhus/got), which is available through the `$http` object. For instructions on creating a monitor, see [Adding monitors](/docs/synthetics/new-relic-synthetics/using-monitors/adding-editing-monitors#adding-monitors).
 
 Read on to learn how to [define metadata for your request](#request-options), [make a GET request](#get), [make a POST request](#post), and how to [validate the results](#validating).
 

--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/manage-monitor-runtimes.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/manage-monitor-runtimes.mdx
@@ -336,7 +336,7 @@ $browser.get('<var>https://example.com</var>');
 
 ## Review API monitor runtime dependencies [#apidependencies]
 
-Starting with the Node 16.10.0 runtime release, the API runtime will be managed separately from the [browser runtime](/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime). This is also known as our next-generation runtime. This is the first scripted API runtime based on the `got` module instead of the deprecated `request` module. The `got` module is exposed in a `request` compatible format via the `$http` object.
+Starting with the Node 16.10.0 runtime release, the API runtime will be managed separately from the [browser runtime](/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime). This is the first scripted API runtime based on the `got` module instead of the deprecated `request` module. The `got` module is exposed in a `request` compatible format via the `$http` object. The `request`-like experience provided by the `$http` object will also be returned for any customers attempting to use `request` directly in the Node 16 and newer scripted API runtimes.
 
 The API runtime is used for these monitor types:
 
@@ -380,6 +380,7 @@ The API runtime is used for these monitor types:
       * [nodejs-traceroute](https://github.com/zulhilmizainuddin/nodejs-traceroute) 1.2.0
       * [protocol-buffers](https://developers.google.com/protocol-buffers/) 4.2.0
       * [q](https://github.com/kriskowal/q) 1.5.1
+      * [request](/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests) Via our `request`-like `got` experience
       * [should](https://github.com/shouldjs/should.js) 13.2.3
       * [ssh2-sftp-client](https://www.npmjs.com/package/ssh2-sftp-client) 7.0.4
       * [ssl-checker](https://github.com/dyaa/ssl-checker) 2.0.7


### PR DESCRIPTION
Customers now attempting to use the request module in scripted API runtimes will receive our request like implementation of the got module instead.