### PR TITLE
Remove UI instruction

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/createtracer-browser-spa-api.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-agent-spa-api/createtracer-browser-spa-api.mdx
@@ -37,10 +37,7 @@ This method provides a way to time sub-components of a SPA interaction separatel
 
 This method also can be used to bridge the asynchronous gap created by uninstrumented async methods.
 
-If the current interaction is saved, New Relic will create a [`BrowserTiming` event](/docs/insights/explore-data/attributes/browser-default-attributes-insights#browsertiming-attributes). To view this timing information in browser:
-
-1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities), click on Browser > (select a SPA app) > Page views**.
-2. From **Page views**, select a browser interaction, then select the **Ajax requests** tab.
+If the current interaction is saved, New Relic will create a [`BrowserTiming` event](/docs/insights/explore-data/attributes/browser-default-attributes-insights#browsertiming-attributes).
 
 The `createTracer()` method returns a wrapped callback method, which you must invoke from your code. The returned wrapped callback will do three things when invoked:
 


### PR DESCRIPTION
To address user feedback from https://issues.newrelic.com/browse/NR-64616, I spoke with a browser SME (Grady Ellison) who said the UI reference to view browserTiming is based on the old UI. He also said there's no longer a consistent place in the new UI to see these browserTiming events. So I removed the UI reference in the doc - hopefully this will reduce confusion. 