### PR TITLE
style(kubernetes): updating the entire page

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Kubernetes integration
   - Get started
-metaDescription: "New Relic's Kubernetes integration: features, requirements, and getting started."
+metaDescription: "Kubernetes integration into New Relic: features, requirements, and getting started."
 redirects:
   - /docs/integrations/kubernetes-integration/get-started/introduction-kubernetes-integration
   - /docs/integrations/kubernetes-integration/getting-started/getting-started
@@ -25,7 +25,9 @@ import kubernetesDashboard from 'images/kubernetes_screenshot-full_dashboard.png
 
 import kubernetesEvents from 'images/kubernetes_screenshot-full_events.gif'
 
-New Relic's Kubernetes integration gives you full observability into the health and performance of your environment, no matter whether you run Kubernetes on-premises or in the cloud. With our [cluster explorer](/docs/integrations/kubernetes-integration/cluster-explorer/kubernetes-cluster-explorer), you can cut through layers of complexity to see how your cluster is performing, from the heights of the control plane down to applications running on a single pod.
+Kubernetes is an open-source system for automating deployment, scaling, and management of containerized applications. The New Relic Kubernetes monitoring integration gives you visibility into your Kubernetes clusters and workloads in minutes, whether your clusters are hosted on-premises or in the cloud.
+
+Thanks to our [cluster explorer](/docs/integrations/kubernetes-integration/cluster-explorer/kubernetes-cluster-explorer), you can cut through layers of complexity to see how your cluster is performing, from the heights of the control plane down to applications running on a single pod.
 
 <img
 title="New Relic - Kubernetes Cluster Explorer"
@@ -34,7 +36,7 @@ src={kubernetesClusterExplorer}
 />
 
 <figcaption>
-  **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Kubernetes cluster explorer**: The cluster explorer is our powerful, fully visual answer to the challenges associated with running Kubernetes at a large scale.
+  **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > All capabilities > Kubernetes > Kubernetes cluster explorer**: The cluster explorer is our powerful, fully visual answer to the challenges associated with running Kubernetes at a large scale.
 </figcaption>
 
 You can see the power of the Kubernetes integration in the [cluster explorer](/docs/integrations/kubernetes-integration/cluster-explorer/kubernetes-cluster-explorer), where the full picture of a cluster is made available on a single screen: nodes and pods are visualised according to their health and performance, with pending and alerting nodes in the innermost circles. [Predefined alert conditions](/docs/integrations/kubernetes-integration/kubernetes-events/kubernetes-integration-predefined-alert-policy) help you troubleshoot issues right from the start. Clicking each node reveals its status and how each app is performing.
@@ -45,36 +47,13 @@ You'll be able to configure Kubernetes to suit your environment after you [creat
 
 We have an automated installer to help you with many types of installations: servers, virtual machines, and unprivileged environments. It can also help you with installations in managed services or platforms, but you'll need to review a few [preliminary notes](/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration#cloud-platforms) before getting started.
 
-Our automated installer will generate either a helm command or a set of plain manifests for you to install. Our automated installer:
+You have these options to install the Kubernetes integration:
 
