### PR TITLE
chore(release): Update docs for Ruby agent 8.13.0

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -92,30 +92,6 @@ These settings are available for agent configuration. Some settings depend on yo
 
 <CollapserGroup>
 
-  <Collapser id="license_key" title="license_key">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`""`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_LICENSE_KEY`</td></tr>
-      </tbody>
-    </table>
-
-  Your New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).
-  </Collapser>
-
-  <Collapser id="api_key" title="api_key">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`""`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_API_KEY`</td></tr>
-      </tbody>
-    </table>
-
-  Your New Relic [user key](/docs/apis/intro-apis/new-relic-api-keys/#overview-keys). Required when using the New Relic REST API v2 to record deployments using the `newrelic deployments` command. 
-  </Collapser>
-
   <Collapser id="agent_enabled" title="agent_enabled">
     <table>
       <tbody>
@@ -140,16 +116,16 @@ These settings are available for agent configuration. Some settings depend on yo
   Specify the [application name](/docs/apm/new-relic-apm/installation-configuration/name-your-application) used to aggregate data in the New Relic UI. To report data to [multiple apps at the same time](/docs/apm/new-relic-apm/installation-configuration/using-multiple-names-app), specify a list of names separated by a semicolon `;`. For example, `MyApp` or `MyStagingApp;Instance1`.
   </Collapser>
 
-  <Collapser id="monitor_mode" title="monitor_mode">
+  <Collapser id="license_key" title="license_key">
     <table>
       <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`true`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_MONITOR_MODE`</td></tr>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`""`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_LICENSE_KEY`</td></tr>
       </tbody>
     </table>
 
-  When `true`, the agent transmits data about your app to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector).
+  Your New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).
   </Collapser>
 
   <Collapser id="log_level" title="log_level">
@@ -164,76 +140,64 @@ These settings are available for agent configuration. Some settings depend on yo
   Sets the level of detail of log messages. Possible log levels, in increasing verbosity, are: `error`, `warn`, `info` or `debug`.
   </Collapser>
 
-  <Collapser id="high_security" title="high_security">
+  <Collapser id="apdex_t" title="apdex_t">
     <table>
       <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_HIGH_SECURITY`</td></tr>
+        <tr><th>Type</th><td>Float</td></tr>
+        <tr><th>Default</th><td>`0.5`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_APDEX_T`</td></tr>
       </tbody>
     </table>
 
-  If `true`, enables [high security mode](/docs/accounts-partnerships/accounts/security/high-security). Ensure you understand the implications of high security mode before enabling this setting.
+  <b>DEPRECATED</b> For agent versions 3.5.0 or higher, [set your Apdex T via the New Relic UI](/docs/apm/new-relic-apm/apdex/changing-your-apdex-settings).
   </Collapser>
 
-  <Collapser id="security_policies_token" title="security_policies_token">
+  <Collapser id="api_key" title="api_key">
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
         <tr><th>Default</th><td>`""`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_POLICIES_TOKEN`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_API_KEY`</td></tr>
       </tbody>
     </table>
 
-  Applies language agent security policy settings.
+  Your New Relic [user key](/docs/apis/intro-apis/new-relic-api-keys/#overview-keys). Required when using the New Relic REST API v2 to record deployments using the `newrelic deployments` command.
   </Collapser>
 
-  <Collapser id="proxy_host" title="proxy_host">
+  <Collapser id="backport_fast_active_record_connection_lookup" title="backport_fast_active_record_connection_lookup">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_BACKPORT_FAST_ACTIVE_RECORD_CONNECTION_LOOKUP`</td></tr>
+      </tbody>
+    </table>
+
+  Backports the faster ActiveRecord connection lookup introduced in Rails 6, which improves agent performance when instrumenting ActiveRecord. Note that this setting may not be compatible with other gems that patch ActiveRecord.
+  </Collapser>
+
+  <Collapser id="ca_bundle_path" title="ca_bundle_path">
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
         <tr><th>Default</th><td>`nil`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_PROXY_HOST`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_CA_BUNDLE_PATH`</td></tr>
       </tbody>
     </table>
 
-  Defines a host for communicating with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) via a proxy server.
+  Manual override for the path to your local CA bundle. This CA bundle will be used to validate the SSL certificate presented by New Relic's data collection service.
   </Collapser>
 
-  <Collapser id="proxy_port" title="proxy_port">
+  <Collapser id="capture_memcache_keys" title="capture_memcache_keys">
     <table>
       <tbody>
-        <tr><th>Type</th><td>Integer</td></tr>
-        <tr><th>Default</th><td>`8080`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_PROXY_PORT`</td></tr>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_CAPTURE_MEMCACHE_KEYS`</td></tr>
       </tbody>
     </table>
 
-  Defines a port for communicating with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) via a proxy server.
-  </Collapser>
-
-  <Collapser id="proxy_user" title="proxy_user">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`nil`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_PROXY_USER`</td></tr>
-      </tbody>
-    </table>
-
-  Defines a user for communicating with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) via a proxy server.
-  </Collapser>
-
-  <Collapser id="proxy_pass" title="proxy_pass">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`nil`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_PROXY_PASS`</td></tr>
-      </tbody>
-    </table>
-
-  Defines a password for communicating with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) via a proxy server.
+  Enable or disable the capture of memcache keys from transaction traces.
   </Collapser>
 
   <Collapser id="capture_params" title="capture_params">
@@ -253,6 +217,18 @@ These settings are available for agent configuration. Some settings depend on yo
 
   </Collapser>
 
+  <Collapser id="clear_transaction_state_after_fork" title="clear_transaction_state_after_fork">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_CLEAR_TRANSACTION_STATE_AFTER_FORK`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent will clear `Tracer::State` in `Agent.drop_buffered_data`.
+  </Collapser>
+
   <Collapser id="config_path" title="config_path">
     <table>
       <tbody>
@@ -265,52 +241,16 @@ These settings are available for agent configuration. Some settings depend on yo
   Path to <b>newrelic.yml</b>. If undefined, the agent checks the following directories (in order): <b>config/newrelic.yml</b>, <b>newrelic.yml</b>, <b>$HOME/.newrelic/newrelic.yml</b> and <b>$HOME/newrelic.yml</b>.
   </Collapser>
 
-  <Collapser id="apdex_t" title="apdex_t">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Float</td></tr>
-        <tr><th>Default</th><td>`0.5`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_APDEX_T`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> For agent versions 3.5.0 or higher, [set your Apdex T via the New Relic UI](/docs/apm/new-relic-apm/apdex/changing-your-apdex-settings).
-  </Collapser>
-
-  <Collapser id="sync_startup" title="sync_startup">
+  <Collapser id="exclude_newrelic_header" title="exclude_newrelic_header">
     <table>
       <tbody>
         <tr><th>Type</th><td>Boolean</td></tr>
         <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_SYNC_STARTUP`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_EXCLUDE_NEWRELIC_HEADER`</td></tr>
       </tbody>
     </table>
 
-  When set to `true`, forces a synchronous connection to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) during application startup. For very short-lived processes, this helps ensure the New Relic agent has time to report.
-  </Collapser>
-
-  <Collapser id="send_data_on_exit" title="send_data_on_exit">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`true`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_SEND_DATA_ON_EXIT`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, enables the exit handler that sends data to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) before shutting down.
-  </Collapser>
-
-  <Collapser id="timeout" title="timeout">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Integer</td></tr>
-        <tr><th>Default</th><td>`120`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_TIMEOUT`</td></tr>
-      </tbody>
-    </table>
-
-  Defines the maximum number of seconds the agent should spend attempting to connect to the collector.
+  Allows newrelic distributed tracing headers to be suppressed on outbound requests.
   </Collapser>
 
   <Collapser id="force_install_exit_handler" title="force_install_exit_handler">
@@ -322,7 +262,31 @@ These settings are available for agent configuration. Some settings depend on yo
       </tbody>
     </table>
 
-  Forces the exit handler that sends all cached data to collector before shutting down to be installed regardless of detecting scenarios where it generally should not be. Known use-case for this option is where Sinatra is running as an embedded service within another framework and the agent is detecting the Sinatra app and skipping the `at_exit` handler as a result. Sinatra classically runs the entire application in an `at_exit` block and would otherwise misbehave if the agent's `at_exit` handler was also installed in those circumstances. Note: `send_data_on_exit` should also be set to `true` in  tandem with this setting.
+  Forces the exit handler that sends all cached data to collector before shutting down to be installed regardless of detecting scenarios where it generally should not be. Known use-case for this option is where Sinatra is running as an embedded service within another framework and the agent is detecting the Sinatra app and skipping the `at_exit` handler as a result. Sinatra classically runs the entire application in an `at_exit` block and would otherwise misbehave if the Agent's `at_exit` handler was also installed in those circumstances. Note: `send_data_on_exit` should also be set to `true` in  tandem with this setting.
+  </Collapser>
+
+  <Collapser id="high_security" title="high_security">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_HIGH_SECURITY`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables [high security mode](/docs/accounts-partnerships/accounts/security/high-security). Ensure you understand the implications of high security mode before enabling this setting.
+  </Collapser>
+
+  <Collapser id="labels" title="labels">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`""`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_LABELS`</td></tr>
+      </tbody>
+    </table>
+
+  A dictionary of [label names](/docs/data-analysis/user-interface-functions/labels-categories-organize-your-apps-servers) and values that will be applied to the data sent from this agent. May also be expressed as a semicolon-delimited `;` string of colon-separated `:` pairs. For example, `<var>Server</var>:<var>One</var>;<var>Data Center</var>:<var>Primary</var>`.
   </Collapser>
 
   <Collapser id="log_file_name" title="log_file_name">
@@ -349,30 +313,6 @@ These settings are available for agent configuration. Some settings depend on yo
   Defines a path to the agent log file, excluding the filename.
   </Collapser>
 
-  <Collapser id="prepend_active_record_instrumentation" title="prepend_active_record_instrumentation">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_PREPEND_ACTIVE_RECORD_INSTRUMENTATION`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, uses `Module#prepend` rather than `alias_method` for ActiveRecord instrumentation.
-  </Collapser>
-
-  <Collapser id="capture_memcache_keys" title="capture_memcache_keys">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_CAPTURE_MEMCACHE_KEYS`</td></tr>
-      </tbody>
-    </table>
-
-  Enable or disable the capture of memcache keys from transaction traces.
-  </Collapser>
-
   <Collapser id="marshaller" title="marshaller">
     <table>
       <tbody>
@@ -385,64 +325,124 @@ These settings are available for agent configuration. Some settings depend on yo
   Specifies a marshaller for transmitting data to the New Relic [collector](/docs/apm/new-relic-apm/getting-started/glossary#collector). Currently `json` is the only valid value for this setting.
   </Collapser>
 
-  <Collapser id="backport_fast_active_record_connection_lookup" title="backport_fast_active_record_connection_lookup">
+  <Collapser id="monitor_mode" title="monitor_mode">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_MONITOR_MODE`</td></tr>
+      </tbody>
+    </table>
+
+  When `true`, the agent transmits data about your app to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector).
+  </Collapser>
+
+  <Collapser id="prepend_active_record_instrumentation" title="prepend_active_record_instrumentation">
     <table>
       <tbody>
         <tr><th>Type</th><td>Boolean</td></tr>
         <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_BACKPORT_FAST_ACTIVE_RECORD_CONNECTION_LOOKUP`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_PREPEND_ACTIVE_RECORD_INSTRUMENTATION`</td></tr>
       </tbody>
     </table>
 
