### PR TITLE
**ON HOLD: WILL LET DOCS TEAM KNOW WHEN READY TO MERGE*** chore: Update .NET Agent release notes for 9.7 to 10.1 with a notice

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-0-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-0-0.mdx
@@ -7,6 +7,8 @@ redirects:
   - /docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10000
 ---
 
+**Notice:** If using Microsoft.Extensions.Logging as your logging framework of choice, please use .NET agent version 10.1.0 or newer.  We encourage you to adopt the newer version due to bug [#1230](https://github.com/newrelic/newrelic-dotnet-agent/issues/1230), which we fixed in [#1237](https://github.com/newrelic/newrelic-dotnet-agent/pull/1237), that was resolved in .NET agent version 10.1.0.
+
 ### New Features
 
 * Adds support for forwarding application logs to New Relic for .NET Framework 4.6.2 and newer applications using Microsoft.Extensions.Logging. [#1172](https://github.com/newrelic/newrelic-dotnet-agent/pull/1172)

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-1-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-1-0.mdx
@@ -7,6 +7,8 @@ redirects:
   - /docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/net-agent-1010
 ---
 
+**Notice:** If using Microsoft.Extensions.Logging as your logging framework of choice, please use .NET agent version 10.1.0 or newer.  We encourage you to adopt the newer version due to bug [#1230](https://github.com/newrelic/newrelic-dotnet-agent/issues/1230), which we fixed in [#1237](https://github.com/newrelic/newrelic-dotnet-agent/pull/1237), that was resolved in .NET agent version 10.1.0.
+
 ### New Features
 * Support of setting up labels via appsettings.json and app/web.config file. [#1204](https://github.com/newrelic/newrelic-dotnet-agent/pull/1204)
 * Additional DEBUG-level logging of all environment variables.

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9700.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9700.mdx
@@ -7,6 +7,8 @@ downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
 
 **Notice:** For the new application logging features, if you install using the MSI, please update to version 9.7.1 or later.
 
+**Notice:** If using Microsoft.Extensions.Logging as your logging framework of choice, please use .NET agent version 10.1.0 or newer.  We encourage you to adopt the newer version due to bug [#1230](https://github.com/newrelic/newrelic-dotnet-agent/issues/1230), which we fixed in [#1237](https://github.com/newrelic/newrelic-dotnet-agent/pull/1237), that was resolved in .NET agent version 10.1.0.
+
 ### New Features
 * Adds support for logging metrics which shows the rate of log message by severity in the Logs chart in the APM **Summary** view for Log4net, Serilog, and Microsoft.Extensions.Logging. This is enabled by default in this release. ([#1034](https://github.com/newrelic/newrelic-dotnet-agent/pull/1034))
 * Adds support for forwarding application logs to New Relic. This automatically sends enriched application logs for Log4net, Serilog, and Microsoft.Extensions.Logging. This is disabled by default in this release. ([#1034](https://github.com/newrelic/newrelic-dotnet-agent/pull/1034))

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9710.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9710.mdx
@@ -5,6 +5,8 @@ version: 9.7.1.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
 ---
 
+**Notice:** If using Microsoft.Extensions.Logging as your logging framework of choice, please use .NET agent version 10.1.0 or newer.  We encourage you to adopt the newer version due to bug [#1230](https://github.com/newrelic/newrelic-dotnet-agent/issues/1230), which we fixed in [#1237](https://github.com/newrelic/newrelic-dotnet-agent/pull/1237), that was resolved in .NET agent version 10.1.0.
+
 ### Fixes
 * Adds missing instrumentation for application logging feature when using the MSI installer ([#1055](https://github.com/newrelic/newrelic-dotnet-agent/pull/1055))
 * Fixes [issue on Linux](https://github.com/newrelic/newrelic-dotnet-agent/issues/763) when specifying a non-default profiler log directory with non-existent intermediate directories. ([#1051](https://github.com/newrelic/newrelic-dotnet-agent/pull/1051))

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9800.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9800.mdx
@@ -5,6 +5,8 @@ version: 9.8.0.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
 ---
 
+**Notice:** If using Microsoft.Extensions.Logging as your logging framework of choice, please use .NET agent version 10.1.0 or newer.  We encourage you to adopt the newer version due to bug [#1230](https://github.com/newrelic/newrelic-dotnet-agent/issues/1230), which we fixed in [#1237](https://github.com/newrelic/newrelic-dotnet-agent/pull/1237), that was resolved in .NET agent version 10.1.0.
+
 ### APM logs in context
 Automatic application log forwarding is now enabled by default. This version of the agent will automatically send enriched application logs to New Relic. To learn more about about this feature, see the [APM logs in context documentation](https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/get-started-logs-context/). For additional configuration options, see the [.NET logs in context documentation](https://docs.newrelic.com/docs/logs/logs-context/net-configure-logs-context-all). To learn about how to toggle log ingestion on or off by account, see our documentation to [disable automatic logging](https://docs.newrelic.com/docs/logs/logs-context/disable-automatic-logging) via the UI or API.
 

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9810.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9810.mdx
@@ -5,6 +5,8 @@ version: 9.8.1.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
 ---
 
+**Notice:** If using Microsoft.Extensions.Logging as your logging framework of choice, please use .NET agent version 10.1.0 or newer.  We encourage you to adopt the newer version due to bug [#1230](https://github.com/newrelic/newrelic-dotnet-agent/issues/1230), which we fixed in [#1237](https://github.com/newrelic/newrelic-dotnet-agent/pull/1237), that was resolved in .NET agent version 10.1.0.
+
 ### Fixes
 * Fixes an [issue with log forwarding](https://github.com/newrelic/newrelic-dotnet-agent/issues/1088) where an agent could momentarily forward logs even if the feature had been disabled at an account level. ([#1051](https://github.com/newrelic/newrelic-dotnet-agent/pull/1097))
 * Adds an internal list of deprecated instrumentation xml files which will cause the profiler to ignore deprecated instrumentation. This feature avoids an issue where orphaned deprecated log forwarding instrumentation could conflict with newer instrumentation. ([#1051](https://github.com/newrelic/newrelic-dotnet-agent/pull/1097))

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9900.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9900.mdx
@@ -5,6 +5,8 @@ version: 9.9.0.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
 ---
 
+**Notice:** If using Microsoft.Extensions.Logging as your logging framework of choice, please use .NET agent version 10.1.0 or newer.  We encourage you to adopt the newer version due to bug [#1230](https://github.com/newrelic/newrelic-dotnet-agent/issues/1230), which we fixed in [#1237](https://github.com/newrelic/newrelic-dotnet-agent/pull/1237), that was resolved in .NET agent version 10.1.0.
+
 ### New Features
 * Adds support for logging metrics, forwarding application logs, and enriching application logs written to disk or standard out for NLog versions v5 and v4. [#1087](https://github.com/newrelic/newrelic-dotnet-agent/pull/1087)
 * Adds integration with CodeStream, introducing code-level metrics! Golden signals visible in your IDE through New Relic CodeStream. [Learn more here](https://docs.newrelic.com/docs/apm/agents/net-agent/other-features/net-codestream-integration). For any issues or direct feedback, please reach out to support@codestream.com


### PR DESCRIPTION
There was a issue with our Microsoft.Extensions.Logging that requires a notice to be added to the release notes for a range .NET Agent versions.   We are also updating the changelog in our repo to match ones in this PR.

* If your issue relates to an existing GitHub issue, please link to it.
bug [#1230](https://github.com/newrelic/newrelic-dotnet-agent/issues/1230)
fixed in PR [#1237](https://github.com/newrelic/newrelic-dotnet-agent/pull/1237)