### PR TITLE
Fix tile select css bug

### DIFF
--- a/src/components/TileSelect/TileOption.js
+++ b/src/components/TileSelect/TileOption.js
@@ -28,6 +28,10 @@ const TileOption = ({ displayName, value, logo, onChange, isSelected }) => {
             ? '1.25px solid var(--attention-notification-info)'
             : '1px solid var(--system-border-strong-light)'};
         }
+        div {
+          white-space: normal;
+          line-height: 1.2;
+        }
       `}
     >
       {logo && (

--- a/src/components/TileSelect/TileSelect.js
+++ b/src/components/TileSelect/TileSelect.js
@@ -44,7 +44,7 @@ const TileSelect = ({
           role="listbox"
           css={css`
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
             grid-gap: 1rem;
           `}
         >


### PR DESCRIPTION
We had some tiles with overflowing contents, this wraps the text within tiles so they don't become super long