-  Backports the faster ActiveRecord connection lookup introduced in Rails 6, which improves agent performance when instrumenting ActiveRecord. Note that this setting may not be compatible with other gems that patch ActiveRecord.
+  If `true`, uses `Module#prepend` rather than `alias_method` for ActiveRecord instrumentation.
   </Collapser>
 
-  <Collapser id="labels" title="labels">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`""`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_LABELS`</td></tr>
-      </tbody>
-    </table>
-
-  A dictionary of [label names](/docs/data-analysis/user-interface-functions/labels-categories-organize-your-apps-servers) and values that will be applied to the data sent from this agent. May also be expressed as a semicolon-delimited `;` string of colon-separated `:` pairs. For example, `<var>Server</var>:<var>One</var>;<var>Data Center</var>:<var>Primary</var>`.
-  </Collapser>
-
-  <Collapser id="ca_bundle_path" title="ca_bundle_path">
+  <Collapser id="proxy_host" title="proxy_host">
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
         <tr><th>Default</th><td>`nil`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_CA_BUNDLE_PATH`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_PROXY_HOST`</td></tr>
       </tbody>
     </table>
 
-  Manual override for the path to your local CA bundle. This CA bundle will be used to validate the SSL certificate presented by New Relic's data collection service.
+  Defines a host for communicating with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) via a proxy server.
   </Collapser>
 
-  <Collapser id="clear_transaction_state_after_fork" title="clear_transaction_state_after_fork">
+  <Collapser id="proxy_pass" title="proxy_pass">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`nil`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_PROXY_PASS`</td></tr>
+      </tbody>
+    </table>
+
+  Defines a password for communicating with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) via a proxy server.
+  </Collapser>
+
+  <Collapser id="proxy_port" title="proxy_port">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`8080`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_PROXY_PORT`</td></tr>
+      </tbody>
+    </table>
+
+  Defines a port for communicating with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) via a proxy server.
+  </Collapser>
+
+  <Collapser id="proxy_user" title="proxy_user">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`nil`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_PROXY_USER`</td></tr>
+      </tbody>
+    </table>
+
+  Defines a user for communicating with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) via a proxy server.
+  </Collapser>
+
+  <Collapser id="security_policies_token" title="security_policies_token">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`""`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_POLICIES_TOKEN`</td></tr>
+      </tbody>
+    </table>
+
+  Applies Language Agent Security Policy settings.
+  </Collapser>
+
+  <Collapser id="send_data_on_exit" title="send_data_on_exit">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SEND_DATA_ON_EXIT`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables the exit handler that sends data to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) before shutting down.
+  </Collapser>
+
+  <Collapser id="sync_startup" title="sync_startup">
     <table>
       <tbody>
         <tr><th>Type</th><td>Boolean</td></tr>
         <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_CLEAR_TRANSACTION_STATE_AFTER_FORK`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SYNC_STARTUP`</td></tr>
       </tbody>
     </table>
 
-  If `true`, the agent will clear `Tracer::State` in `Agent.drop_buffered_data`.
+  When set to `true`, forces a synchronous connection to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) during application startup. For very short-lived processes, this helps ensure the New Relic agent has time to report.
   </Collapser>
 
-  <Collapser id="exclude_newrelic_header" title="exclude_newrelic_header">
+  <Collapser id="timeout" title="timeout">
     <table>
       <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_EXCLUDE_NEWRELIC_HEADER`</td></tr>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`120`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TIMEOUT`</td></tr>
       </tbody>
     </table>
 
-  Allows newrelic distributed tracing headers to be suppressed on outbound requests.
+  Defines the maximum number of seconds the agent should spend attempting to connect to the collector.
   </Collapser>
 
 </CollapserGroup>
@@ -452,6 +452,18 @@ These settings are available for agent configuration. Some settings depend on yo
 The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces) feature collects detailed information from a selection of transactions, including a summary of the calling sequence, a breakdown of time spent, and a list of SQL queries and their query plans (on mysql and postgresql). Available features depend on your New Relic subscription level.
 
 <CollapserGroup>
