### PR TITLE
fix: NR-54396 updated custom event limit for node.js agent to 3000

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -58,7 +58,7 @@ Here are detailed descriptions of each configuration method:
     title="Agent configuration file"
   >
     The config file (`newrelic.js`) contains every Node.js agent setting. When you [install the Node.js agent](/docs/agents/nodejs-agent/installation-configuration/installing-maintaining-nodejs#installing), you must copy `newrelic.js` into your app's root directory. Most settings are empty by default; they inherit their values from `config/default.js`.
-    
+
     If your application is running on CommonJS, simply change the configuration file type to (`newrelic.cjs`). This filetype is supported as of [v7.5.0](/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-5-0/) of the Node.js agent.
   </Collapser>
 
@@ -2406,7 +2406,7 @@ This section defines the Node.js agent variables in the order they typically app
       </tbody>
     </table>
 
-    Define a list of request URLs you want the agent to ignore. Specify the list as patterns, which can be strings or regular expressions. The default value is a regular expression to match socket.io long-polling requests 
+    Define a list of request URLs you want the agent to ignore. Specify the list as patterns, which can be strings or regular expressions. The default value is a regular expression to match socket.io long-polling requests
   </Collapser>
 
   <Collapser
@@ -3019,7 +3019,7 @@ This section defines the Node.js agent variables in the order they typically app
           </th>
 
           <td>
-            `1000`
+            `3000`
           </td>
         </tr>
 
@@ -3809,7 +3809,7 @@ The `grpc` section controls the behavior of how the gRPC server is instrumented.
   Defines the maximum number of events the agent collects per minute. If there are more than this number, the agent collects a statistical sampling.
 
   We do not recommend configuring past 10k. The server will cap data at 10k per-minute.
-  
+
   <Callout variant="important">
     `max_samples_stored` configuration settings require [Node.JS agent version 8.3.0 or higher](/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent/).
   </Callout>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
This will increase the custom event limit to 3,000 to align with 9.5.0 of Node.js agent which is shipping today
