### PR TITLE
fix: updated links to node-newrelic api docs to strip /docs

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -156,7 +156,7 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     * Instrument your own code.
     * Replace the Node.js agent's built-in instrumentation with your own.
 
-    For more information, see New Relic's [Node.js instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/docs/tutorial-Instrumentation-Basics.html).
+    For more information, see New Relic's [Node.js instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/tutorial-Instrumentation-Basics.html).
   </Collapser>
 
   <Collapser
@@ -169,7 +169,7 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
 
     Sets an instrumentation callback for a datastore module.
 
-    This method is just like [`newrelic.instrument()`](#instrument), except it provides a [datastore-specialized shim](https://newrelic.github.io/node-newrelic/docs/DatastoreShim.html). For more information, see New Relic's [Node.js datastore instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/docs/tutorial-Datastore-Simple.html).
+    This method is just like [`newrelic.instrument()`](#instrument), except it provides a [datastore-specialized shim](https://newrelic.github.io/node-newrelic/DatastoreShim.html). For more information, see New Relic's [Node.js datastore instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/tutorial-Datastore-Simple.html).
   </Collapser>
 
   <Collapser
@@ -216,7 +216,7 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
 
     Sets an instrumentation callback for a message service client module.
 
-    This method is just like [`newrelic.instrument()`](#instrument), except it provides a [message-service-specialized shim](https://newrelic.github.io/node-newrelic/docs/MessageShim.html). For more information, see New Relic's [Node.js message service instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/docs/tutorial-Messaging-Simple.html).
+    This method is just like [`newrelic.instrument()`](#instrument), except it provides a [message-service-specialized shim](https://newrelic.github.io/node-newrelic/MessageShim.html). For more information, see New Relic's [Node.js message service instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/tutorial-Messaging-Simple.html).
   </Collapser>
 
   <Collapser
@@ -229,7 +229,7 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
 
     Sets an instrumentation callback for a web framework module.
 
-    This method is just like [`newrelic.instrument()`](#instrument), except it provides a [web-framework-specialized shim](https://newrelic.github.io/node-newrelic/docs/WebFrameworkShim.html). For more information, see New Relic's [Node.js web framework instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/docs/tutorial-Webframework-Simple.html).
+    This method is just like [`newrelic.instrument()`](#instrument), except it provides a [web-framework-specialized shim](https://newrelic.github.io/node-newrelic/WebFrameworkShim.html). For more information, see New Relic's [Node.js web framework instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/tutorial-Webframework-Simple.html).
   </Collapser>
 
   <Collapser
@@ -394,7 +394,7 @@ Use these API calls to record additional events:
     newrelic.recordLogEvent({message, level})
     ```
 
-    Use `recordLogEvent` to record a log event, in case that automatic logging instrumentation is insufficient for your logging framework. [Consult the auto-generated documentation](https://newrelic.github.io/node-newrelic/docs/API.html#recordLogEvent) for the details of the parameter types accepted.
+    Use `recordLogEvent` to record a log event, in case that automatic logging instrumentation is insufficient for your logging framework. [Consult the auto-generated documentation](https://newrelic.github.io/node-newrelic/API.html#recordLogEvent) for the details of the parameter types accepted.
 
     <CollapserGroup>
       <Collapser

--- a/src/content/docs/apm/agents/nodejs-agent/attributes/nodejs-agent-attributes.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/attributes/nodejs-agent-attributes.mdx
@@ -75,7 +75,7 @@ In addition to the [default APM attributes](/docs/insights/new-relic-insights/de
     id="NRaddCustomParameter"
     title="Custom attributes"
   >
-    Attributes added to an [`addCustomAttribute()`](https://newrelic.github.io/node-newrelic/docs/API.html#addCustomAttribute) call to the Node.js agent API. The key name for this attribute depends on what you specify when you call the method.
+    Attributes added to an [`addCustomAttribute()`](https://newrelic.github.io/node-newrelic/API.html#addCustomAttribute) call to the Node.js agent API. The key name for this attribute depends on what you specify when you call the method.
 
     The default setting for each destination is:
 
@@ -93,7 +93,7 @@ In addition to the [default APM attributes](/docs/insights/new-relic-insights/de
     id="NRaddnoticeError"
     title={<><InlineCode>noticeError()</InlineCode> API calls</>}
   >
-    Attributes added to a [`noticeError()`](https://newrelic.github.io/node-newrelic/docs/API.html#noticeError) call on the Node.js agent API. The key name for this attribute depends on what you specify when you call the method.
+    Attributes added to a [`noticeError()`](https://newrelic.github.io/node-newrelic/API.html#noticeError) call on the Node.js agent API. The key name for this attribute depends on what you specify when you call the method.
 
     The default setting for each destination is:
 
@@ -140,7 +140,7 @@ In addition to the [default APM attributes](/docs/insights/new-relic-insights/de
     id="requestparams"
     title="Request parameters"
   >
-    Request parameters from the transaction. The Node.js agent does not capture parameters by default. All GET parameters can be captured if the `request.parameters.*` entry is added to [`attributes.include`](#cfg-attributes-include), or specific request parameters can be added to the list, for example, `request.parameters.foo` or `request.parameters.bar`. In order to capture POST parameters, use the [`addCustomAttribute()`](https://newrelic.github.io/node-newrelic/docs/API.html#addCustomAttribute) Node.js agent API call.
+    Request parameters from the transaction. The Node.js agent does not capture parameters by default. All GET parameters can be captured if the `request.parameters.*` entry is added to [`attributes.include`](#cfg-attributes-include), or specific request parameters can be added to the list, for example, `request.parameters.foo` or `request.parameters.bar`. In order to capture POST parameters, use the [`addCustomAttribute()`](https://newrelic.github.io/node-newrelic/API.html#addCustomAttribute) Node.js agent API call.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
@@ -745,7 +745,7 @@ Before upgrading to Node.js agent v2, review this information for major changes.
         id="newrelic_instrument"
         title={<><InlineCode>newrelic.instrument()</InlineCode><InlineCode>newrelic.instrumentDatastore()</InlineCode><InlineCode>newrelic.instrumentWebframework()</InlineCode><InlineCode>newrelic.instrumentMessages()</InlineCode></>}
       >
-        Use these methods to add custom instrumentation for third party modules, including those already instrumented by the New Relic Node.js agent. For more information, see New Relic's [Node.js instrumentation tutorials on GitHub](https://newrelic.github.io/node-newrelic/docs/tutorial-Instrumentation-Basics.html).
+        Use these methods to add custom instrumentation for third party modules, including those already instrumented by the New Relic Node.js agent. For more information, see New Relic's [Node.js instrumentation tutorials on GitHub](https://newrelic.github.io/node-newrelic/tutorial-Instrumentation-Basics.html).
       </Collapser>
 
       <Collapser

--- a/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
@@ -33,7 +33,7 @@ Supported frameworks for automatic logs in context include:
  * [Pino](https://github.com/pinojs/pino) 7.0.0 or higher.
  * [Bunyan](https://www.npmjs.com/package/bunyan) 1.8.12 or higher (since agent version 9.3.0)
 
-If you're not using a supported framework, you may instead use the agent's log forwarding API method to perform your own instrumentation. For details, see the [Node.js agent API docs](https://newrelic.github.io/node-newrelic/docs/API.html#recordLogEvent). 
+If you're not using a supported framework, you may instead use the agent's log forwarding API method to perform your own instrumentation. For details, see the [Node.js agent API docs](https://newrelic.github.io/node-newrelic/API.html#recordLogEvent). 
 
   <Callout variant="important">
     Agent releases 8.16.0 and higher have this feature enabled in the agent configuration file by default.
@@ -196,7 +196,7 @@ To enable logs in context for APM apps monitored by Node.js, you can use our man
 
 1. Make sure you have already [set up logging in New Relic](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/enable-log-management-new-relic/). This includes configuring a supported log forwarder that collects your application logs and extends the metadata that is forwarded to New Relic.
 2. [Install](/docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent/) or [update](/docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent/) to the latest Node.js agent version, and [enable distributed tracing](/docs/distributed-tracing/enable-configure/quick-start/). Use [Node.js agent version 6.2.0 or higher](/docs/release-notes/agent-release-notes/nodejs-release-notes/) for logs in context.
-3. Install [a supported framework](#automatic) to enrich your log data, or directly use [the agent's log forwarding API](https://newrelic.github.io/node-newrelic/docs/API.html#recordLogEvent).
+3. Install [a supported framework](#automatic) to enrich your log data, or directly use [the agent's log forwarding API](https://newrelic.github.io/node-newrelic/API.html#recordLogEvent).
 4. In your agent configuration, set `application_config.enabled` to `false`. (Otherwise, the agent will automatically instrument your logger and calling these enrichers yourself will do nothing.)
 5. Configure logs in context for Node.js using the appropriate log extension.
 

--- a/src/i18n/content/jp/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -154,7 +154,7 @@ New Relic の Node.js エージェントの Request API コールをまとめま
     * 自分のコードをインストゥルメント化する。
     * Node.jsエージェントに内蔵されているインスツルメンテーションを独自のものに置き換えます。
 
-    詳しくは、New Relic の [Node.js instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/docs/tutorial-Instrumentation-Basics.html) をご覧ください。
+    詳しくは、New Relic の [Node.js instrumentation tutorial on Github](https://newrelic.github.io/node-newrelic/tutorial-Instrumentation-Basics.html) をご覧ください。
   </Collapser>
 
   <Collapser
@@ -167,7 +167,7 @@ New Relic の Node.js エージェントの Request API コールをまとめま
 
     データストア・モジュールのインストルメンテーション・コールバックを設定します。
 
-    このメソッドは[`newrelic.instrument()`](#instrument)と同じですが、[データストアに特化した shim](https://newrelic.github.io/node-newrelic/docs/DatastoreShim.html)を提供する点が異なります。詳細については[、Github の New Relic の Node.js データストア インストルメンテーション チュートリアルを](https://newrelic.github.io/node-newrelic/docs/tutorial-Datastore-Simple.html)参照してください。
+    このメソッドは[`newrelic.instrument()`](#instrument)と同じですが、[データストアに特化した shim](https://newrelic.github.io/node-newrelic/DatastoreShim.html)を提供する点が異なります。詳細については[、Github の New Relic の Node.js データストア インストルメンテーション チュートリアルを](https://newrelic.github.io/node-newrelic/tutorial-Datastore-Simple.html)参照してください。
   </Collapser>
 
   <Collapser
@@ -213,7 +213,7 @@ New Relic の Node.js エージェントの Request API コールをまとめま
 
     メッセージサービスクライアントモジュールのインスツルメンテーションコールバックを設定します。
 
-    このメソッドは、[メッセージ サービスに特化した shim を](https://newrelic.github.io/node-newrelic/docs/MessageShim.html)提供することを除いて、 [`newrelic.instrument()`](#instrument)と同じです。詳細については[、Github の New Relic の Node.js メッセージ サービス インストルメンテーション チュートリアルを](https://newrelic.github.io/node-newrelic/docs/tutorial-Messaging-Simple.html)参照してください。
+    このメソッドは、[メッセージ サービスに特化した shim を](https://newrelic.github.io/node-newrelic/MessageShim.html)提供することを除いて、 [`newrelic.instrument()`](#instrument)と同じです。詳細については[、Github の New Relic の Node.js メッセージ サービス インストルメンテーション チュートリアルを](https://newrelic.github.io/node-newrelic/tutorial-Messaging-Simple.html)参照してください。
   </Collapser>
 
   <Collapser
@@ -226,7 +226,7 @@ New Relic の Node.js エージェントの Request API コールをまとめま
 
     Webフレームワークモジュールのインスツルメンテーションコールバックを設定します。
 
-    このメソッドは、[ウェブ フレームワークに特化した shim を](https://newrelic.github.io/node-newrelic/docs/WebFrameworkShim.html)提供することを除いて、 [`newrelic.instrument()`](#instrument)と同じです。詳細については[、Github の New Relic の Node.js Web フレームワーク インストルメンテーション チュートリアルを](https://newrelic.github.io/node-newrelic/docs/tutorial-Webframework-Simple.html)参照してください。
+    このメソッドは、[ウェブ フレームワークに特化した shim を](https://newrelic.github.io/node-newrelic/WebFrameworkShim.html)提供することを除いて、 [`newrelic.instrument()`](#instrument)と同じです。詳細については[、Github の New Relic の Node.js Web フレームワーク インストルメンテーション チュートリアルを](https://newrelic.github.io/node-newrelic/tutorial-Webframework-Simple.html)参照してください。
   </Collapser>
 
   <Collapser
@@ -391,7 +391,7 @@ New Relic の Node.js エージェントの Request API コールをまとめま
     newrelic.recordLogEvent({message, level})
     ```
 
-    ロギング フレームワークに対して自動ロギング インストルメンテーションが不十分な場合は、 `recordLogEvent`を使用してログ イベントを記録します。受け入れられるパラメータ タイプの詳細については[、自動生成されたドキュメント](https://newrelic.github.io/node-newrelic/docs/API.html#recordLogEvent)を参照してください。
+    ロギング フレームワークに対して自動ロギング インストルメンテーションが不十分な場合は、 `recordLogEvent`を使用してログ イベントを記録します。受け入れられるパラメータ タイプの詳細については[、自動生成されたドキュメント](https://newrelic.github.io/node-newrelic/API.html#recordLogEvent)を参照してください。
 
     <CollapserGroup>
       <Collapser

--- a/src/i18n/content/jp/docs/apm/agents/nodejs-agent/attributes/nodejs-agent-attributes.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/nodejs-agent/attributes/nodejs-agent-attributes.mdx
@@ -77,7 +77,7 @@ New Relic [属性](/docs/agents/manage-apm-agents/agent-data/agent-attributes) �
     id="NRaddCustomParameter"
     title="カスタムアトリビュート"
   >
-    Node.js エージェント API への[`addCustomAttribute()`](https://newrelic.github.io/node-newrelic/docs/API.html#addCustomAttribute)呼び出しに追加された属性。この属性のキー名は、メソッドを呼び出すときに指定した内容によって異なります。
+    Node.js エージェント API への[`addCustomAttribute()`](https://newrelic.github.io/node-newrelic/API.html#addCustomAttribute)呼び出しに追加された属性。この属性のキー名は、メソッドを呼び出すときに指定した内容によって異なります。
 
     各デスティネーションのデフォルト設定は
 
@@ -98,7 +98,7 @@ New Relic [属性](/docs/agents/manage-apm-agents/agent-data/agent-attributes) �
     id="NRaddnoticeError"
     title={<><InlineCode>noticeError()</InlineCode> APIコール</>}
   >
-    Node.js エージェント API の[`noticeError()`](https://newrelic.github.io/node-newrelic/docs/API.html#noticeError)呼び出しに追加された属性。この属性のキー名は、メソッドを呼び出すときに指定した内容によって異なります。
+    Node.js エージェント API の[`noticeError()`](https://newrelic.github.io/node-newrelic/API.html#noticeError)呼び出しに追加された属性。この属性のキー名は、メソッドを呼び出すときに指定した内容によって異なります。
 
     各デスティネーションのデフォルト設定は
 
@@ -145,7 +145,7 @@ New Relic [属性](/docs/agents/manage-apm-agents/agent-data/agent-attributes) �
     id="requestparams"
     title="リクエストパラメータ"
   >
-    トランザクションからパラメーターを要求します。Node.js エージェントは、デフォルトではパラメーターをキャプチャしません。`request.parameters.*`エントリを[`attributes.include`](#cfg-attributes-include)に追加すると、すべての GET パラメータをキャプチャできます。または、特定のリクエスト パラメータをリストに追加できます (例: `request.parameters.foo`または`request.parameters.bar` 。POST パラメーターを取得するには、 [`addCustomAttribute()`](https://newrelic.github.io/node-newrelic/docs/API.html#addCustomAttribute) Node.js エージェント API 呼び出しを使用します。
+    トランザクションからパラメーターを要求します。Node.js エージェントは、デフォルトではパラメーターをキャプチャしません。`request.parameters.*`エントリを[`attributes.include`](#cfg-attributes-include)に追加すると、すべての GET パラメータをキャプチャできます。または、特定のリクエスト パラメータをリストに追加できます (例: `request.parameters.foo`または`request.parameters.bar` 。POST パラメーターを取得するには、 [`addCustomAttribute()`](https://newrelic.github.io/node-newrelic/API.html#addCustomAttribute) Node.js エージェント API 呼び出しを使用します。
   </Collapser>
 </CollapserGroup>
 

--- a/src/i18n/content/jp/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
@@ -739,7 +739,7 @@ Node.js agent v2 にアップグレードする前に、主要な変更点につ
         id="newrelic_instrument"
         title={<><InlineCode>newrelic.instrument()</InlineCode><InlineCode>newrelic.instrumentDatastore()</InlineCode><InlineCode>newrelic.instrumentWebframework()</InlineCode><InlineCode>newrelic.instrumentMessages()</InlineCode></>}
       >
-        これらのメソッドを使用して、New Relic Node.js エージェントによってすでにインスツルメンテーションされているモジュールを含む、サードパーティモジュールのカスタムインスツルメンテーションを追加します。詳細は、New Relic の [Node.js instrumentation tutorials on GitHub](https://newrelic.github.io/node-newrelic/docs/tutorial-Instrumentation-Basics.html) をご覧ください。
+        これらのメソッドを使用して、New Relic Node.js エージェントによってすでにインスツルメンテーションされているモジュールを含む、サードパーティモジュールのカスタムインスツルメンテーションを追加します。詳細は、New Relic の [Node.js instrumentation tutorials on GitHub](https://newrelic.github.io/node-newrelic/tutorial-Instrumentation-Basics.html) をご覧ください。
       </Collapser>
 
       <Collapser

--- a/src/i18n/content/jp/docs/logs/logs-context/configure-logs-context-nodejs.mdx
+++ b/src/i18n/content/jp/docs/logs/logs-context/configure-logs-context-nodejs.mdx
@@ -24,7 +24,7 @@ translationType: machine
 * [ピノ](https://github.com/pinojs/pino)7.0.0 以降。
 * [Bunyan](https://www.npmjs.com/package/bunyan) 1.8.12 以降 (エージェント バージョン 9.3.0 以降)
 
-サポートされているフレームワークを使用していない場合は、代わりにエージェントのログ転送 API メソッドを使用して独自のインストルメンテーションを実行できます。詳細については、 [Node.js エージェント API ドキュメント](https://newrelic.github.io/node-newrelic/docs/API.html#recordLogEvent)を参照してください。
+サポートされているフレームワークを使用していない場合は、代わりにエージェントのログ転送 API メソッドを使用して独自のインストルメンテーションを実行できます。詳細については、 [Node.js エージェント API ドキュメント](https://newrelic.github.io/node-newrelic/API.html#recordLogEvent)を参照してください。
 
 <Callout variant="important">
   エージェント リリース 8.16.0 以降では、エージェント構成ファイルでこの機能がデフォルトで有効になっています。
@@ -186,7 +186,7 @@ Node.jsによって監視されるAPMアプリのコンテキストでログを�
 
 1. [NewRelicでのロギングをすでに設定し](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/enable-log-management-new-relic/)ていることを確認してください。これには、アプリケーションログを収集し、NewRelicに転送されるメタデータを拡張するサポートされているログフォワーダーの構成が含まれます。
 2. [](/docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent/)をインストールするか、 [](/docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent/)を最新の Node.js エージェントバージョンに更新し、 [分散型トレーシングを有効にする](/docs/distributed-tracing/enable-configure/quick-start/) 。 [Node.js agent version 6.2.0 or higher](/docs/release-notes/agent-release-notes/nodejs-release-notes/) を使用して、コンテキスト内のログを取得します。
-3. [サポートされているフレームワーク](#automatic)をインストールしてログ データを充実させるか[、エージェントのログ転送 API](https://newrelic.github.io/node-newrelic/docs/API.html#recordLogEvent)を直接使用します。
+3. [サポートされているフレームワーク](#automatic)をインストールしてログ データを充実させるか[、エージェントのログ転送 API](https://newrelic.github.io/node-newrelic/API.html#recordLogEvent)を直接使用します。
 4. エージェント構成で、 `application_config.enabled`を`false`に設定します。 （それ以外の場合、エージェントは自動的にロガーを計測し、これらのエンリッチャーを自分で呼び出しても何も起こりません。）
 5. 適切なログエクステンションを使用して、Node.jsのコンテキストでログを設定します。
 

--- a/src/i18n/content/kr/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -154,7 +154,7 @@ var newrelic = require('newrelic');
     * 자신의 코드를 계측합니다.
     * Node.js 에이전트의 내장 계측을 자신의 계측으로 교체하십시오.
 
-    자세한 내용 [은 Github에서 New Relic의 Node.js 계측 자습서를](https://newrelic.github.io/node-newrelic/docs/tutorial-Instrumentation-Basics.html) 참조하십시오.
+    자세한 내용 [은 Github에서 New Relic의 Node.js 계측 자습서를](https://newrelic.github.io/node-newrelic/tutorial-Instrumentation-Basics.html) 참조하십시오.
   </Collapser>
 
   <Collapser
@@ -167,7 +167,7 @@ var newrelic = require('newrelic');
 
     데이터 저장소 모듈에 대한 계측 콜백을 설정합니다.
 
-    이 메서드는 [데이터 저장소에 특화된 shim](https://newrelic.github.io/node-newrelic/docs/DatastoreShim.html) 을 제공한다는 점을 제외하고는 [`newrelic.instrument()`](#instrument) 과 비슷합니다. 자세한 내용 [은 Github에서 New Relic의 Node.js 데이터 저장소 계측 자습서를](https://newrelic.github.io/node-newrelic/docs/tutorial-Datastore-Simple.html) 참조하십시오.
+    이 메서드는 [데이터 저장소에 특화된 shim](https://newrelic.github.io/node-newrelic/DatastoreShim.html) 을 제공한다는 점을 제외하고는 [`newrelic.instrument()`](#instrument) 과 비슷합니다. 자세한 내용 [은 Github에서 New Relic의 Node.js 데이터 저장소 계측 자습서를](https://newrelic.github.io/node-newrelic/tutorial-Datastore-Simple.html) 참조하십시오.
   </Collapser>
 
   <Collapser
@@ -213,7 +213,7 @@ var newrelic = require('newrelic');
 
     메시지 서비스 클라이언트 모듈에 대한 계측 콜백을 설정합니다.
 
-    이 메서드는 [message-service-specialized shim을](https://newrelic.github.io/node-newrelic/docs/MessageShim.html) 제공한다는 점을 제외하고는 [`newrelic.instrument()`](#instrument) 과 같습니다. 자세한 내용 [은 Github에서 New Relic의 Node.js 메시지 서비스 계측 자습서를](https://newrelic.github.io/node-newrelic/docs/tutorial-Messaging-Simple.html) 참조하십시오.
+    이 메서드는 [message-service-specialized shim을](https://newrelic.github.io/node-newrelic/MessageShim.html) 제공한다는 점을 제외하고는 [`newrelic.instrument()`](#instrument) 과 같습니다. 자세한 내용 [은 Github에서 New Relic의 Node.js 메시지 서비스 계측 자습서를](https://newrelic.github.io/node-newrelic/tutorial-Messaging-Simple.html) 참조하십시오.
   </Collapser>
 
   <Collapser
@@ -226,7 +226,7 @@ var newrelic = require('newrelic');
 
     웹 프레임워크 모듈에 대한 계측 콜백을 설정합니다.
 
-    이 메서드는 [웹 프레임워크에 특화된 shim](https://newrelic.github.io/node-newrelic/docs/WebFrameworkShim.html) 을 제공한다는 점을 제외하고는 [`newrelic.instrument()`](#instrument) 과 비슷합니다. 자세한 내용 [은 Github에서 New Relic의 Node.js 웹 프레임워크 계측 자습서를](https://newrelic.github.io/node-newrelic/docs/tutorial-Webframework-Simple.html) 참조하십시오.
+    이 메서드는 [웹 프레임워크에 특화된 shim](https://newrelic.github.io/node-newrelic/WebFrameworkShim.html) 을 제공한다는 점을 제외하고는 [`newrelic.instrument()`](#instrument) 과 비슷합니다. 자세한 내용 [은 Github에서 New Relic의 Node.js 웹 프레임워크 계측 자습서를](https://newrelic.github.io/node-newrelic/tutorial-Webframework-Simple.html) 참조하십시오.
   </Collapser>
 
   <Collapser
@@ -391,7 +391,7 @@ var newrelic = require('newrelic');
     newrelic.recordLogEvent({message, level})
     ```
 
-    자동 로깅 계측이 로깅 프레임워크에 충분하지 않은 경우 `recordLogEvent` 를 사용하여 로그 이벤트를 기록합니다. 허용되는 매개변수 유형에 대한 자세한 내용은 [자동 생성 문서](https://newrelic.github.io/node-newrelic/docs/API.html#recordLogEvent) 를 참조하세요.
+    자동 로깅 계측이 로깅 프레임워크에 충분하지 않은 경우 `recordLogEvent` 를 사용하여 로그 이벤트를 기록합니다. 허용되는 매개변수 유형에 대한 자세한 내용은 [자동 생성 문서](https://newrelic.github.io/node-newrelic/API.html#recordLogEvent) 를 참조하세요.
 
     <CollapserGroup>
       <Collapser

--- a/src/i18n/content/kr/docs/apm/agents/nodejs-agent/attributes/nodejs-agent-attributes.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/nodejs-agent/attributes/nodejs-agent-attributes.mdx
@@ -77,7 +77,7 @@ New Relic [속성](/docs/agents/manage-apm-agents/agent-data/agent-attributes) �
     id="NRaddCustomParameter"
     title="사용자 정의 속성"
   >
-    Node.js 에이전트 API에 대한 [`addCustomAttribute()`](https://newrelic.github.io/node-newrelic/docs/API.html#addCustomAttribute) 호출에 속성이 추가되었습니다. 이 속성의 키 이름은 메서드를 호출할 때 지정하는 항목에 따라 다릅니다.
+    Node.js 에이전트 API에 대한 [`addCustomAttribute()`](https://newrelic.github.io/node-newrelic/API.html#addCustomAttribute) 호출에 속성이 추가되었습니다. 이 속성의 키 이름은 메서드를 호출할 때 지정하는 항목에 따라 다릅니다.
 
     각 대상에 대한 기본 설정은 다음과 같습니다.
 
@@ -98,7 +98,7 @@ New Relic [속성](/docs/agents/manage-apm-agents/agent-data/agent-attributes) �
     id="NRaddnoticeError"
     title={<><InlineCode>noticeError()</InlineCode> API 호출</>}
   >
-    Node.js 에이전트 API의 [`noticeError()`](https://newrelic.github.io/node-newrelic/docs/API.html#noticeError) 호출에 속성이 추가되었습니다. 이 속성의 키 이름은 메서드를 호출할 때 지정하는 항목에 따라 다릅니다.
+    Node.js 에이전트 API의 [`noticeError()`](https://newrelic.github.io/node-newrelic/API.html#noticeError) 호출에 속성이 추가되었습니다. 이 속성의 키 이름은 메서드를 호출할 때 지정하는 항목에 따라 다릅니다.
 
     각 대상에 대한 기본 설정은 다음과 같습니다.
 
@@ -145,7 +145,7 @@ New Relic [속성](/docs/agents/manage-apm-agents/agent-data/agent-attributes) �
     id="requestparams"
     title="요청 매개변수"
   >
-    트랜잭션에서 매개변수를 요청합니다. Node.js 에이전트는 기본적으로 매개변수를 캡처하지 않습니다. `request.parameters.*` 항목이 [`attributes.include`](#cfg-attributes-include) 에 추가되거나 특정 요청 매개변수(예: `request.parameters.foo` 또는 `request.parameters.bar` )가 목록에 추가되는 경우 모든 GET 매개변수를 캡처할 수 있습니다. POST 매개변수를 캡처하려면 [`addCustomAttribute()`](https://newrelic.github.io/node-newrelic/docs/API.html#addCustomAttribute) Node.js 에이전트 API 호출을 사용하세요.
+    트랜잭션에서 매개변수를 요청합니다. Node.js 에이전트는 기본적으로 매개변수를 캡처하지 않습니다. `request.parameters.*` 항목이 [`attributes.include`](#cfg-attributes-include) 에 추가되거나 특정 요청 매개변수(예: `request.parameters.foo` 또는 `request.parameters.bar` )가 목록에 추가되는 경우 모든 GET 매개변수를 캡처할 수 있습니다. POST 매개변수를 캡처하려면 [`addCustomAttribute()`](https://newrelic.github.io/node-newrelic/API.html#addCustomAttribute) Node.js 에이전트 API 호출을 사용하세요.
   </Collapser>
 </CollapserGroup>
 

--- a/src/i18n/content/kr/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
@@ -739,7 +739,7 @@ Node.js 에이전트 v2로 업그레이드하기 전에 이 정보에서 주요 
         id="newrelic_instrument"
         title={<><InlineCode>newrelic.instrument()</InlineCode><InlineCode>newrelic.instrumentDatastore()</InlineCode><InlineCode>newrelic.instrumentWebframework()</InlineCode><InlineCode>newrelic.instrumentMessages()</InlineCode></>}
       >
-        이 방법을 사용하여 New Relic Node.js 에이전트에 의해 이미 계측된 모듈을 포함하여 타사 모듈에 대한 사용자 지정 계측을 추가하십시오. 자세한 내용 [은 GitHub에서 New Relic의 Node.js 계측 자습서를](https://newrelic.github.io/node-newrelic/docs/tutorial-Instrumentation-Basics.html) 참조하십시오.
+        이 방법을 사용하여 New Relic Node.js 에이전트에 의해 이미 계측된 모듈을 포함하여 타사 모듈에 대한 사용자 지정 계측을 추가하십시오. 자세한 내용 [은 GitHub에서 New Relic의 Node.js 계측 자습서를](https://newrelic.github.io/node-newrelic/tutorial-Instrumentation-Basics.html) 참조하십시오.
       </Collapser>
 
       <Collapser

--- a/src/i18n/content/kr/docs/logs/logs-context/configure-logs-context-nodejs.mdx
+++ b/src/i18n/content/kr/docs/logs/logs-context/configure-logs-context-nodejs.mdx
@@ -24,7 +24,7 @@ Node.js APM 에이전트를 사용하면 컨텍스트에서 **로그를** 가져
 * [피노](https://github.com/pinojs/pino) 7.0.0 이상.
 * [Bunyan](https://www.npmjs.com/package/bunyan) 1.8.12 이상(에이전트 버전 9.3.0부터)
 
-지원되는 프레임워크를 사용하지 않는 경우 에이전트의 로그 전달 API 메서드를 대신 사용하여 자체 계측을 수행할 수 있습니다. 자세한 내용은 [Node.js 에이전트 API 문서](https://newrelic.github.io/node-newrelic/docs/API.html#recordLogEvent) 를 참조하세요.
+지원되는 프레임워크를 사용하지 않는 경우 에이전트의 로그 전달 API 메서드를 대신 사용하여 자체 계측을 수행할 수 있습니다. 자세한 내용은 [Node.js 에이전트 API 문서](https://newrelic.github.io/node-newrelic/API.html#recordLogEvent) 를 참조하세요.
 
 <Callout variant="important">
   에이전트 릴리스 8.16.0 이상에는 기본적으로 에이전트 구성 파일에서 이 기능이 활성화되어 있습니다.
@@ -186,7 +186,7 @@ Node.js에서 모니터링하는 APM 앱에 대한 컨텍스트에서 로그를 
 
 1. [New Relic 에서 이미 로그인을 설정](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/enable-log-management-new-relic/) 했는지 확인하십시오. 여기에는 애플리케이션 로그를 수집하고 New Relic으로 전달되는 메타데이터를 확장하는 지원되는 로그 전달자 구성이 포함됩니다.
 2. 최신 Node.js 에이전트 버전을 [설치](/docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent/) 하거나 [업데이트](/docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent/) 하고 [분산 추적을 활성화합니다](/docs/distributed-tracing/enable-configure/quick-start/) . 컨텍스트의 로그에 [Node.js 에이전트 버전 6.2.0 이상](/docs/release-notes/agent-release-notes/nodejs-release-notes/) 을 사용합니다.
-3. [지원되는 프레임워크](#automatic) 를 설치하여 로그 데이터를 보강하거나 [에이전트의 로그 전달 API를 직접 사용하십시오](https://newrelic.github.io/node-newrelic/docs/API.html#recordLogEvent) .
+3. [지원되는 프레임워크](#automatic) 를 설치하여 로그 데이터를 보강하거나 [에이전트의 로그 전달 API를 직접 사용하십시오](https://newrelic.github.io/node-newrelic/API.html#recordLogEvent) .
 4. 에이전트 구성에서 `application_config.enabled` 을 `false` 로 설정합니다. (그렇지 않으면 에이전트가 자동으로 로거를 계측하고 이러한 농축기를 직접 호출하면 아무 일도 하지 않습니다.)
 5. 적절한 로그 확장을 사용하여 Node.js에 대한 컨텍스트에서 로그를 구성합니다.
 


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
  * Our team had to change how we deploy our auto-generated API docs and URLs no longer work with `/docs` in the href.
