### PR TITLE
Removing reference to Logging's Saved Queries

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-capabilities.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-capabilities.mdx
@@ -220,7 +220,6 @@ These capabilities pertain to [incident intelligence](/docs/alerts-applied-intel
 * **Obfuscation rules**: relates to [log obfuscation](/docs/logs/ui-data/obfuscation-ui).
 * **Parsing rules**: relates to [log parsing](/docs/logs/ui-data/parsing).
 * **Pipeline configuration**: relates to configuring the log data pipeline. Currently this governs [log patterns](/docs/logs/ui-data/find-unusual-logs-log-patterns). 
-* **Public saved queries**: deprecated feature, replaced with **Public saved views**.
 * **Public saved views**: relates to [saved views](/docs/logs/ui-data/use-logs-ui/#saved-views) that are public. 
 </Collapser>
 


### PR DESCRIPTION
This feature is obsolete. It was replaced two years ago by Saved Views, and we finally got rid of the last references to it. 

See account-auth-and-access/authorization_management_service#1198

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.