### PR TITLE
Update cocreateinstance-errors-no-profiler-log.mdx

### DIFF
--- a/src/content/docs/apm/agents/net-agent/troubleshooting/cocreateinstance-errors-no-profiler-log.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/cocreateinstance-errors-no-profiler-log.mdx
@@ -37,13 +37,13 @@ To verify whether New Relic has the necessary permissions and resolve the proble
     1. Check your application event log for errors like this:
 
        ```
-       NET Runtime version 4.0.30319.296 - Loading profiler failed during CoCreateInstance. Profiler CLSID: '{FF68FEB9-E58A-4B75-A2B8-90CE7D915A26}'
+       NET Runtime version 4.0.30319.296 - Loading profiler failed during CoCreateInstance. Profiler CLSID: '{71DA0A04-7777-4EC6-9643-7D28B46A8A41}'
        ```
     2. Compare the CLSID in the error to New Relic's CLSIDs:
 
        ```
-       71DA0A04-7777-4EC6-9643-7D28B46A8A41
-       FF68FEB9-E58A-4B75-A2B8-90CE7D915A26
+       {71DA0A04-7777-4EC6-9643-7D28B46A8A41} (.NET Framework agent)
+       {36032161-FFC0-4B61-B559-F6C5D41BAE5A} (.NET Core agent)
        ```
     3. Do one of the following:
 


### PR DESCRIPTION
Confirmed with ENG that 'FF68FEB9-E58A-4B75-A2B8-90CE7D915A26' is no longer a CLSID we use. Agents that still use this CLSID are non-functional and are not supported.

https://newrelic.slack.com/archives/C7HNR7WNR/p1671065903362929

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.