### PR TITLE
Update .NET Codestream documentation

### DIFF
--- a/src/content/docs/apm/agents/net-agent/other-features/net-codestream-integration.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-features/net-codestream-integration.mdx
@@ -14,7 +14,7 @@ Display context-sensitive APM data directly in your IDE by integrating [New Reli
 First, [install](/docs/codestream/start-here/install-codestream) the New Relic CodeStream extension into your supported IDE of choice, and log in.
 
 <Callout variant="important">
-  As of .NET agent version 10.2.0 the New Relic CodeStream Integration is enabled by default. 
+  With the release of .NET agent version 10.2.0, the New Relic CodeStream Integration is enabled by default. 
   
   The New Relic CodeStream integration is available in [.NET agent version 9.9.0 and higher](/docs/release-notes/agent-release-notes/net-release-notes) and is disabled by default. To change this configuration, check out our [documentation](/docs/apm/agents/net-agent/configuration/net-agent-configuration#code_level_metrics).
 </Callout>

--- a/src/content/docs/apm/agents/net-agent/other-features/net-codestream-integration.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-features/net-codestream-integration.mdx
@@ -14,6 +14,8 @@ Display context-sensitive APM data directly in your IDE by integrating [New Reli
 First, [install](/docs/codestream/start-here/install-codestream) the New Relic CodeStream extension into your supported IDE of choice, and log in.
 
 <Callout variant="important">
+  As of .NET agent version 10.2.0 the New Relic CodeStream Integration is enabled by default. 
+  
   The New Relic CodeStream integration is available in [.NET agent version 9.9.0 and higher](/docs/release-notes/agent-release-notes/net-release-notes) and is disabled by default. To change this configuration, check out our [documentation](/docs/apm/agents/net-agent/configuration/net-agent-configuration#code_level_metrics).
 </Callout>
 


### PR DESCRIPTION
Codestream will be enabled by default in the .NET agent, as of version 10.2.0 (unreleased currently).