### PR TITLE
Updates to VPC flow log install documentation

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/aws-vpc-flow-log-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/aws-vpc-flow-log-monitoring.mdx
@@ -57,14 +57,14 @@ Amazon Virtual Private Cloud (VPC) enables you to launch AWS resources into an i
 * Environment:
     * [AWS CLI (v 1.9.15+) installed](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html).
     * A list of AWS regions where you collect Amazon VPC Flow Logs.
+    * [VPC IDs](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/describe-vpcs.html) that will be configured to ship VPC flow logs. If you want more granular control, specify the [subnet IDs](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/describe-subnets.html) instead of the VPC IDs.
 * Permissions:
     * An AWS user with [permissions to create VPC flow logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html#flow-logs-s3-iam).
     * Amazon S3 log file permissions to [read and write for the log delivery owner](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html#flow-logs-file-permissions).
+    * Allow [Kinesis Data Firehose to Assume an IAM Role](https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#firehose-assume-role).
 * [Amazon Resource Names (ARNs)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-arn-format.html):
     * ARN of an S3 bucket with permissions to [store undelivered flow log messages](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html#flow-logs-s3-permissions).
-    * Allow [Kinesis Data Firehose to Assume an IAM Role](https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#firehose-assume-role).
     * If you wish to enable sampling, you'll need the ARN for the Lambda's IAM role.
-    * [VPC IDs](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/describe-vpcs.html) that will be configured to ship VPC flow logs. If you want more granular control, specify the [subnet IDs](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/describe-subnets.html) instead of the VPC IDs.
     * ARN for the [Kinesis Data Firehose with S3 bucket access](https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3).
     <Callout variant="tip">
         We recommend you create a new data firehose with our guided install the first time you configure VPC flow logs for a specific region. For subsequent VPCs and subnets in the same region, you can reuse the existing data firehose.
@@ -170,22 +170,7 @@ ${version} ${account-id} ${region} ${az-id} ${sublocation-type} ${vpc-id} ${subn
 You must use a [log partition](https://docs.newrelic.com/docs/logs/ui-data/data-partitions/) for VPC flow logs named `Log_VPC_Flows_AWS`. If you use the [guided install](https://one.newrelic.com/nr1-core?&state=bd947742-3034-63b7-7196-8baaf36dd8d9), this is handled automatically.
 
 ## Set up Amazon VPC Flow Logs monitoring in New Relic [#setup-aws-vpc-flow-logs]
-
-You can set up your Amazon VPC Flow Logs by installing a bundle that includes a dashboard designed for Amazon VPC Flow Logs.
-
-1. Go to New Relic Instant Observability page for [Amazon VPC Flow Logs](https://newrelic.com/instant-observability/aws-vpc-flow-logs/61d2ff67-f519-492c-a8de-6019b47d5bb2).
-    <img title="Amazon VPC Flow Logs I/O page" alt="Amazon VPC Flow Logs instant observability page" src={networkAwsVpcFlowLogsIo}/>
-
-    <figcaption>
-    **[New Relic Instant Observability](https://newrelic.com/instant-observability/aws-vpc-flow-logs/61d2ff67-f519-492c-a8de-6019b47d5bb2)** to set up Amazon VPC Flow Logs monitoring.
-    </figcaption>
-
-2. Click **Install now** to get directed to your New Relic account, and follow the guided install process.
-3. [Visualize your network performance data in New Relic](/docs/network-performance-monitoring/monitoring-network-data/visualize-network-data).
-
-## Send additional Amazon VPC Flow Logs [#additional-aws-vpc-flow-logs]
-
-Additionally, if you need to install more Amazon VPC Flow Logs or you don't want to install the bundle with a custom dashboard, follow these steps:
+Follow the guided wizard to install Amazon VPC Flow Logs:
 
 1. Start the **[guided install process](https://one.newrelic.com/nr1-core?&state=bd947742-3034-63b7-7196-8baaf36dd8d9)**.
 2. From the **Select an account** dropdown, choose the New Relic account you want to send Amazon VPC Flow Logs to, and click **Continue**.


### PR DESCRIPTION
The documentation for AWS VPC Flow Logs currently has a few rough edges that need to be smoothed out.  Reference https://issues.newrelic.com/browse/NR-62033

Prerequisites section talks about using ARNs for things that are not ARNs.  Rearranged prerequisites so items correspond to the appropriate heading. The "Set up Amazon VPC Flow Logs monitoring in New Relic" section points users to an IO page which then goes back to the install wizard. I removed the link out to the Instant Observability page and go directly to the install wizard.

Changed:
Docs -> Instant Observability page outside NR1 -> Quickstart page in NR1 -> Intermediate screen -> wizard simplified to this
Docs -> Wizard

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.