### PR TITLE
Fix(Go Agent)correct pluralization of function names

### DIFF
--- a/src/content/docs/apm/agents/go-agent/instrumentation/go-agent-code-level-metrics-instrument.mdx
+++ b/src/content/docs/apm/agents/go-agent/instrumentation/go-agent-code-level-metrics-instrument.mdx
@@ -26,36 +26,36 @@ defer txn.End()
 
 ### Adjusting the file path prefix [#instrument-transactions-path-prefix-clm]
 
-By default, the Go agent will report full (absolute) file pathnames for the source files referenced by code-level metrics. The [configuration guide](/docs/apm/agents/go-agent/configuration/go-agent-code-level-metrics-config) has information about how you can truncate file pathnames globally to start at your choice of directory name via the `ConfigCodeLevelMetricsPathPrefix` setting, but you may need to specify a different file pathname prefix for individual transactions. If so, just add a `WithPathPrefix` option to the transaction:
+By default, the Go agent will report full (absolute) file pathnames for the source files referenced by code-level metrics. The [configuration guide](/docs/apm/agents/go-agent/configuration/go-agent-code-level-metrics-config) has information about how you can truncate file pathnames globally to start at your choice of directory name via the `ConfigCodeLevelMetricsPathPrefixes` setting, but you may need to specify a different file pathname prefix for individual transactions. If so, just add a `WithPathPrefixes` option to the transaction:
 
 ```go
-txn := app.StartTransaction("mytransaction", newrelic.WithPathPrefix("otherproject/lib/src"))
+txn := app.StartTransaction("mytransaction", newrelic.WithPathPrefixes("otherproject/lib/src"))
 defer txn.End()
 ```
 
 This means that, for this transaction only, a source file pathname of, for example, `"/usr/src/otherproject/lib/src/main.go"` is shortened to `"otherproject/lib/src/main.go"`.
 
-If you have multiple path prefixes you wish to use, simply pass them as additional parameters to `WithPathPrefix`:
+If you have multiple path prefixes you wish to use, simply pass them as additional parameters to `WithPathPrefixes`:
 
 ```go
-txn := app.StartTransaction("mytransaction", newrelic.WithPathPrefix("otherproject/lib/src", "myproject/src"))
+txn := app.StartTransaction("mytransaction", newrelic.WithPathPrefixes("otherproject/lib/src", "myproject/src"))
 defer txn.End()
 ```
 
 ### Adjusting the function recognition heuristic's ignore prefix [#instrument-transactions-ignore-prefix-clm]
 
 By default, the Go agent contains logic to skip over functions in the call stack which are internal to the agent itself, in order to arrive at the one you are instrumenting. The [configuration guide](/docs/apm/agents/go-agent/configuration/go-agent-code-level-metrics-config)
-has information about how you can globally change this heuristic via the `ConfigCodeLevelMetricsIgnoredPrefix` setting, but you may wish to provide a custom namespace ignore prefix for a single transaction. You can do so by adding a `WithIgnoredPrefix` option to the transaction:
+has information about how you can globally change this heuristic via the `ConfigCodeLevelMetricsIgnoredPrefixes` setting, but you may wish to provide a custom namespace ignore prefix for a single transaction. You can do so by adding a `WithIgnoredPrefixes` option to the transaction:
 
 ```go
-txn := app.StartTransaction("mytransaction", newrelic.WithIgnoredPrefix("github.com/ignore/this/"))
+txn := app.StartTransaction("mytransaction", newrelic.WithIgnoredPrefixes("github.com/ignore/this/"))
 defer txn.End()
 ```
 
-You can specify multiple string arguments to `WithIgnoredPrefix` if there are multiple packages whose functions should be ignored:
+You can specify multiple string arguments to `WithIgnoredPrefixes` if there are multiple packages whose functions should be ignored:
 
 ```go
-txn := app.StartTransaction("mytransaction", newrelic.WithIgnoredPrefix("github.com/ignore/this/", "github.com/ignore/that/"))
+txn := app.StartTransaction("mytransaction", newrelic.WithIgnoredPrefixes("github.com/ignore/this/", "github.com/ignore/that/"))
 defer txn.End()
 ```
 


### PR DESCRIPTION
Go agent release 3.20.1 corrects pluralization of some method function names. This updates the docs to match.