### PR TITLE
AM JANUARY 9 -- chore: Update Ruby agent documentation for 8.15.0 release

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -140,6 +140,23 @@ These settings are available for agent configuration. Some settings depend on yo
   Sets the level of detail of log messages. Possible log levels, in increasing verbosity, are: `error`, `warn`, `info` or `debug`.
   </Collapser>
 
+  <Collapser id="active_support_custom_events_names" title="active_support_custom_events_names">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ACTIVE_SUPPORT_CUSTOM_EVENTS_NAMES`</td></tr>
+      </tbody>
+    </table>
+
+  An array of ActiveSupport custom events names to subscribe to and provide
+instrumentation for. For example,
+  - my.custom.event
+  - another.event
+  - a.third.event
+
+  </Collapser>
+
   <Collapser id="apdex_t" title="apdex_t">
     <table>
       <tbody>
@@ -2081,6 +2098,33 @@ If `true`, the agent won't install instrumentation for the typhoeus gem.
   Configures the TCP/IP port for the Trace Observer Host
   </Collapser>
 
+  <Collapser id="infinite_tracing-batching" title="infinite_tracing.batching">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INFINITE_TRACING_BATCHING`</td></tr>
+      </tbody>
+    </table>
+
+  If true (the default), data sent to the Trace Observer will be batched
+instead of each span being sent individually
+  </Collapser>
+
+  <Collapser id="infinite_tracing-compression_level" title="infinite_tracing.compression_level">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Symbol</td></tr>
+        <tr><th>Default</th><td>`:high`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INFINITE_TRACING_COMPRESSION_LEVEL`</td></tr>
+      </tbody>
+    </table>
+
+  Configure the compression level for data sent to the Trace Observer
+May be one of [none|low|medium|high]
+'high' is the default. Set the level to 'none' to disable compression
+  </Collapser>
+
 </CollapserGroup>
 
 ## Instrumentation
@@ -2111,6 +2155,18 @@ If `true`, the agent won't install instrumentation for the typhoeus gem.
     </table>
 
   Controls auto-instrumentation of bunny at start up. May be one of [auto|prepend|chain|disabled].
+  </Collapser>
+
+  <Collapser id="instrumentation-concurrent_ruby" title="instrumentation.concurrent_ruby">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"auto"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_CONCURRENT_RUBY`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the concurrent-ruby library at start up. May be one of [auto|prepend|chain|disabled].
   </Collapser>
 
   <Collapser id="instrumentation-curb" title="instrumentation.curb">
