### PR TITLE
Replace CAT reference with DT reference in nav

### DIFF
--- a/src/content/docs/apm/agents/java-agent/api-guides/java-agent-api-instrumenting-example-app-external-datastore-calls-dt.mdx
+++ b/src/content/docs/apm/agents/java-agent/api-guides/java-agent-api-instrumenting-example-app-external-datastore-calls-dt.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Java agent API: Instrumenting example app for external datastore calls and DT'
+title: 'Java agent API: Instrumenting example app for external datastore calls and distributed tracing'
 tags:
   - Agents
   - Java agent

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -280,8 +280,8 @@ pages:
                 path: /docs/apm/agents/java-agent/api-guides/java-agent-api-instrument-external-calls-messaging-datastore-web-frameworks
               - title: 'API: Annotating example app'
                 path: /docs/apm/agents/java-agent/api-guides/java-agent-api-custom-instrumentation-annotation-example-app
-              - title: 'API example: Datastore and CAT'
-                path: /docs/apm/agents/java-agent/api-guides/java-agent-api-instrumenting-example-app-external-datastore-calls-cat
+              - title: 'API: External datastore calls and distributed tracing'
+                path: /docs/apm/agents/java-agent/api-guides/java-agent-api-instrumenting-example-app-external-datastore-calls-dt
           - title: Troubleshooting
             path: /docs/apm/agents/java-agent/troubleshooting
             pages:


### PR DESCRIPTION
We had an outdated URL and title in the API section of the Java instructions. I updated the title and the URL.