### PR TITLE
chore(go agent): update EOL version matrix

### DIFF
--- a/src/content/docs/apm/agents/go-agent/get-started/go-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/go-agent/get-started/go-agent-eol-policy.mdx
@@ -29,6 +29,20 @@ Any versions not listed in the following table are no longer supported. Please [
     <tbody>
     <tr>
       <td>
+        v3.20.0
+      </td>
+
+      <td>
+        Nov 2, 2022
+      </td>
+
+      <td>
+        Nov 2, 2023
+      </td>
+    </tr>
+    
+    <tr>
+      <td>
         v3.19.2
       </td>
 
@@ -402,62 +416,6 @@ Any versions not listed in the following table are no longer supported. Please [
 
       <td>
         Nov 22, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v2.15.0
-      </td>
-
-      <td>
-        Oct 24, 2019
-      </td>
-
-      <td>
-        Oct 24, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v2.14.1
-      </td>
-
-      <td>
-        Oct 15, 2019
-      </td>
-
-      <td>
-        Oct 15, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v2.14.0
-      </td>
-
-      <td>
-        Oct 14, 2019
-      </td>
-
-      <td>
-        Oct 14, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v2.13.0
-      </td>
-
-      <td>
-        Sep 23, 2019
-      </td>
-
-      <td>
-        Sep 23, 2022
       </td>
     </tr>
     


### PR DESCRIPTION
Updates the supported version table for the Go agent to add the current 3.20.0 release and remove now-EOLed versions.