### PR TITLE
chore: add syntax highlighting

### DIFF
--- a/src/content/docs/apm/agents/net-agent/troubleshooting/no-data-appears-after-disabling-tls-10.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/no-data-appears-after-disabling-tls-10.mdx
@@ -63,7 +63,7 @@ To enable a specific TLS version protocol:
 
     1. Copy and paste the following into a file:
 
-       ```
+       ```ini
        Windows Registry Editor Version 5.00
 
        [HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2]
@@ -99,7 +99,7 @@ To enable a specific TLS version protocol:
 
         1. Copy and paste the following into a file:
 
-           ```
+           ```ini
            Windows Registry Editor Version 5.00
 
            [HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\.NETFramework\v4.0.30319] 
@@ -118,7 +118,7 @@ To enable a specific TLS version protocol:
       >
         You can change .NET's default security protocols by modifying your application's source code. The following command enables TLS 1.2, 1.1, and 1.0 as default protocols for your application. It's a global setting and should be set early in your application's start-up. You can modify it to enable the specific protocols you want.
 
-        ```
+        ```cs
         System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
         ```
       </Collapser>


### PR DESCRIPTION
`reg` files use the same syntax highlighting as `ini` in Notepad++. `ini` highlighting was added to the docs site recently so this should colorize properly..
