### PR TITLE
docs: Add version information for default log forwarding in Ruby.

### DIFF
--- a/src/content/docs/logs/logs-context/configure-logs-context-ruby.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-ruby.mdx
@@ -53,7 +53,7 @@ You have three options to configure APM logs in context to send your app's logs 
     NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=true
     ```
 
-    This option may be on by default in a future agent version.
+    This option is enabled by default in version 8.7.0 and later. To disable log forwarding, you must set the value to `false`.
 
     **Optional adjustments:**
 


### PR DESCRIPTION
The documentation states that it may be the default in a future release, but it was made the default in the release following the one in which it was added. This patch clarifies that.