### PR TITLE
chore(Style Guide): typos and formatting

### DIFF
--- a/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
@@ -279,7 +279,7 @@ For consistency across New Relic content, here are our general word usage guidel
   >
     In general, use `click` rather than the vaguer `select`. For example, you might click something in the UI, but then select something from a list.
 
-    Be particularly careful to use `click` to describe actions that only make sense with a mouse; for example, with a `right click` or a `click and drag`. Also use `click` when the user must click on a non-selectable object (`to save your changes, click anywhere outside the dialog box`). See also [mouse over]#mouse-over).
+    Be particularly careful to use `click` to describe actions that only make sense with a mouse; for example, with a `right click` or a `click and drag`. Also use `click` when the user must click on a non-selectable object (`to save your changes, click anywhere outside the dialog box`). See also [mouse over](#mouse-over).
   </Collapser>
 
   <Collapser
@@ -403,7 +403,7 @@ Really, we recommend being as specific as possible to establish context. If a pi
     id="etc"
     title="etc."
   >
-    Unlike the Latin abbreviations [`e.g.`](#eg) or [`i.e.`](#ie)), you're welcome to use etc. It should have a period at the end (`etc.`). Ensure that you have several meaningful examples, though, before using it. For example, `cities including Portland, Seattle, Dublin, etc.` but not `cities including Portland, etc.`.
+    Unlike the Latin abbreviations [`e.g.`](#eg) or [`i.e.`](#ie), you're welcome to use etc. It should have a period at the end (`etc.`). Ensure that you have several meaningful examples, though, before using it. For example, `cities including Portland, Seattle, Dublin, etc.` but not `cities including Portland, etc.`.
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
Fixing a typo and a formatting issue for the mouse over link
