### PR TITLE
fix(PHP agent): Update framework INI options

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -376,9 +376,8 @@ These settings are available in the `newrelic.ini` file.
     * `"magento"`
     * `"magento2"`
     * `"mediawiki"`
-    * `"silex"`
-    * `"symfony1"`
-    * `"symfony2"` (for Symfony 2 and 3)
+    * `"slim"`
+    * `"symfony2"` (for Symfony 3 - Symfony 2.x is not supported)
     * `"symfony4"` (for Symfony 4 and 5)
     * `"wordpress"`
     * `"yii"`
@@ -387,6 +386,10 @@ These settings are available in the `newrelic.ini` file.
     * `"no_framework"` (to force no framework even if one was detected)
 
       If the framework auto-detection fails, this command will also fail.
+
+    <Callout variant="tip">
+      Check the [PHP compatibility page](/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) for the latest information on supported framworks.
+    </Callout>
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
Doc update from PHP team to improve accuracy of frameworks supported by INI option.  Currently a draft document will communicate when it is finalized by moving from draft status.