### PR TITLE
chore: Add instructions for user API key

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/features/record-deployments-ruby-agent.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/features/record-deployments-ruby-agent.mdx
@@ -24,11 +24,9 @@ To assign an application name:
 
 This will assign instances in the given environment the label given by `app_name` when browsing your data in the New Relic user interface. The deployment upload script will use that label to associate an app with the deployment.
 
-## Add your user API key (Optional) [#Api-Key]
+## Add your user key [#api-key]
 
-You can use the New Relic REST API v2 to record deployments by providing your user API key to the agent configuration using `api_key`. 
-
-When this configuration option is present, the `newrelic deployments` command will automatically use the New Relic REST API v2 deployment endpoint.
+Optionally, you can record deployments via the New Relic REST API v2. To do this, provide your [user key](/docs/apis/intro-apis/new-relic-api-keys/#overview-keys) to the agent configuration using `api_key`. When this configuration is present, the `newrelic deployments` command automatically uses the REST API v2 deployment endpoint.
 
 ## Record with the command line [#Manual]
 

--- a/src/content/docs/apm/agents/ruby-agent/features/record-deployments-ruby-agent.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/features/record-deployments-ruby-agent.mdx
@@ -24,6 +24,12 @@ To assign an application name:
 
 This will assign instances in the given environment the label given by `app_name` when browsing your data in the New Relic user interface. The deployment upload script will use that label to associate an app with the deployment.
 
+## Add your user API key (Optional) [#Api-Key]
+
+You can use the New Relic REST API v2 to record deployments by providing your user API key to the agent configuration using `api_key`. 
+
+When this configuration option is present, the `newrelic deployments` command will automatically use the New Relic REST API v2 deployment endpoint.
+
 ## Record with the command line [#Manual]
 
 If you installed the Ruby agent as a gem, you can record deployments directly by using the `newrelic` executable:
@@ -44,6 +50,8 @@ You can use several optional values with `newrelic`. The `description` is short 
 deployments [OPTIONS] [description]
 OPTIONS:
    -a, --appname=name           Set the application name.
+   -i, --appid=ID               Set the application ID
+                                If not provided, will connect to the New Relic collector to get it
                                 Default is app_name setting in newrelic.yml
    -e, --environment=name       Override the (RAILS|RUBY)_ENV setting
    -u, --user=USER              Specify the user deploying.


### PR DESCRIPTION
## Give us some context

PR https://github.com/newrelic/newrelic-ruby-agent/pull/1461 added support for deployment recording using a customer's user API key. This update was missing from the document.