### PR TITLE
Update 1220 release notes

### DIFF
--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1220.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1220.mdx
@@ -4,10 +4,6 @@ releaseDate: '2022-10-07'
 version: '1220'
 ---
 
-* Internal NR Platform release date: 10/5/2022
-* Production APM-injected release date: 10/6/2022
-* Production Standalone release date: 10/17/2022
-
 ## New Features
 ### Capture unhandled Promise rejections
 The Agent now observes and captures unhandled Promise rejections as JavaScript Error objects.


### PR DESCRIPTION
This PR updates the Browser Agent 1220 release doc.  The browser agent team has decided to no longer include arbitrary internal release dates, as they are misleading and not always applicable to our deploy process.