### PR TITLE
.NET Agent: update list of supported operating systems

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -253,11 +253,14 @@ Before you install the New Relic .NET agent on [Windows](/docs/agents/net-agent/
           </td>
 
           <td>
-            * Server 2008 R2 SP1
-            * Server 2012
-            * Server 2012 R2
-            * Server 2016
-            * Server 2019
+            * Windows Server 2008 R2 SP1
+            * Windows Server 2012
+            * Windows Server 2012 R2
+            * Windows Server 2016
+            * Windows Server 2019
+            * Windows Server 2022
+            * Windows 10
+            * Windows 11
             * Windows containers running on Server 2016 (NanoServer based images are not supported)
           </td>
         </tr>

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -188,7 +188,9 @@ Before you [install New Relic's .NET agent](/docs/agents/net-agent/installation/
     * Windows Server 2012 R2
     * Windows Server 2016
     * Windows Server 2019
+    * Windows Server 2022
     * Windows 10
+    * Windows 11
     * Windows Azure (OS Family 1, 2, and 3)
     * Windows containers running on Windows 2016 (NanoServer based images are not supported)
 </Collapser>


### PR DESCRIPTION
Add Windows Server 2022 and Windows 11 to the list of operating systems we support running the .NET Agent on.