+
+  <Collapser id="transaction_tracer-capture_attributes" title="transaction_tracer.capture_attributes">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_CAPTURE_ATTRIBUTES`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Use [`transaction_tracer.attributes.enabled`](#transaction_tracer-attributes-enabled) instead.
+  </Collapser>
 
   <Collapser id="transaction_tracer-enabled" title="transaction_tracer.enabled">
     <table>
@@ -465,16 +477,52 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
   If `true`, enables collection of [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces).
   </Collapser>
 
-  <Collapser id="transaction_tracer-transaction_threshold" title="transaction_tracer.transaction_threshold">
+  <Collapser id="transaction_tracer-explain_enabled" title="transaction_tracer.explain_enabled">
     <table>
       <tbody>
-        <tr><th>Type</th><td>Float</td></tr>
-        <tr><th>Default</th><td>`(Dynamic)`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_TRANSACTION_THRESHOLD`</td></tr>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_EXPLAIN_ENABLED`</td></tr>
       </tbody>
     </table>
 
-  Specify a threshold in seconds. Transactions with a duration longer than this threshold are eligible for transaction traces. Specify a float value or the string `apdex_f`.
+  If `true`, enables the collection of explain plans in transaction traces. This setting will also apply to explain plans in slow SQL traces if [`slow_sql.explain_enabled`](#slow_sql-explain_enabled) is not set separately.
+  </Collapser>
+
+  <Collapser id="transaction_tracer-explain_threshold" title="transaction_tracer.explain_threshold">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Float</td></tr>
+        <tr><th>Default</th><td>`0.5`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_EXPLAIN_THRESHOLD`</td></tr>
+      </tbody>
+    </table>
+
+  Threshold (in seconds) above which the agent will collect explain plans. Relevant only when [`explain_enabled`](#transaction_tracer.explain_enabled) is true.
+  </Collapser>
+
+  <Collapser id="transaction_tracer-limit_segments" title="transaction_tracer.limit_segments">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`4000`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_LIMIT_SEGMENTS`</td></tr>
+      </tbody>
+    </table>
+
+  Maximum number of transaction trace nodes to record in a single transaction trace.
+  </Collapser>
+
+  <Collapser id="transaction_tracer-record_redis_arguments" title="transaction_tracer.record_redis_arguments">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_RECORD_REDIS_ARGUMENTS`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent records Redis command arguments in transaction traces.
   </Collapser>
 
   <Collapser id="transaction_tracer-record_sql" title="transaction_tracer.record_sql">
@@ -496,54 +544,6 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
 
   </Collapser>
 
-  <Collapser id="transaction_tracer-record_redis_arguments" title="transaction_tracer.record_redis_arguments">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_RECORD_REDIS_ARGUMENTS`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, the agent records Redis command arguments in transaction traces.
-  </Collapser>
-
-  <Collapser id="transaction_tracer-capture_attributes" title="transaction_tracer.capture_attributes">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`true`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_CAPTURE_ATTRIBUTES`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Use [`transaction_tracer.attributes.enabled`](#transaction_tracer-attributes-enabled) instead.
-  </Collapser>
-
-  <Collapser id="transaction_tracer-explain_threshold" title="transaction_tracer.explain_threshold">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Float</td></tr>
-        <tr><th>Default</th><td>`0.5`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_EXPLAIN_THRESHOLD`</td></tr>
-      </tbody>
-    </table>
-
-  Threshold (in seconds) above which the agent will collect explain plans. Relevant only when [`explain_enabled`](#transaction_tracer.explain_enabled) is true.
-  </Collapser>
-
-  <Collapser id="transaction_tracer-explain_enabled" title="transaction_tracer.explain_enabled">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`true`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_EXPLAIN_ENABLED`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, enables the collection of explain plans in transaction traces. This setting will also apply to explain plans in slow SQL traces if [`slow_sql.explain_enabled`](#slow_sql-explain_enabled) is not set separately.
-  </Collapser>
-
   <Collapser id="transaction_tracer-stack_trace_threshold" title="transaction_tracer.stack_trace_threshold">
     <table>
       <tbody>
@@ -556,16 +556,16 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
   Specify a threshold in seconds. The agent includes stack traces in transaction trace nodes when the stack trace duration exceeds this threshold.
   </Collapser>
 
-  <Collapser id="transaction_tracer-limit_segments" title="transaction_tracer.limit_segments">
+  <Collapser id="transaction_tracer-transaction_threshold" title="transaction_tracer.transaction_threshold">
     <table>
       <tbody>
-        <tr><th>Type</th><td>Integer</td></tr>
-        <tr><th>Default</th><td>`4000`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_LIMIT_SEGMENTS`</td></tr>
+        <tr><th>Type</th><td>Float</td></tr>
+        <tr><th>Default</th><td>`(Dynamic)`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_TRANSACTION_THRESHOLD`</td></tr>
       </tbody>
     </table>
 
-  Maximum number of transaction trace nodes to record in a single transaction trace.
+  Specify a threshold in seconds. Transactions with a duration longer than this threshold are eligible for transaction traces. Specify a float value or the string `apdex_f`.
   </Collapser>
 
 </CollapserGroup>
@@ -574,21 +574,9 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
 
 The agent collects and reports all uncaught exceptions by default. These configuration options allow you to customize the error collection.
 
-For information on ignored and expected errors, [see this page on Error Analytics in APM](/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected/). To set expected errors via the `NewRelic::Agent.notice_error` Ruby method, [consult the Ruby agent API](/docs/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/).
+For information on ignored and expected errors, [see this page on Error Analytics in APM](/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected/). To set expected errors via the `NewRelic::Agent.notice_error` Ruby method, [consult the Ruby Agent API](/docs/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/).
 
 <CollapserGroup>
-
-  <Collapser id="error_collector-enabled" title="error_collector.enabled">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`true`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_ENABLED`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, the agent captures traced errors and error count metrics.
-  </Collapser>
 
   <Collapser id="error_collector-capture_attributes" title="error_collector.capture_attributes">
     <table>
@@ -600,23 +588,6 @@ For information on ignored and expected errors, [see this page on Error Analytic
     </table>
 
   <b>DEPRECATED</b> Use [`error_collector.attributes.enabled`](#error_collector-attributes-enabled) instead.
-  </Collapser>
-
-  <Collapser id="error_collector-ignore_errors" title="error_collector.ignore_errors">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`"ActionController::RoutingError,Sinatra::NotFound"`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERRORS`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Use `error_collector.ignore_classes` instead. Specify a comma-delimited list of error classes that the agent should ignore.
-
-    <Callout variant="caution">
-      Server side configuration takes precedence for this setting over all environment configurations. This differs from all other configuration settings where environment variable take precedence over server side configuration.
-    </Callout>
-
   </Collapser>
 
   <Collapser id="error_collector-ignore_classes" title="error_collector.ignore_classes">
@@ -636,33 +607,28 @@ For information on ignored and expected errors, [see this page on Error Analytic
 
   </Collapser>
 
-  <Collapser id="error_collector-ignore_messages" title="error_collector.ignore_messages">
+  <Collapser id="error_collector-capture_events" title="error_collector.capture_events">
     <table>
       <tbody>
-        <tr><th>Type</th><td>Hash</td></tr>
-        <tr><th>Default</th><td>`{}`</td></tr>
-        <tr><th>Environ variable</th><td>`None`</td></tr>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_CAPTURE_EVENTS`</td></tr>
       </tbody>
     </table>
 
-  A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored.
-
-  <Callout variant="caution">
-    This option can't be set via environment variable.
-  </Callout>
-
+  If `true`, the agent collects [TransactionError events](/docs/insights/new-relic-insights/decorating-events/error-event-default-attributes-insights).
   </Collapser>
 
-  <Collapser id="error_collector-ignore_status_codes" title="error_collector.ignore_status_codes">
+  <Collapser id="error_collector-enabled" title="error_collector.enabled">
     <table>
       <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`""`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_IGNORE_STATUS_CODES`</td></tr>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_ENABLED`</td></tr>
       </tbody>
     </table>
 
-  A comma separated list of status codes, possibly including ranges. Errors associated with these status codes, where applicable, will be ignored.
+  If `true`, the agent captures traced errors and error count metrics.
   </Collapser>
 
   <Collapser id="error_collector-expected_classes" title="error_collector.expected_classes">
@@ -711,6 +677,52 @@ For information on ignored and expected errors, [see this page on Error Analytic
   A comma separated list of status codes, possibly including ranges. Errors associated with these status codes, where applicable, will be treated as expected.
   </Collapser>
 
+  <Collapser id="error_collector-ignore_errors" title="error_collector.ignore_errors">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"ActionController::RoutingError,Sinatra::NotFound"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERRORS`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Use `error_collector.ignore_classes` instead. Specify a comma-delimited list of error classes that the agent should ignore.
+
+    <Callout variant="caution">
+      Server side configuration takes precedence for this setting over all environment configurations. This differs from all other configuration settings where environment variable take precedence over server side configuration.
+    </Callout>
+
+  </Collapser>
+
+  <Collapser id="error_collector-ignore_messages" title="error_collector.ignore_messages">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Hash</td></tr>
+        <tr><th>Default</th><td>`{}`</td></tr>
+        <tr><th>Environ variable</th><td>`None`</td></tr>
+      </tbody>
+    </table>
+
+  A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored.
+
+  <Callout variant="caution">
+    This option can't be set via environment variable.
+  </Callout>
+
+  </Collapser>
+
+  <Collapser id="error_collector-ignore_status_codes" title="error_collector.ignore_status_codes">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`""`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_IGNORE_STATUS_CODES`</td></tr>
+      </tbody>
+    </table>
+
+  A comma separated list of status codes, possibly including ranges. Errors associated with these status codes, where applicable, will be ignored.
+  </Collapser>
+
   <Collapser id="error_collector-max_backtrace_frames" title="error_collector.max_backtrace_frames">
     <table>
       <tbody>
@@ -721,18 +733,6 @@ For information on ignored and expected errors, [see this page on Error Analytic
     </table>
 
   Defines the maximum number of frames in an error backtrace. Backtraces over this amount are truncated at the beginning and end.
-  </Collapser>
-
-  <Collapser id="error_collector-capture_events" title="error_collector.capture_events">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`true`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_CAPTURE_EVENTS`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, the agent collects [TransactionError events](/docs/insights/new-relic-insights/decorating-events/error-event-default-attributes-insights).
   </Collapser>
 
   <Collapser id="error_collector-max_event_samples_stored" title="error_collector.max_event_samples_stored">
@@ -787,6 +787,18 @@ The browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
 
 <CollapserGroup>
 
+  <Collapser id="analytics_events-capture_attributes" title="analytics_events.capture_attributes">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ANALYTICS_EVENTS_CAPTURE_ATTRIBUTES`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Use [`transaction_events.attributes.enabled`](#transaction_events-attributes-enabled) instead.
+  </Collapser>
+
   <Collapser id="analytics_events-enabled" title="analytics_events.enabled">
     <table>
       <tbody>
@@ -796,7 +808,7 @@ The browser monitoring [page load timing](/docs/browser/new-relic-browser/page-l
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [transaction_events.enabled](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#transaction_events-enabled).
+  <b>DEPRECATED</b> Please see: [transaction_events.enabled](docs/agents/ruby-agent/configuration/ruby-agent-configuration#transaction_events-enabled).
 
 If `true`, enables analytics event sampling.
   </Collapser>
@@ -810,21 +822,9 @@ If `true`, enables analytics event sampling.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [transaction_events.max_samples_stored](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#transaction_events-max_samples_stored).
+  <b>DEPRECATED</b> Please see: [transaction_events.max_samples_stored](docs/agents/ruby-agent/configuration/ruby-agent-configuration#transaction_events-max_samples_stored).
 
 Defines the maximum number of request events reported from a single harvest.
-  </Collapser>
-
-  <Collapser id="analytics_events-capture_attributes" title="analytics_events.capture_attributes">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`true`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_ANALYTICS_EVENTS_CAPTURE_ATTRIBUTES`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Use [`transaction_events.attributes.enabled`](#transaction_events-attributes-enabled) instead.
   </Collapser>
 
 </CollapserGroup>
@@ -861,11 +861,10 @@ Defines the maximum number of request events reported from a single harvest.
 
 </CollapserGroup>
 
-## Application Logging [#app-logging]
+## Application logging [#app-logging]
 
-The Ruby agent supports [APM logs in context](/docs/apm/new-relic-apm/getting-started/get-started-logs-context). For some tips on configuring logs for the Ruby agent, see [Configure Ruby logs in context](/docs/logs/logs-context/configure-logs-context-ruby). 
-
-Available logging-related config options include: 
+The Ruby agent supports [APM logs in context](/docs/apm/new-relic-apm/getting-started/get-started-logs-context). For some tips on configuring logs for the Ruby agent, see [Configure Ruby logs in context](/docs/logs/logs-context/configure-logs-context-ruby).
+Available logging-related config options include:
 
 <CollapserGroup>
 
@@ -902,25 +901,7 @@ Available logging-related config options include:
       </tbody>
     </table>
 
-    Defines the maximum number of log records to buffer in memory at a time.
-
-    Set this to a lower value to reduce the amount of log lines sent (may cause log sampling). Set this to a higher value to send more log lines.
-
-    Each log receives the same priority as its associated transaction. Logs that occur outside of a transaction will receive a random priority. Some logs may not be included because they are limited by `max_samples_stored`. For example, if logging `max_samples_stored` is set to 10,000 and transaction 1 has 10,000 log entries, only log entries for transaction 1 will be recorded. If transaction 1 has less than 10,000 logs you receive all logs for transaction 1. If there is still space, you receive all the logs for transaction 2, and so on.
-
-    If after all the logs for sampled transactions are recorded, and they haven't reached the limit in `max_samples_stored`, then log messages for transactions that were not in our sampling are sent. If there are any left, log messages outside of transactions are recorded.
-  </Collapser>
-
-  <Collapser id="application_logging-metrics-enabled" title="application_logging.metrics.enabled">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`true`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, the agent captures metrics related to logging for your application.
+  Defines the maximum number of log records to buffer in memory at a time.
   </Collapser>
 
   <Collapser id="application_logging-local_decorating-enabled" title="application_logging.local_decorating.enabled">
@@ -933,6 +914,18 @@ Available logging-related config options include:
     </table>
 
   If `true`, the agent decorates logs with metadata to link to entities, hosts, traces, and spans.
+  </Collapser>
+
+  <Collapser id="application_logging-metrics-enabled" title="application_logging.metrics.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures metrics related to logging for your application.
   </Collapser>
 
 </CollapserGroup>
@@ -955,78 +948,6 @@ Available logging-related config options include:
   If `true`, enables capture of attributes for all destinations.
   </Collapser>
 
-  <Collapser id="transaction_tracer-attributes-enabled" title="transaction_tracer.attributes.enabled">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`true`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_ATTRIBUTES_ENABLED`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, the agent captures attributes from transaction traces.
-  </Collapser>
-
-  <Collapser id="transaction_events-attributes-enabled" title="transaction_events.attributes.enabled">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`true`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_ENABLED`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, the agent captures attributes from transaction events.
-  </Collapser>
-
-  <Collapser id="error_collector-attributes-enabled" title="error_collector.attributes.enabled">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`true`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_ATTRIBUTES_ENABLED`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, the agent captures attributes from error collection.
-  </Collapser>
-
-  <Collapser id="browser_monitoring-attributes-enabled" title="browser_monitoring.attributes.enabled">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_BROWSER_MONITORING_ATTRIBUTES_ENABLED`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, the agent captures attributes from browser monitoring.
-  </Collapser>
-
-  <Collapser id="span_events-attributes-enabled" title="span_events.attributes.enabled">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`true`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_SPAN_EVENTS_ATTRIBUTES_ENABLED`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, the agent captures attributes on span events.
-  </Collapser>
-
-  <Collapser id="transaction_segments-attributes-enabled" title="transaction_segments.attributes.enabled">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`true`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_SEGMENTS_ATTRIBUTES_ENABLED`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, the agent captures attributes on transaction segments.
-  </Collapser>
-
   <Collapser id="attributes-exclude" title="attributes.exclude">
     <table>
       <tbody>
@@ -1037,78 +958,6 @@ Available logging-related config options include:
     </table>
 
   Prefix of attributes to exclude from all destinations. Allows `*` as wildcard at end.
-  </Collapser>
-
-  <Collapser id="transaction_tracer-attributes-exclude" title="transaction_tracer.attributes.exclude">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Array</td></tr>
-        <tr><th>Default</th><td>`[]`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_ATTRIBUTES_EXCLUDE`</td></tr>
-      </tbody>
-    </table>
-
-  Prefix of attributes to exclude from transaction traces. Allows `*` as wildcard at end.
-  </Collapser>
-
-  <Collapser id="transaction_events-attributes-exclude" title="transaction_events.attributes.exclude">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Array</td></tr>
-        <tr><th>Default</th><td>`[]`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_EXCLUDE`</td></tr>
-      </tbody>
-    </table>
-
-  Prefix of attributes to exclude from transaction events. Allows `*` as wildcard at end.
-  </Collapser>
-
-  <Collapser id="error_collector-attributes-exclude" title="error_collector.attributes.exclude">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Array</td></tr>
-        <tr><th>Default</th><td>`[]`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_ATTRIBUTES_EXCLUDE`</td></tr>
-      </tbody>
-    </table>
-
-  Prefix of attributes to exclude from error collection. Allows `*` as wildcard at end.
-  </Collapser>
-
-  <Collapser id="browser_monitoring-attributes-exclude" title="browser_monitoring.attributes.exclude">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Array</td></tr>
-        <tr><th>Default</th><td>`[]`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_BROWSER_MONITORING_ATTRIBUTES_EXCLUDE`</td></tr>
-      </tbody>
-    </table>
-
-  Prefix of attributes to exclude from browser monitoring. Allows `*` as wildcard at end.
-  </Collapser>
-
-  <Collapser id="span_events-attributes-exclude" title="span_events.attributes.exclude">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Array</td></tr>
-        <tr><th>Default</th><td>`[]`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_SPAN_EVENTS_ATTRIBUTES_EXCLUDE`</td></tr>
-      </tbody>
-    </table>
-
-  Prefix of attributes to exclude from span events. Allows `*` as wildcard at end.
-  </Collapser>
-
-  <Collapser id="transaction_segments-attributes-exclude" title="transaction_segments.attributes.exclude">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Array</td></tr>
-        <tr><th>Default</th><td>`[]`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_SEGMENTS_ATTRIBUTES_EXCLUDE`</td></tr>
-      </tbody>
-    </table>
-
-  Prefix of attributes to exclude from transaction segments. Allows `*` as wildcard at end.
   </Collapser>
 
   <Collapser id="attributes-include" title="attributes.include">
@@ -1123,40 +972,28 @@ Available logging-related config options include:
   Prefix of attributes to include in all destinations. Allows `*` as wildcard at end.
   </Collapser>
 
-  <Collapser id="transaction_tracer-attributes-include" title="transaction_tracer.attributes.include">
+  <Collapser id="browser_monitoring-attributes-enabled" title="browser_monitoring.attributes.enabled">
     <table>
       <tbody>
-        <tr><th>Type</th><td>Array</td></tr>
-        <tr><th>Default</th><td>`[]`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_ATTRIBUTES_INCLUDE`</td></tr>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_BROWSER_MONITORING_ATTRIBUTES_ENABLED`</td></tr>
       </tbody>
     </table>
 
-  Prefix of attributes to include in transaction traces. Allows `*` as wildcard at end.
+  If `true`, the agent captures attributes from browser monitoring.
   </Collapser>
 
-  <Collapser id="transaction_events-attributes-include" title="transaction_events.attributes.include">
+  <Collapser id="browser_monitoring-attributes-exclude" title="browser_monitoring.attributes.exclude">
     <table>
       <tbody>
         <tr><th>Type</th><td>Array</td></tr>
         <tr><th>Default</th><td>`[]`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_INCLUDE`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_BROWSER_MONITORING_ATTRIBUTES_EXCLUDE`</td></tr>
       </tbody>
     </table>
 
-  Prefix of attributes to include in transaction events. Allows `*` as wildcard at end.
-  </Collapser>
-
-  <Collapser id="error_collector-attributes-include" title="error_collector.attributes.include">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Array</td></tr>
-        <tr><th>Default</th><td>`[]`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_ATTRIBUTES_INCLUDE`</td></tr>
-      </tbody>
-    </table>
-
-  Prefix of attributes to include in error collection. Allows `*` as wildcard at end.
+  Prefix of attributes to exclude from browser monitoring. Allows `*` as wildcard at end.
   </Collapser>
 
   <Collapser id="browser_monitoring-attributes-include" title="browser_monitoring.attributes.include">
@@ -1171,6 +1008,66 @@ Available logging-related config options include:
   Prefix of attributes to include in browser monitoring. Allows `*` as wildcard at end.
   </Collapser>
 
+  <Collapser id="error_collector-attributes-enabled" title="error_collector.attributes.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_ATTRIBUTES_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures attributes from error collection.
+  </Collapser>
+
+  <Collapser id="error_collector-attributes-exclude" title="error_collector.attributes.exclude">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_ATTRIBUTES_EXCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to exclude from error collection. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="error_collector-attributes-include" title="error_collector.attributes.include">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_ATTRIBUTES_INCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to include in error collection. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="span_events-attributes-enabled" title="span_events.attributes.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SPAN_EVENTS_ATTRIBUTES_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures attributes on span events.
+  </Collapser>
+
+  <Collapser id="span_events-attributes-exclude" title="span_events.attributes.exclude">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SPAN_EVENTS_ATTRIBUTES_EXCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to exclude from span events. Allows `*` as wildcard at end.
+  </Collapser>
+
   <Collapser id="span_events-attributes-include" title="span_events.attributes.include">
     <table>
       <tbody>
@@ -1183,6 +1080,66 @@ Available logging-related config options include:
   Prefix of attributes to include on span events. Allows `*` as wildcard at end.
   </Collapser>
 
+  <Collapser id="transaction_events-attributes-enabled" title="transaction_events.attributes.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures attributes from transaction events.
+  </Collapser>
+
+  <Collapser id="transaction_events-attributes-exclude" title="transaction_events.attributes.exclude">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_EXCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to exclude from transaction events. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="transaction_events-attributes-include" title="transaction_events.attributes.include">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_INCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to include in transaction events. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="transaction_segments-attributes-enabled" title="transaction_segments.attributes.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_SEGMENTS_ATTRIBUTES_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures attributes on transaction segments.
+  </Collapser>
+
+  <Collapser id="transaction_segments-attributes-exclude" title="transaction_segments.attributes.exclude">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_SEGMENTS_ATTRIBUTES_EXCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to exclude from transaction segments. Allows `*` as wildcard at end.
+  </Collapser>
+
   <Collapser id="transaction_segments-attributes-include" title="transaction_segments.attributes.include">
     <table>
       <tbody>
@@ -1193,6 +1150,42 @@ Available logging-related config options include:
     </table>
 
   Prefix of attributes to include on transaction segments. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="transaction_tracer-attributes-enabled" title="transaction_tracer.attributes.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_ATTRIBUTES_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures attributes from transaction traces.
+  </Collapser>
+
+  <Collapser id="transaction_tracer-attributes-exclude" title="transaction_tracer.attributes.exclude">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_ATTRIBUTES_EXCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to exclude from transaction traces. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="transaction_tracer-attributes-include" title="transaction_tracer.attributes.include">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_ATTRIBUTES_INCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to include in transaction traces. Allows `*` as wildcard at end.
   </Collapser>
 
 </CollapserGroup>
@@ -1215,18 +1208,6 @@ Available logging-related config options include:
   If `true`, enables an audit log which logs communications with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector).
   </Collapser>
 
-  <Collapser id="audit_log-path" title="audit_log.path">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`config/newrelic_audit.log`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_AUDIT_LOG_PATH`</td></tr>
-      </tbody>
-    </table>
-
-  Specifies a path to the audit log file (including the filename).
-  </Collapser>
-
   <Collapser id="audit_log-endpoints" title="audit_log.endpoints">
     <table>
       <tbody>
@@ -1237,6 +1218,18 @@ Available logging-related config options include:
     </table>
 
   List of allowed endpoints to include in audit log
+  </Collapser>
+
+  <Collapser id="audit_log-path" title="audit_log.path">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`config/newrelic_audit.log`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_AUDIT_LOG_PATH`</td></tr>
+      </tbody>
+    </table>
+
+  Specifies a path to the audit log file (including the filename).
   </Collapser>
 
 </CollapserGroup>
@@ -1300,12 +1293,15 @@ Available logging-related config options include:
       </tbody>
     </table>
 
-  If `true`, the agent will report source code level metrics for traced methods. Please see [New Relic CodeStream integration](/docs/apm/agents/ruby-agent/features/ruby-codestream-integration/).
+  If `true`, the agent will report source code level metrics for traced methods.
+see: https://docs.newrelic.com/docs/apm/agents/ruby-agent/features/ruby-codestream-integration/
   </Collapser>
 
 </CollapserGroup>
 
 ## Cross Application Tracer
+
+
 
 <CollapserGroup>
 
@@ -1318,7 +1314,7 @@ Available logging-related config options include:
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [distributed_tracing-enabled](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#distributed_tracing-enabled).
+  <b>DEPRECATED</b> Please see: [distributed_tracing-enabled](docs/agents/ruby-agent/configuration/ruby-agent-configuration#distributed_tracing-enabled).
 
 If `true`, enables [cross-application tracing](/docs/agents/ruby-agent/features/cross-application-tracing-ruby/) when `distributed_tracing.enabled` is set to `false`.
   </Collapser>
@@ -1383,18 +1379,6 @@ If `true`, enables [cross-application tracing](/docs/agents/ruby-agent/features/
 
 <CollapserGroup>
 
-  <Collapser id="datastore_tracer-instance_reporting-enabled" title="datastore_tracer.instance_reporting.enabled">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`true`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DATASTORE_TRACER_INSTANCE_REPORTING_ENABLED`</td></tr>
-      </tbody>
-    </table>
-
-  If `false`, the agent will not report datastore instance metrics, nor add `host` or `port_path_or_id` parameters to transaction or slow SQL traces.
-  </Collapser>
-
   <Collapser id="datastore_tracer-database_name_reporting-enabled" title="datastore_tracer.database_name_reporting.enabled">
     <table>
       <tbody>
@@ -1407,6 +1391,18 @@ If `true`, enables [cross-application tracing](/docs/agents/ruby-agent/features/
   If `false`, the agent will not add `database_name` parameter to transaction or slow sql traces.
   </Collapser>
 
+  <Collapser id="datastore_tracer-instance_reporting-enabled" title="datastore_tracer.instance_reporting.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DATASTORE_TRACER_INSTANCE_REPORTING_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `false`, the agent will not report datastore instance metrics, nor add `host` or `port_path_or_id` parameters to transaction or slow SQL traces.
+  </Collapser>
+
 </CollapserGroup>
 
 ## Disabling
@@ -1415,148 +1411,16 @@ Use these settings to toggle instrumentation types during agent startup.
 
 <CollapserGroup>
 
-  <Collapser id="disable_rake" title="disable_rake">
+  <Collapser id="disable_action_cable_instrumentation" title="disable_action_cable_instrumentation">
     <table>
       <tbody>
         <tr><th>Type</th><td>Boolean</td></tr>
         <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_RAKE`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTION_CABLE_INSTRUMENTATION`</td></tr>
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.rake](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-rake).
-
-If `true`, disables Rake instrumentation.
-  </Collapser>
-
-  <Collapser id="disable_samplers" title="disable_samplers">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_SAMPLERS`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, disables the collection of sampler metrics. Sampler metrics are metrics that are not event-based (such as CPU time or memory usage).
-  </Collapser>
-
-  <Collapser id="disable_resque" title="disable_resque">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_RESQUE`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Please see: [instrumentation.resque](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-resque).
-
-If `true`, disables [Resque instrumentation](/docs/agents/ruby-agent/background-jobs/resque-instrumentation).
-  </Collapser>
-
-  <Collapser id="disable_sidekiq" title="disable_sidekiq">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_SIDEKIQ`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, disables [Sidekiq instrumentation](/docs/agents/ruby-agent/background-jobs/sidekiq-instrumentation).
-  </Collapser>
-
-  <Collapser id="disable_dj" title="disable_dj">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_DJ`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Please see: [instrumentation.delayed_job](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-delayed_job).
-
-If `true`, disables [Delayed::Job instrumentation](/docs/agents/ruby-agent/background-jobs/delayedjob).
-  </Collapser>
-
-  <Collapser id="disable_sinatra" title="disable_sinatra">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_SINATRA`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Please see: [instrumentation.sinatra](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-sinatra).
-
-If `true` , disables [Sinatra instrumentation](/docs/agents/ruby-agent/frameworks/sinatra-support).
-  </Collapser>
-
-  <Collapser id="disable_sinatra_auto_middleware" title="disable_sinatra_auto_middleware">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_SINATRA_AUTO_MIDDLEWARE`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, disables agent middleware for Sinatra. This middleware is responsible for advanced feature support such as [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing), [page load timing](/docs/browser/new-relic-browser/getting-started/new-relic-browser), and [error collection](/docs/apm/applications-menu/events/view-apm-error-analytics).
-
-    <Callout variant="important">
-      Cross application tracing is deprecated in favor of [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). Distributed tracing is on by default for Ruby agent versions 8.0.0 and above. Middlewares are not required to support distributed tracing.
-
-      To continue using cross application tracing, update the following options in your `newrelic.yml` configuration file:
-
-      ```yml
-      # newrelic.yml
-
-        cross_application_tracer:
-          enabled: true
-        distributed_tracing:
-          enabled: false
-      ```
-    </Callout>
-
-  </Collapser>
-
-  <Collapser id="disable_view_instrumentation" title="disable_view_instrumentation">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_VIEW_INSTRUMENTATION`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, disables view instrumentation.
-  </Collapser>
-
-  <Collapser id="disable_activerecord_instrumentation" title="disable_activerecord_instrumentation">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTIVERECORD_INSTRUMENTATION`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, disables active record instrumentation.
-  </Collapser>
-
-  <Collapser id="disable_data_mapper" title="disable_data_mapper">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_DATA_MAPPER`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, disables DataMapper instrumentation.
+  If `true`, disables Action Cable instrumentation.
   </Collapser>
 
   <Collapser id="disable_activejob" title="disable_activejob">
@@ -1571,18 +1435,6 @@ If `true` , disables [Sinatra instrumentation](/docs/agents/ruby-agent/framework
   If `true`, disables ActiveJob instrumentation.
   </Collapser>
 
-  <Collapser id="disable_action_cable_instrumentation" title="disable_action_cable_instrumentation">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTION_CABLE_INSTRUMENTATION`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, disables Action Cable instrumentation.
-  </Collapser>
-
   <Collapser id="disable_active_storage" title="disable_active_storage">
     <table>
       <tbody>
@@ -1595,186 +1447,16 @@ If `true` , disables [Sinatra instrumentation](/docs/agents/ruby-agent/framework
   If `true`, disables ActiveStorage instrumentation.
   </Collapser>
 
-  <Collapser id="disable_memcached" title="disable_memcached">
+  <Collapser id="disable_activerecord_instrumentation" title="disable_activerecord_instrumentation">
     <table>
       <tbody>
         <tr><th>Type</th><td>Boolean</td></tr>
         <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_MEMCACHED`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTIVERECORD_INSTRUMENTATION`</td></tr>
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.memcached](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcached).
-
-If `true`, disables instrumentation for the memcached gem.
-  </Collapser>
-
-  <Collapser id="disable_memcache_client" title="disable_memcache_client">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_MEMCACHE_CLIENT`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Please see: [instrumentation.memcache-client](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache-client).
-
-If `true`, disables instrumentation for the memcache-client gem.
-  </Collapser>
-
-  <Collapser id="disable_dalli" title="disable_dalli">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_DALLI`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Please see: [instrumentation.memcache](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache).
-
-If `true`, disables instrumentation for the dalli gem.
-  </Collapser>
-
-  <Collapser id="disable_dalli_cas_client" title="disable_dalli_cas_client">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_DALLI_CAS_CLIENT`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Please see: [instrumentation.memcache](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache).
-
-If `true`, disables instrumentation for the dalli gem's additional CAS client support.
-  </Collapser>
-
-  <Collapser id="disable_memcache_instrumentation" title="disable_memcache_instrumentation">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_MEMCACHE_INSTRUMENTATION`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Please see: [instrumentation.memcache](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache).
-
-If `true`, disables memcache instrumentation.
-  </Collapser>
-
-  <Collapser id="disable_gc_profiler" title="disable_gc_profiler">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_GC_PROFILER`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, disables the use of GC::Profiler to measure time spent in garbage collection
-  </Collapser>
-
-  <Collapser id="disable_sequel_instrumentation" title="disable_sequel_instrumentation">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_SEQUEL_INSTRUMENTATION`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, disables [Sequel instrumentation](/docs/agents/ruby-agent/frameworks/sequel-instrumentation).
-  </Collapser>
-
-  <Collapser id="disable_database_instrumentation" title="disable_database_instrumentation">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_DATABASE_INSTRUMENTATION`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Use [`disable_sequel_instrumentation`](#disable_sequel_instrumentation) instead.
-  </Collapser>
-
-  <Collapser id="disable_mongo" title="disable_mongo">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_MONGO`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Please see: [instrumentation.mongo](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-mongo).
-
-If `true`, the agent won't install [instrumentation for the Mongo gem](/docs/agents/ruby-agent/frameworks/mongo-instrumentation).
-  </Collapser>
-
-  <Collapser id="disable_redis" title="disable_redis">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_REDIS`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Please see: [instrumentation.redis](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-redis).
-
-If `true`, the agent won't install [instrumentation for Redis](/docs/agents/ruby-agent/frameworks/redis-instrumentation).
-  </Collapser>
-
-  <Collapser id="disable_vm_sampler" title="disable_vm_sampler">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_VM_SAMPLER`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, the agent won't [sample performance measurements from the Ruby VM](/docs/agents/ruby-agent/features/ruby-vm-measurements).
-  </Collapser>
-
-  <Collapser id="disable_memory_sampler" title="disable_memory_sampler">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_MEMORY_SAMPLER`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, the agent won't sample the memory usage of the host process.
-  </Collapser>
-
-  <Collapser id="disable_cpu_sampler" title="disable_cpu_sampler">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_CPU_SAMPLER`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, the agent won't sample the CPU usage of the host process.
-  </Collapser>
-
-  <Collapser id="disable_delayed_job_sampler" title="disable_delayed_job_sampler">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_DELAYED_JOB_SAMPLER`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, the agent won't measure the depth of Delayed Job queues.
+  If `true`, disables active record instrumentation.
   </Collapser>
 
   <Collapser id="disable_active_record_notifications" title="disable_active_record_notifications">
@@ -1798,9 +1480,21 @@ If `true`, the agent won't install [instrumentation for Redis](/docs/agents/ruby
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.bunny](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-bunny).
+  <b>DEPRECATED</b> Please see: [instrumentation.bunny](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-bunny).
 
 If `true`, disables instrumentation for the bunny gem.
+  </Collapser>
+
+  <Collapser id="disable_cpu_sampler" title="disable_cpu_sampler">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_CPU_SAMPLER`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent won't sample the CPU usage of the host process.
   </Collapser>
 
   <Collapser id="disable_curb" title="disable_curb">
@@ -1812,9 +1506,87 @@ If `true`, disables instrumentation for the bunny gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.curb](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-curb).
+  <b>DEPRECATED</b> Please see: [instrumentation.curb](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-curb).
 
 If `true`, disables instrumentation for the curb gem.
+  </Collapser>
+
+  <Collapser id="disable_database_instrumentation" title="disable_database_instrumentation">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_DATABASE_INSTRUMENTATION`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Use [`disable_sequel_instrumentation`](#disable_sequel_instrumentation) instead.
+  </Collapser>
+
+  <Collapser id="disable_data_mapper" title="disable_data_mapper">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_DATA_MAPPER`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables DataMapper instrumentation.
+  </Collapser>
+
+  <Collapser id="disable_dalli" title="disable_dalli">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_DALLI`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.memcache](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache).
+
+If `true`, disables instrumentation for the dalli gem.
+  </Collapser>
+
+  <Collapser id="disable_dalli_cas_client" title="disable_dalli_cas_client">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_DALLI_CAS_CLIENT`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.memcache](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache).
+
+If `true`, disables instrumentation for the dalli gem's additional CAS client support.
+  </Collapser>
+
+  <Collapser id="disable_delayed_job_sampler" title="disable_delayed_job_sampler">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_DELAYED_JOB_SAMPLER`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent won't measure the depth of Delayed Job queues.
+  </Collapser>
+
+  <Collapser id="disable_dj" title="disable_dj">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_DJ`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.delayed_job](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-delayed_job).
+
+If `true`, disables [Delayed::Job instrumentation](/docs/agents/ruby-agent/background-jobs/delayedjob).
   </Collapser>
 
   <Collapser id="disable_excon" title="disable_excon">
@@ -1826,9 +1598,77 @@ If `true`, disables instrumentation for the curb gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.excon](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-excon).
+  <b>DEPRECATED</b> Please see: [instrumentation.excon](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-excon).
 
 If `true`, disables instrumentation for the excon gem.
+  </Collapser>
+
+  <Collapser id="disable_memcached" title="disable_memcached">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_MEMCACHED`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.memcached](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcached).
+
+If `true`, disables instrumentation for the memcached gem.
+  </Collapser>
+
+  <Collapser id="disable_memcache_client" title="disable_memcache_client">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_MEMCACHE_CLIENT`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.memcache-client](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache-client).
+
+If `true`, disables instrumentation for the memcache-client gem.
+  </Collapser>
+
+  <Collapser id="disable_memcache_instrumentation" title="disable_memcache_instrumentation">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_MEMCACHE_INSTRUMENTATION`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.memcache](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache).
+
+If `true`, disables memcache instrumentation.
+  </Collapser>
+
+  <Collapser id="disable_gc_profiler" title="disable_gc_profiler">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_GC_PROFILER`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables the use of GC::Profiler to measure time spent in garbage collection
+  </Collapser>
+
+  <Collapser id="disable_grape" title="disable_grape">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_GRAPE`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.grape](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-grape).
+
+If `true`, the agent won't install Grape instrumentation.
   </Collapser>
 
   <Collapser id="disable_httpclient" title="disable_httpclient">
@@ -1840,93 +1680,9 @@ If `true`, disables instrumentation for the excon gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.httpclient](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-httpclient).
+  <b>DEPRECATED</b> Please see: [instrumentation.httpclient](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-httpclient).
 
 If `true`, disables instrumentation for the httpclient gem.
-  </Collapser>
-
-  <Collapser id="disable_net_http" title="disable_net_http">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_NET_HTTP`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Please see: [instrumentation.net_http](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-net_http).
-
-If `true`, disables instrumentation for Net::HTTP.
-  </Collapser>
-
-  <Collapser id="disable_rack" title="disable_rack">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_RACK`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Please see: [instrumentation.rack](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-rack).
-
-If `true`, prevents the agent from hooking into the `to_app` method in Rack::Builder to find gems to instrument during application startup.
-  </Collapser>
-
-  <Collapser id="disable_rack_urlmap" title="disable_rack_urlmap">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_RACK_URLMAP`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Please see: [instrumentation.rack_urlmap](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-rack_urlmap).
-
-If `true`, prevents the agent from hooking into Rack::URLMap to install middleware tracing.
-  </Collapser>
-
-  <Collapser id="disable_puma_rack" title="disable_puma_rack">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_PUMA_RACK`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Please see: [instrumentation.puma_rack](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-puma_rack).
-
-If `true`, prevents the agent from hooking into the `to_app` method in Puma::Rack::Builder to find gems to instrument during application startup.
-  </Collapser>
-
-  <Collapser id="disable_puma_rack_urlmap" title="disable_puma_rack_urlmap">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_PUMA_RACK_URLMAP`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Please see: [instrumentation.puma_rack_urlmap](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-puma_rack_urlmap).
-
-If `true`, prevents the agent from hooking into Puma::Rack::URLMap to install middleware tracing.
-  </Collapser>
-
-  <Collapser id="disable_typhoeus" title="disable_typhoeus">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_TYPHOEUS`</td></tr>
-      </tbody>
-    </table>
-
-  <b>DEPRECATED</b> Please see: [instrumentation.typhoeus](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-typhoeus).
-
-If `true`, the agent won't install instrumentation for the typhoeus gem.
   </Collapser>
 
   <Collapser id="disable_httprb" title="disable_httprb">
@@ -1938,9 +1694,35 @@ If `true`, the agent won't install instrumentation for the typhoeus gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.httprb](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-httprb).
+  <b>DEPRECATED</b> Please see: [instrumentation.httprb](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-httprb).
 
 If `true`, the agent won't install instrumentation for the http.rb gem.
+  </Collapser>
+
+  <Collapser id="disable_mongo" title="disable_mongo">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_MONGO`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.mongo](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-mongo).
+
+If `true`, the agent won't install [instrumentation for the Mongo gem](/docs/agents/ruby-agent/frameworks/mongo-instrumentation).
+  </Collapser>
+
+  <Collapser id="disable_memory_sampler" title="disable_memory_sampler">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_MEMORY_SAMPLER`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent won't sample the memory usage of the host process.
   </Collapser>
 
   <Collapser id="disable_middleware_instrumentation" title="disable_middleware_instrumentation">
@@ -1955,23 +1737,239 @@ If `true`, the agent won't install instrumentation for the http.rb gem.
   If `true`, the agent won't wrap third-party middlewares in instrumentation (regardless of whether they are installed via Rack::Builder or Rails).
   </Collapser>
 
-  <Collapser id="disable_grape" title="disable_grape">
+  <Collapser id="disable_net_http" title="disable_net_http">
     <table>
       <tbody>
         <tr><th>Type</th><td>Boolean</td></tr>
         <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_GRAPE`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_NET_HTTP`</td></tr>
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.grape](/docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-grape).
+  <b>DEPRECATED</b> Please see: [instrumentation.net_http](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-net_http).
 
-If `true`, the agent won't install Grape instrumentation.
+If `true`, disables instrumentation for Net::HTTP.
+  </Collapser>
+
+  <Collapser id="disable_puma_rack" title="disable_puma_rack">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_PUMA_RACK`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.puma_rack](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-puma_rack).
+
+If `true`, prevents the agent from hooking into the `to_app` method in Puma::Rack::Builder to find gems to instrument during application startup.
+  </Collapser>
+
+  <Collapser id="disable_puma_rack_urlmap" title="disable_puma_rack_urlmap">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_PUMA_RACK_URLMAP`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.puma_rack_urlmap](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-puma_rack_urlmap).
+
+If `true`, prevents the agent from hooking into Puma::Rack::URLMap to install middleware tracing.
+  </Collapser>
+
+  <Collapser id="disable_rack" title="disable_rack">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_RACK`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.rack](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-rack).
+
+If `true`, prevents the agent from hooking into the `to_app` method in Rack::Builder to find gems to instrument during application startup.
+  </Collapser>
+
+  <Collapser id="disable_rack_urlmap" title="disable_rack_urlmap">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_RACK_URLMAP`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.rack_urlmap](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-rack_urlmap).
+
+If `true`, prevents the agent from hooking into Rack::URLMap to install middleware tracing.
+  </Collapser>
+
+  <Collapser id="disable_rake" title="disable_rake">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_RAKE`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.rake](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-rake).
+
+If `true`, disables Rake instrumentation.
+  </Collapser>
+
+  <Collapser id="disable_redis" title="disable_redis">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_REDIS`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.redis](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-redis).
+
+If `true`, the agent won't install [instrumentation for Redis](/docs/agents/ruby-agent/frameworks/redis-instrumentation).
+  </Collapser>
+
+  <Collapser id="disable_resque" title="disable_resque">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_RESQUE`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.resque](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-resque).
+
+If `true`, disables [Resque instrumentation](/docs/agents/ruby-agent/background-jobs/resque-instrumentation).
+  </Collapser>
+
+  <Collapser id="disable_samplers" title="disable_samplers">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_SAMPLERS`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables the collection of sampler metrics. Sampler metrics are metrics that are not event-based (such as CPU time or memory usage).
+  </Collapser>
+
+  <Collapser id="disable_sequel_instrumentation" title="disable_sequel_instrumentation">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_SEQUEL_INSTRUMENTATION`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables [Sequel instrumentation](/docs/agents/ruby-agent/frameworks/sequel-instrumentation).
+  </Collapser>
+
+  <Collapser id="disable_sidekiq" title="disable_sidekiq">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_SIDEKIQ`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables [Sidekiq instrumentation](/docs/agents/ruby-agent/background-jobs/sidekiq-instrumentation).
+  </Collapser>
+
+  <Collapser id="disable_sinatra" title="disable_sinatra">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_SINATRA`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.sinatra](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-sinatra).
+
+If `true` , disables [Sinatra instrumentation](/docs/agents/ruby-agent/frameworks/sinatra-support).
+  </Collapser>
+
+  <Collapser id="disable_sinatra_auto_middleware" title="disable_sinatra_auto_middleware">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_SINATRA_AUTO_MIDDLEWARE`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables agent middleware for Sinatra. This middleware is responsible for advanced feature support such as [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing), [page load timing](/docs/browser/new-relic-browser/getting-started/new-relic-browser), and [error collection](/docs/apm/applications-menu/events/view-apm-error-analytics).
+
+    <Callout variant="important">
+      Cross application tracing is deprecated in favor of [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). Distributed tracing is on by default for Ruby agent versions 8.0.0 and above. Middlewares are not required to support distributed tracing.
+
+      To continue using cross application tracing, update the following options in your `newrelic.yml` configuration file:
+
+      ```
+      # newrelic.yml
+
+        cross_application_tracer:
+          enabled: true
+        distributed_tracing:
+          enabled: false
+      ```
+    </Callout>
+
+  </Collapser>
+
+  <Collapser id="disable_typhoeus" title="disable_typhoeus">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_TYPHOEUS`</td></tr>
+      </tbody>
+    </table>
+
+  <b>DEPRECATED</b> Please see: [instrumentation.typhoeus](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-typhoeus).
+
+If `true`, the agent won't install instrumentation for the typhoeus gem.
+  </Collapser>
+
+  <Collapser id="disable_view_instrumentation" title="disable_view_instrumentation">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_VIEW_INSTRUMENTATION`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables view instrumentation.
+  </Collapser>
+
+  <Collapser id="disable_vm_sampler" title="disable_vm_sampler">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_VM_SAMPLER`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent won't [sample performance measurements from the Ruby VM](/docs/agents/ruby-agent/features/ruby-vm-measurements).
   </Collapser>
 
 </CollapserGroup>
 
