### PR TITLE
Adding asnLatitude, asnLongitude attributes to Mobile events to documentation

### DIFF
--- a/src/data-dictionary/events/PageView/asnLatitude.md
+++ b/src/data-dictionary/events/PageView/asnLatitude.md
@@ -5,8 +5,13 @@ events:
   - PageView
   - PageAction
   - BrowserInteraction
-  - BrowserTiming
+  - MobileSession
+  - MobileHandledException
+  - MobileCrash
+  - MobileRequest
+  - MobileRequestError
   - AjaxRequest
+  - BrowserTiming
   - PageViewTiming
   - JavaScriptError
 ---

--- a/src/data-dictionary/events/PageView/asnLongitude.md
+++ b/src/data-dictionary/events/PageView/asnLongitude.md
@@ -5,6 +5,11 @@ events:
   - PageView
   - PageAction
   - BrowserInteraction
+  - MobileSession
+  - MobileHandledException
+  - MobileCrash
+  - MobileRequest
+  - MobileRequestError
   - AjaxRequest
   - BrowserTiming
   - PageViewTiming


### PR DESCRIPTION
Those were recently added to the platform
Related to NR-54990

## Give us some context
Added Mobile events references to asnLatitude/asnLongitude description to reflect latest platform changes
