### PR TITLE
Conditionally add install steps

### DIFF
--- a/plugins/gatsby-source-install-config/gatsby-node.js
+++ b/plugins/gatsby-source-install-config/gatsby-node.js
@@ -95,7 +95,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       filePath: String 
       mdx: Mdx
       skip: Boolean
-      addStep: Boolean
+      isConditionalStep: Boolean
       selectedOptions: [AppInfoSelectedOption]
     }
     type AppInfoSelectedOption @dontInfer {

--- a/plugins/gatsby-source-install-config/gatsby-node.js
+++ b/plugins/gatsby-source-install-config/gatsby-node.js
@@ -88,7 +88,6 @@ exports.createSchemaCustomization = ({ actions }) => {
     }
     type InstallStep @dontInfer {
       filePath: String
-      skip: Boolean
       mdx: Mdx
       overrides: [StepOverride]
     }
@@ -96,6 +95,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       filePath: String 
       mdx: Mdx
       skip: Boolean
+      addStep: Boolean
       selectedOptions: [AppInfoSelectedOption]
     }
     type AppInfoSelectedOption @dontInfer {

--- a/src/install/config/demo.yaml
+++ b/src/install/config/demo.yaml
@@ -56,7 +56,7 @@ steps:
               - value: 'fourthOption'
   - filePath: 'src/install/demo/dropdown2/addStep.mdx'
     overrides:
-      - addStep: true
+      - isConditionalStep: true
         selectedOptions:
           - optionType: dropdown2
             options:

--- a/src/install/config/demo.yaml
+++ b/src/install/config/demo.yaml
@@ -54,4 +54,11 @@ steps:
           - optionType: dropdown2
             options:
               - value: 'fourthOption'
+  - filePath: 'src/install/demo/dropdown2/addStep.mdx'
+    overrides:
+      - addStep: true
+        selectedOptions:
+          - optionType: dropdown2
+            options:
+              - value: 'thirdOption'
 whatsNextFilePath: 'src/install/demo/whatsNext.mdx'

--- a/src/install/demo/dropdown2/addStep.mdx
+++ b/src/install/demo/dropdown2/addStep.mdx
@@ -1,0 +1,6 @@
+---
+componentType: default
+headingText: This step was added
+---
+
+🎉 and only appears if you select option 3

--- a/src/pages/install/{installConfig.agentName}.js
+++ b/src/pages/install/{installConfig.agentName}.js
@@ -115,14 +115,13 @@ const InstallPage = ({ data, location }) => {
     let shouldNotRender = false;
     if (overrides) {
       for (const override of overrides) {
-        const { selectedOptions, addStep } = override;
+        const { selectedOptions, isConditionalStep } = override;
         const isOverridden = selectedOptions.every(matchOverride);
-        const hasAddOption = addStep;
-        if (isOverridden && hasAddOption) {
+        if (isOverridden && isConditionalStep) {
           return { content: renderFromComponentType(step), step };
         } else if (isOverridden) {
           return { content: renderFromComponentType(override), step: override };
-        } else if (hasAddOption) {
+        } else if (isConditionalStep) {
           shouldNotRender = true;
         }
       }
@@ -352,7 +351,7 @@ export const pageQuery = graphql`
           mdx {
             ...MDXInstallFragment
           }
-          addStep
+          isConditionalStep
           skip
           selectedOptions {
             optionType

--- a/src/pages/install/{installConfig.agentName}.js
+++ b/src/pages/install/{installConfig.agentName}.js
@@ -112,16 +112,23 @@ const InstallPage = ({ data, location }) => {
 
   const renderStep = (step) => {
     const { overrides } = step;
-
+    let shouldNotRender = false;
     if (overrides) {
       for (const override of overrides) {
-        const { selectedOptions } = override;
-        const isOverrided = selectedOptions.every(matchOverride);
-
-        if (isOverrided) {
+        const { selectedOptions, addStep } = override;
+        const isOverridden = selectedOptions.every(matchOverride);
+        const hasAddOption = addStep;
+        if (isOverridden && hasAddOption) {
+          return { content: renderFromComponentType(step), step };
+        } else if (isOverridden) {
           return { content: renderFromComponentType(override), step: override };
+        } else if (hasAddOption) {
+          shouldNotRender = true;
         }
       }
+    }
+    if (shouldNotRender) {
+      return { content: null };
     }
     return { content: renderFromComponentType(step), step };
   };
@@ -345,6 +352,7 @@ export const pageQuery = graphql`
           mdx {
             ...MDXInstallFragment
           }
+          addStep
           skip
           selectedOptions {
             optionType


### PR DESCRIPTION
this adds a boolean to overrides called addStep. setting it to true will cause the step to not render unless the options defined in the override are selected