### PR TITLE
Neutral double qoutation marks to be used for string defined inside the `include_matching_metrics:`

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -3003,10 +3003,10 @@ See our [github documentation](https://github.com/newrelic/infrastructure-agent/
     ```
     include_matching_metrics: # You can combine attributes from different metrics
         process.name:
-          - regex “^java”    # Include all processes starting with "java"
+          - regex "^java"    # Include all processes starting with "java"
         process.executable:
-          - “/usr/bin/python2”              # Include the Python 2.x executable
-          - regex “\\System32\\svchost”     # Include all svchost executables
+          - "/usr/bin/python2"              # Include the Python 2.x executable
+          - regex "\\System32\\svchost"     # Include all svchost executables
     ```
 
     If you need to include command line arguments in any of the values, set [`strip_command_line`](#strip-command-line) to false (the infrastructure agents removes CLI arguments by default to prevent secrets from leaking).


### PR DESCRIPTION
Unicode left double qoutation marks and right double qoutation marks in the sample YAML snippet when copied to use was not matching process names and resulted in a quite lot of debugging effort  to get the process filtering working from Infrastructure agents from Windows hosts. The sample yaml snippets should be updated with Neutral double qoutation marks (vertical) to prevent such issues

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.