### PR TITLE
feat(analytics): add agent name to all events that fire on install ui page

### DIFF
--- a/src/pages/install/{installConfig.agentName}.js
+++ b/src/pages/install/{installConfig.agentName}.js
@@ -48,6 +48,7 @@ const InstallPage = ({ data, location }) => {
 
   if (typeof window !== 'undefined' && typeof newrelic === 'object') {
     window.newrelic.setCustomAttribute('pageType', 'Interactive/Install');
+    window.newrelic.setCustomAttribute('agentName', agentName);
   }
 
   const selectOptions = appInfo.map((select) => ({


### PR DESCRIPTION
## Description

Adds custom attribute to explicitly identify the agent name for all events that Tessen forwards via our Browser agent  events (`PageView` and `PageAction`).

Currently, not all events have the `agentName` set which causes you to have rely on a URL path based attribute like `path`, `currentUrl`, or `pageUrl` which have some issues as well. `path` is not available on all events and the page can resolve with a trailing slash or without, which makes it filtering or faceting on `currentUrl` or `pageUrl` a little difficult / confusing. Additionally, it wasn't clear when to use `pageUrl` vs `currentUrl` in various queries. And relying on url path forces you to account for:
* prod vs dev
* localized pages

if `agentName` is set via Tessen call, it's maintained when data is reported as expected. I left that in because that attribute also gets reported to Segment and beyond which _could_ useful to downstream queries.

## Related issues / PRs
Closes https://issues.newrelic.com/browse/NR-54870

