### PR TITLE
Feat(Go Agent): updated clm configuration info

### DIFF
--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-code-level-metrics-config.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-code-level-metrics-config.mdx
@@ -97,23 +97,23 @@ There are additional configuration options you may wish to use to further refine
 
   To accomplish this, do one of the following:
 
-  * If configuring via the `NewApplication` function, add a `ConfigCodeLevelMetricsIgnoredPrefix` option, passing any number of prefix strings as separate string arguments:
+  * If configuring via the `NewApplication` function, add a `ConfigCodeLevelMetricsIgnoredPrefixes` option, passing any number of prefix strings as separate string arguments:
 
     ```go
     app, err := newrelic.NewApplication(
        newrelic.ConfigAppName("Your Application Name"),
        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
        newrelic.ConfigCodeLevelMetricsEnabled(true),
-       newrelic.ConfigCodeLevelMetricsIgnoredPrefix("github.com/some/other/name/"),
+       newrelic.ConfigCodeLevelMetricsIgnoredPrefixes("github.com/some/other/name/"),
     )
     ```
 
-  * If configuring via environment variables, set `NEW_RELIC_CODE_LEVEL_METRICS_IGNORED_PREFIX` to the desired prefix (or a comma-separated list of prefixes):
+  * If configuring via environment variables, set `NEW_RELIC_CODE_LEVEL_METRICS_IGNORED_PREFIXES` to the desired prefix (or a comma-separated list of prefixes):
     ```
-    NEW_RELIC_CODE_LEVEL_METRICS_IGNORED_PREFIX="github.com/some/other/name/"
+    NEW_RELIC_CODE_LEVEL_METRICS_IGNORED_PREFIXES="github.com/some/other/name/"
     ```
 
-    Don't forget to also include the `newrelic.ConfigFromEnvironmet` option when setting up the application:
+    Don't forget to also include the `newrelic.ConfigFromEnvironment()` option when setting up the application:
 
     ```go
     app, err := newrelic.NewApplication(
@@ -126,40 +126,40 @@ There are additional configuration options you may wish to use to further refine
 
   * It is also possible to directly set the `CodeLevelMetrics.IgnoredPrefixes` member of the `Config` struct (which is a `[]string` value), but we recommend using one of the above-mentioned methods instead of directly manipulating the `Config` structure.
 
+<Callout variant="important">
+In Go Agent versions prior to 3.20.0, this option was named with in the singular form rather than plural (i.e., `ConfigCodeLevelMetricsIgnoredPrefix`). These names are deprecated and the ones documented here should be used. The older names are also still supported for backward compatibility.
+</Callout>
+
   </Collapser>
   <Collapser
-    id="go-clm-config-path-prefix"
-    title={<>Truncate source path prefix</>}
+    id="go-clm-config-redact-ignored-prefix"
+    title={<>Redact ignored module prefixes</>}
   >
-  By default, with code-level metrics enabled, the agent will report the full pathname of each source file. However, this may
-  not be desired. For example, you may wish to only report application paths relative to the root of the project source
-  tree, allowing data to be correlated between instances regardless of where they are installed in the filesystem.
 
-  To accomplish this, specify a `PathPrefix` string that indicates the start of your local project source path. If that string is found
-  in a source file pathname, everything that appears before it will be removed. For example, if the `PathPrefix` parameter
-  is set to `myproject/src` then `/usr/local/projects/myproject/src/widget/main.go` would be reported in the code-level metrics
-  as `myproject/src/widget/main.go`.
-  
-  If you have multiple path prefixes you wish to use, simply list all of their names as separate parameters.
+  If, for reasons such as confidentiality, you choose to ignore some modules via
+  `ConfigCodeLevelMetricsIgnoredPrefixes` option, you may also wish to redact the list of such prefixes
+  from the agent's reported configuration data as well.
 
-  If `PathPrefix` is empty, or a source file doesn't contain any of your prefix strings at all, the full pathname will be reported.
+  This is accomplished by setting the `ConfigCodeLevelMetricsRedactIgnoredPrefixes` option. If given a `true` value,
+  your list of ignored prefixes will not be shown in the configuration data that are reported by the agent. Otherwise,
+  they will be reported.
 
   Do one of the following:
 
-  * If configuring via the `NewApplication` function, add a `ConfigCodeLevelMetricsPathPrefix` option:
+  * If configuring via the `NewApplication` function, add a `ConfigCodeLevelMetricsRedactIgnoredPrefixes` option:
 
     ```go
     app, err := newrelic.NewApplication(
        newrelic.ConfigAppName("Your Application Name"),
        newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
        newrelic.ConfigCodeLevelMetricsEnabled(true),
-       newrelic.ConfigCodeLevelMetricsPathPrefix("myprojects/src/", "otherproject/src/"),
+       newrelic.ConfigCodeLevelMetricsRedactIgnoredPrefixes(true),
     )
     ```
 
-  * If configuring via environment variables, set `NEW_RELIC_CODE_LEVEL_METRICS_PATH_PREFIX` to the desired prefix(es):
+  * If configuring via environment variables, set `NEW_RELIC_CODE_LEVEL_METRICS_REDACT_IGNORED_PREFIXES`:
     ```
-    NEW_RELIC_CODE_LEVEL_METRICS_PATH_PREFIX="myprojects/src/,otherproject/src/"
+    NEW_RELIC_CODE_LEVEL_METRICS_REDACT_IGNORED_PREFIXES=true
     ```
 
     Don't forget to also include the `newrelic.ConfigFromEnvironment` option when setting up the application:
@@ -172,6 +172,109 @@ There are additional configuration options you may wish to use to further refine
        newrelic.ConfigFromEnvironment(),
     )
     ```
