### PR TITLE
Add custom attribute to identify type of page

### DIFF
--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -31,7 +31,7 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
   if (typeof window !== 'undefined' && typeof newrelic === 'object') {
     window.newrelic.setCustomAttribute(
       'pageType',
-      'Interactive:PagesAttributeDictionary'
+      'Interactive/AttributeDictionary'
     );
   }
 

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -28,6 +28,13 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
   const [searchedAttribute, setSearchedAttribute] = useState(null);
   const { queryParams } = useQueryParams();
 
+  if (typeof window !== 'undefined' && typeof newrelic === 'object') {
+    window.newrelic.setCustomAttribute(
+      'pageType',
+      'Interactive:PagesAttributeDictionary'
+    );
+  }
+
   const events = useMemo(
     () => allDataDictionaryEvent.edges.map((edge) => edge.node),
     [allDataDictionaryEvent]

--- a/src/pages/install/{installConfig.agentName}.js
+++ b/src/pages/install/{installConfig.agentName}.js
@@ -47,7 +47,7 @@ const InstallPage = ({ data, location }) => {
   const tessen = useTessen();
 
   if (typeof window !== 'undefined' && typeof newrelic === 'object') {
-    window.newrelic.setCustomAttribute('pageType', 'Interactive:PagesInstall');
+    window.newrelic.setCustomAttribute('pageType', 'Interactive/Install');
   }
 
   const selectOptions = appInfo.map((select) => ({

--- a/src/pages/install/{installConfig.agentName}.js
+++ b/src/pages/install/{installConfig.agentName}.js
@@ -99,13 +99,6 @@ const InstallPage = ({ data, location }) => {
 
   const handleSelectIndex = (index) => {
     setSelectedIndex(index);
-    tessen.track({
-      eventName: 'activeStepUpdated',
-      category: 'StepProgress',
-      activeStep: index + 1,
-      path: location.pathname,
-      agentName,
-    });
   };
 
   const matchOverride = ({ optionType, options }) => {

--- a/src/pages/install/{installConfig.agentName}.js
+++ b/src/pages/install/{installConfig.agentName}.js
@@ -46,6 +46,10 @@ const InstallPage = ({ data, location }) => {
 
   const tessen = useTessen();
 
+  if (typeof window !== 'undefined' && typeof newrelic === 'object') {
+    window.newrelic.setCustomAttribute('pageType', 'Interactive:PagesInstall');
+  }
+
   const selectOptions = appInfo.map((select) => ({
     ...select,
     value: queryParams.has(select.optionType)
@@ -97,6 +101,7 @@ const InstallPage = ({ data, location }) => {
     setSelectedIndex(index);
     tessen.track({
       eventName: 'activeStepUpdated',
+      category: 'StepProgress',
       activeStep: index + 1,
       path: location.pathname,
       agentName,

--- a/src/pages/whats-new.js
+++ b/src/pages/whats-new.js
@@ -32,7 +32,7 @@ const WhatsNew = ({ data, location, pageContext }) => {
   );
 
   if (typeof window !== 'undefined' && typeof newrelic === 'object') {
-    window.newrelic.setCustomAttribute('pageType', 'Dynamic:PagesWhatsNew');
+    window.newrelic.setCustomAttribute('pageType', 'Dynamic/WhatsNew');
   }
 
   const { t } = useTranslation();

--- a/src/pages/whats-new.js
+++ b/src/pages/whats-new.js
@@ -31,6 +31,10 @@ const WhatsNew = ({ data, location, pageContext }) => {
       .entries()
   );
 
+  if (typeof window !== 'undefined' && typeof newrelic === 'object') {
+    window.newrelic.setCustomAttribute('pageType', 'Dynamic:PagesWhatsNew');
+  }
+
   const { t } = useTranslation();
 
   return (

--- a/src/templates/docPage.js
+++ b/src/templates/docPage.js
@@ -54,6 +54,10 @@ const BasicDoc = ({ data, location, pageContext }) => {
     dataSource,
   } = frontmatter;
 
+  if (typeof window !== 'undefined' && typeof newrelic === 'object') {
+    window.newrelic.setCustomAttribute('pageType', 'Template:docPage');
+  }
+
   return (
     <>
       <SEO

--- a/src/templates/docPage.js
+++ b/src/templates/docPage.js
@@ -55,7 +55,7 @@ const BasicDoc = ({ data, location, pageContext }) => {
   } = frontmatter;
 
   if (typeof window !== 'undefined' && typeof newrelic === 'object') {
-    window.newrelic.setCustomAttribute('pageType', 'Template:docPage');
+    window.newrelic.setCustomAttribute('pageType', 'Template/DocPage');
   }
 
   return (

--- a/src/templates/landingPage.js
+++ b/src/templates/landingPage.js
@@ -47,6 +47,9 @@ const LandingPage = ({ data, location, pageContext }) => {
   const { mdx } = data;
   const { frontmatter, body } = mdx;
   const { disableSwiftype } = pageContext;
+  if (typeof window !== 'undefined' && typeof newrelic === 'object') {
+    window.newrelic.setCustomAttribute('pageType', 'Template:landingPage');
+  }
 
   return (
     <>

--- a/src/templates/landingPage.js
+++ b/src/templates/landingPage.js
@@ -48,7 +48,7 @@ const LandingPage = ({ data, location, pageContext }) => {
   const { frontmatter, body } = mdx;
   const { disableSwiftype } = pageContext;
   if (typeof window !== 'undefined' && typeof newrelic === 'object') {
-    window.newrelic.setCustomAttribute('pageType', 'Template:landingPage');
+    window.newrelic.setCustomAttribute('pageType', 'Template/LandingPage');
   }
 
   return (

--- a/src/templates/releaseNote.js
+++ b/src/templates/releaseNote.js
@@ -29,6 +29,10 @@ const ReleaseNoteTemplate = ({ data, location, pageContext }) => {
 
   const title = getTitle(frontmatter);
 
+  if (typeof window !== 'undefined' && typeof newrelic === 'object') {
+    window.newrelic.setCustomAttribute('pageType', 'Template:releaseNote');
+  }
+
   return (
     <>
       <SEO

--- a/src/templates/releaseNote.js
+++ b/src/templates/releaseNote.js
@@ -30,7 +30,7 @@ const ReleaseNoteTemplate = ({ data, location, pageContext }) => {
   const title = getTitle(frontmatter);
 
   if (typeof window !== 'undefined' && typeof newrelic === 'object') {
-    window.newrelic.setCustomAttribute('pageType', 'Template:releaseNote');
+    window.newrelic.setCustomAttribute('pageType', 'Template/ReleaseNote');
   }
 
   return (

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -50,6 +50,13 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
 
   const title = `${subject} release notes`;
 
+  if (typeof window !== 'undefined' && typeof newrelic === 'object') {
+    window.newrelic.setCustomAttribute(
+      'pageType',
+      'Template:releaseNoteLanding'
+    );
+  }
+
   return (
     <>
       <SEO

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -53,7 +53,7 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
   if (typeof window !== 'undefined' && typeof newrelic === 'object') {
     window.newrelic.setCustomAttribute(
       'pageType',
-      'Template:releaseNoteLanding'
+      'Template/ReleaseNoteLanding'
     );
   }
 

--- a/src/templates/whatsNew.js
+++ b/src/templates/whatsNew.js
@@ -34,7 +34,7 @@ const WhatsNewTemplate = ({ data, location, pageContext }) => {
   const { disableSwiftype } = pageContext;
 
   if (typeof window !== 'undefined' && typeof newrelic === 'object') {
-    window.newrelic.setCustomAttribute('pageType', 'Template:whatsNew');
+    window.newrelic.setCustomAttribute('pageType', 'Template/WhatsNew');
   }
 
   return (

--- a/src/templates/whatsNew.js
+++ b/src/templates/whatsNew.js
@@ -33,6 +33,10 @@ const WhatsNewTemplate = ({ data, location, pageContext }) => {
 
   const { disableSwiftype } = pageContext;
 
+  if (typeof window !== 'undefined' && typeof newrelic === 'object') {
+    window.newrelic.setCustomAttribute('pageType', 'Template:whatsNew');
+  }
+
   return (
     <>
       <SEO


### PR DESCRIPTION
## Description

Adds custom attribute to Browser `PageAction` and `PageView` events to explicitly identify the type of page for more reliable querying.

Partiuclarly useful when querying data for new install UI pages generated via `src/pages/install/{installConfig.agentName}.js`

Also removes tessen tracking for when a step is made active because it's very noisy and likely not very useful

## Categories

Kinda just making up a nomenclature, but I thought it could be useful to categorize pages first as:
* Interactive
  * Pages that change based on user input
* Dynamic
  * Pages where content on the page updates automatically / dynamically based on where data is sourced
* Template
  * Page of templated content rendered via a template in `src/templates`

Then just try to match file names mostly so it's obvious what template or page generated it


