### PR TITLE
Fix(Go Agent): corrected release date

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-20-2.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-20-2.mdx
@@ -1,8 +1,8 @@
 ---
 subject: Go agent
-releaseDate: '2022-11-15'
+releaseDate: '2022-12-14'
 version: 3.20.2
-downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.20.1'
+downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.20.2'
 ---
 ## 3.20.2
 


### PR DESCRIPTION
Corrects the release date and git link for the 3.20.2 Go agent release