### PR TITLE
chore: clarify the use of `maximumSamplesStored`

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -2250,7 +2250,7 @@ The `transactionEvents` element supports the following attributes:
       </tbody>
     </table>
 
-    The maximum number of samples to store in memory at once.
+    The maximum number of sampled transaction events the agent can store in memory at once. This will be the maximum number of transactions events the agent can send per minute.
 
     Alternatively, set the `MAX_TRANSACTION_SAMPLES_STORED` environment variable in the application's environment.
 
@@ -2283,7 +2283,7 @@ The `customEvents` element is a child of the `configuration` element. Use `custo
 <customEvents enabled="true" maximumSamplesStored="10000"/>
 ```
 
-The `CustomEvents` element supports the following attributes:
+The `customEvents` element supports the following attributes:
 
 <CollapserGroup>
   <Collapser
@@ -2345,7 +2345,7 @@ The `CustomEvents` element supports the following attributes:
       </tbody>
     </table>
 
-    The maximum number of samples to store in memory at once.
+    The maximum number of sampled custom events the agent can store in memory at once. This will be the maximum number of custom events the agent can send per minute.
 
     Alternatively, set the `MAX_EVENT_SAMPLES_STORED` environment variable in the application's environment.
 
@@ -2363,7 +2363,7 @@ The `customParameters` element is a child of the `configuration` element. Use `c
 <customParameters enabled="true" />
 ```
 
-The `CustomParameters` element supports the following attributes:
+The `customParameters` element supports the following attributes:
 
 <CollapserGroup>
   <Collapser
@@ -3102,7 +3102,9 @@ The `spanEvents` element supports the following attributes:
       </tbody>
     </table>
 
-    The maximum number of samples to store in memory at a time. This may be configured using the `NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED` environment variable as well.
+    The maximum number of sampled span events the agent can store in memory at a time. This will be the maximum number of span events the agent can send per minute.
+    
+    This may be configured using the `NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED` environment variable as well.
 
     We do not recommend configuring past 10k. The server will cap data at 10k per-minute.
 


### PR DESCRIPTION
This came as a recommendation from a customer on a support ticket:

> The default value for maximumSamplesStored is 10000 and the description text says:
> > “The maximum number of samples to store in memory at once”

> Maybe you can update the documentation with the below description since that was more understandable:
> > “The maximumSamplesStored configuration options set a limit to the amount of data that the agent can hold in memory between uploads to NR1. This mean the default value of 10000 for transactionEvents will allow the agent to hold in memory 10000 transactions at one time, which acts as a cap the amount they can send. You can think of it as the maximum transactions the agent can send per minute.”

I simplified the text but please feel free to make any further improvements you think would be helpful to people here.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.