### PR TITLE
feat(whats-new): add custom events post for Oct 24

### DIFF
--- a/src/content/whats-new/2022/10/whats-new-10-24-custom-events.md
+++ b/src/content/whats-new/2022/10/whats-new-10-24-custom-events.md
@@ -1,0 +1,18 @@
+---
+title: 'Send more custom events with the next APM agent update starting Oct 24'
+summary: 'Track critical actions for analysis using the increased custom event limits'
+releaseDate: '2022-10-24'
+learnMoreLink: ''
+getStartedLink: 'https://docs.newrelic.com/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes/'
+---
+
+Starting Oct 24th, 2022, when you update to the latest APM language agents(Go, Java, .NET, Node.js, PHP, Python, Ruby) the default custom event limit will be automatically increased. Additionally, we are introducing a new higher maximum limit. 
+
+Custom events can be used to define, visualize, and get alerts on additional data, just as you can with any data we provide from our core agents. With the custom event limit increase,  you can now ingest more custom events to track critical actions for analysis and troubleshooting. 
+
+You always have direct control over which data you send to New Relic:
+
+**Ingest monitoring:** To monitor the current custom events ingested in the New Relic UI under “Manage your data” select “Data ingestion” and view “Custom events”. 
+**Change custom event limit anytime:** You can modify the maximum number of custom events you send to New Relic anytime by configuring the respective agents([**Go**](https://docs.newrelic.com/docs/apm/agents/go-agent/configuration/go-agent-configuration/#custom-insights-events-settings), [**Java**](https://docs.newrelic.com/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file/#Custom_Events), [**.NET**](https://docs.newrelic.com/docs/apm/agents/net-agent/configuration/net-agent-configuration/#custom_events), [**Node.js**](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#custom-events), [**Python**](https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/#custom-events-settings), [**Ruby**](https://docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#custom-events)).
+**Disable custom events:** Turn off custom events reporting at any point by configuring the respective agents([**Go**](https://docs.newrelic.com/docs/apm/agents/go-agent/configuration/go-agent-configuration/#custom-insights-events-settings), [**Java**](https://docs.newrelic.com/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file/#Custom_Events), [**.NET**](https://docs.newrelic.com/docs/apm/agents/net-agent/configuration/net-agent-configuration/#custom_events), [**Node.js**](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#custom-events), [**Python**](https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/#custom-events-settings), [**Ruby**](https://docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#custom-events)).
+


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

To be posted on Oct 24, 2022

Starting Oct 24, the next APM agent update will increase the default and maximum custom event limit allowing customers to send more data for visibility and analysis.

No PMM review needed

