### PR TITLE
fix(node agent): document new grpc.ignore_status_codes flag

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -3576,6 +3576,52 @@ The `grpc` section controls the behavior of how the gRPC server is instrumented.
   </Collapser>
 </CollapserGroup>
 
+  <Collapser
+    id="grpc_error_ignore"
+    title="ignore_status_codes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Array of Integers
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `[]`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_GRPC_IGNORE_STATUS_CODES`
+          </td>
+        </tr>
+
+      </tbody>
+    </table>
+
+    Comma-delimited list of gRPC status codes for the error collector to ignore, both on client-side and server-side instrumentation.
+
+    <Callout variant="caution">
+      Errors recorded using [`newrelic.noticeError()`](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#noticeError) do not obey this configuration value.
+    </Callout>
+  </Collapser>
+
 
 ## Span events
 


### PR DESCRIPTION
It's very analogous to a similar flag for HTTP status codes, except nothing is ignored by default here.
