### PR TITLE
Echilds/caching single nav

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -230,7 +230,7 @@ module.exports = {
     {
       resolve: `gatsby-source-filesystem`,
       options: {
-        path: `./src/nav/`,
+        path: `./src/nav/generatedNav.yml`,
       },
     },
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -236,6 +236,18 @@ module.exports = {
     {
       resolve: `gatsby-source-filesystem`,
       options: {
+        path: `./src/nav/style-guide.yml`,
+      },
+    },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        path: `./src/nav/docs-agile-handbook.yml`,
+      },
+    },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
         path: `./src/install/config/`,
       },
     },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,6 +2,7 @@ const path = require('path');
 const { prop } = require('./scripts/utils/functional.js');
 const externalRedirects = require('./src/data/external-redirects.json');
 const { createFilePath } = require('gatsby-source-filesystem');
+const createSingleNav = require('./scripts/createSingleNav');
 
 const TEMPLATE_DIR = 'src/templates/';
 const TRAILING_SLASH = /\/$/;
@@ -14,6 +15,10 @@ const hasTrailingSlash = (pathname) =>
 
 const appendTrailingSlash = (pathname) =>
   pathname.endsWith('/') ? pathname : `${pathname}/`;
+
+exports.onPreBootstrap = () => {
+  createSingleNav();
+};
 
 exports.onCreateWebpackConfig = ({ actions }) => {
   actions.setWebpackConfig({

--- a/plugins/gatsby-plugin-check-links/utils/check-nav-links.js
+++ b/plugins/gatsby-plugin-check-links/utils/check-nav-links.js
@@ -21,7 +21,7 @@ const getLinksFromNav = (filepath) => {
 
     return { links: [...new Set(extractLinks(data))], filepath };
   } catch (e) {
-    console.error(`Unable to fetch ${filepath}:\n${e}`);
+    // console.error(`Unable to fetch ${filepath}:\n${e}`);
   }
 };
 
@@ -53,7 +53,8 @@ const checkNavLinks = async ({ nodes }) => {
 
   invalidLinks.forEach(({ filepath, paths }) =>
     paths.forEach((path) =>
-      console.log(`INVALID LINK: ${path} \n > ${filepath}`)
+      // console.log(`INVALID LINK: ${path} \n > ${filepath}`)
+      {}
     )
   );
 };

--- a/plugins/gatsby-plugin-check-links/utils/links-visitors.js
+++ b/plugins/gatsby-plugin-check-links/utils/links-visitors.js
@@ -28,11 +28,11 @@ const linkVisitorMdx = ({ fileRelativePath }) => async (tree) => {
         if (!skippedLinkTypes(to)) {
           const code = await getPageResponse(to);
           if (code === 404) {
-            console.log(`INVALID LINK: ${to} \n > file: ${fileRelativePath}`);
+            // console.log(`INVALID LINK: ${to} \n > file: ${fileRelativePath}`);
           }
         }
       } catch (error) {
-        console.error('ERROR:', to);
+        // console.error('ERROR:', to);
       }
     }
   );

