### PR TITLE
updates elasticsearch supported versions

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/elasticsearch/elasticsearch-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/elasticsearch/elasticsearch-integration.mdx
@@ -24,7 +24,7 @@ Our Elasticsearch integration collects and sends inventory and metrics from your
 
 To install the Elasticsearch monitoring integration, run through the following steps:
 
-1. [Install and activate the integration](#install). 
+1. [Install and activate the integration](#install).
 2. [Configure the integration](#config).
 3. [Find and use data](#find-and-use).
 4. Optionally, see [Elasticsearch's configuration settings](/docs/infrastructure/host-integrations/host-integrations-list/elasticsearch/elasticsearch-config).
@@ -33,7 +33,7 @@ To install the Elasticsearch monitoring integration, run through the following s
 
 ### Elasticsearch versions [#elasticsearch-versions]
 
-Our integration is compatible with Elasticsearch 5.X through 7.X.
+Our integration is compatible with Elasticsearch 7.x through 8.X.
 
 ### Supported operating systems [#supported-os]
 
@@ -1690,51 +1690,11 @@ The Elasticsearch integration collects the following metrics. Each metric name i
 
         <tr>
           <td>
-            `threadpool.indexActive`
-          </td>
-
-          <td>
-            The number of active threads in the index pool.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `threadpool.indexQueue`
-          </td>
-
-          <td>
-            The number of queued threads in the index pool.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `threadpool.indexRejected`
-          </td>
-
-          <td>
-            The number of rejected threads in the index pool.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `threadpool.indexThreads`
-          </td>
-
-          <td>
-            The number of threads in the index pool.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
             `threadpool.listenerActive`
           </td>
 
           <td>
-            The number of active threads in the listener pool.
+            The number of active threads in the listener pool.<br/><span style={{ fontSize: "0.9rem" }}>(Deprecated on Elasticsearch 8)</span>
           </td>
         </tr>
 
@@ -1744,7 +1704,7 @@ The Elasticsearch integration collects the following metrics. Each metric name i
           </td>
 
           <td>
-            The number of queued threads in the listener pool.
+            The number of queued threads in the listener pool.<br/><span style={{ fontSize: "0.9rem" }}>(Deprecated on Elasticsearch 8)</span>
           </td>
         </tr>
 
@@ -1754,7 +1714,7 @@ The Elasticsearch integration collects the following metrics. Each metric name i
           </td>
 
           <td>
-            The number of rejected threads in the listener pool.
+            The number of rejected threads in the listener pool.<br/><span style={{ fontSize: "0.9rem" }}>(Deprecated on Elasticsearch 8)</span>
           </td>
         </tr>
 
@@ -1764,7 +1724,7 @@ The Elasticsearch integration collects the following metrics. Each metric name i
           </td>
 
           <td>
-            The number of threads in the listener pool.
+            The number of threads in the listener pool.<br/><span style={{ fontSize: "0.9rem" }}>(Deprecated on Elasticsearch 8)</span>
           </td>
         </tr>
 


### PR DESCRIPTION
We are releasing a new version of nri-elasticsearch which adds support for newer versions.

This PR updates the supported versions requirements section to elastic v7.x and v8.x, removes 4 metrics that are already deprecated and adds a small note on 4 other metrics that are deprecated only on elastic version 8. We still support them on version 7