### PR TITLE
fix: NR-58642: Add documentation of the length() function for strings

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -2437,7 +2437,7 @@ Note: `aparse()` is case-insensitive.
 
     <CollapserGroup>
       <Collapser title="Get the URL length from PageView">
-        This query returns the length of each Url from the `PageView` event.
+        This query returns the length of each URL string from the `PageView` event.
 
         ```sql
         SELECT length(pageUrl) FROM PageView

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -2428,6 +2428,26 @@ Note: `aparse()` is case-insensitive.
 
   <Collapser
     className="freq-link"
+    id="func-length"
+    title={<InlineCode>length(attribute)</InlineCode>}
+  >
+    Use the `length()` function to return the length of a string value or the number of elements in an array value.
+
+    It takes a single argument. Arguments after the first will be ignored.
+
+    <CollapserGroup>
+      <Collapser title="Get the URL length from PageView">
+        This query returns the length of each Url from the `PageView` event.
+
+        ```sql
+        SELECT length(pageUrl) FROM PageView
+        ```
+      </Collapser>
+    </CollapserGroup>
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
     id="func-string"
     title={<InlineCode>string(attribute [, precision: ]))</InlineCode>}
   >


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
The length() function was documented for arrays (on src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/arrays-in-nrql.mdx) but not for strings.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.
https://issues.newrelic.com/browse/NR-58642