### PR TITLE
Add python agent v8.2.1 release notes

### DIFF
--- a/src/content/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy.mdx
@@ -29,6 +29,20 @@ Any versions not listed in the following table are no longer supported. Please [
   <tbody>
     <tr>
       <td>
+        v8.2.1
+      </td>
+
+      <td>
+        Oct 10, 2022
+      </td>
+
+      <td>
+        Oct 10, 2023
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         v8.2.0.181
       </td>
 
@@ -699,35 +713,6 @@ Any versions not listed in the following table are no longer supported. Please [
         Nov 6, 2022
       </td>
     </tr>
-    
-    <tr>
-      <td>
-        v5.2.1.129
-      </td>
-
-      <td>
-        Oct 9, 2019
-      </td>
-
-      <td>
-        Oct 9, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v5.2.0.127
-      </td>
-
-      <td>
-        Oct 1, 2019
-      </td>
-
-      <td>
-        Oct 1, 2022
-      </td>
-    </tr>
-
 
   </tbody>
 </table>

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80201.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80201.mdx
@@ -11,27 +11,27 @@ This release of the Python agent provides numerous bug fixes, including several 
 
 Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the New Relic [download site](http://download.newrelic.com/python_agent/release).
 
-## Version Numbering Change
+## Version numbering change
 
 The version number of the agent did not previously follow [Semantic Versioning](https://semver.org/) properly. This has been changed. Going forward build numbers have been removed from the version number, and version increments will follow semantic versioning fully. No retroactive changes will be made to previous version numbers.
 
-## Instrumentation Updates
+## Instrumentation updates
 
-* **Updated Sanic Middleware Support**
+* **Updated Sanic middleware support**
 
     Sanic recently changed their APIs surrounding middleware, and instrumentation has been updated to support it.
 
-## Package Updates
+## Package updates
 
 * **Update wrapt to v1.14.1**
 
     The internal copy of the wrapt library used by the agent has been updated to v1.14.1 for Python 3.11 compatibility.
 
-* **Protobuf v4 Now Supported**
+* **Protobuf v4 now supported**
 
-    The agent is now fully compatible with Protobuf v4 when using infinite tracing. Backwards compatibility with Protobuf v3 has been preserved.
+    The agent is now fully compatible with Protobuf v4 when using Infinite Tracing. Backwards compatibility with Protobuf v3 has been preserved.
 
-## Bug Fixes
+## Bug fixes
 
 * **Fixed a RuntimeError in the trace cache when using the coroutine profiler.**
 
@@ -65,4 +65,4 @@ The version number of the agent did not previously follow [Semantic Versioning](
 
 ## Support statement
 
-New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.2.2.130](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-522130).  More information can be found in the [EOL Policy Page](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/).
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.2.2.130](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-522130). More information can be found in the [EOL Policy Page](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/).

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80201.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80201.mdx
@@ -1,0 +1,68 @@
+---
+subject: Python agent
+releaseDate: '2022-10-10'
+version: 8.2.1
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+---
+
+## Notes
+
+This release of the Python agent provides numerous bug fixes, including several community contributions, provides updates to Sanic instrumentation, Protobuf v4 compatiblity, and updates internal packages for Python 3.11 support.
+
+Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the New Relic [download site](http://download.newrelic.com/python_agent/release).
+
+## Version Numbering Change
+
+The version number of the agent did not previously follow [Semantic Versioning](https://semver.org/) properly. This has been changed. Going forward build numbers have been removed from the version number, and version increments will follow semantic versioning fully. No retroactive changes will be made to previous version numbers.
+
+## Instrumentation Updates
+
+* **Updated Sanic Middleware Support**
+
+    Sanic recently changed their APIs surrounding middleware, and instrumentation has been updated to support it.
+
+## Package Updates
+
+* **Update wrapt to v1.14.1**
+
+    The internal copy of the wrapt library used by the agent has been updated to v1.14.1 for Python 3.11 compatibility.
+
+* **Protobuf v4 Now Supported**
+
+    The agent is now fully compatibile with Protobuf v4 when using infinite tracing. Backwards compatibility with Protobuf v3 has been preserved.
+
+## Bug Fixes
+
+* **Fixed a RuntimeError in the trace cache when using the coroutine profiler.**
+
+    A RuntimeError occured if traces were started or stopped while the coroutine profiler was sampling the active traces. This should no longer be possible.
+
+    Thank you [@lovmat](https://github.com/lovmat) for your contribution!
+
+* **Fixed an issue with case sensitivity in record-deploy** 
+
+    Previously application names were incorrectly being treated as case-sensitive when running `newrelic-admin record-deploy`.
+
+    Thank you [@michalborkowski96](https://github.com/michalborkowski96) for your contribution!
+
+* **Fixed an issue with newer installers failing to install the agent.**
+
+    Due to the inclusion of both `scripts` and `entry_points` configuration options, the agent would fail to install with newer installers. This has been corrected and newer PEP compliant installers should have no trouble installing the agent.
+
+    Thank you [@admp-fh](https://github.com/admp-fh) for your contribution!
+
+* **Fixed instrumentation for AioRedis interfering with transactions.**
+
+    The agent does not currently support transactions for Redis clients, and previous instrumentation broke transaction functionality in AioRedis. This has been fixed to provide no instrumentation within transactions at this time.
+
+* **Fixed a crash when completing various kinds of traces inside a stopped transaction.**
+
+    Previously certain types of traces could throw exceptions and fail to complete when inside stopped transactions. This has been corrected and should no longer be possible.
+
+* **Fixed a bug where instrumentation caused certain arguments to Confluent-Kafka Producers to stop working.**
+
+    Previously callback and on_delivery arguments were passed through improperly leading to them not working as expected.
+
+## Support statement
+
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.2.2.130](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-520127/).  More information can be found in the [EOL Policy Page](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/).

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80201.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80201.mdx
@@ -29,13 +29,13 @@ The version number of the agent did not previously follow [Semantic Versioning](
 
 * **Protobuf v4 Now Supported**
 
-    The agent is now fully compatibile with Protobuf v4 when using infinite tracing. Backwards compatibility with Protobuf v3 has been preserved.
+    The agent is now fully compatible with Protobuf v4 when using infinite tracing. Backwards compatibility with Protobuf v3 has been preserved.
 
 ## Bug Fixes
 
 * **Fixed a RuntimeError in the trace cache when using the coroutine profiler.**
 
-    A RuntimeError occured if traces were started or stopped while the coroutine profiler was sampling the active traces. This should no longer be possible.
+    A RuntimeError occurred if traces were started or stopped while the coroutine profiler was sampling the active traces. This should no longer be possible.
 
     Thank you [@lovmat](https://github.com/lovmat) for your contribution!
 
@@ -65,4 +65,4 @@ The version number of the agent did not previously follow [Semantic Versioning](
 
 ## Support statement
 
-New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.2.2.130](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-520127/).  More information can be found in the [EOL Policy Page](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/).
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.2.2.130](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-522130).  More information can be found in the [EOL Policy Page](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/).


### PR DESCRIPTION
* Adds release notes for Python Agent v8.2.1 and updates EOL policy for Python agent versions.