### PR TITLE
chore: update codeowners for docs eng files to review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,17 @@
 # .github directory & its subdirectories
-
 /.github/ @newrelic/docs-engineering
 
 # Changes to yarn.lock & package.json file
-
 package.json @newrelic/docs-engineering
 yarn.lock @newrelic/docs-engineering
 
-# Changes to gatsby-config.js file
+# all javascript files
+*.js @newrelic/docs-engineering
 
-gatsby-config.js @newrelic/docs-engineering
+/plugins/ @newrelic/docs-engineering
+
+# .github directory & its subdirectories
+/scripts/ @newrelic/docs-engineering
 
 # Whats new files (pings individual project marketing managers)
 


### PR DESCRIPTION
## Description

Updates code owners file to try to catch as many relevant file types as possible for docs engineering review.

You [cannot negate pattern matches](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax) unfortunately, so it seems you'd have to specify all files/dirs you want to own.

I also updated the docs eng team setting to auto assign two people from the team via round robin. seemed to work on this PR at least 😬 