### PR TITLE
add "Order" to available fields and explain that lower number = higher precedence. 

### DIFF
--- a/src/content/docs/new-relic-solutions/new-relic-one/ui-data/metric-normalization-rules.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/ui-data/metric-normalization-rules.mdx
@@ -32,6 +32,7 @@ There you can see the existing rules or create new ones. Click a rule to modify 
 
 Available fields are:
 
+* **Order**: determines the precedence of the rule. A lower number means higher precedence. 
 * **Match expression**: enter the regular expression to group all the metrics you want to include in the rule.
 * **Matches**: here you will see a preview of the metrics matched by the regular expression above.
 * **Action**: the action you want to perform on the metrics.


### PR DESCRIPTION
Hello! I'm a 1st shift TSE on the APM team! There is an order field that is used to determine the precedence of created normalization rules, and has been a source of confusion for customers and support engineers. I've spoken with members of the 3rd shift TSE's who are working on the new MGI UI and they've confirmed that a lower number means higher precedence. I think this should be added to the docs!

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.