### PR TITLE
Update generating-logs-troubleshooting-php.mdx

### DIFF
--- a/src/content/docs/apm/agents/php-agent/troubleshooting/generating-logs-troubleshooting-php.mdx
+++ b/src/content/docs/apm/agents/php-agent/troubleshooting/generating-logs-troubleshooting-php.mdx
@@ -22,10 +22,6 @@ You encounter problems with your New Relic for PHP installation but are not sure
 
 Monitoring your New Relic logs may help diagnose the problem. The New Relic PHP agent and daemon have their own logs. To monitor the logs:
 
-    Default agent log location:
-    Default daemon log location: 
-
-
 1. Check both logs for content:
    * **[Default agent log location](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#inivar-logfile)**: `/var/log/newrelic/php_agent.log`
    * **[Default daemon log location](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#inivar-daemon-logfile)**: `/var/log/newrelic/newrelic-daemon.log`


### PR DESCRIPTION
Removed extra "Default agent log location:" and "Default daemon log location:" in the ##Solution section.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

There appears to be leftover text from a previous edit that is now addressed in step 1 of the solutions section of the troubleshooting doc. 