### PR TITLE
fix(style guide): update var tag guidance

### DIFF
--- a/scripts/actions/__tests__/kitchen-sink.mdx
+++ b/scripts/actions/__tests__/kitchen-sink.mdx
@@ -12,12 +12,12 @@ import { Link } from '@newrelic/gatsby-theme-newrelic'
 New Relic defines a [web or non-web transaction](/docs/apm/transactions/intro-transactions/transactions-new-relic-apm) as one logical unit of work in a software application. Once you [instrument a transaction](/docs/instrument-transactions-c-agent), you can also instrument errors in the transaction so you can monitor them in the New Relic UI. In order to use the C SDK to monitor errors, you must manually instrument your source code by adding the New Relic function `newrelic_notice_error()` to it.
 
 <Callout variant="tip">
-  To include `function` calls in error traces, use GNU's `-rdynamic` linker flag to [link your apps when compiling](/docs/install-c-agent-compile-link-your-code#compile). The `-rdynamic` linker flag gives you more meaningful error traces.
+  To include <var>function</var> calls in error traces, use GNU's `-rdynamic` linker flag to [link your apps when compiling](/docs/install-c-agent-compile-link-your-code#compile). The `-rdynamic` linker flag gives you more meaningful error traces.
 </Callout>
 
 ## Contents [#in-page-toc]
 
