### PR TITLE
chore(infra-agent): Amazon Linux 2022 repo url

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -295,6 +295,18 @@ To install infrastructure in Linux, follow these instructions:
        ```
        sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2/aarch64/newrelic-infra.repo
        ```
+       
+       **Amazon Linux 2022 (x86)**
+
+       ```
+       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2022/x86_64/newrelic-infra.repo
+       ```
+
+       **Amazon Linux 2022 (arm64)**
+
+       ```
+       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2022/aarch64/newrelic-infra.repo
+       ```
      </Collapser>
 
      <Collapser


### PR DESCRIPTION
## Give us some context

* Updated install instructions for Amazon Linux 2022, the .repo url is different.