### PR TITLE
.NET 7.0 updates

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -49,7 +49,7 @@ Before you install the New Relic .NET agent on [Windows](/docs/agents/net-agent/
     The official product lifecycle start and end dates can be found in the [Microsoft documentation](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core). Our .NET agent support of these framework versions end with the latest 9.x New Relic .NET agent. Starting from the New Relic .NET agent version 10.0, we will target .NET Core 3.1 onwards.
   </Callout>
 
-    The .NET agent supports .NET Core versions 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0 and 6.0.
+    The .NET agent supports .NET Core versions 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0, 6.0, and 7.0.
 
     <table style={{ width: "500px" }}>
       Table of minimum agent versions required per .NET Core version
@@ -135,6 +135,15 @@ Before you install the New Relic .NET agent on [Windows](/docs/agents/net-agent/
           <td>
             9.2.0 and higher
           </td>
+
+        <tr>
+          <td>
+            .NET 7.0
+          </td>
+
+          <td>
+            10.0.0 and higher
+          </td>
         </tr>
       </tbody>
     </table>
@@ -151,7 +160,7 @@ Before you install the New Relic .NET agent on [Windows](/docs/agents/net-agent/
     id="target-framework"
     title="Target framework version"
   >
-    The .NET agent only supports applications targeting .NET Core 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0 and 6.0. You can find the target framework in your `.csproj` file:
+    The .NET agent only supports applications targeting .NET Core 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0, 6.0 and 7.0. You can find the target framework in your `.csproj` file:
 
     Supported:
 
@@ -181,6 +190,10 @@ Before you install the New Relic .NET agent on [Windows](/docs/agents/net-agent/
 
     ```xml
     <TargetFramework>net6.0</TargetFramework>
+    ```
+
+    ```xml
+    <TargetFramework>net7.0</TargetFramework>
     ```
 
     <Callout variant="important">
@@ -376,7 +389,7 @@ If your application is hosted in ASP.NET Core, the agent automatically creates a
   >
     The .NET agent automatically instruments these application frameworks:
 
-    * ASP.NET Core MVC 2.0, 2.1, 2.2, 3.0, 3.1, 5.0 and 6.0 (includes Web API)
+    * ASP.NET Core MVC 2.0, 2.1, 2.2, 3.0, 3.1, 5.0, 6.0, and 7.0 (includes Web API)
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -135,7 +135,7 @@ Before you install the New Relic .NET agent on [Windows](/docs/agents/net-agent/
           <td>
             9.2.0 and higher
           </td>
-
+        </tr>
         <tr>
           <td>
             .NET 7.0


### PR DESCRIPTION
Update the .NET Core agent compatibility/support doc to include .NET 7.0, which GAed last week.