### PR TITLE
Update vale and verify-install script

### DIFF
--- a/scripts/validate-install/schema.js
+++ b/scripts/validate-install/schema.js
@@ -130,6 +130,7 @@ const Override = object({
   filePath: optional(MdxFilePath),
   selectedOptions: array(SelectedOption),
   skip: optional(boolean()),
+  isConditionalStep: optional(boolean()),
 });
 
 const Step = object({

--- a/vale.ini
+++ b/vale.ini
@@ -9,7 +9,7 @@ Vocab = Docs
 [formats]
 mdx = md
 
-[*.{md}]
+[**/src/content/**/*.{md}]
 
 BasedOnStyles = Microsoft, new-relic
 


### PR DESCRIPTION
This has a couple of housekeeping items 🧹 
1. Update vale to only look in the src/content folder (mostly to ignore i18n)
2. Update the verify install script schema with the new isConditionalStep override type