### PR TITLE
fix: add caveat regarding facet selection for COMPARE WITH queries

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -208,6 +208,10 @@ Every NRQL query will begin with a `SELECT` statement or a `FROM` clause. All ot
     SELECT percentile(duration) FROM PageView
       SINCE 1 week ago COMPARE WITH 1 week AGO TIMESERIES AUTO
     ```
+
+    <Callout variant="important">
+      For `FACET` queries using `COMPARE WITH`, the facets in the result are selected based on the time range specified using `SINCE` and `UNTIL` and not the prior time range being compared. The results of a `FACET` query for the prior time range alone may include a different set of facets.
+    </Callout>
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
It is not clear how facets are selected for COMPARE WITH NRQL queries.  This PR adds an info box explaining that the SINCE...UNTIL time range is used when selecting facets for the result and not the prior time range being compared.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.
https://issues.newrelic.com/browse/NR-41039