### PR TITLE
Style guide addition to Usage page

### DIFF
--- a/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
@@ -779,22 +779,22 @@ See [our glossary entry for quickstart](/docs/new-relic-solutions/get-started/gl
     ```
   </Collapser>
 
-  <Collapser
-    id="you"
-    title="you"
-  >
-    We use `you` and `your` liberally in our docs. Addressing the reader directly makes for simpler, cleaner sentences. It also tends to expose lazy uses of passive construction and it helps users to understand procedures.
-  </Collapser>
-  
-  <Collapser
+   <Collapser
     id="x"
     title="x"
   >
     Use a lowercase x to signify "times." For example:
         
     * Cloud adoption can increase the number of hosts 2–50x.
-    * Customers generally report 2–10x telemetry data increases or more.
+    * Up to 10x the max duration per query and 3x the max query limit.
 
   </Collapser>
   
+  <Collapser
+    id="you"
+    title="you"
+  >
+    We use `you` and `your` liberally in our docs. Addressing the reader directly makes for simpler, cleaner sentences. It also tends to expose lazy uses of passive construction and it helps users to understand procedures.
+  </Collapser>
+
 </CollapserGroup>


### PR DESCRIPTION
Moved "x" entry before "you" entry, and revised one of the examples under "x" entry.

<!-- Thanks for contributing to our docs! -->

