### PR TITLE
NEWRELIC-4620 - Nodejs Agent: correct version for DT enabled by default

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/distributed-tracing-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/distributed-tracing-nodejs-agent.mdx
@@ -11,7 +11,7 @@ import nodejslogo from 'images/nodejslogo.png'
 
 Distributed tracing allows you to see the entire journey of your requests throughout a [distributed system](/docs/distributed-tracing/concepts/introduction-distributed-tracing). For the Node.js agent, we offer two types of distributed tracing (for more details, see [How span sampling works](/docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works#sampling)):
 
-* Standard (head-based sampling): Before any traces arrive, we determine a set percentage of traces to accept and analyze. This gives you a solid starting point to see how tracing can help you. It is turned on by default in Node.js agents 7.2.0 and higher.
+* Standard (head-based sampling): Before any traces arrive, we determine a set percentage of traces to accept and analyze. This gives you a solid starting point to see how tracing can help you. It is turned on by default in Node.js agents 8.3.0 and higher.
 
 * Infinite Tracing (tail-based sampling): Our cloud-based service accepts all your traces and then sorts through them to find the most important. After you set up standard tracing, we recommend you add this option because it analyzes all of your traces and gives you configuration options to sample the traces that matter most to you.
 

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -3453,7 +3453,7 @@ The Node.js agent variables that control error message redaction appear in the `
 
 ## Distributed tracing [#dt-main]
 
-[Distributed tracing](/docs/intro-distributed-tracing) lets you see the path that a request takes as it travels through a distributed system. When configuring via the config file, place the following option in the `distributed_tracing` section. It is turned on by default in Node.js agents 7.2.0 and higher.
+[Distributed tracing](/docs/intro-distributed-tracing) lets you see the path that a request takes as it travels through a distributed system. When configuring via the config file, place the following option in the `distributed_tracing` section. It is turned on by default in Node.js agents 8.3.0 and higher.
 
 <Callout variant="important">
   Enabling distributed tracing disables [cross application tracing](#cross-app-tracing), and has effects on other APM features. Before enabling, read the [transition guide](/docs/transition-guide-distributed-tracing). Requires [Node.js agent version 4.7.0 or higher](/docs/agents/nodejs-agent/installation-configuration/upgrade-nodejs-agent).


### PR DESCRIPTION
There was some confusion these docs caused with a customer, in [7.2.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-2-0/) we updated the default config that customers can copy as an example to have DT enabled, but DT was not always enabled by default until [8.3.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-3-0/)

This PR uses the correct version number for DT enabled by default.

Closes [NEWRELIC-4620](https://issues.newrelic.com/browse/NEWRELIC-4620)