### PR TITLE
Adding and updating templates

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/migration-to-workflows.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/migration-to-workflows.mdx
@@ -23,7 +23,7 @@ Notifications will not substantially change during the migration.  They will con
 
 * All _url attribute values will change and lead to issue based pages, not incident based pages.
 condition_id will now always have the same value as condition_family_id.
-* issue_id has been added. Consumers should switch all integrations to using the issue_id instead of the incident_id, as the incident_id may be removed at some point.
+* issue_id has been added. Consumers should switch all integrations to using the issue_id instead of the incident_id, as the incident_id will be removed at some point.
 * radar_entity.entityGuid and targets[0].id will be an entity guid when one is available for all types except for Webhooks.
 * targets[0].labels will contain all tags from the issue, not just the tags for the entity defined by the target.
 * targets[0].link and violation_callback_url will lead to the issue page.
@@ -33,13 +33,20 @@ condition_id will now always have the same value as condition_family_id.
 * closed_violations_count.warning will always be 0. Priority specific counts are unavailable.
 * owner will have a value of NA if the issue has not been acknowledged
 
+### incident_id
+The incident_id on PagerDuty, Webhook, VictorOps, OpsGenie and xMatters notifications refers to the classic incident id.  The classic incident id will be removed at some point, consumers should start to use the issue_id instead.  Due to the way the classic incident id is added to the issue, it cannot be guaranteed to be present.
+
+To avoid generating invalid json on custom webhooks, a value of -1 will be used when the classic incident id is not available.
+
+To limit the impact to VictorOps, OpsGenie and xMatters notifications, the incident_id will be populated by the issue id.  That will cause the New Relic steps to acknowledge or close an incident in xMatters to no longer work.
+
 ## Configuring custom payloads [#configure-custom-payloads]
 
 When moving from notification channels to workflows your team may want to make some tweaks to your custom payloads. Workflows still function in the same way as notifications in that, when a condition is violated then a notification is sent to a webhook and when it is sent, it goes with its custom payload. The migration from notification channels to workflows requires changing some of the terminology in this payload.
 
-The following table provides a translation between what the webhook payload names used in our classic notification system and their new, corresponding names in the issue payload.  
+The following table provides a translation between what the webhook payload names used in our classic notification system and their new, corresponding names in the issue payload.
 
-For many keys, the issue payload may contain a list of values.
+For many keys, the issue payload may contain a list of values.  To provide a one-to-one mapping, only the first value is used in the replacement.
 
 <table>
 
@@ -56,10 +63,6 @@ For many keys, the issue payload may contain a list of values.
       <th>
         **Workflow template replacement**
       </th>
-
-      <th>
-        **Notes**
-      </th>
     </tr>
   </thead>
 
@@ -74,9 +77,6 @@ For many keys, the issue payload may contain a list of values.
       <td>
         `{{nrAccountId}}`
       </td>
-      <td>
-        The account associated with the issue. 
-      </td>
     </tr>
 
 
@@ -90,9 +90,6 @@ For many keys, the issue payload may contain a list of values.
       <td>
         `{{ accumulations.tag.account.[0] }}`
       </td>
-      <td>
-        New Relic account name.
-      </td>
     </tr>
 
 
@@ -105,8 +102,7 @@ For many keys, the issue payload may contain a list of values.
       </td>
       <td>
         `{{closedIncidentsCount}}`
-      </td>
-      <td>
+
         The number of closed incidents across all priorities.
       </td>
     </tr>
@@ -121,8 +117,7 @@ For many keys, the issue payload may contain a list of values.
       </td>
       <td>
         `0`
-      </td>
-      <td>
+
         There is no replacement for warning counts.  All closed incident counts will be represented as critical to avoid double counting incidents. 
       </td>
     </tr>
@@ -137,9 +132,8 @@ For many keys, the issue payload may contain a list of values.
       </td>
       <td>
         `{{accumulations.conditionDescription.[0] }}`
-      </td>
-      <td>
-        Custom violation description.
+
+        The custom incident description, if one is defined.
       </td>
     </tr>
 
@@ -154,9 +148,6 @@ For many keys, the issue payload may contain a list of values.
       <td>
         `{{accumulations.conditionFamilyId.[0]}}`
       </td>
-      <td>
-        The issue payload can have multiple conditions.
-      </td>
     </tr>
 
 
@@ -168,9 +159,8 @@ For many keys, the issue payload may contain a list of values.
         N/A
       </td>
       <td>
