### PR TITLE
fix(security policy): X-ref to .com page

### DIFF
--- a/src/content/docs/licenses/license-information/referenced-policies/security-policy.mdx
+++ b/src/content/docs/licenses/license-information/referenced-policies/security-policy.mdx
@@ -9,6 +9,10 @@ redirects:
   - /docs/licenses/license-information/referenced-policies/security-exhibit
 ---
 
+<Callout variant="tip">
+   This doc describes New Relic's security policies and procedures. To get a general overview of our approach to security, or get in touch with our Security Team, see [newrelic.com/security](https://newrelic.com/security).
+</Callout>
+
 **Updated 23 September 2021.**
 
 The below Security Policy applies only to customers with an existing New Relic agreement in place that explicitly references this Security Policy applying to the Service purchased in an Order. Capitalized terms not defined below shall take on the meaning set forth in such New Relic agreement.


### PR DESCRIPTION
This was a pain point in user research—users getting stuck in this policy page when they're really looking for a general overview of how we approach security.

cc @jjang-nr , minor change to the security policy page to x-ref the .com friendly overview. 