### PR TITLE
style(Sonic): Optimized the getting started doc for VSU…

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
@@ -31,41 +31,13 @@ import apmPrometheus from 'images/apm_logo_prometheus.png'
 
 import kubernetesNewRelicKubernetesClusterExplorer from 'images/kubernetes_screenshot-full_new-relic-kubernetes-cluster-explorer.gif'
 
-New Relic is an observability platform that helps you build better software. You can bring in data from any digital source so that you can fully understand your system and how to improve it.
+New Relic is an observability platform that helps you build better software. You can bring in data from any digital source so that you can fully understand your system, analyze that data efficiently, and respond to incidents quickly before they become problems. As complex as the capablities of New Relic are, getting started with the platform can be done with a simple 3-step procedure.
 
-With New Relic, you can:
+## Get started quickly with New Relic [#get-started-now]
 
-* **[Bring all your data together](#bring-your-data)**: Instrument everything and import data from across your technology stack using our agents, integrations, and APIs, and access it from a single UI.
-* [**Analyze your data**](#analyze-your-data): Get all your data at your fingertips to find the root causes of problems and optimize your systems. Build dashboards and charts or use our powerful query language.
-* **[Respond to incidents quickly](#respond-faster)**: Our machine learning solution proactively detects and explains anomalies and warns you before they become problems.
-
-<img
-  title="2020-04-28-17.26.02.gif"
-  alt="New Relic - Kubernetes Cluster Explorer"
-  src={kubernetesNewRelicKubernetesClusterExplorer}
-/>
-
-<figcaption>
-  **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Kubernetes cluster explorer**: Our Kubernetes UI is just one of our many features.
-</figcaption>
-
-## Get started with New Relic [#get-started-now]
-
-Here's how you can quickly get started:
-
-1. If you don't have a New Relic account, sign up at [newrelic.com/signup](https://newrelic.com/signup). It's free, forever!
-2. For a recommended path on how to set up New Relic, see [our quick launch guide](/docs/new-relic-solutions/get-started/quick-launch-guide). If you'd prefer to add monitoring for some specific entities and services, use the [Add your data](https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJ0dWNzb24ucGxnLWluc3RydW1lbnQtZXZlcnl0aGluZyJ9) UI page. 
-3. Once you have data coming into New Relic, learn more about the [New Relic UI](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one) or [set up alerts](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-alerts/).
-
-Want to estimate costs? See [our blog post on estimating costs](https://newrelic.com/blog/nerdlog/estimate-data-cost). 
-
-## All the answers in one place [#answers-in-one-place]
-
-New Relic is built for full stack observability. It links all relevant data so that you get the whole picture of everything that enables your systems to deliver value to your customers, from the container running a microservice in the cloud to a mobile website's shopping cart button.
-
-## Bring all your data together [#bring-your-data]
-
-Capture, organize, and make sense of your data in New Relic, no matter where it comes from. Use our [agents and integrations](/docs/infrastructure/host-integrations/get-started/introduction-host-integrations/) to automatically collect data from common frameworks and tools, or use [our APIs](/docs/apis/get-started/intro-apis/introduction-new-relic-apis) for data that's more specific to your business or technology.
+1. [Sign up for a free account](https://newrelic.com/signup) if you haven't already.
+2. See [our quick launch guide](/docs/new-relic-solutions/get-started/quick-launch-guide) for a recommended path on how to set up New Relic. If you'd prefer to add monitoring for some specific entities and services, use the [Add your data](https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJ0dWNzb24ucGxnLWluc3RydW1lbnQtZXZlcnl0aGluZyJ9) UI page. 
+3. Use our [agents and integrations](/docs/infrastructure/host-integrations/get-started/introduction-host-integrations/) to automatically collect data from common frameworks and tools, or use [our APIs](/docs/apis/get-started/intro-apis/introduction-new-relic-apis) for data that's more specific to your business or technology.
 
 <TechTileGrid>
   <TechTile
@@ -203,7 +175,15 @@ Capture, organize, and make sense of your data in New Relic, no matter where it 
 
 </TechTileGrid>
 
-If you don't see your technologies or tasks listed here, see a larger list at [New Relic Instant Observability](https://newrelic.com/instant-observability/). There you will find integrations bundled into quickstarts, providing you instant access to pre-built dashboards and alerts specific to your technology.
+If you don't see your technologies or tasks listed here, see the larger list at [New Relic Instant Observability](https://newrelic.com/instant-observability/). You'll find integrations bundled into quickstarts, providing you instant access to pre-built dashboards and alerts specific to your technology.
+
+Once you have data coming into New Relic, learn more about the [New Relic UI](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one) or [set up alerts](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-alerts/).
+
+If you're curious about pricing, we have a [blog post set up to help you with cost estimation](https://newrelic.com/blog/nerdlog/estimate-data-cost). 
+
+## All the answers in one place [#answers-in-one-place]
+
+New Relic is built for full stack observability. It links all relevant data so that you get the whole picture of everything that enables your systems to deliver value to your customers, from the container running a microservice in the cloud to a mobile website's shopping cart button.
 
 ## Analyze your data
 

--- a/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
@@ -31,7 +31,7 @@ import apmPrometheus from 'images/apm_logo_prometheus.png'
 
 import kubernetesNewRelicKubernetesClusterExplorer from 'images/kubernetes_screenshot-full_new-relic-kubernetes-cluster-explorer.gif'
 
-New Relic is an observability platform that helps you build better software. You can bring in data from any digital source so that you can fully understand your system, analyze that data efficiently, and respond to incidents before they become problems. As complex as the capablities of New Relic are, you can get started with the platform by following a 3-step procedure.
+New Relic is an observability platform that helps you build better software. You can bring in data from any digital source so that you can fully understand your system, analyze that data efficiently, and respond to incidents before they become problems. As extensive as the capablities of New Relic are, you can get started with the platform by following a 3-step procedure.
 
 <Video
   id="nbM9dyRF1Kc"

--- a/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
@@ -31,13 +31,17 @@ import apmPrometheus from 'images/apm_logo_prometheus.png'
 
 import kubernetesNewRelicKubernetesClusterExplorer from 'images/kubernetes_screenshot-full_new-relic-kubernetes-cluster-explorer.gif'
 
-New Relic is an observability platform that helps you build better software. You can bring in data from any digital source so that you can fully understand your system, analyze that data efficiently, and respond to incidents quickly before they become problems. As complex as the capablities of New Relic are, getting started with the platform can be done with a simple 3-step procedure.
+New Relic is an observability platform that helps you build better software. You can bring in data from any digital source so that you can fully understand your system, analyze that data efficiently, and respond to incidents before they become problems. As complex as the capablities of New Relic are, you can get started with the platform by following a 3-step procedure.
 
-## Get started quickly with New Relic [#get-started-now]
+<Video
+  id="nbM9dyRF1Kc"
+  type="youtube"
+/>
+
+## Get started with New Relic [#get-started-now]
 
 1. [Sign up for a free account](https://newrelic.com/signup) if you haven't already.
-2. See [our quick launch guide](/docs/new-relic-solutions/get-started/quick-launch-guide) for a recommended path on how to set up New Relic. If you'd prefer to add monitoring for some specific entities and services, use the [Add your data](https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJ0dWNzb24ucGxnLWluc3RydW1lbnQtZXZlcnl0aGluZyJ9) UI page. 
-3. Use our [agents and integrations](/docs/infrastructure/host-integrations/get-started/introduction-host-integrations/) to automatically collect data from common frameworks and tools, or use [our APIs](/docs/apis/get-started/intro-apis/introduction-new-relic-apis) for data that's more specific to your business or technology.
+2. Use our [agents and integrations](/docs/infrastructure/host-integrations/get-started/introduction-host-integrations/) to automatically collect data from common frameworks and tools.
 
 <TechTileGrid>
   <TechTile
@@ -174,16 +178,13 @@ New Relic is an observability platform that helps you build better software. You
   />
 
 </TechTileGrid>
+3. See [our quick launch guide](/docs/new-relic-solutions/get-started/quick-launch-guide) for a recommended path on how to set up New Relic. If you'd prefer to add monitoring for some specific entities and services, use the [Add your data](https://one.newrelic.com/launcher/nr1-core.settings?pane=eyJuZXJkbGV0SWQiOiJ0dWNzb24ucGxnLWluc3RydW1lbnQtZXZlcnl0aGluZyJ9) UI page. 
 
 If you don't see your technologies or tasks listed here, see the larger list at [New Relic Instant Observability](https://newrelic.com/instant-observability/). You'll find integrations bundled into quickstarts, providing you instant access to pre-built dashboards and alerts specific to your technology.
 
 Once you have data coming into New Relic, learn more about the [New Relic UI](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one) or [set up alerts](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-alerts/).
 
 If you're curious about pricing, we have a [blog post set up to help you with cost estimation](https://newrelic.com/blog/nerdlog/estimate-data-cost). 
-
-## All the answers in one place [#answers-in-one-place]
-
-New Relic is built for full stack observability. It links all relevant data so that you get the whole picture of everything that enables your systems to deliver value to your customers, from the container running a microservice in the cloud to a mobile website's shopping cart button.
 
 ## Analyze your data
 
@@ -200,3 +201,5 @@ DevOps, site-reliability, and network operation teams need reliable, real-time a
 * Let [applied intelligence](/docs/new-relic-one/use-new-relic-one/new-relic-ai/introduction-new-relic-ai), our hybrid machine learning engine, automatically detect anomalies, reduce alert noise, and enrich incidents with context so that you can respond faster to incidents.
 * [Proactive detection](/docs/new-relic-one/use-new-relic-one/new-relic-ai/proactive-detection-new-relic-ai): Be notified of unusual app behavior and get an analysis of this unusual behavior sent to Slack. Not using Slack? Set up a webhook to deliver messages when you need them.
 * [Get notifications:](/docs/alerts/new-relic-alerts/getting-started/introduction-new-relic-alerts) Set up alerts across your data sources and get notified when systems need your attention. Preserve your attention and control how many threshold violations should fire before you're notified.
+
+Ready to try New Relic for yourself? [Sign up for an account](https://newrelic.com/signup) and start maximizing your data for free!


### PR DESCRIPTION
- [x] Address redundancy between "Get started with New Relic" and "Bring all your data together" sections
- [x] Reduce link fatigue early on; particularly the anchor links at the top
- [x] Use more customer-centric language, e.g. "Install" or "Get started" vs "Bring all your data together"
- [x] Consider bringing up the tiles earlier in the doc
- [x] Add one more CTA near the bottom
