### PR TITLE
Revert "Updated the graphql URL"

### DIFF
--- a/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
@@ -49,14 +49,13 @@ Notes on NerdGraph requirements:
 
 The NerdGraph endpoints are:
 
-The endpoints are:
-* Main endpoint: `https://api.newrelic.com/graphiql`
-* Endpoint for accounts using EU data center: `https://api.eu.newrelic.com/graphiql`
+* Main endpoint: `https://api.newrelic.com/graphql`
+* Endpoint for accounts using EU data center: `https://api.eu.newrelic.com/graphql`
 
 To access the endpoint, use the following cURL command:
 
 ```
-curl -X POST https://api.newrelic.com/graphiql \
+curl -X POST https://api.newrelic.com/graphql \
 -H 'Content-Type: application/json' \
 -H 'API-Key: <var>YOUR_NEW_RELIC_USER_KEY</var>' \
 -d '{ "query":  "{ requestContext { userId apiKey } }" } '


### PR DESCRIPTION
Reverts newrelic/docs-website#10621

I'm a Unified API engineer reverting an incorrect change in the docs. https://api.newrelic.com/graphql is the endpoint used for requests. https://api.newrelic.com/graphiql is the API explorer UI and doesn't accept POST requests or API key auth.