### PR TITLE
feat(Query your data): modifying the with timezone clause

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -1023,7 +1023,7 @@ Here are some example queries:
       ```
       This resolves as `"beginTime": "2022-05-19T00:00:00Z"` and `"endTime": "2022-05-19T17:00:00Z"`.
 
-    * Time zone in date time string, using the `WITH TIMEZONE` clause America/Los Angeles (which is -0700 during daylight saving time):
+    * Time zone in date time string, using the `WITH TIMEZONE` clause America/Los Angeles, which is -0700 during daylight saving time:
 
       ```sql
       SINCE today UNTIL '2022-05-19T12:00-0500' WITH TIMEZONE 'America/Los_Angeles'


### PR DESCRIPTION
Modified the `WITH TIMEZONE clause` on the [NRQL syntax, clauses, and functions](https://docs.newrelic.com/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#sel-timezone) page.

These changes have been mentioned in [this thread](https://newrelic.slack.com/archives/C01508Q2879/p1652972767102749?thread_ts=1652884824.046819&cid=C01508Q2879) of Slack.

This is the ticket: NR-22972.

