### PR TITLE
docs: Update subqueries-in-nrql.mdx

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/subqueries-in-nrql.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/subqueries-in-nrql.mdx
@@ -26,7 +26,7 @@ A subquery's results must make sense in context. In the example above, the great
 
 A subquery may be nested inside another subquery. A maximum of three subqueries, nested or unnested, is allowed in a query.
 
-The subquery's time range will be the same as the outer query's, unless explicitly specified with [`SINCE`](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#sel-since)/[`UNTIL`](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#sel-until).
+The subquery's time range will be the same as the outer query's, unless explicitly specified with [`SINCE`](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#sel-since)/[`UNTIL`](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#sel-until). In a dashboard, choosing a window from the [time picker](https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/#dash-time-picker) will also set the subquery's time range to be the same as the outer query's, unless "Ignore Time Picker" is set for that chart.
 
 ## Subquery execution [#subquery-execution]
 

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/subqueries-in-nrql.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/subqueries-in-nrql.mdx
@@ -26,7 +26,7 @@ A subquery's results must make sense in context. In the example above, the great
 
 A subquery may be nested inside another subquery. A maximum of three subqueries, nested or unnested, is allowed in a query.
 
-The subquery's time range will be the same as the outer query's, unless explicitly specified with [`SINCE`](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#sel-since)/[`UNTIL`](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#sel-until). In a dashboard, choosing a window from the [time picker](https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/#dash-time-picker) will also set the subquery's time range to be the same as the outer query's, unless "Ignore Time Picker" is set for that chart.
+The subquery's time range will be the same as the outer query's, unless explicitly specified with [`SINCE`](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#sel-since)/[`UNTIL`](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#sel-until). In a dashboard, choosing a window from the [time picker](https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/#dash-time-picker) aligns the subquery's time range with the outer query's. If you've set **Ignore Time Picker** for that chart, then the subquery's time range and the outer query's time range will not be the same.
 
 ## Subquery execution [#subquery-execution]
 


### PR DESCRIPTION
Clarify behavior of subqueries and time picker


* What problems does this PR solve?
Currently, the docs aren't clear on the interaction between the time picker and subqueries. Since time pickers override SINCE/UNTIL in subqueries, clarifying the docs here will help people understand the expected behavior.

https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/#dash-time-picker