### PR TITLE
Fixing a broken link

### DIFF
--- a/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
@@ -722,7 +722,7 @@ See [our glossary entry for quickstart](/docs/new-relic-solutions/get-started/gl
     id="users"
     title="users"
   >
-    For styles and formats related to user roles and groups and more, see [User-related style](/docs/new-relic-only/basic-style-guide/style-guide-quick-reference/user-related-language-styles-recommended-phrasings).
+    For styles and formats related to user roles and groups and more, see [User-related style](/docs/style-guide/word-choice/user-related-language-guidelines/).
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
The link _User-related style_  link under the [users section](https://docs.newrelic.com/docs/style-guide/word-choice/usage-dictionary/#users) is a broken link.