### PR TITLE
Update docs for Ruby agent v8.13.1 (Publish on Nov 21, 2022 with morning merge)

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-eol-policy.mdx
@@ -27,6 +27,21 @@ Any versions not listed in the following table are no longer supported. Please [
   </thead>
 
   <tbody>
+
+    <tr>
+      <td>
+        v8.13.1
+      </td>
+
+      <td>
+        Nov 21, 2022
+      </td>
+
+      <td>
+        Nov 21, 2023
+      </td>
+    </tr>
+
     <tr>
       <td>
         v8.13.0

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8130.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8130.mdx
@@ -15,7 +15,7 @@ downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.13.0.gem'
 
   * **Support for Sidekiq v7.0**
 
-    Sidekiq v7.0 removed Delayed Extensions and began offering client and server [middleware](https://github.com/mperham/sidekiq/blob/main/docs/middleware.md) classes to inherit from. The agent's Sidekiq instrumentation has been updated accordingly. The agent's behavior when used with older Sidekiq versions will remain unaffected. [PR#1615](https://github.com/newrelic/newrelic-ruby-agent/pull/1615)
+    Sidekiq v7.0 removed Delayed Extensions and began offering client and server [middleware](https://github.com/mperham/sidekiq/blob/main/docs/middleware.md) classes to inherit from. The agent's Sidekiq instrumentation has been updated accordingly. The agent's behavior when used with older Sidekiq versions will remain unaffected. [PR#1615](https://github.com/newrelic/newrelic-ruby-agent/pull/1615) **NOTE:** an issue was discovered with Sidekiq v7.0+ and addressed by Ruby agent v8.13.1. If you are using Sidekiq, please skip Ruby agent v8.13.0 and use v8.13.1 or above.
 
   * **Support for Rack v3.0: Rack::Builder#new accepting a block**
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8131.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8131.mdx
@@ -1,0 +1,19 @@
+---
+subject: Ruby agent
+releaseDate: '2022-11-21'
+version: 8.13.1
+downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.13.1.gem'
+---
+
+  ## v8.13.1
+
+  Version 8.13.1 of the agent provides a bugfix for Redis v5.0 instrumentation.
+
+  * **Fix NoMethodError when using Sidekiq v7.0 with Redis Client v0.11**
+
+    In some cases, the `RedisClient` object cannot directly access methods like db, port, or path. These methods are always available on the `client.config` object. This raised a `NoMethodError` in environments that used Sidekiq v7.0 and [Redis Client](https://rubygems.org/gems/redis-client) v0.11. Thank you to [fcheung](https://github.com/fcheung) and [@stevenou](https://github.com/stevenou) for bringing this to our attention! [Issue#1639](https://github.com/newrelic/newrelic-ruby-agent/issues/1639)
+
+
+## Support statement
+
+New Relic recommends that you upgrade the Ruby agent regularly and at a minimum of every 3 months. As of this release, the oldest supported version is [6.8.0.359](https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-680360).


### PR DESCRIPTION
Update docs for Ruby agent release v8.13.1. 

**NOTE**: Please merge on Monday, November 21, 2022 (This can go out with the typical morning merge around 9:00 am pacific time)