### PR TITLE
fix: render icon suffix for external links

### DIFF
--- a/src/components/MDXContainer.js
+++ b/src/components/MDXContainer.js
@@ -22,6 +22,11 @@ import TechTile from './TechTile';
 import WhatsNextTile from './WhatsNextTile';
 
 const defaultComponents = {
+  a: ({ href, children }) => (
+    <Link to={href} displayExternalIcon={href?.startsWith('http')}>
+      {children}
+    </Link>
+  ),
   img: (props) =>
     props.style || props.variant === 'TechTile' ? (
       <img


### PR DESCRIPTION
This PR fixes markdown links pointed at external domains which have not been rendering with the icon suffix.

## Give us some context

* What problems does this PR solve?
This PR fixes markdown links pointed at external domains which have not been rendering with the icon suffix.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  
<img width="1146" alt="Screen Shot 2022-12-14 at 12 08 10 PM" src="https://user-images.githubusercontent.com/120055750/207661125-afe2e6f9-a952-4855-b69e-45415a0b573b.png">

  
* If your issue relates to an existing GitHub issue, please link to it.
https://issues.newrelic.com/browse/NR-35724