### PR TITLE
Add a note about Insights query keys

### DIFF
--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -249,7 +249,7 @@ Besides our [main API keys explained above](#overview-keys), we have several oth
 
   <Collapser
     id="insights-query-key"
-    title="Insights query key (not recommended*)"
+    title="Insights query key (not recommended)"
   >
     One of our older API keys is the Insights query key, which is used for our [Insights query API](/docs/insights/insights-api/get-data/query-insights-event-data-api). For almost all purposes, **we recommend using [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) to query and return New Relic data.** The one exception is that this key is still used to configure [New Relic as a Prometheus data source for Grafana](/docs/more-integrations/grafana-integrations/set-configure/configure-new-relic-prometheus-data-source-grafana). 
     

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -251,9 +251,7 @@ Besides our [main API keys explained above](#overview-keys), we have several oth
     id="insights-query-key"
     title="Insights query key (not recommended*)"
   >
-    One of our older API keys is the Insights query key, which is used for our [Insights query API](/docs/insights/insights-api/get-data/query-insights-event-data-api). **We recommend using [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) to query and return New Relic data.**
-
-    *To configure [New Relic as a Prometheus data source for Grafana](https://docs.newrelic.com/docs/more-integrations/grafana-integrations/set-configure/configure-new-relic-prometheus-data-source-grafana/), this is the key you need to use. 
+    One of our older API keys is the Insights query key, which is used for our [Insights query API](/docs/insights/insights-api/get-data/query-insights-event-data-api). For almost all purposes, **we recommend using [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) to query and return New Relic data.** The one exception is that this key is still used to configure [New Relic as a Prometheus data source for Grafana](/docs/more-integrations/grafana-integrations/set-configure/configure-new-relic-prometheus-data-source-grafana). 
     
     To find and manage Insights query keys: From the [account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown), click **API keys** (get [a direct link to the API keys page](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher)). Then click **Insights query keys**.
   </Collapser>

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -249,10 +249,12 @@ Besides our [main API keys explained above](#overview-keys), we have several oth
 
   <Collapser
     id="insights-query-key"
-    title="Insights query key (not recommended)"
+    title="Insights query key (not recommended*)"
   >
     One of our older API keys is the Insights query key, which is used for our [Insights query API](/docs/insights/insights-api/get-data/query-insights-event-data-api). **We recommend using [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) to query and return New Relic data.**
 
+    *To configure [New Relic as a Prometheus data source for Grafana](https://docs.newrelic.com/docs/more-integrations/grafana-integrations/set-configure/configure-new-relic-prometheus-data-source-grafana/), this is the key you need to use. 
+    
     To find and manage Insights query keys: From the [account dropdown](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#account-dropdown), click **API keys** (get [a direct link to the API keys page](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher)). Then click **Insights query keys**.
   </Collapser>
 


### PR DESCRIPTION
This adds a note about Insights query keys. The collapser title states it is not recommended, but it is the key you need to use to configure NR as a Prometheus data source for Grafana (per this [doc](https://docs.newrelic.com/docs/more-integrations/grafana-integrations/set-configure/configure-new-relic-prometheus-data-source-grafana/). 

This should help create a better user experience for users when they're looking to use/create an insights query key for this integration. 

Slack thread [here](https://newrelic.slack.com/archives/CH292BVUZ/p1665507210032249) on the above with the team that owns Prometheus remote write. 