### PR TITLE
fix(synthetics apdex): Removed references for editing Apdex T

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/pages/synthetic-monitoring-aggregate-monitor-metrics.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/pages/synthetic-monitoring-aggregate-monitor-metrics.mdx
@@ -42,7 +42,7 @@ Use SLA reports to view aggregated performance metrics for a single monitor, or 
   (29+148)/(50+150)=88.5
 
   For individual SLA reports, the uptime score only includes the selected monitor.
-* **Apdex**: The average [Apdex](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction) across all monitors. Monitors have a default [Apdex T](/docs/apm/new-relic-apm/getting-started/glossary#apdex_t) of 7 seconds, but you can customize Apdex T for individual monitors by [editing their settings](/docs/synthetics/new-relic-synthetics/using-monitors/adding-editing-monitors#editing-monitors). [Apdex F](/docs/apm/new-relic-apm/getting-started/glossary#apdex_f), which defines a frustrating result, is always four times Apdex T. For more information about Apdex, see [Apdex: Measuring user satisfaction](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction).
+* **Apdex**: The average [Apdex](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction) across all monitors. Monitors have a [Apdex T](/docs/apm/new-relic-apm/getting-started/glossary#apdex_t) of 7 seconds and cannot be modified. [Apdex F](/docs/apm/new-relic-apm/getting-started/glossary#apdex_f), which defines a frustrating result, is always four times Apdex T. For more information about Apdex, see [Apdex: Measuring user satisfaction](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction). To view Apdex scores for your synthetic monitors using a different Apdex T value, please use the [NRQL apdex function](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#func-apdex) and the [SyntheticCheck event](/attribute-dictionary/?event=SyntheticCheck).
 
   For individual SLA reports, the Apdex score only includes the selected monitor.
 * **% Satisfied**: The percentage of monitor results which complete in a ["satisfying" time](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction#bullet-satisfied). A satisfying time is defined as a monitor result that completes in [Apdex T](/docs/apm/new-relic-apm/getting-started/glossary#apdex_t) or less.
@@ -76,16 +76,6 @@ SLA reports support the following features:
 
       <td>
         Select **Download this report as .csv** to download a copy of your SLA data. Open the file in Excel, Google Drive, or another spreadsheet editor to analyze your data.
-      </td>
-    </tr>
-
-    <tr id="apdex-targets">
-      <td>
-        Change your Apdex targets
-      </td>
-
-      <td>
-        The default [Apdex T](/docs/apm/new-relic-apm/getting-started/glossary#apdex_t) for all monitors is 7 seconds. You can customize your Apdex T target for individual monitors by [editing your monitor](/docs/synthetics/new-relic-synthetics/using-monitors/adding-editing-monitors#editing-monitors).
       </td>
     </tr>
 


### PR DESCRIPTION
The synthetics UI and APIs no longer allow you to modify the Apdex T value used in the SLA report. I clarified the documentation and referred to the NRQL apdex function if an Apdex value is needed.