### PR TITLE
chore: minor code cleanup, added missing config option for fedramp

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -678,6 +678,48 @@ The `service` element supports the following attributes:
 
     Automatically start the .NET agent when the first instrumented method is hit.
   </Collapser>
+  
+  <Collapser
+    id="service-host"
+    title="host"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Provides the ability to configure a [FedRAMP compliant endpoint](/docs/security/security-privacy/compliance/fedramp-compliant-endpoints/) for the agent to use, with the value `gov-collector.newrelic.com`. 
+  
+    ```xml
+    <service licenseKey="YOUR_LICENSE_KEY"
+      host="gov-collector.newrelic.com"/>
+    ```
+    
+    You can also use the environment variable `NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD`.
+  
+    ```ini
+    NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD=gov-collector.newrelic.com
+    ```
+  </Collapser>
 </CollapserGroup>
 
 ### Obscuring key element [#obscuring-key]

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -711,13 +711,13 @@ The `service` element supports the following attributes:
   
     ```xml
     <service licenseKey="YOUR_LICENSE_KEY"
-      host="gov-collector.newrelic.com"/>
+      host="gov-collector.newrelic.com" />
     ```
     
-    You can also use the environment variable `NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD`.
+    You can also use the environment variable `NEW_RELIC_HOST`.
   
     ```ini
-    NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD=gov-collector.newrelic.com
+    NEW_RELIC_HOST=gov-collector.newrelic.com
     ```
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -139,7 +139,7 @@ Our .NET agent relies on environment variables to tell the .NET Common Language 
   >
     For .NET Framework, the following variables are required:
 
-    ```
+    ```ini
     COR_ENABLE_PROFILING=1
     COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
     NEWRELIC_INSTALL_PATH="INSERT_THE_PATH_TO_THE_AGENT_DIRECTORY"
@@ -160,7 +160,7 @@ Our .NET agent relies on environment variables to tell the .NET Common Language 
 
     **Linux:**
 
-    ```
+    ```ini
     CORECLR_ENABLE_PROFILING=1
     CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
     CORECLR_NEWRELIC_HOME=<var>path/to/agent/directory</var>
@@ -169,7 +169,7 @@ Our .NET agent relies on environment variables to tell the .NET Common Language 
 
     **Windows (MSI Installer):**
 
-    ```
+    ```ini
     CORECLR_ENABLE_PROFILING=1
     CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
     NEWRELIC_INSTALL_PATH=<var>C:\Program Files\New Relic\.NET Agent\</var>
@@ -382,7 +382,7 @@ The `service` element supports the following attributes:
 
     Alternatively, set the `NEW_RELIC_LICENSE_KEY` environment variable in the application's environment.
 
-    ```
+    ```ini
     NEW_RELIC_LICENSE_KEY=<var>XXXXXXXX</var>
     ```
   </Collapser>
@@ -481,7 +481,7 @@ The `service` element supports the following attributes:
   
     Alternatively, set the `NEW_RELIC_SEND_DATA_ON_EXIT` environment variable in the application's environment.
 
-    ```
+    ```ini
     NEW_RELIC_SEND_DATA_ON_EXIT=<var>true|false</var>
     ```
   </Collapser>
@@ -528,7 +528,7 @@ The `service` element supports the following attributes:
   
     Alternatively, set the `NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS` environment variable in the application's environment.
 
-    ```
+    ```ini
     NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS=<var>2000</var>
     ```
   </Collapser>
@@ -600,7 +600,7 @@ The `service` element supports the following attributes:
 
     Alternatively, the `NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD` environment variable may be used to control this behavior.
 
-    ```
+    ```ini
     NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD=<var>true|false</var>
     ```
   </Collapser>
@@ -686,7 +686,7 @@ The `obscuringKey` element is an optional child of the `service` element. The .N
 
 ```xml
 <service licenseKey="<var>YOUR_LICENSE_KEY</var>">
-    <obscuringKey><var>OBSCURING_KEY</var></obscuringKey>
+  <obscuringKey><var>OBSCURING_KEY</var></obscuringKey>
 </service>
 ```
 
