### PR TITLE
Add translate functionality to nav footer

### DIFF
--- a/src/components/NavFooter.js
+++ b/src/components/NavFooter.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
-import { ExternalLink, Icon } from '@newrelic/gatsby-theme-newrelic';
+import {
+  ExternalLink,
+  Icon,
+  useTranslation,
+} from '@newrelic/gatsby-theme-newrelic';
 
 const NavFooter = ({ className }) => {
+  const { t } = useTranslation();
   return (
     <div
       css={css`
@@ -33,7 +38,7 @@ const NavFooter = ({ className }) => {
           text-underline-offset: 10px;
         `}
       >
-        See our 500+ quickstarts
+        {t('nav.footer')}
         <Icon
           css={css`
             position: absolute;

--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -33,7 +33,13 @@
     },
     "search": {
       "popularSearches": {
-        "options": ["NRQL", "logs", "alert", "best practices", "Kubernetes"],
+        "options": [
+          "NRQL",
+          "logs",
+          "alert",
+          "best practices",
+          "Kubernetes"
+        ],
         "title": "Popular searches"
       },
       "placeholder": "What are you looking for?"
@@ -55,10 +61,8 @@
       "title": "What's new"
     }
   },
-  "subNav": {
-    "filter": {
-      "placeholder": "Filter navigation"
-    }
+  "nav": {
+    "footer": "See our 500+ quickstarts"
   },
   "machineTranslation": {
     "calloutHeading": "This machine translation is provided for your convenience.",
@@ -75,5 +79,4 @@
     "submitButton": "Submit comment",
     "submitMessage": "Thank you for your feedback!"
   }
-
 }

--- a/src/i18n/translations/jp/translation.json
+++ b/src/i18n/translations/jp/translation.json
@@ -57,10 +57,8 @@
       "title": "新機能"
     }
   },
-  "subNav": {
-    "filter": {
-      "placeholder": "フィルターナビゲーション"
-    }
+  "nav": {
+    "footer": "500以上のクイックスタートの表示"
   },
   "machineTranslation": {
     "calloutHeading": "本書は、お客様のご参考のために原文の英語版を機械翻訳したものです。",

--- a/src/i18n/translations/kr/translation.json
+++ b/src/i18n/translations/kr/translation.json
@@ -50,10 +50,8 @@
       "title" : "새로워진 사항"
     }
   },
-  "subNav" : {
-    "filter" : {
-      "placeholder" : "필터 탐색"
-    }
+  "nav": {
+    "footer": "500개 이상의 퀵스타트 보기"
   },
   "machineTranslation" : {
     "calloutHeading" : "사용자의 편의를 위해 제공되는 기계 번역입니다.",


### PR DESCRIPTION
The 'see our 500+ quickstarts' nav footer was hardcoded in english, this adds it to the translation json so it can be dynamic instead
<img width="337" alt="Screen Shot 2023-01-13 at 11 12 41 AM" src="https://user-images.githubusercontent.com/39655074/212400054-6fadc472-aa45-471b-a713-cfaf8b826e1d.png">
<img width="332" alt="Screen Shot 2023-01-13 at 11 12 48 AM" src="https://user-images.githubusercontent.com/39655074/212400060-4a3a6bd5-9fe4-4c9b-907e-b8bf5b44c58e.png">
