### PR TITLE
bug: correct infinte tracing location in NR1

### DIFF
--- a/src/content/docs/distributed-tracing/infinite-tracing/infinite-tracing-configure-trace-observer-monitoring.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/infinite-tracing-configure-trace-observer-monitoring.mdx
@@ -32,7 +32,7 @@ When you enable monitoring, the trace observer metrics can be written to any acc
 
 You can turn on trace observer monitoring by clicking a toggle in the New Relic Edge app. As soon as you enable trace observer monitoring, trace observer metrics are captured and displayed in the app or you can view them in query builder. Trace observer metrics are not retroactive and are only captured when trace observer monitoring is enabled.
 
-1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Apps > All capabilities > Infinite Tracing settings**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/) > [All capabilities](https://one.newrelic.com/all-capabilities) > Infinite Tracing settings**.
 2. Use the account selector to choose the account you'll use for trace observer metrics.
 3. To enable, click the **Trace observer monitoring** toggle.
 
@@ -40,7 +40,7 @@ You can turn on trace observer monitoring by clicking a toggle in the New Relic 
 
 If you decide at some point that you want to change which account receives the trace observer metrics, you can do this in the Infinite Tracing settings app.
 
-1. Go to **Apps > All capabilities > Infinite Tracing settings**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/) > [All capabilities](https://one.newrelic.com/all-capabilities) > Infinite Tracing settings**.
 2. Use the account selector to switch to the account where you want trace observer metrics written.
 3. Click the toggle to disable trace observer monitoring.
 4. Click the toggle to re-enable trace observer monitoring in the current account.

--- a/src/content/docs/distributed-tracing/infinite-tracing/infinite-tracing-configure-trace-observer-monitoring.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/infinite-tracing-configure-trace-observer-monitoring.mdx
@@ -32,7 +32,7 @@ When you enable monitoring, the trace observer metrics can be written to any acc
 
 You can turn on trace observer monitoring by clicking a toggle in the New Relic Edge app. As soon as you enable trace observer monitoring, trace observer metrics are captured and displayed in the app or you can view them in query builder. Trace observer metrics are not retroactive and are only captured when trace observer monitoring is enabled.
 
-1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Apps > Your apps > New Relic Edge**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Apps > All capabilities > Infinite Tracing settings**.
 2. Use the account selector to choose the account you'll use for trace observer metrics.
 3. To enable, click the **Trace observer monitoring** toggle.
 
@@ -40,7 +40,7 @@ You can turn on trace observer monitoring by clicking a toggle in the New Relic 
 
 If you decide at some point that you want to change which account receives the trace observer metrics, you can do this in the Infinite Tracing settings app.
 
-1. Go to **Apps > Your apps > Infinite Tracing settings**.
+1. Go to **Apps > All capabilities > Infinite Tracing settings**.
 2. Use the account selector to switch to the account where you want trace observer metrics written.
 3. Click the toggle to disable trace observer monitoring.
 4. Click the toggle to re-enable trace observer monitoring in the current account.
@@ -90,12 +90,14 @@ When you turn on trace observer monitoring, trace observer metrics are added to 
 
   **How many traces were kept?** (top chart):
 
-  ```
-  FROM Metric SELECT sum(monitoring.trace.opened.session.count) AS 'Traces seen', sum(monitoring.trace.sampled.count) AS 'Traces kept' WHERE account = <var>INSERT_THE_MONITORING_ACCOUNT_ID</var> TIMESERIES
+  ```sql
+  FROM Metric SELECT sum(monitoring.trace.opened.session.count) AS 'Traces seen', 
+  sum(monitoring.trace.sampled.count) AS 'Traces kept' WHERE account = INSERT_THE_MONITORING_ACCOUNT_ID TIMESERIES
   ```
 
   **Which traces were kept?** (bottom chart):
 
-  ```
-  FROM Metric SELECT sum(monitoring.trace.sampled.count) WHERE account = <var>INSERT_THE_MONITORING_ACCOUNT_ID</var> AND newRelic.traceFilter.type IS NOT NULL FACET newRelic.traceFilter.type LIMIT 3 TIMESERIES
+  ```sql
+  FROM Metric SELECT sum(monitoring.trace.sampled.count) WHERE account = INSERT_THE_MONITORING_ACCOUNT_ID 
+  AND newRelic.traceFilter.type IS NOT NULL FACET newRelic.traceFilter.type LIMIT 3 TIMESERIES
   ```


### PR DESCRIPTION
Infinite tracing was moved with the new UI and customers are getting lost. NR Edge is gone now, it's all done with _Infinite Tracing settings_, and that has moved to _All Capabilities_.

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/48165493/202509869-9f684cf6-bba1-4257-bdda-acbf96b012dd.png">
