### PR TITLE
Update dashboard permission labels to match UI

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards.mdx
@@ -115,7 +115,7 @@ Create a dashboard from the dashboards index by selecting the **+ Create a dashb
 3. Press **Create** to continue, or **Cancel** to return to the index.
 
 <Callout variant="tip">
-  By default a dashboard is created with [**Public - Read and write**](#dashboards-permissions) permissions. You can edit them from the settings menu once you access the dashboard.
+  By default a dashboard is created with [**Edit - everyone in account**](#dashboards-permissions) permissions. You can edit them from the settings menu once you access the dashboard.
 </Callout>
 
 Alternatively, you can also create a new dashboard:
@@ -151,7 +151,7 @@ To organize dashboards with multiple pages, see [Add pages to a dashboard](/docs
 
     The dashboard is automatically copied and the duplicate is added to the index. Access the new dashboard by clicking on the message that pops up on your screen.
 
-    The duplicated dashboard is named like the original dashboard followed by the word "copy". For example, if you duplicate a dashboard named `this is my dashboard`, the duplicate will be created as `this is my dashboard copy`. The duplicate has **Public - Read and write** permissions.
+    The duplicated dashboard is named like the original dashboard followed by the word "copy". For example, if you duplicate a dashboard named `this is my dashboard`, the duplicate will be created as `this is my dashboard copy`. The duplicate has **Edit - everyone in account** permissions.
 
     You can edit the name and other properties of the dashboard, like the permissions, at any time.
 
@@ -164,7 +164,7 @@ To organize dashboards with multiple pages, see [Add pages to a dashboard](/docs
     id="dashboards-delete"
     title="Delete a dashboard"
   >
-    To delete a dashboard, hover over the dashboard row at the index until the **Delete** button appears. You can only delete a dashboard if you created it, or if it has **Public - Read and write** permissions. For more information, [see the permissions information](#dashboards-permissions).
+    To delete a dashboard, hover over the dashboard row at the index until the **Delete** button appears. You can only delete a dashboard if you created it, or if it has **Edit - everyone in account** permissions. For more information, [see the permissions information](#dashboards-permissions).
 
     You can also delete a dashboard from the settings panel of the dashboard.
   </Collapser>
@@ -192,11 +192,11 @@ To organize dashboards with multiple pages, see [Add pages to a dashboard](/docs
 
 Dashboards have three types of permissions:
 
-* **Public - Read and write**: All users have full rights to the dashboard.
-* **Public - Read only**: All users are able to see the dashboard, but only you have full rights to work with the dashboard. Other users can access the dashboard but are not able to edit or delete it, although they can duplicate it.
+* **Edit - everyone in account**: All users have full rights to the dashboard.
+* **Read-only - everyone in account**: All users are able to see the dashboard, but only you have full rights to work with the dashboard. Other users can access the dashboard but are not able to edit or delete it, although they can duplicate it.
 * **Private**: Only you can see the dashboard. Everything but the metadata is hidden.
 
-When you [create a dashboard](/docs/dashboards/explore-dashboards-index/explore-dashboards-index#create-dashboard) using the **Create a dashboard** button or by duplicating another dashboard, it will have **Public - Read and write** rights by default. Access the new dashboard to change this setting.
+When you [create a dashboard](/docs/dashboards/explore-dashboards-index/explore-dashboards-index#create-dashboard) using the **Create a dashboard** button or by duplicating another dashboard, it will have **Edit - everyone in account** rights by default. Access the new dashboard to change this setting.
 
 ## Create and manage dashboards via API [#nerdgraph]
 


### PR DESCRIPTION
The UI labels appear to have changed for dashboard permission on the create and edit dashboard pages. This commit updates the documentation to reflect the current dashboard permission labels.


<img width="437" alt="2022-12-15_Dashboard_Permission_Label_Update" src="https://user-images.githubusercontent.com/51721024/207897101-d9ca6016-3de7-4098-b791-ab9bd4a9d48e.png">
Screenshot of current labels on the create/edit dashboard pages.