### PR TITLE
(mobile) NR-62961: Update EOL doc for iOS version (mobile-agents-eol-policy.mdx)

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/mobile-agents-eol-policy.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/mobile-agents-eol-policy.mdx
@@ -7,7 +7,7 @@ The following are the specific policies and dates for support of our mobile moni
 
 ## iOS/XCFramework [#ios-eol]
 
-The following are the specific policies and dates for support of our mobile monitoring agents for iOS/XCFramework. Any versions not listed in the following table are no longer supported. Please [update your iOS/XCFramework agent version](/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk) to the [latest release](/docs/release-notes/mobile-release-notes/xcframework-release-notes/).
+The following are the specific policies and dates for support of our mobile monitoring agents for iOS/XCFramework. Any versions not listed in the following table are no longer supported. Please [update your XCFramework agent version](/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk) to the [latest release](/docs/release-notes/mobile-release-notes/xcframework-release-notes/).
 
 <table>
   <thead>
@@ -27,6 +27,48 @@ The following are the specific policies and dates for support of our mobile moni
   </thead>
 
   <tbody>
+    <tr>
+      <td>
+        [v7.4.0 (last iOS agent release)](/docs/release-notes/mobile-release-notes/xcframework-release-notes/)
+      </td>
+
+      <td>
+        October 20, 2022
+      </td>
+
+      <td>
+        October 20, 2023
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        v7.3.8
+      </td>
+
+      <td>
+        August 24, 2022
+      </td>
+
+      <td>
+        August 24, 2023
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        v7.3.7
+      </td>
+
+      <td>
+        July 13, 2022
+      </td>
+
+      <td>
+        July 13, 2024
+      </td>
+    </tr>
+
     <tr>
       <td>
         v7.3.6
@@ -150,104 +192,6 @@ The following are the specific policies and dates for support of our mobile moni
     
       <td>
         Nov 19, 2022
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        v7.1.0
-      </td>
-
-      <td>
-        Oct 15, 2020
-      </td>
-    
-      <td>
-        Oct 15, 2022
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [v6.14.0 (last iOS agent release)](/docs/release-notes/mobile-release-notes/ios-release-notes/)
-      </td>
-
-      <td>
-        Aug 25, 2020
-      </td>
-    
-      <td>
-        Aug 25, 2022
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        v6.13.0
-      </td>
-
-      <td>
-        Jul 21, 2020
-      </td>
-    
-      <td>
-        Jul 21, 2022
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        v6.11.0
-      </td>
-
-      <td>
-        Apr 20, 2020
-      </td>
-    
-      <td>
-        Apr 20, 2022
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        v6.10.0
-      </td>
-
-      <td>
-        Nov 20, 2019
-      </td>
-    
-      <td>
-        Nov 20, 2021
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        v6.9.0
-      </td>
-
-      <td>
-        Oct 24, 2019
-      </td>
-    
-      <td>
-        Oct 24, 2021
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        v6.8.0
-      </td>
-
-      <td>
-        Sep 13, 2019
-      </td>
-
-      <td>
-        Sep 13, 2021
       </td>
     </tr>
 


### PR DESCRIPTION

## Give us some context

* What problems does this PR solve?

Adds latest releases to iOS mobile EOL doc and highlights the 7.4.0 iOS/XCFramework as latest.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.
https://issues.newrelic.com/browse/NR-62961