### PR TITLE
chore: fix typo

### DIFF
--- a/src/content/docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes.mdx
@@ -209,7 +209,7 @@ There are two ways to add custom attributes to the `PageView` event:
              </td>
 
              <td>
-               Add [`attributes: {enabled: true}`](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#browser-debug-enabled) to the `browser_monitoring` section of your app's `newrelicjs` configuration file.
+               Add [`attributes: {enabled: true}`](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#browser-debug-enabled) to the `browser_monitoring` section of your app's `newrelic.js` configuration file.
              </td>
            </tr>
 


### PR DESCRIPTION
`newrelicjs` -> `newrelic.js`
