### PR TITLE
Fixed version details

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
@@ -40,6 +40,8 @@ To read about best practices when monitoring Kafka, check [this blogpost](https:
 
 Our integration is compatible with Kafka versions 3.0 or lower.
 
+[Apache Kafka](https://cwiki.apache.org/confluence/display/KAFKA/Time+Based+Release+Plan#TimeBasedReleasePlan-WhatIsOurEOLPolicy?) 0.10, 0.11, 1.0 and 1.1 are now [End of Life](https://docs.confluent.io/platform/current/installation/versions-interoperability.html#cp-and-apache-ak-compatibility).  The current recommended version is 2.2.1 or above.
+
 ### Supported operating systems [#supported-os]
 
 * Windows <img style={{ width: '32px', height: '32px'}} class="inline" title="Windows" alt="Windows" src={osWindows}/>


### PR DESCRIPTION
Apache Kafka 0.10, 0.11, 1.0 and 1.1 are now EOL for Apache Kafka on Heroku. The current recommended version is 2.2.1 or above.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.