### PR TITLE
fix(mobile): delete circular redirect

### DIFF
--- a/src/content/docs/mobile-apps/ios.mdx
+++ b/src/content/docs/mobile-apps/ios.mdx
@@ -17,7 +17,6 @@ redirects:
   - /docs/mobile-apps/new-relic-ios-app/features/new-relic-ios-app
   - /docs/mobile-monitoring/new-relic-mobile-apps/ios-app/install-new-relic-ios-mobile-app
   - /docs/mobile-apps/new-relic-mobile-apps/ios-app/install-new-relic-ios-mobile-app
-  - /docs/mobile-apps/ios
   - /docs/mobile-apps/ios-app/ios
 ---
 


### PR DESCRIPTION
This probably came up during @austin-schaefer's revamp of the mobile docs. Very quick fix. 