### PR TITLE
Clarify warning threshold

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/set-thresholds-alert-condition.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/set-thresholds-alert-condition.mdx
@@ -131,7 +131,7 @@ Details about other functionality and rules:
           </td>
 
           <td>
-            Optional. Will open warning-level incident and may roll up into and issue that is already open. Use a warning threshold if you want to monitor when a system behavior is concerning or noteworthy but not important enough to require a critical-level threshold.
+            Optional. Will open warning-level incident and may send notifications depending on the policy's [issue creation preference setting](/docs/alerts/new-relic-alerts/configuring-alert-policies/specify-when-new-relic-creates-incidents) and any [workflow](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/) you may have configured. Use a warning threshold if you want to monitor when a system behavior is concerning or noteworthy but not important enough to require a critical-level threshold.
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
Warning incidents can now open issues just like critical incidents can -- there is functionally no longer any difference between the two (besides the color of the traffic light yellow/red depending on priority level of incident warning/critical).

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.