### PR TITLE
feat: infra-agent macos arm support

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -55,7 +55,7 @@ The infrastructure agent supports these processor architectures:
 * **Linux**: 64-bit for x86 processor architectures (also requires 64-bit package manager and dependencies)
 * **Windows**: both 32 and 64-bit for x86 processor architectures
 * **ARM**: arm64 architecture including [AWS Graviton 2 processor](https://aws.amazon.com/ec2/graviton/) is supported on compatible Linux operating sytems. On-host integrations are also supported (with the exception of the Oracle integration).
-* **macOS**: 64-bit x86 processor (ARM processor is not supported yet).
+* **macOS**: both 64-bit x86 and Apple silicon.
 
 ## Operating systems
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
@@ -58,7 +58,7 @@ To install the infrastructure monitoring agent, follow the step-by-step instruct
     3. Then, open the terminal and run the following command:
 
        ```
-         brew install newrelic/tap/newrelic-infra-agent -q
+         brew install newrelic-infra-agent -q
        ```
 
     4. Start the infrastructure agent service:
@@ -69,8 +69,15 @@ To install the infrastructure monitoring agent, follow the step-by-step instruct
     
     5. Create the configuration file and add your [license key](/docs/accounts-partnerships/accounts/account-setup/license-key/):
 
+       Intel x86:
+
        ```
          echo "license_key: YOUR_LICENSE_KEY" | sudo tee -a /usr/local/etc/newrelic-infra/newrelic-infra.yml
+       ```
+
+       Apple Silicon:
+       ```
+         echo "license_key: YOUR_LICENSE_KEY" | sudo tee -a /opt/homebrew/etc/newrelic-infra/newrelic-infra.yml
        ```
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
## Give us some context

* Starting with infrastructure agent 1.30.0, macos is supported on Apple silicon too (M1, M2 processors).