### PR TITLE
docs: put backticks around the entire method name

### DIFF
--- a/src/content/docs/apm/agents/net-agent/troubleshooting/missing-couchbase-metrics-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/missing-couchbase-metrics-net.mdx
@@ -15,11 +15,11 @@ redirects:
 
 You see metrics and transaction segments for some of your Couchbase activity, but not all of it. For example, New Relic's .NET agent is not instrumenting calls to:
 
-* `Get`(string key)
-* `GetDocument`(string key)
-* `Remove`(string key)
-* `Remove`(string key, ulong cas)
-* `Upsert<T>`(string key, T value)
+* `Get(string key)`
+* `GetDocument(string key)`
+* `Remove(string key)`
+* `Remove(string key, ulong cas)`
+* `Upsert<T>(string key, T value)`
 
 ## Solution
 
@@ -49,7 +49,7 @@ To see additional metrics and transaction segments for Couchbase activity, use e
       </td>
 
       <td>
-        Use other methods in the Couchbase SDK where .NET agent instrumentation is not disabled. For example, if you use `GetAsync`(string key) instead of `Get`(string key), your calls will be instrumented.
+        Use other methods in the Couchbase SDK where .NET agent instrumentation is not disabled. For example, if you use `GetAsync(string key)` instead of `Get(string key)`, your calls will be instrumented.
       </td>
     </tr>
 

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/missing-couchbase-metrics-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/missing-couchbase-metrics-net.mdx
@@ -23,7 +23,7 @@ You see metrics and transaction segments for some of your Couchbase activity, bu
 
 ## Solution
 
-The Couchbase SDK contains methods for `Get`, `Remove`, and `Upsert` that act on multiple documents. These methods use multithreaded processes to call into other public methods in the Couchbase SDK.
+The Couchbase SDK contains methods for `Get()`, `Remove()`, and `Upsert()` that act on multiple documents. These methods use multithreaded processes to call into other public methods in the Couchbase SDK.
 
 To avoid double instrumentation, New Relic's .NET agent automatically instruments the multiple document methods. However, the agent does not automatically instrument the base methods they call into.
 

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/missing-couchbase-metrics-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/missing-couchbase-metrics-net.mdx
@@ -15,11 +15,11 @@ redirects:
 
 You see metrics and transaction segments for some of your Couchbase activity, but not all of it. For example, New Relic's .NET agent is not instrumenting calls to:
 
-* `Get(string key)`
-* `GetDocument(string key)`
-* `Remove(string key)`
-* `Remove(string key, ulong cas)`
-* `Upsert<T>(string key, T value)`
+* `Get(string id)`
+* `GetDocument(string id)`
+* `Remove(string id)`
+* `Remove(string id, ulong cas)`
+* `Upsert<T>(string id, T value)`
 
 ## Solution
 
@@ -49,7 +49,7 @@ To see additional metrics and transaction segments for Couchbase activity, use e
       </td>
 
       <td>
-        Use other methods in the Couchbase SDK where .NET agent instrumentation is not disabled. For example, if you use `GetAsync(string key)` instead of `Get(string key)`, your calls will be instrumented.
+        Use other methods in the Couchbase SDK where .NET agent instrumentation is not disabled. For example, if you use `GetAsync(string id)` instead of `Get(string id)`, your calls will be instrumented.
       </td>
     </tr>
 


### PR DESCRIPTION
`GetAsync`(string key) doesn't really make sense, it would normally be written `GetAsync(string key)` with the parameters included

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.