### PR TITLE
docs: remove duplicate page entry

### DIFF
--- a/src/nav/kubernetes-pixie.yml
+++ b/src/nav/kubernetes-pixie.yml
@@ -49,8 +49,6 @@ pages:
           path: /docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-apm-applications-kubernetes
         - title: Link OTel-instrumented apps to Kubernetes
           path: /docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes
-        - title: Configure control plane monitoring
-          path: /docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/configure-control-plane-monitoring
         - title: Kubernetes logs
           path: /docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/get-logs-version
         - title: Configure Kubernetes with a proxy


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
Removes redundant information from documentation, avoids confusion.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

[Current Docs Page](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/configure-control-plane-monitoring)

( Notice the two highlights in the page nav menu )

I removed the second occurrence in the list, not sure what the preferred ordering is on the page. Let me know if it's better to keep the second item instead.

* If your issue relates to an existing GitHub issue, please link to it.