### PR TITLE
Update net-agent-configuration.mdx

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -169,15 +169,15 @@ Our .NET agent relies on environment variables to tell the .NET Common Language 
     CORECLR_PROFILER_PATH="${CORECLR_NEWRELIC_HOME}/libNewRelicProfiler.so"
     ```
 
-    **Windows:**
+    **Windows (MSI Installer):**
 
     ```
     CORECLR_ENABLE_PROFILING=1
     CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
-    NEWRELIC_INSTALL_PATH=<var>%PROGRAMFILES%\New Relic\.NET Agent\</var>
-    CORECLR_NEWRELIC_HOME=<var>%PROGRAMDATA%\New Relic\.NET Agent\</var>
+    NEWRELIC_INSTALL_PATH=<var>C:\Program Files\New Relic\.NET Agent\</var>
+    CORECLR_NEWRELIC_HOME=<var>C:\ProgramData\New Relic\.NET Agent\</var>
     ```
-
+    
     The Windows .NET agent installer will add these to IIS by default, or as system-wide environment variables when enabling `Instrument All`. Exception: `CORECLR_ENABLE_PROFILING` needs to be set manually in order to instrument non-IIS hosted .NET Core applications. For more information, see our [installation documentation](/docs/apm/agents/net-agent/installation/install-net-agent-windows/#enable-net-core).
 
     When installing the agent via the Nuget package in Windows, the agent requires a [different set of environment variables](/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget/#nuget-windows).

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -174,18 +174,14 @@ Our .NET agent relies on environment variables to tell the .NET Common Language 
     ```
     CORECLR_ENABLE_PROFILING=1
     CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
-    NEWRELIC_INSTALL_PATH=<var>path\to\agent\directory</var>
-    CORECLR_NEWRELIC_HOME=<var>path\to\agent\directory</var>
+    NEWRELIC_INSTALL_PATH=<var>%PROGRAMFILES%\New Relic\.NET Agent\</var>
+    CORECLR_NEWRELIC_HOME=<var>%PROGRAMDATA%\New Relic\.NET Agent\</var>
     ```
 
     The Windows .NET agent installer will add these to IIS by default, or as system-wide environment variables when enabling `Instrument All`. Exception: `CORECLR_ENABLE_PROFILING` needs to be set manually in order to instrument non-IIS hosted .NET Core applications. For more information, see our [installation documentation](/docs/apm/agents/net-agent/installation/install-net-agent-windows/#enable-net-core).
 
     When installing the agent via the Nuget package in Windows, the agent requires a [different set of environment variables](/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget/#nuget-windows).
 
-    When using the Windows .NET agent installer:
-    
-    * Ensure that `NEWRELIC_INSTALL_PATH` is set to `C:\Program Files\New Relic\.NET Agent\`. This is where the agent DLLs are placed on the system.
-    * Ensure that `CORECLR_NEWRELIC_HOME` is set to `C:\ProgramData\New Relic\.NET Agent\`. This is where configuration and logs exist on the system.
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
Modified the copy-paste section to be more specific to avoid errors of choosing the directory level too deep.  Condensed the steps outlined in the text:
When using the Windows .NET agent installer: Ensure that NEWRELIC_INSTALL_PATH is set to C:\Program Files\New Relic\.NET Agent\. This is where the agent DLLs are placed on the system. Ensure that CORECLR_NEWRELIC_HOME is set to C:\ProgramData\New Relic\.NET Agent\. This is where configuration and logs exist on the system.

to the section that users can copy & paste.  The .NET agent installer should insert the right environment variables, otherwise, that's a bug on our end.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.