### PR TITLE
chore: refactor to use MDXLink

### DIFF
--- a/src/components/MDXContainer.js
+++ b/src/components/MDXContainer.js
@@ -2,6 +2,7 @@ import {
   ExternalLink,
   Link,
   Lightbox,
+  MDXLink,
   MDX,
   MarkdownContainer,
   Tabs,
@@ -22,11 +23,7 @@ import TechTile from './TechTile';
 import WhatsNextTile from './WhatsNextTile';
 
 const defaultComponents = {
-  a: ({ href, children }) => (
-    <Link to={href} displayExternalIcon={href?.startsWith('http')}>
-      {children}
-    </Link>
-  ),
+  a: (props) => <MDXLink {...props} displayExternalIcon />,
   img: (props) =>
     props.style || props.variant === 'TechTile' ? (
       <img


### PR DESCRIPTION
This PR fixes markdown links pointed at external domains which have not been rendering with the icon suffix. It also fixes the hover link behavior introduced in the first PR https://github.com/newrelic/docs-website/pull/10727

## Give us some context

* What problems does this PR solve?
This PR fixes markdown links pointed at external domains which have not been rendering with the icon suffix. It also fixes the hover link behavior introduced in the first PR https://github.com/newrelic/docs-website/pull/10727


* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
<img width="895" alt="Screen Shot 2022-12-14 at 1 42 26 PM" src="https://user-images.githubusercontent.com/120055750/207684618-ab9135e8-84c1-449f-843d-55aa05ebd8e1.png">

* If your issue relates to an existing GitHub issue, please link to it.
* https://issues.newrelic.com/browse/NR-35724