### PR TITLE
chore: fix section link for TransactionEvents.MaxSamplesStored

### DIFF
--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
@@ -1361,7 +1361,7 @@ Transaction events are used in collecting events corresponding to web requests a
   </Collapser>
 
   <Collapser
-    id="transaction-events"
+    id="transaction-events-maxsamplesstored"
     title="TransactionEvents.MaxSamplesStored"
   >
     <table>


### PR DESCRIPTION
The link for `TransactionEvents.MaxSamplesStored` was linking to `TransactionEvents.Enabled`

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.