### PR TITLE
Oct 31: whats-new: add streaming data export

### DIFF
--- a/src/content/whats-new/2022/10/whats-new-10-12-streaming-data-exports.md
+++ b/src/content/whats-new/2022/10/whats-new-10-12-streaming-data-exports.md
@@ -1,0 +1,35 @@
+---
+title: 'New Relic Data Plus allows for streaming export of your data through AWS Kinesis Firehose for deeper data exploration and compliance needs.
+releaseDate: '2022-10-12'
+getStartedLink: 'https://newrelic.com/blog/nerdlog/data-plus-pricing'
+---
+#  Streaming data export allows you to stream data out of New Relic for deeper data exploration as well as for compliance and security 
+
+Today, [Data Plus](https://docs.newrelic.com/whats-new/2022/06/whats-new-6-1-data-plus-available) customers can stream data out of New Relic (as it is being ingested) for compliance, security, and deeper data analysis. This is done through AWS Kinesis Firehose via NerdGraph. Using NerdGraph queries, you can create and manage streaming rules that determine what sort of data will be exported in real-time. As this data is only exported during [ingestion](https://docs.newrelic.com/docs/data-apis/manage-data/manage-data-coming-new-relic/), it differs from [historical data export](https://docs.newrelic.com/whats-new/2022/09/whats-new-9-14-historical-data-exports) which sends past data post ingestion stage.  
+
+In addition Data Plus also includes:
+
+* Up to 90 days of data retention 
+* FedRAMP authorized
+* HIPAA compliance with HITRUST certification (Pro and Enterprise customers only) 
+* Logs obfuscation
+* Historical data export
+* Vulnerability management (Q4 2022)
+* Cloud provider choice (Q1 2023)
+
+[Read more here](https://newrelic.com/blog/nerdlog/data-plus-pricing)
+
+# Learn more about Streaming Data Export
+1. Take a deep dive into all the capabilities available for streaming data export on [our docs page](https://docswebsitedevelop-newstreamingexportngdoc.gtsb.io/).
+
+
+Footer
+© 2022 GitHub, Inc.
+Footer navigation
+Terms
+Privacy
+Security
+Status
+Docs
+Contact GitHub
+Pricing

--- a/src/content/whats-new/2022/10/whats-new-10-12-streaming-data-exports.md
+++ b/src/content/whats-new/2022/10/whats-new-10-12-streaming-data-exports.md
@@ -1,5 +1,5 @@
 ---
-title: 'New Relic Data Plus allows for streaming export of your data through AWS Kinesis Firehose for deeper data exploration and compliance needs.
+title: 'New Relic Data Plus allows for streaming export of your data through AWS Kinesis Firehose for deeper data exploration and compliance needs.'
 releaseDate: '2022-10-12'
 getStartedLink: 'https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-streaming-export'
 ---

--- a/src/content/whats-new/2022/10/whats-new-10-12-streaming-data-exports.md
+++ b/src/content/whats-new/2022/10/whats-new-10-12-streaming-data-exports.md
@@ -3,9 +3,10 @@ title: 'New Relic Data Plus allows for streaming export of your data through AWS
 releaseDate: '2022-10-12'
 getStartedLink: 'https://newrelic.com/blog/nerdlog/data-plus-pricing'
 ---
+
 #  Streaming data export allows you to stream data out of New Relic for deeper data exploration as well as for compliance and security 
 
-Today, [Data Plus](https://docs.newrelic.com/whats-new/2022/06/whats-new-6-1-data-plus-available) customers can stream data out of New Relic (as it is being ingested) for compliance, security, and deeper data analysis. This is done through AWS Kinesis Firehose via NerdGraph. Using NerdGraph queries, you can create and manage streaming rules that determine what sort of data will be exported in real-time. As this data is only exported during [ingestion](https://docs.newrelic.com/docs/data-apis/manage-data/manage-data-coming-new-relic/), it differs from [historical data export](https://docs.newrelic.com/whats-new/2022/09/whats-new-9-14-historical-data-exports) which sends past data post ingestion stage.  
+Today, [Data Plus](https://docs.newrelic.com/whats-new/2022/06/whats-new-6-1-data-plus-available) customers can stream data out of New Relic (as it is being ingested) for compliance, security, and deeper data analysis. This is done through AWS Kinesis Firehose via NerdGraph. Using NerdGraph queries, you can create and manage streaming rules that determine what sort of data will be exported in real time. As this data is only exported during [ingestion](https://docs.newrelic.com/docs/data-apis/manage-data/manage-data-coming-new-relic), it differs from [historical data export](https://docs.newrelic.com/whats-new/2022/09/whats-new-9-14-historical-data-exports) which reports past data, after the ingestion stage.  
 
 In addition Data Plus also includes:
 
@@ -19,17 +20,7 @@ In addition Data Plus also includes:
 
 [Read more here](https://newrelic.com/blog/nerdlog/data-plus-pricing)
 
-# Learn more about Streaming Data Export
-1. Take a deep dive into all the capabilities available for streaming data export on [our docs page](https://docswebsitedevelop-newstreamingexportngdoc.gtsb.io/).
+# Learn more about streaming data export
 
+Take a deep dive into all the capabilities available in [our streaming data export doc](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-streaming-export).
 
-Footer
-© 2022 GitHub, Inc.
-Footer navigation
-Terms
-Privacy
-Security
-Status
-Docs
-Contact GitHub
-Pricing

--- a/src/content/whats-new/2022/10/whats-new-10-12-streaming-data-exports.md
+++ b/src/content/whats-new/2022/10/whats-new-10-12-streaming-data-exports.md
@@ -1,21 +1,21 @@
 ---
 title: 'New Relic Data Plus allows for streaming export of your data through AWS Kinesis Firehose for deeper data exploration and compliance needs.'
-releaseDate: '2022-10-12'
+releaseDate: '2022-10-25'
 getStartedLink: 'https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-streaming-export'
 ---
 
 #  Streaming data export allows you to stream data out of New Relic for deeper data exploration as well as for compliance and security 
 
-Today, [Data Plus](https://docs.newrelic.com/whats-new/2022/06/whats-new-6-1-data-plus-available) customers can stream data out of New Relic (as it is being ingested) for compliance, security, and deeper data analysis. This is done through AWS Kinesis Firehose via NerdGraph. Using NerdGraph queries, you can create and manage streaming rules that determine what sort of data will be exported in real time. As this data is only exported during [ingestion](https://docs.newrelic.com/docs/data-apis/manage-data/manage-data-coming-new-relic), it differs from [historical data export](https://docs.newrelic.com/whats-new/2022/09/whats-new-9-14-historical-data-exports) which reports past data, after the ingestion stage.  
+Today, [Data Plus](https://docs.newrelic.com/whats-new/2022/06/whats-new-6-1-data-plus-available) customers can stream data out of New Relic (as it is being ingested) for compliance, security, and deeper data analysis. This is done through AWS Kinesis Firehose via NerdGraph. Using NerdGraph queries, you can create and manage streaming rules that determine what sort of data will be exported in real time. As this data is only exported during [ingestion](https://docs.newrelic.com/docs/data-apis/manage-data/manage-data-coming-new-relic), it differs from [historical data export](https://docs.newrelic.com/whats-new/2022/09/whats-new-9-14-historical-data-exports) which reports past data, not data currently being ingested.  
 
-In addition Data Plus also includes:
+In addition, Data Plus also includes:
 
 * Up to 90 days of data retention across all data types
 * FedRAMP authorized
 * HIPAA compliance with HITRUST certification (Pro and Enterprise customers only) 
 * Logs obfuscation
 * Historical data export
-* Vulnerability management (Q4 2022)
+* Vulnerability management
 * Cloud provider choice (Q1 2023)
 
 [Read more here](https://newrelic.com/blog/nerdlog/data-plus-pricing)

--- a/src/content/whats-new/2022/10/whats-new-10-12-streaming-data-exports.md
+++ b/src/content/whats-new/2022/10/whats-new-10-12-streaming-data-exports.md
@@ -1,6 +1,6 @@
 ---
 title: 'New Relic Data Plus allows for streaming export of your data through AWS Kinesis Firehose for deeper data exploration and compliance needs.'
-releaseDate: '2022-10-25'
+releaseDate: '2022-10-31'
 getStartedLink: 'https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-streaming-export'
 ---
 
@@ -23,4 +23,3 @@ In addition, Data Plus also includes:
 # Learn more about streaming data export
 
 Take a deep dive into all the capabilities available in [our streaming data export doc](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-streaming-export).
-

--- a/src/content/whats-new/2022/10/whats-new-10-12-streaming-data-exports.md
+++ b/src/content/whats-new/2022/10/whats-new-10-12-streaming-data-exports.md
@@ -10,7 +10,7 @@ Today, [Data Plus](https://docs.newrelic.com/whats-new/2022/06/whats-new-6-1-dat
 
 In addition Data Plus also includes:
 
-* Up to 90 days of data retention 
+* Up to 90 days of data retention across all data types
 * FedRAMP authorized
 * HIPAA compliance with HITRUST certification (Pro and Enterprise customers only) 
 * Logs obfuscation

--- a/src/content/whats-new/2022/10/whats-new-10-12-streaming-data-exports.md
+++ b/src/content/whats-new/2022/10/whats-new-10-12-streaming-data-exports.md
@@ -1,7 +1,7 @@
 ---
 title: 'New Relic Data Plus allows for streaming export of your data through AWS Kinesis Firehose for deeper data exploration and compliance needs.
 releaseDate: '2022-10-12'
-getStartedLink: 'https://newrelic.com/blog/nerdlog/data-plus-pricing'
+getStartedLink: 'https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-streaming-export'
 ---
 
 #  Streaming data export allows you to stream data out of New Relic for deeper data exploration as well as for compliance and security 


### PR DESCRIPTION
Prob Oct 19 or later, waiting to hear from SMEs.
@zuluecho9 will review. 

## Give us some context

*Streaming data export releases on 10-12-2022, we will delay the launch announcement.
*Data Plus exclusive feature
*This requires AWS Kinesis Firehose (must be AWS customer in this instance)
*Doc page link is not live, I put the github commit repo link