### PR TITLE
Fix references to some UI elements

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-alerts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-alerts.mdx
@@ -21,7 +21,7 @@ Conditions use NRQL queries to define what you want to be notified about. Use th
 
 Here's how to try this:
 
-1. In the upper right corner of any chart, click the ellipses button, then click **Create alert condition**. Click on the image to enlarge it:
+1. In the upper right corner of any chart, click the ellipsis button ('...'), then click **Create alert condition**:
 
     <img
       src={opentelemetryCreateAlertCondition}
@@ -30,15 +30,15 @@ Here's how to try this:
     />
     * If the chart displays a single metric, use the slide-out window to create a new alert condition, with the NRQL query pre-populated.
     * If the chart displays multiple queries, you will be asked to choose which query you want to use.
-2. In the condition creation form, you can select an existing policy or create a new one.
+2. In the condition creation form, you can select an existing policy or create a new one. The policy will determine how you are notified when the condition triggers an alert.
 
-For additional help creating alerts, see [Introduction to alerts](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition).
+For more help creating alerts, see [Create your first alert](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition).
 
 ## See your current alerts [#see-alerts-list]
 
 If you are responsible for responding to violations, you may also want to know what alerts are set up for each of your services. You can quickly get a list of all the conditions and their related policies from the UI:
 
-1. From **[one.newrelic.com](https://one.newrelic.com/all-capabilities)**, click **Explorer**.
+1. From **[one.newrelic.com](https://one.newrelic.com/all-capabilities)**, click **All entities**.
 2. In the left navigation pane, select **Services - OpenTelemetry**.
 3. Click the service name you want to investigate.
 4. In the left pane under **Settings**, click **Alert conditions**.
@@ -50,4 +50,4 @@ If you are responsible for responding to violations, you may also want to know w
 
 On the **Alert conditions** page, besides being able to see details about the alerts, you can also add a warning. You might do this to ensure you are notified if a threshold is approaching critical. In the **Thresholds** column, when you click on **Create a warning**, you are taken directly to the alert condition editor where you can add a warning threshold.
 
-If you need an overview, see [Create your first alert](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition).
+For more help creating alerts, see [Create your first alert](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition).


### PR DESCRIPTION
Refer to the new nav name for Explorer. Consistency in the links to further alerts docs, since they go to the same place.