-        `{{json accumulations.tag.metricName.[0]}}`
-      </td>
-      <td>
+        `{{accumulations.evaluationName.[0]}}`
+
         Only valid for APM conditions.
       </td>
     </tr>
@@ -184,9 +174,8 @@ For many keys, the issue payload may contain a list of values.
         N/A
       </td>
       <td>
-        `{{json accumulations.tag.name.[0]}}`
-      </td>
-      <td>
+        `{{accumulations.evaluationMetricValueFunction.[0]}}`
+
         Only valid for APM conditions.
       </td>
     </tr>
@@ -200,10 +189,7 @@ For many keys, the issue payload may contain a list of values.
         `$CONDITION_NAME`
       </td>
       <td>
-        `{{json accumulations.conditionName.[0]}}`
-      </td>
-      <td>
-        An issue can have multiple conditions.
+        `{{accumulations.conditionName.[0]}}`
       </td>
     </tr>
 
@@ -217,25 +203,8 @@ For many keys, the issue payload may contain a list of values.
       </td>
       <td>
         `{{#if issueClosedAt}}"closed"{{else if issueAcknowledgedAt}}"acknowledged"{{else}}"open"{{/if}}`
-      </td>
-      <td>
-        The issue values are created, activated, merged and closed.
-      </td>
-    </tr>
 
-
-    <tr>
-      <td>
-        `Custom Violation description`
-      </td>
-      <td>
-        `VIOLATION DESCRIPTION`
-      </td>
-      <td>
-        `{{#if accumulations.conditionDescription}}"VIOLATION DESCRIPTION": {{json accumulations.conditionDescription.[0]}},{{/if}}`
-      </td>
-      <td>
-        An issue contains a list of custom violation description (if they exist).
+        The state of an issue has more states, but doesn't have one for acknowledged.
       </td>
     </tr>
 
@@ -250,9 +219,6 @@ For many keys, the issue payload may contain a list of values.
       <td>
         `{{issueTitle}}`
       </td>
-      <td>
-        The title of the issue.
-      </td>
     </tr>
 
 
@@ -265,9 +231,8 @@ For many keys, the issue payload may contain a list of values.
       </td>
       <td>
         `{{#if issueDurationMs}}{{issueDurationMs}}{{else}}0{{/if}}`
-      </td>
-      <td>
-        The duration of the issue since it was created.
+
+        `issueDurationMs` isn't available on newly opened issues
       </td>
     </tr>
 
@@ -281,8 +246,7 @@ For many keys, the issue payload may contain a list of values.
       </td>
       <td>
         `"INCIDENT"`
-      </td>
-      <td>
+
         There is no matching attribute on the issue level.
       </td>
     </tr>
@@ -298,9 +262,6 @@ For many keys, the issue payload may contain a list of values.
       <td>
         `{{issueAckUrl}}`
       </td>
-      <td>
-        Link to acknowledge the issue.
-      </td>
     </tr>
 
 
@@ -312,10 +273,11 @@ For many keys, the issue payload may contain a list of values.
         `$INCIDENT_ID`
       </td>
       <td>
-        `{{issueAckUrl}}`
-      </td>
-      <td>
-        Issue payload can contain multiple incidents, we recommend using the issue id. Incident_id will be removed at a later date.
+        `{{issueId}}`
+          OR
+        `{{labels.nrIncidentId.[0]}}`
+
+        Prefer `issueId` since `labels.nrIncidentId` will be removed at some point.
       </td>
     </tr>
 
@@ -330,9 +292,6 @@ For many keys, the issue payload may contain a list of values.
       <td>
         `{{issuePageUrl}}`
       </td>
-      <td>
-        Link to the issue.
-      </td>
     </tr>
 
 
@@ -345,9 +304,6 @@ For many keys, the issue payload may contain a list of values.
       </td>
       <td>
         `{{issueId}}`
-      </td>
-      <td>
-      The issue ID.
       </td>
     </tr>
 