-## Distributed Tracing [#dt-main]
+## Distributed Tracing
+
+
 
 <CollapserGroup>
 
@@ -1984,14 +1982,13 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Distributed tracing lets you see the path that a request takes through your distributed system. It is turned on by default in Ruby agents 8.0.0 and higher.
-
-  For more information, see [Distributed tracing for your Ruby services](/docs/apm/agents/ruby-agent/configuration/distributed-tracing-ruby-agent).
+  Distributed tracing lets you see the path that a request takes through your distributed system. Enabling distributed tracing changes the behavior of some New Relic features, so carefully consult the [transition guide](/docs/transition-guide-distributed-tracing) before you enable this feature.
   </Collapser>
 
 </CollapserGroup>
 
 ## Elasticsearch
+
 
 
 <CollapserGroup>
@@ -2006,7 +2003,6 @@ If `true`, the agent won't install Grape instrumentation.
     </table>
 
   If `true`, the agent captures Elasticsearch queries in transaction traces.
-
   </Collapser>
 
   <Collapser id="elasticsearch-obfuscate_queries" title="elasticsearch.obfuscate_queries">
@@ -2019,12 +2015,12 @@ If `true`, the agent won't install Grape instrumentation.
     </table>
 
   If `true`, the agent obfuscates Elasticsearch queries in transaction traces.