@@ -702,14 +702,14 @@ The `proxy` element is an optional child of the `service` element. The `proxy` e
 
 ```xml
 <service licenseKey="<var>YOUR_LICENSE_KEY</var>">
- <proxy
-   host="<var>hostname</var>"
-   port="<var>PROXY_PORT</var>"
-   uriPath="<var>path/to/something.aspx</var>"
-   domain="<var>mydomain.com</var>"
-   user="<var>PROXY_USERNAME</var>"
-   password="<var>PROXY_PASSWORD</var>"
-   passwordObfuscated="<var>OBFUSCATED_PROXY_PASSWORD</var>"/>
+  <proxy
+    host="<var>hostname</var>"
+    port="<var>PROXY_PORT</var>"
+    uriPath="<var>path/to/something.aspx</var>"
+    domain="<var>mydomain.com</var>"
+    user="<var>PROXY_USERNAME</var>"
+    password="<var>PROXY_PASSWORD</var>"
+    passwordObfuscated="<var>OBFUSCATED_PROXY_PASSWORD</var>"/>
 </service>
 ```
 
@@ -1141,7 +1141,7 @@ The `log` element supports the following attributes:
 
     Alternatively, set the `NEW_RELIC_LOG` environment variable in the application's environment.
 
-    ```
+    ```ini
     NEW_RELIC_LOG=MyApp.log
     ```
   </Collapser>
@@ -1194,7 +1194,7 @@ The `application` element is a child of the `configuration` element. This requir
 
     Alternatively, set the `NEW_RELIC_APP_NAME` environment variable in the application's environment.
 
-    ```
+    ```ini
     NEW_RELIC_APP_NAME=Descriptive Name
     ```
   </Collapser>
@@ -1231,7 +1231,7 @@ The `application` element is a child of the `configuration` element. This requir
 
     Alternatively, set the `NEW_RELIC_DISABLE_SAMPLERS` environment variable in the application's environment.
 
-    ```
+    ```ini
     NEW_RELIC_DISABLE_SAMPLERS=true
     ```
   </Collapser>
@@ -1297,7 +1297,7 @@ To set a display name, choose one of the following options. The environment vari
 
     ```xml
     <configuration . . . >
-       <processHost displayName="<var>CUSTOM_NAME</var>" />
+      <processHost displayName="<var>CUSTOM_NAME</var>" />
     </configuration>
     ```
   </Collapser>
@@ -1308,8 +1308,8 @@ To set a display name, choose one of the following options. The environment vari
   >
     Set the `NEW_RELIC_PROCESS_HOST_DISPLAY_NAME` environment variable:
 
-    ```
-    NEW_RELIC_PROCESS_HOST_DISPLAY_NAME = "<var>CUSTOM_NAME</var>"
+    ```ini
+    NEW_RELIC_PROCESS_HOST_DISPLAY_NAME="<var>CUSTOM_NAME</var>"
     ```
   </Collapser>
 </CollapserGroup>
@@ -1359,7 +1359,7 @@ The `utilization` element supports the following attributes:
 
     Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_AWS` environment variable:
 
-    ```
+    ```ini
     NEW_RELIC_UTILIZATION_DETECT_AWS=<var>true|false</var>
     ```
   </Collapser>
@@ -1396,7 +1396,7 @@ The `utilization` element supports the following attributes:
 
     Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_AZURE` environment variable:
 
-    ```
+    ```ini
     NEW_RELIC_UTILIZATION_DETECT_AZURE=<var>true|false</var>
     ```
   </Collapser>
@@ -1433,7 +1433,7 @@ The `utilization` element supports the following attributes:
 
     Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_GCP` environment variable:
 
-    ```
+    ```ini
     NEW_RELIC_UTILIZATION_DETECT_GCP=<var>true|false</var>
     ```
   </Collapser>
