### PR TITLE
Adding callout for ksm supported versions and upgrade [NR-43838]

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/changes-since-v3.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/changes-since-v3.mdx
@@ -53,6 +53,8 @@ Thus, a specific Deployment `nrk8s-ksm` now takes care of finding KSM and scrapi
 
 While a sharded KSM setup is not supported yet, this new code was built with this future improvement in mind.
 
+For more information on KSM supported versions please visit [this document](https://github.com/newrelic/helm-charts/blob/master/charts/nri-bundle/README.md#bring-your-own-ksm)
+
 <Callout variant="important">
   Cloud provider host tags, like `aws.ec2.*`, are no longer included in samples related to entities that are not strictly tied to a particular node: `K8sNamespaceSample`, `K8sDeploymentSample`, `K8sReplicasetSample`, `K8sDaemonsetSample`, `K8sStatefulsetSample`, `K8sServiceSample`, and `K8sHpaSample`.
 These tags were erroneously sourced from a single, arbitrary node in the cluster. This resulted in misleading situations such as `K8sServiceSample` having a `hostname` property, with said `hostname` being that of a node and not the service, or a `K8sDeploymentSample` having a `numCores` property with those  being from an arbitrary node in the cluster, and not the total number of cores associated to the deployment.

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
@@ -172,9 +172,9 @@ The New Relic Kubernetes integration has the following requirements:
 
 <Callout variant="important">
   From integration version 2.14.0+ only kube-state-metrics v2+ is supported.<br/>If you are using kube-state-metrics 1.9.8 or below, you can only install the kubernetes integration up to version 2.13.5.<br/><br/>
-  If updating kube-state-metrics from v1.9.8 to v2.x, we strongly recommend to check your `values.yaml` file as some names may have changed:
+  If updating kube-state-metrics from v1.9.8 to v2.x, we strongly recommend to check your `values.yaml` file as some variable may have changed:
     - [KSM v1.9.8](https://github.com/kubernetes/kube-state-metrics/blob/0f5e4969f24bfa5f7c884f66d9d6fdf6f1921c16/charts/kube-state-metrics/values.yaml)
-    - [KSM Current version](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-state-metrics/values.yaml)
+    - [KSM v2.x](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-state-metrics/values.yaml)
 </Callout>
 
 ## Container information [#containers]

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
@@ -167,8 +167,15 @@ The New Relic Kubernetes integration has the following requirements:
 
 * A New Relic account. Don't have one? [Sign up for free](https://newrelic.com/signup). No credit card required.
 * Linux distribution [compatible with New Relic infrastructure agent](/docs/infrastructure/new-relic-infrastructure/getting-started/compatibility-requirements-new-relic-infrastructure#operating-systems).
-* [`kube-state-metrics` version 1.9.8](https://github.com/kubernetes/kube-state-metrics) running on the cluster.
+* [`kube-state-metrics`](https://github.com/kubernetes/kube-state-metrics) running on the cluster.
 * When using CRI-O as the container runtime, the [processes](/attribute-dictionary/?event=ProcessSample) inside containers are not reported. Performance data is collected at the [container](/docs/integrations/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data#container-data) level.
+
+<Callout variant="important">
+  From integration version 2.14.0+ only kube-state-metrics v2+ is supported.<br/>If you are using kube-state-metrics 1.9.8 or below, you can only install the kubernetes integration up to version 2.13.5.<br/><br/>
+  If updating kube-state-metrics from v1.9.8 to v2.x, we strongly recommend to check your `values.yaml` file as some names may have changed:
+    - [KSM v1.9.8](https://github.com/kubernetes/kube-state-metrics/blob/0f5e4969f24bfa5f7c884f66d9d6fdf6f1921c16/charts/kube-state-metrics/values.yaml)
+    - [KSM Current version](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-state-metrics/values.yaml)
+</Callout>
 
 ## Container information [#containers]
 


### PR DESCRIPTION
Core Integrations will be releasing soon support for kube-state-metrics 2.x
This PR adds a callout on the requirements section to clarify which integration version support which ksm version.