### PR TITLE
Refer to global search, reorder "find your entity" parts

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-find-entities.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-find-entities.mdx
@@ -4,24 +4,36 @@ tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
-metaDescription: Here are some tips for filtering your entities in the New Relic UI.
+metaDescription: Here are some tips for finding entities and filtering data in the New Relic UI.
 ---
 
 import metricSpanToggleSummary from 'images/otel-metric-span-toggle-summary.png'
 
 Once you've sent your data to New Relic, you can view it by service (entity) in the UI. You have a number of options to locate your services and their associated data in the UI.
 
+Once you find the service to view, you'll land on the Summary page. From there, several views will be available that offer deeper insight into the data associated with that service. You can then filter that data to answer questions about how particular aspects of your service are performing.
+
 ## Find your service (entity) [#find-entity]
 
-To get started:
+1. Go to **[one.newrelic.com](https://one.newrelic.com)**.
+2. In the left sidebar, click either **All entities** or **APM & services**.
+3. In the center pane, click **Services - OpenTelemetry**.
+4. Click the service you want to know more about, or find your service by entering its name in the top filter bar.
+
+<Callout variant="tip">
+  Use `Ctrl-k` to search for your service by name from anywhere in the UI.
+  
+  You may have to look for your OpenTelemetry service in the "Other" category if there are many matches for your search terms.
+</Callout>
+
+### Find your service using tags [#tags]
+
+[Tags](https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data/) are key-value pairs you can add to entities, like monitored apps and hosts. Certain important data attributes are automatically assigned as tags, such as account ID. You can also add your own [custom tags](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-resources/tags). 
+
+In the New Relic UI, you can filter lists of entities by one or more tags to find the service you're looking for:
 
 1. Go to **[one.newrelic.com](https://one.newrelic.com)**.
-
-2. In the left sidebar, click **All entities**.
-
-3. In the center pane, click **Services - OpenTelemetry**:
-
-3. Click the service you want to know more about, or find your service by entering the name in the top filter bar.
+2. Click the **Filter by...** field. A dropdown will populate available tags, or you can enter a tag's name or value yourself.
 
 ## Narrow down your data with filters [#filter]
 
@@ -29,20 +41,11 @@ Once you have your entity, you can then filter for data from your service.
 
 With the filter bar **Narrow data to...**, you can highlight a specific facet of the telemetry recorded for your service. For example, you may want to see the error rate for a particular version of the service that you've deployed in a canary instance, so you add a filter for `service.version='1.2.3'`.
 
-Filters are preserved when navigating between different views of your data for a service. For example, the filter for `service.version='1.2.3'` carries over to the **Transactions** view, so that you would see telemetry on requests to the endpoints (transactions) that are running version 1.2.3 of your service, and not any other versions.
+Filters are preserved when navigating between different views of your data for a service. For example, the filter you set on **Summary** for `service.version='1.2.3'` carries over to the **Transactions** view, so that you would see telemetry on requests to the endpoints (transactions) that are running version 1.2.3 of your service, and not any other versions.
 
-Filters are preserved when navigating between the **Summary**, **Transactions**, **Databases**, **Externals**, **Errors**, and **JVMs** views.
+Filters are preserved when navigating between the **Summary**, **Transactions**, **Databases**, **External services**, **Errors**, and **JVMs** views.
 
 Filters are also preserved when navigating to the **Distributed tracing** view, but with limitations. Only filter conditions that use the equals operator ("=") are currently supported when navigating to **Distributed tracing**. If you navigate back from the **Distributed tracing** page, the filters you selected on the previous view will come back.
-
-## View your entities by tags [#tags]
-
-[Tags](https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data/) are key-value pairs you can add to various sets of data, like monitored apps and hosts. Certain important attributes are automatically assigned as tags, such as account ID. You can also add your own [custom tags](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-resources/tags). 
-
-You can filter by single or multiple elements, or use advanced search options. To use tags to filter various entities:
-
-1. Go to one.newrelic.com.
-2. Click the **Filter by ...** field. A dropdown will populate available attributes and tags, or you can enter a tag yourself.
 
 ## Control the data type that populates certain charts [#metric-span-toggle]
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-find-entities.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-find-entities.mdx
@@ -11,7 +11,7 @@ import metricSpanToggleSummary from 'images/otel-metric-span-toggle-summary.png'
 
 Once you've sent your data to New Relic, you can view it by service (entity) in the UI. You have a number of options to locate your services and their associated data in the UI.
 
-Once you find the service to view, you'll land on the Summary page. From there, several views will be available that offer deeper insight into the data associated with that service. You can then filter that data to answer questions about how particular aspects of your service are performing.
+Once you find the service to view, you'll land on the **Summary** page. From there, several views will be available that offer deeper insight into the data associated with that service. You can then filter that data to answer questions about how particular aspects of your service are performing.
 
 ## Find your service (entity) [#find-entity]
 
@@ -23,7 +23,7 @@ Once you find the service to view, you'll land on the Summary page. From there, 
 <Callout variant="tip">
   Use `Ctrl-k` to search for your service by name from anywhere in the UI.
   
-  You may have to look for your OpenTelemetry service in the "Other" category if there are many matches for your search terms.
+  You may have to look for your OpenTelemetry service in the **Other** category if there are many matches for your search terms.
 </Callout>
 
 ### Find your service using tags [#tags]


### PR DESCRIPTION
- Moved the sections on finding your entity next to each other and made one a sub-section of the other
- Added a tip callout for global search, with specific advice for OTel services
- Cleaned up language about the overall page being about both finding entities and filtering data
- Consistent formatting for numbered lists
- Fixed name of External services