### PR TITLE
Added link to "restart your infrastructure agent"

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -838,9 +838,9 @@ The .NET agent does not directly monitor datastore processes. Also, by default t
 If your application uses ADO.NET, you can install a combination of New Relic agents that will generate an ADO dashboard. Here’s what you need to do:
 
 1. Install the New Relic APM .NET agent and the infrastructure agent by following the steps in our [installation tool](https://one.newrelic.com/marketplace?account=2498654&state=e56ce690-3ecc-e8cf-e36e-b40d96ff24f2).
-2. Install the Microsoft Windows Perfmon/WMI on-host integration for New Relic infrastructure by [following these instructions](https://github.com/newrelic/nri-perfmon#nri-perfmon---windows-perfmonwmi-on-host-integration-for-new-relic-infrastructure).
-3. If you installed Perfmon manually, restart your infrastructure agent.
-4. Go to our ADO.net quickstart page to [install the ADO.net dashboards](https://newrelic.com/instant-observability/ado-dotnet).
+2. Install the Microsoft Windows Perfmon/WMI on-host integration for New Relic infrastructure by [following the nri-perfmon instructions](https://github.com/newrelic/nri-perfmon#nri-perfmon---windows-perfmonwmi-on-host-integration-for-new-relic-infrastructure).
+3. If you installed Perfmon manually, [restart your infrastructure agent](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/manage-your-agent/start-stop-restart-infrastructure-agent).
+4. Go to our ADO.NET quickstart page to [install the ADO.NET dashboards](https://newrelic.com/instant-observability/ado-dotnet).
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
Changes on ADO.NET's Additional configuration description
1. Applied link to "restart your infrastructure agent" text
2. Changed ADO.net to ADO.NET in the 4th point

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.