### PR TITLE
fix: introduction-new-relic-rest-api-v2.mdx - typo

### DIFF
--- a/src/content/docs/apis/rest-api-v2/get-started/introduction-new-relic-rest-api-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/get-started/introduction-new-relic-rest-api-v2.mdx
@@ -49,7 +49,7 @@ The API calls require a URL to specify the location from which the data will be 
 https://api.newrelic.com/v2/applications/<var>$APP_ID</var>/<var>metrics/data.json</var>
 ```
 
-The <var>[$APPID](/docs/apis/rest-api-v2/requirements/finding-product-id)</var> specifies the exact application or product for which the data is being requested. The information following this parameter will vary depending on the data request.
+The <var>[$APP_ID](/docs/apis/rest-api-v2/requirements/finding-product-id)</var> specifies the exact application or product for which the data is being requested. The information following this parameter will vary depending on the data request.
 
 If you have an [EU region account](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center), the URL is:
 


### PR DESCRIPTION
variable $APPID becomes $APP_ID for consistency in the example/tutorial

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
A small typo exists in the documentation. Variable $APPID should be $APP_ID for consistency in the example/tutorial.

* Add any context that will help us review your changes such as testing notes, links to related docs, screenshots, etc.
https://docs.newrelic.com/docs/apis/rest-api-v2/get-started/introduction-new-relic-rest-api-v2/#appid
As per:
![image](https://user-images.githubusercontent.com/78896694/208776566-57f41bbb-f840-4ea1-bc9a-71f9fce37dae.png)



* If your issue relates to an existing GitHub issue, please link to it.
N/A