### PR TITLE
multiple app names doc: remove 'manage insights data'

### DIFF
--- a/src/content/docs/apm/agents/manage-apm-agents/app-naming/use-multiple-names-app.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/app-naming/use-multiple-names-app.mdx
@@ -17,26 +17,26 @@ redirects:
 
 When working with your APM data in New Relic, you may want to view aggregated, "rolled up" data for an application that spans multiple clusters, environments, or data centers, but also be able to view each of the app instance's data separately. You can do this by setting multiple app names for your APM-monitored apps.
 
-## Important notes [#important-notes]
+## Before you start [#important-notes]
 
 Here are some important caveats to be aware of when using multiple app names.
 
-### Alternative options [#alt-options]
+### Alternative solutions [#alt-options]
 
-Because adding multiple app names results in [duplicate data](#duplicate), you may want to consider these other options. 
+Because adding multiple app names results in [reporting duplicate data](#duplicate), you may want to consider these other options. 
 
-If your goal is to be able to filter your telemetry data by attributes (for example, like the agent region), we recommend one of these options instead:
+If your goal is to be able to more easily filter your telemetry data by attributes (for example, filter by agent region), we recommend one of these options instead:
 
-* Add tags via the agent config file (for example, [this Java config](/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file/#labels))
-* Use [custom attributes](/docs/data-apis/custom-data/custom-events/collect-custom-attributes/#enabling-custom)
+* Add [tags](/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data) via the agent config file (for example, [this Java config](/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file/#labels))
+* Add [custom attributes](/docs/data-apis/custom-data/custom-events/collect-custom-attributes/#enabling-custom)
 
-You can also set distinct performance thresholds for each environment using [alert conditions](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts) and [key transactions](/docs/apm/transactions/key-transactions/create-update-key-transactions). These thresholds will apply to the individual apps, while the overall app won't have its own thresholds. The overall app will treat incoming data according to the threshold for the relevant environment.
+As another option for organizing your app data, you can set distinct performance thresholds for each environment using [alert conditions](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts) and [key transactions](/docs/apm/transactions/key-transactions/create-update-key-transactions). These thresholds will apply to the individual apps, while the overall rolled-up app won't have its own thresholds. The overall app will treat incoming data according to the threshold for the relevant environment.
 
 ### Duplicate data [#duplicate]
 
-Using multiple app names results in generating duplicate events and metrics. For example, if your New Relic-monitored app has three app names set, it will report three times the events and metrics. 
+Using multiple app names results in generating duplicate events and metrics, which is counted as ingested data. For example, if your New Relic-monitored app has three app names set, it will report three times the events and metrics. 
 
-If you do want to use multiple app names and not one of the alternate solutions below, you can use [drop data rules](/docs/data-apis/manage-data/drop-data-using-nerdgraph) to drop specific events. 
+If you do want to use multiple app names and not one of the alternate solutions below, you can use [drop data rules](/docs/data-apis/manage-data/drop-data-using-nerdgraph) to drop some specific events you don't need.
 
 ### Priority of names [#priority]
 
@@ -284,9 +284,3 @@ Here are examples of how you could use multiple rollup names for a single app.
     * One app for the overall data across clusters and data centers (`EcomAll`)
   </Collapser>
 </CollapserGroup>
-
-## Other options to organize your apps [#other]
-
-If you do not want to apply multiple names to your apps, you can organize them with [tags](/docs/new-relic-one/use-new-relic-one/core-concepts/use-tags-help-organize-find-your-data). This allows you to easily sort, filter, and page through them from their product index pages in the New Relic UI.
-
-You can also set distinct performance thresholds for each environment with [alert conditions](/docs/alerts/new-relic-alerts/getting-started/alerting-new-relic) and [key transactions](/docs/apm/transactions/key-transactions/key-transactions-tracking-important-transactions-or-events). These thresholds will apply to the individual apps, while the overall app will not have its own thresholds. The overall app will treat incoming data according to the threshold for the relevant enviroment.

--- a/src/content/docs/apm/agents/manage-apm-agents/app-naming/use-multiple-names-app.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/app-naming/use-multiple-names-app.mdx
@@ -15,36 +15,40 @@ redirects:
   - /docs/apm/new-relic-apm/installation-configuration/use-multiple-names-app
 ---
 
-import apmInsightsToggleonandOff from 'images/apm_screenshot-full_insights-toggle-on-and-off.png'
+When working with your APM data in New Relic, you may want to view aggregated, "rolled up" data for an application that spans multiple clusters, environments, or data centers, but also be able to view each of the app instance's data separately. You can do this by setting multiple app names for your APM-monitored apps.
 
-When working with your data in New Relic, you may want to view aggregated data for an application across clusters, environments, or data centers, while at the same time be able to view each of your application instance's data individually.
+## Important notes [#important-notes]
 
-<Callout variant="important">
-  If you use multiple names for an app, the last name assigned is the least specific name New Relic uses to roll up the data. For best results to view both instance-level and aggregated data, set the order of your app's rollup names from **most specific to least specific** in your configuration file.
-</Callout>
+Here are some important caveats to be aware of when using multiple app names.
 
-## Roll up app data [#rollup]
+### Alternative options [#alt-options]
+
+Because adding multiple app names results in [duplicate data](#duplicate), you may want to consider these other options. 
+
+If your goal is to be able to filter your telemetry data by attributes (for example, like the agent region), we recommend one of these options instead:
+
+* Add tags via the agent config file (for example, [this Java config](/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file/#labels))
+* Use [custom attributes](/docs/data-apis/custom-data/custom-events/collect-custom-attributes/#enabling-custom)
+
+You can also set distinct performance thresholds for each environment using [alert conditions](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts) and [key transactions](/docs/apm/transactions/key-transactions/create-update-key-transactions). These thresholds will apply to the individual apps, while the overall app won't have its own thresholds. The overall app will treat incoming data according to the threshold for the relevant environment.
+
+### Duplicate data [#duplicate]
+
+Using multiple app names results in generating duplicate events and metrics. For example, if your New Relic-monitored app has three app names set, it will report three times the events and metrics. 
+
+If you do want to use multiple app names and not one of the alternate solutions below, you can use drop data rules to drop specific events from specific agents. 
+
+### Priority of names [#priority]
+
+The order of app names in the agent configuration matters. For more information, see [Define app names](#most-least-specific). 
+
+## How using multiple app names works [#rollup]
 
 Normally, when two instances report with the same app name, agent language, and [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key), New Relic aggregates their data into a single New Relic-monitored app. You can also view data for the individual hosts and instances from the app's New Relic [APM **Overview** page](/docs/apm/applications-menu/monitoring/apm-overview-page#infra-server).
 
 To segment your app in a different way, or to work with each instance as an individual app while maintaining the overall view of the data, use your New Relic agent's [config file](#agent) to give an app up to three different rollup names. New Relic will then report the app's data separately to each app listed in the config file.
 
 For example, you might want to separate the data collected for your app running in development, staging, and production environments, but also have a common view of the app in every environment. Or, if you have two data centers running the same code, you could name one app `EastCoastApp;AggregateApp` and the second app `WestCoastApp;AggregateApp`.
-
-## Prevent duplicate transaction events [#events]
-
-By default, an app with multiple names will generate multiple events for transactions (a duplicate transaction for each name). For example, if you give your app three names, that's three times the number of events for transactions.
-
-To avoid duplicate events, disable collection for each of the duplicate app names:
-
-1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities)**, then select **More > Manage Insights Data**.
-2. Toggle data collection on/off for duplicate app names, then save.
-
-<img
-  title="Transaction events"
-  alt="Transaction events"
-  src={apmInsightsToggleonandOff}
-/>
 
 ## Roll up browser data [#browser-rollup]
 

--- a/src/content/docs/apm/agents/manage-apm-agents/app-naming/use-multiple-names-app.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/app-naming/use-multiple-names-app.mdx
@@ -36,7 +36,7 @@ You can also set distinct performance thresholds for each environment using [ale
 
 Using multiple app names results in generating duplicate events and metrics. For example, if your New Relic-monitored app has three app names set, it will report three times the events and metrics. 
 
-If you do want to use multiple app names and not one of the alternate solutions below, you can use drop data rules to drop specific events from specific agents. 
+If you do want to use multiple app names and not one of the alternate solutions below, you can use [drop data rules](/docs/data-apis/manage-data/drop-data-using-nerdgraph) to drop specific events. 
 
 ### Priority of names [#priority]
 


### PR DESCRIPTION
Work done: 

* Removed outdated 'Manage Insights data' reference, as that UI no longer exists. Replaced with reference to drop data. 
* Clarified there are other options that may be preferable due to the duplicate data issue. 