### PR TITLE
Service maps now supported for OTel services

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-comparison.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-comparison.mdx
@@ -489,17 +489,17 @@ New Relic agents offer automatic log collection by default for services. OpenTel
 
 ## Service map [#service-maps]
 
-New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: ❌
+New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: ✅
 
-The service map, accessible when looking at a single service in the UI, displays an entire set of entities connected to that service and is currently only supported by New Relic agents. The interconnected services must be actively reporting to appear in this map.
+The **Service map**, accessible when looking at a single service in the UI, displays the entire set of entities connected directly to that service. Interconnected entities must be actively reporting to appear in this map.
 
-OpenTelemetry data does power the **Related entities**, **Automap**, and **Trace map** features.
+Other features that display maps or entity relationships include **Related entities**, **Automap**, and **Trace map**.
 
 ## Dependencies [#dependencies]
 
 New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: ❌
 
-For OpenTelemetry, the **Related entities** or **Automap** views can take you to all the dependencies for a given service.
+For OpenTelemetry, the **Service map**, **Related entities**, or **Automap** views can take you to all the dependencies for a given service.
 
 ## Errors [#errors]
 


### PR DESCRIPTION
Service map is now in production for OTel services, so we have parity now with APM agents.