### PR TITLE
feat: new troubleshooting doc for meraki controller

### DIFF
--- a/src/content/docs/network-performance-monitoring/troubleshooting/meraki-controller-no-data.mdx
+++ b/src/content/docs/network-performance-monitoring/troubleshooting/meraki-controller-no-data.mdx
@@ -1,0 +1,92 @@
+---
+title: Meraki controller entities have metrics missing
+tags:
+  - Integrations
+  - Network monitoring
+  - Troubleshooting
+metaDescription: Meraki API polling is working, but expected metrics are missing.
+---
+
+## Problem [#problem]
+
+During Meraki API monitoring, you don't see all of the expected metrics for your controller.
+
+## Solutions [#solutions]
+
+Identify what metrics exist in New Relic by running the following NRQL query:
+
+```sql
+FROM Metric, KExtEvent SELECT
+count(*)
+FACET metricName OR eventType()
+WHERE instrumentation.name LIKE 'meraki%'
+OR eventType() = 'KExtEvent'
+SINCE 1 HOUR AGO LIMIT MAX
+```
+
+This query will give you a list of every dimensional metric and event being collected from your Meraki controller in the last hour. The sections below map each metric and event to its relative visualization in the Meraki controller entity dashboard.
+
+### Meraki API metrics [#meraki-metrics]
+
+<CollapserGroup>
+  <Collapser
+    id="client-metrics"
+    title="Client Metrics"
+  >
+    ```
+    kentik.meraki.clients.Recv
+    kentik.meraki.clients.RecvTotal
+    kentik.meraki.clients.Sent
+    kentik.meraki.clients.SentTotal
+    ```
+
+    These metrics map to these widgets:
+      * Summary
+      * Connected Clients
+      * Top 10 - Clients by Recv Bytes
+      * Top 10 - Clients by Sent Bytes
+      * Top 10 - Applications by Recv Bytes
+      * Top 10 - Applications by Sent Bytes
+      * Device Inventory
+      * Client Summary
+
+    Collection of these metrics is dictated by the `meraki_config.monitor_devices: true` setting in the [Meraki Dashboard API](https://docs.newrelic.com/docs/network-performance-monitoring/advanced/advanced-config/#meraki-dashboard-api) settings of your configuration file.
+
+    If the value of this setting is already set to `true` and you are still missing data, check your container logs for API failures and the next step would be to open a support ticket for assistance.
+  </Collapser>
+
+  <Collapser
+    id="uplink-metrics"
+    title="Uplink Metrics"
+  >
+    ```
+    kentik.meraki.uplinks.LatencyMS
+    kentik.meraki.uplinks.LossPct
+    kentik.meraki.uplinks.Recv
+    kentik.meraki.uplinks.Sent
+    ```
+
+    These metrics map to the **WAN Health** table.
+
+    Collection of these metrics is dictated by the `meraki_config.monitor_uplinks: true` setting in the [Meraki Dashboard API](https://docs.newrelic.com/docs/network-performance-monitoring/advanced/advanced-config/#meraki-dashboard-api) settings of your configuration file.
+
+    If the value of this setting is already set to `true` and you are still missing data, check your container logs for API failures and the next step would be to open a support ticket for assistance.
+  </Collapser>
+
+  <Collapser
+    id="config-change-events"
+    title="Config Change Events"
+  >
+    ```
+    KExtEvent
+    ```
+
+    This event maps to the **Meraki Configuration Changes** table.
+
+    Collection of these metrics is dictated by the `meraki_config.monitor_devices: true` setting in the [Meraki Dashboard API](https://docs.newrelic.com/docs/network-performance-monitoring/advanced/advanced-config/#meraki-dashboard-api) settings of your configuration file.
+
+    Note that this event can be very "quiet" and will only generate data when there are organization-level change events in the Meraki API endpoint for [getOrganizationConfigurationChanges](https://developer.cisco.com/meraki/api-latest/#!get-organization-configuration-changes). 
+
+    If the value of this setting is already set to `true` and you are still missing data, check your container logs for API failures and the next step would be to open a support ticket for assistance.
+  </Collapser>
+</CollapserGroup>

--- a/src/nav/network-performance-monitoring.yml
+++ b/src/nav/network-performance-monitoring.yml
@@ -43,3 +43,5 @@ pages:
         path: /docs/network-performance-monitoring/troubleshooting/no-device-in-UI
       - title: Sankey chart shows 'no data found' error
         path: /docs/network-performance-monitoring/troubleshooting/sankey-chart-no-data
+      - title: Meraki controller entity has charts with missing data
+        path: /docs/network-performance-monitoring/troubleshooting/meraki-controller-no-data

--- a/src/nav/network-performance-monitoring.yml
+++ b/src/nav/network-performance-monitoring.yml
@@ -29,19 +29,19 @@ pages:
         path: /docs/network-performance-monitoring/advanced/ktranslate-container-health
   - title: Troubleshooting network monitoring
     pages:
-      - title: SNMP discovery results in Kentik Default entities
-        path: /docs/network-performance-monitoring/troubleshooting/snmp-discovery-kentik-default
-      - title: SNMP discovery does not find any devices
-        path: /docs/network-performance-monitoring/troubleshooting/snmp-discovery-no-devices
-      - title: SNMP monitoring results have metrics missing
-        path: /docs/network-performance-monitoring/troubleshooting/snmp-polling-missing-metrics
-      - title: SNMP discovery maps to an unexpected profile
-        path: /docs/network-performance-monitoring/troubleshooting/snmp-discovery-unexpected-profile
-      - title: Collecting data for troubleshooting with the snmpwalk utility
-        path: /docs/network-performance-monitoring/troubleshooting/snmp-walk
       - title: Collecting data but no entity in Explorer
         path: /docs/network-performance-monitoring/troubleshooting/no-device-in-UI
-      - title: Sankey chart shows 'no data found' error
-        path: /docs/network-performance-monitoring/troubleshooting/sankey-chart-no-data
+      - title: Collecting data for troubleshooting with the snmpwalk utility
+        path: /docs/network-performance-monitoring/troubleshooting/snmp-walk
       - title: Meraki controller entity has charts with missing data
         path: /docs/network-performance-monitoring/troubleshooting/meraki-controller-no-data
+      - title: Sankey chart shows 'no data found' error
+        path: /docs/network-performance-monitoring/troubleshooting/sankey-chart-no-data
+      - title: SNMP discovery does not find any devices
+        path: /docs/network-performance-monitoring/troubleshooting/snmp-discovery-no-devices
+      - title: SNMP discovery maps to an unexpected profile
+        path: /docs/network-performance-monitoring/troubleshooting/snmp-discovery-unexpected-profile
+      - title: SNMP discovery results in Kentik Default entities
+        path: /docs/network-performance-monitoring/troubleshooting/snmp-discovery-kentik-default
+      - title: SNMP monitoring results have metrics missing
+        path: /docs/network-performance-monitoring/troubleshooting/snmp-polling-missing-metrics


### PR DESCRIPTION
adding a new troubleshooting doc for [EXT-MERAKI_CONTROLLER](https://github.com/newrelic/entity-definitions/tree/main/definitions/ext-meraki_controller) entities missing data in Network Monitoring.