-1. Allows users to select the cluster name and namespace for the installation.
-2. Allows users to selectively enable or disable bundling of Kube-state-metrics, a dependency of the Kubernetes integration.
-3. Allows users to seamlessly install our other products related to Kubernetes such as:
+* Downloading the [New Relic Kubernetes quickstart](https://newrelic.com/instant-observability/kubernetes)
 
-* Kubernetes events monitoring
-* In-cluster prometheus services monitoring
-* Service instrumentation without code changes using Pixie
+* Following the [automated and guided installer](https://one.newrelic.com/launcher/k8s-cluster-explorer-nerdlet.cluster-explorer-launcher?pane=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsInBhdGgiOiJndWlkZWQiLCJlbnYiOiJrdWJlcm5ldGVzIiwiaW5pdGlhbEFjdGlvbkluZGV4IjpudWxsLCJhY3Rpb25JbmRleCI6MX0=). See [Kubernetes integration: install and configure](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure)
 
-4. Automatically fills the required properties with the license keys the integration needs to work.
-
-<ButtonGroup>
-  <ButtonLink
-    role="button"
-    to="/docs/integrations/kubernetes-integration/installation/kubernetes-integration-install-configure"
-    variant="link"
-  >
-    Read the install docs
-  </ButtonLink>
-
-  <ButtonLink
-    data-tessen="stitchedPathLinkClick"
-    role="button"
-    to="https://one.newrelic.com/launcher/k8s-cluster-explorer-nerdlet.cluster-explorer-launcher?pane=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsInBhdGgiOiJndWlkZWQiLCJlbnYiOiJrdWJlcm5ldGVzIiwiaW5pdGlhbEFjdGlvbkluZGV4IjpudWxsLCJhY3Rpb25JbmRleCI6MX0="
-    variant="primary"
-  >
-    Start the installer
-  </ButtonLink>
-</ButtonGroup>
+* Following the installation plan using [Helm](https://onenr.io/0Y8wpoYJJQO). See [Install the Kubernetes integration using Helm](/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm)
 
 <Callout variant="tip">
   If your New Relic account [is in the EU region](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers), access the automated installer from **[one.eu.newrelic.com](http://one.eu.newrelic.com/launcher/k8s-cluster-explorer-nerdlet.cluster-explorer-launcher?pane=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5ucjEtaW5zdGFsbC1uZXdyZWxpYyIsInBhdGgiOiJndWlkZWQiLCJlbnYiOiJrdWJlcm5ldGVzIiwiaW5pdGlhbEFjdGlvbkluZGV4IjpudWxsLCJhY3Rpb25JbmRleCI6MX0=)**.
@@ -93,7 +72,7 @@ In New Relic, you can build your own charts and [query](/docs/using-new-relic/da
 />
 
 <figcaption>
-  **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Dashboards**: Using the [query builder](/docs/chart-builder/use-chart-builder/get-started/introduction-chart-builder) you can turn any query on Kubernetes data to clear visuals.
+  **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > All capabilities > Dashboards**: Using the [query builder](/docs/chart-builder/use-chart-builder/get-started/introduction-chart-builder) you can turn any query on Kubernetes data to clear visuals.
 </figcaption>
 
 With the Kubernetes integration you can also:
@@ -101,22 +80,19 @@ With the Kubernetes integration you can also:
 * [Link your APM data to Kubernetes](/docs/integrations/kubernetes-integration/link-your-applications/link-your-applications-kubernetes) to measure the performance of your web and mobile applications, with metrics such as request rate, throughput, error rate, and availability.
 * [Monitor services running on Kubernetes](/docs/integrations/kubernetes-integration/link-apps-services/monitor-services-running-kubernetes), such as Apache, NGINX, Cassandra, and many more (see our [tutorial for monitoring Redis on Kubernetes](/docs/integrations/kubernetes-integration/link-apps-services/tutorial-monitor-redis-running-kubernetes)).
 * Create new alert policies and alert conditions based on your Kubernetes data, or extend the [predefined alert conditions](/docs/integrations/kubernetes-integration/kubernetes-events/kubernetes-integration-predefined-alert-policy).
+* Navigate all your Kubernetes events. The [Kubernetes events integration](/docs/integrations/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration), which is installed separately, watches for events happening in your Kubernetes clusters and sends those events to New Relic. Events data is then visualized in the cluster explorer. To set it up, check the **Kubernetes events** box in step 3 of [our install wizard](/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration#install-wizard), or follow the [instructions](/docs/integrations/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration#install).
+
+  <img
+    title="New Relic - Kubernetes Events"
+    alt="New Relic - Kubernetes Events"
+    src={kubernetesEvents}
+  />
+
+  <figcaption>
+    **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Kubernetes cluster explorer > Events**: Browse and filter all your Kubernetes events, and dig into application logs and infrastructure data.
+  </figcaption>
 
 These features are in addition to the data New Relic already reports for [containerized processes running on instrumented hosts](/docs/infrastructure/new-relic-infrastructure/data-instrumentation/docker-instrumentation-infrastructure).
-
-## Navigate all your Kubernetes events [#navigate-events]
-
-The [Kubernetes events integration](/docs/integrations/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration), which is installed separately, watches for events happening in your Kubernetes clusters and sends those events to New Relic. Events data is then visualized in the cluster explorer. To set it up, check the **Kubernetes events** box in step 3 of [our install wizard](/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration#install-wizard), or follow the [instructions](/docs/integrations/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration#install).
-
-<img
-  title="New Relic - Kubernetes Events"
-  alt="New Relic - Kubernetes Events"
-  src={kubernetesEvents}
-/>
-
-<figcaption>
-  **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Kubernetes cluster explorer > Events**: Browse and filter all your Kubernetes events, and dig into application logs and infrastructure data.
-</figcaption>
 
 ## Bring your cluster logs to New Relic [#k8s-logs]
 


### PR DESCRIPTION
Modifying the introduction page to Kubernetes:

- Updating the intro paragraph.
- Updating the [Get started: Install the Kubernetes integration](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration#install) section.
- Adding the info that is inside the _Navigate all your Kubernetes events_ inside the _Why it matters_ section. 
- Removing the _Navigate all your Kubernetes events_ title.

This is the ticket: [NR-64587](https://issues.newrelic.com/browse/NR-64587)