### PR TITLE
fix(codeowners): add kevin remove john

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,4 @@ gatsby-config.js @newrelic/docs-engineering
 
 # Whats new files (pings individual project marketing managers)
 
-/src/content/whats-new/ @jkinmonth @john-withers @aalfano7
+/src/content/whats-new/ @kupsand @john-withers @aalfano7


### PR DESCRIPTION
Removes John Kinmouth from What's New codeowners and adds Kevin Downs instead