### PR TITLE
chore: add syntax highlighting & minor cleanup

### DIFF
--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -203,7 +203,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
     To report data to [more than one application](/docs/java/multiple-application-names), separate the application names with a semicolon. For example, to report data to **My Application** and **My Application 2** use this:
 
-    ```
+    ```yml
     app_name: My Application;My Application 2
     ```
 
@@ -302,7 +302,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
     Number to differentiate JVMs for the same app on the same machine. New Relic [uses host/port for uniqueness](/docs/agents/java-agent/configuration/hostname-logic-java#unique-identifier), so you can distinguish the JVMs by putting a switch like this into the startup arguments for each JVM:
 
-    ```
+    ```ini
     -Dnewrelic.config.appserver_port=<var>8081</var>
     ```
 
@@ -407,8 +407,8 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
     ```
     META-INF/certs/eu-newrelic-com.pem
-      META-INF/certs/eu01-nr-data-net.pem
-      META-INF/certs/newrelic-com.pem
+    META-INF/certs/eu01-nr-data-net.pem
+    META-INF/certs/newrelic-com.pem
     ```
 
     By default (`use_private_ssl: false`) the agent will use the SSL certificates bundled into the JDK to establish a secure connection to New Relic or the custom SSL certificates bundle specified by `ca_bundle_path`. If you want to use the SSL certificates bundled with the agent, set `use_private_ssl: true`.
@@ -539,13 +539,13 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
           </th>
 
           <td>
