### PR TITLE
JVM runtime metrics are specified now

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-jvms-page.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-jvms-page.mdx
@@ -7,7 +7,7 @@ tags:
 metaDescription: Here are some tips for understanding the OpenTelemetry JVMs page in the New Relic UI.
 ---
 
-After you've sent us your OpenTelemetry data and opened your service (entity) in the UI, you can click **JVMs** to identify which service instances instrumented with OpenTelemetry have unusual or unhealthy performance patterns.
+After you've sent us your OpenTelemetry data and opened your service (entity) in the UI, click **JVMs** to identify which service instances have unusual or unhealthy performance patterns related to the behavior of the Java Virtual Machine.
 
 You can choose several service instances to compare based on summaries of key metrics: response time, throughput, error rate, garbage collection time, and memory usage. Then, you can compare all those instances' JVM metrics collected by OpenTelemetry instrumentation using timeseries charts to spot problems.
 
@@ -15,12 +15,12 @@ Here's a typical workflow:
 
 1. Click **JVMs**.
 2. Find interesting JVMs using the table of summarized health metrics:
-   * Use the filter bar to narrow down your search.
-   * Sort to find outliers.
+   * Use the filter bar to narrow down your search
+   * Sort the columns of metric values to find outliers
 3. Select those interesting JVMs.
 4. Click **Compare** to see a display of the health and runtime metrics faceted by JVM.
 
-Review these additional topics about using the JVMs page:
+You can also view all the runtime metrics for a single JVM by clicking the name of the instance in the table.
 
 <CollapserGroup>
   <Collapser
@@ -28,7 +28,7 @@ Review these additional topics about using the JVMs page:
     id="metric-details"
     title="Runtime metric details"
   >
-    When you drill into a specific JVM, the UI display charts driven by JVM metric data. The Java specific runtime metrics are not well documented. The [implementation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics) is effectively the documentation and may be subject to change.
+    When you compare JVMs or drill into a single JVM, you will see several timeseries charts of runtime metric data, including garbage collection and memory usage. The JVM-specific runtime metrics are specified in the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/reference/specification/metrics/semantic_conventions/runtime-environment-metrics/#jvm-metrics) and [implemented](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics) in recent versions of the OTel auto-instrumentation agent.
   </Collapser>
 
   <Collapser
@@ -38,8 +38,7 @@ Review these additional topics about using the JVMs page:
   >
     For your data to appear in this section, make sure it has the following:
 
-    * A unique `service.instance.id` attribute for rendering the list of JVMs.
-    * An OpenTelemetry resource attribute `service.instance.id`.
+    * The OpenTelemetry resource attribute `service.instance.id`, used to group JVM metrics by instance
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
Thanks to @jack-berg and others in the OTel community, the JVM runtime metrics are documented in the semantic conventions, so let's refer to them here.