### PR TITLE
docs: add info about `shutdown` callback

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -780,9 +780,9 @@ New Relic's Node.js agent includes additional API calls.
     newrelic.shutdown(options, callback)
     ```
 
-    Use this method to gracefully shut down the agent, both parameters are optional.
-    
-     <table>
+    Use this method to gracefully shut down the agent, both parameters are optional. Here's an overview table showing the parameters:
+
+    <table>
       <tr>
         <th style={{ width: "180px" }}>
           Parameter
@@ -803,6 +803,24 @@ New Relic's Node.js agent includes additional API calls.
 
       <tr>
         <td>
+          `options `
+        </td>
+
+        <td>
+          `object`
+        </td>
+
+        <td>
+          Optional
+        </td>
+
+        <td>
+          Object with shut down options
+        </td>
+      </tr>
+
+      <tr>
+        <td>
           `callback`
         </td>
 
@@ -815,28 +833,12 @@ New Relic's Node.js agent includes additional API calls.
         </td>
 
         <td>
-          Callback function that runs when agent stops.
-        </td>
-      </tr>
-      
-      <tr>
-        <td>
-          `options`
-        </td>
-
-        <td>
-          `object`
-        </td>
-
-        <td>
-          Optional
-        </td>
-
-        <td>
-          Object with shut down options.
+          Callback function that runs when agent stops
         </td>
       </tr>
     </table>
+
+Here is a detail table showing the object shutdown options:
 
     <table>
       <tr>

--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -777,10 +777,66 @@ New Relic's Node.js agent includes additional API calls.
     title={<InlineCode>newrelic.shutdown([options], callback)</InlineCode>}
   >
     ```js
-    newrelic.shutdown([options], callback)
+    newrelic.shutdown(options, callback)
     ```
 
-    Use this method to gracefully shut down the agent.
+    Use this method to gracefully shut down the agent, both parameters are optional.
+    
+     <table>
+      <tr>
+        <th style={{ width: "180px" }}>
+          Parameter
+        </th>
+
+        <th style={{ width: "100px" }}>
+          Type
+        </th>
+
+        <th style={{ width: "100px" }}>
+          Attributes
+        </th>
+
+        <th style={{ width: "200px" }}>
+          Description
+        </th>
+      </tr>
+
+      <tr>
+        <td>
+          `callback`
+        </td>
+
+        <td>
+          `function`
+        </td>
+
+        <td>
+          Optional
+        </td>
+
+        <td>
+          Callback function that runs when agent stops.
+        </td>
+      </tr>
+      
+      <tr>
+        <td>
+          `options`
+        </td>
+
+        <td>
+          `object`
+        </td>
+
+        <td>
+          Optional
+        </td>
+
+        <td>
+          Object with shut down options.
+        </td>
+      </tr>
+    </table>
 
     <table>
       <tr>


### PR DESCRIPTION
data comes from this doc: https://newrelic.github.io/node-newrelic/docs/API.html#shutdown

added a new table for the parameters above the table of 'options'. Feel free make this look better or suggest changes. `callback` is optional but that was not made clear on this doc.