+
+<Callout variant="important">
+This redaction option is available in Go Agent versions 3.20.0 and later.
+</Callout>
+  </Collapser>
+  </Collapser>
+  <Collapser
+    id="go-clm-config-path-prefix"
+    title={<>Truncate source path prefix</>}
+  >
+  By default, with code-level metrics enabled, the agent will report the full pathname of each source file. However, this may
+  not be desired. For example, you may wish to only report application paths relative to the root of the project source
+  tree, allowing data to be correlated between instances regardless of where they are installed in the filesystem.
+
+  To accomplish this, specify a string that indicates the start of your local project source path. If that prefix is found
+  in a source file pathname, everything that appears before it will be removed. For example, if the path prefix string
+  is set to `myproject/src` then `/usr/local/projects/myproject/src/widget/main.go` would be reported in the code-level metrics
+  as `myproject/src/widget/main.go`.
+  
+  If you have multiple path prefixes you wish to use, simply list all of their names as separate parameters.
+
+  If `PathPrefixes` is empty, or a source file path doesn't contain any of your prefix strings at all, the full pathname will be reported.
+
+  Do one of the following:
+
+  * If configuring via the `NewApplication` function, add a `ConfigCodeLevelMetricsPathPrefixes` option:
+
+    ```go
+    app, err := newrelic.NewApplication(
+       newrelic.ConfigAppName("Your Application Name"),
+       newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+       newrelic.ConfigCodeLevelMetricsEnabled(true),
+       newrelic.ConfigCodeLevelMetricsPathPrefixes("myprojects/src/", "otherproject/src/"),
+    )
+    ```
+
+  * If configuring via environment variables, set `NEW_RELIC_CODE_LEVEL_METRICS_PATH_PREFIXES` to the desired prefix(es):
+    ```
+    NEW_RELIC_CODE_LEVEL_METRICS_PATH_PREFIXES="myprojects/src/,otherproject/src/"
+    ```
+
+    Don't forget to also include the `newrelic.ConfigFromEnvironment` option when setting up the application:
+
+    ```go
+    app, err := newrelic.NewApplication(
+       newrelic.ConfigAppName("Your Application Name"),
+       newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+       newrelic.ConfigCodeLevelMetricsEnabled(true),
+       newrelic.ConfigFromEnvironment(),
+    )
+    ```
+
+<Callout variant="important">
+In Go Agent versions prior to 3.20.0, this option was named with in the singular form rather than plural (i.e., `ConfigCodeLevelMetricsPathPrefix`). These names are deprecated and the ones documented here should be used. The older names are also still supported for backward compatibility.
+</Callout>
+
+  </Collapser>
+  <Collapser
+    id="go-clm-config-redact-path-prefix"
+    title={<>Redact source path prefixes</>}
+  >
+
+  If, for reasons such as confidentiality, you choose to shorten reported source pathnames via the
+  `ConfigCodeLevelMetricsPathPrefixes` option, you may also wish to redact the list of path prefixes
+  from the agent's reported configuration data as well.
+
+  This is accomplished by setting the `ConfigCodeLevelMetricsRedactPathPrefixes` option. If given a `true` value,
+  your list of path prefixes will not be shown in the configuration data that are reported by the agent. Otherwise,
+  they will be reported.
+
+  Do one of the following:
+
+  * If configuring via the `NewApplication` function, add a `ConfigCodeLevelMetricsRedactPathPrefixes` option:
+
+    ```go
+    app, err := newrelic.NewApplication(
+       newrelic.ConfigAppName("Your Application Name"),
+       newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+       newrelic.ConfigCodeLevelMetricsEnabled(true),
+       newrelic.ConfigCodeLevelMetricsPathPrefixes("myprojects/src/", "otherproject/src/"),
+       newrelic.ConfigCodeLevelMetricsRedactPathPrefixes(true),
+    )
+    ```
+
+  * If configuring via environment variables, set `NEW_RELIC_CODE_LEVEL_METRICS_REDACT_PATH_PREFIXES`:
+    ```
+    NEW_RELIC_CODE_LEVEL_METRICS_REDACT_PATH_PREFIXES=true
+    ```
+
+    Don't forget to also include the `newrelic.ConfigFromEnvironment` option when setting up the application:
+
+    ```go
+    app, err := newrelic.NewApplication(
+       newrelic.ConfigAppName("Your Application Name"),
+       newrelic.ConfigLicense("YOUR_NEW_RELIC_LICENSE_KEY"),
+       newrelic.ConfigCodeLevelMetricsEnabled(true),
+       newrelic.ConfigFromEnvironment(),
+    )
+    ```
+
+<Callout variant="important">
+This redaction option is available in Go Agent versions 3.20.0 and later.
+</Callout>
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-code-level-metrics-config.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-code-level-metrics-config.mdx
@@ -177,7 +177,6 @@ In Go Agent versions prior to 3.20.0, this option was named with in the singular
 This redaction option is available in Go Agent versions 3.20.0 and later.
 </Callout>
   </Collapser>
-  </Collapser>
   <Collapser
     id="go-clm-config-path-prefix"
     title={<>Truncate source path prefix</>}


### PR DESCRIPTION
This updates the configuration options for code level metrics in the go agent as of v3.20.0.