### PR TITLE
fix(PHP agent): Clarify newrelic_record_datastore_segment string restrictions

### DIFF
--- a/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_record_datastore_segment.mdx
+++ b/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_record_datastore_segment.mdx
@@ -20,17 +20,17 @@ newrelic_record_datastore_segment(callable $func, array $parameters)
 
 Records a datastore segment.
 
-## Requirements
+## Requirements [#require]
 
 Agent version [7.5.0.199](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-750199) or higher.
 
-## Description
+## Description [#desc]
 
 Records a datastore segment. Datastore segments appear in the **Breakdown table** and **Databases** tab of the [Transactions page](/docs/apm/applications-menu/monitoring/transactions-page) in the New Relic UI.
 
 This function allows an unsupported datastore to be instrumented in the same way as the PHP agent automatically instruments its [supported datastores](/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements#databases).
 
-## Parameters
+## Parameters [#para]
 
 <table>
   <thead>
@@ -204,11 +204,15 @@ The supported keys in the `$parameters` array are as follows:
   </tbody>
 </table>
 
-## Return values
+<Callout variant="important">
+  The _string_ arguments used in the `$parameters` array should not contain the special character '/'.
+</Callout>
+
+## Return values [#return]
 
 The return value of `$callback` is returned. If an error occurs, `false` is returned, and an error at the `E_WARNING` level will be triggered.
 
-## Examples
+## Examples [#examples]
 
 ### Instrumenting an unsupported NoSQL datastore [#unsupported-nosql]
 


### PR DESCRIPTION
This change make it clear that a special character ('/') should not be used with certain parameters for the `newrelic_record_datastore_segment()` PHP agent API call.