### PR TITLE
Add information about time agnostic widets

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard.mdx
@@ -158,6 +158,55 @@ Dashboards features include:
     You can edit the name and other properties of the dashboard, such as permissions, any time.
   </Collapser>
 
+<Collapser
+    id="dash-color"
+    title="Color customization"
+>
+    You can customize the color of your charts per series in area, bar, line, pie, and stacked bar charts.
+  
+    To customize the color per series:
+    1. Run your query.
+    2. Open the Colors menu in the chart settings.
+    3. Select the plus <Icon name="fe-plus"/> icon.
+    4. Select the series you want to change the color.
+    5. Select the desired color.
+    
+    <img
+      title="Change the color of a series"
+      alt="Change the color of a series"
+      src={dashboardsDashboardChartColor}
+    />
+
+  <figcaption>
+  **Query builder**: This is an example of how to set the Login Service series to a different color.
+  </figcaption>
+
+  </Collapser>
+
+<Collapser
+    id="dash-units"
+    title="Units customization"
+>
+    You can customize the unit on your Y axis and in each of your series. It is available in bar, line, and stacked charts. 
+        
+    To customize the unit on your Y axis:
+    1. Run a time series query.
+    2. Open the units menu in the customizations UI.
+    3. Use the plus <Icon name="fe-plus"/> icon to add a per series customization.
+    4. Select the series that needs another unit.
+    5. Select the unit.
+        
+    <img
+      title="Customize your unit on your Y axis"
+      alt="Customize your unit on your Y axis"
+      src={dashboardsCustomizeChartUnits}
+    />
+
+  <figcaption>
+  **Query builder**: This is an example of how to customize your unit on your Y axis.
+  </figcaption>
+
+  </Collapser>
 </CollapserGroup>
 
 <Callout variant="tip">
@@ -278,6 +327,13 @@ To change the time range:
 
 * Select one of the available options from the dropdown menu (ranging from `Last 30 minutes` to `Last 7 days`).
 * Customize the time range with specific start and end timestamps using the custom menu.
+
+<Callout variant="tip">
+If you do not want a chart to change the time range of data when interacting with the time picker. You can do it by: 
+1. Select Edit chart.
+2. Open the Dashboard Options menu in the customizations UI.
+3. Turn the toggle on for Ignore time picker.
+</Callout>
 
 ## Export and share your data [#dash-export]
 

--- a/src/content/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard.mdx
@@ -157,56 +157,6 @@ Dashboards features include:
 
     You can edit the name and other properties of the dashboard, such as permissions, any time.
   </Collapser>
-
-<Collapser
-    id="dash-color"
-    title="Color customization"
->
-    You can customize the color of your charts per series in area, bar, line, pie, and stacked bar charts.
-  
-    To customize the color per series:
-    1. Run your query.
-    2. Open the Colors menu in the chart settings.
-    3. Select the plus <Icon name="fe-plus"/> icon.
-    4. Select the series you want to change the color.
-    5. Select the desired color.
-    
-    <img
-      title="Change the color of a series"
-      alt="Change the color of a series"
-      src={dashboardsDashboardChartColor}
-    />
-
-  <figcaption>
-  **Query builder**: This is an example of how to set the Login Service series to a different color.
-  </figcaption>
-
-  </Collapser>
-
-<Collapser
-    id="dash-units"
-    title="Units customization"
->
-    You can customize the unit on your Y axis and in each of your series. It is available in bar, line, and stacked charts. 
-        
-    To customize the unit on your Y axis:
-    1. Run a time series query.
-    2. Open the units menu in the customizations UI.
-    3. Use the plus <Icon name="fe-plus"/> icon to add a per series customization.
-    4. Select the series that needs another unit.
-    5. Select the unit.
-        
-    <img
-      title="Customize your unit on your Y axis"
-      alt="Customize your unit on your Y axis"
-      src={dashboardsCustomizeChartUnits}
-    />
-
-  <figcaption>
-  **Query builder**: This is an example of how to customize your unit on your Y axis.
-  </figcaption>
-
-  </Collapser>
 </CollapserGroup>
 
 <Callout variant="tip">
@@ -328,12 +278,11 @@ To change the time range:
 * Select one of the available options from the dropdown menu (ranging from `Last 30 minutes` to `Last 7 days`).
 * Customize the time range with specific start and end timestamps using the custom menu.
 
-<Callout variant="tip">
-If you do not want a chart to change the time range of data when interacting with the time picker. You can do it by: 
-1. Select Edit chart.
-2. Open the Dashboard Options menu in the customizations UI.
-3. Turn the toggle on for Ignore time picker.
-</Callout>
+If you don't want to change the time range of a chart when using the time picker: 
+1. Select Edit chart
+2. Open the Dashboard Options menu in the customizations UI
+3. Set the Ignore time picker toggle to on
+
 
 ## Export and share your data [#dash-export]
 

--- a/src/content/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard.mdx
@@ -279,9 +279,9 @@ To change the time range:
 * Customize the time range with specific start and end timestamps using the custom menu.
 
 If you don't want to change the time range of a chart when using the time picker: 
-1. Select Edit chart
-2. Open the Dashboard Options menu in the customizations UI
-3. Set the Ignore time picker toggle to on
+1. Select **Edit chart**
+2. Open the **Dashboard Options** menu in the customizations UI
+3. Set the **Ignore time picker** toggle to on
 
 
 ## Export and share your data [#dash-export]


### PR DESCRIPTION
Unfortunately, I can't see exactly how my changes will look like, in preview it seems that the ordered list doesn't work as expected (an item per line) inside the tip callout.

What I wanted to do is to show users that the changes in the time picker in a dashboard affect to all charts, however, if they want 1 or many charts to not be affected by the time picker they can configure those charts by:
1. Click edit chart 
<img width="176" alt="image" src="https://user-images.githubusercontent.com/93198075/204877894-042ab710-bbaf-4f5b-8d3a-a6bc51ef5837.png">

2. Change the setting of the "Ignore time picker" under Dashboard options 
<img width="369" alt="image" src="https://user-images.githubusercontent.com/93198075/204877999-a4489436-3e3f-41e3-8147-e128aefdbef1.png">

3. Save the query After that, the chart won't update after interactions with the time picker

You can find more information here https://newrelic.com/blog/how-to-relic/dashboard-chart-customizations 

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.