### PR TITLE
fix(node agent): remove hide_internals config option

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -2173,47 +2173,6 @@ This section defines the Node.js agent variables in the order they typically app
   </Collapser>
 
   <Collapser
-    id="hide-internals"
-    title="hide_internals"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `true`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_HIDE_INTERNALS`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    The agent uses a small amount of CPU in order to hide internal properties that are attached to the web application. If you change this configuration to `false`, it may slightly decrease your agent overhead, but it could also have an impact on the performance of the agent.
-  </Collapser>
-
-  <Collapser
     id="hide-attributes-enabled"
     title="attributes.enabled"
   >


### PR DESCRIPTION
This configuration option was removed in node release v9.6.0 and is no longer needed in the agent.
