### PR TITLE
Add section on automated sources of tags

### DIFF
--- a/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data.mdx
@@ -36,9 +36,9 @@ import solutionsTagFilterQuery from 'images/solutions_screenshot-full_tag-filter
 
 import solutionsTagManagement from 'images/solutions_screenshot-full_tag-management.png'
 
-Tags are key-value pairs, for example `team: operations`, added to various sets of data, like monitored apps and hosts, agents, dashboards, and [workloads](/docs/new-relic-one/use-new-relic-one/workloads/workloads-isolate-resolve-incidents-faster). We make some important [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute) available as tags such as app metadata like app name and language, and host metadata like host name and AWS region. You can also add your own custom tags.
+Tags are key-value pairs, for example `team: operations`, added to entities, like monitored apps and hosts, agents, dashboards, and [workloads](/docs/new-relic-one/use-new-relic-one/workloads/workloads-isolate-resolve-incidents-faster). We make some important [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute) available as tags such as app metadata like app name and language, and host metadata like host name and AWS region. You can also add your own custom tags.
 
-You can use tags in the UI to filter down to relevant data. Here is an example:
+You can use tags in the UI to filter down to relevant entities. Here is an example:
 
 <img
   title="New Relic filtering workloads using tags"
@@ -58,6 +58,68 @@ Tags help you:
 - [Query and chart APM data](#query-apm-tags).
 
 Tags are useful for organizing data at a high level. If you want to add more fine-grained detail, like capturing user names or other high-cardinality values, [custom attributes](/docs/using-new-relic/data/customize-data/collect-custom-attributes) or [custom events](/docs/insights/insights-data-sources/custom-data/report-custom-event-data) are a better solution.
+
+## Automated tags [#automated-tags]
+
+Tags are automatically applied to entities in some cases, from the following sources:
+- Account metadata
+- New Relic agent configuration
+- New Relic agent environment
+- OpenTelemetry resource attributes
+
+Tags from these sources can be removed or changed only by modifying the source of the tag, not via the UI or API.
+
+You can also programmatically automate tags using our [API](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial/) or the [New Relic CLI](https://developer.newrelic.com/automate-workflows/5-mins-tag-resources).
+
+<CollapserGroup>
+  <Collapser
+    id="tags-from-account-metadata"
+    title="Tags from account metadata"
+  >
+    New Relic automatically applies certain tags to entities that include account information. These tags include:
+    - `account`
+    - `accountId`
+
+  </Collapser>
+
+  <Collapser
+    id="tags-from-agent-config"
+    title="Tags from New Relic agent configuration"
+  >
+    New Relic agents can be configured to apply tags to the entities created from their data. [Configuration options](https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/install-configure/configure-new-relic-agents/) are somewhat agent-specific, but generally use the `labels` key. Some examples:
+    - [Java agent tag configuration](https://docs.newrelic.com/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file/#labels)
+    - [.NET agent tag configuration](https://docs.newrelic.com/docs/apm/agents/net-agent/configuration/net-agent-configuration/#labels-tags)
+    
+    Tags applied from APM agent configuration can result in multiple values for a given tag key on a given entity, because each deployed instance of the agent could be configured to send a different value.
+  </Collapser>
+
+  <Collapser
+    id="tags-from-agent-env"
+    title="Tags from New Relic agent environment"
+  >
+    The New Relic agent automatically applies certain tags to service entities based on the environment. These include (but are not limited to):
+    - For service/application entities
+      - `language`: Values are, for example, `java`, `python`, etc.
+    - For host entities
+      - `awsRegion`, when applicable
+    
+  </Collapser>
+
+  <Collapser
+    id="tags-from-agent-host"
+    title="Tags from OpenTelemetry resource attributes"
+  >
+    Certain [OpenTelemetry resource attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md) are automatically applied as entity tags. When the following attributes are present on span data associated with a service entity, they will be attached to that entity:
+    - k8s.cluster.name
+    - k8s.deployment.name
+    - k8s.namespace.name
+    - telemetry.sdk.language: Will be stored as a tag named `language`
+    - telemetry.sdk.version
+    - service.namespace
+    
+    This automated tagging is done using New Relic entity synthesis, which is [documented on GitHub](https://github.com/newrelic/entity-definitions#entity-definitions). In the case of OpenTelemetry services, the [tagging definitions](https://github.com/newrelic/entity-definitions/blob/main/definitions/ext-service/definition.yml#L58) are on `ext-service` entities.
+  </Collapser>
+</CollapserGroup>
 
 ## Manage tags [#tag-management]
 


### PR DESCRIPTION
Describe the various ways tags can be automatically applied to entities. There is a bias toward service entities here, so any more detail on hosts or other entities might be nice. I don't think the doc has to be completely exhaustive, though. Would appreciate a review from @erabug @josemore @jlegoff 

Also make it a little more clear that tags go on entities, while attributes go on data.