### PR TITLE
Updated "Logs API example" logtype value

### DIFF
--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -849,7 +849,7 @@ Here are some examples of how to add `logtype` to logs sent by some of our [supp
     {
       "timestamp": <var>TIMESTAMP_IN_UNIX_EPOCH</var>,
       "message": "User '<var>xyz</var>' logged in",
-      "logtype": "accesslogs",
+      "logtype": "nginx",
       "service": "login-service",
       "hostname": "<var>login.example.com</var>"
     }


### PR DESCRIPTION
Inconsistency of the description with the example of "Logs API".
Changed the value of logtype from "accesslog" to "nginx" as said in the description above. 
As you can see in this other part of the documentation, indeed the logtype value for NGINX parse rules is "nginx" and not "accesslog":  https://docs.newrelic.com/docs/logs/ui-data/built-log-parsing-rules#nginx