### PR TITLE
chore: net-ping is no longer a supported module for Chrome 100

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/manage-monitor-runtimes.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/manage-monitor-runtimes.mdx
@@ -438,7 +438,6 @@ The browser runtime is used for these monitor types:
       * [ldapauth-fork](https://www.npmjs.com/package/ldapauth-fork) 5.0.1
       * [lodash](https://lodash.com/) 4.17.21
       * [moment](http://momentjs.com/) 2.29.1
-      * [net-ping](https://www.npmjs.com/package/net-ping) 1.2.3
       * [net-snmp](https://www.npmjs.com/package/net-snmp) 3.5.5
       * [Nodemailer](https://www.npmjs.com/package/nodemailer) 6.4.13
       * [nodejs-traceroute](https://github.com/zulhilmizainuddin/nodejs-traceroute) 1.2.0


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Net-Ping is no longer a supported module in the Chrome 100 runtime hence this PR is to update the docs to show that. Here a link to the Jira Ticket in our sprint that explains why we are doing this: [NR-65559](https://issues.newrelic.com/browse/NR-65559)
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.