-            [https://insights-collector.newrelic.com/v1/accounts/events](https://insights-collector.newrelic.com/v1/accounts/events)
+            [`https://insights-collector.newrelic.com/v1/accounts/events`](https://insights-collector.newrelic.com/v1/accounts/events)
           </td>
         </tr>
       </tbody>
     </table>
 
-    Event ingest URI used by some agent features. Defaults to the US production ingest endpoint. Can be manually configured to send events to other ingest endpoints (for example, EU production: [https://insights-collector.eu01.nr-data.net/v1/accounts/events](https://insights-collector.eu01.nr-data.net/v1/accounts/events)).
+    Event ingest URI used by some agent features. Defaults to the US production ingest endpoint. Can be manually configured to send events to other ingest endpoints (for example, EU production: [`https://insights-collector.eu01.nr-data.net/v1/accounts/events`](https://insights-collector.eu01.nr-data.net/v1/accounts/events)).
   </Collapser>
 
   <Collapser
@@ -676,7 +676,9 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
     Attach [tags](/docs/apm/new-relic-apm/maintenance/labels-categories-organize-your-apps-servers) to this app.
 
     Note that this option now enables tags, which replaced the label feature. You can still query your historical [labels](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor#labels). Multiple tags can be attached by using a semicolon as a separator as follows:
-    `-Dnewrelic.config.labels="tagName1:tagValue1;tagName2:tagValue2;tagName3:tagValue3"`
+    ```ini
+    -Dnewrelic.config.labels="tagName1:tagValue1;tagName2:tagValue2;tagName3:tagValue3"
+    ```
   </Collapser>
 
   <Collapser
@@ -732,13 +734,13 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
           </th>
 
           <td>
-            [https://metric-api.newrelic.com/metric/v1](https://metric-api.newrelic.com/metric/v1)
+            [`https://metric-api.newrelic.com/metric/v1`](https://metric-api.newrelic.com/metric/v1)
           </td>
         </tr>
       </tbody>
     </table>
 
-    Metric ingest URI used by some agent features. Defaults to the US production ingest endpoint. Can be manually configured to send metrics to other ingest endpoints (example EU production URI: [https://metric-api.eu.newrelic.com/metric/v1](https://metric-api.eu.newrelic.com/metric/v1)).
+    Metric ingest URI used by some agent features. Defaults to the US production ingest endpoint. Can be manually configured to send metrics to other ingest endpoints (example EU production URI: [`https://metric-api.eu.newrelic.com/metric/v1`](https://metric-api.eu.newrelic.com/metric/v1)).
   </Collapser>
 
   <Collapser
@@ -1169,7 +1171,7 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
 
     Enabling `scala_futures_as_segments` increases your overhead. If you want Scala Futures to report as transaction segments so you can view them in a transaction trace, you can enable it:
 
-    ```
+    ```yml
     scala_futures_as_segments:
       enabled: true
     ```
@@ -1224,11 +1226,11 @@ For agent versions 4.10.0 or higher the following environment variables are avai
 
     This setting is **required**. Contains the application name under which to report data to New Relic. Set the name of your application as you want it to appear in New Relic.
 
-    If `enable_auto_app_naming` is false, the agent reports all data to this application. Otherwise, the agent reports only background tasks (transactions for non-web applications) to this application.
+    If `enable_auto_app_naming` is `false`, the agent reports all data to this application. Otherwise, the agent reports only background tasks (transactions for non-web applications) to this application.
 
     To report data to more than one application, separate the application names with a semicolon `;`. For example, to report data to **My Application** and **My Application 2**:
 
-    ```
+    ```yml
     app_name: My Application;My Application 2
     ```
 
@@ -1257,7 +1259,7 @@ For agent versions 4.10.0 or higher the following environment variables are avai
           </th>
 
           <td>
-            false
+            `false`
           </td>
         </tr>
       </tbody>
@@ -1395,7 +1397,7 @@ In addition to overriding configuration settings, the following system propertie
           </th>
 
           <td>
-            `(none)`
+            (none)
           </td>
         </tr>
       </tbody>
@@ -1823,7 +1825,7 @@ Browser monitoring gives you insight into the performance real users are experie
 
     For example:
 
-    ```
+    ```yml
     browser_monitoring:
       disabled_auto_pages: /WEB-INF/jsp/testpage_1.jsp, /WEB-INF/jsp/testpage_2.jsp
     ```
@@ -1929,7 +1931,7 @@ These settings customize the behavior of the [Java circuit breaker](/docs/agents
 
 If you want to customize the circuit breaker, add the stanza under the `common` stanza:
 
-```
+```yml
 common: &default_settings​
   <var>OTHER_CONFIG_SETTINGS</var>
   circuitbreaker:
@@ -1992,7 +1994,7 @@ common: &default_settings​
           </th>
 
           <td>
-            20
+            `20`
           </td>
         </tr>
       </tbody>
@@ -2023,7 +2025,7 @@ common: &default_settings​
           </th>
 
           <td>
-            10
+            `10`
           </td>
         </tr>
       </tbody>
@@ -2320,14 +2322,14 @@ APM lets you [record custom event data](/docs/insights/insights-data-sources/cus
 <Callout variant="important">
   For Java agent versions prior to 4.1.0, the following YAML configuration is recognized:
 
-  ```
+  ```yml
   custom_insights_events.enabled: true
     custom_insights_events.max_samples_stored: 5000
   ```
 
   For agent versions 4.1.0 and above, the YAML configuration uses the nested stanza formatting:
 
-  ```
+  ```yml
   custom_insights_events:
     enabled: false
     max_samples_stored: 5000
@@ -2511,7 +2513,7 @@ For more information about setting up distributed tracing, see [Enable distribut
 
     Set this to `false` to disable distributed tracing. For example, in the config file, you would use:
 
-    ```
+    ```yml
     distributed_tracing:
       enabled: false
     ```
@@ -2520,12 +2522,12 @@ For more information about setting up distributed tracing, see [Enable distribut
 
     [System property](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#System_Properties):
 
-    ```
+    ```ini
     -Dnewrelic.config.distributed_tracing.enabled=false
     ```
     Evironment variable:
 
-    ```
+    ```ini
     NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=false
     ```
   </Collapser>
@@ -2564,14 +2566,14 @@ For more information about setting up distributed tracing, see [Enable distribut
 
     For example, to exclude `newrelic` headers in the config file, you would use:
 
-    ```
+    ```yml
     distributed_tracing:
       exclude_newrelic_header: true
     ```
 
     To exclude `newrelic` headers using a [system property](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#System_Properties), you would use:
 
-    ```
+    ```ini
     -Dnewrelic.config.distributed_tracing.exclude_newrelic_header=true
     ```
   </Collapser>
@@ -2651,7 +2653,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     For example:
 
-    ```
+    ```yml
     error_collector:
       ignore_classes:
         - "com.example.MyException"
@@ -2660,7 +2662,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     An environment variable can be used to list exception class names you want to be ignored:
 
-    ```
+    ```ini
     NEW_RELIC_ERROR_COLLECTOR_IGNORE_CLASSES="[\"com.example.MyException\", \"com.example.DifferentException\"]"
     ```
   </Collapser>
@@ -2706,7 +2708,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
       For example:
 
-      ```
+      ```yml
       error_collector:
         ignore_messages:
           com.example.MyException:
@@ -2718,7 +2720,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
       An environment variable can be used to list exception class names and messages you want to be ignored:
 
-      ```
+      ```ini
       NEW_RELIC_ERROR_COLLECTOR_IGNORE_MESSAGES="{\"com.example.MyException\": [\"Some error message to ignore\", \"Some other error message to ignore\"], \"com.example.DifferentException\": [\"Some different error message to ignore\"]}"
       ```
   </Collapser>
@@ -2759,7 +2761,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     For example:
 
-    ```
+    ```yml
     error_collector:
       ignore_status_codes: 404,507-511
     ```
@@ -2799,7 +2801,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     For example:
 
-    ```
+    ```yml
     error_collector:
       expected_classes:
         - "com.example.MyException"
@@ -2808,7 +2810,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     An environment variable can be used to list expected exception class names:
 
-    ```
+    ```ini
     NEW_RELIC_ERROR_COLLECTOR_EXPECTED_CLASSES="[\"com.example.MyException\", \"com.example.DifferentException\"]"
     ```
   </Collapser>
@@ -2849,7 +2851,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     For example:
 
-    ```
+    ```yml
     error_collector:
       expected_messages:
         com.example.MyException:
@@ -2861,7 +2863,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     An environment variable can be used to list expected exception class names and messages:
 
-    ```
+    ```ini
     NEW_RELIC_ERROR_COLLECTOR_EXPECTED_MESSAGES="{\"com.example.MyException\": [\"Some error message to ignore\", \"Some other error message to ignore\"], \"com.example.DifferentException\": [\"Some different error message to ignore\"]}"
     ```
   </Collapser>
@@ -2900,7 +2902,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     For example:
 
-    ```
+    ```yml
     error_collector:
       expected_status_codes: 415,500-506
     ```
@@ -3032,7 +3034,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
     When multiple errors are noticed in a transaction, only the last error will be reported by default. Setting this property to `false` will instead report only the first error that is noticed. For more information, see the [noticeError API](/docs/agents/java-agent/configuration/java-agent-error-configuration/).
     For example:
 
-    ```
+    ```yml
     error_collector:
       ignoreErrorPriority: false
     ```
@@ -3070,7 +3072,7 @@ These options are set in the `error_collector` stanza and unless noted otherwise
 
     For example:
 
-    ```
+    ```yml
     error_collector:
       ignore_errors: some.other.MyException
     ```
@@ -3218,7 +3220,7 @@ To turn on Infinite Tracing, enable distributed tracing and add the additional s
           </th>
 
           <td>
-            None
+            (none)
           </td>
         </tr>
       </tbody>
@@ -3228,7 +3230,7 @@ To turn on Infinite Tracing, enable distributed tracing and add the additional s
 
     You can configure this via YAML:
 
-    ```
+    ```yml
     infinite_tracing:
       trace_observer:
         host: <var>YOUR_TRACE_OBSERVER_HOST</var>
@@ -3497,7 +3499,7 @@ Starting with Java agent version `7.6.0`, support for [logs in context](/docs/lo
 
 Changing these settings in your local agent configuration file happens dynamically and doesn't require a restart of the agent for those changes to take effect. An example configuration:
 
-```
+```yml
 application_logging:
   enabled: true
   forwarding:
@@ -3581,7 +3583,7 @@ If you're using a supported logging framework and want to use the agent to send 
           </th>
 
           <td>
-            true
+            `true`
           </td>
         </tr>
       </tbody>
@@ -3624,7 +3626,7 @@ If you're using a supported logging framework and want to use the agent to send 
           </th>
 
           <td>
-            10,000
+            `10000`
           </td>
         </tr>
       </tbody>
@@ -3635,7 +3637,7 @@ If you're using a supported logging framework and want to use the agent to send 
     Set this to `0` to effectively disable the sending of logs.
 
     <Callout variant="important">
-      This controls the number of logs sent *per minute*. Setting `max_samples_stored` to 0 - or any value less than 12 - does _not_ disable the feature itself, though it does result in no log lines being sent to New Relic.
+      This controls the number of logs sent *per minute*. Setting `max_samples_stored` to `0` - or any value less than `12` - does _not_ disable the feature itself, though it does result in no log lines being sent to New Relic.
     </Callout>
 
     Set this to a lower value to reduce the amount of log lines sent (may cause log sampling). Set this to a higher value to send more log lines.
@@ -3674,7 +3676,7 @@ The Java agent can capture context data (Mapped Diagnostic Context in logback/sl
               </th>
 
               <td>
-                false
+                `false`
               </td>
             </tr>
           </tbody>
@@ -3707,7 +3709,7 @@ The Java agent can capture context data (Mapped Diagnostic Context in logback/sl
               </th>
 
               <td>
-                none
+                (none)
               </td>
             </tr>
           </tbody>
@@ -3738,7 +3740,7 @@ The Java agent can capture context data (Mapped Diagnostic Context in logback/sl
               </th>
 
               <td>
-                none
+                (none)
               </td>
             </tr>
           </tbody>
@@ -3776,7 +3778,7 @@ In addition to allowing you to decorate and send individual log lines, the Java 
           </th>
 
           <td>
-            true
+            `true`
           </td>
         </tr>
       </tbody>
@@ -3784,7 +3786,7 @@ In addition to allowing you to decorate and send individual log lines, the Java 
 
     Enables the capture of metrics information about your logs and log levels, which is displayed in a chart on the NR1 summary page.
 
-    Leave this set to true to allow the agent to capture metric information about your logs.
+    Leave this set to `true` to allow the agent to capture metric information about your logs.
 
     Set this to `false` to disable this feature.
 
@@ -4270,7 +4272,7 @@ Span configuration is set in the `span_events` stanza and can be [overridden](#S
 
 ## Strip exceptions [#strip_exceptions]
 
-These options are set in the `strip_exception_messages` stanza and unless noted otherwise can be [overridden](#System_Properties) by using a `newrelic.config.strip_exception_messages​`prefixed system property. This configuration can be enabled to control whether Java exception messages are reported to New Relic.
+These options are set in the `strip_exception_messages` stanza and unless noted otherwise can be [overridden](#System_Properties) by using a `newrelic.config.strip_exception_messages` prefixed system property. This configuration can be enabled to control whether Java exception messages are reported to New Relic.
 
 <CollapserGroup>
   <Collapser
@@ -4519,7 +4521,7 @@ Transaction events provide the data for displaying histograms and percentiles in
           </th>
 
           <td>
-            None
+            (none)
           </td>
         </tr>
       </tbody>
@@ -4529,11 +4531,11 @@ Transaction events provide the data for displaying histograms and percentiles in
       Unlike other settings, `custom_request_headers` have to be paired together and must be set in the `newrelic.yml` file. They can't be overwritten by Java virtual machine arguments (system property) or environment variables.
     </Callout>
 
-    A list of maps with the paired keys `header_name` and the optional `header_alias. Choose one or more custom HTTP request headers to add as transaction attributes.`
+    A list of maps with the paired keys `header_name` and the optional `header_alias`. Choose one or more custom HTTP request headers to add as transaction attributes.
 
     You can list multiple header configurations:
 
-    ```
+    ```yml
     transaction_events:
       custom_request_headers:
         -
@@ -4873,7 +4875,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
           </th>
 
           <td>
-            2000
+            `2000`
           </td>
         </tr>
       </tbody>
@@ -4970,7 +4972,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
           </th>
 
           <td>
-            `False`
+            `false`
 
             Defaulted to `true` until Java agent version 3.12.1, when it was changed to `false`.
           </td>
@@ -5045,7 +5047,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
     * If you want transaction traces to more accurately reflect the actual slowest transactions in your app, make this value **lower**.
     * If you want to sample a more diverse array of transactions, make the value **higher**.
 
-      A value of 0 would mean that **only** the slowest transaction is always traced. This is considered not to be optimal, though, because you may have one or two transactions that are always the slowest, and repeatedly seeing those same transaction traces will probably not give you much value.
+      A value of `0` would mean that **only** the slowest transaction is always traced. This is considered not to be optimal, though, because you may have one or two transactions that are always the slowest, and repeatedly seeing those same transaction traces will probably not give you much value.
 
       If the same transaction is often the slowest, the `top_n` setting allows the Java agent (over time) to sample the slowest `n` transactions. This gives you greater variety and more insight into your application.
   </Collapser>
@@ -5080,7 +5082,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
     The time threshold used to determine when a transaction is eligible to be traced. When the transaction's response time exceeds this threshold, a [transaction trace](/docs/apm/transactions/transaction-traces/transaction-traces) will be recorded and sent to New Relic.
 
-    The default is `apdex_f` (default), which sets the threshold to be the ["Frustrated"](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#apdex_f) [Apdex](/docs/site/apdex-measuring-user-satisfaction) level (four times the apdex_t value). You can also set a specific time threshold by entering a float value that represents a number of seconds.
+    The default is `apdex_f` (default), which sets the threshold to be the ["Frustrated"](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#apdex_f) [Apdex](/docs/site/apdex-measuring-user-satisfaction) level (four times the `apdex_t` value). You can also set a specific time threshold by entering a float value that represents a number of seconds.
   </Collapser>
 
   <Collapser
@@ -5119,7 +5121,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
     For DataStax driver 2.1.2, add this rule to your allow list:
 
-    ```
+    ```yml
     transaction_tracer:
       slow_query_whitelist:
         'com.newrelic.instrumentation.cassandra-datastax-2.1.2'
@@ -5127,7 +5129,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
     For DataStax driver 3.0.0, add this rule to your allow list:
 
-    ```
+    ```yml
     transaction_tracer:
       slow_query_whitelist:
         'com.newrelic.instrumentation.cassandra-datastax-3.0.0'
@@ -5166,7 +5168,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
     For DataStax driver 2.1.2, add this rule to your allow list:
 
-    ```
+    ```yml
     transaction_tracer:
       collect_slow_queries_from:
         'com.newrelic.instrumentation.cassandra-datastax-2.1.2'
@@ -5174,7 +5176,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
 
     For DataStax driver 3.0.0, add this rule to your allow list:
 
-    ```
+    ```yml
     transaction_tracer:
       collect_slow_queries_from:
         'com.newrelic.instrumentation.cassandra-datastax-3.0.0'
@@ -5296,7 +5298,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
           </th>
 
           <td>
-            3000
+            `3000`
           </td>
         </tr>
       </tbody>
@@ -5327,7 +5329,7 @@ These options are set in the `transaction_tracer` stanza and can be [overridden]
           </th>
 
           <td>
-            3000
+            `3000`
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
Added syntax highlighting to code examples and did some small cleanup for consistency. For example making default values always in backticks, or (none) without backticks. Fixed a few stray typos.

`ini` as a syntax highlighting example looks good in the .NET docs but it's kind of a taste choice for env vars. I can remove it if anyone objects