### PR TITLE
Updating Certification dates for SOC2 + FedRAMP

### DIFF
--- a/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/fedramp-moderate.mdx
+++ b/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/fedramp-moderate.mdx
@@ -47,7 +47,7 @@ The following applies to the New Relic platform:
       </td>
 
       <td>
-        2021-OCT-08
+        2022-OCT-19
       </td>
 
       <td>

--- a/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/soc2.mdx
+++ b/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/soc2.mdx
@@ -45,7 +45,7 @@ The following applies to the New Relic platform:
       </td>
 
       <td>
-        2021-AUG-20
+        2022-AUG-31
       </td>
 
       <td>
@@ -63,7 +63,7 @@ The following applies to the New Relic platform:
       </td>
 
       <td>
-        2022-JAN-17
+        2022-AUG-31
       </td>
 
       <td>

--- a/src/content/docs/security/security-privacy/compliance/regulatory-audits-new-relic-services.mdx
+++ b/src/content/docs/security/security-privacy/compliance/regulatory-audits-new-relic-services.mdx
@@ -12,7 +12,7 @@ redirects:
 
 This document describes New Relic's products and services as they relate to regulatory framework compliance status.
 
-**Updated on March 10, 2022.**
+**Updated on January 9, 2023.**
 
 ## Certifications, standards, and regulations [#cer-std-reg]
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

-- Updating our Certifications and Regs documents since we have our SOC 2 Type 2 reports. This last cycle covered both NR1 and Pixie, updating and adjusting dates accordingly. 