@@ -1470,7 +1470,7 @@ The `utilization` element supports the following attributes:
 
     Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_PCF` environment variable:
 
-    ```
+    ```ini
     NEW_RELIC_UTILIZATION_DETECT_PCF=<var>true|false</var>
     ```
   </Collapser>
@@ -1507,7 +1507,7 @@ The `utilization` element supports the following attributes:
 
     Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_DOCKER` environment variable:
 
-    ```
+    ```ini
     NEW_RELIC_UTILIZATION_DETECT_DOCKER=<var>true|false</var>
     ```
   </Collapser>
@@ -1544,7 +1544,7 @@ The `utilization` element supports the following attributes:
 
     Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_KUBERNETES` environment variable:
 
-    ```
+    ```ini
     NEW_RELIC_UTILIZATION_DETECT_KUBERNETES=<var>true|false</var>
     ```
   </Collapser>
@@ -2179,9 +2179,8 @@ The `stripExceptionMessages` element is a child of the `configuration` element. 
 The `transactionEvents` element is a child of the `configuration` element. Use `transactionEvents` to configure transaction events.
 
 ```xml
-<transactionEvents enabled="true"
-  maximumSamplesStored="10000">
- <attributes enabled="true">
+<transactionEvents enabled="true" maximumSamplesStored="10000">
+  <attributes enabled="true">
     <exclude><var>myApiKey.*</var></exclude>
     <include><var>myApiKey.foo</var></include>
   </attributes>
@@ -2254,7 +2253,7 @@ The `transactionEvents` element supports the following attributes:
 
     Alternatively, set the `MAX_TRANSACTION_SAMPLES_STORED` environment variable in the application's environment.
 
-    ```
+    ```ini
     MAX_TRANSACTION_SAMPLES_STORED=500
     ```
   </Collapser>
@@ -2349,7 +2348,7 @@ The `customEvents` element supports the following attributes:
 
     Alternatively, set the `MAX_EVENT_SAMPLES_STORED` environment variable in the application's environment.
 
-    ```
+    ```ini
     MAX_EVENT_SAMPLES_STORED=500
     ```
   </Collapser>
@@ -2924,7 +2923,7 @@ The `distributedTracing` element supports the following attributes:
 
     Alternatively, enable distributed tracing via the `NEW_RELIC_DISTRIBUTED_TRACING_ENABLED` environment variable in the application's environment.
 
-    ```
+    ```ini
     NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true
     ```
   </Collapser>
@@ -2974,7 +2973,7 @@ Distributed tracing reports span events. Span event reporting is enabled by defa
 
     ```xml
     <configuration . . . >
-       <spanEvents enabled="false" />
+      <spanEvents enabled="false" />
     </configuration>
     ```
   </Collapser>
@@ -2985,7 +2984,7 @@ Distributed tracing reports span events. Span event reporting is enabled by defa
   >
     Set the `NEW_RELIC_SPAN_EVENTS_ENABLED` environment variable in the application's environment.
 
-    ```
+    ```ini
     NEW_RELIC_SPAN_EVENTS_ENABLED=false
     ```
   </Collapser>
@@ -2999,10 +2998,10 @@ To turn on [Infinite Tracing](https://newrelic.com/products/edge-infinite-tracin
 
 ```xml
 <configuration . . . >
-   <distributedTracing enabled="true" />
-   <infiniteTracing>
-      <trace_observer host="<var>YOUR_TRACE_OBSERVER_HOST</var>" />
-   </infiniteTracing>
+  <distributedTracing enabled="true" />
+  <infiniteTracing>
+    <trace_observer host="<var>YOUR_TRACE_OBSERVER_HOST</var>" />
+  </infiniteTracing>
 </configuration>
 ```
 
@@ -3033,7 +3032,7 @@ The `spanEvents` element is a child of the `configuration` element. Use `spanEve
 
 ```xml
 <spanEvents enabled="true">
- <attributes enabled="true">
+  <attributes enabled="true">
     <exclude><var>myApiKey.*</var></exclude>
     <include><var>myApiKey.foo</var></include>
   </attributes>
@@ -3221,17 +3220,17 @@ For more details, see [our docs on using .NET agent logs in context](/docs/logs/
 
 ```xml
 <applicationLogging enabled="true">
