### PR TITLE
Add a callout to the older winlog plugin about classic events

### DIFF
--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -543,6 +543,9 @@ What you use for the log source will depend on where you want to forward your lo
     id="winlog"
     title="winlog"
   >
+    <Callout variant="important">
+    Winlog can only collect classic Event logs. Attempting to capture others will silently collect the Applications log.
+    </Callout>
     Collect events from Windows log channels.
 
     **Parameters:**


### PR DESCRIPTION
The winlog fluentbit plugin can only collect Classic Windows Events. Attempting to collect others will silently collect the Application log and set the channel on the event incorrectly.

See https://github.com/fluent/fluent-bit/issues/3383

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Using winlog on the newer Windows Event Logs causes some weird behavior that's difficult to pin down, this call out will help highlight the behavior. 
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.
 https://github.com/fluent/fluent-bit/issues/3383
In fact you can see one of the examples of difficulty is when ingesting logs to New Relic
https://github.com/fluent/fluent-bit/issues/3383#issuecomment-852357294