### PR TITLE
Update configure-logs-context-go.mdx

### DIFF
--- a/src/content/docs/logs/logs-context/configure-logs-context-go.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-go.mdx
@@ -102,7 +102,7 @@ writer := logWriter.New(os.Stdout, newRelicApp)
 4. Create a logger object with your new logWriter object as the logger's output destination.
 
 ```go
-logger := log.New(&writer, "", log.Default.Flags())
+logger := log.New(&writer, "", log.Default().Flags())
 ```
 
 At this point, any log written with the logger created will be handled by the go-agent based on your logging config settings.


### PR DESCRIPTION
As of go v1.19.3, logger doesn't have `Default` (struct), it has `Default()` (function).
