### PR TITLE
chore: Add import spacing check to check-image-imports script

### DIFF
--- a/scripts/checkForOrphanImports.js
+++ b/scripts/checkForOrphanImports.js
@@ -31,7 +31,24 @@ const getAllImageImports = (path) => {
         return null;
       }
       const textfile = fs.readFileSync(file, 'utf-8');
-      const imports = textfile.match(importRegex)?.map((importStatement) => {
+      const fullImportStatements = textfile.match(importRegex);
+      if (fullImportStatements?.length > 1) {
+        const lines = textfile.split('\n');
+        for (let i = 0; i < fullImportStatements.length - 1; i++) {
+          const importLine1 = lines.indexOf(fullImportStatements[i]);
+          const importLine2 = lines.indexOf(fullImportStatements[i + 1]);
+          if (importLine2 - importLine1 <= 1) {
+            console.log(
+              `\n The imports on lines \x1b[31m${file}:${
+                importLine1 + 1
+              }\x1b[0m and \x1b[31m${
+                importLine2 + 1
+              }\x1b[0m do not have adequate spacing.`
+            );
+          }
+        }
+      }
+      const imports = fullImportStatements?.map((importStatement) => {
         return importStatement.split(/'|"/)[0].split(' ')[1];
       });
       const imgSrcs = textfile.match(imgSrcRegex)?.map((source) => {
@@ -45,7 +62,7 @@ const getAllImageImports = (path) => {
         }
       });
 
-      return textfile.match(importRegex);
+      return fullImportStatements;
     })
     .filter(Boolean);
 

--- a/scripts/checkForOrphanImports.js
+++ b/scripts/checkForOrphanImports.js
@@ -43,12 +43,17 @@ const getAllImageImports = (path) => {
                 importLine1 + 1
               }\x1b[0m and \x1b[31m${
                 importLine2 + 1
-              }\x1b[0m do not have adequate spacing.`
+              }\x1b[0m do not have adequate spacing`
             );
           }
         }
       }
       const imports = fullImportStatements?.map((importStatement) => {
+        if (importStatement.trim().split(' ').length !== 4) {
+          console.log(
+            `\n The import \x1b[31m${importStatement}\x1b[0m in \x1b[31m${file}\x1b[0m has incorrect spacing`
+          );
+        }
         return importStatement.split(/'|"/)[0].split(' ')[1];
       });
       const imgSrcs = textfile.match(imgSrcRegex)?.map((source) => {

--- a/scripts/checkForOrphanImports.js
+++ b/scripts/checkForOrphanImports.js
@@ -43,7 +43,7 @@ const getAllImageImports = (path) => {
                 importLine1 + 1
               }\x1b[0m and \x1b[31m${
                 importLine2 + 1
-              }\x1b[0m do not have adequate spacing`
+              }\x1b[0m need a new line between them`
             );
           }
         }


### PR DESCRIPTION
### Description

A common issue encountered in .mdx files regards the formatting of imports, and specifically, the need for a line of whitespace between each import. This PR adds a check for this whitespace to the `check-image-imports` script, and prints the file name and offending lines when that whitespace is not found. You can execute this using `yarn check-image-imports`.