- <metrics enabled="true" />
- <forwarding enabled="true" maxSamplesStored="10000">
-  <contextData enabled="false" include="" exclude="" />
- </forwarding>
- <localDecorating enabled="false" />
+  <metrics enabled="true" />
+  <forwarding enabled="true" maxSamplesStored="10000">
+    <contextData enabled="false" include="" exclude="" />
+  </forwarding>
+  <localDecorating enabled="false" />
 </applicationLogging>
 ```
 
 These features can also be configured via environment variables:
 
-```
+```ini
 NEW_RELIC_APPLICATION_LOGGING_ENABLED=<var>true|false</var>
 NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED=<var>true|false</var>
 NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=<var>true|false</var>
@@ -3335,7 +3334,7 @@ For more details, see our documentation for [New Relic CodeStream integration](/
 
 This can also be configured via environment variable:
 
-```
+```ini
 NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=<var>true|false</var>
 ```
 
@@ -3350,7 +3349,7 @@ For ASP.NET and .NET Framework console apps you can also configure the following
   >
     ```xml
     <appSettings>
-       <add key = "NewRelic.AgentEnabled" value="false" />
+       <add key="NewRelic.AgentEnabled" value="false" />
     </appSettings>
     ```
 
@@ -3367,7 +3366,7 @@ For ASP.NET and .NET Framework console apps you can also configure the following
 
     ```xml
     <appSettings>
-       <add key = "NewRelic.AppName" value ="Descriptive Name" />
+      <add key="NewRelic.AppName" value="Descriptive Name" />
     </appSettings>
     ```
   </Collapser>
@@ -3378,7 +3377,7 @@ For ASP.NET and .NET Framework console apps you can also configure the following
   >
     ```xml
     <appSettings>
-       <add key = "NewRelic.LicenseKey" value ="XXXXXXXX" />
+      <add key="NewRelic.LicenseKey" value="XXXXXXXX" />
     </appSettings>
     ```
   </Collapser>
@@ -3391,7 +3390,7 @@ For ASP.NET and .NET Framework console apps you can also configure the following
 
     ```xml
     <appSettings>
-       <add key = "NewRelic.ConfigFile" value="C:\Path-to-alternate-config-dir\newrelic.config" />
+      <add key="NewRelic.ConfigFile" value="C:\Path-to-alternate-config-dir\newrelic.config" />
     </appSettings>
     ```
   </Collapser>
@@ -3431,7 +3430,7 @@ For .NET Core apps, you can configure the following settings in `appsettings.jso
 
     ```json
     {
-       "NewRelic.AppName": "Descriptive Name"
+        "NewRelic.AppName": "Descriptive Name"
     }
     ```
   </Collapser>
@@ -3442,7 +3441,7 @@ For .NET Core apps, you can configure the following settings in `appsettings.jso
   >
     ```json
     {
-       "NewRelic.LicenseKey": "XXXXXXXX"
+        "NewRelic.LicenseKey": "XXXXXXXX"
     }
     ```
   </Collapser>
@@ -3455,7 +3454,7 @@ For .NET Core apps, you can configure the following settings in `appsettings.jso
 
     ```json
     {
-       "NewRelic.ConfigFile": "C:\Path-to-alternate-config-dir\newrelic.config"
+        "NewRelic.ConfigFile": "C:\Path-to-alternate-config-dir\newrelic.config"
     }
     ```
   </Collapser>


### PR DESCRIPTION
I fixed a bunch of small things like:
- indentation being inconsistent (3 spaces for example). 
- spaces between `key = "something"` in XML which isn't usually done
- added `ini` as a code type for env vars. It looks nice where I've seen it elsewhere, so I figured I'd add it here while I was at it.
