### PR TITLE
chore: bump theme to 4.16.0

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -541,6 +541,7 @@ module.exports = {
             process.env.FEEDBACK_RECAPTCHA_TOKEN ||
             '6Lfn8wUiAAAAANBY-ZtKg4V9b4rdGZtJuAng62jo',
         },
+        newRelicRequestingServicesHeader: 'docs-website',
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "6.13.15",
+    "@newrelic/gatsby-theme-newrelic": "6.14.0",
     "@splitsoftware/splitio-react": "^1.2.4",
     "cockatiel": "^3.0.0-beta.0",
     "common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2609,10 +2609,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@6.13.15":
-  version "6.13.15"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.13.15.tgz#e77fd9ab271d14bd83f41785e883f347caec030e"
-  integrity sha512-Rf/KsYF0qhfK11uj7MfhwMptHXgdutof4dwoX1fxH17zMIOevd34XonW+9nDHBGie9G2CIr/waey86odBU0xwg==
+"@newrelic/gatsby-theme-newrelic@6.14.0":
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.14.0.tgz#ed35a74815bbb26c343c1ba4e2359a7781de5b19"
+  integrity sha512-WErcoRPotC1AYtjUHOEhd5knoZk0kHogzFA8UipHypmv9ktearUJKCTl0y5prJSI6CKTfi3Ox/zHc8lNJis0WQ==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
bumps theme to 4.16.0 and adds `newRelicRequestingServicesHeader` theme option so Tessen events will include a `loggedIn` field