### PR TITLE
NEWRELIC-3777 add docs for custom instrumentation in ESM

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api.mdx
@@ -409,3 +409,5 @@ You can also control the browser agent via APM agent API calls. For more informa
 ## Extend custom instrumentation [#custom-instrumentation]
 
 The `newrelic.instrument()` provides additional flexibility for custom instrumentation. For more information, including tutorials and examples, see the [shims documentation on GitHub](http://newrelic.github.io/node-newrelic/docs/Shim.html).
+
+To add custom instrumentation in ES module applications, please refer to our [ES module](/docs/apm/agents/nodejs-agent/installation-configuration/es-modules) documentation or [example application](https://github.com/newrelic/newrelic-node-examples/tree/main/esm-app) in GitHub.

--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -176,6 +176,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     id="instrumentLoadedModule"
     title={<InlineCode>newrelic.instrumentLoadedModule(moduleName, moduleInstance)</InlineCode>}
   >
+    <Callout variant="important">
+      This method is not supported in ES module applications.
+    </Callout>
+    
     ```js
     newrelic.instrumentLoadedModule(moduleName, moduleInstance)
     ```

--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -177,9 +177,10 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     title={<InlineCode>newrelic.instrumentLoadedModule(moduleName, moduleInstance)</InlineCode>}
   >
     <Callout variant="important">
-      This method is not supported in ES module applications.
+      This method is not supported or necessary in ES module applications, as agent bootstrapping in ES module applications is different than CommonJS applications.
+      In ES module applications, the agent is able to compensate for the issue this method solves for CommonJS applications.
     </Callout>
-    
+
     ```js
     newrelic.instrumentLoadedModule(moduleName, moduleInstance)
     ```

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/es-modules.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/es-modules.mdx
@@ -78,6 +78,13 @@ You can add the loader to your application by using the Node.js `--experimental-
 node --experimental-loader newrelic/esm-loader.mjs your-program.js
 ```
 
+## Custom instrumentation [#custom-instrumentation]
+The Node.js APM agent supports adding custom instrumentation to your ES module applications.
+You can create instrumentation in ES module applications using most of the [instrumentation registration methods on the API](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#custom-instrumentation-api).
+Due to the nature of ES module imports, we are unable to support `newrelic.instrumentLoadedModule`. ES module bindings are not assignable, which prevent the agent from replacing a module's exported members with instrumentation after the module has been loaded.
+
+To see a demonstration of how to use the custom instrumentation API in an ES module application, check out our [example app](https://github.com/newrelic/newrelic-node-examples/tree/main/esm-app) in GitHub.
+
 ## Learn More [#learn-more]
 * [Node.js ES module documentation](https://nodejs.org/api/esm.html#introduction)
 * [Node.js Packaging documentation](https://nodejs.org/api/packages.html#introduction)

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/es-modules.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/es-modules.mdx
@@ -83,9 +83,10 @@ The Node.js APM agent supports adding custom instrumentation to your ES module a
 You can create instrumentation in ES module applications using most of the [instrumentation registration methods on the API](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#custom-instrumentation-api).
 Due to the nature of ES module imports, we are unable to support `newrelic.instrumentLoadedModule`. ES module bindings are not assignable, which prevent the agent from replacing a module's exported members with instrumentation after the module has been loaded.
 
-To see a demonstration of how to use the custom instrumentation API in an ES module application, check out our [example app](https://github.com/newrelic/newrelic-node-examples/tree/main/esm-app) in GitHub.
+To see a demonstration of how to use the custom instrumentation API in an ES module application, check out our [example](https://github.com/newrelic/newrelic-node-examples/blob/main/esm-app/custom-instrumentation/index.js) in GitHub.
 
 ## Learn More [#learn-more]
 * [Node.js ES module documentation](https://nodejs.org/api/esm.html#introduction)
 * [Node.js Packaging documentation](https://nodejs.org/api/packages.html#introduction)
 * [ECMAScript Standards documentation](https://tc39.es/ecma262/#sec-modules)
+* [Demo ES Module Application](https://github.com/newrelic/newrelic-node-examples/tree/main/esm-app)

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -1049,7 +1049,7 @@ This section allows you to choose which API methods are enabled. Each configurat
     Complete filepath to custom instrumentation definition, enables the ability to load custom instrumentation in ES module applications.
 
     Setting this configuration option will instruct the agent's ES module loader to load any custom instrumentation defined at the path provided.
-    To see a working example of defining custom instrumentation in an ES module application, check out our [example app](https://github.com/newrelic/newrelic-node-examples/tree/main/esm-app) in GitHub.
+    To see a working example of defining custom instrumentation in an ES module application, check out our [example](https://github.com/newrelic/newrelic-node-examples/blob/main/esm-app/custom-instrumentation/index.js) in GitHub.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -1046,7 +1046,7 @@ This section allows you to choose which API methods are enabled. Each configurat
       </tbody>
     </table>
 
-    Relative filepath to custom instrumentation definition, which is relative to the application root. Enables the ability to load custom instrumentation in ES module applications.
+    This uses the relative filepath to the custom instrumentation definition, which is relative to the application root. It enables you to load custom instrumentation in ES module applications.
 
     Setting this configuration option will instruct the agent's ES module loader to load any custom instrumentation defined at the path provided.
     To see a working example of defining custom instrumentation in an ES module application, check out our [example](https://github.com/newrelic/newrelic-node-examples/blob/main/esm-app/custom-instrumentation/index.js) in GitHub.

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -1046,7 +1046,7 @@ This section allows you to choose which API methods are enabled. Each configurat
       </tbody>
     </table>
 
-    Complete filepath to custom instrumentation definition, enables the ability to load custom instrumentation in ES module applications.
+    Relative filepath to custom instrumentation definition, which is relative to the application root. Enables the ability to load custom instrumentation in ES module applications.
 
     Setting this configuration option will instruct the agent's ES module loader to load any custom instrumentation defined at the path provided.
     To see a working example of defining custom instrumentation in an ES module application, check out our [example](https://github.com/newrelic/newrelic-node-examples/blob/main/esm-app/custom-instrumentation/index.js) in GitHub.

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -1007,6 +1007,52 @@ This section defines the Node.js agent variables in the order they typically app
 
 This section allows you to choose which API methods are enabled. Each configuration option allows you to modularly enable API methods that are responsible for sending custom information to New Relic.
 
+<CollapserGroup>
+  <Collapser
+    id="custom-attributes"
+    title="esm.custom_instrumentation_entrypoint"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_API_ESM_CUSTOM_INSTRUMENTATION_ENTRYPOINT`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Complete filepath to custom instrumentation definition, enables the ability to load custom instrumentation in ES module applications.
+
+    Setting this configuration option will instruct the agent's ES module loader to load any custom instrumentation defined at the path provided.
+    To see a working example of defining custom instrumentation in an ES module application, check out our [example app](https://github.com/newrelic/newrelic-node-examples/tree/main/esm-app) in GitHub.
+  </Collapser>
+</CollapserGroup>
+
 <Callout variant="important">
   All of these are set to `false` when the agent is in high security mode.
 </Callout>


### PR DESCRIPTION
**What problems does this PR solve?**
* Creates documentation explaining how custom instrumentation works for ES module applications, including caveats about `newrelic.instrumentLoadedModule`

**Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.**
* Due to the nature of ES modules, we had to add a new configuration value that allows customers to inject their custom instrumentation definition into our ES module loader. This PR documents that configuration value, and also updates our newly created ESM documentation to link to our custom instrumentation example application. It also documents that `newrelic.instrumentLoadedModule` does not work in ESM apps, due to immutability of module bindings after load.

**If your issue relates to an existing GitHub issue, please link to it.**
* Part of NEWRELIC-3777