### PR TITLE
fix (node agent): add noticeError example

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -801,7 +801,18 @@ New Relic's Node.js agent includes additional API calls.
     `error` should be an `Error` or one of its subtypes, but the API will handle strings and objects that have an attached `.message` or `.stack` property.
 
     `customAttributes` is an optional object of any custom attributes to be displayed in the New Relic UI.
-
+    
+    **Example:**
+    ```js
+    try {
+      performSomeTask();
+    } catch (err) {
+      newrelic.noticeError(
+        err,
+        {extraInformation: "error already handled in the application"}
+      );
+    }
+    ```
     <Callout variant="caution">
       Errors recorded using this method do not obey the [`ignore_status_codes`](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#error_ignore) configuration value.
     </Callout>


### PR DESCRIPTION
Just a simple example of the basic idea of how to use this function.

## Give us some context

* Closes #3560
* Corresponding PR for our repo and therefore the API docs at https://github.com/newrelic/node-newrelic/pull/1437/