### PR TITLE
style guide changes to capitalization table

### DIFF
--- a/src/content/docs/style-guide/capitalization/product-capability-feature-usage.mdx
+++ b/src/content/docs/style-guide/capitalization/product-capability-feature-usage.mdx
@@ -518,7 +518,20 @@ Notes about features and capabilities:
         Do not use: Browser Monitoring, Browser monitoring
       </td>
     </tr>
-
+    <tr>
+      <td>
+        code-level metric(s)
+      </td>
+      <td>
+        feature of the New Relic CodeStream capability that allows you to see the golden signals (throughput, error rate, response rate) at the method level within your code.
+      </td>
+      <td>
+        code-level metric or code-level metrics
+      </td>
+      <td>
+        Do not use: code level metric(s), Code-Level Metric(s), Code-level Metric(s), Code-level metric(s) (unless at the beginning of a sentence), CLM
+      </td>
+    </tr>
     <tr>
       <td>
         containers
@@ -1039,19 +1052,22 @@ Notes about features and capabilities:
 
     <tr>
       <td>
-        vulnerability management
+        New Relic Vulnerability Management
       </td>
 
       <td>
-        capability of New Relic; used to aggregate vulnerabilities and display them for observability and remediation
+        capability of New Relic; used to aggregate vulnerabilities and display them for observability and remediation. As of January, 2023, Vulnerability Management is initial capped and sold as an add-on.
       </td>
 
       <td>
-        vulnerability management
+        - When writing about the activity of managing vulnerabilities: vulnerability management
+        - When referring to the capability on first mention in body copy: New Relic Vulnerability Management
+        - When referring to the capability in headings or on subsequent mentions in body copy: 
+         Vulnerability Management
       </td>
 
       <td>
-        Do not use: Vulnerability Management, Vulnerability management monitoring, vulnerability monitoring
+        Do not use: vulnerability management monitoring, vulnerability monitoring
       </td>
     </tr>
 


### PR DESCRIPTION
These updates to the style guide change the presentation of Vulnerability Management in content and add one new feature.

