### PR TITLE
Made revision to Style Guide on Usage page

### DIFF
--- a/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
@@ -68,19 +68,6 @@ For consistency across New Relic content, here are our general word usage guidel
   </Collapser>
 
   <Collapser
-    id="Preview"
-    title="Preview"
-  >
-    Use the [preview callout](/docs/style-guide/quick-reference/callouts/). In the body text, use lowercase. For example:
-
-    <Callout title="PREVIEW FEATURE">
-      This feature is currently in preview.
-    </Callout>
-
-    If the developer team prefers to use a term other than preview, clarify what is driving that use of the term (Legal requirement?), and add any relevant info here in the usage dictionary.
-  </Collapser>
-
-  <Collapser
     id="byte"
     title="bits and bytes"
   >
@@ -608,6 +595,19 @@ Really, we recommend being as specific as possible to establish context. If a pi
     See [User-related language](/docs/new-relic-only/basic-style-guide/style-guide-quick-reference/user-related-language-styles-recommended-phrasings).
 
     For pricing tier/edition language, see [Pricing language](/docs/new-relic-only/basic-style-guide/style-guide-quick-reference/pricing-related-language).
+  </Collapser>
+
+  <Collapser
+    id="Preview"
+    title="Preview"
+  >
+    Use the [preview callout](/docs/style-guide/quick-reference/callouts/). In the body text, use lowercase. For example:
+
+    <Callout title="PREVIEW FEATURE">
+      This feature is currently in preview.
+    </Callout>
+
+    If the developer team prefers to use a term other than preview, clarify what is driving that use of the term (Legal requirement?), and add any relevant info here in the usage dictionary.
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
I moved "Preview" entry, which was after "app name vs. app alias," to the "P" entries.

<!-- Thanks for contributing to our docs! -->

