### PR TITLE
chore/meraki api config

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -117,6 +117,7 @@ devices:
     - HOST-RESOURCES-MIB
     - IF-MIB
     ext:
+      ext_only: false
       eapi_config:
         username: usernameAPI
         password: passwordAPI
@@ -1182,6 +1183,15 @@ global:
           </td>
           <td>
             TCP port number for eAPI authentication
+          </td>
+        </tr>
+        <tr>
+          <td>
+            ext_only
+          </td>
+          <td/>
+          <td>
+            Disables all SNMP polling for this `device_name` config. Default: `false`
           </td>
         </tr>
       </tbody>

--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -122,6 +122,23 @@ devices:
         password: passwordAPI
         transport: https
         port: 443
+  # Sample of Meraki Dashboard API device
+  meraki_dashboard_api:
+    device_name: meraki_controller
+    device_ip: snmp.meraki.com
+    provider: meraki-cloud-controller
+    ext:
+      ext_only: true
+      meraki_config:
+        api_key: APIKEY123ABC
+        monitor_uplinks: true
+        monitor_devices: true
+        monitor_org_changes: true
+        organizations:
+          - "Top Org.*"
+        networks:
+          - "Production"
+          - "Guest"
 trap:
   listen: 0.0.0.0:1620
   community: public
@@ -1170,8 +1187,122 @@ global:
       </tbody>
     </table>
 
+    ### Meraki Dashboard API
+    
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: "200px" }}>
+            Key name
+          </th>
+          
+          <th>
+            Required
+          </th>
+          
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+
+     <tbody>
+        <tr>
+          <td>
+            meraki_config.api_key
+          </td>
+          
+          <td>
+            ✓
+          </td>
+          
+          <td>
+            [Meraki Dashboard API key](https://documentation.meraki.com/General_Administration/Other_Topics/Cisco_Meraki_Dashboard_API#Enable_API_Access) for authentication
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            meraki_config.monitor_uplinks
+          </td>
+          
+          <td>
+            ✓
+          </td>
+          
+          <td>
+            Monitor uplink performance and status for all Meraki appliances in target organizations
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            meraki_config.monitor_devices
+          </td>
+          
+          <td>
+            ✓
+          </td>
+          
+          <td>
+            Monitor connected client performance and status for all devices in target networks
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            meraki_config.monitor_org_changes
+          </td>
+          
+          <td>
+            ✓
+          </td>
+          
+          <td>
+            Monitor [Organization configuration changes](https://developer.cisco.com/meraki/api-latest/#!get-organization-configuration-changes). Creates events in the `KExtEvent` namespace.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            meraki_config.organizations
+          </td>
+          
+          <td/>
+          
+          <td>
+            List of regex patterns to match Organization names for monitoring
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            meraki_config.networks
+          </td>
+          
+          <td/>
+          
+          <td>
+            List of regex patterns to match Network names for monitoring
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            ext_only
+          </td>
+          
+          <td/>
+          
+          <td>
+            Disables all SNMP polling for this `device_name` config. Default: `false`
+          </td>
+        </tr>
+     </tbody>
+    </table>
+
     <Callout variant="tip">
-      You can use [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) natively in your eAPI config using the `aws.sm.$SECRET_NAME` syntax, replacing `$SECRET_NAME` as necessary to have **ktranslate** pull in your credentials during Docker runtime.
+      You can use [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) natively in your API config using the `aws.sm.$SECRET_NAME` syntax, replacing `$SECRET_NAME` as necessary to have **ktranslate** pull in your credentials during Docker runtime.
     </Callout>
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
adding new config settings to existing docs for network monitoring covering Meraki API polling.

adding small edit to existing Arista eAPI polling config doc to include new `ext_only` option.