### PR TITLE
Update curl and printf commands

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -158,7 +158,7 @@ To install infrastructure in Linux, follow these instructions:
        title={<><img src={osDebian} title="Debian.png" alt="Debian.png" style={{ height: '32px', width: '32px', verticalAlign: 'middle' }}/> Debian</>}
      >
        ```
-       curl -s https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
+       curl -fsSL https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
        ```
      </Collapser>
 
@@ -167,7 +167,7 @@ To install infrastructure in Linux, follow these instructions:
        title={<><img src={osUbuntu} title="ubuntu icon" alt="ubuntu icon" style={{ height: '32px', width: '32px', verticalAlign: 'middle' }}/> Ubuntu</>}
      >
        ```
-       curl -s https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
+       curl -fsSL https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/newrelic-infra.gpg
        ```
      </Collapser>
 
@@ -201,25 +201,25 @@ To install infrastructure in Linux, follow these instructions:
        **Debian 8 ("Jessie")**
 
        ```
-       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt jessie main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       echo "deb https://download.newrelic.com/infrastructure_agent/linux/apt jessie main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
        **Debian 9 ("Stretch")**
 
        ```
-       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt stretch main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       echo "deb https://download.newrelic.com/infrastructure_agent/linux/apt stretch main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
        **Debian 10 ("Buster")**
 
        ```
-       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt buster main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       echo "deb https://download.newrelic.com/infrastructure_agent/linux/apt buster main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
        **Debian 11 ("Bullseye")**
 
        ```
-       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt bullseye main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       echo "deb https://download.newrelic.com/infrastructure_agent/linux/apt bullseye main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
      </Collapser>
 
@@ -230,37 +230,37 @@ To install infrastructure in Linux, follow these instructions:
        **Ubuntu 16.04 LTS (Xenial Xerus)**
 
        ```
-       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt xenial main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       echo "deb https://download.newrelic.com/infrastructure_agent/linux/apt xenial main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
        **Ubuntu 18.04 LTS (Bionic Beaver)**
 
        ```
-       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt bionic main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       echo "deb https://download.newrelic.com/infrastructure_agent/linux/apt bionic main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
        **Ubuntu 20.04 LTS (Focal Fossa)**
 
        ```
-       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt focal main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       echo "deb https://download.newrelic.com/infrastructure_agent/linux/apt focal main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
        **Ubuntu 20.10 (Groovy Gorilla)**
 
        ```
-       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt groovy main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       echo "deb https://download.newrelic.com/infrastructure_agent/linux/apt groovy main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
        **Ubuntu 21.04 (Hirsute Hippo)**
 
        ```
-       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt hirsute main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       echo "deb https://download.newrelic.com/infrastructure_agent/linux/apt hirsute main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
 
        **Ubuntu 22.04 (Jammy Jellyfish)**
 
        ```
-       printf "deb https://download.newrelic.com/infrastructure_agent/linux/apt/ jammy main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       echo "deb https://download.newrelic.com/infrastructure_agent/linux/apt/ jammy main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
      </Collapser>
 


### PR DESCRIPTION
- curl should use -fsSL options to retry on failure, silent, show errors, and redirect if needed
- Ubuntu 22.04 needs to use `gpg` instead of `apt-key` to store the key in a different location
- `echo` is more user friendly than `printf` since it adds a line break