### PR TITLE
fix(synth): fix small typo

### DIFF
--- a/src/content/docs/synthetics/new-relic-synthetics/pages/synthetics-results-access-individual-monitor-runs.mdx
+++ b/src/content/docs/synthetics/new-relic-synthetics/pages/synthetics-results-access-individual-monitor-runs.mdx
@@ -4,7 +4,7 @@ tags:
   - Synthetics
   - Synthetic monitoring
   - Pages
-metaDescription: 'Use the synthetics sesults page to quickly access interesting monitor results, and to sort your results by location and performance.'
+metaDescription: 'Use the synthetics results page to quickly access interesting monitor results, and to sort your results by location and performance.'
 redirects:
   - /docs/synthetics/new-relic-synthetics/dashboards/synthetics-results-dashboard
   - /docs/synthetics/new-relic-synthetics/dashboards/synthetics-results-dashboard-access-individual-monitor-runs


### PR DESCRIPTION
Fixes a small typo in a meta description