### PR TITLE
Add gRPC

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -733,15 +733,16 @@ Background jobs supported by the New Relic Ruby agent include:
   </tbody>
 </table>
 
-## HTTP clients [#http_clients]
+## HTTP / network clients [#http_network_clients]
 
 HTTP clients supported by the Ruby agent include:
 
-* Net::HTTP&#x3A; Supported for all [agent-supported versions](/docs/agents/ruby-agent/features/http-client-tracing-ruby) of Ruby.
 * Curb: 0.8.1 or higher
 * Excon: 0.10.1 or higher (Versions 0.10.1 - 0.55.0 are Deprecated)
+* gPRC: 1.0.0 or higher
 * HttpClient: 2.2.0 or higher (Versions 2.2.0 - 2.8.0 are Deprecated)
 * HttpRb: 0.9.9 or higher (Versions 0.9.9 - 2.2.1 are Deprecated)
+* Net::HTTP&#x3A; Supported for all [agent-supported versions](/docs/agents/ruby-agent/features/http-client-tracing-ruby) of Ruby.
 * Typhoeus: 0.5.3 or higher (Versions 0.5.3 - 1.2.x are Deprecated)
 
 ## Message queuing [#http_clients]


### PR DESCRIPTION
The Ruby agent team added instrumentation for gPRC a few weeks ago, but it's missing from this page. gPRC most closely fits in the HTTP client section, but its not really one, so the title is changed to `HTTP / network clients`. The list was also alphabetized.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.