### PR TITLE
Fix(Go agent): corrected release note metadata

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-20-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-20-0.mdx
@@ -1,8 +1,8 @@
 ---
 subject: Go agent
-releaseDate: '2022-09-16'
-version: 3.19.1
-downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.19.1'
+releaseDate: '2022-11-02'
+version: 3.20.0
+downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.20.0'
 ---
 ## 3.20.0
 


### PR DESCRIPTION
In the 3.20.0 release, the release note document had an incorrect metadata header. This corrects that error.