### PR TITLE
Add updates for python agent release v8.3.0.

### DIFF
--- a/src/content/docs/apm/agents/python-agent/python-agent-api/addcustomattribute-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/addcustomattribute-python-agent-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: add_custom_parameter (Python agent API)
+title: add_custom_attribute (Python agent API)
 type: apiDoc
 shortDescription: Adds a custom attribute to a transaction.
 tags:
@@ -8,21 +8,24 @@ tags:
   - Python agent API
 metaDescription: 'Python API: This call adds a custom attribute (key/value pair) to a transaction.'
 redirects:
-  - /docs/agents/python-agent/python-agent-api/addcustomparameter-python-agent-api
-  - /docs/agents/python-agent/python-agent-api/add_custom_parameter
+  - /docs/agents/python-agent/python-agent-api/addcustomattribute-python-agent-api
+  - /docs/agents/python-agent/python-agent-api/add_custom_attribute
 ---
 
 ## Syntax
 
 ```
-newrelic.agent.add_custom_parameter(key, value)
+newrelic.agent.add_custom_attribute(key, value)
 ```
+<Callout variant="important">
+  This API was previously named add_custom_parameter and was changed in Python agent v8.3.0.
+</Callout>
 
 Adds a custom attribute to a transaction.
 
 ## Description
 
-This call records a [custom attribute](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) (a key/value pair attached to your [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction)). (The call name is `add_custom_parameter` because "custom attributes" were previously called "custom parameters.")
+This call records a [custom attribute](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) (a key/value pair attached to your [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction)).
 
 Attributes may be found in APM if the transaction is associated with an error or if a transaction trace is generated for that transaction. Attributes can also be found and queried in the New Relic UI.
 
@@ -36,7 +39,7 @@ Attributes may be found in APM if the transaction is associated with an error or
   <thead>
     <tr>
       <th width="25%">
-        Parameter
+        Attribute
       </th>
 
       <th>
@@ -78,23 +81,23 @@ Returns `True` if attribute was added successfully. 
 
 ## Examples
 
-### Adding custom parameters to background task [#custom-parameter-example]
+### Adding custom attributes to background task [#custom-attributes-example]
 
-An example of adding custom parameters to a [background task](/docs/agents/python-agent/python-agent-api/background_task):
+An example of adding custom attributes to a [background task](/docs/agents/python-agent/python-agent-api/background_task):
 
 ```
 @newrelic.agent.background_task()
-def send_request(): 
-	response = requests.post('http://URL_path', headers=headers, data=data) 
-	newrelic.agent.add_custom_parameter('url_path_status_code', response.status_code)
+def send_request():
+	response = requests.post('http://URL_path', headers=headers, data=data)
+	newrelic.agent.add_custom_attribute('url_path_status_code', response.status_code)
 ```
 
-### Using custom parameters to troubleshoot [#parameter-troubleshooting]
+### Using custom attributes to troubleshoot [#attributes-troubleshooting]
 
-You can also use custom parameters to troubleshoot performance issues. For example, you might see occasional slow response times from a pool of memcache instances, but you don't know what instance is causing the problem. You might add an attribute to the transaction indicating the server, like so:
+You can also use custom attributes to troubleshoot performance issues. For example, you might see occasional slow response times from a pool of memcache instances, but you don't know what instance is causing the problem. You might add an attribute to the transaction indicating the server, like so:
 
 ```
 # Set server_ip to be the current server processing the transaction
 
-newrelic.agent.add_custom_parameter("memcache_query_frontend_lookup", server_ip)
+newrelic.agent.add_custom_attribute("memcache_query_frontend_lookup", server_ip)
 ```

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/addcustomattributes-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/addcustomattributes-python-agent-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: add_custom_parameters (Python agent API)
+title: add_custom_attributes (Python agent API)
 type: apiDoc
 shortDescription: Adds one or more custom attributes to a transaction.
 tags:
@@ -8,20 +8,23 @@ tags:
   - Python agent API
 metaDescription: 'Python API: This call adds a custom attribute (key/value tuple) to a transaction.'
 redirects:
-  - /docs/agents/python-agent/python-agent-api/addcustomparameters-python-agent-api
+  - /docs/agents/python-agent/python-agent-api/addcustomattributes-python-agent-api
 ---
 
 ## Syntax
 
 ```
-newrelic.agent.add_custom_parameters(items)
+newrelic.agent.add_custom_attributes(items)
 ```
