### PR TITLE
Update custom event limit

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -2917,7 +2917,7 @@ This section defines the Node.js agent variables in the order they typically app
 
 ## Custom events variables [#custom_events]
 
-This section defines the Node.js agent variables in the order they typically appear in the `custom_insights_events: {` section of your app's `newrelic.js` configuration file. Currently there are no environment variables for custom events.
+This section defines the Node.js agent variables in the order they typically appear in the `custom_insights_events: {` section of your app's `newrelic.js` configuration file.
 
 <CollapserGroup>
   <Collapser
@@ -2973,7 +2973,7 @@ This section defines the Node.js agent variables in the order they typically app
           </th>
 
           <td>
-            `1000`
+            `30000`
           </td>
         </tr>
 
@@ -2992,7 +2992,7 @@ This section defines the Node.js agent variables in the order they typically app
     Defines the maximum number of custom events the agent collects per minute. If the number of custom events exceeds this limit, the agent collects a statistical sampling.
 
     <Callout variant="important">
-      Increasing this limit increases memory usage.
+      Increasing this limit may increase memory usage.
     </Callout>
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
Now the default is 30k, up from 1k.

Memory can be increased, but in my testing, it's a very slight
increase. It depends on the complexity of the custom events and the
rate at which they are being generated.

The server will soon only accept a maximum of 100k custom events per
minute, so that's also a hard limit for the agent.
