### PR TITLE
fix: remove unnecessary hashes from redirect paths

### DIFF
--- a/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
+++ b/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
@@ -9,7 +9,7 @@ redirects:
   - /docs/telemetry-data-platform/get-data-new-relic/manage-data/manage-retention-stored-data
   - /docs/telemetry-data-platform/ingest-manage-data/manage-data/manage-data-retention
   - /telemetry-data-platform/get-started/manage-data/manage-stored-data/
-  - /docs/telemetry-data-platform/get-started/manage-data/manage-stored-data#adjust-retention
+  - /docs/telemetry-data-platform/get-started/manage-data/manage-stored-data
 ---
 
 import editRetentionSettings from 'images/edit_retention_settings.png'

--- a/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
+++ b/src/content/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works.mdx
@@ -12,7 +12,7 @@ redirects:
   - /docs/apm/distributed-tracing/ui-data/explanation-how-sampling-works-distributed-tracing-data
   - /docs/apm/distributed-tracing/getting-started/how-new-relic-distributed-tracing-works
   - /docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works
-  - /docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works/#head-based
+  - /docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works
   - /docs/distributed-tracing/get-started/how-new-relic-distributed-tracing-works
 ---
 

--- a/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/install-auto-telemetry-pixie.mdx
+++ b/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/install-auto-telemetry-pixie.mdx
@@ -8,7 +8,7 @@ tags:
 metaDescription: How to install Auto-telemetry with Pixie in New Relic.
 redirects:
   - /docs/auto-telemetry-pixie/install-auto-telemetry-pixie
-  - /docs/auto-telemetry-pixie/get-started-auto-telemetry-pixie/#install-auto-telemetry-with-pixie
+  - /docs/auto-telemetry-pixie/get-started-auto-telemetry-pixie
 ---
 
 To get up and running with Auto-telemetry with Pixie, start with our guided installation. The guided installation deploys Pixie with New Relic's Kubernetes integration on your cluster. You don't need to do any further configuration or installation to start using Pixie.


### PR DESCRIPTION
## Description

Removes hashes from redirect url paths because they're unnecessary. And could cause weird build issues (at least it did in netlify)

