### PR TITLE
chore(.NET): Clarify custom metric naming NR-65573

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/incrementcounter-net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/incrementcounter-net-agent-api.mdx
@@ -32,7 +32,7 @@ Compatible with all app types.
 Increment the counter for a [custom metric](/docs/agents/manage-apm-agents/agent-metrics/custom-metrics) by 1. To view these custom metrics, use the [query builder](/docs/query-your-data/explore-query-data/query-builder/use-advanced-nrql-mode-specify-data) to search metrics and create customizable charts. See also [`RecordMetric()`](/docs/agents/net-agent/net-agent-api/recordmetric-net-agent) and [`RecordResponseTimeMetric()`](/docs/agents/net-agent/net-agent-api/recordresponsetimemetric-net-agent).
 
 <Callout variant="important">
-  When creating a custom metric, start the name with `Custom/` (for example, `Custom/MyMetric`).
+  When creating a custom metric, start the name with `Custom/` (for example, `Custom/MyMetric`). For more on naming, see [Collect custom metrics](/docs/apm/agents/manage-apm-agents/agent-data/collect-custom-metrics/).
 </Callout>
 
 ## Parameters
@@ -68,5 +68,5 @@ Increment the counter for a [custom metric](/docs/agents/manage-apm-agents/agent
 ## Examples
 
 ```cs
-NewRelic.Api.Agent.NewRelic.IncrementCounter("ExampleMetric");
+NewRelic.Api.Agent.NewRelic.IncrementCounter("Custom/ExampleMetric");
 ```


### PR DESCRIPTION
Clarifies naming confusion reported in https://issues.newrelic.com/browse/NR-65573