### PR TITLE
chore: add release notes for minion 3.0.70 and node-browser-runtime 1.1.70

### DIFF
--- a/src/content/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3070.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3070.mdx
@@ -1,0 +1,9 @@
+---
+subject: Containerized private minion (CPM)
+releaseDate: '2022-11-29'
+version: 3.0.70
+---
+
+### Fixes
+
+* Updated lodash version to address CVE-2019-10744

--- a/src/content/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3071.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/containerized-private-minions-release-notes/containerized-private-minion-cpm-3071.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Containerized private minion (CPM)
 releaseDate: '2022-11-29'
-version: 3.0.70
+version: 3.0.71
 ---
 
 ### Fixes

--- a/src/content/docs/release-notes/synthetics-release-notes/node-browser-runtime-release-notes/node-browser-runtime-1.1.70.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/node-browser-runtime-release-notes/node-browser-runtime-1.1.70.mdx
@@ -1,0 +1,8 @@
+---
+subject: Node browser runtime
+releaseDate: '2022-11-29'
+version: 1.1.70
+---
+
+### Fixes
+* Removed support for net-ping module


### PR DESCRIPTION

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve? Adds release notes for synthetics services that were released today.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
Today we released CPM 3.0.70 and node-browser-runtime 1.1.70
* If your issue relates to an existing GitHub issue, please link to it.