### PR TITLE
Added new terms to Usage page

### DIFF
--- a/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
@@ -38,6 +38,13 @@ For consistency across New Relic content, here are our general word usage guidel
   </Collapser>
 
   <Collapser
+    id="AIOps"
+    title="AIOps"
+  >
+    Short for artificial intelligence for IT operations.
+  </Collapser>
+  
+  <Collapser
     id="ampm"
     title="am and pm"
   >
@@ -330,6 +337,13 @@ Really, we recommend being as specific as possible to establish context. If a pi
   </Collapser>
   
   <Collapser
+    id="DevOps"
+    title="DevOps"
+  >
+    Short for software developers and operations.
+  </Collapser>
+  
+  <Collapser
     id="document"
     title="doc, document, documentation, docs site"
   >
@@ -456,6 +470,20 @@ Really, we recommend being as specific as possible to establish context. If a pi
     title="index"
   >
     A list of entities, such as the [APM applications index](/docs/apm/applications-menu/monitoring/viewing-your-applications-index), the [synthetic monitor index](/docs/synthetics/new-relic-synthetics/dashboards/synthetics-monitors-index-access-your-monitors), or the [alerts incidents index](/docs/alerts/new-relic-alerts-beta/reviewing-alert-incidents/explore-incident-history-incidents-index). See also [`page`](#pages).
+  </Collapser>
+
+<Collapser
+    id="InfoSec"
+    title="InfoSec"
+  >
+    Short for information security.
+  </Collapser>
+
+<Collapser
+    id="InfraOps"
+    title="InfraOps"
+  >
+    Short for infrastructure and operations.
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
Per discussion with Alicia, Amy, and Michelle, added the following terms to Usage page in style guide: AIOps, DevOps, InfoSec, and InfraOps.

<!-- Thanks for contributing to our docs! -->
