### PR TITLE
docs: clarify element location & +fix identifiers

### DIFF
--- a/src/content/docs/apm/agents/net-agent/installation/install-net-agent-windows.mdx
+++ b/src/content/docs/apm/agents/net-agent/installation/install-net-agent-windows.mdx
@@ -105,7 +105,7 @@ msiexec.exe /i C:\<var>PATH_TO</var>\newrelic-agent-win-<var>x86</var>-VERSION.m
 The `INSTALLLEVEL` can be either `1` or `50`:
 
 * `1`: Installs .NET agent with default options (described in table below). If your application is not hosted on IIS or uses IIS as a reverse proxy, you should use option `50`.
-* `50`: Installs the agent with InstrumentAllNETFramework enabled (described below).
+* `50`: Installs the agent with `InstrumentAllNETFramework` enabled (described below).
 
 Instead of using the `INSTALLLEVEL` presets, you can customize which features to install with the `ADDLOCAL` command shown below. This is also the command you'd use to update an existing installation.
 
@@ -198,12 +198,12 @@ Enable the agent for your application with one of the following methods:
   >
     In the application's config file, add a new `appSetting` with a key named `NewRelic.AgentEnabled` and a value of `true`. For example, if the application name is `DataServices.exe`, edit `DataServices.exe.config` to:
 
-    ```yaml
+    ```xml
     <?xml version="1.0" encoding="utf-8"?>
     <configuration>
       <appSettings>
-        <var><add key="NewRelic.AgentEnabled" value="true" /></var>
-        <var><add key="NewRelic.AppName" value="DataServices" /></var>
+        <add key="NewRelic.AgentEnabled" value="true" />
+        <add key="NewRelic.AppName" value="DataServices" />
       </appSettings>
     ```
   </Collapser>
@@ -212,16 +212,16 @@ Enable the agent for your application with one of the following methods:
     id="newrelic-config"
     title="Enable by app name via newrelic.config (global or local)"
   >
-    You can use the [`newrelic.config` file](/docs/agents/net-agent/configuration/net-agent-configuration) (either global or local), to choose what applications to monitor. In the configuration file, add an `instrumentation` element with a child `application` element for each application. In the instrumentation element, provide the base file name, with extension, you want to instrument (for example, `<application name="DataServices.exe" />`).
+    You can use the [`newrelic.config` file](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#application-instrumentation) (either global or local), to choose what applications to monitor. In the configuration file, add an `instrumentation` element with a child `applications` element, with another child element, `application`, for each application. In the instrumentation element, provide the base file name, with extension, you want to instrument (for example, `<application name="DataServices.exe" />`).
 
     For example:
 
-    ```yaml
+    ```xml
     <instrumentation>
-        <applications>
-          <application name="<var>BusinessLogicServices.exe</var>" />
-          <application name="<var>DataServices.exe</var>" />
-        </applications>
+      <applications>
+        <application name="BusinessLogicServices.exe" />
+        <application name="DataServices.exe" />
+      </applications>
     </instrumentation>
     ```
   </Collapser>
@@ -237,9 +237,9 @@ Enable the agent for your application with one of the following methods:
 
       For example:
 
-      ```
+      ```xml
       <configuration xmlns="urn:newrelic-config"
-        <var>agentEnabled="true"></var>
+        agentEnabled="true">
       ```
   </Collapser>
 </CollapserGroup>
@@ -248,7 +248,7 @@ Enable the agent for your application with one of the following methods:
 
 For .NET Core, you must configure your application to be monitored by setting the following environment variable:
 
-```
+```cs
 CORECLR_ENABLE_PROFILING=1
 ```
 


### PR DESCRIPTION
language identifiers were `yaml` but that is `xml` code. Trying to clarify that it goes `<instrumentation>` -> `<applications>` -> `<application>`, the instructions as written made it sound like `<instrumentation>` -> `<application>`, I hope that sentence I wrote is clear.