### PR TITLE
fix: Add notice to .NET Agent configuration for app pools setting

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1776,6 +1776,10 @@ Use these options to enable, disable, and configure New Relic features. New Reli
   This is only applicable to a system's [global config file](#config-options-precedence).
 </Callout>
 
+<Callout variant="important">
+  This setting only applies when the IIS hosting model is set to in-process.
+</Callout>
+
 The `applicationPools` element is a child of the `configuration` element. The `applicationPools` element specifies for the profiler exactly which application pools to instrument and uses the same name as the IIS application pool name. This configuration element is useful when you may need to instrument only a small subset of your app pools. For example, a given server might have several hundred application pools, but only a few of those pools need to be instrumented by the .NET agent.
 
 Here is an example of disabling instrumentation for specific application pools:


### PR DESCRIPTION
## Give us some context

Adds notice to .NET Agent configuration for app pools setting that lets folks know that the seeing only works for in-process IIS hosted applications. 

This is related to the following bugs:
https://github.com/newrelic/newrelic-dotnet-agent/issues/1353 or https://issues.newrelic.com/browse/NEWRELIC-6368