### PR TITLE
OM section: improve intro section

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/introduction.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/introduction.mdx
@@ -19,13 +19,22 @@ import observabilitymaturityOmavDrivers from 'images/observability-maturity_diag
 
 <LandingPageHero>
   <HeroContent>
-New Relic's **Observability maturity** practice is about making our customers successful in one or more of the value drivers shown in the diagram on the right. This practice aims to identify common customer needs, articulate them, and define a path forward to meet them. In this section of docs you'll find:
+New Relic's **Observability maturity** practice is about making our customers successful in one or more of the value drivers shown in the diagram on the right. This practice aims to identify common customer needs, articulate them, and define a path forward to meet them. 
+
+<Callout variant="tip">
+This series is aimed at optimizing your observability. For best results, you should have some experience using New Relic. If you're looking for tips on initially setting up New Relic, see our [implementation guide](/docs/new-relic-solutions/get-started/implementation-guide-intro).
+</Callout>
+
+The **Observability maturity** section of docs includes:
 
 * Use case implementation guides. Each implementation guide defines KPIs to measure and improve as well as how to improve them. The value realization section in each guide outlines the value of the use case to practitioners and to the business.
 * Reference guides. These are referenced within the implementation guides. They explain industry concepts in greater detail or cover how to do something, such as improve a specific KPI.
 * Links to self-paced training and hands-on labs.
 
-The content in these resources comes from industry best practices, our experiences consulting with customers, as well as our own experiences as software engineers, operations engineers, and SREs. It's open source, and we'd love to include your contributions. We're always looking for new use cases and new visualizations. We'd love you to help us build out [new best practices](/docs/style-guide/writing-docs/article-templates/om-implementation-guide).
+The content in these resources comes from industry best practices, our experiences consulting with customers, as well as our own experiences as software engineers, operations engineers, and SREs. It's open source, and we'd love your contributions. Have feedback or ideas? Click the feedback button on the right side on any doc.
+
+Click a value driver to get started. 
+
   </HeroContent>
 
   <img
@@ -42,13 +51,16 @@ The content in these resources comes from industry best practices, our experienc
     id="upr"
     title="Uptime, performance, and reliability"
   >
-Guides:
+
+The **Uptime, performance, and reliability** value driver is about improving reliability. To optimize your observability practice, you'll need to have a strong understanding of the performance of your system and its baseline behavior. Guides include: 
+
 * [Alert quality management (AQM)](/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/aqm-implementation-guide/)
 * [Service level management (SLM)](/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/slm-implementation-guide/)
 * [Reliability engineering diagnostics (RED)](/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/diagnostics-beginner-guide)
 * [Error tracking optimization](/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/error-optimization)
 
 Self-paced training and labs:
+
 * [Hands-on lab: Alert quality management](https://learn.newrelic.com/hands-on-lab-alert-quality-management)
 * [Self-paced training: Service level management](https://learn.newrelic.com/self-paced-service-level-management)
 
@@ -58,11 +70,14 @@ Self-paced training and labs:
     id="cx"
     title="Customer experience"
   >
-Guides:
+
+The **Customer experience** value driver is about improving and optimizing your end user experiences. Guides include:
+
 * [Quality foundation (QF)](/docs/new-relic-solutions/observability-maturity/customer-experience/quality-foundation-implementation-guide)
 * [Bottom-of-the-funnel analysis (BotFA)](/docs/new-relic-solutions/observability-maturity/customer-experience/bofta-implementation-guide)
 
 Related reference docs:
+
 * [Improve web uptime](/docs/new-relic-solutions/observability-maturity/customer-experience/cx-improve-web-uptime)
 * [Improve page load performance](/docs/new-relic-solutions/observability-maturity/customer-experience/cx-improve-page-load)
 
@@ -72,7 +87,8 @@ Related reference docs:
     id="op-eff"
     title="Operational efficiency"
   >
-Guides:
+The **Operational efficiency** value driver is about improving and optimizing your observability costs. To meet that goal, you'll want to ensure your observability tools are set up intelligently, and being used efficiently. Guides include:
+
 * [Observability Center of Excellence (OCoE)](/docs/new-relic-solutions/observability-maturity/operational-efficiency/observability-coe)
 * [Service characterization (SC)](/docs/new-relic-solutions/observability-maturity/operational-efficiency/sc-implementation-guide/)
 * [Data ingest governance (DG)](/docs/new-relic-solutions/observability-maturity/operational-efficiency/dg-intro/)
@@ -84,10 +100,11 @@ Guides:
     id="innov-growth"
     title="Innovation and growth"
   >
-Guides:
+
+The **Innovation and growth** value driver is about setting up processes to ensure you're continually improving your observability practices. Guides include:
+
 * [Development quality](/docs/new-relic-solutions/observability-maturity/innovation-growth/development-quality-implementation-guide)
 * [Release quality](/docs/new-relic-solutions/observability-maturity/innovation-growth/release-quality-implementation-guide)
   </Collapser>
-
 
 </CollapserGroup>


### PR DESCRIPTION
Work done: 

* Added mention of implementation guide, clarifying that beginners should go there
* Added introductory context for each of the four value driver sections
* Took out link to style guide 'OM guide template', as I'm not sure we want to encourage customers to do that (and don't think they ever will do it) and replaced that with note about giving ideas/comments using feedback button