### PR TITLE
Update spa-data-collection.mdx

### DIFF
--- a/src/content/docs/browser/single-page-app-monitoring/use-spa-data/spa-data-collection.mdx
+++ b/src/content/docs/browser/single-page-app-monitoring/use-spa-data/spa-data-collection.mdx
@@ -34,7 +34,7 @@ Three major categories of single page app data can be reported to New Relic:
 
 * Initial page loads
 * Route changes
-* Custom browser interactions created via the [SPA API](/docs/browser/single-page-app-monitoring/spa-api/spa-api)
+* Custom browser interactions created via the [SPA API](/docs/browser/single-page-app-monitoring/use-spa-data/use-spa-api)
 
 Each of these creates a `BrowserInteraction` event. If one or more AJAX requests are part of an interaction, then associated `AjaxRequest` events are also created. These events and their attributes can be queried in the [query builder](/docs/query-your-data/explore-query-data/query-builder/use-advanced-nrql-mode-specify-data).
 

--- a/src/content/docs/browser/single-page-app-monitoring/use-spa-data/use-spa-api.mdx
+++ b/src/content/docs/browser/single-page-app-monitoring/use-spa-data/use-spa-api.mdx
@@ -8,6 +8,7 @@ metaDescription: "New Relic's single page app (SPA) monitoring includes an API t
 redirects:
   - /docs/browser/single-page-app-monitoring/single-page-app-api
   - /docs/browser/single-page-app-monitoring/spa-api
+  - /docs/browser/single-page-app-monitoring/spa-api/spa-api
 ---
 
 Browser's single-page application (SPA) monitoring includes an API to add custom monitoring of specific browser interactions. This is useful for monitoring interactions that New Relic does not record automatically because they do not result in route changes, such as a dynamically-updated widget. The SPA API also allows you to turn off default monitoring for interactions that you do not consider important enough to monitor.


### PR DESCRIPTION
Link for SPA API is pointing to a non-existing URL i.e., https://docs.newrelic.com/docs/browser/single-page-app-monitoring/spa-api/spa-api/ So, I changed it to https://docs.newrelic.com/docs/browser/single-page-app-monitoring/use-spa-data/use-spa-api/

Attaching screenshot of the 404 page.
![image](https://user-images.githubusercontent.com/104448291/204982123-53844d8f-df00-4389-810a-01eb75b32fcd.png)




<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.