### PR TITLE
added references to oma where needed

### DIFF
--- a/src/content/docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices.mdx
+++ b/src/content/docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices.mdx
@@ -14,7 +14,7 @@ redirects:
   - /docs/alerts/new-relic-alerts/getting-started/best-practices-alert-policies
   - /docs/alerts/new-relic-alerts/getting-started/alerts-best-practices
   - /docs/alerts-applied-intelligence/new-relic-alerts/get-started/alerts-best-practices
-  - /docs/new-relic-solutions/new-relic-solutions/optimize-your-cloud-native-environment 
+  - /docs/new-relic-solutions/new-relic-solutions/optimize-your-cloud-native-environment
   - /set-proactive-alerts-align-teams-tools-processes-incident-response/
   - /docs/4-fail-fast-set-proactive-alerts-align-teams-tools-processes-incident-response
   - /docs/set-proactive-alerts-align-teams-tools-processes-incident-response
@@ -23,6 +23,10 @@ redirects:
 ---
 
 Improve your alerts coverage by implementing the following recommendations and get the most out of your alerts configuration.
+
+<Callout variant="tip">
+  See [Alert quality management](/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/alert-quality-management-guide) for a guide on how to measure and improve your alerting quality.
+</Callout>
 
 And check out this video on finding the root cause for an alert (5:01 minutes):
 

--- a/src/content/docs/new-relic-solutions/best-practices-guides/full-stack-observability/apm-best-practices-guide.mdx
+++ b/src/content/docs/new-relic-solutions/best-practices-guides/full-stack-observability/apm-best-practices-guide.mdx
@@ -28,6 +28,10 @@ It's one thing to know how to use APM, but it's another thing to know how to use
   To get a high-level overview of all your applications and services, use the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer) in New Relic.
 </Callout>
 
+<Callout variant="tip">
+  See [Reliablity engineering diagnostics](/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/diagnostics-beginner-guide) for a guide on how to find common performance issues using APM and other New Relic capabilities.
+</Callout>
+
 ## 1. Standardize application names [#naming]
 
 Most New Relic agents provide a default application name, such as "My Application" or "PHP Application," if you don't specify one in your New Relic configuration file. You don't want to end up with 20 identically named applications, be sure to select a descriptive identifier for your apps as soon you deploy them.


### PR DESCRIPTION
Added references

* Reference link to AQM from alerts best practices guide.
* Reference link to RED from APM best practices guide.

Both guides are more technical bias, where users may also be looking for more process bias provided by the OMA documents.