### PR TITLE
Feat(Go agent): add module dependency metrics configuration

### DIFF
--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
@@ -2253,10 +2253,9 @@ The following settings are available for configuration of application logging in
 </CollapserGroup>
 
 
-## Module Dependency Metrics settings [#mdm]
+## Module dependency metrics settings [#mdm]
 
-Module dependency metrics can be configured in a variety of ways in the Go agent. We've inculuded a list of all the available settings below.  This feature reports the list of imported modules used by the application along with their version
-information, to help facilitate code dependency management.
+Module dependency metrics can be configured in a variety of ways in the Go agent. Module dependency metrics reports the list of imported modules used by your Go application to help facilitate code dependency management. It also includes the version information of the modules of their app. 
 
 <Callout variant="important">
   Requires Go agent version 3.20.0 or higher
@@ -2309,7 +2308,7 @@ information, to help facilitate code dependency management.
     )
     ```
 
-    Alternatively, if you enabled the setting of agent options via environment variables by inserting `ConfigFromEnvironment()` into your call to `NewApplication`, you may enable or disable module dependency metrics collection by setting the environment variable
+    You can enable the setting of your Go agent options via environment variables by inserting `ConfigFromEnvironment()` into your call to `NewApplication`. If you've done this you can enable or disable module dependency metrics collection by setting the environment variable.
 
     ```sh
     NEW_RELIC_MODULE_DEPENDENCY_METRICS_ENABLED=true
@@ -2365,7 +2364,7 @@ to report all modules found.
   )
   ```
 
-    Alternatively, if you enabled the setting of agent options via environment variables by inserting `ConfigFromEnvironment()` into your call to `NewApplication`, you may list the path prefixes by setting the environment variable
+    If you enabled the setting of your Go agent options via environment variables by inserting `ConfigFromEnvironment()` into your call to `NewApplication`, you can list the path prefixes by setting the environment variable.
 
     ```sh
     NEW_RELIC_MODULE_DEPENDENCY_METRICS_IGNORED_PREFIXES="example.com/packageAlpha,example.com/packageBeta"
@@ -2409,10 +2408,10 @@ to report all modules found.
       </tbody>
     </table>
 
-Normally, all of the options set as part of your agent configuration are reported and visible on the New Relic UI. However, it may be the case that if you choose to exclude some modules from being reported via the `ConfigModuleDependencyIgnoredPrefixes` option, you may wish those exluded names to be redacted from the configuration data as well. (For example, if the modules were excluded for reasons of confidentiality.)
+Normally all of the options you set as part of your agent configuration are reported and visible in the New Relic UI. If you choose to exclude some modules from being reported via the `ConfigModuleDependencyIgnoredPrefixes` option, you can also redact them from the configuration data as well. For example, if the modules were excluded for reasons of confidentiality.
 
   Enable or disable the redaction of excluded paths by calling `ConfigModuleDependencyMetricsRedactIgnoredPrefixes`.
-  If `true`, the list of excluded module prefixes will not be reported; otherwise they will be.
+  If `true`, the list of excluded module prefixes won't be reported. If `false`, they are reported.
 
   ```go
   app, err := newrelic.NewApplication(
@@ -2420,7 +2419,7 @@ Normally, all of the options set as part of your agent configuration are reporte
   )
   ```
 
-    Alternatively, if you enabled the setting of agent options via environment variables by inserting `ConfigFromEnvironment()` into your call to `NewApplication`, you may list the path prefixes by setting the environment variable
+    If you enabled the setting of your Go agent options via environment variables by inserting `ConfigFromEnvironment()` into your call to `NewApplication`, you can list the path prefixes by setting the environment variable.
 
     ```sh
     NEW_RELIC_MODULE_DEPENDENCY_METRICS_REDACT_IGNORED_PREFIXES=false

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
@@ -2251,3 +2251,181 @@ The following settings are available for configuration of application logging in
   ```
   </Collapser>
 </CollapserGroup>
