### PR TITLE
fix(Metrics): Fixing time window in query

### DIFF
--- a/src/content/docs/data-apis/convert-to-metrics/create-metrics-other-data-types.mdx
+++ b/src/content/docs/data-apis/convert-to-metrics/create-metrics-other-data-types.mdx
@@ -71,13 +71,12 @@ The most important part of [creating a metrics rule](#overview-process) is const
 
 3. Decide on the attributes you want to attach to the metric, following the [limits on the cardinality of unique metric-name/attribute-value combinations](#attributes-limit).
 
-   **Recommendation:** Run a separate query to ensure this count isn't over 50,000 for a 24-hour window. For example:
+   **Recommendation:** Run a separate query to ensure the maximum cardinality isn't over 50,000 for a 30 second window. For example, the following query will find the maximum cardinality encountered in a 30 second period over the last 3 hours for the `ProcessSample` event when including the `awsRegion`, `awsAvailabilityZone`, and `commandName` attributes:
 
    ```
-   FROM ProcessSample
-   SELECT uniqueCount(awsRegion, awsAvailabilityZone, commandName)
-   WHERE nr.entityType = 'HOST'
-   SINCE 1 DAY AGO
+FROM (FROM ProcessSample
+    SELECT rate(uniqueCount(awsRegion, awsAvailabilityZone, commandName), 30 seconds) AS 'cardinalityRate'
+    WHERE nr.entityType = 'HOST' TIMESERIES 30 seconds) SELECT max(cardinalityRate) AS 'maxCardinalityRate' SINCE 3 hours AGO
    ```
 
 4. To be able to aggregate and filter your metrics, add the attributes you want to attach to the metric using the `FACET` clause. For example:


### PR DESCRIPTION
* What problems does this PR solve?
We enforce a 50k per 30 second window cardinality limit, not per 24 hours.  Updating docs to reflect that.