### PR TITLE
chore: Exclude style-guide and agile-handbook from search results

### DIFF
--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -27,6 +27,18 @@ const crazyEgg = (location) => {
   }
 };
 
+const isStyleGuidePage = (url) => {
+  return url.includes('docs/style-guide');
+};
+
+const isAgileHandbookPage = (url) => {
+  return url.includes('docs/agile-handbook');
+};
+
+const isExcludedFromSwiftype = (url) => {
+  return isStyleGuidePage(url) || isAgileHandbookPage(url);
+};
+
 const DocsSiteSeo = ({
   location,
   title,
@@ -77,6 +89,10 @@ const DocsSiteSeo = ({
         data-type="string"
         content={dataSource}
       />
+    )}
+
+    {isExcludedFromSwiftype(location.pathname) && (
+      <meta name="st:robots" content="noindex, nofollow" />
     )}
 
     {(description || title) && (


### PR DESCRIPTION
### Description

The 'docs/style-guide' and 'docs/agile-handbook' page categories can muddy search results, leading to confusion. This PR will exclude these pages search results altogether by instructing swiftype not to index them. The affected pages will have to be re-crawled for this to take effect.