### PR TITLE
docs: Update page view timings in dictionary (BA current rls)

### DIFF
--- a/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
+++ b/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
@@ -25,7 +25,7 @@ The `PageViewTiming` event provides a more real-time delivery mechanism that doe
 
 ## Support for Google's Core Web Vitals
 
-As of [agent version 1177](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1177) for browser monitoring, we have full support for [Google's Core Web Vitals](https://web.dev/vitals/#core-web-vitals). It requires a [Pro or above Browser agent](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/#agent-types).
+As of [agent version 1177](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1177) for browser monitoring, we have full support for [Google's Core Web Vitals](https://web.dev/vitals/#core-web-vitals). This feature is available in all flavors of the agent (Lite, Pro, or Pro+SPA).
 
 Note that the metrics that make up Core Web Vitals [evolve](https://web.dev/vitals/#evolving-web-vitals) over time. The current set focuses on three aspects of the user experience: loading, interactivity, and visual stability. It includes the following metrics and their respective thresholds:
 

--- a/src/data-dictionary/events/PageViewTiming/cumulativeLayoutShift.md
+++ b/src/data-dictionary/events/PageViewTiming/cumulativeLayoutShift.md
@@ -7,4 +7,4 @@ events:
 
 An important, user-centric metric for measuring visual stability because it helps quantify how often users experience unexpected layout shifts—a low CLS helps ensure that the page is delightful. 
 
-Cumulative Layout Shift is one of three metrics identified by Google as the Core Web Vitals. CLS scores up to 0.1 are considered "Good", between 0.1-0.25 considered "Needs Improvement", and above 0.25 considered "Poor."
+For more information, see the [`PageViewTiming` documentation](https://docs.newrelic.com/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics).

--- a/src/data-dictionary/events/PageViewTiming/firstContentfulPaint.md
+++ b/src/data-dictionary/events/PageViewTiming/firstContentfulPaint.md
@@ -6,15 +6,6 @@ events:
   - PageViewTiming
 ---
 
-The first contentful paint timing rounded down to the nearest second. This attribute only occurs when the value of the timingName attribute is firstContentfulPaint.
-
 The first contentful paint timing rounded down to the nearest second. This attribute only occurs when the value of the `timingName` attribute is `firstContentfulPaint`.
 
-Supported browser versions:
-
-*   Chrome 60 or higher for desktop and mobile (Android webview and Chrome for Android)
-*   Opera 47 or higher for desktop
-*   Opera 44 or higher for Android mobile
-*   Samsung Internet for mobile
-
-For more information, see the [`PageViewTiming` documentation](https://docs.newrelic.com/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details).
+For more information, see the [`PageViewTiming` documentation](https://docs.newrelic.com/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics).

--- a/src/data-dictionary/events/PageViewTiming/firstInputDelay.md
+++ b/src/data-dictionary/events/PageViewTiming/firstInputDelay.md
@@ -6,17 +6,8 @@ events:
   - PageViewTiming
 ---
 
-The first input delay measures the duration from the first interaction to the moment the web application responds, rounded down to the nearest millisecond. First Input Delay and First Interaction are recorded on the same event, when the timingName value is firstInteraction.
-
 The first input delay measures the duration from the first interaction to the moment the web application responds. The duration is rounded down to the nearest millisecond. This attribute only occurs when the value of the `timingName` attribute is `firstInteraction`.
 
 The `firstInputDelay` goes one step beyond `firstInteraction`. It measures how long the user has to wait until their action is registered and they receive the expected response from the browser.
 
-The `firstInputDelay` metric requires the [`addEventListener` Browser API](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener). This API is available in all modern browsers, including:
-
-*   Apple Safari
-*   Google Chrome
-*   Microsoft Internet Explorer (IE) versions 9 or higher
-*   Mozilla Firefox
-
-For more information, see the [`PageViewTiming` documentation](https://docs.newrelic.com/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details).
+For more information, see the [`PageViewTiming` documentation](https://docs.newrelic.com/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics).

--- a/src/data-dictionary/events/PageViewTiming/firstInteraction.md
+++ b/src/data-dictionary/events/PageViewTiming/firstInteraction.md
@@ -6,8 +6,6 @@ events:
   - PageViewTiming
 ---
 
-A timing that captures when customers begin to engage with a website, such as clicking a button or typing in a box, rounded down to the nearest second. Occurs when the timingName value is firstInteraction.
-
 First interaction is a timing that captures when customers begin to engage with a website, such as clicking a button or typing in a box. The first interaction timing is rounded down to the nearest second. This attribute only occurs when the value of the `timingName` attribute is `firstInteraction`.
 
 Events are handled at the document level with `addEventListener()`. Clicking an empty page will cause an interaction to fire. Valid event `type` values include:
@@ -18,13 +16,6 @@ Events are handled at the document level with `addEventListener()`. Clicking an 
 *   `keydown`
 *   `touchstart`
 
-For additional details, you can use `firstInputDelay`. It goes one step farther and measures how long the user has to wait until their action is registered and they receive the expected response from the browser.
+Note that this attribute represents the time of the event; to know which event triggered it, use `interactionType`.
 
-The `firstInteraction` metric requires the [`addEventListener` Browser API](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener). This API is available in all modern browsers, including:
-
-*   Apple Safari
-*   Google Chrome
-*   Microsoft Internet Explorer (IE) versions 9 or higher
-*   Mozilla Firefox
-
-For more information, see the [`PageViewTiming` documentation](https://docs.newrelic.com/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details).
+For more information, see the [`PageViewTiming` documentation](https://docs.newrelic.com/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics).

--- a/src/data-dictionary/events/PageViewTiming/firstPaint.md
+++ b/src/data-dictionary/events/PageViewTiming/firstPaint.md
@@ -6,15 +6,6 @@ events:
   - PageViewTiming
 ---
 
-The first paint timing rounded down to the nearest second. Occurs when the timingName value is firstPaint.
-
 The first paint timing rounded down to the nearest second. Occurs when the `timingName` value is firstPaint.
 
-Supported browser versions:
-
-*   Chrome 60 or higher for desktop and mobile (Android webview and Chrome for Android)
-*   Opera 47 or higher for desktop
-*   Opera 44 or higher for Android mobile
-*   Samsung Internet for mobile
-
-For more information, see the [`PageViewTiming` documentation](https://docs.newrelic.com/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details).
+For more information, see the [`PageViewTiming` documentation](https://docs.newrelic.com/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics).

--- a/src/data-dictionary/events/PageViewTiming/interactionType.md
+++ b/src/data-dictionary/events/PageViewTiming/interactionType.md
@@ -5,8 +5,6 @@ events:
   - PageViewTiming
 ---
 
-The event type of the first interaction that occurs on the web app: pointerdown, mousedown, click, keydown, or touchstart.
-
 The event type of the first interaction that occurs on the web application. The type can be one of the following:
 
 *   `pointerdown`

--- a/src/data-dictionary/events/PageViewTiming/largestContentfulPaint.md
+++ b/src/data-dictionary/events/PageViewTiming/largestContentfulPaint.md
@@ -6,6 +6,6 @@ events:
   - PageViewTiming
 ---
 
-This metric, available with agent version 1163, largestContentfulPaint, reports the render time of the largest content element visible in the viewport.
+This metric reports the render time of the largest content element visible in the viewport, which is a more accurate way to measure when the main content of a page is loaded and useful.
 
-This metric, available with [agent version 1163](https://docs.newrelic.com/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1163), [`largestContentfulPaint`](http://docs.newrelic.com/attribute-dictionary/pageviewtiming/largestcontentfulpaint), reports the render time of the largest content element visible in the viewport. Research from Google shows that when the largest element is rendered is a more accurate way to measure when the main content of a page is loaded and useful. Details on this metric, including limitations and considerations can be found in the [w3c draft on GitHub](https://wicg.github.io/largest-contentful-paint/).
+For more information, see the [`PageViewTiming` documentation](https://docs.newrelic.com/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics).


### PR DESCRIPTION
* What problems does this PR solve?

There are some inaccuracies and redundancy around the current browser agent's page view timings and details. This PR cleans them up as a basis for future work to add more.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

n/a

* If your issue relates to an existing GitHub issue, please link to it.

n/a