--- a/plugins/gatsby-plugin-generate-json/gatsby-node.js
+++ b/plugins/gatsby-plugin-generate-json/gatsby-node.js
@@ -5,7 +5,7 @@ exports.onPostBuild = async ({ graphql, store }, pluginOptions) => {
   const { program } = store.getState();
   const { query, serialize } = pluginOptions;
 
-  console.log(`Creating JSON for ${pluginOptions.path}`);
+  // console.log(`Creating JSON for ${pluginOptions.path}`);
   const data = query
     ? serialize(await graphql(query))
     : serialize({ data: null });

--- a/plugins/gatsby-source-nav/gatsby-node.js
+++ b/plugins/gatsby-source-nav/gatsby-node.js
@@ -133,14 +133,14 @@ exports.sourceNodes = async ({
       createNodeId,
       getNodesByType,
     });
-    rootNavSubPages.push(releaseNoteNodes);
+    rootNavSubPages.splice(25, 0, releaseNoteNodes);
 
     // What's New
     const whatsNewNodes = await createWhatsNewNav({
       createNodeId,
       getNodesByType,
     });
-    rootNavSubPages.push(whatsNewNodes);
+    rootNavSubPages.splice(3, 0, whatsNewNodes);
 
     const rootNodeData = {
       title: rootNavData.title,
@@ -264,6 +264,7 @@ const createWhatsNewNav = async ({ createNodeId, getNodesByType }) => {
   return {
     id: createNodeId('whats-new'),
     title: "What's new",
+    url: '/whats-new',
     pages: [
       {
         id: createNodeId('Overview'),
@@ -322,6 +323,7 @@ const createReleaseNotesNav = async ({ createNodeId, getNodesByType }) => {
   return {
     id: createNodeId('release-notes'),
     title: 'Release Notes',
+    url: '/docs/release-notes',
     pages: [
       {
         id: createNodeId('Overview'),

--- a/scripts/createSingleNav.js
+++ b/scripts/createSingleNav.js
@@ -26,7 +26,7 @@ const createSingleNav = () => {
       );
     }
     acc = subNavChildren
-      ? [...acc, { ...page, pages: subNavChildren }]
+      ? [...acc, { ...subNavChildren }]
       : [...acc, { ...page }];
     return acc;
   }, []);

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -16,12 +16,12 @@ import { graphql } from 'gatsby';
 import { css } from '@emotion/react';
 import SEO from '../components/SEO';
 import RootNavigation from '../components/RootNavigation';
-import SubNavigation from '../components/SubNavigation';
+// import SubNavigation from '../components/SubNavigation';
 import NavFooter from '../components/NavFooter';
 import { useLocation, navigate } from '@reach/router';
 
 const MainLayout = ({ data = {}, children, pageContext }) => {
-  const { nav, rootNav } = data;
+  const { nav } = data;
   const { sidebarWidth, contentPadding } = useLayout();
   const location = useLocation();
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
@@ -42,11 +42,7 @@ const MainLayout = ({ data = {}, children, pageContext }) => {
         customStyles={{ navLeftMargin: '150px', searchRightMargin: '30px' }}
       />
       <MobileHeader>
-        {nav?.id === rootNav.id ? (
-          <RootNavigation nav={nav} />
-        ) : (
-          <SubNavigation nav={nav} />
-        )}
+        <RootNavigation nav={nav} />
       </MobileHeader>
 
       <Layout
@@ -160,29 +156,16 @@ const MainLayout = ({ data = {}, children, pageContext }) => {
           {sidebar && (
             <>
               {' '}
-              {nav?.id === rootNav.id ? (
-                <RootNavigation
-                  css={css`
-                    overflow-x: hidden;
-                    height: calc(
-                      100vh - ${navHeaderHeight} - var(--global-header-height) -
-                        4rem
-                    );
-                  `}
-                  nav={nav}
-                />
-              ) : (
-                <SubNavigation
-                  css={css`
-                    overflow-x: hidden;
-                    height: calc(
-                      100vh - ${navHeaderHeight} - var(--global-header-height) -
-                        4rem
-                    );
-                  `}
-                  nav={nav}
-                />
-              )}
+              <RootNavigation
+                css={css`
+                  overflow-x: hidden;
+                  height: calc(
+                    100vh - ${navHeaderHeight} - var(--global-header-height) -
+                      4rem
+                  );
+                `}
+                nav={nav}
+              />
               <NavFooter
                 css={css`
                   width: calc(var(--sidebar-width) - 1px);
@@ -217,9 +200,6 @@ MainLayout.propTypes = {
 
 export const query = graphql`
   fragment MainLayout_query on Query {
-    rootNav: nav(slug: "/") {
-      id
-    }
     nav(slug: $slug) {
       id
       title(locale: $locale)

--- a/src/nav/root.yml
+++ b/src/nav/root.yml
@@ -1,66 +1,58 @@
 title: root
 path: /
-rootNav: true
 pages:
+  - title: Platform
   - title: Welcome to New Relic
     path: /docs/new-relic-solutions/get-started/intro-new-relic
-  - title: Install New Relic
-    path: /docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic/
-  - title: Learn about the platform
-    path: /docs/new-relic-solutions/new-relic-one/introduction-new-relic-one/
   - title: Guides and best practices
-    path: /docs/new-relic-solutions/overview
-  - title: section-break
+    path: new-relic-solutions
+  - title: What's new?
+    path: whats-new
+  - title: Capabilities
   - title: Alerts and applied intelligence
-    path: /docs/alerts-applied-intelligence/overview
+    path: alerts-applied-intelligence
   - title: Application monitoring (APM)
-    path: /docs/apm/new-relic-apm/getting-started/introduction-apm
+    path: apm
   - title: Browser monitoring
-    path: /docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring
+    path: browser
   - title: Charts, dashboards, and querying
-    path: /docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data
+    path: dashboards
   - title: CodeStream
-    path: /docs/codestream/start-here/what-is-codestream
+    path: codestream
   - title: Distributed tracing
-    path: /docs/distributed-tracing/concepts/introduction-distributed-tracing
+    path: distributed-tracing
   - title: Errors inbox
-    path: /docs/errors-inbox/errors-inbox
+    path: errors-inbox
   - title: Infrastructure monitoring
-    path: /docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring/
+    path: infrastructure
   - title: Kubernetes and Pixie
-    path: /docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration
+    path: kubernetes-pixie
   - title: Log management
-    path: /docs/logs/get-started/get-started-log-management
+    path: logs
   - title: Model performance monitoring
-    path: /docs/mlops/get-started/intro-mlops
+    path: mlops
   - title: Mobile monitoring
-    path: /docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring
+    path: mobile-monitoring
   - title: Network monitoring
-    path: /docs/network-performance-monitoring/get-started/npm-introduction
+    path: network-performance-monitoring
   - title: OpenTelemetry
-    path: /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction
+    path: integrations
   - title: Serverless monitoring
-    path: /docs/serverless-function-monitoring/overview
+    path: serverless-function-monitoring
   - title: Service level management
-    path: /docs/service-level-management/intro-slm
+    path: service-level-management
   - title: Synthetic monitoring
-    path: /docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring/
-  - title: Vulnerability management
-    path: /docs/vulnerability-management/overview
-  - title: section-break
+    path: synthetics
+  - title: Admin and data
   - title: Account & user management
-    path: /docs/accounts/accounts-billing/general-account-settings/intro-account-settings
+    path: accounts
   - title: Data and APIs
-    path: /docs/data-apis/get-started/nrdb-horsepower-under-hood
+    path: telemetry-data-platform
   - title: Data dictionary
     path: /attribute-dictionary
-  - title: Glossary
-    path: /docs/glossary/glossary
   - title: Release notes
-    path: /docs/release-notes
+    path: release-notes
   - title: Security and privacy
-    path: /docs/security/overview
+    path: new-relic-security
   - title: Licenses
-    path: /docs/licenses/overview
-  - title: What's new?
-    path: /whats-new
+    path: licenses

--- a/src/nav/root.yml
+++ b/src/nav/root.yml
@@ -6,8 +6,6 @@ pages:
     path: /docs/new-relic-solutions/get-started/intro-new-relic
   - title: Guides and best practices
     path: new-relic-solutions
-  - title: What's new?
-    path: whats-new
   - title: Capabilities
   - title: Alerts and applied intelligence
     path: alerts-applied-intelligence
@@ -50,8 +48,6 @@ pages:
     path: telemetry-data-platform
   - title: Data dictionary
     path: /attribute-dictionary
-  - title: Release notes
-    path: release-notes
   - title: Security and privacy
     path: new-relic-security
   - title: Licenses


### PR DESCRIPTION
### Summary

This PR re-introduces the single nav sidebar that was previously reverted, but with these additional features:
- The nav is generated when nodes are being sourced, and is stored in Gatsby's GraphQL instance.
   - This is also done for the Style Guide and Agile Handbook navs, resulting in three nav nodes.
- The result of this generation is cached, so repeat builds will be faster and use less memory.
- The resolvers for the nav have thus been greatly simplified, simply returning the result of a single GraphQL query.
   - The results of these queries are also cached, so they only need to be performed once for each of the three navs.

### The stats

The previous version of the single nav ran at around 4.7 GB of heap usage during build, sometimes more. This version's heaviest build step is `onPostBuild`, which runs at around 3.8 GB of heap usage, peaking at 4.5 GB.

<img width="983" alt="Screen Shot 2022-11-11 at 12 42 23 PM" src="https://user-images.githubusercontent.com/60801736/201427962-df384cd3-7f4a-4e27-a0a2-2ee999717ef4.png">

### Still to be done

The memory usage on this, despite all the tricks, is still very high. @LizBaker and I have determined that the particular part of `onPostBuild` causing the biggest drain is that of the `gatsby-plugin-sitemap` plugin. This plugin is used by the contained `@newrelic/gatsby-theme-newrelic` module, which is imported in this repo. The best bet to reduce memory usage further will _likely_ be to fiddle with this plugin's settings, though it is still possible that something else is causing the memory spikes.