### PR TITLE
Update new-relic-one-usage-plan-descriptions.mdx

### DIFF
--- a/src/content/docs/licenses/license-information/usage-plans/new-relic-one-usage-plan-descriptions.mdx
+++ b/src/content/docs/licenses/license-information/usage-plans/new-relic-one-usage-plan-descriptions.mdx
@@ -44,6 +44,7 @@ The Order and Usage Plan may contain defined terms that are denoted by capitaliz
     * The Commitment Fee will be invoiced as per the 'Billing Terms' described in an Order. On a monthly cadence during the Commitment Term, Customer's Per Unit usage of the Products will be multiplied by the corresponding Monthly Discounted Rate and summed (“Monthly Product Usage”). Monthly Product Usage will be deducted from the Commitment Fee amounts that are paid in advance. If Monthly Product Usage exceeds any remaining unconsumed amounts, Customer will be invoiced for the difference (“Additional Usage”), including for any Monthly Product Usage during the last month of the Commitment Term. Payment of such invoices will be governed by the Order.
     * A final payment for the full outstanding amount of any remaining unpaid Commitment Fee and/or Additional Usage/Monthly Add-on Invoice may be invoiced upon each anniversary date of the term start date.
     * Any unconsumed balances from the payment of each annual Commitment Fee and any additional payments, if applicable, as set out in an Order will expire and lapse at the end of each year of the Commitment Term.
+    * Applicable customers after auto-renewal are subject to our primary method of counting and billing for users described [here](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing/).
   </Collapser>
 
   <Collapser

--- a/src/content/docs/licenses/license-information/usage-plans/new-relic-one-usage-plan-descriptions.mdx
+++ b/src/content/docs/licenses/license-information/usage-plans/new-relic-one-usage-plan-descriptions.mdx
@@ -44,7 +44,7 @@ The Order and Usage Plan may contain defined terms that are denoted by capitaliz
     * The Commitment Fee will be invoiced as per the 'Billing Terms' described in an Order. On a monthly cadence during the Commitment Term, Customer's Per Unit usage of the Products will be multiplied by the corresponding Monthly Discounted Rate and summed (“Monthly Product Usage”). Monthly Product Usage will be deducted from the Commitment Fee amounts that are paid in advance. If Monthly Product Usage exceeds any remaining unconsumed amounts, Customer will be invoiced for the difference (“Additional Usage”), including for any Monthly Product Usage during the last month of the Commitment Term. Payment of such invoices will be governed by the Order.
     * A final payment for the full outstanding amount of any remaining unpaid Commitment Fee and/or Additional Usage/Monthly Add-on Invoice may be invoiced upon each anniversary date of the term start date.
     * Any unconsumed balances from the payment of each annual Commitment Fee and any additional payments, if applicable, as set out in an Order will expire and lapse at the end of each year of the Commitment Term.
-    * Applicable customers after auto-renewal are subject to our primary method of counting and billing for users described [here](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing/).
+    * After auto-renewal you're subject to our primary method of counting and billing for users described [here](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing/).
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
Hi, this is a new bullet point that applies to Annual Pool of Funds buying program that applies to certain customers at their auto-renewal. The "here" should be a link to this page https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing/ Please feel free to fix if my syntax isn't correct make the "here" a link to that page.