-For an index of docs available during the preview, see the [C SDK table of contents](https://docs.newrelic.com/docs/c-agent-table-contents).
+For an index of <mark>documentation</mark> available during the preview, see the [C SDK table of contents](https://docs.newrelic.com/docs/c-agent-table-contents).
 
 ## Instrument errors in transactions [#errors]
 

--- a/scripts/actions/__tests__/kitchen-sink.mdx
+++ b/scripts/actions/__tests__/kitchen-sink.mdx
@@ -12,12 +12,12 @@ import { Link } from '@newrelic/gatsby-theme-newrelic'
 New Relic defines a [web or non-web transaction](/docs/apm/transactions/intro-transactions/transactions-new-relic-apm) as one logical unit of work in a software application. Once you [instrument a transaction](/docs/instrument-transactions-c-agent), you can also instrument errors in the transaction so you can monitor them in the New Relic UI. In order to use the C SDK to monitor errors, you must manually instrument your source code by adding the New Relic function `newrelic_notice_error()` to it.
 
 <Callout variant="tip">
-  To include <var>function</var> calls in error traces, use GNU's `-rdynamic` linker flag to [link your apps when compiling](/docs/install-c-agent-compile-link-your-code#compile). The `-rdynamic` linker flag gives you more meaningful error traces.
+  To include `function` calls in error traces, use GNU's `-rdynamic` linker flag to [link your apps when compiling](/docs/install-c-agent-compile-link-your-code#compile). The `-rdynamic` linker flag gives you more meaningful error traces.
 </Callout>
 
 ## Contents [#in-page-toc]
 
-For an index of <mark>documentation</mark> available during the preview, see the [C SDK table of contents](https://docs.newrelic.com/docs/c-agent-table-contents).
+For an index of docs available during the preview, see the [C SDK table of contents](https://docs.newrelic.com/docs/c-agent-table-contents).
 
 ## Instrument errors in transactions [#errors]
 

--- a/src/content/docs/style-guide/formatting/code-examples.mdx
+++ b/src/content/docs/style-guide/formatting/code-examples.mdx
@@ -173,30 +173,24 @@ To format one or more lines of code, insert three backticks ( ```` ``` ```` ) ab
   </Collapser>
 </CollapserGroup>
 
-## Customer-specific values [#var-tags]
+## Customer-specific values [#value-placeholders]
 
-Traditionally, we used `<var>` tags to highlight customer-specific values in code snippets. For example: we'd use `<var>YOUR_ACCOUNT_ID</var>` to draw a user's attention to a place they'll need to input their account ID.
+Traditionally, we've used `<var>` tags for customer-specific value placeholders in code snippets. For example: we'd use `<var>YOUR_ACCOUNT_ID</var>` to draw a user's attention to a place they'd need to input their account ID.
 
-In November of 2022, we found out that language-specific syntax coloring doesn't work with var tags. Using var tags in a code block disables syntax-specific coloring for that block. Going forward, we want to avoid using var tags and instead focus on creating strong placeholder text to make it clear to customers what they should put in those places. For example, instead of `<var>YOUR_ACCOUNT_ID</var>`, we'd remove the var tags and make it a bit more descriptive, like `INSERT_YOUR_ACCOUNT_ID`. 
+In November of 2022, we found out that language-specific [syntax highlighting](#synax-highlight-exampl) doesn't work with var tags: Using var tags in a code block disables syntax-specific coloring for that block. Going forward, for customer-specific value placeholders, avoid using var tags and instead focus on creating strong placeholder text to make it clear to customers what they should put in those places. For example, instead of using `<var>YOUR_NR_ACCOUNT_ID</var>`, we'd remove the var tags and make it a bit more descriptive, like `INSERT_YOUR_NR_ACCOUNT_ID`. 
 
-That said, `<var>` tags can still be used if you think it's important to highlight something in a code snippet and you don't need of syntax highlighting. One example of this is shown here: [Activate Azure integrations doc](/docs/infrastructure/microsoft-azure-integrations/getting-started/activate-azure-integrations#get-ids). 
+That said, `<var>` tags can still be used if you think it's important to highlight something in a code snippet and you're okay losing syntax highlighting. For tips on using var tags, see [Var tags](#var-tags).
 
-Some tips for writing strong customer-specific value placeholders: 
+Some tips on crafting customer-specific value placeholders: 
 
 * Use `INSERT` to make it more clear what customers are to do. 
-* Address the reader directly. For example, using `INSERT_YOUR_ACCOUNT_ID` and not `INSERT_ACCOUNT_ID`).
+* Address the reader directly using `YOUR`. For example, use `INSERT_YOUR_NR_ACCOUNT_ID` and not `INSERT_NR_ACCOUNT_ID`).
 * Use all caps and underscores `_` to separate words (also known as [SCREAMING_SNAKE_CASE](https://github.com/rubocop-hq/ruby-style-guide#screaming-snake-case)).
 * Don't combine them with other punctuation to indicate variables (such as wrapping the text in angle brackets or curly braces).
-* You **don't** have to use placeholders for either of these situations: 
+* If you explicitly say that a customer must replace some values, you can break some of the usual rules. For example, if you preface a code snippet with an instruction that they'll have to replace some of the values, you can use more brief placeholder text, like `YOUR_ACCOUNT_ID` or `YOUR_USER_KEY`. 
+* **Don't** use placeholders for either of these situations: 
   * Example code or files: if you're showing an example config file or another example that's simply meant to give a rough sense of what something will look like, and there is no direct procedure involved, you don't have to worry about placeholders and can use example values. 
   * Results of API calls: if you're including the response of a call, you also don't have to use placeholders. 
-* If you make it clear that a customer will have to replace some values, you can get away with breaking some of the usual rules. For example, if you show a config file and you preface that with saying they'll have to replace many of the values, feel free to use a more brief placeholder format. 
-
-Tips on using `<var>` tags: 
-* You can use `<var>` tags to indicate a bit of code that will be referenced later in a procedure or doc, assuming you are okay with there not being syntax highlighting. Examples:
-  * Highlighting values in code response that are meant for later use: [Activate Azure integrations doc](/docs/infrastructure/microsoft-azure-integrations/getting-started/activate-azure-integrations#get-ids).
-  * Highlighting the commands in a large code block example that are New Relic-specific commands, with explanations below: [Java API doc](/docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications#use-gettoken).
-* When you use `<var>`, you should usually follow the code block with a list of bullets that explain what each API call is doing and link to method syntax.
 
 <CollapserGroup>
   <Collapser
@@ -216,3 +210,9 @@ Tips on using `<var>` tags:
       </Callout>
   </Collapser>
 </CollapserGroup>
+
+### Tips on using var tags [#var-tags]
+
+If it's important to highlight something in a code snippet and you're okay losing syntax highlighting, you can use `<var>` tags. Some examples of why you'd do this: 
+* To highlight values in a code snippet that you want to define or that customers will later use. For an example of this, see this [Activate Azure integrations doc](/docs/infrastructure/microsoft-azure-integrations/getting-started/activate-azure-integrations#get-ids).
+* To highlight multiple lines of code to draw attention to the snippet a customer needs to use or input.

--- a/src/content/docs/style-guide/formatting/code-examples.mdx
+++ b/src/content/docs/style-guide/formatting/code-examples.mdx
@@ -173,79 +173,46 @@ To format one or more lines of code, insert three backticks ( ```` ``` ```` ) ab
   </Collapser>
 </CollapserGroup>
 
-## Highlight user input with `<var>` [#var-tags]
+## Customer-specific values [#var-tags]
 
-The `<var>` tag is used to highlight areas the user needs to customize the value in a code snippet. For example: you might use `<var>YOUR_ACCOUNT_ID</var>` to draw a user's attention to a place they'll need to input their account ID.
+Traditionally, we used `<var>` tags to highlight customer-specific values in code snippets. For example: we'd use `<var>YOUR_ACCOUNT_ID</var>` to draw a user's attention to a place they'll need to input their account ID.
 
-Follow these guidelines when you use `<var>` tags:
+In November of 2022, we found out that language-specific syntax coloring doesn't work with var tags. Using var tags in a code block disables syntax-specific coloring for that block. Going forward, we want to avoid using var tags and instead focus on creating strong placeholder text to make it clear to customers what they should put in those places. For example, instead of `<var>YOUR_ACCOUNT_ID</var>`, we'd remove the var tags and make it a bit more descriptive, like `INSERT_YOUR_ACCOUNT_ID`. 
 
-* Address the reader directly (`YOUR_CONFIG_FILE` not `CONFIG_FILE`).
+That said, `<var>` tags can still be used if you think it's important to highlight something in a code snippet and you don't need of syntax highlighting. One example of this is shown here: [Activate Azure integrations doc](/docs/infrastructure/microsoft-azure-integrations/getting-started/activate-azure-integrations#get-ids). 
+
+Some tips for writing strong customer-specific value placeholders: 
+
+* Use `INSERT` to make it more clear what customers are to do. 
+* Address the reader directly. For example, using `INSERT_YOUR_ACCOUNT_ID` and not `INSERT_ACCOUNT_ID`).
 * Use all caps and underscores `_` to separate words (also known as [SCREAMING_SNAKE_CASE](https://github.com/rubocop-hq/ruby-style-guide#screaming-snake-case)).
 * Don't combine them with other punctuation to indicate variables (such as wrapping the text in angle brackets or curly braces).
-* Don't overuse them. For example, if you're showing a complete config file where the user is expected to customize many values, a `<var>` tag on each configurable value is overkill.
-* Highlight areas of a code block that are particularly important but not directly procedural-related. Most commonly, `<var>` is used to highlight New Relic API methods in sample code that contains a lot of "other logic." They're also handy when you want to indicate a bit of code that will be referenced later in a procedure or doc. Examples:
-    * Highlighting values in code response that are meant for later use: [Activate Azure integrations doc](/docs/infrastructure/microsoft-azure-integrations/getting-started/activate-azure-integrations#get-ids).
-    * Highlighting the commands in a large code block example that are New Relic-specific commands, with explanations below: [Java API doc](/docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications#use-gettoken).
-    
-When you use `<var>`, you should usually follow the code block with a list of bullets that explain what each API call is doing and link to method syntax.
+* You **don't** have to use placeholders for either of these situations: 
+  * Example code or files: if you're showing an example config file or another example that's simply meant to give a rough sense of what something will look like, and there is no direct procedure involved, you don't have to worry about placeholders and can use example values. 
+  * Results of API calls: if you're including the response of a call, you also don't have to use placeholders. 
+* If you make it clear that a customer will have to replace some values, you can get away with breaking some of the usual rules. For example, if you show a config file and you preface that with saying they'll have to replace many of the values, feel free to use a more brief placeholder format. 
+
+Tips on using `<var>` tags: 
+* You can use `<var>` tags to indicate a bit of code that will be referenced later in a procedure or doc, assuming you are okay with there not being syntax highlighting. Examples:
+  * Highlighting values in code response that are meant for later use: [Activate Azure integrations doc](/docs/infrastructure/microsoft-azure-integrations/getting-started/activate-azure-integrations#get-ids).
+  * Highlighting the commands in a large code block example that are New Relic-specific commands, with explanations below: [Java API doc](/docs/agents/java-agent/async-instrumentation/java-agent-api-asynchronous-applications#use-gettoken).
+* When you use `<var>`, you should usually follow the code block with a list of bullets that explain what each API call is doing and link to method syntax.
 
 <CollapserGroup>
   <Collapser
-    id="mark-tag-example"
-    title="Example of using the <var> tag"
+    id="placeholder-examples"
+    title="Examples of placeholders"
   >
-    ```
-    private void storeItem(long id) {
-        Segment segment = NewRelic.getAgent().getTransaction(). <var>startSegment("storeItem")</var>;
+    Below are some general style recommendations for formatting user-specific values: 
 
-          segment.<var>reportAsExternal(DatastoreParameters
-                  .product("H2")
-                  .collection(null)
-                  .operation("insert")
-                  .instance("localhost", 8080)
-                  .databaseName("test")
-                  .build())</var>;
-
-          // fire and forget
-          DB_POOL.submit(() -> {
-              <var>segment.end()</var>;
-              insertData(id);
-          });
-      }
-    ```
-
-    The agent API calls in this sample are:
-
-    * `startSegment(...)`: Begins the segment that will time the code. For method syntax, see the [Javadoc](https://example.com).
-    * `reportAsExternal(DatastoreParameters())`: Associates the time with a datastore external call This will show up in APM with [datastore data](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues). For more information, see [reportAsExternal API](http://newrelic.github.io/java-agent-api/javadoc/index.html?com/newrelic/api/agent/TracedMethod.html). For method syntax, see the [Javadoc](https://example.com).
-    * `segment.end()`: Stops timing this segment. For method syntax, see the [Javadoc](https://example.com).
-  </Collapser>
-</CollapserGroup>
-
-Do **not** use a `<var>` tag for:
-
-* Example code: If the code is meant to be an example, to show the format of the code, and there is not an actual procedure the customer is following, var tags are not needed. A couple reasons for this: 1) The important part of showing an example config file is to show the overall structure of the file, 2) Usually the number of config options present in a file will vary based on whatever the customer wishes to use, so using `<var>` tags can actually be confusing as it implies that these values must be present. Examples:
-  * [Example configuration file](/docs/integrations/host-integrations/host-integrations-list/oracledb-monitoring-integration#example-config) (or this [Java agent config template](/docs/agents/java-agent/configuration/java-agent-config-file-template)): if you are showing an example config file that isn't part of a procedure, you shouldn't use the `<var>` tag.
-  * [Instrumentation procedure](/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/enable-new-relic-monitoring-aws-lambda#java) (at bottom of the Java section): the var tag wouldn't be necessary because it's an example, not part of a procedure, and the main goal is seeing the general structure. Also, because it's an example of app code, the concept of user-specific values doesn't have much meaning, because the entire code will vary dependent on how the customer has written their code. (If anything, this would be a potential for using [`<var>` format](#highlighting) to emphasize the New Relic functions.)
-* Response/output code: If the code is meant to show an expected return, and is not related to a procedure, then var tags shouldn't be used. Here's [a doc section](/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api#get-all-monitors) (the returned JSON) where var tags are not needed.
-
-For some use cases, [highlighting](#annotate-mark) may be a better choice than a `var` tag.
-
-<CollapserGroup>
-  <Collapser
-    id="var-tag-examples"
-    title="Examples of `<var>` tag use"
-  >
-    Below are some general style recommendations for formatting user-specific `<var>` values. `<var>` tag formatting may vary based on language- or system-specific expectations, so be sure check the style used in the documentation section in question, and to ask relevant SMEs what they think of the style.
-
-    * Account IDs and other IDs/#s: `<var>YOUR_ACCOUNT_ID</var>`, `<var>YOUR_API_KEY</var>`, etc. **This should be the general style used.**
-    * URLs: [example.com](https://example.com), or maybe <var>`YOUR_URL`</var>
-    * Paths: `<var>PATH/TO/SOMETHING.exe</var>` or maybe `<var>PATH_TO_FILE</var>`
-    * Emails: [datanerd@example.com](mailto:datanerd@example.com) or maybe `<var>YOUR_EMAIL</var>`
-    * Bash variables for REST API code: Some `<var>` tagged code values on the docs site have the form $&#x7B;API_KEY}. This is a format used for variables in bash scripts, where users assign values to specific variable names and then call those variables later in the script by using the $VARIABLE_NAME. For more info, see this [explanation of bash variables](http://tldp.org/HOWTO/Bash-Prog-Intro-HOWTO-5.html).
+    * Account IDs and other IDs/#s: `INSERT_YOUR_ACCOUNT_ID`, `INSERT_YOUR_NR_USER_KEY`, etc. **This should be the general style used.**
+    * URLs: [example.com](https://example.com), or maybe `INSERT_YOUR_URL`
+    * Paths: `PATH/TO/SOMETHING.exe` or maybe `PATH_TO_FILE`
+    * Emails: [datanerd@example.com](mailto:datanerd@example.com) or maybe `INSERT_YOUR_EMAIL`
+    * Bash variables for REST API code: Some code values on the docs site have the form $&#x7B;API_KEY}. This is a format used for variables in bash scripts, where users assign values to specific variable names and then call those variables later in the script by using the $VARIABLE_NAME. For more info, see this [explanation of bash variables](http://tldp.org/HOWTO/Bash-Prog-Intro-HOWTO-5.html).
 
       <Callout variant="important">
-        The bash variable style is currently used in the REST API docs, and in some Synthetics docs. However, going forward we should use the general variable style, without the $ and `&lt;` >.
+        The bash variable style is currently used in the REST API docs, and in some Synthetics docs. However, going forward we should use the general variable style.
       </Callout>
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/style-guide/formatting/code-examples.mdx
+++ b/src/content/docs/style-guide/formatting/code-examples.mdx
@@ -167,7 +167,7 @@ To format one or more lines of code, insert three backticks ( ```` ``` ```` ) ab
     3. If you still can't find your language, you can make a PR to add it to `gatsby-config.js`. Before you submit a PR, make sure this language is listed in the [Prism site](https://prismjs.com/#supported-languages).
 
   <Callout variant="important">
-    If your code snippet contains `<var>` tags, it will not be formatted.
+    If your code snippet contains `<var>` tags, syntax highlighting won't work.
   </Callout>
 
   </Collapser>

--- a/src/content/docs/style-guide/formatting/code-examples.mdx
+++ b/src/content/docs/style-guide/formatting/code-examples.mdx
@@ -184,7 +184,7 @@ That said, `<var>` tags can still be used if you think it's important to highlig
 Some tips on crafting customer-specific value placeholders: 
 
 * Use `INSERT` to make it more clear what customers are to do. 
-* Address the reader directly using `YOUR`. For example, use `INSERT_YOUR_NR_ACCOUNT_ID` and not `INSERT_NR_ACCOUNT_ID`).
+* Address the reader directly using `YOUR`. For example, use `INSERT_YOUR_NR_ACCOUNT_ID` and not `INSERT_NR_ACCOUNT_ID`.
 * Use all caps and underscores `_` to separate words (also known as [SCREAMING_SNAKE_CASE](https://github.com/rubocop-hq/ruby-style-guide#screaming-snake-case)).
 * Don't combine them with other punctuation to indicate variables (such as wrapping the text in angle brackets or curly braces).
 * If you explicitly say that a customer must replace some values, you can break some of the usual rules. For example, if you preface a code snippet with an instruction that they'll have to replace some of the values, you can use more brief placeholder text, like `YOUR_ACCOUNT_ID` or `YOUR_USER_KEY`. 

--- a/src/content/docs/style-guide/formatting/code-examples.mdx
+++ b/src/content/docs/style-guide/formatting/code-examples.mdx
@@ -213,6 +213,9 @@ Some tips on crafting customer-specific value placeholders:
 
 ### Tips on using var tags [#var-tags]
 
-If it's important to highlight something in a code snippet and you're okay losing syntax highlighting, you can use `<var>` tags. Some examples of why you'd do this: 
+If it's important to highlight something in a code snippet and you're okay losing syntax highlighting, you can use `<var>` tags. Some examples of why you'd do this:
+
 * To highlight values in a code snippet that you want to define or that customers will later use. For an example of this, see this [Activate Azure integrations doc](/docs/infrastructure/microsoft-azure-integrations/getting-started/activate-azure-integrations#get-ids).
-* To highlight multiple lines of code to draw attention to the snippet a customer needs to use or input.
+* To highlight multiple lines of code to draw attention to the snippet a customer needs to use or input. Note that in this case, you may need to use var tags around each line to avoid excessive highlighting. 
+
+

--- a/src/content/docs/style-guide/formatting/code-examples.mdx
+++ b/src/content/docs/style-guide/formatting/code-examples.mdx
@@ -177,7 +177,7 @@ To format one or more lines of code, insert three backticks ( ```` ``` ```` ) ab
 
 Traditionally, we've used `<var>` tags for customer-specific value placeholders in code snippets. For example: we'd use `<var>YOUR_ACCOUNT_ID</var>` to draw a user's attention to a place they'd need to input their account ID.
 
-In November of 2022, we found out that language-specific [syntax highlighting](#synax-highlight-exampl) doesn't work with var tags: Using var tags in a code block disables syntax-specific coloring for that block. Going forward, for customer-specific value placeholders, avoid using var tags and instead focus on creating strong placeholder text to make it clear to customers what they should put in those places. For example, instead of using `<var>YOUR_NR_ACCOUNT_ID</var>`, we'd remove the var tags and make it a bit more descriptive, like `INSERT_YOUR_NR_ACCOUNT_ID`. 
+In November of 2022, we found out that language-specific [syntax highlighting](#synax-highlight-example) doesn't work with var tags: Using var tags in a code block disables syntax-specific coloring for that block. Going forward, for customer-specific value placeholders, avoid using var tags and instead focus on creating strong placeholder text to make it clear to customers what they should put in those places. For example, instead of using `<var>YOUR_NR_ACCOUNT_ID</var>`, we'd remove the var tags and make it a bit more descriptive, like `INSERT_YOUR_NR_ACCOUNT_ID`. 
 
 That said, `<var>` tags can still be used if you think it's important to highlight something in a code snippet and you're okay losing syntax highlighting. For tips on using var tags, see [Var tags](#var-tags).
 


### PR DESCRIPTION
This was work to: 

* Update style guide with better guidance on customer-specific value placeholders, which previously we said to use `<var>` tags for, but now we have to update because those tags disable code syntax highlighting. 
* I left in room to use `<var>` tags if we really want to and are okay with there not being syntax highlighting, but main guidance is to avoid var tags almost entirely.  

Questions: 
* Is saying to include 'INSERT' in placeholder text too much? Is it enough to just say 'YOUR_X...'? Or would it be more helpful to say 'INSERT_YOUR_X...' ? On one hand, getting rid of `<var>` tag makes it so that the placeholders are harder to recognize, so having 'INSERT' would help make things more clear in that regard. On other hand, it would take up more room. 