### PR TITLE
Remove "Limited Preview" label (merge before 9am 12/15)

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/gcp-vpc-flow-log-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/gcp-vpc-flow-log-monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-title: Set up Google VPC Flow Logs monitoring - Limited Preview
+title: Set up Google VPC Flow Logs monitoring
 tags:
   - Integrations
   - Network monitoring
@@ -10,8 +10,6 @@ metaDescription: Set up Amazon VPC Flow Logs monitoring.
 ---
 
 import networkCloudFlowLogsOverview from 'images/network_screenshot-crop_cloud-flow-logs-overview.png'
-
-This feature is in a [limited preview](https://docs.newrelic.com/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
 
 Google Cloud's Virtual Private Cloud Flow (VPC) Logs supports the frictionless transmission of logs to New Relic. With VPC flow logs from across your GCP estates, you can quickly understand key insights for performance analytics and troubleshooting network connectivity.
 


### PR DESCRIPTION
GCP Flow Logs are being released to GA tomorrow so we're ready to remove this "Limited Preview" label