### PR TITLE
fix: Correct query parameter

### DIFF
--- a/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts.mdx
+++ b/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts.mdx
@@ -173,7 +173,7 @@ curl -v -X GET --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-starte
 To get a list of the 10 Infrastructure conditions beyond the 50 limit:
 
 ```
-curl -v -X GET --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>" "https://infra-api.newrelic.com/v2/alerts/conditions?policy_id=111111&offset=50&list=10"
+curl -v -X GET --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key"><var>$API_KEY</var></a>" "https://infra-api.newrelic.com/v2/alerts/conditions?policy_id=111111&offset=50&limit=10"
 ```
 
 ### GET a specific infrastructure condition [#get-one-condition]


### PR DESCRIPTION
API example used a `list` query parameter, which doesn't exist. Updated to use `limit` instead.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.