### PR TITLE
chore: Browser Agent 1221 Release - 1/9 12pm

### DIFF
--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1221.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1221.mdx
@@ -26,4 +26,4 @@ Fixed an issue where when using the SPA loader with Nuxt, the initial page load 
 ### Fix error with jsPDF library and SPA agent
 Fixed an issue with the jsPDF library where it was not correctly detecting browser native support for Promises due to our wrapper. This resulted in an exception and jsPDF not generating the PDF. This issue is not present with the pro or lite agent.
 
-**Note**: This issue does not affect the pro or lite agent. This change allows the jsPDF library to function correctly when the spa agent is used. However, it does cause an internal error within the agent to be generated. This error does not break the agent, jsPDF, or other functionality. The issue is planned to be addressed in a future update.
+**Note**: This issue does not affect the pro or lite agent. This change allows the jsPDF library to function correctly when the SPA agent is used. However, it does cause an internal error within the agent to be generated. This error does not break the agent, jsPDF, or other functionality. The issue is planned to be addressed in a future update.

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1221.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1221.mdx
@@ -1,0 +1,29 @@
+---
+subject: Browser agent
+releaseDate: '2023-01-09'
+version: '1221'
+---
+
+## New Features
+
+### Add infrastructure to run on web workers
+The agent's infrastructure will now allow for the agent to be built to run on web workers for future projects.
+
+## Bug Fixes
+
+### Expose webpack library as output type "self" vs. "umd"
+To address "mismatched anonymous define" errors thrown by RequireJS, the agent's webpack library output will no longer include UMD checks for CommonJS and AMD module environments, and will instead be exposed globally via `self`.
+
+### Fix custom attribute handling in cases where the info block is loaded after initialization
+Fixed an issue where custom attributes could be cleared and reset if the info block was included on the page below the loader script. Our guidance still remains that **all configurations should be included on the page above the loader code**, however this is an attempt to do no harm when feasible for backwards compatibility.
+
+### Update JS error bucketing algorithm
+The Agent will now take into account the error object type, message, and original stack trace when deciding on whether multiple JS errors should be bucketed together.
+
+### Fix initial page load interaction reporting with Nuxt
+Fixed an issue where when using the SPA loader with Nuxt, the initial page load interaction was never being completed. This resulted in events like errors being retained in memory and never harvested because they were tied to an incomplete interaction.
+
+### Fix error with jsPDF library and SPA agent
+Fixed an issue with the jsPDF library where it was not correctly detecting browser native support for Promises due to our wrapper. This resulted in an exception and jsPDF not generating the PDF. This issue is not present with the pro or lite agent.
+
+**Note**: This issue does not affect the pro or lite agent. This change allows the jsPDF library to function correctly when the spa agent is used. However, it does cause an internal error within the agent to be generated. This error does not break the agent, jsPDF, or other functionality. The issue is planned to be addressed in a future update.

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1221.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1221.mdx
@@ -18,7 +18,7 @@ To address "mismatched anonymous define" errors thrown by RequireJS, the agent's
 Fixed an issue where custom attributes could be cleared and reset if the info block was included on the page below the loader script. Our guidance still remains that **all configurations should be included on the page above the loader code**, however this is an attempt to do no harm when feasible for backwards compatibility.
 
 ### Update JS error bucketing algorithm
-The Agent will now take into account the error object type, message, and original stack trace when deciding on whether multiple JS errors should be bucketed together.
+The agent will now take into account the error object type, message, and original stack trace when deciding on whether multiple JS errors should be bucketed together.
 
 ### Fix initial page load interaction reporting with Nuxt
 Fixed an issue where when using the SPA loader with Nuxt, the initial page load interaction was never being completed. This resulted in events like errors being retained in memory and never harvested because they were tied to an incomplete interaction.


### PR DESCRIPTION
Update Dec 29 2022: team had been blocked from deploying. 

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Release notes update for Browser Agent release version 1221.