### PR TITLE
fix: change `eventType()` to `entityType()`

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-baseline-ingest-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-baseline-ingest-guide.mdx
@@ -616,13 +616,13 @@ FROM ProcessSample SELECT rate(bytecountestimate()/10e8, 30 day) AS 'GB Ingested
 
       <Collapser
         id="entitytype-examples"
-        title="entityType()"
+        title="eventType()"
       >
 <Callout
   variant="important"
   title="When to use"
 >
-  Use the `entityType()` operator when you need to have event level granularity in your query and when you are unfamiliar with what custom events are present in your account.
+  Use the `eventType()` operator when you need to have event level granularity in your query and when you are unfamiliar with what custom events are present in your account.
 </Callout>
 
 Often times we'll use a query that selects multiple events. This one of the primary means we have to determine how much data a given agent or integration is sending us.
@@ -657,9 +657,9 @@ It's powerful in itself, but it'll only return a single aggregate value:
 42.341 Gigabytes
 ```
 
-When we need to drill deeper to know how much data specific event is consuming, we can use `entityType()` in a facet clause to get that result.
+When we need to drill deeper to know how much data specific event is consuming, we can use `eventType()` in a facet clause to get that result.
 
-Adding the clause `FACET entityType()` to the previous query gives us:
+Adding the clause `FACET eventType()` to the previous query gives us:
 
 <img
     src={omaoedgEntityTypeExample}


### PR DESCRIPTION
Seems like `entityType` no longer works but `eventType()` does.

working example:

```
FROM Mobile, MobileRequest, MobileRequestError, MobileSession, MobileHandleException, MobileCrash select rate(bytecountestimate() / 10e8, 1 day) as 'GB Ingest' facet appName, eventType() limit 100 TIMESERIES since 1 day ago
```