### PR TITLE
fix(Prometheus Integration): add Prometheus operator instructions to install guide. 

### DIFF
--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
@@ -21,17 +21,17 @@ You can get Prometheus data flowing in New Relic with just a few simple steps. O
 
 ### (Optional) Prometheus Operator configuration
 
-If you're using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) you'll need to create a secret with your NR license key. Make sure the NR API key is of type **Ingest - License**.
+If you're using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), you'll need to create a secret with the New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#overview-keys) for the account to which you want to report data. Make sure the API key is of the type `Ingest - License`.
 
 ```
-kubectl -n YOUR_PROM_NAMESPACE create secret generic nr-license-key --from-literal=value=<YOUR_NEW_RELIC_API_INGEST_KEY>
+kubectl -n <var>YOUR_PROM_NAMESPACE</var> create secret generic nr-license-key --from-literal=value=<var>YOUR_LICENSE_KEY</var>
 ```
 
 Next, add the following to your Prometheus CRD (`kind:Prometheus`):
 
 ```
   remoteWrite:
-      - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=<YOUR_CLUSTER_NAME>
+      - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=<var>YOUR_CLUSTER_NAME</var>
         authorization:
           credentials:
             key: value

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
@@ -19,6 +19,25 @@ redirects:
 
 You can get Prometheus data flowing in New Relic with just a few simple steps. Once you integrate, your data will be visible in query-based dashboards (and other query results), often within about five minutes. This page covers basic setup for the remote write integration, as well as a few common troubleshooting topics. For information on integrating Prometheus servers in a high availability (HA) configuration, see our [Prometheus high availability](/docs/prometheus-high-availability-ha) documentation.
 
+### (Optional) Prometheus Operator configuration
+
+If you're using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) you'll need to create a secret with your NR license key. Make sure the NR API key is of type **Ingest - License**.
+
+```
+kubectl -n YOUR_PROM_NAMESPACE create secret generic nr-license-key --from-literal=value=<YOUR_NEW_RELIC_API_INGEST_KEY>
+```
+
+Next, add the following to your Prometheus CRD (`kind:Prometheus`):
+
+```
+  remoteWrite:
+      - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=<YOUR_CLUSTER_NAME>
+        authorization:
+          credentials:
+            key: value
+            name: nr-license-key
+```
+
 ## Set up the integration [#setup]
 
 Go to the [Prometheus remote write setup launcher in the UI](https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJwcm9tZXRoZXVzLXJlbW90ZS13cml0ZS1pbnRlZ3JhdGlvbi1uZXJkbGV0cy5zZXR1cC1wcm9tZXRoZXVzIn0=), and complete these steps to add Prometheus data.
@@ -40,8 +59,8 @@ Go to the [Prometheus remote write setup launcher in the UI](https://one.newreli
    **Prometheus v2.26 and newer**
 
    ```
-   remote_write: 
-   - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=<var>YOUR_DATA_SOURCE_NAME</var>  
+   remote_write:
+   - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=<var>YOUR_DATA_SOURCE_NAME</var>
      authorization:
        credentials: <var>YOUR_LICENSE_KEY</var>
    ```
@@ -49,8 +68,8 @@ Go to the [Prometheus remote write setup launcher in the UI](https://one.newreli
    **Prometheus older than v2.26**
 
    ```
-   remote_write: 
-   - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=<var>YOUR_DATA_SOURCE_NAME</var>  
+   remote_write:
+   - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=<var>YOUR_DATA_SOURCE_NAME</var>
      bearer_token:<var>YOUR_LICENSE_KEY</var>
    ```
 
@@ -59,7 +78,7 @@ Go to the [Prometheus remote write setup launcher in the UI](https://one.newreli
    **Any Prometheus version**
 
    ```
-   remote_write: 
+   remote_write:
    - url: https://metric-api.newrelic.com/prometheus/v1/write?X-License-Key=<var>YOUR_LICENSE_KEY</var>&prometheus_server=<var>YOUR_DATA_SOURCE_NAME</var>
    ```
 
@@ -74,8 +93,8 @@ Go to the [Prometheus remote write setup launcher in the UI](https://one.newreli
    **Kubernetes and Helm remote write integrations:** Add the remote write URL to your Helm [`values.yaml`](https://github.com/helm/charts/blob/c40486ab2eba0391119b7cc1509d6958fd21c31d/stable/prometheus/values.yaml#L631) file. Replace `remoteWrite: []` with two lines similar to the following example. Be sure to use your remote write URL and use indentation that matches the rest of the file:
 
    ```
-   remoteWrite: 
-   - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=<var>YOUR_DATA_SOURCE_NAME</var> 
+   remoteWrite:
+   - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=<var>YOUR_DATA_SOURCE_NAME</var>
      bearer_token:<var>YOUR_LICENSE_KEY</var>
    ```
 3. Restart your Prometheus server.


### PR DESCRIPTION
**What problems does this PR solve?**

The Prometheus integration install page doesn’t explain how to set up remote write for developers who use the Prometheus Operator (which most on Kubernetes do). This PR adds those instructions. 
