### PR TITLE
fix: CAT is deprecated

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1751,7 +1751,6 @@ You can view the .NET APM attributes on the [.NET agent attributes](/docs/agents
 Use these options to enable, disable, and configure New Relic features. New Relic for .NET allows you to configure the following features:
 
 * [App pools](#include_exclude_apps)
-* [Cross application traces](#cross_application_tracer)
 * [Error collection](#error_collector)
 * [High security mode](#high_security_mode)
 * [Strip exception messages](#strip_exception_messages)
@@ -1764,6 +1763,8 @@ Use these options to enable, disable, and configure New Relic features. New Reli
 * [Transaction traces](#transaction_tracer)
 * [Datastore tracer](#datastore_tracer)
 * [Distributed tracing](#distributed_tracing)
+* [Infinite Tracing](#infinite_tracing)
+* [Cross application traces](#cross_application_tracer)
 * [Span events](#span-events)
 * [Capture HTTP Request Headers](#capture_http_request_headers)
 * [Application logging](#application_logging)
@@ -1837,49 +1838,6 @@ The `applicationPools` element supports the following elements:
     title="applicationPool"
   >
     Defines instrumentation behavior for a specific application pool. The `name` attribute is the name of an application pool. Enable or disable profiling in the `instrument` attribute. Define this application in the `name` attribute.
-  </Collapser>
-</CollapserGroup>
-
-### Cross application traces [#cross_application_tracer]
-
-The `crossApplicationTracer` element is a child of the `configuration` element. `crossApplicationTracer` links transaction traces across applications. When linked in a service-oriented architecture, all instrumented applications that communicate with each other via HTTP will now "link" transaction traces with the applications that they call and the applications they are called by. [Cross application tracing](/docs/traces/cross-application-traces) makes it easier to understand the performance relationship between services and applications.
-
-```xml
-<crossApplicationTracer enabled="true"/>
-```
-
-The `crossApplicationTracer` element supports the following attribute:
-
-<CollapserGroup>
-  <Collapser
-    id="catracer-enabled"
-    title="enabled"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `true`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Enable or disable cross application tracing
   </Collapser>
 </CollapserGroup>
 
@@ -2927,7 +2885,7 @@ The `distributedTracing` element is a child of the `configuration` element.
 Distributed tracing lets you see the path that a request takes as it travels through a distributed system. It requires [.NET agent version 8.6.45.0 or higher](/docs/agents/net-agent/installation/update-net-agent) and is on by default in .NET agents 9.0.0.0 and higher.
 
 <Callout variant="important">
-Enabling [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing) disables [cross application tracing](#cross_application_tracer), and has other effects on APM features. Before enabling, read the [planning guide](/docs/transition-guide-distributed-tracing).
+  Enabling [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing) disables [cross application tracing](#cross_application_tracer), and has other effects on APM features. Before enabling, read the [planning guide](/docs/transition-guide-distributed-tracing).
 </Callout>
 
 For more information about setting up distributed tracing, see [Enable distributed tracing for your .NET applications](/docs/apm/agents/net-agent/configuration/distributed-tracing-net-agent).
@@ -3065,6 +3023,53 @@ The `infiniteTracing` element supports the following elements:
     <Callout variant="important">
       When configuring the trace observer, you should not supply the protocol as part of the host. For example, use `myhost.infinitetracing.com` instead of `https://myhost.infinitetracing.com`.
     </Callout>
+  </Collapser>
+</CollapserGroup>
+    
+### Cross application traces [#cross_application_tracer]
+
+The `crossApplicationTracer` element is a child of the `configuration` element. `crossApplicationTracer` links transaction traces across applications. When linked in a service-oriented architecture, all instrumented applications that communicate with each other via HTTP will now "link" transaction traces with the applications that they call and the applications they are called by. [Cross application tracing](/docs/traces/cross-application-traces) makes it easier to understand the performance relationship between services and applications.
+    
+<Callout variant="important">
+  Cross application tracing has been deprecated as of [v9.0.0 of the agent](docs/release-notes/agent-release-notes/net-release-notes/net-agent-9000/) and disabled by default. To use CAT with v9+ of the agent you must set both `crossApplicationTracer.enabled = true` and `distributedTracing.enabled = false`. Enabling [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing) will disable [cross application tracing](#cross_application_tracer).
+</Callout>
+
+```xml
+<crossApplicationTracer enabled="true"/>
+```
+
+The `crossApplicationTracer` element supports the following attribute:
+
+<CollapserGroup>
+  <Collapser
+    id="catracer-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable cross application tracing
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
I moved the section for CAT below DT and 8T, we want customers to use those instead but the deprecated option was presented first in the doc. I also added a note about that deprecation, and updated the default value for the CAT setting to `false`.

I also added an 8T link in the navigation links.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.