### PR TITLE
fix reference to cloud provider

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/getting-started/polling-intervals-gcp-integrations.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/getting-started/polling-intervals-gcp-integrations.mdx
@@ -4,12 +4,12 @@ tags:
   - Integrations
   - Google Cloud Platform integrations
   - Get started
-metaDescription: Understand polling intervals for each of your New Relic AWS integrations.
+metaDescription: Understand polling intervals for each of your New Relic GCP integrations.
 redirects:
   - /docs/integrations/google-cloud-platform-integrations/getting-started/polling-intervals-gcp-integrations
 ---
 
-New Relic's GCP integrations query your GCP services according to a polling interval, which varies depending [on the integration](#aws-integrations). Each polling interval by New Relic occurs for every GCP entity.
+New Relic's GCP integrations query your GCP services according to a polling interval, which varies depending [on the integration](#manage-polling). Each polling interval by New Relic occurs for every GCP entity.
 
 ## New Relic polling intervals [#manage-polling]
 


### PR DESCRIPTION
Page was referring to AWS in the short description. Updated this reference and changed an anchor link to point to the one on the page instead of an AWS one.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.