### PR TITLE
feat(java): removed redirect to jvm arguments doc

### DIFF
--- a/src/install/config/java.yaml
+++ b/src/install/config/java.yaml
@@ -8,7 +8,6 @@ redirects:
   - /docs/apm/agents/java-agent/getting-started/introduction-new-relic-java
   - /docs/apm/agents/java-agent/getting-started/monitor-your-java-app
   - /docs/apm/agents/java-agent/installation/java-install-overview
-  - /docs/apm/agents/java-agent/installation/include-java-agent-jvm-argument
 appInfo:
   - optionType: deployment
     label: 'Where is your app deployed?'


### PR DESCRIPTION
The Java team asked that we remove this redirect.