### PR TITLE
Update not-seeing-host-integration-data.mdx with trace mode

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/troubleshooting/not-seeing-host-integration-data.mdx
+++ b/src/content/docs/infrastructure/host-integrations/troubleshooting/not-seeing-host-integration-data.mdx
@@ -127,7 +127,7 @@ To troubleshoot and resolve the problem:
      >
        **Recommendation:** [Configure a log file](/docs/infrastructure/new-relic-infrastructure/troubleshooting/generating-logs-troubleshooting-infrastructure) in the infrastructure agent configuration. This helps separate the types of errors so you can spot integration errors more easily.
 
-       When there is an error loading or running your integration, the infrastructure agent adds an error message to the log file. Errors are logged even if `verbose` mode is disabled.
+       When there is an error loading or running your integration, the infrastructure agent adds an error message to the log file. Errors are logged even if `trace` mode is disabled.
 
        1. Check the log file for lines that include `"level=error"`.
        2. If there are no error messages, check whether the infrastructure agent is [loading the integration correctly](#check-loading).
@@ -139,7 +139,7 @@ To troubleshoot and resolve the problem:
      >
        To verify whether the infrastructure agent is loading the integration correctly, try these steps:
 
-       1. Enable [`verbose` mode](/docs/infrastructure/new-relic-infrastructure/troubleshooting/generating-logs-troubleshooting-infrastructure) in the infrastructure agent configuration.
+       1. Enable [`trace` mode](/docs/infrastructure/new-relic-infrastructure/troubleshooting/generating-logs-troubleshooting-infrastructure) in the infrastructure agent configuration.
        2. [Restart the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
        3. Verify that the first lines of the log file contain two messages:
 


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
On host integration troubleshooting guide still pointed to `verbose` mode instead of `trace` level to retrieve the integration's logs.