### PR TITLE
docs: Add New Relic for iOS 4.4.2 release notes

### DIFF
--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-4042.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-4042.mdx
@@ -1,0 +1,21 @@
+---
+subject: Mobile app for iOS
+releaseDate: '2022-09-28'
+version: 4.4.2
+downloadLink: 'https://apps.apple.com/app/id594038638'
+---
+
+### Notes
+
+Improved widget center controls for editing existing iOS widgets, and adding from the NRQL editor.
+
+### Improvements
+
+* Added ability to create iOS widgets from the NRQL editor
+* Added ability to save changes to existing iOS widgets
+* Improved Infrastructure charts, allowing for dragging to change time windows
+
+### Fixes
+
+* Fixed a crash in the tags search view
+ 


### PR DESCRIPTION
The latest version of the iOS mobile app has been release, so this PR updates our release notes.