### PR TITLE
Fix agent version in record_log_event docs.

### DIFF
--- a/src/content/docs/apm/agents/python-agent/python-agent-api/recordlogevent-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/recordlogevent-python-agent-api.mdx
@@ -19,7 +19,7 @@ Records a log event for use in logging in context.
 
 ## Requirements
 
-Python agent version 9.0.0 or higher.
+Python agent version 8.5.0 or higher.
 
 ## Description
 
@@ -114,8 +114,8 @@ None.
 Here's an example of recording a log event associated with a background task:
 
 ```
-@newrelic.agent.background_task() 
-def bg_task(): 
+@newrelic.agent.background_task()
+def bg_task():
 	# do some type of work in this background task...
 	application = newrelic.agent.application()
 	newrelic.agent.record_log_event('My log message.', application)
@@ -126,7 +126,7 @@ def bg_task():
 An example of recording a log event inside a transaction:
 
 ```
-def fetch(): 
+def fetch():
 	newrelic.agent.record_log_event('Fetching data.')
 	# do some type of work in this transaction...
 ```


### PR DESCRIPTION
This PR corrects the python agent version in which the record_log_event is publicly available.