### PR TITLE
Remove Rails7 callout

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ignoring-specific-transactions.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ignoring-specific-transactions.mdx
@@ -17,10 +17,6 @@ redirects:
 
 New Relic for Ruby allows you to selectively disable instrumentation for particular requests within your Rails or Sinatra application.
 
-<Callout variant="important">
-  This procedure has not been tested with Rails version 7 or higher.
-</Callout>
-
 ## Blocking all instrumentation [#ignore]
 
 Call `newrelic_ignore` with no arguments from within a Rails controller or Sinatra application to prevent instrumentation of all requests serviced by that controller or application:

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
@@ -67,10 +67,6 @@ The `add_method_tracer` method takes an optional metric name and a hash of optio
 
 ## Tracing initializers
 
-<Callout variant="important">
-  This procedure does not work for Rails version 7 or higher.
-</Callout>
-
 For Rails, a common way to add instrumentation is to create an initializer and "monkey patch" the instrumentation directives.
 
 For example, to add a method tracer to `MyCache#get`:

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-metrics.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-metrics.mdx
@@ -22,10 +22,6 @@ Custom metrics let you record arbitrary performance data via an API call (for ex
   Collecting too many metrics can impact the performance of your application and your New Relic agent. To avoid data problems, keep the total number of unique custom metrics under 2000.
 </Callout>
 
-<Callout variant="important">
-  These procedures have not been tested with Rails version 7 or higher.
-</Callout>
-
 ## Naming metrics [#metric_names]
 
 Metric names identify specific data values tracked by New Relic. When using the New Relic Ruby agent's API to track custom metrics, it's important to consider your metric naming and how the values will aggregate.

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic.mdx
@@ -16,10 +16,6 @@ redirects:
 
 To send error data that you are handling in your own code to New Relic, use the Ruby agent API [`NewRelic::Agent.notice_error`](https://www.rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent#notice_error-instance_method) call within your error handler.
 
-<Callout variant="important">
-  These procedures have not been tested with Rails version 7 or higher.
-</Callout>
-
 ## Notify the New Relic Ruby agent of an error [#solution]
 
 This API call takes the exception and an optional options hash. Use this format:


### PR DESCRIPTION
The ruby agent team tested the procedures on this page with Rails7. Remove the callout warning.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.