### PR TITLE
Fix/#10051 kafka otel example

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud.mdx
@@ -51,23 +51,26 @@ Create a new file called `config.yaml` from the example below.
 
 Replace the following keys in the file with your own values:
 
-* [Cloud API key](https://docs.confluent.io/cloud/current/access-management/authenticate/api-keys/api-keys.html#cloud-cloud-api-keys)
+* [Cloud API key](https://docs.confluent.io/cloud/current/monitoring/metrics-api.html#metrics-quick-start)
 	* CONFLUENT_API_ID
 	* CONFLUENT_API_SECRET
 * [Kafka Client API key](https://docs.confluent.io/cloud/current/access-management/authenticate/api-keys/api-keys.html#resource-specific-api-keys)
-	* CONFLUENT_API_ID
-	* CONFLUENT_API_SECRET
+	* CLUSTER_API_KEY
+	* CLUSTER_API_SECRET
 * [New Relic Ingest key](/docs/apis/intro-apis/new-relic-api-keys/#license-key)
 	* NEW RELIC LICENSE KEY
 * CLUSTER_ID
 	* Cluster ID from Confluent cloud
 	* Cluster key/secret should be specific to this cluster
+* CLUSTER_BOOTSTRAP_SERVER
+  * bootstrap server provided by confluent for the cluster
+  * example: xxx-xxxx.us-east-2.aws.confluent.cloud:9092
 
 ```yaml
 receivers:
   kafkametrics:
     brokers:
-      -
+      - CLUSTER_BOOTSTRAP_SERVER
     protocol_version: 2.0.0
     scrapers:
       - brokers
@@ -75,8 +78,8 @@ receivers:
       - consumers
     auth:
       sasl:
-        username: <var>INSERT_CONFLUENT_CLUSTER_API_ID</var>
-        password: <var>INSERT_CONFLUENT_CLUSTER_SECRET</var>
+        username: <var>CLUSTER_API_KEY</var>
+        password: <var>CLUSTER_API_SECRET</var>
         mechanism: PLAIN
       tls:
         insecure_skip_verify: false
@@ -92,8 +95,9 @@ receivers:
             - targets: ["api.telemetry.confluent.cloud"]
           scheme: https
           basic_auth:
-            username: <var>INSERT_CONFLUENT_API_ID</var>
-            password: <var>INSERT_CONFLUENT_API_SECRET</var>
+            username: <var>CONFLUENT_API_ID</var>
+            password: <var>CONFLUENT_API_SECRET</var>
+          metrics_path: /v2/metrics/cloud/export
           params:
             "resource.kafka.id":
               - <var>CLUSTER_ID</var>
@@ -101,7 +105,7 @@ exporters:
   otlp:
     endpoint: https://otlp.nr-data.net:4317
     headers:
-      api-key: <var>INSERT_NEW_RELIC_LICENSE_KEY</var>
+      api-key: <var>NEW_RELIC_LICENSE_KEY</var>
 processors:
   batch:
   memory_limiter:


### PR DESCRIPTION
This fixes #10051.

The replace variables are renamed to match the rest of the document. Also updated missing path config.