### PR TITLE
fix(noticeError): dedupe anchor id

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/noticeerror-browser-agent-api.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/noticeerror-browser-agent-api.mdx
@@ -137,7 +137,7 @@ rest('/').then(function(res) {
 });
 ```
 
-### Capturing custom attributes example [#promise-js]
+### Capturing custom attributes example [#custom-attributes]
 
 ```js
 try {


### PR DESCRIPTION
The `#promise-js` id attribute is used twice. This PR fixes the 2nd occurrence by renaming the id to a new, unique value so then it fixes the ability to directly link to the "Capturing custom attributes example" heading of the page.