### PR TITLE
Update theme version to 6.13.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "6.13.5",
+    "@newrelic/gatsby-theme-newrelic": "6.13.8",
     "@splitsoftware/splitio-react": "^1.2.4",
     "cockatiel": "^3.0.0-beta.0",
     "common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2885,10 +2885,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@6.13.5":
-  version "6.13.5"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.13.5.tgz#4edd33cf4afb0897e6c8d54662d45ad6044706fd"
-  integrity sha512-DmdHUTKDWWJSVjGUPtpRTX7eW8njRriz8RXCpou8+njsFtC3wMOwqTDLFxl6JaK/Q9EPHdzaaUrW4RiKyikH5g==
+"@newrelic/gatsby-theme-newrelic@6.13.8":
+  version "6.13.8"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.13.8.tgz#114f02e6b4734a1cde6f03fcdad4e1adabf4e5b7"
+  integrity sha512-P4V988W06KKA9rwRBII6tbo2WNEii71o8c8FLqEkUu26wpa8ThJBFcjugH9Bg/fGPMy72Vrgt+TyF/C+HpPKLA==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
We made an update to the way the feedback form submits page urls.

This is a bump from 6.13.5 to 6.13.8. I did not notice any breaking changes locally. 