### PR TITLE
fix(node agent): document that bunyan is now an instrumented library

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -345,6 +345,7 @@ In order to support [APM logs in context](/docs/apm/new-relic-apm/getting-starte
 
 * [winston](https://www.npmjs.com/package/winston)
 * [pino](https://www.npmjs.com/package/pino)
+* [bunyan](https://www.npmjs.com/package/bunyan)
 </Collapser>
 
 

--- a/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
@@ -38,6 +38,7 @@ If you are using a supported framework, you have three options to configure APM 
 Supported frameworks for automatic logs in context include:
  * [Winston](https://github.com/winstonjs/winston) 3.0.0 or higher.
  * [Pino](https://github.com/pinojs/pino) 7.0.0 or higher.
+ * [Bunyan](https://www.npmjs.com/package/bunyan) 1.8.12 or higher (since agent version 9.3.0)
 
   <Callout variant="important">
     Agent releases 8.16.0 and higher have this feature enabled in the agent configuration file by default.
@@ -75,7 +76,7 @@ Supported frameworks for automatic logs in context include:
     NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=true
     ```
 
-    This option may be on by default in a future agent version.
+    This option may is on by default since agent version 8.16.0.
 
     **Optional adjustments:**
 


### PR DESCRIPTION
Also, the future for enabling log forwarding by default is now!

## Give us some context

* New release, new instrumentation: https://github.com/newrelic/docs-website/pull/9837