-
   </Collapser>
 
 </CollapserGroup>
 
 ## Heroku
+
 
 
 <CollapserGroup>
@@ -2093,28 +2089,16 @@ If `true`, the agent won't install Grape instrumentation.
 
 <CollapserGroup>
 
-  <Collapser id="instrumentation-net_http" title="instrumentation.net_http">
+  <Collapser id="instrumentation-active_support_logger" title="instrumentation.active_support_logger">
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
         <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_NET_HTTP`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_ACTIVE_SUPPORT_LOGGER`</td></tr>
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Net::HTTP at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-typhoeus" title="instrumentation.typhoeus">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_TYPHOEUS`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of Typhoeus at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
+  Controls auto-instrumentation of ActiveSupport::Logger at start up. May be one of [auto|prepend|chain|disabled].
   </Collapser>
 
   <Collapser id="instrumentation-bunny" title="instrumentation.bunny">
@@ -2126,128 +2110,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of bunny at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-elasticsearch" title="instrumentation.elasticsearch">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_ELASTICSEARCH`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of the elasticsearch library at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-    
-  </Collapser>
-
-  <Collapser id="instrumentation-httprb" title="instrumentation.httprb">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_HTTPRB`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of http.rb gem at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-resque" title="instrumentation.resque">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RESQUE`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of resque at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-thread" title="instrumentation.thread">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`"auto"`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_THREAD`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of the Thread class at start up to allow the agent to correctly nest spans inside of an asyncronous transaction. This does not enable the agent to automatically trace all threads created (see `instrumentation.thread.tracing`). May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-thread-tracing" title="instrumentation.thread.tracing">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_THREAD_TRACING`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of the Thread class at start up to automatically add tracing to all Threads created in the application.
-  </Collapser>
-
-  <Collapser id="instrumentation-redis" title="instrumentation.redis">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_REDIS`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of Redis at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-rake" title="instrumentation.rake">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RAKE`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of rake at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-mongo" title="instrumentation.mongo">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`enabled`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_MONGO`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of Mongo at start up. May be one of [enabled|disabled].
-  </Collapser>
-
-  <Collapser id="instrumentation-delayed_job" title="instrumentation.delayed_job">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_DELAYED_JOB`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of Delayed Job at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-httpclient" title="instrumentation.httpclient">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_HTTPCLIENT`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of HTTPClient at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
+  Controls auto-instrumentation of bunny at start up. May be one of [auto|prepend|chain|disabled].
   </Collapser>
 
   <Collapser id="instrumentation-curb" title="instrumentation.curb">
