### PR TITLE
Remove `simple definitions` distinction in entity list

### DIFF
--- a/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor.mdx
@@ -9,7 +9,7 @@ This feature is currently a public preview.
 </Callout>
 
 
-Monitor and report data about your Microsoft Azure services to New Relic with the New Relic Azure Monitor integration. 
+Monitor and report data about your Microsoft Azure services to New Relic with the New Relic Azure Monitor integration.
 
 Our Azure Monitor integartion improves upon our past Azure solutions;
 - Coverage: New metrics will be available the moment Azure adds it to their Azure Monitor API endpoints, including data from new Azure services.
@@ -30,9 +30,9 @@ Once you enable the New Relic Azure Monitor integration, New Relic queries your 
 - Ability to filter monitored resources by group, type and tags
 
 ## Why Azure Monitor over traditional Azure integrations?
-Before the Azure Monitor integration, monitoring azure required service-specific Azure APIs to retreive metrics and metadata.  
+Before the Azure Monitor integration, monitoring azure required service-specific Azure APIs to retreive metrics and metadata.
 
-In contrast, the new **Azure Monitor** integration retrieves all [available Azure Monitor metrics](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported), enhancing our Azure support and accelerating the availability of new Azure services and metrics.  
+In contrast, the new **Azure Monitor** integration retrieves all [available Azure Monitor metrics](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported), enhancing our Azure support and accelerating the availability of new Azure services and metrics.
 
 The following table shows the differences between both solutions:
 
@@ -93,7 +93,7 @@ Consider the following when evaluating the costs of the **Azure Monitor** integr
 
 Given that the new integration enables ingesting all metrics from all services, **the amount of API calls to Azure will depend on the number of resources that are monitored by New Relic**. Configuration of the integration's polling interval parameters can help controlling the amount of these API calls.
 
-Review [Microsoft Azure Monitor pricing documentation](https://azure.microsoft.com/en-in/pricing/details/monitor/#pricing) for additional detail. 
+Review [Microsoft Azure Monitor pricing documentation](https://azure.microsoft.com/en-in/pricing/details/monitor/#pricing) for additional detail.
 
 <Callout variant="important">
 Rate limits as enforced by Azure will be shared between any current polling integrations that exist from within other New Relic Azure integrations.
@@ -107,7 +107,7 @@ Rate limits as enforced by Azure will be shared between any current polling inte
   >
 
 **Standard data ingest costs apply**, based on your New Relic pricing plan. Multiple controls exist to control the amount of data being ingested, including inclusion/exclusion filters and [data dropping rules](/docs/data-apis/manage-data/drop-data-using-nerdgraph/).
-  </Collapser>  
+  </Collapser>
 </CollapserGroup>
 
 ## Setting up the Azure Monitor integration
@@ -122,7 +122,7 @@ Rate limits as enforced by Azure will be shared between any current polling inte
 />
 
 
-Once you activate the integration, we recommend: 
+Once you activate the integration, we recommend:
 
 - Start by validating and testing the new integration on testing environments first.
 - Review the [integration settings](#integration-settings) section to adjust polling intervals and filters based on your observability requirements.
@@ -168,7 +168,7 @@ All Azure Monitor metrics will have these attributes:
 -   `azure.resourceId`
 -   `azure.resourceType`
 -   `azure.resourceId`
-  
+
   For example, to see the amount of metric updates received from Azure Monitor in the last hour, you can run this query:
 
 ```
@@ -183,18 +183,18 @@ Custom metrics are not supported by the Azure Monitor integration at the moment.
     title="Alert conditions"
   >
 
-You can create [NRQL](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/) [alert conditions](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions/) on metrics from the New Relic Azure Monitor integration. 
+You can create [NRQL](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/) [alert conditions](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions/) on metrics from the New Relic Azure Monitor integration.
 
 Make sure your filter limits data to metrics from the Azure Monitor integration only. For example:
 
 ```
 FROM Metric
 SELECT max(`azure.storage.storageaccounts.SuccessServerLatency`)
-WHERE collector.name = 'azure-monitor' 
+WHERE collector.name = 'azure-monitor'
 FACET azure.region, azure.resourceId
 ```
 
-Then, to make sure that alerts processes the data correctly, configure the advanced signal settings. These settings are needed because Azure Monitor receives metrics from services with a certain delay. 
+Then, to make sure that alerts processes the data correctly, configure the advanced signal settings. These settings are needed because Azure Monitor receives metrics from services with a certain delay.
 
 To configure the signal settings, under **Condition Settings**, click on **Advanced Signal Settings** and enter the following values:
 
@@ -228,9 +228,6 @@ List of services that create entities:
 - Azure Virtual Networks
 - Azure Virtual Networks Network Interfaces
 - Azure Virtual Networks Public IP Address
-
-List of services from the simple definitions (synthesis rules):
-
 - Azure API Management
 - Azure App Gateways
 - Azure Containers
@@ -255,5 +252,5 @@ List of services from the simple definitions (synthesis rules):
 
 When migrating from individual Azure integration to the Azure Monitor integration, there are a few things to keep in mind:
 
-- When you enable an Azure Monitor integration, new separate entities will be created for all of your resources. The entities created by the Azure Polling integration are staying as they are. This means you must update dashboards, alerts, and any other capability that refrences those entities.  
-- Old entities are available for 24 hours 
+- When you enable an Azure Monitor integration, new separate entities will be created for all of your resources. The entities created by the Azure Polling integration are staying as they are. This means you must update dashboards, alerts, and any other capability that refrences those entities.
+- Old entities are available for 24 hours


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* Remove the line "List of services from the simple definitions (synthesis rules):" from the entity list
* My IDE just removed automatically some trailing spaces.