### PR TITLE
fix(node agent): properly document how to set up request parameters

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -26,7 +26,7 @@ For more information, see the [Node.js agent configuration](/docs/agents/nodejs-
 
 The Node.js agent captures the HTTP method along with a potentially parameterized path (such as `/user/:id`) or a regular expression (such as `/^/user/([-0-9a-f]+)$/`). These pieces of information become part of the request name.
 
-If you have support for slow transaction traces and have added `'request.parameters.*'` to [`attributes.include`](/docs/agents/nodejs-agent/attributes/nodejs-agent-attributes#cfg-attributes-include) in your config file, the transaction trace will also have the request's parameters and their values attached to it. If you are dissatisfied with the request names that the Node.js agent uses, you can use API calls to create more descriptive names.
+If you have support for slow transaction traces and have added `'request.parameters.*'` to [`attributes.include`](/docs/agents/nodejs-agent/attributes/nodejs-agent-attributes#cfg-attributes-include) in your config file, the transaction trace will also have the request's parameters and their values attached. If you don't like the request names that the Node.js agent uses, you can use API calls to create more descriptive names.
 
 <Callout variant="tip">
   If grouping your requests under the generic name, then `/*` is sufficient, and you do not need to customize your configuration file or API calls.

--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -26,7 +26,7 @@ For more information, see the [Node.js agent configuration](/docs/agents/nodejs-
 
 The Node.js agent captures the HTTP method along with a potentially parameterized path (such as `/user/:id`) or a regular expression (such as `/^/user/([-0-9a-f]+)$/`). These pieces of information become part of the request name.
 
-If you have support for slow transaction traces and have enabled [`capture_params`](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#params) in your config file, the transaction trace will also have the request's parameters and their values attached to it. If you are dissatisfied with the request names that the Node.js agent uses, you can use API calls to create more descriptive names.
+If you have support for slow transaction traces and have added `'request.parameters.*'` to [`attributes.include`](/docs/agents/nodejs-agent/attributes/nodejs-agent-attributes#cfg-attributes-include) in your config file, the transaction trace will also have the request's parameters and their values attached to it. If you are dissatisfied with the request names that the Node.js agent uses, you can use API calls to create more descriptive names.
 
 <Callout variant="tip">
   If grouping your requests under the generic name, then `/*` is sufficient, and you do not need to customize your configuration file or API calls.

--- a/src/content/docs/apm/agents/nodejs-agent/attributes/nodejs-agent-attributes.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/attributes/nodejs-agent-attributes.mdx
@@ -140,7 +140,7 @@ In addition to the [default APM attributes](/docs/insights/new-relic-insights/de
     id="requestparams"
     title="Request parameters"
   >
-    Request parameters from the transaction. The Node.js agent captures GET parameters by default. In order to capture POST parameters, use the [`addCustomAttribute()`](https://newrelic.github.io/node-newrelic/docs/API.html#addCustomAttribute) Node.js agent API call.
+    Request parameters from the transaction. The Node.js agent does not capture parameters by default. All GET parameters can be captured if the `request.parameters.*` entry is added to [`attributes.include`](#cfg-attributes-include), or specific request parameters can be added to the list, for example, `request.parameters.foo` or `request.parameters.bar`. In order to capture POST parameters, use the [`addCustomAttribute()`](https://newrelic.github.io/node-newrelic/docs/API.html#addCustomAttribute) Node.js agent API call.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/apm-agent-security-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/apm-agent-security-nodejs.mdx
@@ -19,7 +19,7 @@ For more information about New Relic's security measures, see our [security and 
 
 By default, here is how the Node.js agent handles the following potentially sensitive data:
 
-* [Request parameters](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#params): The agent does not capture HTTP request parameters.
+* Request parameters: The agent does not capture HTTP request parameters. If you wish to capture all request parameters, add `'request.parameters.*'` to [`attributes.include`](/docs/agents/nodejs-agent/attributes/nodejs-agent-attributes#cfg-attributes-include) in your config file.
 * [HTTPS](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#ssl): The agent communicates with New Relic using HTTPS.
 * [SQL](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#record-sql): The agent sets SQL recording to `off`. When set to `off`, the agent does not capture slow queries and does not include backtraces or SQL in transaction traces.
 


### PR DESCRIPTION
At some point in the distant past (circa 2018) the way we capture request parameters changed, but our documentation just wasn't properly updated to reflect this. Let's finally fix this, since now, four years later, someone tried to make sense of it, failed, and told us about it.

Closes NEWRELIC-5477