### PR TITLE
Update docker start procedure  (Draft in progress)

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-job-manager.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-job-manager.mdx
@@ -340,31 +340,22 @@ Below are the applicable Docker or Kubernetes instructions to start the job mana
     title={<><img src={syntheticDocker} title="Docker icon" alt="Docker icon" style={{ height: '35px', width: '40px' }}/> Docker start procedure</>}
   >
     1. Locate your [private location key](#private-location-key).
-    2. Ensure you've enabled [Docker dependencies](#sandboxing-and-docker-deps) for sandboxing and [installed](#install-update) synthetics job manager on your system.
-    3. Run the appropriate script for your system. Tailor the common default `/var/run/docker.sock` in the following examples to match your system.
+    2. Ensure you've enabled [Docker dependencies](#sandboxing-and-docker-deps) for sandboxing and [installed Docker Engine](https://docs.docker.com/engine/install/) for your platform. If running as a [non-root user](#run-non-root), also complete the Docker Post-installation steps to [Manage Docker as a non-root user](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user).
+    3. Run the following command from a Linux Terminal. Tailor the common default for `/var/run/docker.sock` to match your system. For Windows, install a Linux distribution in WSL 2 and run the command from there.
 
-       * Linux/macOS:
+       ```
+       docker run \
+           --name <var>YOUR_CONTAINER_NAME</var> \
+           -e "PRIVATE_LOCATION_KEY=<var>YOUR_PRIVATE_LOCATION_KEY</var>" \
+           -v /var/run/docker.sock:/var/run/docker.sock:rw \
+           -d \
+           --restart unless-stopped \
+           newrelic/synthetics-job-manager:latest
+       ```
 
-         ```
-         docker run \
-             --name <var>YOUR_CONTAINER_NAME</var> \
-             -e "PRIVATE_LOCATION_KEY=<var>YOUR_PRIVATE_LOCATION_KEY</var>" \
-             -v /var/run/docker.sock:/var/run/docker.sock:rw \
-             -d \
-             --restart unless-stopped \
-             newrelic/synthetics-job-manager:latest
-         ```
-       * Windows:
-
-         ```
-         docker run ^
-             --name <var>YOUR_CONTAINER_NAME</var> ^
-             -e "PRIVATE_LOCATION_KEY=<var>YOUR_PRIVATE_LOCATION_KEY</var>" ^
-             -v /var/run/docker.sock:/var/run/docker.sock:rw ^
-             -d ^
-             --restart unless-stopped ^
-             newrelic/synthetics-job-manager:latest
-         ```
+       <Callout variant="caution">
+         Do not use `sudo` or `--privileged` with the `docker run` command to avoid permission issues for the runtime containers created by the job manager. See [Aruguments passed at launch](#FAQ) in our FAQ.
+       </Callout>
 
        View the logs for your minion container:
 


### PR DESCRIPTION
- Docker Engine must be installed first
- The Linux Terminal must be used for all platforms (including Windows)
- Clarify common permissions issues