### PR TITLE
fix(infra-agent): version param deprecated

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-using-ansible.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-using-ansible.mdx
@@ -54,7 +54,7 @@ Here are available variables for configuring the `newrelic.newrelic-infra` role:
 <table>
   <thead>
     <tr>
-      <th style={{ width: "200px" }}>
+      <th style={{ width: "300px" }}>
         Variable
       </th>
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-using-ansible.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-using-ansible.mdx
@@ -90,19 +90,6 @@ Here are available variables for configuring the `newrelic.newrelic-infra` role:
 
     <tr>
       <td>
-        `nrinfragent_version` (Optional)
-      </td>
-
-      <td>
-        The version of the agent you want to install:
-
-        * `'*'`: Default. Installs the latest version of the infrastructure agent.
-        * `'x.y.zzz'`: String specifying a specific agent version number you want to install; for example, `1.0.682`.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         `nrinfragent_os_name` (Optional)
       </td>
 


### PR DESCRIPTION
## Give us some context

* The version param has been deprecated long time in the ansible repo for the infra-agent. We are removing this from doc to avoid confusion until there's an alternative param.