### PR TITLE
fix(OTel): remove port 443 example from HTTP

### DIFF
--- a/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
+++ b/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
@@ -469,8 +469,6 @@ To ensure FedRAMP compliance when using the OpenTelemetry API, only send data to
           </td>
           <td>
             `https://gov-otlp.nr-data.net:4318`
-
-            `https://gov-otlp.nr-data.net:443`
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

## Give us some context

* What problems does this PR solve?
  * This removes an example URL that won't work for FedRAMP customers. 
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  * I overlooked this change from https://github.com/newrelic/docs-website/pull/10975 and am fixing it here. 
* If your issue relates to an existing GitHub issue, please link to it.