### PR TITLE
Update user-count-billing.mdx

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing.mdx
@@ -26,24 +26,24 @@ For how to view your billable user count in the UI, see [Billing-related UI](/do
 
 For how to manage users in the UI, see [User management](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks). 
 
-## Pricing versions: with and without core users [#pricing-versions]
+## Pricing versions: primary and initial [#pricing-versions]
 
 We have two versions of our usage-based pricing model:
 
-* **Our primary usage-based pricing version**, which includes core users. This was released January 12, 2022. This version gives you access to a third user type: the [core user](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type). It also has different [billing calculations](#user-count) and [user downgrade rules](#user-downgrade-rules).
-* **The "without core users" version.** If your New Relic organization existed prior to January 12, 2022, and hasn't switched to the newer version, this is your version. Organizations on this version can add only basic users and full platform users; they don't have access to core users. This version will be increasingly deprecated over time as customers on this version switch to the core user version. See the [rules for this version](#non-core).
+* **Our primary usage-based pricing version**, which includes core users for many organizations. This was released January 12, 2022. This version released on January 12, 2022 gives you access to a third user type: the [core user](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type). Many organizations on PAYG are now on this primary usage-based pricing version, which was effective November 1, 2022. Some organizations on the Annual Pool of Funds buying programs that auto-renew after January 15, 2023, even without access to core, will be on this primary pricing version. It also has different [billing calculations](#user-count) and [user downgrade rules](#user-downgrade-rules).
+* **The initial usage-based pricing version.** If your New Relic organization existed prior to January 12, 2022, and hasn't switched to the newer version, this is your version. Organizations on this version can add only basic users and full platform users; they don't have access to core users. This version will be increasingly deprecated over time as customers on this version switch to the primary version. See the [rules for this version](#non-core). Note: some organizations that auto-renew on Annual Pool of Funds after February 15, 2023 (a) may need to accept additional terms in order to add core users, but (b) are on the primary pricing version, not the initial pricing version.
 
 Tips for determining which version you're on:
 
-* If your organization has core users or has the ability to add core users, you're on our primary version. If you can only add basic users and full platform users, you're on the version of pricing without core users. You can view your users by going to the [**User management** UI](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/#where).
-* Another way to determine your version is by going to the [**Manage your plan** UI](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/billing-ui). If you see "New Relic One - Users", that means you're on the version of pricing without core users.
+* If your organization has core users or has the ability to add core users, you're on our primary version. If you are on PAYG buying program starting November 1, then you are on our primary version. If you are on New Relic’s latest Savings Plan or Volume Plan buying programs, then you are on our primary version. If your contract auto-renews on Annual Pool of Funds after January 15, 2023, then you will be on the primary version at that time. All other customers are likely on the initial version.
+* Another way to determine your version is by going to the [**Manage your plan** UI](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/billing-ui). If you see "New Relic One - Users", that means you're on the initial version of pricing.
 
 For more about the differences between these versions, see [Core users release](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/core-users-release).
 
-## User calculation for the primary pricing version (with core users) [#user-count]
+## User calculation for the primary pricing version [#user-count]
 
 <Callout variant="important">
-  These rules apply for organizations on our [primary pricing version](#pricing-versions) (the version that includes core users).
+  These rules apply for organizations on our [primary pricing version](#pricing-versions) (the version that includes core users for many buying programs; some organizations still on Annual Pool of Funds after January 15, 2023 will be on this version upon renewal).
 </Callout>
 
 You can use the [usage UI](/docs/accounts/accounts-billing/general-account-settings/introduction-account-settings/#pricing) to get an overview of your billable user count. If you need more detail than the UI provides, you can also run [usage-related NRQL queries](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts).
@@ -67,10 +67,10 @@ The cost of your billable users depends on an organization's [pricing edition](h
 
 When a New Relic organization first starts being billed, their billable user count is pro-rated based on when during the month they started. If an organization cancels their subscription, prorating is also applied for their last month.
 
-## User downgrade rules for primary pricing version (with core users) [#user-downgrade-rules]
+## User downgrade rules for primary pricing version [#user-downgrade-rules]
 
 <Callout variant="important">
-  This section applies only for organizations on the [our primary pricing version](#pricing-versions) (the version with core users).
+  This section applies only for organizations on the [our primary pricing version](#pricing-versions).
 </Callout>
 
 The rules pertaining to how many times you can downgrade full platform users differ depending on your [usage plan](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing#usage-plans):
@@ -101,9 +101,9 @@ The rules pertaining to how many times you can downgrade full platform users dif
 
 Some organizations have access to tiered pricing for billable users. For details on that, see [Tiered pricing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing#tiered-pricing).
 
-## Rules for the pricing version without core users [#non-core]
+## Rules for the initial pricing version [#non-core]
 
-The following rules apply only for organizations on the [version of pricing **without core users**](#pricing-versions):
+The following rules apply only for organizations on the inital [version of pricing](#pricing-versions):
 
 * **How billable users are determined.** For a calendar month, an organization is billed based on a calculation of the number of full platform users for that month.
 * **Prorating in first and last month.** The count of billable users is prorated based on when a New Relic organization starts their subscription, or based on when a user becomes a full platform user (added as a full platform user or converted to one).
@@ -118,7 +118,7 @@ For user downgrade rules, see below:
     id="non-core-downgrade-rules"
     title="User downgrade rules"
   >
-    The following user downgrade rules apply for organizations on the [pricing version without core users](#pricing-versions):
+    The following user downgrade rules apply for organizations on the [initial pricing version ](#pricing-versions):
 
     User type is meant to be a fairly long-term setting based on a user's expected New Relic duties and responsibilities. For that reason, a full platform user may only be downgraded a maximum of two times in a 12-month period. If a user's user type has changed more than this allowed number of changes, New Relic can charge that user as a full platform user.
   </Collapser>

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing.mdx
@@ -30,12 +30,16 @@ For how to manage users in the UI, see [User management](/docs/accounts/accounts
 
 We have two versions of our usage-based pricing model:
 
-* **Our primary usage-based pricing version**, which includes core users for many organizations. This was released January 12, 2022. This version released on January 12, 2022 gives you access to a third user type: the [core user](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type). Many organizations on PAYG are now on this primary usage-based pricing version, which was effective November 1, 2022. Some organizations on the Annual Pool of Funds buying programs that auto-renew after January 15, 2023, even without access to core, will be on this primary pricing version. It also has different [billing calculations](#user-count) and [user downgrade rules](#user-downgrade-rules).
-* **The initial usage-based pricing version.** If your New Relic organization existed prior to January 12, 2022, and hasn't switched to the newer version, this is your version. Organizations on this version can add only basic users and full platform users; they don't have access to core users. This version will be increasingly deprecated over time as customers on this version switch to the primary version. See the [rules for this version](#non-core). Note: some organizations that auto-renew on Annual Pool of Funds after February 15, 2023 (a) may need to accept additional terms in order to add core users, but (b) are on the primary pricing version, not the initial pricing version.
+* **Our primary usage-based pricing version**, which includes core users for many organizations. This version released on January 12, 2022 gives you access to a third user type: the [core user](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type). Many organizations on PAYG are now on this primary usage-based pricing version, which was effective on November 1, 2022. Some organizations on the Annual Pool of Funds buying programs that auto-renew after January 15, 2023, even without access to core, will be on this primary pricing version. It also has different [billing calculations](#user-count) and [user downgrade rules](#user-downgrade-rules).
+* **The initial usage-based pricing version.** If your New Relic organization existed prior to January 12, 2022, and hasn't switched to the newer version, this is your version. Organizations on this version can add only basic users and full platform users; they don't have access to core users. This version will be increasingly deprecated over time as customers on this version switch to the primary version. See the [rules for this version](#non-core). 
+
+<Callout variant="important">
+  Some organizations that auto-renew on Annual Pool of Funds after February 15, 2023 may need to accept additional terms in order to add core users, but are on the primary pricing version, not the initial pricing version.
+</Callout>
 
 Tips for determining which version you're on:
 
-* If your organization has core users or has the ability to add core users, you're on our primary version. If you are on PAYG buying program starting November 1, then you are on our primary version. If you are on New Relic’s latest Savings Plan or Volume Plan buying programs, then you are on our primary version. If your contract auto-renews on Annual Pool of Funds after January 15, 2023, then you will be on the primary version at that time. All other customers are likely on the initial version.
+* If your organization has core users or has the ability to add core users, you're on our primary version. If you're on PAYG buying program starting November 1, then you're on our primary version. If you're on the latest Savings Plan or Volume Plan buying programs of New Relic, then you're on the primary version. If your contract auto-renews on Annual Pool of Funds after January 15, 2023, then you will be on the primary version at that time. All others are likely on the initial version.
 * Another way to determine your version is by going to the [**Manage your plan** UI](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/billing-ui). If you see "New Relic One - Users", that means you're on the initial version of pricing.
 
 For more about the differences between these versions, see [Core users release](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/core-users-release).
@@ -70,7 +74,7 @@ When a New Relic organization first starts being billed, their billable user cou
 ## User downgrade rules for primary pricing version [#user-downgrade-rules]
 
 <Callout variant="important">
-  This section applies only for organizations on the [our primary pricing version](#pricing-versions).
+  This section applies only for organizations on the [primary pricing version](#pricing-versions).
 </Callout>
 
 The rules pertaining to how many times you can downgrade full platform users differ depending on your [usage plan](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing#usage-plans):
@@ -103,7 +107,7 @@ Some organizations have access to tiered pricing for billable users. For details
 
 ## Rules for the initial pricing version [#non-core]
 
-The following rules apply only for organizations on the inital [version of pricing](#pricing-versions):
+The following rules apply only for organizations on the initial [version of pricing](#pricing-versions):
 
 * **How billable users are determined.** For a calendar month, an organization is billed based on a calculation of the number of full platform users for that month.
 * **Prorating in first and last month.** The count of billable users is prorated based on when a New Relic organization starts their subscription, or based on when a user becomes a full platform user (added as a full platform user or converted to one).
@@ -118,7 +122,7 @@ For user downgrade rules, see below:
     id="non-core-downgrade-rules"
     title="User downgrade rules"
   >
-    The following user downgrade rules apply for organizations on the [initial pricing version ](#pricing-versions):
+    The following user downgrade rules apply for organizations on the [initial pricing version](#pricing-versions):
 
     User type is meant to be a fairly long-term setting based on a user's expected New Relic duties and responsibilities. For that reason, a full platform user may only be downgraded a maximum of two times in a 12-month period. If a user's user type has changed more than this allowed number of changes, New Relic can charge that user as a full platform user.
   </Collapser>


### PR DESCRIPTION
Update references to "with core" and "without core" to be "primary" and "initial" for clarification purposes.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

While "With Core" and "without core" made sense at the time this was introduced, due to recent changes in NR on how accounts will be changed over at auto-renewal, whether an account has Core alone is not determinative of the pricing version. Updating terms used so it's not tied directly to "Core Users"