### PR TITLE
Add callout re: Sitecore log4net incompatibility

### DIFF
--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -42,6 +42,7 @@ For more information, including examples, learn how to get started with [APM log
 You have three options to configure APM logs in context to send your app's logs and linking metadata automatically to New Relic. Supported frameworks for automatic logs in context using in agent forwarding include:
 
 - log4net: 1.2.10+ (.NET Framework), 2.0.10+ (.NET Core). Requires .NET Agent v9.7.0+.
+  - Note: Many versions of Sitecore use log4net for logging.  However, this version of log4net is currently unsupported by the agent.
 - NLog: 4.1+ (.NET Framework), 4.5+ (.NET Core). Requires .NET Agent v9.7.0+.
 - Serilog: 2.0+ (.NET Framework), 2.5+ (.NET Core). Requires .NET Agent v9.7.0+.
 - Microsoft.Extensions.Logging: 3.0+. Requires .NET Agent v9.7.0+ (.NET Core), Agent v10.0.0+ (.NET Framework).


### PR DESCRIPTION
## Give us some context

Since releasing the in-agent log forwarding and local decoration features, the .NET agent has had several customers using Sitecore CMS wondering why their Sitecore logs weren't being forwarded (or decorated) by the agent.  Unfortunately Sitecore uses an older version of log4net with different assembly and class names that our log4net instrumentation does not match at the present time.  This PR updates the relevant doc to specifically warn users about Sitecore's log4net being unsupported. 