### PR TITLE
Update SLM, move instrumentation features

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-comparison.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-comparison.mdx
@@ -74,7 +74,7 @@ We recommend you start with the table at the beginning that shows high-level com
         ✅
       </td>
       <td>
-        🟡 Spans only at present
+        ✅
       </td>
     </tr>
     <tr>
@@ -1029,11 +1029,11 @@ Conditions, violations, incidents, and issues all work for any entity.
   <Collapser
     className="freq-link"
     id="slm"
-    title="Service Level Management (SLM) (Beta)"
+    title="Service Level Management (SLM)"
   >
     New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: ✅ 
 
-    OpenTelemetry service entities do not have a dedicated SLM UI, but SLIs (service level indicators) can be viewed for them in a workload or in the mini-overview. SLIs for OpenTelemetry services can only be created from log, span, or span event data.
+    OpenTelemetry service entities do not have a dedicated Service Levels UI, but SLIs (service level indicators) can be viewed for them in a workload or in the mini-overview.
   </Collapser>
   <Collapser
     className="freq-link"
@@ -1074,15 +1074,6 @@ Conditions, violations, incidents, and issues all work for any entity.
 
     Entities coming both from New Relic agent and OpenTelemetry data can be added to a workload. The golden metrics for each entity depend on the entity type. 
   </Collapser>
-  <Collapser
-    className="freq-link"
-    id="live-inst"
-    title="Live instrumentation"
-  >
-    New Relic agents: 🟡 Limited support &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: ❌ 
-
-    Entities coming both from New Relic agent and OpenTelemetry data can be added to a workload. The golden metrics for each entity depend on the entity type. 
-  </Collapser>
 </CollapserGroup>
 
 ## Configuration options [#configuration-opts]
@@ -1118,6 +1109,24 @@ Conditions, violations, incidents, and issues all work for any entity.
     New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: ❌
 
     The restrictions on data enforced by New Relic agents’ high security mode feature could be enforced by configuring or modifying the OpenTelemetry collector, but New Relic could not enforce them because OTLP does not specify such controls.
+  </Collapser>
+  <Collapser
+    className="freq-link"
+    id="live-inst"
+    title="Instrumentation editor"
+  >
+    New Relic agents: 🟡 Java only &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: ❌ 
+
+    Only the New Relic Java agent supports creating, applying, and exporting custom instrumentation via the UI.
+  </Collapser>
+  <Collapser
+    className="freq-link"
+    id="live-inst"
+    title="Live instrumentation"
+  >
+    New Relic agents: 🟡 Limited release for .NET &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: ❌ 
+
+    Only the New Relic .NET agent supports a live custom instrumentation update via the UI, without agent restart. This feature is in limited release. 
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
SLM is not in beta, and with metrics support now has comparable features between OTel and NR agent, minus the per-entity UI.

The "Live instrumentation" had accidental copy-paste content; replaced that with appropriate description. Added "Custom instrumentation" feature for Java.