### PR TITLE
fix: update option from bar to area chart for units

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/use-charts/use-your-charts.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/use-charts/use-your-charts.mdx
@@ -172,7 +172,7 @@ Read the sections below to learn more about the customization features. You can 
     id="dash-units"
     title="Units customization"
 >
-    You can customize the unit on your Y axis and in each of your series. It is available in bar, line, and stacked charts. 
+    You can customize the unit on your Y axis and in each of your series. It is available in area, line, and stacked charts. 
         
     To customize the unit on your Y axis:
     1. Run a time series query.


### PR DESCRIPTION
small fix to update the scope of the "units customization" to include area charts, not bar charts (which are not time series and don't have this option).