### PR TITLE
fix: NR-77864 Add sumOfSquares to the list of timeslice fields for getField()

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -2315,7 +2315,7 @@ Note: `aparse()` is case-insensitive.
           </td>
 
           <td>
-            `count`, `total`, `totalExclusive`, `min`, `max`
+            `count`, `total`, `totalExclusive`, `min`, `max`, `sumOfSquares`
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
sumOfSquares is a timeslice field that can be retrieved using getField, but it's not in the docs
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
https://staging.onenr.io/0M8jqPn0GRl 
* If your issue relates to an existing GitHub issue, please link to it.
https://issues.newrelic.com/browse/NR-77684