### PR TITLE
chore: add handler for install feedback component for i18n

### DIFF
--- a/scripts/actions/utils/handlers.js
+++ b/scripts/actions/utils/handlers.js
@@ -175,6 +175,10 @@ module.exports = {
     serialize: serializeComponent,
     deserialize: deserializeComponent,
   },
+  InstallFeedback: {
+    serialize: serializeComponent,
+    deserialize: deserializeComponent,
+  },
   Side: {
     serialize: serializeComponent,
     deserialize: deserializeComponent,


### PR DESCRIPTION
## Description

I _thought_ i added i18n handlers for new `InstallFeedback` component, but i guess i didn't. We'll want that in place so i18n workflows don't break

## Related issues / PRs
Related to https://github.com/newrelic/docs-website/pull/9244 

