### PR TITLE
feat(logging): Add info about restricted attribute name appId behaviour

### DIFF
--- a/src/content/docs/logs/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-api/introduction-log-api.mdx
@@ -475,7 +475,7 @@ Restrictions on logs sent to the Log API:
 Some specific attributes have additional restrictions:
 
 * `accountId`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
-* `appId`: Must be an integer. If you set a string or other type, the data is ingested but becomes unqueryable.
+* `appId`: Must be an integer. When using other data type rather than integer, the data will be ingested but becomes unqueryable.
 * `entity.guid`, `entity.name`, and `entity.type`: These attributes are used internally to identify entities. Any values submitted with these keys in the attributes section of a metric data point may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities. For more information please refer to [Entity synthesis](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#entity-synthesis).
 * `eventType`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
 * `timestamp`: Must be a Unix epoch timestamp. You can define timestamps either in seconds or in milliseconds.

--- a/src/content/docs/logs/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-api/introduction-log-api.mdx
@@ -475,7 +475,7 @@ Restrictions on logs sent to the Log API:
 Some specific attributes have additional restrictions:
 
 * `accountId`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
-* `appId`: Must be an integer. In case you set a string or other type, it would be ingested but the data will not be queryable.
+* `appId`: Must be an integer. If you set a string or other type, the data is ingested but becomes unqueryable.
 * `entity.guid`, `entity.name`, and `entity.type`: These attributes are used internally to identify entities. Any values submitted with these keys in the attributes section of a metric data point may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities. For more information please refer to [Entity synthesis](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#entity-synthesis).
 * `eventType`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
 * `timestamp`: Must be a Unix epoch timestamp. You can define timestamps either in seconds or in milliseconds.

--- a/src/content/docs/logs/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-api/introduction-log-api.mdx
@@ -475,6 +475,7 @@ Restrictions on logs sent to the Log API:
 Some specific attributes have additional restrictions:
 
 * `accountId`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
+* `appId`: Must be an integer. In case you set a string or other type, it would be ingested but the data will not be queryable.
 * `entity.guid`, `entity.name`, and `entity.type`: These attributes are used internally to identify entities. Any values submitted with these keys in the attributes section of a metric data point may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities. For more information please refer to [Entity synthesis](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#entity-synthesis).
 * `eventType`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
 * `timestamp`: Must be a Unix epoch timestamp. You can define timestamps either in seconds or in milliseconds.

--- a/src/content/docs/logs/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-api/introduction-log-api.mdx
@@ -475,7 +475,7 @@ Restrictions on logs sent to the Log API:
 Some specific attributes have additional restrictions:
 
 * `accountId`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
-* `appId`: Must be an integer. When using a non-integer data type other, the data will be ingested but becomes unqueryable.
+* `appId`: Must be an integer. When using a non-integer data type, the data will be ingested but becomes unqueryable.
 * `entity.guid`, `entity.name`, and `entity.type`: These attributes are used internally to identify entities. Any values submitted with these keys in the attributes section of a metric data point may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities. For more information please refer to [Entity synthesis](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#entity-synthesis).
 * `eventType`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
 * `timestamp`: Must be a Unix epoch timestamp. You can define timestamps either in seconds or in milliseconds.

--- a/src/content/docs/logs/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-api/introduction-log-api.mdx
@@ -475,7 +475,7 @@ Restrictions on logs sent to the Log API:
 Some specific attributes have additional restrictions:
 
 * `accountId`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
-* `appId`: Must be an integer. When using other data type rather than integer, the data will be ingested but becomes unqueryable.
+* `appId`: Must be an integer. When using a non-integer data type other, the data will be ingested but becomes unqueryable.
 * `entity.guid`, `entity.name`, and `entity.type`: These attributes are used internally to identify entities. Any values submitted with these keys in the attributes section of a metric data point may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities. For more information please refer to [Entity synthesis](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#entity-synthesis).
 * `eventType`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
 * `timestamp`: Must be a Unix epoch timestamp. You can define timestamps either in seconds or in milliseconds.


### PR DESCRIPTION
* What problem do this PR solve?
There are some restrictions to query `appId` attribute on logs, so this PR adds a line of info under attributes that has a restriction.