@@ -366,9 +322,6 @@ For many keys, the issue payload may contain a list of values.
         {{#if accumulations.metadata_entity_name}}"entity.name": {{json accumulations.metadata_entity_name.[0]}}{{/if}}
         ``` 
       </td>
-      <td>
-        None
-      </td>
     </tr>
 
 
@@ -381,8 +334,7 @@ For many keys, the issue payload may contain a list of values.
       </td>
       <td>
         `{{openIncidentsCount}}`
-      </td>
-      <td>
+
         Open incident counts of all incident regardless of priority.
       </td>
     </tr>
@@ -397,8 +349,7 @@ For many keys, the issue payload may contain a list of values.
       </td>
       <td>
         `N/A`
-      </td>
-      <td>
+
         Open incident counts of all incidents regardless of priority.
       </td>
     </tr>
@@ -414,9 +365,6 @@ For many keys, the issue payload may contain a list of values.
       <td>
         `{{owner}}`
       </td>
-      <td>
-        There is no matching attribute on the issue level.
-      </td>
     </tr>
 
 
@@ -430,9 +378,6 @@ For many keys, the issue payload may contain a list of values.
       <td>
         `{{accumulations.policyName.[0]}}`
       </td>
-      <td>
-        An issue can have multiple policies.
-      </td> 
     </tr>
 
 
@@ -444,10 +389,7 @@ For many keys, the issue payload may contain a list of values.
         `$POLICY_URL`
       </td>
       <td>
-        `{{#if policyUrl}}"policy_url": {{json policyUrl}},{{/if}}`
-      </td>
-      <td>
-        The URL link to the first policy
+        `{{policyUrl}}`
       </td>
     </tr>
 
@@ -460,10 +402,7 @@ For many keys, the issue payload may contain a list of values.
         `$RUNBOOK_URL`
       </td>
       <td>
-        `{{accumulations.runbookUrl.[0] }}`
-      </td>
-      <td>
-        The first runbook associated to a condition in the issue
+        `{{accumulations.runbookUrl.[0]}}`
       </td>
     </tr>
 
@@ -476,9 +415,8 @@ For many keys, the issue payload may contain a list of values.
         `$SEVERITY`
       </td>
       <td>
-        `{{#eq HIGH priority}}"WARNING"{{else}}{{json priority}}{{/eq}}`
-      </td>
-      <td>
+        `{{#eq 'HIGH' priority}}WARNING{{else}}{{priority}}{{/eq}}`
+
         An issue has priority, which can have different values than severity.
       </td>
     </tr>
@@ -492,11 +430,16 @@ For many keys, the issue payload may contain a list of values.
         `$TARGETS`
       </td>
       <td>
-      `[ { "id": "{{labels.targetId.[0]}}", "name": "{{#if accumulations.     targetName}}{{accumulations.targetName.[0]}}{{else if entitiesData.entities}}{{entitiesData.entities.[0].name}}{{else}}N/A{{/if}}", "link": "{{issuePageUrl}}", "product": "{{accumulations.conditionProduct.[0]}}", "type": "{{#if entitiesData.types.[0]}}{{entitiesData.types.[0]}}{{else}}N/A{{/if}}", "labels": { {{#each accumulations.rawTag}}{{#if this.[0]}}"{{@key}}":{{json this.[0]}},{{/if}}{{/each}}
-]`
-      </td>
-      <td>
-        N/A
+      ```[
+    {
+      "id": "{{labels.targetId.[0]}}",
+      "name": "{{#if accumulations.targetName}}{{accumulations.targetName.[0]}}{{else if entitiesData.entities}}{{entitiesData.entities.[0].name}}{{else}}N/A{{/if}}",
+      "link": "{{issuePageUrl}}",
+      "product": "{{accumulations.conditionProduct.[0]}}",
+      "type": "{{#if entitiesData.types.[0]}}{{entitiesData.types.[0]}}{{else}}N/A{{/if}}",
+      "labels": { {{#each accumulations.rawTag}}{{#if this.[0]}}"{{@key}}":{{json this.[0]}}{{#unless @last}},{{/unless}}{{/if}}{{/each}} }
+    }
+  ]```
       </td>
     </tr>
 
@@ -509,10 +452,7 @@ For many keys, the issue payload may contain a list of values.
         `$TIMESTAMP`
       </td>
       <td>
-        `{{#if closedAt}}{{closedAt}}{{else if acknowledgedAt}}{{acknowledgedAt}}{{else}}{{createdAt}}{{/if}}`
-      </td>
-      <td>
-        The timestamp of when the issue was created.
+        `{{updatedAt}}`
       </td>
     </tr>
 
@@ -525,10 +465,7 @@ For many keys, the issue payload may contain a list of values.
         `$TIMESTAMP_UTC_STRING`
       </td>
       <td>
-        `{{#if issueClosedAtUtc}}{{json issueClosedAtUtc}}{{else if issueAcknowledgedAt}}{{json issueAcknowledgedAt}}{{else}}{{json issueCreatedAtUtc}}{{/if}}`
-      </td>
-      <td>
-        The timestamp of when the issue was created.
+        `{{issueUpdatedAt}}`
       </td>
     </tr>
 
@@ -542,8 +479,7 @@ For many keys, the issue payload may contain a list of values.
       </td>
       <td>
         `"1.0"`
-      </td>
-      <td>
+
         There is no matching attribute on the issue level.
       </td>
     </tr>
@@ -559,9 +495,6 @@ For many keys, the issue payload may contain a list of values.
       <td>
         `{{issuePageUrl}}`
       </td>
-      <td>
-        N/A
-      </td>
     </tr>
 
 
@@ -575,9 +508,6 @@ For many keys, the issue payload may contain a list of values.
       <td>
         `{{violationChartUrl}}`
       </td>
-      <td>
-        Link to the first violation chart in the issue.
-      </td>
     </tr>
   </tbody>
 </table>
@@ -586,15 +516,15 @@ For many keys, the issue payload may contain a list of values.
 <CollapserGroup>
   <Collapser
     id=""
-    title="Alerts (classic) default payload in workflows"
+    title=" Migrated workflow payload for Alerts (classic) default webhook channels"
   >
 
-The following template maps the issue payload to the payload used by the classic webhook channel. You can use some or all of the dynamic variables, along with any custom variables, to define your own payload.
+The following template maps the issue payload to the default payload used by the classic webhook channel. You can use some or all of the dynamic variables, along with any custom variables, to define your own payload.
 
-```json
+```
 {
   "owner": {{json owner}},
-  "severity": "{{#eq HIGH priority}}WARNING{{else}}{{priority}}{{/eq}}",
+  "severity": "{{#eq 'HIGH' priority}}WARNING{{else}}{{priority}}{{/eq}}",
   "policy_url": {{json policyUrl}},
   "closed_violations_count_critical": {{closedIncidentsCount}},
   "closed_violations_count_warning": 0,
@@ -604,27 +534,26 @@ The following template maps the issue payload to the payload used by the classic
   "condition_family_id": {{accumulations.conditionFamilyId.[0]}},
   "incident_acknowledge_url": {{json issueAckUrl}},
   "targets":[
- {
- "id": "{{labels.targetId.[0]}}",
-"name": "{{#if accumulations.targetName}}{{accumulations.targetName.[0]}}{{else if entitiesData.entities}}{{entitiesData.entities.[0].name}}{{else}}N/A{{/if}}",
-"link": "{{issuePageUrl}}",
-"product": "{{accumulations.conditionProduct.[0]}}",
-"type": "{{#if entitiesData.types.[0]}}{{entitiesData.types.[0]}}{{else}}N/A{{/if}}",
-"labels": { {{#each accumulations.rawTag}}{{#if this.[0]}}"{{@key}}":{{json this.[0]}},{{/if}}{{/each}}
-}
-}
- ],
+    {
+      "id": "{{labels.targetId.[0]}}",
+      "name": "{{#if accumulations.targetName}}{{accumulations.targetName.[0]}}{{else if entitiesData.entities}}{{entitiesData.entities.[0].name}}{{else}}N/A{{/if}}",
+      "link": "{{issuePageUrl}}",
+      "product": "{{accumulations.conditionProduct.[0]}}",
+      "type": "{{#if entitiesData.types.[0]}}{{entitiesData.types.[0]}}{{else}}N/A{{/if}}",
+      "labels": { {{#each accumulations.rawTag}}{{#if this.[0]}}"{{@key}}":{{json this.[0]}}{{#unless @last}},{{/unless}}{{/if}}{{/each}} }
+    }
+  ],
   "version": "1.0",
   "condition_id": {{accumulations.conditionFamilyId.[0]}},
   "duration": {{#if issueDurationMs}}{{issueDurationMs}}{{else}}0{{/if}},
   "account_id": {{nrAccountId}},
-  "incident_id": {{#if labels.nrIncidentId}}{{labels.nrIncidentId.[0]}}{{else}}"N/A"{{/if}},
+  "incident_id": {{#if labels.nrIncidentId}}{{labels.nrIncidentId.[0]}}{{else}}-1{{/if}},
   "issue_id": "{{issueId}}",
   "metadata":{
     {{#if locationStatusesObject}}"location_statuses": {{locationStatusesObject}},{{/if}}
     {{#if accumulations.metadata_entity_type}}"entity.type": {{json accumulations.metadata_entity_type.[0]}},{{/if}}
     {{#if accumulations.metadata_entity_name}}"entity.name": {{json accumulations.metadata_entity_name.[0]}}{{/if}}
-},
+  },
   "event_type": "INCIDENT",
   "runbook_url": {{json accumulations.runbookUrl.[0]}},
   "account_name": {{json accumulations.tag.account.[0]}},
@@ -634,7 +563,214 @@ The following template maps the issue payload to the payload used by the classic
   "details": {{json issueTitle}},
   "violation_callback_url": {{json issuePageUrl}},
   "condition_name": {{json accumulations.conditionName.[0]}},
-  "timestamp": "{{#if closedAt}}{{closedAt}}{{else if acknowledgedAt}}{{acknowledgedAt}}{{else}}{{createdAt}}{{/if}}"
+  "timestamp": {{updatedAt}}
+}
+```
+
+  </Collapser>
+  <Collapser
+    id=""
+    title=" Migrated workflow payload for Alerts (classic) VictorOps and xMatters channels"
+  >
+
+The following template maps the issue payload to the payload used by the classic VictorOps and xMatters channels.  You can use some or all of the dynamic variables, along with any custom variables, to define your own payload.
+
+```
+{
+    {{#if nrAccountId}}"account_id": {{nrAccountId}},{{/if}}
+    "account_name": {{json accumulations.tag.account.[0]}},
+    {{#if accumulations.tag.action}}"action":{{json accumulations.tag.action.[0]}},{{/if}}
+    "closed_violations_count": {
+        "critical": {{#if closedIncidentsCount}}{{closedIncidentsCount}}{{else}}0{{/if}},
+        "warning": 0,
+        "total": {{#if closedIncidentsCount}}{{closedIncidentsCount}}{{else}}0{{/if}}
+    },
+    "condition_family_id": {{accumulations.conditionFamilyId.[0]}},
+    "condition_id": {{accumulations.conditionFamilyId.[0]}},
+    "condition_name": {{json accumulations.conditionName.[0]}},
+    {{#if accumulations.evaluationName}}"condition_metric_name": {{json accumulations.evaluationName.[0]}},{{/if}}
+    {{#if accumulations.evaluationMetricValueFunction}}"condition_metric_value_function": {{json accumulations.evaluationMetricValueFunction.[0]}},{{/if}}
+    "current_state": {{#if issueClosedAt}}"closed"{{else if issueAcknowledgedAt}}"acknowledged"{{else}}"open"{{/if}},
+    "details": {{json issueTitle}},
+    "duration": {{#if issueDurationMs}}{{issueDurationMs}}{{else}}0{{/if}},
+    "event_type": "INCIDENT",
+    "incident_acknowledge_url": {{json issueAckUrl}},
+    "incident_url": {{json issuePageUrl}},
+    "incident_id": {{json issueId}},
+    "issue_close_url": {{json issueCloseUrl}},
+    "metadata": {
+        {{#if locationStatusesObject}}"location_statuses": {{locationStatusesObject}},{{/if}}
+        {{#if accumulations.metadata_entity_type}}"entity.type": {{json accumulations.metadata_entity_type.[0]}},{{/if}}
+        {{#if accumulations.metadata_entity_name}}"entity.name": {{json accumulations.metadata_entity_name.[0]}}{{/if}}
+    },
+    "open_violations_count": {
+        "critical": {{#if openIncidentsCount}}{{openIncidentsCount}}{{else}}0{{/if}},
+        "warning": 0,
+        "total": {{#if openIncidentsCount}}{{openIncidentsCount}}{{else}}0{{/if}}
+    },
+    "policy_name": {{json accumulations.policyName.[0]}},
+    {{#if policyUrl}}"policy_url": {{json policyUrl}},{{/if}}
+    "radar_entity": {
+        "accountId": {{json accumulations.tag.accountId.[0]}},
+        "domain": {{json accumulations.conditionProduct.[0]}},
+        "domainId": {{json issueId}},
+        "entityGuid": {{json entitiesData.entities.[0].id}},
+        "name": {{#if accumulations.targetName}}{{json accumulations.targetName.[0]}}{{else if entitiesData.entities}}{{json entitiesData.entities.[0].name}}{{else}}"NA"{{/if}},
+        "type": {{#if entitiesData.types.[0]}}{{json entitiesData.types.[0]}}{{else}}"NA"{{/if}}
+    },
+    {{#if accumulations.runbookUrl}}"runbook_url": {{json accumulations.runbookUrl.[0]}},{{/if}}
+    "severity": "{{#eq 'HIGH' priority}}WARNING{{else}}{{priority}}{{/eq}}",
+    "state": {{json state}},
+    "status": {{json status}},
+    "targets": [
+        {
+            "id": {{#if entitiesData.entities.[0].id}}{{json entitiesData.entities.[0].id}}{{else if accumulations.nrqlEventType}}{{json accumulations.nrqlEventType.[0]}}{{else}}"N/A"{{/if}},
+            "name": {{#if accumulations.targetName}}{{json accumulations.targetName.[0]}}{{else if entitiesData.entities}}{{json entitiesData.entities.[0].name}}{{else}}"NA"{{/if}},
+            "link": {{json issuePageUrl}},
+            "product": {{json accumulations.conditionProduct.[0]}},
+            "type": {{#if entitiesData.types.[0]}}{{json entitiesData.types.[0]}}{{else}}"NA"{{/if}},
+            "labels": {
+                {{#each accumulations.rawTag}}{{#if this.[0]}}"{{@key}}":{{json this.[0]}}{{#unless @last}},{{/unless}}{{/if}}{{/each}}
+            }
+        }
+    ],
+    "timestamp": {{updatedAt}},
+    "timestamp_utc_string": {{json issueUpdatedAt}},
+    "version": "1.0",
+    {{#if accumulations.conditionDescription}}"VIOLATION DESCRIPTION": {{json accumulations.conditionDescription.[0]}},{{/if}}
+    {{#if violationChartUrl}}"violation_chart_url": {{json violationChartUrl}},{{/if}}
+    "violation_callback_url": {{json issuePageUrl}}
+}```
+
+  </Collapser>
+  <Collapser
+    id=""
+    title=" Migrated workflow payload for Alerts (classic) OpsGenie channels"
+  >
+
+The following template maps the issue payload to the payload used by the classic OpsGenie channel.  You can use some or all of the dynamic variables, along with any custom variables, to define your own payload.
+
+```
+{
+    "condition_id": {{accumulations.conditionFamilyId.[0]}},
+    "condition_name": {{json accumulations.conditionName.[0]}},
+    "current_state": {{#if issueClosedAt}}"closed"{{else if issueAcknowledgedAt}}"acknowledged"{{else}}"open"{{/if}},
+    "details": {{json issueTitle}},
+    "event_type": "INCIDENT",
+    "incident_acknowledge_url": {{json issueAckUrl}},
+    "incident_api_url": "N/A",
+    "incident_id": {{json issueId}},
+    "incident_url": {{json issuePageUrl}},
+    "owner": {{json owner}},
+    "policy_name": {{json accumulations.policyName.[0]}},
+    "policy_url": {{json policyUrl}},
+    {{#if accumulations.runbookUrl}}"runbook_url": {{json accumulations.runbookUrl.[0]}},{{/if}}
+    "severity": "{{#eq 'HIGH' priority}}WARNING{{else}}{{priority}}{{/eq}}",
+    "metadata": {
+        {{#if locationStatusesObject}}"location_statuses": {{locationStatusesObject}},{{/if}}
+        {{#if accumulations.metadata_entity_type}}"entity.type": {{json accumulations.metadata_entity_type.[0]}},{{/if}}
+        {{#if accumulations.metadata_entity_name}}"entity.name": {{json accumulations.metadata_entity_name.[0]}}{{/if}}
+    },
+    "radar_entity": {
+        "accountId": {{json accumulations.tag.accountId.[0]}},
+        "domain": {{json accumulations.conditionProduct.[0]}},
+        "domainId": {{json issueId}},
+        "entityGuid": {{json entitiesData.entities.[0].id}},
+        "name": {{#if accumulations.targetName}}{{json accumulations.targetName.[0]}}{{else if entitiesData.entities}}{{json entitiesData.entities.[0].name}}{{else}}"NA"{{/if}},
+        "type": {{#if entitiesData.types.[0]}}{{json entitiesData.types.[0]}}{{else}}"NA"{{/if}}
+    },
+    "targets": [
+        {
+            "id": {{#if entitiesData.entities.[0].id}}{{json entitiesData.entities.[0].id}}{{else if accumulations.nrqlEventType}}{{json accumulations.nrqlEventType.[0]}}{{else}}"N/A"{{/if}},
+            "name": {{#if accumulations.targetName}}{{json accumulations.targetName.[0]}}{{else if entitiesData.entities}}{{json entitiesData.entities.[0].name}}{{else}}"NA"{{/if}},
+            "link": {{json issuePageUrl}},
+            "product": {{json accumulations.conditionProduct.[0]}},
+            "type": {{#if entitiesData.types.[0]}}{{json entitiesData.types.[0]}}{{else}}"NA"{{/if}},
+            "labels": {
+                {{#each accumulations.rawTag}}{{#if this.[0]}}"{{@key}}":{{json this.[0]}}{{#unless @last}},{{/unless}}{{/if}}{{/each}}
+            }
+        }
+    ],
+    {{#if nrAccountId}}"account_id": {{nrAccountId}},{{/if}}
+    "account_name": {{json accumulations.tag.account.[0]}},
+    "timestamp": {{updatedAt}}
+}
+```
+
+  </Collapser>
+  <Collapser
+    id=""
+    title=" Migrated workflow payload for Alerts (classic) PagerDuty channels"
+  >
+
+The following template maps the issue payload to the default payload used by the classic webhook channel. You can use some or all of the dynamic variables, along with any custom variables, to define your own payload.
+
+```
+{
+    {{#if nrAccountId}}"account_id": {{nrAccountId}},{{/if}}
+    "account_name": {{json accumulations.tag.account.[0]}},
+    {{#if accumulations.tag.action}}"action":{{json accumulations.tag.action.[0]}},{{/if}}
+    "closed_violations_count": {
+        "critical": {{#if closedIncidentsCount}}{{closedIncidentsCount}}{{else}}0{{/if}},
+        "warning": 0,
+        "total": {{#if closedIncidentsCount}}{{closedIncidentsCount}}{{else}}0{{/if}}
+    },
+    "condition_family_id": {{accumulations.conditionFamilyId.[0]}},
+    "condition_id": {{accumulations.conditionFamilyId.[0]}},
+    "condition_name": {{json accumulations.conditionName.[0]}},
+    {{#if accumulations.evaluationName}}"condition_metric_name": {{json accumulations.evaluationName.[0]}},{{/if}}
+    {{#if accumulations.evaluationMetricValueFunction}}"condition_metric_value_function": {{json accumulations.evaluationMetricValueFunction.[0]}},{{/if}}
+    "current_state": {{#if issueClosedAt}}"closed"{{else if issueAcknowledgedAt}}"acknowledged"{{else}}"open"{{/if}},
+    "details": {{json issueTitle}},
+    "duration": {{#if issueDurationMs}}{{issueDurationMs}}{{else}}0{{/if}},
+    "event_type": "INCIDENT",
+    "incident_acknowledge_url": {{json issueAckUrl}},
+    {{#if labels.nrIncidentId}}"incident_id": {{labels.nrIncidentId.[0]}},{{/if}}
+    "incident_url": {{json issuePageUrl}},
+    "issue_id": {{json issueId}},
+    "metadata": {
+        {{#if locationStatusesObject}}"location_statuses": {{locationStatusesObject}},{{/if}}
+        {{#if accumulations.metadata_entity_type}}"entity.type": {{json accumulations.metadata_entity_type.[0]}},{{/if}}
+        {{#if accumulations.metadata_entity_name}}"entity.name": {{json accumulations.metadata_entity_name.[0]}}{{/if}}
+    },
+    "open_violations_count": {
+        "critical": {{#if openIncidentsCount}}{{openIncidentsCount}}{{else}}0{{/if}},
+        "warning": 0,
+        "total": {{#if openIncidentsCount}}{{openIncidentsCount}}{{else}}0{{/if}}
+    },
+    {{#if owner}}"owner": {{json owner}},{{/if}}
+    "policy_name": {{json accumulations.policyName.[0]}},
+    {{#if policyUrl}}"policy_url": {{json policyUrl}},{{/if}}
+    "radar_entity": {
+        "accountId": {{json accumulations.tag.accountId.[0]}},
+        "domain": {{json accumulations.conditionProduct.[0]}},
+        "domainId": {{json issueId}},
+        "entityGuid": {{json entitiesData.entities.[0].id}},
+        "name": {{#if accumulations.targetName}}{{json accumulations.targetName.[0]}}{{else if entitiesData.entities}}{{json entitiesData.entities.[0].name}}{{else}}"NA"{{/if}},
+        "type": {{#if entitiesData.types.[0]}}{{json entitiesData.types.[0]}}{{else}}"NA"{{/if}}
+    },
+    {{#if accumulations.runbookUrl}}"runbook_url": {{json accumulations.runbookUrl.[0]}},{{/if}}
+    "severity": "{{#eq 'HIGH' priority}}WARNING{{else}}{{priority}}{{/eq}}",
+    "state": {{json state}},
+    "status": {{json status}},
+    "targets": [
+        {
+            "id": {{#if entitiesData.entities.[0].id}}{{json entitiesData.entities.[0].id}}{{else if accumulations.nrqlEventType}}{{json accumulations.nrqlEventType.[0]}}{{else}}"N/A"{{/if}},
+            "name": {{#if accumulations.targetName}}{{json accumulations.targetName.[0]}}{{else if entitiesData.entities}}{{json entitiesData.entities.[0].name}}{{else}}"NA"{{/if}},
+            "link": {{json issuePageUrl}},
+            "product": {{json accumulations.conditionProduct.[0]}},
+            "type": {{#if entitiesData.types.[0]}}{{json entitiesData.types.[0]}}{{else}}"NA"{{/if}},
+            "labels": {
+                {{#each accumulations.rawTag}}{{#if this.[0]}}"{{@key}}":{{json this.[0]}}{{#unless @last}},{{/unless}}{{/if}}{{/each}}
+            }
+        }
+    ],
+    "timestamp": {{updatedAt}},
+    "timestamp_utc_string": {{json issueUpdatedAt}},
+    "version": "1.0",
+    {{#if accumulations.conditionDescription}}"VIOLATION DESCRIPTION": {{json accumulations.conditionDescription.[0]}},{{/if}}
+    {{#if violationChartUrl}}"violation_chart_url": {{json violationChartUrl}},{{/if}}
+    "violation_callback_url": {{json issuePageUrl}}
 }
 ```
 

--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/migration-to-workflows.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/migration-to-workflows.mdx
@@ -34,7 +34,7 @@ condition_id will now always have the same value as condition_family_id.
 * owner will have a value of NA if the issue has not been acknowledged
 
 ### incident_id
-The incident_id on PagerDuty, Webhook, VictorOps, OpsGenie and xMatters notifications refers to the classic incident id.  The classic incident id will be soon and consumers should start to use the issue_id instead.  Due to the way the classic incident id is added to the issue, it cannot be guaranteed to be present.
+The incident_id on PagerDuty, Webhook, VictorOps, OpsGenie and xMatters notifications refers to the classic incident id.  The classic incident id will be soon and consumers should start to use the issue_id instead.  Previously, the incident_id was present on every notification. Now, it is not guaranteed to be added to every issue by the time the first notification is sent.
 
 Incident_id changes:
 

--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/migration-to-workflows.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/migration-to-workflows.mdx
@@ -34,11 +34,12 @@ condition_id will now always have the same value as condition_family_id.
 * owner will have a value of NA if the issue has not been acknowledged
 
 ### incident_id
-The incident_id on PagerDuty, Webhook, VictorOps, OpsGenie and xMatters notifications refers to the classic incident id.  The classic incident id will be removed at some point, consumers should start to use the issue_id instead.  Due to the way the classic incident id is added to the issue, it cannot be guaranteed to be present.
+The incident_id on PagerDuty, Webhook, VictorOps, OpsGenie and xMatters notifications refers to the classic incident id.  The classic incident id will be soon and consumers should start to use the issue_id instead.  Due to the way the classic incident id is added to the issue, it cannot be guaranteed to be present.
 
-To avoid generating invalid json on custom webhooks, a value of -1 will be used when the classic incident id is not available.
+Incident_id changes:
 
-To limit the impact to VictorOps, OpsGenie and xMatters notifications, the incident_id will be populated by the issue id.  That will cause the New Relic steps to acknowledge or close an incident in xMatters to no longer work.
+* To avoid generating invalid json on custom webhooks, a value of -1 will be used when the classic incident id is not available.
+* To limit the impact to VictorOps, OpsGenie and xMatters notifications, the incident_id will be populated by the issue id.  That will cause the New Relic steps to acknowledge or close an incident in xMatters to no longer work.
 
 ## Configuring custom payloads [#configure-custom-payloads]
 


### PR DESCRIPTION
This adds templates for PagerDuty, OpsGenie, VictorOps and xMatters.  It also updates and corrects several of the existing mapping and webhook template entries.  Finally, it updates the table to be more consumable since many of the notes weren't helpful or descriptive and that column took room away from the expressions.