### PR TITLE
Add new line to prevent serialization issues

### DIFF
--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-code-level-metrics-config.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-code-level-metrics-config.mdx
@@ -32,6 +32,7 @@ app, err := newrelic.NewApplication(
 ```
 
 With that simple step, the Go agent will add the source code context information in the following agent attributes on transactions:
+
 <table>
   <thead>
     <tr>


### PR DESCRIPTION
This doc currently serializes into html with a p tag wrapping a whole table, adding the new line will prevent that behavior