### PR TITLE
Distributed tracing: Reverse planning sections and fix links (Publish on 11/18/2022)

### DIFF
--- a/src/content/docs/distributed-tracing/concepts/distributed-tracing-planning-guide.mdx
+++ b/src/content/docs/distributed-tracing/concepts/distributed-tracing-planning-guide.mdx
@@ -19,27 +19,27 @@ import distributedtracingTraceNameChangeUI from 'images/distributed-tracing_scre
 
 import distributedtracingDistributedTracingRollout from 'images/distributed-tracing_diagram_distributed-tracing-rollout.png'
 
-Distributed tracing is enabled by default in many of our products, but if you are planning on rolling this out in a large distributed system, we recommend you review the [planning](#rollout) steps below.
+Distributed tracing is enabled by default in many of our products, but if you're planning on rolling this out in a large distributed system, we recommend you review the [planning](#rollout) steps below.
 
-Also, if you have been using older versions of the APM agents and have not been using distributed tracing, we recommend you review [Impact to APM features](#changes) before you roll out distributed tracing.
+Also, if you've been using older versions of the APM agents and have not been using distributed tracing, we recommend you review [Impact to APM features](#changes) before you roll out distributed tracing.
 
 ## Plan your rollout [#rollout]
 
 If you're enabling distributed tracing for a large distributed system, here are some tips:
 
-* If you are a current APM user, see [Impact to APM features](/docs/apm/distributed-tracing/getting-started/transition-guide-distributed-tracing).
+* If you're a current APM user, see [Impact to APM features](#changes).
 * Determine the requests that are the most important for your business, or the most likely to require analysis and troubleshooting, and [enable distributed tracing](#enable) for those services. Enable tracing for services at roughly the same time so you can more easily gauge how complete your end-to-end traces are.
 * When you look at traces in the [distributed tracing UI](/docs/apm/distributed-tracing/ui-data/understand-use-distributed-tracing-data), you'll see spans in the trace for external calls to other services. Then, you can [enable distributed tracing](#enable) for any of those services you want. If a service is fairly standalone and not often used in context with other services, you may not want to enable distributed tracing for it.
 
   Here's a visual representation of such a phased roll-out:
 
   <img
-    title="distributed-tracing-roll-out-strategy-image.png"
+    title="Diagram showing a roll-out strategy for distributed tracing."
     alt="Diagram showing a roll-out strategy for distributed tracing."
     src={distributedtracingDistributedTracingRollout}
   />
-* If you are using APM for a large, monolithic service, there may be many sub-process spans per trace and [APM limits](/docs/understand-use-distributed-tracing-data#rules-limits) may result in fewer traces than expected. You can solve this by using APM agent instrumentation to disable the reporting of unimportant data.
-* Distributed tracing works by [propagating header information](/docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works#headers) from service to service in a request path. Some services may communicate through a proxy or other intermediary service that does not automatically propagate the header. In that case, you will need to configure that proxy so that it allows the `newrelic` header value to be propagated from source to destination.
+* If you're using APM for a large, monolithic service, there may be many sub-process spans per trace and [APM limits](/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui/#rules-limits) may result in fewer traces than expected. You can solve this by using APM agent instrumentation to disable the reporting of unimportant data.
+* Distributed tracing works by [propagating header information](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works/#headers) from service to service in a request path. Some services may communicate through a proxy or other intermediary service that does not automatically propagate the header. In that case, you need to configure that proxy so that it allows the `newrelic` header value to be propagated from source to destination.
 
 ## Impact to APM features [#changes]
 

--- a/src/content/docs/distributed-tracing/concepts/distributed-tracing-planning-guide.mdx
+++ b/src/content/docs/distributed-tracing/concepts/distributed-tracing-planning-guide.mdx
@@ -19,7 +19,27 @@ import distributedtracingTraceNameChangeUI from 'images/distributed-tracing_scre
 
 import distributedtracingDistributedTracingRollout from 'images/distributed-tracing_diagram_distributed-tracing-rollout.png'
 
-If you are new to New Relic distributed tracing, we recommend you read the following before you enable distributed tracing.
+Distributed tracing is enabled by default in many of our products, but if you are planning on rolling this out in a large distributed system, we recommend you review the [planning](#rollout) steps below.
+
+Also, if you have been using older versions of the APM agents and have not been using distributed tracing, we recommend you review [Impact to APM features](#changes) before you roll out distributed tracing.
+
+## Plan your rollout [#rollout]
+
+If you're enabling distributed tracing for a large distributed system, here are some tips:
+
+* If you are a current APM user, see [Impact to APM features](/docs/apm/distributed-tracing/getting-started/transition-guide-distributed-tracing).
+* Determine the requests that are the most important for your business, or the most likely to require analysis and troubleshooting, and [enable distributed tracing](#enable) for those services. Enable tracing for services at roughly the same time so you can more easily gauge how complete your end-to-end traces are.
+* When you look at traces in the [distributed tracing UI](/docs/apm/distributed-tracing/ui-data/understand-use-distributed-tracing-data), you'll see spans in the trace for external calls to other services. Then, you can [enable distributed tracing](#enable) for any of those services you want. If a service is fairly standalone and not often used in context with other services, you may not want to enable distributed tracing for it.
+
+  Here's a visual representation of such a phased roll-out:
+
+  <img
+    title="distributed-tracing-roll-out-strategy-image.png"
+    alt="Diagram showing a roll-out strategy for distributed tracing."
+    src={distributedtracingDistributedTracingRollout}
+  />
+* If you are using APM for a large, monolithic service, there may be many sub-process spans per trace and [APM limits](/docs/understand-use-distributed-tracing-data#rules-limits) may result in fewer traces than expected. You can solve this by using APM agent instrumentation to disable the reporting of unimportant data.
+* Distributed tracing works by [propagating header information](/docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works#headers) from service to service in a request path. Some services may communicate through a proxy or other intermediary service that does not automatically propagate the header. In that case, you will need to configure that proxy so that it allows the `newrelic` header value to be propagated from source to destination.
 
 ## Impact to APM features [#changes]
 
@@ -77,24 +97,6 @@ We may provide backward compatibility with some or all of the affected features 
     * The [App server drill-down](/docs/mobile-monitoring/mobile-monitoring-ui/network-pages/http-requests-page#details) feature of the legacy mobile HTTP requests UI page is not available.
   </Collapser>
 </CollapserGroup>
-
-## Plan your rollout [#rollout]
-
-If you're enabling distributed tracing for a large, distributed system, here are some tips:
-
-* If you are a current APM user, see [Impact to APM features](/docs/apm/distributed-tracing/getting-started/transition-guide-distributed-tracing).
-* Determine the requests that are the most important for your business, or the most likely to require analysis and troubleshooting, and [enable distributed tracing](#enable) for those services. Enable tracing for services at roughly the same time so you can more easily gauge how complete your end-to-end traces are.
-* When you look at traces in the [distributed tracing UI](/docs/apm/distributed-tracing/ui-data/understand-use-distributed-tracing-data), you'll see spans in the trace for external calls to other services. Then, you can [enable distributed tracing](#enable) for any of those services you want. If a service is fairly standalone and not often used in context with other services, you may not want to enable distributed tracing for it.
-
-  Here's a visual representation of such a phased roll-out:
-
-  <img
-    title="distributed-tracing-roll-out-strategy-image.png"
-    alt="Diagram showing a roll-out strategy for distributed tracing."
-    src={distributedtracingDistributedTracingRollout}
-  />
-* If you are using APM for a large, monolithic service, there may be many sub-process spans per trace and [APM limits](/docs/understand-use-distributed-tracing-data#rules-limits) may result in fewer traces than expected. You can solve this by using APM agent instrumentation to disable the reporting of unimportant data.
-* Distributed tracing works by [propagating header information](/docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works#headers) from service to service in a request path. Some services may communicate through a proxy or other intermediary service that does not automatically propagate the header. In that case, you will need to configure that proxy so that it allows the `newrelic` header value to be propagated from source to destination.
 
 ## Enable distributed tracing [#enable]
 

--- a/src/content/docs/distributed-tracing/infinite-tracing/infinite-tracing-configure-trace-observer-monitoring.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/infinite-tracing-configure-trace-observer-monitoring.mdx
@@ -30,17 +30,19 @@ When you enable monitoring, the trace observer metrics can be written to any acc
 
 ## Enable trace observer monitoring [#enable-monitoring]
 
-You can turn on trace observer monitoring by clicking a toggle in the New Relic Edge app. As soon as you enable trace observer monitoring, trace observer metrics are captured and displayed in the app or you can view them in query builder. Trace observer metrics are not retroactive and are only captured when trace observer monitoring is enabled.
+You can turn on trace observer monitoring by clicking a toggle in the New Relic UI. As soon as you enable trace observer monitoring, trace observer metrics are captured and displayed in the app or you can view them in query builder. Trace observer metrics are not retroactive and are only captured when trace observer monitoring is enabled.
 
-1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Apps > Your apps > New Relic Edge**.
-2. Use the account selector to choose the account you'll use for trace observer metrics.
-3. To enable, click the **Trace observer monitoring** toggle.
+To enable trace observer monitoring:
+
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > All capabilities > Infinite Tracing settings**.
+2. Confirm that you're in the the account where you want to record trace observer metrics.
+3. Click the **Trace observer monitoring** toggle.
 
 ## Switch trace observer monitoring accounts [#switch-accounts]
 
 If you decide at some point that you want to change which account receives the trace observer metrics, you can do this in the Infinite Tracing settings app.
 
-1. Go to **Apps > Your apps > Infinite Tracing settings**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > All capabilities > Infinite Tracing settings**.
 2. Use the account selector to switch to the account where you want trace observer metrics written.
 3. Click the toggle to disable trace observer monitoring.
 4. Click the toggle to re-enable trace observer monitoring in the current account.

--- a/src/content/docs/distributed-tracing/infinite-tracing/infinite-tracing-configure-trace-observer-monitoring.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/infinite-tracing-configure-trace-observer-monitoring.mdx
@@ -92,12 +92,12 @@ When you turn on trace observer monitoring, trace observer metrics are added to 
 
   **How many traces were kept?** (top chart):
 
-  ```
+  ```sql
   FROM Metric SELECT sum(monitoring.trace.opened.session.count) AS 'Traces seen', sum(monitoring.trace.sampled.count) AS 'Traces kept' WHERE account = <var>INSERT_THE_MONITORING_ACCOUNT_ID</var> TIMESERIES
   ```
 
   **Which traces were kept?** (bottom chart):
 
-  ```
+  ```sql
   FROM Metric SELECT sum(monitoring.trace.sampled.count) WHERE account = <var>INSERT_THE_MONITORING_ACCOUNT_ID</var> AND newRelic.traceFilter.type IS NOT NULL FACET newRelic.traceFilter.type LIMIT 3 TIMESERIES
   ```

--- a/src/content/docs/distributed-tracing/infinite-tracing/infinite-tracing-configure-trace-observer-monitoring.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/infinite-tracing-configure-trace-observer-monitoring.mdx
@@ -16,7 +16,7 @@ import distributedtracingTraceMonitoringToggle from 'images/distributed-tracing_
 
 import distributedtracingHowManyTracesKept from 'images/distributed-tracing_screenshot-crop_how-many-traces-kept.png'
 
-The Infinite Tracing settings app (formerly called "New Relic Edge") offers trace observer monitoring so you can get additional insights into the sampling behavior of the trace observer. This optional feature shows you the amount of traces seen and kept by the trace observer. The trace observer metrics are written to the account you choose and available to view in the New Relic Edge app or in our query builder.
+Infinite Tracing (formerly called "New Relic Edge") offers trace observer monitoring so you can get additional insights into the sampling behavior of the trace observer. This optional feature shows you the amount of traces seen and kept by the trace observer. The trace observer metrics are written to the account you choose and available to view in Infinite Tracing settings or in our query builder.
 
 When you enable monitoring, the trace observer metrics can be written to any account in your New Relic account hierarchy. This allows you to control the visibility of the metrics. Before you turn it on, you need to decide which account should receive the trace observer metrics.
 
@@ -40,7 +40,7 @@ To enable trace observer monitoring:
 
 ## Switch trace observer monitoring accounts [#switch-accounts]
 
-If you decide at some point that you want to change which account receives the trace observer metrics, you can do this in the Infinite Tracing settings app.
+If you decide at some point that you want to change which account receives the trace observer metrics, you can do this in Infinite Tracing settings.
 
 1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > All capabilities > Infinite Tracing settings**.
 2. Use the account selector to switch to the account where you want trace observer metrics written.
@@ -53,19 +53,19 @@ If you decide at some point that you want to change which account receives the t
 
 ## View trace observer metrics [#view-metrics]
 
-Anyone with access to the monitoring account can view the trace observer metrics in the Edge app or in our query builder.
+Anyone with access to the monitoring account can view the trace observer metrics in Infinite Tracing settings or in our query builder.
 
-If you don't have access to the monitoring account, you can't see any trace observer metrics in the Infinite Tracing settings app or execute NRQL queries on these metrics. Here's what you see if you don't have access:
+If you don't have access to the monitoring account, you can't see any trace observer metrics in Infinite Tracing settings or execute NRQL queries on these metrics. Here's what you see if you don't have access:
 
 <img
-  title="trace_observer_monitoring_no_access.png"
-  alt="Screenshot showing what appears in the Edge app if you don't have access to the monitoring account that is receiving metrics."
+  title="Screenshot showing what appears in Infinite Tracing settings if you don't have access to the monitoring account that is receiving metrics."
+  alt="Screenshot showing what appears in Infinite Tracing if you don't have access to the monitoring account that is receiving metrics."
   src={distributedtracingTraceMonitoringToggle}
 />
 
-### View in Infinite Tracing settings app [#view-in-edge]
+### View metrics in Infinite Tracing settings [#view-in-edge]
 
-When you turn on trace observer monitoring, trace observer metrics are added to the Infinite Tracing settings app:
+When you turn on trace observer monitoring, trace observer metrics are displayed in Infinite Tracing settings:
 
 * Two columns are added to the main trace observer listing:
   * **Traces Seen**: How many traces were seen by the trace observer in the last 60 minutes.
@@ -81,23 +81,24 @@ When you turn on trace observer monitoring, trace observer metrics are added to 
     * Span attribute filters (traces with errors or other attributes you specify)
 
     <img
-      title="which_traces_kept.png"
+      title="Screenshot of graph showing which traces were kept."
       alt="Screenshot of graph showing which traces were kept."
       src={distributedtracingHowManyTracesKept}
     />
 
-  ### View in query builder
+### View in query builder
 
-  If you prefer a programmatic way to view the metrics, here are some examples of NRQL queries. These examples replicate the two charts in the Edge app:
+If you prefer a programmatic way to view the metrics, here are some examples of NRQL queries. These examples replicate the two charts from Infinite Tracing settings:
 
-  **How many traces were kept?** (top chart):
 
-  ```sql
-  FROM Metric SELECT sum(monitoring.trace.opened.session.count) AS 'Traces seen', sum(monitoring.trace.sampled.count) AS 'Traces kept' WHERE account = <var>INSERT_THE_MONITORING_ACCOUNT_ID</var> TIMESERIES
-  ```
+**How many traces were kept?** (top chart):
 
-  **Which traces were kept?** (bottom chart):
+```sql
+FROM Metric SELECT sum(monitoring.trace.opened.session.count) AS 'Traces seen', sum(monitoring.trace.sampled.count) AS 'Traces kept' WHERE account = <var>INSERT_THE_MONITORING_ACCOUNT_ID</var> TIMESERIES
+```
 
-  ```sql
-  FROM Metric SELECT sum(monitoring.trace.sampled.count) WHERE account = <var>INSERT_THE_MONITORING_ACCOUNT_ID</var> AND newRelic.traceFilter.type IS NOT NULL FACET newRelic.traceFilter.type LIMIT 3 TIMESERIES
-  ```
+**Which traces were kept?** (bottom chart):
+
+```sql
+FROM Metric SELECT sum(monitoring.trace.sampled.count) WHERE account = <var>INSERT_THE_MONITORING_ACCOUNT_ID</var> AND newRelic.traceFilter.type IS NOT NULL FACET newRelic.traceFilter.type LIMIT 3 TIMESERIES
+```

--- a/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
@@ -32,7 +32,7 @@ Complete the trace observer setup up that fits your types of data sources (servi
 
 To create a new trace observer if you're using New Relic APM agents or third-party integrations:
 
-1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Apps**, and then under **Your apps**, click **Infinite Tracing settings**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > All capabilities > Infinite Tracing settings**.
 
 2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled. If you can't add an observer, it's likely because we allow only [one observer per region, per account family](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works/#infinite-architecture).
 
@@ -178,7 +178,7 @@ If you already created a trace observer while setting up another type of service
 
 If you haven't already set up a trace observer, complete the following:
 
-1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Apps**, and then under **Your apps**, click **Infinite Tracing settings**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > All capabilities > Infinite Tracing settings**.
 
 2. Select an account in the upper-left dropdown. If you have access to multiple accounts, make sure you're in the account where you want Infinite Tracing enabled. If you can't add an observer, it's likely because we allow only [one observer per region, per account family](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works/#infinite-architecture).
 
@@ -342,7 +342,7 @@ The procedure below is for using the New Relic UI, but if you prefer a programma
 
 To finish the configuration for browser, mobile, and Lambda in the UI:
 
-1. Return to the trace observer app (**[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Apps > Your Apps > Infinite Tracing settings**).
+1. Return to the trace observer app (**[one.newrelic.com](https://one.newrelic.com/all-capabilities) > All capabilities > Infinite Tracing settings**).
 
 2. For your trace observer, go to the end of the row, click the three dots, and then click **Edit mobile, browser, lambda sources**.
 

--- a/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
+++ b/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
@@ -729,4 +729,4 @@ To ensure FedRAMP compliance for data sent via the [Trace API](/docs/distributed
 Notes about FedRAMP compliance for other trace data:
 
 * Trace data is reported by some of our agents for APM, infrastructure monitoring, browser monitoring, and mobile monitoring. To enable FedRAMP compliance for trace data, follow the procedures for the [applicable agent](#agents).
-* To enable FedRAMP compliance for [Infinite Tracing](/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing/), create a new FedRAMP-compliant trace observer from the [New Relic Edge app](https://one.newrelic.com/launcher/mtb-nerdlets.edge-launcher).
+* To enable FedRAMP compliance for [Infinite Tracing](/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing/), create a new FedRAMP-compliant trace observer in [Infinite Tracing settings](https://one.newrelic.com/launcher/mtb-nerdlets.edge-launcher).


### PR DESCRIPTION
I am not in the office, but could someone review this and get it published on 11/18/2022? We have already had some customers stumbling over these navigation links.