### PR TITLE
chore: update list of modules

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs.mdx
@@ -18,11 +18,13 @@ Our plugin records overall timings for queries and uses [distributed tracing](/d
 
 The New Relic plugin works with the following Apollo Server modules:
 
+* `@apollo/server`
 * `apollo-server` (>= 2.14)
 * `apollo-server-express`
 * `apollo-server-hapi`
 * `apollo-server-koa`
 * `apollo-server-fastify`
+* `apollo-server-lambda`
 
 Because `fastify` is not fully instrumented in the Node.js agent, transactions are prefixed with `WebTransaction\Nodejs`.
 


### PR DESCRIPTION
The list of modules was missing a few listed in this plugin's github README, so I added them: https://github.com/newrelic/newrelic-node-apollo-server-plugin
\