### PR TITLE
fix: updated remaining links that pointed to github.io/node-newrelic.…

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api.mdx
@@ -27,7 +27,7 @@ Other resources:
 To use the Node.js agent API, make sure you have the [latest Node.js agent release](/docs/release-notes/agent-release-notes/nodejs-release-notes). In addition, see:
 
 * [Node.js agent API requirements](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api)
-* [Getting started procedures on GitHub](http://newrelic.github.io/node-newrelic/index.html#getting-started)
+* [Getting started procedures](http://newrelic.github.io/node-newrelic/index.html#getting-started) on GitHub
 
 ## Instrument missing sections of your code with transactions [#creating-transactions]
 
@@ -68,7 +68,7 @@ Use these methods when New Relic is not instrumenting a particular part of your 
         Use either of these options:
 
         * Return a promise from the callback handed to [`newrelic.startWebTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#startWebTransaction).
-        * Call `end` on a [handle](http://newrelic.github.io/node-newrelic/API.html#getTransaction) returned from [`newrelic.getTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#getTransaction).
+        * Call `end` on a [handle](http://newrelic.github.io/node-newrelic/API.html#getTransaction) (GitHub) returned from [`newrelic.getTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#getTransaction).
       </td>
     </tr>
 
@@ -81,7 +81,7 @@ Use these methods when New Relic is not instrumenting a particular part of your 
         Ignore the transaction using any of these options:
 
         * See [Rules for ignoring requests](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#ignoring)`.`
-        * Call `ignore()` on a [handle](http://newrelic.github.io/node-newrelic/TransactionHandle.html) returned from [`newrelic.getTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#getTransaction).
+        * Call `ignore()` on a [handle](http://newrelic.github.io/node-newrelic/TransactionHandle.html) (GitHub) returned from [`newrelic.getTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#getTransaction).
       </td>
     </tr>
   </tbody>
@@ -308,7 +308,7 @@ Once the [request naming API](/docs/agents/nodejs-agent/supported-features/nodej
         * [Custom instrumentation API](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#custom-instrumentation-api)
         * [Message queues](/docs/agents/nodejs-agent/supported-features/message-queues)
 
-          Also see the tutorials on GitHub for [datastore shims](http://newrelic.github.io/node-newrelic/DatastoreShim.html) and [message shims](http://newrelic.github.io/node-newrelic/MessageShim.html).
+          Also see the [datastore](http://newrelic.github.io/node-newrelic/DatastoreShim.html) and [message shim](http://newrelic.github.io/node-newrelic/MessageShim.html) tutorials on GitHub for .
       </td>
     </tr>
 
@@ -412,6 +412,6 @@ You can also control the browser agent via APM agent API calls. For more informa
 
 ## Extend custom instrumentation [#custom-instrumentation]
 
-The `newrelic.instrument()` provides additional flexibility for custom instrumentation. For more information, including tutorials and examples, see the [shims documentation on GitHub](http://newrelic.github.io/node-newrelic/Shim.html).
+The `newrelic.instrument()` provides additional flexibility for custom instrumentation. For more information, including tutorials and examples, see the [shim documentation](http://newrelic.github.io/node-newrelic/Shim.html)  on GitHub.
 
 To add custom instrumentation in ES module applications, please refer to our [ES module](/docs/apm/agents/nodejs-agent/installation-configuration/es-modules) documentation or [example application](https://github.com/newrelic/newrelic-node-examples/tree/main/esm-app) in GitHub.

--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api.mdx
@@ -18,7 +18,7 @@ You can also use the API for [custom instrumentation](/docs/agents/nodejs-agent/
 
 Other resources:
 
-* The [Node.js agent API documentation on GitHub](http://newrelic.github.io/node-newrelic/docs/) has more detail and practical tutorials.
+* The [Node.js agent API documentation on GitHub](http://newrelic.github.io/node-newrelic/) has more detail and practical tutorials.
 * You can also adjust the Node.js agent's default behavior with [configuration settings](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration).
 * To see all available New Relic APIs, see [Intro to APIs](/docs/apis/getting-started/introduction-new-relic-apis).
 
@@ -27,7 +27,7 @@ Other resources:
 To use the Node.js agent API, make sure you have the [latest Node.js agent release](/docs/release-notes/agent-release-notes/nodejs-release-notes). In addition, see:
 
 * [Node.js agent API requirements](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api)
-* [Getting started procedures on GitHub](http://newrelic.github.io/node-newrelic/docs/index.html#getting-started)
+* [Getting started procedures on GitHub](http://newrelic.github.io/node-newrelic/index.html#getting-started)
 
 ## Instrument missing sections of your code with transactions [#creating-transactions]
 
@@ -68,7 +68,7 @@ Use these methods when New Relic is not instrumenting a particular part of your 
         Use either of these options:
 
         * Return a promise from the callback handed to [`newrelic.startWebTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#startWebTransaction).
-        * Call `end` on a [handle](http://newrelic.github.io/node-newrelic/docs/API.html#getTransaction) returned from [`newrelic.getTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#getTransaction).
+        * Call `end` on a [handle](http://newrelic.github.io/node-newrelic/API.html#getTransaction) returned from [`newrelic.getTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#getTransaction).
       </td>
     </tr>
 
@@ -81,7 +81,7 @@ Use these methods when New Relic is not instrumenting a particular part of your 
         Ignore the transaction using any of these options:
 
         * See [Rules for ignoring requests](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#ignoring)`.`
-        * Call `ignore()` on a [handle](http://newrelic.github.io/node-newrelic/docs/TransactionHandle.html) returned from [`newrelic.getTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#getTransaction).
+        * Call `ignore()` on a [handle](http://newrelic.github.io/node-newrelic/TransactionHandle.html) returned from [`newrelic.getTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#getTransaction).
       </td>
     </tr>
   </tbody>
@@ -119,7 +119,7 @@ Use this method when you want to instrument a method within an existing transact
   </tbody>
 </table>
 
-For more information about timing, see the [instrumentation tutorial on GitHub](http://newrelic.github.io/node-newrelic/docs/tutorial-Instrumentation-Basics.html).
+For more information about timing, see the [instrumentation tutorial on GitHub](http://newrelic.github.io/node-newrelic/tutorial-Instrumentation-Basics.html).
 
 ## Enhance the metadata of a transaction [#metadata]
 
@@ -273,7 +273,7 @@ For [supported frameworks](/docs/agents/nodejs-agent/getting-started/compatibili
       </td>
 
       <td>
-        A common issue is the loss of transaction state while using uninstrumented libraries. For more information, see the [transaction preservation tutorial on GitHub](http://newrelic.github.io/node-newrelic/docs/tutorial-Context-Preservation.html).
+        A common issue is the loss of transaction state while using uninstrumented libraries. For more information, see the [transaction preservation tutorial on GitHub](http://newrelic.github.io/node-newrelic/tutorial-Context-Preservation.html).
       </td>
     </tr>
   </tbody>
@@ -308,7 +308,7 @@ Once the [request naming API](/docs/agents/nodejs-agent/supported-features/nodej
         * [Custom instrumentation API](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#custom-instrumentation-api)
         * [Message queues](/docs/agents/nodejs-agent/supported-features/message-queues)
 
-          Also see the tutorials on GitHub for [datastore shims](http://newrelic.github.io/node-newrelic/docs/DatastoreShim.html) and [message shims](http://newrelic.github.io/node-newrelic/docs/MessageShim.html).
+          Also see the tutorials on GitHub for [datastore shims](http://newrelic.github.io/node-newrelic/DatastoreShim.html) and [message shims](http://newrelic.github.io/node-newrelic/MessageShim.html).
       </td>
     </tr>
 
@@ -412,6 +412,6 @@ You can also control the browser agent via APM agent API calls. For more informa
 
 ## Extend custom instrumentation [#custom-instrumentation]
 
-The `newrelic.instrument()` provides additional flexibility for custom instrumentation. For more information, including tutorials and examples, see the [shims documentation on GitHub](http://newrelic.github.io/node-newrelic/docs/Shim.html).
+The `newrelic.instrument()` provides additional flexibility for custom instrumentation. For more information, including tutorials and examples, see the [shims documentation on GitHub](http://newrelic.github.io/node-newrelic/Shim.html).
 
 To add custom instrumentation in ES module applications, please refer to our [ES module](/docs/apm/agents/nodejs-agent/installation-configuration/es-modules) documentation or [example application](https://github.com/newrelic/newrelic-node-examples/tree/main/esm-app) in GitHub.

--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api.mdx
@@ -27,7 +27,7 @@ Other resources:
 To use the Node.js agent API, make sure you have the [latest Node.js agent release](/docs/release-notes/agent-release-notes/nodejs-release-notes). In addition, see:
 
 * [Node.js agent API requirements](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api)
-* [Getting started procedures](http://newrelic.github.io/node-newrelic/index.html#getting-started) on GitHub
+* [Getting started procedures](http://newrelic.github.io/node-newrelic/index.html) on GitHub
 
 ## Instrument missing sections of your code with transactions [#creating-transactions]
 

--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -20,7 +20,7 @@ New Relic offers several tools to help obtain the information needed to provide 
 
 The number of names that New Relic tracks needs to be small enough so that the user experience is robust. It also needs to be large enough to provide the right amount of information (without overwhelming you with data) so that you can identify problem spots in your applications more easily.
 
-For more information, see the [Node.js agent configuration](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration) documentation and the [Node.js agent API documentation on Github](https://newrelic.github.io/node-newrelic/docs).
+For more information, see the [Node.js agent configuration](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration) documentation and the [Node.js agent API documentation on Github](https://newrelic.github.io/node-newrelic/).
 
 ## Request names
 

--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation.mdx
@@ -27,15 +27,15 @@ The custom instrumentation methods in this document are available as of [Node.js
 
 ## Instrument unsupported web frameworks [#web-framework]
 
-Beginning with Node.js agent version 2.0.0, New Relic provides an API to expand instrumentation for additional web frameworks. For more information, including a tutorial, see the documentation for [Node.js web framework instrumentation on GitHub](http://newrelic.github.io/node-newrelic/docs/tutorial-Webframework-Simple.html).
+Beginning with Node.js agent version 2.0.0, New Relic provides an API to expand instrumentation for additional web frameworks. For more information, including a tutorial, see the documentation for [Node.js web framework instrumentation on GitHub](http://newrelic.github.io/node-newrelic/tutorial-Webframework-Simple.html).
 
 ## Instrument unsupported message service clients [#message-client]
 
-Beginning with Node.js agent version 2.0.0, New Relic provides an API to expand instrumentation for additional message service libraries. For more information, including a tutorial, see the documentation for [Node.js message service client instrumentation on GitHub](http://newrelic.github.io/node-newrelic/docs/tutorial-Messaging-Simple.html).
+Beginning with Node.js agent version 2.0.0, New Relic provides an API to expand instrumentation for additional message service libraries. For more information, including a tutorial, see the documentation for [Node.js message service client instrumentation on GitHub](http://newrelic.github.io/node-newrelic/tutorial-Messaging-Simple.html).
 
 ## Instrument unsupported datastores [#datastore]
 
-Beginning with Node.js agent version 2.0.0, New Relic provides an API to expand instrumentation for additional datastore libraries. For more information, including a tutorial, see the documentation for [Node.js datastore instrumentation on GitHub](http://newrelic.github.io/node-newrelic/docs/tutorial-Datastore-Simple.html).
+Beginning with Node.js agent version 2.0.0, New Relic provides an API to expand instrumentation for additional datastore libraries. For more information, including a tutorial, see the documentation for [Node.js datastore instrumentation on GitHub](http://newrelic.github.io/node-newrelic/tutorial-Datastore-Simple.html).
 
 ## Instrument web transactions [#web-txn]
 
@@ -132,7 +132,7 @@ In order to create custom [web transactions](/docs/apm/transactions/intro-transa
     });
     ```
 
-    This method only gives basic timing data for the transaction created. To create more intricate timing data and transaction naming for a particular framework, see the [Node.js API docs](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#instrumentWebframework) and the [related tutorial on GitHub](http://newrelic.github.io/node-newrelic/docs/tutorial-Webframework-Simple.html).
+    This method only gives basic timing data for the transaction created. To create more intricate timing data and transaction naming for a particular framework, see the [Node.js API docs](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#instrumentWebframework) and the [related tutorial on GitHub](http://newrelic.github.io/node-newrelic/tutorial-Webframework-Simple.html).
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation.mdx
@@ -27,15 +27,15 @@ The custom instrumentation methods in this document are available as of [Node.js
 
 ## Instrument unsupported web frameworks [#web-framework]
 
-Beginning with Node.js agent version 2.0.0, New Relic provides an API to expand instrumentation for additional web frameworks. For more information, including a tutorial, see the documentation for [Node.js web framework instrumentation on GitHub](http://newrelic.github.io/node-newrelic/tutorial-Webframework-Simple.html).
+Beginning with Node.js agent version 2.0.0, New Relic provides an API to expand instrumentation for additional web frameworks. For more information, including a tutorial, see the documentation for the [Node.js web framework instrumentation](http://newrelic.github.io/node-newrelic/tutorial-Webframework-Simple.html) on GitHub.
 
 ## Instrument unsupported message service clients [#message-client]
 
-Beginning with Node.js agent version 2.0.0, New Relic provides an API to expand instrumentation for additional message service libraries. For more information, including a tutorial, see the documentation for [Node.js message service client instrumentation on GitHub](http://newrelic.github.io/node-newrelic/tutorial-Messaging-Simple.html).
+Beginning with Node.js agent version 2.0.0, New Relic provides an API to expand instrumentation for additional message service libraries. For more information, including a tutorial, see the documentation for the [Node.js message service client instrumentation](http://newrelic.github.io/node-newrelic/tutorial-Messaging-Simple.html) on GitHub.
 
 ## Instrument unsupported datastores [#datastore]
 
-Beginning with Node.js agent version 2.0.0, New Relic provides an API to expand instrumentation for additional datastore libraries. For more information, including a tutorial, see the documentation for [Node.js datastore instrumentation on GitHub](http://newrelic.github.io/node-newrelic/tutorial-Datastore-Simple.html).
+Beginning with Node.js agent version 2.0.0, New Relic provides an API to expand instrumentation for additional datastore libraries. For more information, including a tutorial, see the documentation for the [Node.js datastore instrumentation](http://newrelic.github.io/node-newrelic/tutorial-Datastore-Simple.html) on GitHub.
 
 ## Instrument web transactions [#web-txn]
 
@@ -132,7 +132,7 @@ In order to create custom [web transactions](/docs/apm/transactions/intro-transa
     });
     ```
 
-    This method only gives basic timing data for the transaction created. To create more intricate timing data and transaction naming for a particular framework, see the [Node.js API docs](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#instrumentWebframework) and the [related tutorial on GitHub](http://newrelic.github.io/node-newrelic/tutorial-Webframework-Simple.html).
+    This method only gives basic timing data for the transaction created. To create more intricate timing data and transaction naming for a particular framework, see the [Node.js API docs](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#instrumentWebframework) and the [related WebFramework tutorial](http://newrelic.github.io/node-newrelic/tutorial-Webframework-Simple.html) on GitHub.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-200.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-200.mdx
@@ -40,7 +40,7 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
   * `newrelic.instrumentDatastore()`/`DatastoreShim`: This method is good for instrumenting datastore modules such as `mongodb`, `mysql`, or `pg`.
   * `newrelic.instrumentWebframework()`/`WebFrameworkShim`: This method is used for instrumenting web frameworks like `restify` or `express`.
 
-  Documentation and tutorials for the new API can be found on our GitHub documentation page: [http://newrelic.github.io/node-newrelic/docs/](http://newrelic.github.io/node-newrelic/docs/)
+  Documentation and tutorials for the new API can be found on our GitHub documentation page: [http://newrelic.github.io/node-newrelic/](http://newrelic.github.io/node-newrelic/)
 
 ### Improvements
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-260-beta.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-260-beta.mdx
@@ -26,7 +26,7 @@ downloadLink: 'https://www.npmjs.com/package/@newrelic/beta-agent'
 
   These instrumentations were rewritten using the new `WebFrameworkShim`. As a consequence of this rewrite, all our instrumentations now have feature parity, meaning every instrumentation will create Middleware metrics for your server.
 
-  Tutorials on using the new instrumentation shim can be found on our API docs: [http://newrelic.github.io/node-newrelic/docs/](http://newrelic.github.io/node-newrelic/docs/).
+  Tutorials on using the new instrumentation shim can be found on our API docs: [http://newrelic.github.io/node-newrelic/](http://newrelic.github.io/node-newrelic/).
 * Removed `express_segments` feature flag.
 
   This configuration previously controlled the creation of middleware metrics in our Express instrumentation. With the move to the WebFrameworkShim this was dropped.

--- a/src/i18n/content/jp/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api.mdx
@@ -17,9 +17,9 @@ translationType: machine
 
 その他のリソース
 
-* GitHubで公開されている [Node.js agent API documentationには、より詳細な内容と実践的なチュートリアルが掲載されています。](http://newrelic.github.io/node-newrelic/docs/)
-* [](http://newrelic.github.io/node-newrelic/docs/)
-* [また、Node.jsエージェントのデフォルトの動作は、 ](http://newrelic.github.io/node-newrelic/docs/)[の設定で調整することができます。](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration).
+* GitHubで公開されている [Node.js agent API documentationには、より詳細な内容と実践的なチュートリアルが掲載されています。](http://newrelic.github.io/node-newrelic/)
+* [](http://newrelic.github.io/node-newrelic/)
+* [また、Node.jsエージェントのデフォルトの動作は、 ](http://newrelic.github.io/node-newrelic/)[の設定で調整することができます。](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration).
 * 利用可能なすべての New Relic API を参照するには、 [Intro to APIs](/docs/apis/getting-started/introduction-new-relic-apis) を参照してください。
 
 ## 要件
@@ -30,7 +30,7 @@ Node.jsエージェントAPIを使用するには、Node.jsエージェントの
 
 * [](/docs/release-notes/agent-release-notes/nodejs-release-notes)
 * [](/docs/release-notes/agent-release-notes/nodejs-release-notes)[Node.jsエージェントAPIの要件](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api)
-* [GitHubでのスタートアップ手順](http://newrelic.github.io/node-newrelic/docs/index.html#getting-started)
+* [GitHubでのスタートアップ手順](http://newrelic.github.io/node-newrelic/index.html#getting-started)
 
 ## コードの欠落しているセクションをトランザクションで計測する [#creating-transactions]
 
@@ -71,7 +71,7 @@ New Relicがコードの特定の部分をまったくインストルメント�
         次のいずれかのオプションを使用します：
 
         * [`newrelic.startWebTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#startWebTransaction)に渡されたコールバックから promise を返します。
-        * [`newrelic.getTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#getTransaction)から返された[ハンドル](http://newrelic.github.io/node-newrelic/docs/API.html#getTransaction)で`end`を呼び出します。
+        * [`newrelic.getTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#getTransaction)から返された[ハンドル](http://newrelic.github.io/node-newrelic/API.html#getTransaction)で`end`を呼び出します。
       </td>
     </tr>
 
@@ -84,7 +84,7 @@ New Relicがコードの特定の部分をまったくインストルメント�
         以下のいずれかの方法でトランザクションを無視します。
 
         * [リクエストを無視するためのルールを](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#ignoring)参照してください`.`
-        * [`newrelic.getTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#getTransaction)から返された[ハンドル](http://newrelic.github.io/node-newrelic/docs/TransactionHandle.html)で`ignore()`を呼び出します。
+        * [`newrelic.getTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#getTransaction)から返された[ハンドル](http://newrelic.github.io/node-newrelic/TransactionHandle.html)で`ignore()`を呼び出します。
       </td>
     </tr>
   </tbody>
@@ -122,14 +122,14 @@ New Relicがコードの特定の部分をまったくインストルメント�
   </tbody>
 </table>
 
-タイミングの詳細については、GitHub の [instrumentation tutorial を参照してください。](http://newrelic.github.io/node-newrelic/docs/tutorial-Instrumentation-Basics.html)
+タイミングの詳細については、GitHub の [instrumentation tutorial を参照してください。](http://newrelic.github.io/node-newrelic/tutorial-Instrumentation-Basics.html)
 
-## [トランザクションのメタデータを強化する [#metadata]](http://newrelic.github.io/node-newrelic/docs/tutorial-Instrumentation-Basics.html)
+## [トランザクションのメタデータを強化する [#metadata]](http://newrelic.github.io/node-newrelic/tutorial-Instrumentation-Basics.html)
 
-[対象となるコードがNew Relicに表示されていても、そのメソッドの詳細が役に立たないことがあります。例えば、以下のようなものです。](http://newrelic.github.io/node-newrelic/docs/tutorial-Instrumentation-Basics.html)
+[対象となるコードがNew Relicに表示されていても、そのメソッドの詳細が役に立たないことがあります。例えば、以下のようなものです。](http://newrelic.github.io/node-newrelic/tutorial-Instrumentation-Basics.html)
 
-* [](http://newrelic.github.io/node-newrelic/docs/tutorial-Instrumentation-Basics.html)
-* [デフォルト名が有用でない。（](http://newrelic.github.io/node-newrelic/docs/tutorial-Instrumentation-Basics.html)[メトリクスのグループ化問題](/docs/agents/manage-apm-agents/troubleshooting/metric-grouping-issues#video)の原因になっている場合など）。
+* [](http://newrelic.github.io/node-newrelic/tutorial-Instrumentation-Basics.html)
+* [デフォルト名が有用でない。（](http://newrelic.github.io/node-newrelic/tutorial-Instrumentation-Basics.html)[メトリクスのグループ化問題](/docs/agents/manage-apm-agents/troubleshooting/metric-grouping-issues#video)の原因になっている場合など）。
 * トランザクションに [カスタム属性](/docs/agents/manage-apm-agents/agent-data/collect-custom-attributes) を追加して、フィルタリングできるようにしたい。
 
 New Relicがすでに表示されているトランザクションを計測する方法を変更する場合は、次のメソッドを使用します。
@@ -277,9 +277,9 @@ New Relic によって計測されていないロギング メカニズムを使
       </td>
 
       <td>
-        一般的な問題は、インストルメントされていないライブラリを使用する際にトランザクションの状態が失われることです。詳しくは、GitHub の [transaction preservation tutorial をご覧ください。](http://newrelic.github.io/node-newrelic/docs/tutorial-Context-Preservation.html)
+        一般的な問題は、インストルメントされていないライブラリを使用する際にトランザクションの状態が失われることです。詳しくは、GitHub の [transaction preservation tutorial をご覧ください。](http://newrelic.github.io/node-newrelic/tutorial-Context-Preservation.html)
 
-        [](http://newrelic.github.io/node-newrelic/docs/tutorial-Context-Preservation.html)
+        [](http://newrelic.github.io/node-newrelic/tutorial-Context-Preservation.html)
       </td>
     </tr>
   </tbody>
@@ -315,7 +315,7 @@ New Relic によって計測されていないロギング メカニズムを使
 
         * [メッセージキュー](/docs/agents/nodejs-agent/supported-features/message-queues)
 
-          また、GitHubのチュートリアルで、 [データストアシム](http://newrelic.github.io/node-newrelic/docs/DatastoreShim.html) と [メッセージシム](http://newrelic.github.io/node-newrelic/docs/MessageShim.html) をご覧ください。
+          また、GitHubのチュートリアルで、 [データストアシム](http://newrelic.github.io/node-newrelic/DatastoreShim.html) と [メッセージシム](http://newrelic.github.io/node-newrelic/MessageShim.html) をご覧ください。
       </td>
     </tr>
 
@@ -419,6 +419,6 @@ New Relicには、任意のカスタムデータを記録するためのさま�
 
 ## カスタムインストルメントの拡張 [#custom-instrumentation]
 
-`newrelic.instrument()`は、カスタム インストルメンテーションにさらなる柔軟性を提供します。チュートリアルや例などの詳細については、 [GitHub の shims ドキュメントを](http://newrelic.github.io/node-newrelic/docs/Shim.html)参照してください。
+`newrelic.instrument()`は、カスタム インストルメンテーションにさらなる柔軟性を提供します。チュートリアルや例などの詳細については、 [GitHub の shims ドキュメントを](http://newrelic.github.io/node-newrelic/Shim.html)参照してください。
 
 ES モジュール アプリケーションにカスタム インストルメンテーションを追加するには、 [ES モジュール](/docs/apm/agents/nodejs-agent/installation-configuration/es-modules)のドキュメントまたは GitHub の[サンプル アプリケーション](https://github.com/newrelic/newrelic-node-examples/tree/main/esm-app)を参照してください。

--- a/src/i18n/content/jp/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -16,7 +16,7 @@ New Relic は、Node.js アプリケーションに関する有用なメトリ�
 
 New Relic が追跡する名前の数は、ユーザー・エクスペリエンスが堅牢であるように十分小さくする必要があります。また、アプリケーションの問題点をより簡単に特定できるように、（データに圧倒されることなく）適切な量の情報を提供するのに十分な規模である必要があります。
 
-詳しくは、Github [Node.jsエージェントの設定](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration) ドキュメントと、Github [Node.jsエージェントのAPIドキュメント](https://newrelic.github.io/node-newrelic/docs) をご覧ください。
+詳しくは、Github [Node.jsエージェントの設定](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration) ドキュメントと、Github [Node.jsエージェントのAPIドキュメント](https://newrelic.github.io/node-newrelic/) をご覧ください。
 
 ## リクエスト名
 

--- a/src/i18n/content/jp/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation.mdx
@@ -22,15 +22,15 @@ Node.jsエージェントのカスタムインストゥルメンテーションA
 
 ## 未対応のWebフレームワークをインストゥルメントする [#web-framework]
 
-Node.jsエージェントバージョン2.0.0より、New Relicは追加のウェブフレームワークに対するインストゥルメンテーション拡張のためにAPIを提供しています。チュートリアルを含めた詳細に関しては、[GitHubにおけるNode.jsのWebフレームワークのインストゥルメンテーション](http://newrelic.github.io/node-newrelic/docs/tutorial-Webframework-Simple.html)ドキュメントを参照してください。
+Node.jsエージェントバージョン2.0.0より、New Relicは追加のウェブフレームワークに対するインストゥルメンテーション拡張のためにAPIを提供しています。チュートリアルを含めた詳細に関しては、[GitHubにおけるNode.jsのWebフレームワークのインストゥルメンテーション](http://newrelic.github.io/node-newrelic/tutorial-Webframework-Simple.html)ドキュメントを参照してください。
 
 ## 未対応のメッセージサービスクライアントをインストゥルメントする [#message-client]
 
-Node.jsエージェントバージョン2.0.0より、New Relicは追加のメッセージサービスライブラリに対するインストゥルメンテーション拡張のためにAPIを提供しています。チュートリアルを含めた詳細に関しては、[GitHubにおけるNode.jsのメッセージサービスクライアントのインストゥルメンテーション](http://newrelic.github.io/node-newrelic/docs/tutorial-Messaging-Simple.html)ドキュメントを参照してください。
+Node.jsエージェントバージョン2.0.0より、New Relicは追加のメッセージサービスライブラリに対するインストゥルメンテーション拡張のためにAPIを提供しています。チュートリアルを含めた詳細に関しては、[GitHubにおけるNode.jsのメッセージサービスクライアントのインストゥルメンテーション](http://newrelic.github.io/node-newrelic/tutorial-Messaging-Simple.html)ドキュメントを参照してください。
 
 ## 未対応のデータストアをインストゥルメントする [#datastore]
 
-Node.jsエージェントバージョン2.0.0より、New Relicは追加のデータストアライブラリに対するインストゥルメンテーションを拡張するためにAPIを提供しています。チュートリアルを含めた詳細に関しては、[GitHubにおけるNode.jsのデータストアのインストゥルメンテーション](http://newrelic.github.io/node-newrelic/docs/tutorial-Datastore-Simple.html)ドキュメントを参照してください。
+Node.jsエージェントバージョン2.0.0より、New Relicは追加のデータストアライブラリに対するインストゥルメンテーションを拡張するためにAPIを提供しています。チュートリアルを含めた詳細に関しては、[GitHubにおけるNode.jsのデータストアのインストゥルメンテーション](http://newrelic.github.io/node-newrelic/tutorial-Datastore-Simple.html)ドキュメントを参照してください。
 
 ## Webトランザクションをインストゥルメントする [#web-txn]
 
@@ -127,7 +127,7 @@ Node.jsエージェントバージョン2.0.0より、New Relicは追加のデ�
     });
     ```
 
-    この方法で得られるのは、作成したトランザクションに関する基本的なタイミングデータのみとなります。特定のフレームワークに関する、より複雑なタイミングデータとトランザクションの命名を作成するには、[Node.js APIドキュメント](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#instrumentWebframework)ならびに[GitHubにおける関連のチュートリアル](http://newrelic.github.io/node-newrelic/docs/tutorial-Webframework-Simple.html)を参照してください。
+    この方法で得られるのは、作成したトランザクションに関する基本的なタイミングデータのみとなります。特定のフレームワークに関する、より複雑なタイミングデータとトランザクションの命名を作成するには、[Node.js APIドキュメント](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#instrumentWebframework)ならびに[GitHubにおける関連のチュートリアル](http://newrelic.github.io/node-newrelic/tutorial-Webframework-Simple.html)を参照してください。
   </Collapser>
 </CollapserGroup>
 

--- a/src/i18n/content/kr/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api.mdx
@@ -17,7 +17,7 @@ translationType: machine
 
 기타 리소스:
 
-* [GitHub의 Node.js 에이전트 API 문서](http://newrelic.github.io/node-newrelic/docs/) 에는 더 자세하고 실용적인 튜토리얼이 있습니다.
+* [GitHub의 Node.js 에이전트 API 문서](http://newrelic.github.io/node-newrelic/) 에는 더 자세하고 실용적인 튜토리얼이 있습니다.
 * [구성 설정](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration) 을 사용하여 Node.js 에이전트의 기본 동작을 조정할 수도 있습니다.
 * 사용 가능한 모든 New Relic API를 보려면 [API 소개 를](/docs/apis/getting-started/introduction-new-relic-apis) 참조하십시오.
 
@@ -26,7 +26,7 @@ translationType: machine
 Node.js 에이전트 API를 사용하려면 [최신 Node.js 에이전트 릴리스](/docs/release-notes/agent-release-notes/nodejs-release-notes) 가 있는지 확인하세요. 또한 다음을 참조하십시오.
 
 * [Node.js 에이전트 API 요구 사항](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api)
-* [GitHub에서 시작하기 절차](http://newrelic.github.io/node-newrelic/docs/index.html#getting-started)
+* [GitHub에서 시작하기 절차](http://newrelic.github.io/node-newrelic/index.html#getting-started)
 
 ## 트랜잭션으로 코드의 누락된 섹션 계측 [#creating-transactions]
 
@@ -67,7 +67,7 @@ New Relic이 코드의 특정 부분을 전혀 계측하지 않을 때 다음 �
         다음 옵션 중 하나를 사용합니다.
 
         * [`newrelic.startWebTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#startWebTransaction) 에 전달된 콜백에서 약속을 반환합니다.
-        * [`newrelic.getTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#getTransaction) 에서 반환된 [핸들](http://newrelic.github.io/node-newrelic/docs/API.html#getTransaction) 에서 `end` 를 호출합니다.
+        * [`newrelic.getTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#getTransaction) 에서 반환된 [핸들](http://newrelic.github.io/node-newrelic/API.html#getTransaction) 에서 `end` 를 호출합니다.
       </td>
     </tr>
 
@@ -80,7 +80,7 @@ New Relic이 코드의 특정 부분을 전혀 계측하지 않을 때 다음 �
         다음 옵션 중 하나를 사용하여 트랜잭션을 무시합니다.
 
         * [요청 무시 규칙](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#ignoring) 참조`.`
-        * [`newrelic.getTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#getTransaction) 에서 반환된 [핸들](http://newrelic.github.io/node-newrelic/docs/TransactionHandle.html) 에서 `ignore()` 를 호출합니다.
+        * [`newrelic.getTransaction`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#getTransaction) 에서 반환된 [핸들](http://newrelic.github.io/node-newrelic/TransactionHandle.html) 에서 `ignore()` 를 호출합니다.
       </td>
     </tr>
   </tbody>
@@ -118,7 +118,7 @@ New Relic에서 트랜잭션이 이미 표시되지만 해당 트랜잭션 중�
   </tbody>
 </table>
 
-타이밍에 대한 자세한 내용은 [GitHub의 계측 자습서를](http://newrelic.github.io/node-newrelic/docs/tutorial-Instrumentation-Basics.html) 참조하십시오.
+타이밍에 대한 자세한 내용은 [GitHub의 계측 자습서를](http://newrelic.github.io/node-newrelic/tutorial-Instrumentation-Basics.html) 참조하십시오.
 
 ## 트랜잭션의 메타데이터 향상 [#metadata]
 
@@ -272,7 +272,7 @@ New Relic에 의해 계측되지 않은 로깅 메커니즘을 사용하는 경�
       </td>
 
       <td>
-        일반적인 문제는 계측되지 않은 라이브러리를 사용하는 동안 트랜잭션 상태가 손실된다는 것입니다. 자세한 내용 [은 GitHub의 트랜잭션 보존 자습서를](http://newrelic.github.io/node-newrelic/docs/tutorial-Context-Preservation.html) 참조하십시오.
+        일반적인 문제는 계측되지 않은 라이브러리를 사용하는 동안 트랜잭션 상태가 손실된다는 것입니다. 자세한 내용 [은 GitHub의 트랜잭션 보존 자습서를](http://newrelic.github.io/node-newrelic/tutorial-Context-Preservation.html) 참조하십시오.
       </td>
     </tr>
   </tbody>
@@ -308,7 +308,7 @@ New Relic에 의해 계측되지 않은 로깅 메커니즘을 사용하는 경�
 
         * [메시지 대기열](/docs/agents/nodejs-agent/supported-features/message-queues)
 
-          또한 [데이터 저장소 shim](http://newrelic.github.io/node-newrelic/docs/DatastoreShim.html) 및 [메시지 shim](http://newrelic.github.io/node-newrelic/docs/MessageShim.html) 에 대한 GitHub의 자습서를 참조하십시오.
+          또한 [데이터 저장소 shim](http://newrelic.github.io/node-newrelic/DatastoreShim.html) 및 [메시지 shim](http://newrelic.github.io/node-newrelic/MessageShim.html) 에 대한 GitHub의 자습서를 참조하십시오.
       </td>
     </tr>
 
@@ -412,6 +412,6 @@ APM 에이전트 API 호출을 통해 브라우저 에이전트를 제어할 수
 
 ## 맞춤형 계측 확장 [#custom-instrumentation]
 
-`newrelic.instrument()` 은 맞춤 계측을 위한 추가적인 유연성을 제공합니다. 자습서 및 예제를 포함한 자세한 내용 [은 GitHub의 shims 설명서를](http://newrelic.github.io/node-newrelic/docs/Shim.html) 참조하십시오.
+`newrelic.instrument()` 은 맞춤 계측을 위한 추가적인 유연성을 제공합니다. 자습서 및 예제를 포함한 자세한 내용 [은 GitHub의 shims 설명서를](http://newrelic.github.io/node-newrelic/Shim.html) 참조하십시오.
 
 ES 모듈 애플리케이션에 사용자 정의 계측을 추가하려면 [ES 모듈](/docs/apm/agents/nodejs-agent/installation-configuration/es-modules) 설명서 또는 GitHub의 [예제 애플리케이션](https://github.com/newrelic/newrelic-node-examples/tree/main/esm-app) 을 참조하십시오.

--- a/src/i18n/content/kr/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -16,7 +16,7 @@ New Relic은 Node.js 애플리케이션에 대한 유용한 메트릭을 제공�
 
 New Relic이 추적하는 이름의 수는 사용자 경험이 강력하도록 충분히 작아야 합니다. 또한 애플리케이션의 문제 지점을 더 쉽게 식별할 수 있도록 적절한 양의 정보를 제공할 수 있을 만큼(데이터에 부담을 주지 않으면서) 충분히 커야 합니다.
 
-자세한 내용은 Github의 [Node.js 에이전트 구성](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration) 문서 및 [Node.js 에이전트 API 문서를](https://newrelic.github.io/node-newrelic/docs) 참조하세요.
+자세한 내용은 Github의 [Node.js 에이전트 구성](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration) 문서 및 [Node.js 에이전트 API 문서를](https://newrelic.github.io/node-newrelic/) 참조하세요.
 
 ## 요청 이름
 

--- a/src/i18n/content/kr/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation.mdx
@@ -22,15 +22,15 @@ Node.js 에이전트의 사용자 지정 계측 API를 통해 다음을 수행�
 
 ## 지원되지 않는 웹 프레임워크 계측 [#web-framework]
 
-Node.js 에이전트 버전 2.0.0부터 New Relic은 추가 웹 프레임워크에 대한 계측을 확장하는 API를 제공합니다. 자습서를 포함한 자세한 내용 [은 GitHub의 Node.js 웹 프레임워크 계측](http://newrelic.github.io/node-newrelic/docs/tutorial-Webframework-Simple.html) 설명서를 참조하세요.
+Node.js 에이전트 버전 2.0.0부터 New Relic은 추가 웹 프레임워크에 대한 계측을 확장하는 API를 제공합니다. 자습서를 포함한 자세한 내용 [은 GitHub의 Node.js 웹 프레임워크 계측](http://newrelic.github.io/node-newrelic/tutorial-Webframework-Simple.html) 설명서를 참조하세요.
 
 ## 지원되지 않는 메시지 서비스 클라이언트 계측 [#message-client]
 
-Node.js 에이전트 버전 2.0.0부터 New Relic은 추가 메시지 서비스 라이브러리에 대한 계측을 확장하는 API를 제공합니다. 자습서를 포함한 자세한 내용 [은 GitHub의 Node.js 메시지 서비스 클라이언트 계측](http://newrelic.github.io/node-newrelic/docs/tutorial-Messaging-Simple.html) 설명서를 참조하세요.
+Node.js 에이전트 버전 2.0.0부터 New Relic은 추가 메시지 서비스 라이브러리에 대한 계측을 확장하는 API를 제공합니다. 자습서를 포함한 자세한 내용 [은 GitHub의 Node.js 메시지 서비스 클라이언트 계측](http://newrelic.github.io/node-newrelic/tutorial-Messaging-Simple.html) 설명서를 참조하세요.
 
 ## 지원되지 않는 데이터 저장소 계측 [#datastore]
 
-Node.js 에이전트 버전 2.0.0부터 New Relic은 추가 데이터 저장소 라이브러리에 대한 계측을 확장하는 API를 제공합니다. 자습서를 포함한 자세한 내용 [은 GitHub의 Node.js 데이터 저장소 계측](http://newrelic.github.io/node-newrelic/docs/tutorial-Datastore-Simple.html) 설명서를 참조하세요.
+Node.js 에이전트 버전 2.0.0부터 New Relic은 추가 데이터 저장소 라이브러리에 대한 계측을 확장하는 API를 제공합니다. 자습서를 포함한 자세한 내용 [은 GitHub의 Node.js 데이터 저장소 계측](http://newrelic.github.io/node-newrelic/tutorial-Datastore-Simple.html) 설명서를 참조하세요.
 
 ## 웹 트랜잭션 계측 [#web-txn]
 
@@ -127,7 +127,7 @@ Node.js 에이전트 버전 2.0.0부터 New Relic은 추가 데이터 저장소 
     });
     ```
 
-    이 방법은 생성된 트랜잭션에 대한 기본 타이밍 데이터만 제공합니다. 특정 프레임워크에 대한 더 복잡한 타이밍 데이터 및 트랜잭션 이름을 생성하려면 [Node.js API 문서](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#instrumentWebframework) 및 [GitHub의 관련 자습서를](http://newrelic.github.io/node-newrelic/docs/tutorial-Webframework-Simple.html) 참조하세요.
+    이 방법은 생성된 트랜잭션에 대한 기본 타이밍 데이터만 제공합니다. 특정 프레임워크에 대한 더 복잡한 타이밍 데이터 및 트랜잭션 이름을 생성하려면 [Node.js API 문서](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#instrumentWebframework) 및 [GitHub의 관련 자습서를](http://newrelic.github.io/node-newrelic/tutorial-Webframework-Simple.html) 참조하세요.
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION

## Give us some context

* What problems does this PR solve?
In #11114 my global find and replace constrained the links that were prefixed with `https://`.  I checked our docs today and realized I missed a bunch.  This PR resolves the remaining ones.
