### PR TITLE
Removing Alerts Classic references

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts.mdx
@@ -21,6 +21,7 @@ redirects:
   - /docs/alerts/new-relic-alerts/getting-started/introduction-new-relic-alerts
   - /docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-new-relic-alerts
   - /docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-alerts
+  - /docs/alerts-applied-intelligence/notifications/intro-notifications
 ---
 
 import accountsNewRelicSetThresholdsExample from 'images/accounts_screenshot-crop_new-relic-set-thresholds-example.png'
@@ -95,13 +96,13 @@ We give you control over every part of creating a robust alerting solution for y
       </td>
 
       <td>
-        We offer customizable notification channels via many common services, including email, mobile push notifications, OpsGenie, Slack, and more. To see supported services, see [Notification channels](/docs/alerts/new-relic-alerts/managing-notification-channels/notification-channels-control-where-send-alerts).
+        We offer customizable notification channels via many common services, including email, mobile push notifications, PagerDuty, Slack, and more. To get started, see [Introduction to notifications](/docs/alerts-applied-intelligence/notifications/intro-notifications).
       </td>
     </tr>
   </tbody>
 </table>
 
-## Unique, intelligent features [#features]
+## Unique, advanced features [#features]
 
 Besides the standard controls you'd expect from a complete alerting solution, we offer some unique and powerful features, including:
 
@@ -171,31 +172,11 @@ Besides the standard controls you'd expect from a complete alerting solution, we
 
     <tr>
       <td>
-        Webhooks
+        Issue scoping and rollups
       </td>
 
       <td>
-        Customizable [webhooks](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/customize-your-webhook-payload) allow you to define custom headers, basic authentication, custom payloads, and more.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Incident scoping and rollups
-      </td>
-
-      <td>
-        Every alert policy can be configured to use one of [three violation grouping strategies](/docs/alerts/new-relic-alerts-beta/reviewing-alert-incidents/specify-when-new-relic-creates-incidents) to control the number of alert incidents created, and therefore the number of notifications sent.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Cross-product events
-      </td>
-
-      <td>
-        A dedicated [**Events** page](/docs/alerts/new-relic-alerts-beta/reviewing-events/review-events-across-products) that shows operational events across all of your products.
+        Every alert policy can be configured to use one of [three violation grouping strategies](/docs/alerts/new-relic-alerts-beta/reviewing-alert-incidents/specify-when-new-relic-creates-incidents) to control the number of alert issues created, and therefore the number of notifications sent.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
This removes references to the Events page and Classic Notification channels, which will soon EOL.  It replaces terms where possible.