### PR TITLE
Metrics/spans, semantic conventions, server/client distinction

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-summary-page.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-summary-page.mdx
@@ -8,30 +8,29 @@ metaDescription: Tips for understanding the OpenTelemetry service Summary page i
 ---
 
 After you've sent us your OpenTelemetry data and opened your service (entity) in the UI, the **Summary** page offers an overview of your service's health. Here you can see:
-- The **golden signals** for your service: response time, throughput, and error rate
-- Entities this service depends on, with their health status, appear in **Related entities**. This includes other services communicating with this service with and the infrastructure hosting the service.
-- When alerting thresholds are violated, those events appear in the **Activity** sidebar
+* The **golden signals** for your service: response time, throughput, and error rate
+* Entities this service depends on, with their health status, appear in **Related entities**. This includes other services communicating with this service and the infrastructure hosting the service.
+* When alerting thresholds are violated, those events appear in the **Activity** sidebar
 
 By using this information, you can quickly decide whether there's a problem with this service and where you can begin diagnosing the problem.
 
-# How OpenTelemetry data shows up
+## How OpenTelemetry data shows up (server or client?) [#server-client]
 
-## Server or client?
-The Summary page shows the golden signals for the server and/or message consumer roles of a service. Other pages offer different views of the service's roles in your distributed system:
-- **External services** shows the service's behavior as a client calling other services, as well as a breakdown of how other services call its endpoints
-- **Databases** shows the service's behavior as a client of databases, specifically
+The **Summary** page shows the golden signals for the server and/or message consumer roles of a service. Other pages offer different views of the service's roles in your distributed system:
+* **External services** shows the service's behavior as a client calling other services, as well as a breakdown of how other services call its endpoints
+* **Databases** shows the service's behavior as a client of databases, specifically
 
 Services can be both servers (responding to requests) and clients (making requests) in the [OpenTelemetry data model for tracing](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/). Similarly, services using messaging systems like AWS SQS can be producers and/or consumers of messages. The `span.kind` attribute specifies the role of the service in a given tracing span.
 
-## Metrics or spans
+## Metrics or spans [#metrics-or-spans]
 You can [choose to use either metrics or spans](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-find-entities/#metric-span-toggle) to power the charts for the golden signals.
 
 <Callout variant="important">
-  When choosing metrics, error rate is displayed only for HTTP servers. gRPC or other protocol servers' error rate metrics are not yet shown.
+  When choosing metrics, error rate is displayed only for HTTP servers. The error rate metrics for gRPC or other protocols are not yet shown.
 </Callout>
 
 ## Required attributes
-For your OpenTelemetry data to appear in the Summary page, make sure it has the following attributes, in accordance with the OTel semantic conventions:
+For your OpenTelemetry data to appear in the **Summary** page, make sure it has the following attributes, in accordance with the OTel semantic conventions:
 
 <table>
   <thead>

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-summary-page.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-summary-page.mdx
@@ -4,12 +4,34 @@ tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
-metaDescription: Here are some tips for understanding the OpenTelemetry summary page in the New Relic UI.
+metaDescription: Tips for understanding the OpenTelemetry service Summary page in the New Relic UI
 ---
 
-After you've sent us your OpenTelemetry data and opened your service (entity) in the UI, you can view the **Summary** page to get an overview of your services. It lists various golden signals about your entity, which are key monitoring details such as response time, throughput, and error rate. By using this information, you can quickly decide if you need to dig deeper.
+After you've sent us your OpenTelemetry data and opened your service (entity) in the UI, the **Summary** page offers an overview of your service's health. Here you can see:
+- The **golden signals** for your service: response time, throughput, and error rate
+- Entities this service depends on, with their health status, appear in **Related entities**. This includes other services communicating with this service with and the infrastructure hosting the service.
+- When alerting thresholds are violated, those events appear in the **Activity** sidebar
 
-For your OpenTelemetry data to appear in this section, make sure it has the following:
+By using this information, you can quickly decide whether there's a problem with this service and where you can begin diagnosing the problem.
+
+# How OpenTelemetry data shows up
+
+## Server or client?
+The Summary page shows the golden signals for the server and/or message consumer roles of a service. Other pages offer different views of the service's roles in your distributed system:
+- **External services** shows the service's behavior as a client calling other services, as well as a breakdown of how other services call its endpoints
+- **Databases** shows the service's behavior as a client of databases, specifically
+
+Services can be both servers (responding to requests) and clients (making requests) in the [OpenTelemetry data model for tracing](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/). Similarly, services using messaging systems like AWS SQS can be producers and/or consumers of messages. The `span.kind` attribute specifies the role of the service in a given tracing span.
+
+## Metrics or spans
+You can [choose to use either metrics or spans](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-find-entities/#metric-span-toggle) to power the charts for the golden signals.
+
+<Callout variant="important">
+  When choosing metrics, error rate is displayed only for HTTP servers. gRPC or other protocol servers' error rate metrics are not yet shown.
+</Callout>
+
+## Required attributes
+For your OpenTelemetry data to appear in the Summary page, make sure it has the following attributes, in accordance with the OTel semantic conventions:
 
 <table>
   <thead>
@@ -58,7 +80,7 @@ For your OpenTelemetry data to appear in this section, make sure it has the foll
 
     <tr>
       <td>
-        Service instances pane
+        Instances pane
       </td>
 
       <td>


### PR DESCRIPTION
The choice of presenting the 'server' role for a service (vs. 'client', etc.) is not always clear, so calling that out here with references to the OTel data model.

Adding a note on metrics along with a known limitation.
