### PR TITLE
Updates link for insights query key

### DIFF
--- a/src/content/docs/more-integrations/grafana-integrations/set-configure/configure-new-relic-prometheus-data-source-grafana.mdx
+++ b/src/content/docs/more-integrations/grafana-integrations/set-configure/configure-new-relic-prometheus-data-source-grafana.mdx
@@ -24,7 +24,7 @@ Follow these steps to add New Relic as a Prometheus data source for Grafana. The
   You must [complete the Prometheus remote-write integration](/docs/integrations/prometheus-integrations/install-configure/set-your-prometheus-remote-write-integration) process prior to beginning the configuration process.
 </Callout>
 
-1. On New Relic, [Create a new Insights query key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys).
+1. In New Relic, [create a new Insights query key](/docs/apis/intro-apis/new-relic-api-keys/#insights-query-key).
 
    <Callout variant="important">
      Note: In Grafana, you'll need put this in a custom **X-Query-Key** HTTP header (see step 7 below), but it is the same entity as the New Relic Query key.


### PR DESCRIPTION
This updates the link to our doc about the insights key query. Previously, the link went to the general API keys doc, which is very confusing due to the multiple types of keys. 

Updating this link will improve the user experience by making it clearer which key they need. (Prompted by a customer who got confused by this and used a browser key, which of course did not work.) 