### PR TITLE
Regex to update layouts on pages that exist

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -368,6 +368,10 @@ exports.onCreatePage = ({ page, actions }) => {
     page.context.layout = 'basic';
   }
 
+  if (page.path.match(/404/) && page.path.match(/\/docs\//)) {
+    page.context.layout = 'default';
+  }
+
   if (page.path.includes('/install/')) {
     const pagePathArray = page.path.split('/');
     const lastItem = pagePathArray[pagePathArray.length - 1];


### PR DESCRIPTION
Had an issue where the 404 page template was being applied to pages that had "404" anywhere in the file name.  This will update the layout once again if the URL is one that exists in the "/docs/" page routing and is not getting a 404 from gatsby.  I thought this wouldn't work at first since the url doesn't get updated when you get a 404, but it seems like when the 404 page is displayed this doesn't update the layout.

https://issues.newrelic.com/browse/NEWRELIC-3231

BEFORE:
![Screen Shot 2022-09-29 at 5 24 51 PM](https://user-images.githubusercontent.com/26727669/193153095-21681171-d218-4577-884d-c7356223c71d.png)

AFTER:
![Screen Shot 2022-09-29 at 5 35 21 PM](https://user-images.githubusercontent.com/26727669/193154135-1f46ff47-b8e8-4fba-b9a2-0ac84c47380a.png)

to test, go to the build and enter the slug: `/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-4042`

Then, go to a page that doesn't exist to see the 404 page working correctly :) 
