### PR TITLE
Merge ASAP: edit to 'job manager' doc title

### DIFF
--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/index.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/index.mdx
@@ -1,3 +1,3 @@
 ---
-subject: Job Manager
+subject: Job Manager release
 ---

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/index.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/index.mdx
@@ -1,3 +1,3 @@
 ---
-subject: Job Manager release
+subject: Job Manager
 ---

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-160.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-160.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-09-16'
-version: 160
+version: '160'
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-160.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-160.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-09-16'
-version: release-160
+version: 160
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-162.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-162.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-09-23'
-version: 162
+version: '162'
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-162.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-162.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-09-23'
-version: release-162
+version: 162
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-166.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-166.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-10-04'
-version: release-166
+version: 166
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-166.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-166.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-10-04'
-version: 166
+version: '166'
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-168.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-168.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-10-05'
-version: 168
+version: '168'
 ---
 
 

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-168.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-168.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-10-05'
-version: release-168
+version: 168
 ---
 
 

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-172.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-172.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-10-06'
-version: release-172
+version: 172
 ---
 
 ### Improvements

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-172.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-172.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-10-06'
-version: 172
+version: '172'
 ---
 
 ### Improvements

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-183.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-183.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-10-10'
-version: release-183
+version: 183
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-183.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-183.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-10-10'
-version: 183
+version: '183'
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-191.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-191.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-10-17'
-version: 191
+version: '191'
 ---
 
 ### Improvements

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-191.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-191.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-10-17'
-version: release-191
+version: 191
 ---
 
 ### Improvements

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-204.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-204.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-11-03'
-version: release-204
+version: 204
 ---
 
 ### Improvements

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-204.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-204.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-11-03'
-version: 204
+version: '204'
 ---
 
 ### Improvements

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-206.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-206.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-11-10'
-version: 206
+version: '206'
 ---
 
 ### Fixes

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-206.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-206.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Job Manager
 releaseDate: '2022-11-10'
-version: release-206
+version: 206
 ---
 
 ### Fixes


### PR DESCRIPTION

## Give us some context

* What problems does this PR solve?
 Change the job manager title to work around the `v` that gets added by the  `version #`