### PR TITLE
Add margins so entries in attribute-dictionary don't clip

### DIFF
--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -241,6 +241,9 @@ const EventDefinition = memo(
           data-swiftype-index="false"
           css={css`
             margin-bottom: 1rem;
+            @media (max-width: 1240px) {
+              margin-top: 4.1rem;
+            }
           `}
         >
           <span

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -212,7 +212,7 @@ const EventDefinition = memo(
             }
 
             @media (max-width: 1240px) {
-              position: relative;
+              position: initial;
             }
           `}
         >
@@ -241,9 +241,6 @@ const EventDefinition = memo(
           data-swiftype-index="false"
           css={css`
             margin-bottom: 1rem;
-            @media (max-width: 1240px) {
-              margin-top: 4.1rem;
-            }
           `}
         >
           <span


### PR DESCRIPTION
### Description

This Clipping could be seen in the Attribute Dictionary at widths less than 1240px:
<img width="880" alt="image" src="https://user-images.githubusercontent.com/60801736/199586400-27191784-1aba-4471-9466-631a22a1691b.png">

This PR will fix this by changing the "position" field on Attribute headers to "initial" on screen widths less than 1240px.