+<Callout variant="important">
+  This API was previously named add_custom_parameters and was changed in Python agent v8.3.0.
+</Callout>
 
 Adds one or more custom attributes to a transaction.
 
 ## Description
 
-This call records one or more [custom attributes](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) (a key/value tuple attached to your [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction)). The call name is `add_custom_parameters` because "custom attributes" were previously called "custom parameters".
+This call records one or more [custom attributes](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) (a key/value tuple attached to your [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction)).
 
 Attributes may be found in APM if the transaction is associated with an error or if a transaction trace is generated for that transaction. Attributes can also be found and queried in the New Relic UI.
 
@@ -35,7 +38,7 @@ Attributes may be found in APM if the transaction is associated with an error or
   <thead>
     <tr>
       <th width="25%">
-        Parameter
+        Attribute
       </th>
 
       <th>
@@ -65,26 +68,26 @@ Returns `True` if all attributes were added successfully.
 
 ## Examples
 
-### Adding custom parameters to background task [#custom-parameter-example]
+### Adding custom attributes to background task [#custom-attribute-example]
 
-An example of adding custom parameters to a [background task](/docs/agents/python-agent/python-agent-api/background_task):
+An example of adding custom attributes to a [background task](/docs/agents/python-agent/python-agent-api/background_task):
 
 ```
 @newrelic.agent.background_task()
 def send_request():
     response = requests.get("http://example.com")
-    newrelic.agent.add_custom_parameters(
+    newrelic.agent.add_custom_attributes(
         [("url_path_status_code", response.status_code)]
     )
 ```
 
-### Using custom parameters to troubleshoot [#parameter-troubleshooting]
+### Using custom attributes to troubleshoot [#attribute-troubleshooting]
 
-You can also use custom parameters to troubleshoot performance issues. For example, you might see occasional slow response times from a pool of memcache instances, but you don't know what instance is causing the problem. You might add an attribute to the transaction indicating the server, like so:
+You can also use custom attributes to troubleshoot performance issues. For example, you might see occasional slow response times from a pool of memcache instances, but you don't know what instance is causing the problem. You might add an attribute to the transaction indicating the server, like so:
 
 ```
 # Set server_ip to be the current server processing the transaction
-newrelic.agent.add_custom_parameters([
+newrelic.agent.add_custom_attributes([
     ("memcache_query_frontend_lookup", "server_ip")
 ])
 ```

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80300.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80300.mdx
@@ -1,0 +1,36 @@
+---
+subject: Python agent
+releaseDate: '2022-10-24'
+version: 8.3.0
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+---
+
+## Notes
+
+This release of the Python agent adds Python 3.11 support, deprecates the add_custom_parameter API, adds usage metrics for multiple libraries, and includes bug fixes.
+
+Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the New Relic [download site](http://download.newrelic.com/python_agent/release).
+
+## Deprecations
+
+* **add_custom_parameter(s) API is now deprecated**
+  The add_custom_parameter(s) API is deprecated in favor of add_custom_attribute(s).
+
+## New features
+
+* **Adds support for Python 3.11**
+    The agent now supports applications running in Python 3.11.
+
+* **Adds usage metrics for Kafka clients, Daphne, and Hypercorn**
+  The agent now emits a messagebroker metric for Kafka clients and a dispatcher metric for Daphne and Hypercorn. This metric is similar to the framework metric already being emitted for all web frameworks supported by the agent.
+
+
+## Bug fixes
+* **Fixed Flask view support for Code Level Metrics**
+    The agent was previously reporting the class name for the code.function attribute in the case of Flask method dispatching. This has been corrected to report the instrumented function name.
+
+* **Fixed aioredis version crash**
+    A fix has been implemented to address a crash in aioredis in cases where the agent was initialized before importing aioredis on aioredis>=2.0.1.
+
+## Support statement
+  New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.2.2.130](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-522130). More information can be found in the [EOL Policy Page](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/).


### PR DESCRIPTION
This PR adds release notes for the latest python agent release (v8.3.0). It also renames the API guides for add_custom_parameter and add_custom_parameters to add_custom_attribute and add_custom_attributes. 
Note: This PR renames the files for these API guides (just an FYI if this breaks any links within the docs site).