### PR TITLE
chore - typo in heading

### DIFF
--- a/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/install-auto-telemetry-pixie.mdx
+++ b/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/install-auto-telemetry-pixie.mdx
@@ -139,7 +139,7 @@ Use the following table to find out where to start installing Auto-telemetry wit
    Note: if you have a single account, you won't see this option.
 3. Select **Kubernetes** and then continue with step one in the next section.
 
-## Install from the Configure the HELM command/manifest (yaml) file [#install-helm-command-manifest]
+## Install from the HELM command/manifest (yaml) file [#install-helm-command-manifest]
 
 If you arrived in the guided installation process by following a link from Pixie or from within New Relic, your steps begin here.
 


### PR DESCRIPTION
Fix typo in heading.

This makes it easier to read.