### PR TITLE
fix(retention): clarify caps

### DIFF
--- a/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
+++ b/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
@@ -41,7 +41,7 @@ an additional 90 days of retention.
 Permission-related requirements for viewing and editing retention:
 * [Newer user model](/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models): 
   * Setting a contract with longer data retention for your entire organization requires the [**Billing** administration setting](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts#admin-settings)
-  * Adjusting retention for specific types of data or for a specific account within the bounds of a contract requires the [**Insights event retention** capability](/docs/accounts/accounts-billing/new-relic-one-user-management/user-capabilities/#data-retention) 
+  * Adjusting retention within the bounds of a contract for specific types of data or for a specific account requires the [**Insights event retention** capability](/docs/accounts/accounts-billing/new-relic-one-user-management/user-capabilities/#data-retention) 
 * [Original user model](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model): requires the **Insights event retention** capability.
 
 ## The data retention UI [#find-ui]

--- a/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
+++ b/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
@@ -40,8 +40,8 @@ an additional 90 days of retention.
 
 Permission-related requirements for viewing and editing retention:
 * [Newer user model](/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models): 
-  * Changing to a higher data retention contract requires the [**Billing** administration setting](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts#admin-settings)
-  * Editing retention settings within the bounds of a contract requires the [**Insights event retention** capability](/docs/accounts/accounts-billing/new-relic-one-user-management/user-capabilities/#data-retention).  
+  * Setting a contract with longer data retention for your entire organization requires the [**Billing** administration setting](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts#admin-settings)
+  * Adjusting retention for specific types of data or for a specific account within the bounds of a contract requires the [**Insights event retention** capability](/docs/accounts/accounts-billing/new-relic-one-user-management/user-capabilities/#data-retention) 
 * [Original user model](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model): requires the **Insights event retention** capability.
 
 ## The data retention UI [#find-ui]


### PR DESCRIPTION
Work done: 

Make it clearer that one permission is about changing contract for retention, and other is for adjusting within the contract for specific data or specific accounts. 