### PR TITLE
chore: fix code examples

### DIFF
--- a/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
@@ -48,29 +48,29 @@ We recommend you use Heroku HTTPS drains because they're simple to set up and be
 3. Use the Heroku CLI to create a Syslog drain and attach it to the application you want to stream logs from, replacing `YOUR_APP_NAME` with the name of your Heroku application.
 
    ```shell
-   $ heroku drains:add syslog+tls://newrelic.syslog.nr-data.net:6515 -a YOUR_APP_NAME
+   heroku drains:add syslog+tls://newrelic.syslog.nr-data.net:6515 -a YOUR_APP_NAME
    ```
 
    If you're located in Europe, run this command instead:
 
    ```shell
-   $ heroku drains:add syslog+tls://newrelic.syslog.eu.nr-data.net:6515 -a YOUR_APP_NAME
+   heroku drains:add syslog+tls://newrelic.syslog.eu.nr-data.net:6515 -a YOUR_APP_NAME
    ```
 
 4. Run the following command and copy the Heroku Syslog [drain token](https://devcenter.heroku.com/articles/log-drains#drain-tokens) from the `token` attribute:
 
    ```shell
-   $ heroku drains -a YOUR_APP_NAME --json
+   heroku drains -a YOUR_APP_NAME --json
    ```
 
    ```json
    {
-   "addon": null,
-   "created_at": "2018-12-04T00:59:46Z",
-   "id": "906262a4-e151-45d2-b35a-a2dc0ea9e688",
-   "token": "d.f14da5dc-106b-468d-b1bd-bed0ed9fa1e7",
-   "updated_at": "2018-12-04T00:59:47Z",
-   "url": "syslog+tls://newrelic.syslog.nr-data.net:6515
+     "addon": null,
+     "created_at": "2018-12-04T00:59:46Z",
+     "id": "906262a4-e151-45d2-b35a-a2dc0ea9e688",
+     "token": "d.f14da5dc-106b-468d-b1bd-bed0ed9fa1e7",
+     "updated_at": "2018-12-04T00:59:47Z",
+     "url": "syslog+tls://newrelic.syslog.nr-data.net:6515"
    }
    ```
 
@@ -111,7 +111,7 @@ To delete a Heroku syslog drain token mapping via REST API:
 
 
    ```shell
-   curl -H 'api-key: <var>YOUR_NR_LICENSE_KEY</var>' https://log-syslog-configuration-api.service.newrelic.com/heroku-account-mappings?accountId=<var>YOUR_NR_ACCOUNT_ID</var>
+   curl -H 'api-key: YOUR_NR_LICENSE_KEY' https://log-syslog-configuration-api.service.newrelic.com/heroku-account-mappings?accountId=YOUR_NR_ACCOUNT_ID
    ```
 
 The formatted result looks something like this:
@@ -133,7 +133,7 @@ The formatted result looks something like this:
  3. To delete a drain token, run the command below. Make sure to update values for `YOUR_NR_LICENSE_KEY`(https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#license-key),`YOUR_NR_ACCOUNT_ID`(https://docs.newrelic.com/docs/accounts/accounts-billing/account-structure/account-id/), and the `herokuMappingId` you retrieved in the last step:
 
    ```shell
-   curl -XDELETE -H 'api-key: <varYOUR_NR_LICENSE_KEY</var>' https://log-syslog-configuration-api.service.newrelic.com/heroku-account-mappings/<herokuMappingId>?accountId=<var>YOUR_NR_ACCOUNT_ID</var>
+   curl -XDELETE -H 'api-key: YOUR_NR_LICENSE_KEY' https://log-syslog-configuration-api.service.newrelic.com/heroku-account-mappings/<herokuMappingId>?accountId=YOUR_NR_ACCOUNT_ID
    ```
    
 When you're done, the API returns an HTTP 204 response and the drain token mapping is deleted.


### PR DESCRIPTION
The code examples had typos and the `<var>`s were showing as plain text.
<img width="471" alt="image" src="https://user-images.githubusercontent.com/48165493/207727708-56c061d2-0128-4bd5-8f4c-fb8978fac65d.png">

The `$` cmd prompt is added when you make format the code as `shell` or `bash`, so it was there twice:
<img width="344" alt="image" src="https://user-images.githubusercontent.com/48165493/207727557-f6cda773-b9a2-412f-be48-6425c5b8a3d7.png">


