### PR TITLE
Add new queues to SyntheticsPrivateLocationStatus

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/monitor-private-locations.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/monitor-private-locations.mdx
@@ -48,7 +48,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
           "description": null,
           "widgets": [
             {
-              "title": "pending checks by location",
+              "title": "queue size by location",
               "layout": {
                 "column": 1,
                 "row": 1,
@@ -68,16 +68,19 @@ The following Private Minion dashboard example JSON can be imported to your acco
                     "accountId": 0,
                     "query": "FROM SyntheticsPrivateLocationStatus SELECT latest(checksPending) FACET name"
                   }
-                ]
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                }
               }
             },
             {
-              "title": "private location queue",
+              "title": "private location queues",
               "layout": {
                 "column": 4,
                 "row": 1,
                 "width": 9,
-                "height": 4
+                "height": 5
               },
               "linkedEntityGuids": null,
               "visualization": {
@@ -93,11 +96,41 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticsPrivateLocationStatus SELECT max(checksPending) FACET name TIMESERIES MAX SINCE 2 weeks ago"
+                    "query": "FROM SyntheticsPrivateLocationStatus SELECT latest(pingJobs),latest(jobManagerHeavyweightJobs),latest(minionHeavyweightJobs) FACET name TIMESERIES MAX LIMIT 40 SINCE 2 weeks ago"
                   }
                 ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
                 "yAxisLeft": {
                   "zero": true
+                }
+              }
+            },
+            {
+              "title": "queue size by location and type",
+              "layout": {
+                "column": 1,
+                "row": 6,
+                "width": 3,
+                "height": 5
+              },
+              "linkedEntityGuids": null,
+              "visualization": {
+                "id": "viz.bar"
+              },
+              "rawConfiguration": {
+                "facet": {
+                  "showOtherSeries": false
+                },
+                "nrqlQueries": [
+                  {
+                    "accountId": 0,
+                    "query": "FROM SyntheticsPrivateLocationStatus SELECT latest(pingJobs),latest(jobManagerHeavyweightJobs),latest(minionHeavyweightJobs) FACET name "
+                  }
+                ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
                 }
               }
             },
@@ -105,9 +138,9 @@ The following Private Minion dashboard example JSON can be imported to your acco
               "title": "rate of queue growth",
               "layout": {
                 "column": 4,
-                "row": 5,
+                "row": 6,
                 "width": 9,
-                "height": 4
+                "height": 5
               },
               "linkedEntityGuids": null,
               "visualization": {
@@ -123,51 +156,22 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticsPrivateLocationStatus SELECT clamp_min(derivative(checksPending,1 minute),0) AS 'queue growth rate' FACET name TIMESERIES MAX SINCE 2 weeks ago"
+                    "query": "FROM SyntheticsPrivateLocationStatus SELECT clamp_min(derivative(pingJobs,1 minute),0) AS 'ping',clamp_min(derivative(jobManagerHeavyweightJobs,1 minute),0) AS 'job manager heavy',clamp_min(derivative(minionHeavyweightJobs,1 minute),0) AS 'minion heavy' FACET name TIMESERIES MAX LIMIT 40 SINCE 2 weeks ago"
                   }
                 ],
