### PR TITLE
Minor revision in Usage page in style guide

### DIFF
--- a/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
@@ -571,7 +571,7 @@ Really, we recommend being as specific as possible to establish context. If a pi
 
 <Collapser
     id="observability as code"
-    title="Observability as code"
+    title="observability as code"
   >
    Don't hyphenate when using as a noun; hyphenate when using as a compound adjective.
   </Collapser>


### PR DESCRIPTION
Revised "observability as code" entry in Usage page. Currently, appears as "Observability as code"; it should be lowercase "o".

<!-- Thanks for contributing to our docs! -->

