### PR TITLE
docs: infra agent uptime metric

### DIFF
--- a/src/content/docs/infrastructure/manage-your-data/data-instrumentation/host-integrations-metrics.mdx
+++ b/src/content/docs/infrastructure/manage-your-data/data-instrumentation/host-integrations-metrics.mdx
@@ -35,6 +35,20 @@ The following table presents the equivalent dimensional metric names for our inf
       </td>
 
       <td>
+        `host.uptime`
+      </td>
+
+      <td>
+        `uptime`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Agent
+      </td>
+
+      <td>
         `host.cpuIdlePercent`
       </td>
 

--- a/src/data-dictionary/events/SystemSample/uptime.md
+++ b/src/data-dictionary/events/SystemSample/uptime.md
@@ -1,0 +1,9 @@
+---
+name: uptime
+type: attribute
+units: seconds (s)
+events:
+  - SystemSample
+---
+
+The amount of time the system has been active (running), in seconds.


### PR DESCRIPTION
Ready to review, it adds the documentation of a new infra-agent metric: uptime