### PR TITLE
Fix redirect

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/Issues-and-Incident-management-and-response.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/Issues-and-Incident-management-and-response.mdx
@@ -5,13 +5,7 @@ tags:
   - Applied intelligence
 metaDescription: 'Read about how to analyze alert issues and incidents to determine the root cause of an issue.'
 redirects:
-  - /docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/get-started-incident-intelligence/#visual-timeline
-  - /docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/get-started-incident-intelligence/#related-activity
-  - /docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/get-started-incident-intelligence/#issue-summary
-  - /docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/get-started-incident-intelligence/#root-cause-analysis
-  - /docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/get-started-incident-intelligence/#decisions
-  - /docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/get-started-incident-intelligence/#suggested-responders
-  - /docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/get-started-incident-intelligence/#issue-feed
+  - /docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/get-started-incident-intelligence/
 ---
 
 import issueFeed from 'images/issue_feed.png'


### PR DESCRIPTION
This was a hero request asking that we find the doc behind this failing link that was actually a redirect: /docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/get-started-incident-intelligence/