### PR TITLE
fix(infra-agent): support dates

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-monitoring/get-started/infrastructure-agent-eol-policy.mdx
+++ b/src/content/docs/infrastructure/infrastructure-monitoring/get-started/infrastructure-agent-eol-policy.mdx
@@ -7,7 +7,9 @@ The following are the specific policies and dates for support of our infrastruct
 
 ## New Relic infrastructure monitoring agent releases and support dates [#infrastructure-eol]
 
-Any versions not listed in the following table are no longer supported. Please [update your infrastructure monitoring agent version](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent/) to the [latest release](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes).
+Starting with version v1.28.0, all Infrastructure Agent releases are officially supported for one year. 
+
+The following table lists the end support date for older versions. Please [update your infrastructure monitoring agent version](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent/) to the [latest release](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes).
 
 <table>
   <thead>

--- a/src/content/docs/infrastructure/infrastructure-monitoring/get-started/infrastructure-agent-eol-policy.mdx
+++ b/src/content/docs/infrastructure/infrastructure-monitoring/get-started/infrastructure-agent-eol-policy.mdx
@@ -7,7 +7,7 @@ The following are the specific policies and dates for support of our infrastruct
 
 ## New Relic infrastructure monitoring agent releases and support dates [#infrastructure-eol]
 
-Starting with version v1.28.0, all Infrastructure Agent releases are officially supported for one year. 
+Starting with version v1.28.0, all infrastructure agent releases are officially supported for one year. 
 
 The following table lists the end support date for older versions. Please [update your infrastructure monitoring agent version](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent/) to the [latest release](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes).
 


### PR DESCRIPTION
## Give us some context

* Suggesting more details on the EOL policy for the infra agent (feel free to rewrite). The policy is: releases after July-2022 (starting with 1.28.0) are supported for one year, older releases (before July 2022) have a two-year support cycle.