### PR TITLE
Update MacOS infra agent filepath

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent.mdx
@@ -71,8 +71,9 @@ Here are detailed descriptions of each configuration method:
 
     * Linux: `/etc/newrelic-infra.yml`
     * Windows: `C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml`
-    * MacOS: `/usr/local/etc/newrelic-infra/newrelic-infra.yml`
-
+    * MacOS Intel: `/usr/local/etc/newrelic-infra/newrelic-infra.yml`
+    * MacOS Silicon: `/opt/homebrew/etc/newrelic-infra/newrelic-infra.yml`
+    
       For a sample config file, see our [infrastructure config file template](https://github.com/newrelic/infrastructure-agent/blob/master/assets/examples/infrastructure/newrelic-infra-template.yml.example).
   </Collapser>
 


### PR DESCRIPTION
The MacOS configuration file location differs by chipset. On a Mac with a Silicon processor, /usr/local/etc/.. doesn't exist.

Added chipset clarification to label of current location and the location for Macs with Silicon processors.