### PR TITLE
Update supported versions of mongocsharpdriver and MongoDB.Driver

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -470,7 +470,7 @@ If your application is hosted in ASP.NET Core, the agent automatically creates a
           </td>
 
           <td>
-            * [Driver version 2.3.x - 2.13.x](http://docs.mongodb.com/ecosystem/drivers/csharp/#compatibility): The .NET agent will support instrumenting pre-exising and new API methods in 2.6.x, but not new methods introduced in 2.7.x and higher.
+            * [Driver version 2.3.x - 2.17.x](http://docs.mongodb.com/ecosystem/drivers/csharp/#compatibility): The .NET agent instruments pre-existing and new API methods in 2.6.x, but not new methods introduced in 2.7.x and higher.
           </td>
         </tr>
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -549,10 +549,10 @@ The .NET agent does not directly monitor datastore processes. Also, by default t
 
             Legacy - mongocsharpdriver
 
-            * [Driver versions 1.10.0](https://docs.mongodb.com/ecosystem/drivers/csharp/#compatibility) or earlier: Instance details are not available in these driver versions.
+            * [Driver versions 1.11.0](https://docs.mongodb.com/ecosystem/drivers/csharp/#compatibility) or earlier: Instance details are not available in these driver versions.
 
               Modern - MongoDB.Driver
-            * [Driver version 2.3.x - 2.13.x](http://docs.mongodb.com/ecosystem/drivers/csharp/#compatibility): The .NET agent will support instrumenting pre-exising and new API methods in 2.6.x, but not new methods introduced in 2.7.x and higher.
+            * [Driver version 2.3.x - 2.17.x](http://docs.mongodb.com/ecosystem/drivers/csharp/#compatibility): The .NET agent instruments pre-existing and new API methods in 2.6.x, but not new methods introduced in 2.7.x and higher.
           </td>
         </tr>
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -548,10 +548,9 @@ The .NET agent does not directly monitor datastore processes. Also, by default t
             We support both the modern and legacy MongoDB drivers.
 
             Legacy - mongocsharpdriver
-
             * [Driver versions 1.11.0](https://docs.mongodb.com/ecosystem/drivers/csharp/#compatibility) or earlier: Instance details are not available in these driver versions.
 
-              Modern - MongoDB.Driver
+            Modern - MongoDB.Driver
             * [Driver version 2.3.x - 2.17.x](http://docs.mongodb.com/ecosystem/drivers/csharp/#compatibility): The .NET agent instruments pre-existing and new API methods in 2.6.x, but not new methods introduced in 2.7.x and higher.
           </td>
         </tr>


### PR DESCRIPTION
## Give us some context

As part of the .NET agent team's October 2022 "core technology update" milestone, we've tested our agent's support for the latest MongoDB .NET clients and want to update our documentation accordingly.  I also simplified a wording, fixed a typo and adjusted an indentation.