### PR TITLE
Remove Spllt I/O config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -494,19 +494,6 @@ module.exports = {
             'razor',
           ],
         },
-        splitio: {
-          // Mocked features only used when in localhost mode
-          // https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#localhost-mode
-          features: {
-            free_account_button_color: {
-              treatment: 'off',
-            },
-          },
-          core: {
-            authorizationKey: process.env.SPLITIO_AUTH_KEY || 'localhost',
-          },
-          debug: false,
-        },
         newrelic: {
           config: {
             instrumentationType: 'proAndSPA',


### PR DESCRIPTION
Part of the work to remove Split IO configs from all our Gatsby sites.