### PR TITLE
docs: Add example usage for React Native agent recordError API call

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-monitoring-react-native/monitor-your-react-native-application.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-monitoring-react-native/monitor-your-react-native-application.mdx
@@ -224,6 +224,19 @@ We currently provide two routing instrumentations out of the box to instrument r
 
 Our React Native agent utilizes the same API calls as our iOS and Android SDK agents. Please refer to [New Relic iOS SDK doc](/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api) or [Android SDK](/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api).
 
+For errors specific to React Native, you can call `NewRelic.recordError(error)` as follows:
+```js
+import ErrorBoundary from 'react-native-error-boundary';
+const errorHandler = (error: Error, stackTrace: string) => {
+  NewRelic.recordError(error);
+};
+const App = () => (
+  <ErrorBoundary onError={errorHandler}>
+    <ChildrenThatCouldThrowEror />
+  </ErrorBoundary>
+);
+```
+
 ## JavaScript errors [#javascript-errors]
 
 In the New Relic data explorer, you can see JavaScript errors under the custom events section and you can also query them using NRQL.


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
  * We recently released [react-native v0.0.6](https://github.com/newrelic/docs-website/pull/9723) and we wanted to add an example usage of a new API call in our agent.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  * Context is in the above linked release notes PR.