@@ -2519,27 +2575,6 @@ If `true`, the agent won't install instrumentation for the typhoeus gem.
     </table>
 
   Specify a custom host name for [display in the New Relic UI](/docs/apm/new-relic-apm/maintenance/add-rename-remove-hosts#display_name).
-  </Collapser>
-
-</CollapserGroup>
-
-## Rails
-
-
-
-<CollapserGroup>
-
-  <Collapser id="defer_rails_initialization" title="defer_rails_initialization">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>Boolean</td></tr>
-        <tr><th>Default</th><td>`false`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_DEFER_RAILS_INITIALIZATION`</td></tr>
-      </tbody>
-    </table>
-
-  <strong>This configuration option is currently unreachable. Please do not use.</strong>
-  If `true`, when the agent is in an application using Ruby on Rails, it will start after config/initializers are run.
   </Collapser>
 
 </CollapserGroup>

--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -149,9 +149,8 @@ These settings are available for agent configuration. Some settings depend on yo
       </tbody>
     </table>
 
-  An array of ActiveSupport custom events names to subscribe to and provide
-instrumentation for. For example,
-  - my.custom.event
+  An array of ActiveSupport custom events names to subscribe to and instrument. For example,
+  - one.custom.event
   - another.event
   - a.third.event
 

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-eol-policy.mdx
@@ -30,6 +30,20 @@ Any versions not listed in the following table are no longer supported. Please [
 
     <tr>
       <td>
+        v8.15.0
+      </td>
+
+      <td>
+        Jan 9, 2023
+      </td>
+
+      <td>
+        Jan 9, 2024
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         v8.14.0
       </td>
 

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -86,6 +86,7 @@ The New Relic Ruby agent does not support experimental versions. Ruby versions s
         * 2.7.x
         * 3.0.x
         * 3.1.x
+        * 3.2.x
       </td>
 
       <td>
@@ -260,6 +261,7 @@ The Ruby agent does not support experimental versions. Web frameworks supported 
         * 1.4.x
         * 1.5.x
         * 1.6.x
+        * 1.7.x
       </td>
 
       <td/>
@@ -273,6 +275,7 @@ The Ruby agent does not support experimental versions. Web frameworks supported 
       <td>
         * 0.14.x - Deprecated
         * 0.15.1
+        * 0.15.2
       </td>
 
       <td/>
@@ -329,6 +332,7 @@ The Ruby agent does not support experimental versions. Web frameworks supported 
         * 1.5.x - Deprecated
         * 2.0.x
         * 2.1.x
+        * 3.0.x
       </td>
 
       <td>
@@ -453,6 +457,7 @@ The Ruby agent does not support experimental versions. Databases supported by th
         * 3.37.x - Deprecated
         * 4.0.x - Deprecated
         * 4.45.x or higher
+        * 5.x.x
       </td>
 
       <td/>
@@ -766,15 +771,20 @@ HTTP clients supported by the Ruby agent include:
 
 * RabbitMQ
 
+Currently supported gems that facilitate message brokers:
+
+* [Bunny](/docs/agents/ruby-agent/features/message-queues): 2.0 or higher (Versions 2.0.x - 2.6.x are Deprecated)
+
+
 ## Other
 
 APM's Ruby agent also supports:
 
 * ActiveMerchant: 1.25.0 or higher (Versions 1.25.0 - 1.64.x are Deprecated)
-* Acts_as_Solr - Deprecated
-* authlogic - Deprecated
-* [Bunny](/docs/agents/ruby-agent/features/message-queues): 2.0 or higher (Versions 2.0.x - 2.6.x are Deprecated)
-* Sunspot - Deprecated
+* Acts_as_Solr: Deprecated
+* authlogic: Deprecated
+* concurrent-ruby: 1.1.5 or higher
+* Sunspot: Deprecated
 * Tilt: 2.x for Ruby 2.2 or higher; 1.x for Ruby 2.7 or lower
 * Yajl-Ruby: 1.1.0 or higher
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8150.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8150.mdx
@@ -23,18 +23,22 @@ Version 8.15.0 of the agent confirms compatibility with Ruby 3.2.0, adds instrum
 
   The agent now instruments the [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby) gem for versions 1.1.5 and above. This instrumentation provides visibility inside blocks passed to many of the gem's API methods, including `Concurrent::Promises.future` and `Concurrent::Future.execute`.
 
+
   | Configuration name                | Default | Behavior                                                                                                                      |
   | --------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
   | `instrumentation.concurrent_ruby` | auto    | Controls auto-instrumentation of the concurrent-ruby library at start up. May be one of `auto`, `prepend`, `chain`, `disabled`. |
+
 
 - **Infinite Tracing: Use batching and compression**
 
   For [Infinite Tracing](https://docs.newrelic.com/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing/), which Ruby applications can leverage with the `newrelic-infinite_tracing` gem, payloads will now be batched and compressed to signficantly decrease the amount of outbound network traffic. [PR#1723](https://github.com/newrelic/newrelic-ruby-agent/pull/1723)
 
+
   | Configuration name                | Default | Behavior                                                                                                                      |
   | --------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
   | `infinite_tracing.batching` | true   | If true (the default), the Trace Observer will receive data in batches instead of sending each span individually |
   | `infinite_tracing.compression_level` | high    | Configure the compression level for data sent to the trace observer. May be one of [none|low|medium|high]. 'high' is the default. Set the level to 'none' to disable compression. |
+
 
 - **Add Support for Padrino 0.15.2 and Sinatra 3**
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8150.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8150.mdx
@@ -6,7 +6,7 @@ downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.15.0.gem'
 ---
 
 <Callout variant="important">
-We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from upgrading to the latest version, ensure that your agents are regularly updated to a version at most 90 days old. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+We recommend updating to the latest agent version as soon as it's available. If you are prevented from upgrading to the latest version, ensure that your agents are updated to a version at most 90 days old. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
 
 As of this release, the oldest supported version is [6.9.0.363](https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-690363)
 </Callout>
@@ -17,11 +17,11 @@ Version 8.15.0 of the agent confirms compatibility with Ruby 3.2.0, adds instrum
 
 - **Add Support for Ruby 3.2.0**
 
-  Following the 3.2.0 release of Ruby, the New Relic Ruby Agent has confirmed compatibility with and now supports the official release of Ruby 3.2.0. [PR#1715](https://github.com/newrelic/newrelic-ruby-agent/pull/1715)
+  Following the 3.2.0 release of Ruby, the New Relic Ruby agent has confirmed compatibility with and now supports the official release of Ruby 3.2.0. [PR#1715](https://github.com/newrelic/newrelic-ruby-agent/pull/1715)
 
 - **Add instrumentation for concurrent-ruby**
 
-  Instrumentation for the [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby) gem has been added to the agent for versions 1.1.5 and above. When a transaction is already in progress and a call to a `Concurrent::` method that routes through `Concurrent::ThreadPoolExecutor#post` is made, a segment will be added to the transaction. Any content within the block passed to the `Concurrent::` method that is instrumented by the agent, such as a call to `Net::HTTP.get`, will have a nested segment created. [PR#1682](https://github.com/newrelic/newrelic-ruby-agent/pull/1682)
+  The agent now instruments the [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby) gem for versions 1.1.5 and above. This instrumentation provides visibility inside blocks passed to many of the gem's API methods, including `Concurrent::Promises.future` and `Concurrent::Future.execute`.
 
   | Configuration name                | Default | Behavior                                                                                                                      |
   | --------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
@@ -33,8 +33,8 @@ Version 8.15.0 of the agent confirms compatibility with Ruby 3.2.0, adds instrum
 
   | Configuration name                | Default | Behavior                                                                                                                      |
   | --------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
-  | `infinite_tracing.batching` | true    | If true (the default), data sent to the Trace Observer will be batched instead of each span being sent individually |
-  | `infinite_tracing.compression_level` | high    | Configure the compression level for data sent to the Trace Observer. May be one of [none|low|medium|high]. 'high' is the default. Set the level to 'none' to disable compression. |
+  | `infinite_tracing.batching` | true   | If true (the default), the Trace Observer will receive data in batches instead of sending each span individually |
+  | `infinite_tracing.compression_level` | high    | Configure the compression level for data sent to the trace observer. May be one of [none|low|medium|high]. 'high' is the default. Set the level to 'none' to disable compression. |
 
 - **Add Support for Padrino 0.15.2 and Sinatra 3**
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8150.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8150.mdx
@@ -1,0 +1,41 @@
+---
+subject: Ruby agent
+releaseDate: '2023-01-09'
+version: 8.15.0
+downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.15.0.gem'
+---
+
+<Callout variant="important">
+We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from upgrading to the latest version, ensure that your agents are regularly updated to a version at most 90 days old. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+
+As of this release, the oldest supported version is [6.9.0.363](https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-690363)
+</Callout>
+
+  ## v8.15.0
+
+Version 8.15.0 of the agent confirms compatibility with Ruby 3.2.0, adds instrumentation for concurrent-ruby, and confirms Sinatra 3 compatibility with Padrino 0.15.2. It also enables batching and compression for Infinite Tracing.
+
+- **Add Support for Ruby 3.2.0**
+
+  Following the 3.2.0 release of Ruby, the New Relic Ruby Agent has confirmed compatibility with and now supports the official release of Ruby 3.2.0. [PR#1715](https://github.com/newrelic/newrelic-ruby-agent/pull/1715)
+
+- **Add instrumentation for concurrent-ruby**
+
+  Instrumentation for the [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby) gem has been added to the agent for versions 1.1.5 and above. When a transaction is already in progress and a call to a `Concurrent::` method that routes through `Concurrent::ThreadPoolExecutor#post` is made, a segment will be added to the transaction. Any content within the block passed to the `Concurrent::` method that is instrumented by the agent, such as a call to `Net::HTTP.get`, will have a nested segment created. [PR#1682](https://github.com/newrelic/newrelic-ruby-agent/pull/1682)
+
+  | Configuration name                | Default | Behavior                                                                                                                      |
+  | --------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+  | `instrumentation.concurrent_ruby` | auto    | Controls auto-instrumentation of the concurrent-ruby library at start up. May be one of `auto`, `prepend`, `chain`, `disabled`. |
+
+- **Infinite Tracing: Use batching and compression**
+
+  For [Infinite Tracing](https://docs.newrelic.com/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing/), which Ruby applications can leverage with the `newrelic-infinite_tracing` gem, payloads will now be batched and compressed to signficantly decrease the amount of outbound network traffic. [PR#1723](https://github.com/newrelic/newrelic-ruby-agent/pull/1723)
+
+  | Configuration name                | Default | Behavior                                                                                                                      |
+  | --------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+  | `infinite_tracing.batching` | true    | If true (the default), data sent to the Trace Observer will be batched instead of each span being sent individually |
+  | `infinite_tracing.compression_level` | high    | Configure the compression level for data sent to the Trace Observer. May be one of [none|low|medium|high]. 'high' is the default. Set the level to 'none' to disable compression. |
+
+- **Add Support for Padrino 0.15.2 and Sinatra 3**
+
+  We've added testing to confirm Padrino 0.15.2 and Sinatra 3 are compatible with the Ruby agent. Thank you [@nesquena](https://github.com/nesquena) for letting us know 0.15.2 was ready! [PR#1712](https://github.com/newrelic/newrelic-ruby-agent/pull/1712)


### PR DESCRIPTION
## Give us some context

**We're anticipating a release on Monday, January 9. Please hold this PR until the release is ready.**

* Updates documentation for the Ruby agent's 8.15.0 release
  * EOL Policy
  * Release notes
  * Configuration options 
* Checks the "Requirements and Supported Frameworks" documentation to update additional library major versions we've supported for a while

cc @homelessbirds 