### PR TITLE
fix: adding trailing "}" to grok expression examples

### DIFF
--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -372,7 +372,7 @@ Note that variable names must be explicitly set and be lowercase like `%{URI:uri
     And a parsing rule with the following shape:
 
     ```
-    %{GREEDYDATA:log:csv({"columns": ["timestamp", "status", "method", "url", "time", "bytes"]})
+    %{GREEDYDATA:log:csv({"columns": ["timestamp", "status", "method", "url", "time", "bytes"]})}
     ```
 
     Will parse your log as follows:
@@ -389,7 +389,7 @@ Note that variable names must be explicitly set and be lowercase like `%{URI:uri
     If you need to omit the "log" prefix, you can include the `"noPrefix": true` in the configuration.
 
     ```
-    %{GREEDYDATA:log:csv({"columns": ["timestamp", "status", "method", "url", "time", "bytes"], "noPrefix": true})
+    %{GREEDYDATA:log:csv({"columns": ["timestamp", "status", "method", "url", "time", "bytes"], "noPrefix": true})}
     ```
 
     ### Columns configuration:


### PR DESCRIPTION
* What problems does this PR solve?
Add two missing } on the grok expression examples (Thanks @marcelschlapfer)

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
Just fix the grok expression to work as it should.
 
* If your issue relates to an existing GitHub issue, please link to it.
No