### PR TITLE
fix(Style Guide): Fixed a URL

### DIFF
--- a/src/content/docs/style-guide/writing-docs/processes-procedures/rename-or-redirect-document.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/rename-or-redirect-document.mdx
@@ -8,6 +8,7 @@ redirects:
   - /docs/new-relic-only/advanced-style-guide/processes-procedures/renaming-redirecting-document
   - /docs/new-relic-only/advanced-style-guide/processes-procedures/rename-redirect-document
   - /docs/style-guide/processes-procedures/rename-or-redirect-document/
+  - /docs/style-guide/rename-or-redirect-document
 ---
 
 This document describes how to change the title of a document and how to create, edit, and delete redirects. Procedures are the same for both standard docs ("basic pages") and release notes.


### PR DESCRIPTION
Added this URL that doesn't work (https://docs.newrelic.com/docs/style-guide/rename-or-redirect-document/) to the [Rename or redirect a document](https://docs.newrelic.com/docs/style-guide/writing-docs/processes-procedures/rename-or-redirect-document/) page.