### PR TITLE
fix: Critical threshold is optional

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/define-custom-metrics-alert-condition.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/define-custom-metrics-alert-condition.mdx
@@ -27,7 +27,7 @@ Use the policy's **Thresholds** section to define the custom metric values. Thes
 * The exact custom metric name for the selected product category and [targets](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/select-product-targets-alert-condition). Note: wildcard characters are not allowed.
 * Selected threshold value function. The options are average, minimum, maximum, count, and rate.
 * Selected threshold level. The options are above, below, and equal to.
-* Critical (required) and Warning (optional) threshold value and duration that will open a violation. For example, `5 units for at least 5 minutes`.
+* Critical and Warning threshold value and duration that will open a violation. For example, `5 units for at least 5 minutes`.
 * Condition name (required) for the custom metric.
 
 ## Create a custom metric condition [#custom-metrics-threshold]

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/set-thresholds-alert-condition.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/set-thresholds-alert-condition.mdx
@@ -41,7 +41,7 @@ For a [condition](/docs/using-new-relic/welcome-new-relic/get-started/glossary#a
 * An application's error rate per minute hits 10% or higher at least once in an hour.
 * An application's AJAX response time deviates a certain amount from its expected behavior.
 
-Besides a mandatory critical threshold level, you can also set thresholds for a less serious [warning level](#threshold-levels).
+Besides a critical threshold level, you can also set thresholds for a less serious [warning level](#threshold-levels).
 
 ## View and set thresholds [#viewing-thresholds]
 
@@ -97,9 +97,9 @@ Details about other functionality and rules:
 
   <Collapser
     id="threshold-levels"
-    title="Set optional warning level"
+    title="Set thresholds"
   >
-    You can set thresholds for two levels: critical (required) and warning (optional).
+    You can set thresholds for two levels: critical and warning. At least one threshold must be set.
 
     <table>
       <thead>
@@ -121,7 +121,7 @@ Details about other functionality and rules:
           </td>
 
           <td>
-            Required. When an incident occurs, it may send notifications depending on the policy's [issue creation preference setting](/docs/alerts/new-relic-alerts/configuring-alert-policies/specify-when-new-relic-creates-incidents) and any [workflow](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/) you may have configured.
+            Optional. When an incident occurs, it may send notifications depending on the policy's [issue creation preference setting](/docs/alerts/new-relic-alerts/configuring-alert-policies/specify-when-new-relic-creates-incidents) and any [workflow](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/) you may have configured.
           </td>
         </tr>
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition.mdx
@@ -92,7 +92,7 @@ Give your NRQL condition a name that's meaningful to you.
 
 Set critical and warning thresholds to determine when you're notified about your environment's performance.
 
-* A critical threshold is required for your alerts condition.
+* A critical threshold is optional for your alerts condition.  
 
 * A [warning threshold](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/set-thresholds-alert-condition/#threshold-levels) is optional. These thresholds don't create an incident or notify you like the critical threshold does. If a critical threshold opens an incident and notifies you, warning threshold violations created afterwards will be included in the report.
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
https://issues.newrelic.com/browse/NR-54573

NRQL Alert Conditions will _soon_ no longer require critical threshold. NRQL Alert Conditions will allow critical thresholds to be optional.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  
  Upcoming UI changes to the Condition Builder. Users will soon have an updated threshold building experience. They will be able to create NRQL Alert conditions with only warning thresholds. 
  
![Screen Shot 2022-11-09 at 3 17 11 PM](https://user-images.githubusercontent.com/13971824/200962698-c4421924-ef65-46f4-b36b-6c4dfc5d41c9.png)

  
* If your issue relates to an existing GitHub issue, please link to it.