### PR TITLE
Update android crash reporting flag

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags.mdx
@@ -170,9 +170,43 @@ All settings, including the call to invoke the agent, are called in the `onCreat
 ## Crash and error reporting settings [#crash-error-reporting-settings]
 
 <CollapserGroup>
+
   <Collapser
     id="ff-withCrashReportingEnabled"
-    title={<>withCrashReportingEnabled<br/>FeatureFlag.CrashReportingEnabled</>}
+    title="withCrashReportingEnabled"
+  >
+    Enables or disables deferred crash reporting.
+
+    Refer to [Deferred Crash Reporting](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/android-agent-crash-reporting/#deferred-crash-reporting) for more information on deferred crash reporting.
+
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
+
+  <Collapser
+    id="ff-CrashReportingEnabled"
+    title="FeatureFlag.CrashReportingEnabled"
   >
     Enable or disable crash reporting.
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

Updated the default value for different Android agent crash reporting flags and wrote a description for `withCrashReportingEnabled()` to reflect current implementation. 