@@ -2259,163 +2122,31 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Curb at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
+  Controls auto-instrumentation of Curb at start up. May be one of [auto|prepend|chain|disabled].
   </Collapser>
 
-  <Collapser id="instrumentation-sinatra" title="instrumentation.sinatra">
+  <Collapser id="instrumentation-delayed_job" title="instrumentation.delayed_job">
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
         <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_SINATRA`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_DELAYED_JOB`</td></tr>
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Sinatra at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
+  Controls auto-instrumentation of Delayed Job at start up. May be one of [auto|prepend|chain|disabled].
   </Collapser>
 
-  <Collapser id="instrumentation-rack" title="instrumentation.rack">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RACK`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of Rack. When enabled, the agent hooks into the `to_app` method in Rack::Builder to find gems to instrument during application startup. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-rack_urlmap" title="instrumentation.rack_urlmap">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RACK_URLMAP`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of Rack::URLMap at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-puma_rack" title="instrumentation.puma_rack">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_PUMA_RACK`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of Puma::Rack. When enabled, the agent hooks into the `to_app` method in Puma::Rack::Builder to find gems to instrument during application startup. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-puma_rack_urlmap" title="instrumentation.puma_rack_urlmap">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_PUMA_RACK_URLMAP`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of Puma::Rack::URLMap at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-memcached" title="instrumentation.memcached">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_MEMCACHED`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of memcached gem for Memcache at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-memcache_client" title="instrumentation.memcache_client">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_MEMCACHE_CLIENT`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of memcache-client gem for Memcache at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-memcache" title="instrumentation.memcache">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_MEMCACHE`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of dalli gem for Memcache at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-logger" title="instrumentation.logger">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_LOGGER`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of Ruby standard library Logger at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-tilt" title="instrumentation.tilt">
+  <Collapser id="instrumentation-elasticsearch" title="instrumentation.elasticsearch">
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
         <tr><th>Default</th><td>`"auto"`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_TILT`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_ELASTICSEARCH`</td></tr>
       </tbody>
     </table>
 