+                "platformOptions": {
+                  "ignoreTimeRange": false
+                },
                 "yAxisLeft": {
                   "zero": true
                 }
               }
             },
             {
-              "title": "Checks Pending",
-              "layout": {
-                "column": 1,
-                "row": 6,
-                "width": 3,
-                "height": 3
-              },
-              "linkedEntityGuids": null,
-              "visualization": {
-                "id": "viz.billboard"
-              },
-              "rawConfiguration": {
-                "dataFormatters": [],
-                "nrqlQueries": [
-                  {
-                    "accountId": 0,
-                    "query": "FROM SyntheticsPrivateLocationStatus SELECT average(checksPending) SINCE 3 minutes ago UNTIL 2 minutes ago"
-                  }
-                ],
-                "thresholds": [
-                  {
-                    "alertSeverity": "WARNING",
-                    "value": 1
-                  },
-                  {
-                    "alertSeverity": "CRITICAL",
-                    "value": 5
-                  }
-                ]
-              }
-            },
-            {
               "title": "audit events for private locations",
               "layout": {
                 "column": 1,
-                "row": 9,
+                "row": 11,
                 "width": 12,
                 "height": 4
               },
@@ -242,7 +246,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticsPrivateMinion SELECT latest(minionId),uniqueCount(minionId) - 1 AS 'restarts',latest(minionIpv4),latest(timestamp),latest(minionStartTimestamp),max(minionJobsQueued),max(minionJobsFinished),100*max(minionJobsFailed)/max(minionJobsQueued) AS 'job failure rate',latest(minionJobsRunning),max(minionJobsTimedout),max(minionJobsSkipped),max(minionJobsInternalEngineError),latest(minionWorkers),latest(minionProcessors),latest(minionSwapMemoryUsedBytes/pow(1024,3)) AS 'used swap (GiB)',latest(minionSwapMemoryTotalBytes/pow(1024,3)) AS 'total swap (GiB)',latest(minionPhysicalMemoryUsedBytes/pow(1024,3)) AS 'used memory (GiB)',latest(minionPhysicalMemoryTotalBytes/pow(1024,3)) AS 'total memory (GiB)',latest(minionPhysicalMemoryTotalBytes/pow(1024,3))/latest(minionWorkers) AS 'memory (GiB) per heavy worker' WHERE minionLocation NOT LIKE 'AWS_%' FACET minionBuildNumber,minionLocation,minionOsVersion,minionContainerSystemVersion,minionHostname LIMIT 100"
+                    "query": "FROM SyntheticsPrivateMinion SELECT latest(minionId),uniqueCount(minionId) - 1 AS 'restarts',latest(minionIpv4),latest(timestamp),latest(minionStartTimestamp),max(minionJobsQueued),max(minionJobsFinished),100*max(minionJobsFailed)/max(minionJobsQueued) AS 'job failure rate',latest(minionJobsRunning),max(minionJobsTimedout),max(minionJobsSkipped),max(minionJobsInternalEngineError),latest(minionWorkers),latest(minionProcessors),latest(minionSwapMemoryUsedBytes/pow(1024,3)) AS 'used swap (GiB)',latest(minionSwapMemoryTotalBytes/pow(1024,3)) AS 'total swap (GiB)',latest(minionPhysicalMemoryUsedBytes/pow(1024,3)) AS 'used memory (GiB)',latest(minionPhysicalMemoryTotalBytes/pow(1024,3)) AS 'total memory (GiB)',latest(minionPhysicalMemoryTotalBytes/pow(1024,3))/latest(minionWorkers) AS 'memory (GiB) per heavy worker' WHERE minionLocation NOT LIKE 'AWS_%' FACET minionBuildVersion,minionBuildNumber,minionLocation,minionOsVersion,minionContainerSystemVersion,minionHostname LIMIT 100"
                   }
                 ],
                 "platformOptions": {
@@ -359,7 +363,7 @@ The following Private Minion dashboard example JSON can be imported to your acco
                 "nrqlQueries": [
                   {
                     "accountId": 0,
-                    "query": "FROM SyntheticsPrivateMinion SELECT uniqueCount(minionId) AS 'build numbers' WHERE minionLocation NOT LIKE 'AWS_%' FACET minionBuildNumber LIMIT MAX"
+                    "query": "FROM SyntheticsPrivateMinion SELECT uniqueCount(minionId) AS 'build numbers' WHERE minionLocation NOT LIKE 'AWS_%' FACET minionBuildVersion,minionBuildNumber LIMIT MAX"
                   }
                 ],
                 "platformOptions": {


### PR DESCRIPTION
This allows one to see if monitors on a particular runtime are contributing to queue growth. This can happen if:

- Monitors are set to the new runtimes (Chrome 100+, Node 16+) without having a [Synthetics Job Manager](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/install-job-manager/) to process those jobs for a private location.
- Monitors are set to the legacy runtimes (Chrome 72-, Node 10-) without having a [Containerized Private Minion](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms/#start) to process those jobs for a private location.

The new queues are:

- `pingJobs`
- `jobManagerHeavyweightJobs`
- `minionHeavyweightJobs`