### PR TITLE
PHP agent release 10.5.0 (maybe publish on January 17th)

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
@@ -192,34 +192,6 @@ Any versions not listed in the following table are no longer supported. Please [
     
     <tr>
       <td>
-        v9.15.0.293
-      </td>
-
-      <td>
-        Dec 7, 2020
-      </td>
-
-      <td>
-        Dec 7, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v9.14.0.290
-      </td>
-
-      <td>
-        Oct 29, 2020
-      </td>
-
-      <td>
-        Oct 29, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
         v9.13.0.270
       </td>
 
@@ -341,76 +313,6 @@ Any versions not listed in the following table are no longer supported. Please [
 
       <td>
         Jan 22, 2023
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v9.6.0.255
-      </td>
-
-      <td>
-        Jan 16, 2020
-      </td>
-
-      <td>
-        Jan 16, 2023
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v9.5.0.252
-      </td>
-
-      <td>
-        Jan 6, 2020
-      </td>
-
-      <td>
-        Jan 6, 2023
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v9.4.1.250
-      </td>
-
-      <td>
-        Dec 11, 2019
-      </td>
-
-      <td>
-        Dec 11, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v9.4.0.249
-      </td>
-
-      <td>
-        Dec 5, 2019
-      </td>
-
-      <td>
-        Dec 5, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v9.3.0.248
-      </td>
-
-      <td>
-        Nov 11, 2019
-      </td>
-
-      <td>
-        Nov 11, 2022
       </td>
     </tr>
     

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
@@ -30,6 +30,18 @@ Any versions not listed in the following table are no longer supported. Please [
     
     <tr>
       <td>
+        v10.5.0.317
+      </td>
+      <td>
+        Jan 17, 2023
+      </td>
+      <td>
+        Jan 17, 2024
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         v10.4.0.316
       </td>
       <td>

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
@@ -30,6 +30,18 @@ Any versions not listed in the following table are no longer supported. Please [
     
     <tr>
       <td>
+        v10.4.0.316
+      </td>
+      <td>
+        Dec 12, 2022
+      </td>
+      <td>
+        Dec 12, 2023
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         v10.3.0.315
       </td>
       <td>

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-5-0-317.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-5-0-317.mdx
@@ -1,0 +1,27 @@
+---
+subject: PHP agent
+releaseDate: '2023-01-17'
+version: 10.5.0.317
+downloadLink: 'https://download.newrelic.com/php_agent/archive/10.5.0.317'
+---
+## New Relic PHP Agent v10.5.0.317
+
+### Bug Fixes
+* agent: Fixed [#577](https://github.com/newrelic/newrelic-php-agent/issues/577) - Large performance regression in 10.3.0. [#588](https://github.com/newrelic/newrelic-php-agent/pull/588)
+* agent: Fixed [#594](https://github.com/newrelic/newrelic-php-agent/issues/594) - Instrumentation from `opcache.preload` for PHP 8.1. [#595](https://github.com/new^relic/newrelic-php-agent/pull/595)
+* agent: Fixed sending `Supportability` metrics for application logging configuration. [#575](https://github.com/newrelic/newrelic-php-agent/pull/575)
+
+### Support statement
+* Support for 32 bit and FreeBSD binaries were deprecated with release v9.19.0.309 and **are no longer shipped**.
+* Support for ZTS binaries was deprecated with release v9.17.0.300 and will be **removed in a release in the near future**.
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines, check out our [PHP EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
+* The [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page should be consulted for the latest information on supported PHP versions and platforms.
+
+<Callout variant="important">
+**For installations using an unsupported PHP version or platform (32 bit, FreeBSD, ZTS, etc), it is highly recommended to disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades.  Alternatively, the PHP agent packages can be version pinned to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed, removing support for the required, unsupported features. This would disrupt APM data collection.  
+The PHP agent packages which are affected are:
+   - newrelic-php5
+   - newrelic-php5-common
+   - newrelic-daemon
+</Callout>
+


### PR DESCRIPTION
Updates for the PHP agent v10.5.0:

Add 'PHP agent v10.5.0' release notes
Update PHP agent EOL policy