### PR TITLE
Try lessBabel option in gatsby-plugin-mdx

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -221,6 +221,7 @@ module.exports = {
             ),
           },
         ],
+        lessBabel: true,
       },
     },
     `gatsby-transformer-yaml`,


### PR DESCRIPTION
This was suggested as possibly helpful for our issue with builds not failing on mdx errors when they should