### PR TITLE
docs: replace references to proactive detection with anomaly detection

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence.mdx
@@ -108,8 +108,8 @@ As part of applied intelligence, incident intelligence helps you correlate incid
 
 To get started, see [incident intelligence](/docs/enable-new-relic-ai).
 
-## Find unknowns with proactive detection [#proactive-detection]
+## Find unknowns with anomaly detection [#anomaly-detection]
 
-Another feature of applied intelligence is proactive detection. proactive detection is, by default, always on and detecting anomalies. These anomalies are surfaced in the applied intelligence anomalies feed, New Relic activity streams, and can be queried, alerted on, and added to dashboards. Anomalies can be sent to Slack or via webhooks, and/or added as a source for incident intelligence correlation and issue notification. proactive detection also provides automatic analysis of anomalies and alerts via the analysis page.
+Another feature of applied intelligence is anomaly detection. Anomaly detection is, by default, always on and detecting anomalies. These anomalies are surfaced in the applied intelligence anomalies feed, New Relic activity streams, and can be queried, alerted on, and added to dashboards. Anomalies can be sent to Slack or via webhooks, and/or added as a source for incident intelligence correlation and issue notification. Anomaly detection also provides automatic analysis of anomalies and alerts via the analysis page.
 
-To get started, see [proactive detection](/docs/proactive-detection-new-relic-ai).
+To get started, see [anomaly detection](/docs/anomaly-detection-new-relic-ai).


### PR DESCRIPTION
This PR addresses a renaming. Proactive detection is now know as anomaly detection, so the word proactive has been replaced with anomaly.

It may be better to retain the original anchor, in addition to the new anchor, to preserve existing links.