### PR TITLE
bug: fix Env Var Reference  link

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -69,7 +69,7 @@ Here are detailed descriptions of each configuration method:
   >
     All configuration settings in `newrelic.js` have equivalent environment variables. These are useful, for example, if your agent runs in a PaaS environment such as Heroku or Microsoft Azure. Node.js agent environment variables always start with `NEW_RELIC_`.
 
-    These environment variables are documented below under individual config options as the **Environ variable**. There are also two rarely used settings that can [only be configured via environment variables](#environment-variable-overrides). If you are unsure how to specify more complex types as environment variables, [use the reference guide](#environment-variable-reference-guide).
+    These environment variables are documented below under individual config options as the **Environ variable**. There are also two rarely used settings that can [only be configured via environment variables](#environment-variable-overrides). If you are unsure how to specify more complex types as environment variables, [use the reference guide](#environment-variable-type-reference-guide).
 
     If you're using New Relic CodeStream to monitor performance from your IDE, you may also want to [associate repositories with your services](/docs/codestream/how-use-codestream/performance-monitoring#repo-association) and [associate build SHAs or release tags with errors](/docs/codestream/how-use-codestream/performance-monitoring#buildsha).
   </Collapser>


### PR DESCRIPTION
The env var reference guide was a broken link, changed it to `#environment-variable-type-reference-guide`