-  Controls auto-instrumentation of the Tilt template rendering library at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-grpc_client" title="instrumentation.grpc_client">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_GRPC_CLIENT`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of gRPC clients at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
-  <Collapser id="instrumentation-grpc-host_denylist" title="instrumentation.grpc.host_denylist">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Array</td></tr>
-        <tr><th>Default</th><td>`[]`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_GRPC_HOST_DENYLIST`</td></tr>
-      </tbody>
-    </table>
-
-  Specifies a list of hostname patterns separated by commas that will match gRPC hostnames that New Relic will ignore. New Relic's gRPC client instrumentation will ignore traffic streamed to a host matching any of these patterns, and New Relic's gRPC server instrumentation will ignore traffic for a server running on a host whose hostname matches any of these patterns. By default, no traffic is ignored when gRPC instrumentation is itself enabled, for example, `private.com$,exception.*`.
-  </Collapser>
-
-  <Collapser id="instrumentation-grpc_server" title="instrumentation.grpc_server">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_GRPC_SERVER`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of gRPC servers at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
+  Controls auto-instrumentation of the elasticsearch library at start up. May be one of [auto|prepend|chain|disabled].
   </Collapser>
 
   <Collapser id="instrumentation-excon" title="instrumentation.excon">
@@ -2430,18 +2161,6 @@ If `true`, the agent won't install Grape instrumentation.
   Controls auto-instrumentation of Excon at start up. May be one of [enabled|disabled].
   </Collapser>
 
