### PR TITLE
Update minimum support Excon version

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -752,12 +752,12 @@ Background jobs supported by the New Relic Ruby agent include:
 HTTP clients supported by the Ruby agent include:
 
 * Curb: 0.8.1 or higher
-* Excon: 0.19.0 or higher (Versions < 0.55.0 are Deprecated)
+* Excon: 0.19.0 or higher (Versions lower than 0.55.0 are deprecated)
 * gRPC: 1.0.0 or higher
-* HttpClient: 2.2.0 or higher (Versions 2.2.0 - 2.8.0 are Deprecated)
-* HttpRb: 0.9.9 or higher (Versions 0.9.9 - 2.2.1 are Deprecated)
+* HttpClient: 2.2.0 or higher (Versions 2.2.0 - 2.8.0 are deprecated)
+* HttpRb: 0.9.9 or higher (Versions 0.9.9 - 2.2.1 are deprecated)
 * Net::HTTP&#x3A; Supported for all [agent-supported versions](/docs/agents/ruby-agent/features/http-client-tracing-ruby) of Ruby.
-* Typhoeus: 0.5.3 or higher (Versions 0.5.3 - 1.2.x are Deprecated)
+* Typhoeus: 0.5.3 or higher (Versions 0.5.3 - 1.2.x are deprecated)
 
 ## Message queuing [#http_clients]
 

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -752,7 +752,7 @@ Background jobs supported by the New Relic Ruby agent include:
 HTTP clients supported by the Ruby agent include:
 
 * Curb: 0.8.1 or higher
-* Excon: 0.10.1 or higher (Versions 0.10.1 - 0.55.0 are Deprecated)
+* Excon: 0.19.0 or higher (Versions < 0.55.0 are Deprecated)
 * gRPC: 1.0.0 or higher
 * HttpClient: 2.2.0 or higher (Versions 2.2.0 - 2.8.0 are Deprecated)
 * HttpRb: 0.9.9 or higher (Versions 0.9.9 - 2.2.1 are Deprecated)


### PR DESCRIPTION
The Ruby agent supports Excon v0.19.0+. Update docs to reflect.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.