### PR TITLE
fix: Correct alert condition tags instructions

### DIFF
--- a/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data.mdx
@@ -89,13 +89,15 @@ When you add tags via the UI or API, this occurs at the entity level. This means
 <CollapserGroup>
   <Collapser
     id="add-via-ui-api"
-    title="Manage tags via GraphQL"
+    title="Manage alert condition tags"
   >
   1. Navigate to a condition.
   2. Near the condition's name at the top of the form, click **Manage tags**.
   3. In the menu that pops up, add or delete a tag.
 
-  See our tutorial to learn more about [tagging data via the NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
+  You can also add tags to an alert condition as an entity via the NerdGraph API (utilize the condition's entity GUID from the 'manage tags' screen).
+
+See our tutorial to learn more about [tagging data via the NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial).
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
The title of the tags section for alert conditions is incorrect. Revising this and then pointing
to the NerdGraph tutorial appropriately.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
The title is incorrect for this alert condition section for managing tags on alert conditions. I also added some information on finding and supplying the entity guid for adding the tag to the condition entity.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  N/A
* If your issue relates to an existing GitHub issue, please link to it.
N/A