### PR TITLE
Updates to Debian

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -158,7 +158,7 @@ To install infrastructure in Linux, follow these instructions:
        title={<><img src={osDebian} title="Debian.png" alt="Debian.png" style={{ height: '32px', width: '32px', verticalAlign: 'middle' }}/> Debian</>}
      >
        ```
-       curl -fsSL https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
+       curl -fsSL https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/newrelic-infra.gpg
        ```
      </Collapser>
 
@@ -198,18 +198,6 @@ To install infrastructure in Linux, follow these instructions:
        id="debian-repository"
        title={<><img src={osDebian} title="Debian.png" alt="Debian.png" style={{ height: '32px', width: '32px', verticalAlign: 'middle' }}/> Debian</>}
      >
-       **Debian 8 ("Jessie")**
-
-       ```
-       echo "deb https://download.newrelic.com/infrastructure_agent/linux/apt jessie main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
-       ```
-
-       **Debian 9 ("Stretch")**
-
-       ```
-       echo "deb https://download.newrelic.com/infrastructure_agent/linux/apt stretch main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
-       ```
-
        **Debian 10 ("Buster")**
 
        ```


### PR DESCRIPTION
- remove Debian 8 and 9 because they are EOL
- update curl command to use gpg due to deprecated apt-key