### PR TITLE
Remove instructions to use NerdGraph to delete Browser applications

### DIFF
--- a/src/content/docs/apm/new-relic-apm/maintenance/remove-applications-new-relic.mdx
+++ b/src/content/docs/apm/new-relic-apm/maintenance/remove-applications-new-relic.mdx
@@ -66,7 +66,6 @@ Before you can remove an application monitored by New Relic APM, browser monitor
 
     * **Delete an associated APM app.** If your browser app is [linked to an APM application](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/#select-apm-app), deleting the APM application also removes the browser application. See the [instructions for deleting an APM app](#remove-apm-apps).
     * **Delete it from the UI.** Go to **[one.newrelic.com](https://one.newrelic.com) > Browser > (select an app) > Settings > Application settings**, and click the **Delete application** button.
-    * **Use NerdGraph to delete an entity.** If you've done the above and are still seeing that app in the UI, you can [use NerdGraph to delete the relevant entities](/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial/#delete-entities). For how to find entity IDs, see [Entities](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#find).
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
`entityDelete` cannot delete entities of type BROWSER-APPLICATION: https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial/#delete-entities