-  <Collapser id="instrumentation-active_support_logger" title="instrumentation.active_support_logger">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_ACTIVE_SUPPORT_LOGGER`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of ActiveSupport::Logger at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
-  </Collapser>
-
   <Collapser id="instrumentation-grape" title="instrumentation.grape">
     <table>
       <tbody>
@@ -2451,7 +2170,283 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Grape at start up. May be one of `auto`, `prepend`, `chain`, or `disabled`.
+  Controls auto-instrumentation of Grape at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-grpc_client" title="instrumentation.grpc_client">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_GRPC_CLIENT`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of gRPC clients at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-grpc-host_denylist" title="instrumentation.grpc.host_denylist">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_GRPC_HOST_DENYLIST`</td></tr>
+      </tbody>
+    </table>
+
+  Specifies a list of hostname patterns separated by commas that will match gRPC hostnames that traffic is to be ignored by New Relic for. New Relic's gRPC client instrumentation will ignore traffic streamed to a host matching any of these patterns, and New Relic's gRPC server instrumentation will ignore traffic for a server running on a host whose hostname matches any of these patterns. By default, no traffic is ignored when gRPC instrumentation is itself enabled. For example, "private.com$,exception.*"
+  </Collapser>
+
+  <Collapser id="instrumentation-grpc_server" title="instrumentation.grpc_server">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_GRPC_SERVER`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of gRPC servers at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-httpclient" title="instrumentation.httpclient">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_HTTPCLIENT`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of HTTPClient at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-httprb" title="instrumentation.httprb">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_HTTPRB`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of http.rb gem at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-logger" title="instrumentation.logger">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_LOGGER`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Ruby standard library Logger at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-memcache" title="instrumentation.memcache">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_MEMCACHE`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of dalli gem for Memcache at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-memcached" title="instrumentation.memcached">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_MEMCACHED`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of memcached gem for Memcache at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-memcache_client" title="instrumentation.memcache_client">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_MEMCACHE_CLIENT`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of memcache-client gem for Memcache at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-mongo" title="instrumentation.mongo">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`enabled`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_MONGO`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Mongo at start up. May be one of [enabled|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-net_http" title="instrumentation.net_http">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_NET_HTTP`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Net::HTTP at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-puma_rack" title="instrumentation.puma_rack">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_PUMA_RACK`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Puma::Rack. When enabled, the agent hooks into the `to_app` method in Puma::Rack::Builder to find gems to instrument during application startup. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-puma_rack_urlmap" title="instrumentation.puma_rack_urlmap">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_PUMA_RACK_URLMAP`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Puma::Rack::URLMap at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-rack" title="instrumentation.rack">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RACK`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Rack. When enabled, the agent hooks into the `to_app` method in Rack::Builder to find gems to instrument during application startup. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-rack_urlmap" title="instrumentation.rack_urlmap">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RACK_URLMAP`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Rack::URLMap at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-rake" title="instrumentation.rake">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RAKE`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of rake at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-redis" title="instrumentation.redis">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_REDIS`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Redis at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-resque" title="instrumentation.resque">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RESQUE`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of resque at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-sinatra" title="instrumentation.sinatra">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_SINATRA`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Sinatra at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-thread" title="instrumentation.thread">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"auto"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_THREAD`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the Thread class at start up to allow the agent to correctly nest spans inside of an asynchronous transaction. This does not enable the agent to automatically trace all threads created (see `instrumentation.thread.tracing`). May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-thread-tracing" title="instrumentation.thread.tracing">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_THREAD_TRACING`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the Thread class at start up to automatically add tracing to all Threads created in the application.
+  </Collapser>
+
+  <Collapser id="instrumentation-tilt" title="instrumentation.tilt">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"auto"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_TILT`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the Tilt template rendering library at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-typhoeus" title="instrumentation.typhoeus">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_TYPHOEUS`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Typhoeus at start up. May be one of [auto|prepend|chain|disabled].
   </Collapser>
 
 </CollapserGroup>
@@ -2814,30 +2809,6 @@ If `true`, the agent won't install Grape instrumentation.
   If `true`, the agent automatically detects that it is running in an Azure environment.
   </Collapser>
 
-  <Collapser id="utilization-detect_gcp" title="utilization.detect_gcp">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`true`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_UTILIZATION_DETECT_GCP`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, the agent automatically detects that it is running in an Google Cloud Platform environment.
-  </Collapser>
-
-  <Collapser id="utilization-detect_pcf" title="utilization.detect_pcf">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`true`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_UTILIZATION_DETECT_PCF`</td></tr>
-      </tbody>
-    </table>
-
-  If `true`, the agent automatically detects that it is running in a Pivotal Cloud Foundry environment.
-  </Collapser>
-
   <Collapser id="utilization-detect_docker" title="utilization.detect_docker">
     <table>
       <tbody>
@@ -2850,6 +2821,18 @@ If `true`, the agent won't install Grape instrumentation.
   If `true`, the agent automatically detects that it is running in Docker.
   </Collapser>
 
+  <Collapser id="utilization-detect_gcp" title="utilization.detect_gcp">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_UTILIZATION_DETECT_GCP`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent automatically detects that it is running in an Google Cloud Platform environment.
+  </Collapser>
+
   <Collapser id="utilization-detect_kubernetes" title="utilization.detect_kubernetes">
     <table>
       <tbody>
@@ -2860,6 +2843,18 @@ If `true`, the agent won't install Grape instrumentation.
     </table>
 
   If `true`, the agent automatically detects that it is running in Kubernetes.
+  </Collapser>
+
+  <Collapser id="utilization-detect_pcf" title="utilization.detect_pcf">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_UTILIZATION_DETECT_PCF`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent automatically detects that it is running in a Pivotal Cloud Foundry environment.
   </Collapser>
 
 </CollapserGroup>

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-eol-policy.mdx
@@ -29,6 +29,20 @@ Any versions not listed in the following table are no longer supported. Please [
   <tbody>
     <tr>
       <td>
+        v8.13.0
+      </td>
+
+      <td>
+        Nov 15, 2022
+      </td>
+
+      <td>
+        Nov 15, 2023
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         v8.12.0
       </td>
 

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -285,7 +285,8 @@ The Ruby agent does not support experimental versions. Web frameworks supported 
 
       <td>
         * 1.6.x
-        * 2.0.3 or higher
+        * 2.x
+        * 3.0.x
       </td>
 
       <td>
@@ -437,6 +438,7 @@ The Ruby agent does not support experimental versions. Databases supported by th
         * 4.0.x
         * 4.1.x
         * 4.2.x
+        * 5.0.x
       </td>
 
       <td/>
@@ -734,10 +736,9 @@ Background jobs supported by the New Relic Ruby agent include:
 
       <td>
         * 4.2.x - Deprecated
-        * 5.0.x
-        * 6.0.x
-        * 6.1.x
-        * 6.2.x
+        * 5.x
+        * 6.x
+        * 7.0.x
       </td>
 
       <td>

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -79,7 +79,7 @@ The New Relic Ruby agent does not support experimental versions. Ruby versions s
         * ~~2.0.x~~
         * ~~2.1.x~~
         * 2.2.x - Deprecated
-        * 2.3.x
+        * 2.3.x - Deprecated
         * 2.4.x
         * 2.5.x
         * 2.6.x

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8130.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8130.mdx
@@ -1,0 +1,44 @@
+---
+subject: Ruby agent
+releaseDate: '2022-11-15'
+version: 8.13.0
+downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.13.0.gem'
+---
+
+  ## v8.13.0
+
+  Version 8.13.0 of the agent updates our Rack, Redis, and Sidekiq instrumentation. It also delivers some bugfixes.
+
+  * **Support for Redis v5.0**
+
+    Redis v5.0 restructures where some of our instrumented methods are located and how they are named. It also introduces a new [instrumentation middleware API](https://github.com/redis-rb/redis-client#instrumentation-and-middlewares). This API is used for pipelined and multi calls to maintain reporting parity with previous Redis versions. However, it is introduced later in the chain, so you may see errors that used to appear at the segment level on the transaction instead. The agent's behavior when used with older supported Redis versions will remain unaffected. [PR#1611](https://github.com/newrelic/newrelic-ruby-agent/pull/1611)
+
+  * **Support for Sidekiq v7.0**
+
+    Sidekiq v7.0 removed Delayed Extensions and began offering client and server [middleware](https://github.com/mperham/sidekiq/blob/main/docs/middleware.md) classes to inherit from. The agent's Sidekiq instrumentation has been updated accordingly. The agent's behavior when used with older Sidekiq versions will remain unaffected. [PR#1615](https://github.com/newrelic/newrelic-ruby-agent/pull/1615)
+
+  * **Support for Rack v3.0: Rack::Builder#new accepting a block**
+
+    Via [rack/rack#1942](https://github.com/rack/rack/pull/1942) (released with Rack v3.0), `Rack::Builder#run` now optionally accepts a block instead of an app argument. The agent's instrumentation has been updated to support the use of a block with `Rack::Builder#run`. [PR#1600](https://github.com/newrelic/newrelic-ruby-agent/pull/1600)
+
+  * **Bugfix: Correctly identify Unicorn, Rainbows and FastCGI with Rack v3.0**
+
+    Unicorn, Rainbows, or FastCGI web applications using Rack v3.0 may previously have had the "dispatcher" value incorrectly reported as "Webrick" instead of "Unicorn", "Rainbows", or "FastCGI". This issue has now been addressed. [PR#1585](https://github.com/newrelic/newrelic-ruby-agent/pull/1585)
+
+  * **Bugfix: add_method_tracer fails to record code level metric attributes on private methods**
+
+    When using `add_method_tracer` on a private method, the agent was unable to record code level metrics for the method. This resulted in the following being logged to the newrelic_agent.log file.
+    ```
+    WARN : Unable to determine source code info for 'Example', method 'private_method' - NameError: undefined method 'private_method' for class '#<Class:Example\>'
+    ```
+    Thank you [@jdelStrother](https://github.com/jdelStrother) for bringing this issue to our attention and suggesting a fix! [PR#1593](https://github.com/newrelic/newrelic-ruby-agent/pull/1593)
+
+
+  * **Bugfix: Category is a required keyword arg for NewRelic::Agent::Tracer.in_transaction**
+
+    When support for Ruby 2.0 was dropped in version 8.0.0 of the agent, the agent API methods were updated to use the required keyword argument feature built into Ruby, rather than manually raising ArgumentErrors. The API method `NewRelic::Agent::Tracer.in_transaction` removed the ArgumentError raised by the agent, but did not update the method arguments to identify `:category` as a required keyword argument. This is now resolved. Thank you [@tatzsuzuki](https://github.com/tatzsuzuki) for bringing this to our attention. [PR#1587](https://github.com/newrelic/newrelic-ruby-agent/pull/1587)
+
+
+## Support statement
+
+New Relic recommends that you upgrade the Ruby agent regularly and at a minimum of every 3 months. As of this release, the oldest supported version is [6.8.0.359](https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-680360).


### PR DESCRIPTION
## Give us some context

Something went wrong when I created https://github.com/newrelic/docs-website/pull/10308/

Please review this PR instead! 

This PR updates the documentation corresponding with the Ruby agent's 8.13.0 release
Our hopes are to release tomorrow before the code freeze takes place
If our release is unable to be completed tomorrow, this PR should not be merged

Also, this release included a reorganization of our configuration options. The large diff is due to the locations of many settings being swapped. 