### PR TITLE
new(apm no stack traces): new doc

### DIFF
--- a/src/content/docs/apm/agents/apm-no-stack-traces.mdx
+++ b/src/content/docs/apm/agents/apm-no-stack-traces.mdx
@@ -20,7 +20,7 @@ Depending on the situation, you may find [error traces](/docs/apm/applications-m
 Depending on the situation, follow these troubleshooting procedures.
 
 <CollapserGroup>
-    <Collapser
+  <Collapser
     id="Caps on error reporting"
     title="Caps on error reporting"
   >
@@ -29,7 +29,7 @@ Depending on the situation, follow these troubleshooting procedures.
 
     * 100 events per minute per agent instance
     * 20 trace details per minute per agent instance
-
+    </Collapser>
     <Collapser
     id="Handled exceptions"
     title="Handled exceptions"

--- a/src/content/docs/apm/agents/apm-no-stack-traces.mdx
+++ b/src/content/docs/apm/agents/apm-no-stack-traces.mdx
@@ -1,0 +1,51 @@
+---
+title: No stack traces 
+type: troubleshooting
+tags:
+  - Agents
+  - Java agent
+  - Troubleshooting
+metaDescription: Troubleshooting steps for situations when stack traces are missing for error traces with your New Relic Java app.
+redirects:
+---
+
+PLACEHOLDER TEMPLATE FOR CREATING A GENERAL 'NO STACK TRACES' DOC FOR APM THAT ISN'T LANGUAGE-AGENT-SPECIFIC 
+
+## Problem
+
+Depending on the situation, you may find [error traces](/docs/apm/applications-menu/error-analytics/error-analytics-manage-error-traces) in the APM UI that do not include stack traces for your Java app.
+
+## Solution
+
+Depending on the situation, follow these troubleshooting procedures.
+
+<CollapserGroup>
+  <Collapser
+    id="repeated-errors"
+    title="No stack traces for rapidly repeated errors"
+  >
+    When an error is thrown in a rapidly repeated sequence, the Java compiler may optimize the stack trace away to help performance. To disable this optimization: In your JVM flags, include:
+
+    ```
+    -XX:-OmitStackTraceInFastThrow
+    ```
+  </Collapser>
+
+  <Collapser
+    id="500-errors"
+    title="No stack traces for 500 errors"
+  >
+    This is [normal behavior](#cause) for how the Java agent handles 500 errors. To force stack traces to be reported, call the New Relic Java API from your own code. Running the `NewRelic.noticeError (Throwable t)` method will cause an error to be reported along with the stack backtrace represented by the `Throwable`. For more information about this method and its overloads, see New Relic's [Java agent API on GitHub.](https://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/NewRelic.html#noticeError-java.lang.Throwable-)
+  </Collapser>
+</CollapserGroup>
+
+## Cause
+
+Returning a `500` error means that the application server itself detected an error and set the HTTPS `500` status code.
+
+* If the error condition was detected and handled by application logic, there was no exception object and thus, no stack.
+* If there was an exception object at some point, but it was handled internally by the application code that set the `500` status on the response, then the exception never became visible to the Java agent. There is no stack available for the Java agent to report.
+
+When stack traces are reported, the error results from an exception that was not caught and handled within the application server logic. The Java agent sees the unhandled exception during a monitored transaction, so it reports the stack trace.
+
+However, no stack traces appear for the `500` errors because the application server is handling the errors and then setting the status code. The application code itself does not retain any stack traces.

--- a/src/content/docs/apm/agents/apm-no-stack-traces.mdx
+++ b/src/content/docs/apm/agents/apm-no-stack-traces.mdx
@@ -20,7 +20,6 @@ Depending on the situation, you may find [error traces](/docs/apm/applications-m
 Depending on the situation, follow these troubleshooting procedures.
 
 <CollapserGroup>
-
     <Collapser
     id="Caps on error reporting"
     title="Caps on error reporting"
@@ -38,12 +37,13 @@ Depending on the situation, follow these troubleshooting procedures.
     Our APM agents automatically report errors for unhandled exceptions. In situations where application logic handles the error, our APM agent may miss the error, and won't report a stack trace.
 
     You can use the `notice_error()` [agent-specific API](docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected) to record handled exceptions.
-
+</Collapser>
     <Collapser
     id="Ignored errors"
     title="Errors are ignored"
   >
     If you configured errors to be [ignored](docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected), the stack trace will not be avilable
+</Collapser>
 
     <Collapser
     id="500-errors"
@@ -55,7 +55,8 @@ Depending on the situation, follow these troubleshooting procedures.
     * If there was an exception object at some point, but it was handled internally by the application code that set the `500` status on the response, then the exception never became visible to the agent. There is no stack available for the agent to report.
 
     When stack traces are reported, the error results from an exception that was not caught and handled within the application server logic. The agent sees the unhandled exception during a monitored transaction, so it reports the stack trace.
- 
+ </Collapser>
+
 </CollapserGroup>
 
 ## Agent specific behavior for missing stack traces


### PR DESCRIPTION
A template for new general APM category 'No stack traces' doc, that will be useful for all language agents. This was requested by someone in documentation slack channel. 