### PR TITLE
ktranslate for SNMP - support for package deployments

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -37,10 +37,16 @@ Set up your network devices so they send network data to New Relic.
   * A New Relic [account ID](/docs/accounts/accounts-billing/account-setup/account-id).
   * A New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).
 
-### Linux host prerequisites [#prerequisites-host]
+### Linux host prerequisites [#prerequisites-linux-host]
 
-* [Docker](https://docs.docker.com/engine/install) installed in a Linux host.
-* SSH access to the Docker host, with the ability to launch new containers.
+* SSH access to the host
+* Access to install/remove applications and services
+* Network access as defined in the [network prerequisites](/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring#prerequisites-network)
+
+#### If deployed to Docker [#prerequisites-docker]
+
+* [Docker](https://docs.docker.com/engine/install) installed in a Linux host
+* Ability to launch new containers via command line
 
 ### SNMP devices prerequisites [#devices-prerequisites]
 
@@ -109,7 +115,7 @@ Configured network devices for SNMP polling from the **ktranslate** docker conta
           </td>
 
           <td>
-            Docker host
+            Linux host
           </td>
 
           <td>
@@ -133,7 +139,7 @@ Configured network devices for SNMP polling from the **ktranslate** docker conta
         </td>
 
         <td>
-        Docker host
+          Linux host
         </td>
 
         <td>
@@ -157,7 +163,7 @@ Configured network devices for SNMP polling from the **ktranslate** docker conta
           </td>
 
           <td>
-            Docker host
+            Linux host
           </td>
 
           <td>
@@ -181,7 +187,7 @@ Configured network devices for SNMP polling from the **ktranslate** docker conta
           </td>
 
           <td>
-            Docker host
+            Linux host
           </td>
 
           <td>
@@ -196,6 +202,29 @@ Configured network devices for SNMP polling from the **ktranslate** docker conta
             UDP
           </td>
         </tr>
+        
+        <tr>
+          <td>
+            Outbound
+          </td>
+
+          <td>
+            Linux host
+          </td>
+
+          <td>
+            packagecloud.io for downloading rpm or deb packages (not required for Docker-based install)
+          </td>
+
+          <td>
+            443 (default)
+          </td>
+
+          <td>
+            TCP
+          </td>
+        </tr>
+        
 
         <tr>
           <td>
@@ -207,7 +236,7 @@ Configured network devices for SNMP polling from the **ktranslate** docker conta
           </td>
 
           <td>
-            Docker host
+            Linux host
           </td>
 
           <td>

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -43,6 +43,13 @@ Set up your network devices so they send network data to New Relic.
 * Access to install/remove applications and services
 * Network access as defined in the [network prerequisites](/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring#prerequisites-network)
 
+Callout variant="Host-based SNMP trap receiver">
+  To receive SNMP Traps, ktranslate must bind to UDP 162. In a host-based install, the following command will be included during the install process. When executed, ktranslate will be run with elevated privileges.
+  
+  `sudo setcap cap_net_bind_service=+ep /usr/bin/ktranslate`
+
+</Callout>
+
 #### If deployed to Docker [#prerequisites-docker]
 
 * [Docker](https://docs.docker.com/engine/install) installed in a Linux host

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -93,7 +93,7 @@ Configured network devices for SNMP polling from the **ktranslate** docker conta
           </td>
 
           <td>
-            Docker host
+            Docker host only
           </td>
 
           <td>
@@ -115,7 +115,7 @@ Configured network devices for SNMP polling from the **ktranslate** docker conta
           </td>
 
           <td>
-            Linux host
+            Linux or Docker host
           </td>
 
           <td>
@@ -139,7 +139,7 @@ Configured network devices for SNMP polling from the **ktranslate** docker conta
         </td>
 
         <td>
-          Linux host
+          Linux or Docker host
         </td>
 
         <td>
@@ -163,7 +163,7 @@ Configured network devices for SNMP polling from the **ktranslate** docker conta
           </td>
 
           <td>
-            Linux host
+            Linux or Docker host
           </td>
 
           <td>
@@ -187,7 +187,7 @@ Configured network devices for SNMP polling from the **ktranslate** docker conta
           </td>
 
           <td>
-            Linux host
+            Linux or Docker host
           </td>
 
           <td>
@@ -209,7 +209,7 @@ Configured network devices for SNMP polling from the **ktranslate** docker conta
           </td>
 
           <td>
-            Linux host
+            Linux host only
           </td>
 
           <td>
@@ -236,7 +236,7 @@ Configured network devices for SNMP polling from the **ktranslate** docker conta
           </td>
 
           <td>
-            Linux host
+            Linux or Docker host
           </td>
 
           <td>

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -43,7 +43,7 @@ Set up your network devices so they send network data to New Relic.
 * Access to install/remove applications and services
 * Network access as defined in the [network prerequisites](/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring#prerequisites-network)
 
-Callout variant="Host-based SNMP trap receiver">
+<Callout variant="Host-based SNMP trap receiver">
   To receive SNMP Traps, ktranslate must bind to UDP 162. In a host-based install, the following command will be included during the install process. When executed, ktranslate will be run with elevated privileges.
   
   `sudo setcap cap_net_bind_service=+ep /usr/bin/ktranslate`


### PR DESCRIPTION
Added updated requirements to deb/rpm install, including a new package source. Updated security table and split out install requirements for Linux host & Docker host.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Expands documentation to support new rpm and deb installs of the ktranslate agent for network monitoring.