### PR TITLE
Drop old MSSQL versions

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/microsoft-sql/microsoft-sql-server-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/microsoft-sql/microsoft-sql-server-integration.mdx
@@ -31,7 +31,7 @@ To install the Microsoft SQL Server integration, you must run through the follow
 
 ### Microsoft SQL Server versions [#microsoft-sql-server-versions]
 
-Our integration is compatible with Microsoft SQL Server 2008 R2 SP3 or higher.
+Our integration is compatible with Microsoft SQL Server 2014 or higher.
 
 ### Supported operating systems [#supported-os]
 


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
While theoretically we can still support all those versions as the communication protocol has not changed and we should still be able to monitor them, we have lost the possibility to test them as there are no installers available for them.

Microsft does not support these versions so we are dropping support for them too.
