### PR TITLE
Fix DagsHub link (Publish on 11/18/2022)

### DIFF
--- a/src/content/docs/mlops/integrations/dagshub-mlops-integration.mdx
+++ b/src/content/docs/mlops/integrations/dagshub-mlops-integration.mdx
@@ -23,7 +23,7 @@ In order to receive data from DagsHub into New Relic, you need your account numb
 2. **Click on DagsHub:** Type DagsHub in the search bar.
 3. **Select the account ID** you want DagsHub to integrate with.
 4. **Create an access token**: Once you've selected an account ID, under **real-time training metrics**, click **Create an API key** . This will be your new telemetry API key. Keep the New Relic page open for future steps.
-5. **[Log into the DagsHub portal:](https://dagshub.com/user/login)** Once logged in, select the repository you're working on. Click **Settings**, and select the **integrations** button from the left hand menu. Click on the **New Relic** tile.
+5. **Log into the DagsHub portal:** Once you're logged in, select the repository you're working on. Click **Settings**, and select the **integrations** button from the left-hand menu. Click on the **New Relic** tile. To learn how to create a project with real-time experiment monitoring, please read the [DagsHub MLflow documentation page](https://dagshub.com/docs/integration_guide/mlflow_tracking/).
 6. **Copy and paste the token in DagsHub**. Go back to the New Relic integration dashboard and copy the token you created by clicking on the **copy** icon next to the insert key. On the DagsHub’s portal, paste the insert key under **New Relic Insight insert key**, and finish by clicking **Next**. The token will be verified, and a confirmation screen will appear.
 
 <InstallFeedback />
@@ -32,7 +32,7 @@ In order to receive data from DagsHub into New Relic, you need your account numb
 
 Once you configure the New Relic integration in DagsHub, all the training metrics logged to DagsHub in real time are sent to New Relic.
 
-1. Go to the **DagsHub integration dashboard**: Once you’ve tested your tokens and confirmed the integration is set up correctly, return to the New Relic integration dashboard and click on **See your data**. You will be redirected to an automatically generated New Relic dashboard powered by DagsHub.
+1. Go to the **DagsHub integration dashboard**: Once you've tested your tokens and confirmed the integration is set up correctly, return to the New Relic integration dashboard and click on **See your data**. You will be redirected to an automatically generated New Relic dashboard powered by DagsHub.
 2. **Analyze the DagsHub dashboard**: The DagsHub dashboard contains one chart, **Loss metric by repository**, which displays the loss of your models, grouped by their respective repository. It works for any models that you have trained.
 
 <img


### PR DESCRIPTION
This is a replacement for https://github.com/newrelic/docs-website/pull/9300/files because we weren't able to get a signed CLA.