+
+
+## Module Dependency Metrics settings [#mdm]
+
+The following settings are available for configuration of module dependency metrics in the agent.
+This feature reports the list of imported modules used by the application along with their version
+information, to help facilitate code dependency management.
+
+<Callout variant="important">
+  Requires Go agent version 3.20.0 or higher
+</Callout>
+
+<CollapserGroup>
+  <Collapser
+    id="mdm-enabled"
+    title="ModuleDependencyMetrics.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    If `true`, enables the collection of module dependency data.  If `false`, no module dependency information is collected.
+
+    Configure ModuleDependencyMetrics by calling `ConfigModuleDependencyMetricsEnable`.
+
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigModuleDependencyMetricsEnable(true),
+    )
+    ```
+
+    Alternatively, if you enabled the setting of agent options via environment variables by inserting `ConfigFromEnvironment()` into your call to `NewApplication`, you may enable or disable module dependency metrics collection by setting the environment variable
+
+    ```sh
+    NEW_RELIC_MODULE_DEPENDENCY_METRICS_ENABLED=true
+    ```
+  </Collapser>
+
+<Collapser
+    id="mdm-ignored-prefixes"
+    title="ModuleDependencyMetrics.IgnoredPrefixes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+          <td>
+            String(s)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `nil`
+          </td>
+        </tr>
+        
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+This list of module path prefixes specifies that you wish to exclude some modules from the dependency information reported by the agent.
+Any module whose `import` path begins with any of the listed prefix strings will be excluded. The default is an empty list, which means
+to report all modules found.
+
+  Specify a list of path prefix strings to be excluded by calling `ConfigModuleDependencyMetricsIgnoredPrefixes`.
+
+  ```go
+  app, err := newrelic.NewApplication(
+      newrelic.ConfigModuleDependencyMetricsIgnoredPrefixes("example.com/packageAlpha", "example.com/packageBeta"),
+  )
+  ```
+
+    Alternatively, if you enabled the setting of agent options via environment variables by inserting `ConfigFromEnvironment()` into your call to `NewApplication`, you may list the path prefixes by setting the environment variable
+
+    ```sh
+    NEW_RELIC_MODULE_DEPENDENCY_METRICS_IGNORED_PREFIXES="example.com/packageAlpha,example.com/packageBeta"
+    ```
+  </Collapser>
+
+<Collapser
+    id="mdm-redact-ignored-prefixes"
+    title="ModuleDependencyMetrics.RedactIgnoredPrefixes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+        
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+Normally, all of the options set as part of your agent configuration are reported and visible on the New Relic UI. However, it may be the case that if you choose to exclude some modules from being reported via the `ConfigModuleDependencyIgnoredPrefixes` option, you may wish those exluded names to be redacted from the configuration data as well. (For example, if the modules were excluded for reasons of confidentiality.)
+
+  Enable or disable the redaction of excluded paths by calling `ConfigModuleDependencyMetricsRedactIgnoredPrefixes`.
+  If `true`, the list of excluded module prefixes will not be reported; otherwise they will be.
+
+  ```go
+  app, err := newrelic.NewApplication(
+      newrelic.ConfigModuleDependencyMetricsRedactIgnoredPrefixes(false),
+  )
+  ```
+
+    Alternatively, if you enabled the setting of agent options via environment variables by inserting `ConfigFromEnvironment()` into your call to `NewApplication`, you may list the path prefixes by setting the environment variable
+
+    ```sh
+    NEW_RELIC_MODULE_DEPENDENCY_METRICS_REDACT_IGNORED_PREFIXES=false
+    ```
+  </Collapser>
+
+</CollapserGroup>

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
@@ -2302,11 +2302,11 @@ information, to help facilitate code dependency management.
     </table>
     If `true`, enables the collection of module dependency data.  If `false`, no module dependency information is collected.
 
-    Configure ModuleDependencyMetrics by calling `ConfigModuleDependencyMetricsEnable`.
+    Configure ModuleDependencyMetrics by calling `ConfigModuleDependencyMetricsEnabled`.
 
     ```go
     app, err := newrelic.NewApplication(
-        newrelic.ConfigModuleDependencyMetricsEnable(true),
+        newrelic.ConfigModuleDependencyMetricsEnabled(true),
     )
     ```
 

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
@@ -2255,8 +2255,7 @@ The following settings are available for configuration of application logging in
 
 ## Module Dependency Metrics settings [#mdm]
 
-The following settings are available for configuration of module dependency metrics in the agent.
-This feature reports the list of imported modules used by the application along with their version
+Module dependency metrics can be configured in a variety of ways in the Go agent. We've inculuded a list of all the available settings below.  This feature reports the list of imported modules used by the application along with their version
 information, to help facilitate code dependency management.
 
 <Callout variant="important">
@@ -2354,7 +2353,7 @@ information, to help facilitate code dependency management.
       </tbody>
     </table>
 
-This list of module path prefixes specifies that you wish to exclude some modules from the dependency information reported by the agent.
+This list of module path prefixes specifies that you want to exclude some modules from the dependency information reported by the agent.
 Any module whose `import` path begins with any of the listed prefix strings will be excluded. The default is an empty list, which means
 to report all modules found.
 

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
@@ -2255,7 +2255,7 @@ The following settings are available for configuration of application logging in
 
 ## Module dependency metrics settings [#mdm]
 
-Module dependency metrics can be configured in a variety of ways in the Go agent. Module dependency metrics reports the list of imported modules used by your Go application to help facilitate code dependency management. It also includes the version information of the modules of their app. 
+Module dependency metrics can be configured in a variety of ways in the Go agent. Module dependency metrics reports the list of imported modules used by your Go application to help facilitate code dependency management. It also includes the version information of the modules of your app. 
 
 <Callout variant="important">
   Requires Go agent version 3.20.0 or higher


### PR DESCRIPTION
This adds configuration of the module dependency metrics feature to the Go agent docs.