### PR TITLE
chore: Update .NET local log decoration JSON instructions

### DIFF
--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -164,7 +164,7 @@ You have three options to configure APM logs in context to send your app's logs 
   This option should not be used with in-agent forwarding. Using an [external log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding) to send logs to New Relic while in-agent forwarding is enabled will cause your logs to be sent up twice to New Relic. Depending on your account, this may result in double billing.
 
     <Callout variant="important">
-      Local log decoration for the .NET agent does not directly alter log messages.  Your logging framework configuration will need to be updated to write out the NR-LINKING token in messages. For JSON output in log4net and Serilog, additional configuration or code will be required.
+      Local log decoration for the .NET agent does not directly alter log messages. Your logging framework configuration will need to be updated to write out the NR-LINKING token in messages. For JSON output in log4net and Serilog, additional configuration or code will be required.
     </Callout>
 
   1. If you want to use this option, make sure you have the in-agent forwarding configuration option disabled.

--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -196,7 +196,7 @@ You have three options to configure APM logs in context to send your app's logs 
   ```
 
   <Callout variant="important">
-    For JSON, the The NR-LINKING data must be in `message` property.
+    For JSON, the NR-LINKING data must be in the `message` property.
   </Callout>
 
   Some attributes may be empty if the log occurred outside a transaction or if they are not applicable to your application's context. We recommend this option over the manual process to use a decorating formatter.

--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -164,7 +164,7 @@ You have three options to configure APM logs in context to send your app's logs 
   This option should not be used with in-agent forwarding. Using an [external log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding) to send logs to New Relic while in-agent forwarding is enabled will cause your logs to be sent up twice to New Relic. Depending on your account, this may result in double billing.
 
     <Callout variant="important">
-      Local log decoration for the .NET agent does not directly alter log messages.  Your logging framework configuration will need to be updated to write out the NR-LINKING token in messages.
+      Local log decoration for the .NET agent does not directly alter log messages.  Your logging framework configuration will need to be updated to write out the NR-LINKING token in messages. For JSON output in log4net and Serilog, additional configuration or code will be required.
     </Callout>
 
   1. If you want to use this option, make sure you have the in-agent forwarding configuration option disabled.
@@ -189,11 +189,15 @@ You have three options to configure APM logs in context to send your app's logs 
     The environment variable value, if present, takes precedence over the config file value.
   </Callout>
 
-  Our decorator adds five attributes to every log `message`: `entity.guid`, `entity.name`, `hostname`, `trace.id`, and  `span.id`. Example:
+  Our decorator adds five attributes to every log `message` (plain text): `entity.guid`, `entity.name`, `hostname`, `trace.id`, and  `span.id`. Example:
 
   ```
   This is my log message. NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}
   ```
+
+  <Callout variant="important">
+    For JSON, the The NR-LINKING data must be in `message` property.
+  </Callout>
 
   Some attributes may be empty if the log occurred outside a transaction or if they are not applicable to your application's context. We recommend this option over the manual process to use a decorating formatter.
 
@@ -215,15 +219,7 @@ You have three options to configure APM logs in context to send your app's logs 
   ```
 
   **log4net.Ext.Json**:
-  Update the layout to include a member called `NR_LINKING`.
-
-  ```xml
-  <layout type='log4net.Layout.SerializedLayout, log4net.Ext.Json'>
-    <decorator type='log4net.Layout.Decorators.StandardTypesFlatDecorator, log4net.Ext.Json' />
-    ...
-    <member value='NR_LINKING' />
-  </layout>
-  ```
+  Update the layout to include a member called `NR_LINKING` in the message JSON property.
 
   **log4net.Appender.AdoNetAppender**:
   This appender has a slightly different configuration than other layouts.  You will need to update the "message" parameter to include the metadata. The following example demonstrates this using a PatternLayout.
@@ -262,15 +258,8 @@ You have three options to configure APM logs in context to send your app's logs 
   ```
 
   **JSON Formatter with automatic property output**
-  By default, the JsonFormatter will write out every property on a message.
+  The default JsonFormatter will not write the NR_LINKING metadata to the message property, instead it writes each property to its own JSON object.  You will need to create a custom JSON formatter to write the NR_LINKING data to the end of the `message` property before logs in context will work.
 
-  ```csharp
-  Log.Logger = new LoggerConfiguration()
-      .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-      .Enrich.FromLogContext()
-      .WriteTo.Console(new JsonFormatter())
-      .CreateLogger();
-  ```
 
   ### Microsoft.Extensions.Logging configuration
 

--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -258,7 +258,7 @@ You have three options to configure APM logs in context to send your app's logs 
   ```
 
   **JSON Formatter with automatic property output**
-  The default JsonFormatter will not write the NR_LINKING metadata to the message property, instead it writes each property to its own JSON object.  You will need to create a custom JSON formatter to write the NR_LINKING data to the end of the `message` property before logs in context will work.
+  The default JsonFormatter will not write the NR_LINKING metadata to the message property; instead, it writes each property to its own JSON object. You will need to create a custom JSON formatter to write the NR_LINKING data to the end of the `message` property before logs in context will work.
 
 
   ### Microsoft.Extensions.Logging configuration


### PR DESCRIPTION
The current .NET local log decoration for JSON instructions are not correct.  This updates them with better information while we determine a better method of setting up the JSON format.

This removes the examples for JSON since they don't work and instead informs the customer that some custom work will be required.  We are hoping to address this in future and provide a better example or maybe a full project.
