### PR TITLE
Java branching: Re-add step 2 for maven and gradle selections

### DIFF
--- a/src/install/config/java.yaml
+++ b/src/install/config/java.yaml
@@ -137,6 +137,8 @@ steps:
           - optionType: deployment
             options:
               - value: 'appServer'
+              - value: 'maven'
+              - value: 'gradle'
   - filePath: 'src/install/java/download/default.mdx'
     overrides:
       - filePath: 'src/install/java/download/maven.mdx'

--- a/src/install/config/java.yaml
+++ b/src/install/config/java.yaml
@@ -231,6 +231,8 @@ steps:
           - optionType: deployment
             options:
               - value: 'appServer'
+              - value: 'maven'
+              - value: 'gradle'
       - filePath: 'src/install/java/frameworkInstallation/tomcat.mdx'
         selectedOptions:
           - optionType: framework
@@ -239,6 +241,8 @@ steps:
           - optionType: deployment
             options:
               - value: 'appServer'
+              - value: 'maven'
+              - value: 'gradle'
       - filePath: 'src/install/java/frameworkInstallation/tomcat.mdx'
         selectedOptions:
           - optionType: framework


### PR DESCRIPTION
I mistakenly had removed the conditional second step (app server selections) after you initially choose Maven or Gradle in the first step. This simply adds them back. For example, if you select "Maven" in the first question, you'll get a second question about which application server you want to use and the relevant app server details show up later in the steps.