### PR TITLE
Revert "consistent capitalization for terms and acronyms per New Relic style"

### DIFF
--- a/src/content/docs/browser/single-page-app-monitoring/get-started/introduction-single-page-app-monitoring.mdx
+++ b/src/content/docs/browser/single-page-app-monitoring/get-started/introduction-single-page-app-monitoring.mdx
@@ -1,12 +1,12 @@
 ---
-title: Introduction to single page app (SPA) monitoring
+title: Introduction to Single Page App monitoring
 tags:
   - Browser
   - Single page app monitoring
   - Get started
 translate:
   - jp
-metaDescription: The New Relic Browser SPA monitoring examines your users' experience with the frontend logic for single-page apps or any apps that pull content dynamically.
+metaDescription: Browser's SPA monitoring examines your users' experience with the front-end logic for single-page apps or any apps that pull content dynamically.
 redirects:
   - /node/9976
   - /docs/browser/single-page-app-monitoring/get-started/welcome-single-page-app-monitoring
@@ -15,9 +15,9 @@ redirects:
 
 import browserSpaPageview from 'images/browser_screenshot-full_spa-pageview.png'
 
-New Relic browser monitoring includes single-page application (SPA) monitoring to give you deeper visibility and actionable insights into real user interactions with single-page apps, and for any app that uses AJAX requests.
+New Relic browser monitoring has a single-page application (SPA) monitoring feature that provides deeper visibility and actionable insights into real user interactions with single-page apps, and for any app that uses AJAX requests.
 
-In addition to monitoring route changes automatically, our SPA API allows you to monitor virtually anything that executes inside the browser. Developers and their teams can use the API to:
+In addition to monitoring route changes automatically, our SPA API allows you to monitor virtually anything that executes inside the browser. This allows developers and their team to:
 
 * Create faster, more responsive, highly interactive apps.
 * Monitor the throughput and performance that real users are experiencing.


### PR DESCRIPTION
Reverts newrelic/docs-website#10945