### PR TITLE
Add blazor to getbrowsertimingheader api

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent-api.mdx
@@ -127,7 +127,7 @@ An HTML string to be embedded in a page header.
 ### With Blazor [#blazor]
 
 <Callout variant="important">
-  This API is not supported for Blazor Webassembly, because the agent is unable to instrument Webassembly code.  The following examples are for Blazor Server applications only.  Use the Copy-Paste method of adding the Browser Agent to Blazor Webassembly pages.
+  This API is not supported for Blazor Webassembly, because the agent is unable to instrument Webassembly code.  The following examples are for Blazor Server applications only.  Use the [copy-paste method](https://docs.newrelic.com/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/#copy-paste-app) of adding the Browser Agent to Blazor Webassembly pages.
 </Callout>
 
 <Callout variant="important">

--- a/src/content/docs/apm/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent-api.mdx
@@ -131,7 +131,7 @@ An HTML string to be embedded in a page header.
 </Callout>
 
 <Callout variant="important">
-  This API can not be placed in a `<HeadContent>` element of a .razor page.  Instead, it should be called from _Layout.cshtml or an equivalent layout file.
+  This API can not be placed in a `<HeadContent>` element of a `.razor` page.  Instead, it should be called from `_Layout.cshtml` or an equivalent layout file.
 </Callout>
 
 ```cshtml

--- a/src/content/docs/apm/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent-api.mdx
@@ -102,7 +102,7 @@ An HTML string to be embedded in a page header.
 
 ### With Razor [#razor]
 
-```razor
+```cshtml
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -113,7 +113,39 @@ An HTML string to be embedded in a page header.
   ...
 ```
 
-```razor
+```cshtml
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    @Html.Raw(NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader("YOUR_NONCE_VALUE"))
+    ...
+  </head>
+  <body>
+  ...
+```
+
+### With Blazor [#blazor]
+
+<Callout variant="important">
+  This API is not supported for Blazor Webassembly, because the agent is unable to instrument Webassembly code.  The following examples are for Blazor Server applications only.  Use the Copy-Paste method of adding the Browser Agent to Blazor Webassembly pages.
+</Callout>
+
+<Callout variant="important">
+  This API can not be placed in a `<HeadContent>` element of a .razor page.  Instead, it should be called from _Layout.cshtml or an equivalent layout file.
+</Callout>
+
+```cshtml
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    @Html.Raw(NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader())
+    ...
+  </head>
+  <body>
+  ...
+```
+
+```cshtml
 <!DOCTYPE html>
 <html lang="en">
   <head>


### PR DESCRIPTION
The .NET agent had a customer wanting to use the GetBrowserTimingHeader() API in a Blazor Webassembly application.  Unfortunately we don' t support that scenario.  This PR updates our API doc to call out that incompatibility, as well as provide correct instructions for how to use the API for a Blazor Server application, which we do support.

I also changed the code type for the Razor (not Blazor) instructions to be cshtml as that is the actual file type in that case.