### PR TITLE
docs: put code in backticks

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/troubleshooting/troubleshooting-large-memory-usage-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/troubleshooting/troubleshooting-large-memory-usage-nodejs.mdx
@@ -36,7 +36,7 @@ There are several possible causes for this memory increase and potential solutio
 
     In some cases, you can reduce the slab buffer below its 10 MB default.
 
-    To set the slab buffer size, use [tls.SLAB_BUFFER_SIZE](http://nodejs.org/api/tls.html#tls_tls_slab_buffer_size).
+    To set the slab buffer size, use [`tls.SLAB_BUFFER_SIZE`](http://nodejs.org/api/tls.html#tls_tls_slab_buffer_size).
 
     <Callout variant="caution">
       When using the New Relic agent, do not set the slab buffer size below 128 KB. The slab buffer allocation should not be reduced for apps that communicate with services or clients using SSL, HTTPS, or any other form of cryptography.
@@ -64,22 +64,22 @@ There are several possible causes for this memory increase and potential solutio
 
     **Solution:**
 
-    Depending on your version of the Node.js, the agent may default to the **trace** or **info** log levels. Decrease logging verbosity to **info** or **warn** levels to noticeably decrease memory usage and time spent in garbage collection.
+    Depending on your version of the Node.js, the agent may default to the `trace` or `info` log levels. Decrease logging verbosity to `info` or `warn` levels to noticeably decrease memory usage and time spent in garbage collection.
   </Collapser>
 
   <Collapser
     id="mongo"
     title="Increase caused by leaked MongoDB cursors"
   >
-    Many database drivers use an abstraction called a **cursor**. Cursors provide the ability to iterate through the results of queries. For example, the **mongodb** driver provides cursors when executing **find** queries.
+    Many database drivers use an abstraction called a `cursor`. Cursors provide the ability to iterate through the results of queries. For example, the **mongodb** driver provides cursors when executing `find` queries.
 
-    Cursors live both as objects in the Node.js runtime and as entities in the MongoDB server. When an application has finished using a cursor, it should close it to free up resources in both the server and the client application.
+    Cursors live both as objects in the Node.js runtime and as entities in the MongoDB server. When an application has finished using a `cursor`, it should close it to free up resources in both the server and the client application.
 
-    In Node.js, it is possible for a cursor to be garbage collected, freeing resources in the application, without closing the cursor in the server. This may be go unnoticed in the application. However, the New Relic Node.js agent keeps track of open cursors to measure the time spent iterating through results. If your application does not close all the cursors it uses, the agent will continue to track stale cursors and leak memory.
+    In Node.js, it is possible for a cursor to be garbage collected, freeing resources in the application, without closing the `cursor` in the server. This may be go unnoticed in the application. However, the New Relic Node.js agent keeps track of open cursors to measure the time spent iterating through results. If your application does not close all the cursors it uses, the agent will continue to track stale cursors and leak memory.
 
     **Solution:**
 
-    Ensure every cursor created in your application is closed by calling cursor.close() after the application finishes processing the results of the query.
+    Ensure every `cursor` created in your application is closed by calling `cursor.close()` after the application finishes processing the results of the query.
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
`tls.SLAB_BUFFER_SIZE` appears to be pretty old and no longer a thing. there is no mention of it in that link, and googling the phrase only brings up very old docs (Node 0.x) as well as this page on docs.NR and a 2014 stack overflow. I couldn't figure out what the updated version might be though.
