### PR TITLE
Add python agent release notes for v8.3.0

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80300.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80300.mdx
@@ -1,0 +1,36 @@
+---
+subject: Python agent
+releaseDate: '2022-10-24'
+version: 8.3.0
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+---
+
+## Notes
+
+This release of the Python agent adds Python 3.11 support, deprecates the add_custom_parameter(s) API, adds usage metrics for multiple libraries, and includes bug fixes.
+
+Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the New Relic [download site](http://download.newrelic.com/python_agent/release).
+
+## Deprecations
+
+* **add_custom_parameter(s) API is now deprecated**
+  The add_custom_parameter(s) API has been renamed to add_custom_attribute(s). A deprecation warning will be emitted when calling add_custom_parameter() from this agent version and higher.
+
+## New features
+
+* **Adds support for Python 3.11**
+    The agent now supports applications running in Python 3.11.
+
+* **Adds usage metrics for Kafka clients, Daphne, and Hypercorn**
+  The agent now emits a messagebroker metric for Kafka clients and a dispatcher metric for Daphne and Hypercorn. This metric is similar to the framework metric already being emitted for all web frameworks supported by the agent.
+
+
+## Bug fixes
+* **Fixed Flask view support for Code Level Metrics**
+    The agent was previously reporting the class name for the code.function attribute in the case of Flask method dispatching. This has been corrected to report the instrumented function name.
+
+* **Fixed aioredis version crash**
+    A fix has been implemented to address a crash in aioredis in cases where the agent was initialized before importing aioredis on aioredis>=2.0.1.
+
+## Support statement
+  New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.2.2.130](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-522130). More information can be found in the [EOL Policy Page](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/).


### PR DESCRIPTION
This PR adds release notes for Python agent release v8.3.0.