### PR TITLE
Documenting new .NET version filtering feature

### DIFF
--- a/src/content/docs/apm/agents/net-agent/custom-instrumentation/create-transactions-xml-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/custom-instrumentation/create-transactions-xml-net.mdx
@@ -98,12 +98,18 @@ To create a custom instrumentation file:
            <exactMethodMatcher methodName="MethodName2" />
          </match>
        </tracerFactory>
+       <!-- Define the method which triggers the creation of a transaction. -->
+       <tracerFactory name="NewRelic.Agent.Core.Tracer.Factories.BackgroundThreadTracerFactory" metricName="TransactionName3">
+         <match assemblyName="AssemblyName" className="NameSpace.ClassName3" minVersion="1.0.0" maxVersion="99.99.99">
+           <exactMethodMatcher methodName="MethodName3" />
+         </match>
+       </tracerFactory>
      </instrumentation>
    </extension>
    ```
 
 
-1. In the file you created, customize the attribute values `TransactionName`, `AssemblyName`, `NameSpace.ClassName`, and `MethodName`. Customize these values for both the trigger method and for any methods called by the trigger method.
+1. In the file you created, customize the attribute values `TransactionName`, `AssemblyName`, `NameSpace.ClassName`, and `MethodName`. Customize these values for both the trigger method and for any methods called by the trigger method. You can also use the optional `minVersion` and `maxVersion` attribute values to target specific versions of an Assembly, as shown in the third example. Note that this functionality requires agent 10.6.0 or higher.
 
    <Callout variant="tip">
      These values are case sensitive.
@@ -113,6 +119,8 @@ To create a custom instrumentation file:
    * `AssemblyName`: The assembly that contains the trigger method.
    * `NameSpace.ClassName`: The fully-qualified class name that contains the trigger method.
    * `MethodName`: The exact name of the trigger method.
+   * `minVersion`: Optional, can be removed. The minimum Assembly version to instrument, inclusive. If omitted, the minimum version is considered to be 0. Requires agent 10.6.0 or higher.
+   * `maxVersion`: Optional, can be removed. The maximum Assembly version to instrument, exclusive. If ommitted, there is no maximum version. Requires agent 10.6.0 or higher.
 2. Adding additional methods must include the `"NewRelic.Agent.Core.Tracer.Factories.BackgroundThreadTracerFactory"` attribute to be defined as a transaction. Tags without this attribute will [add detail to existing transactions](/docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net) only.
 3. Optional: To check if the XML file is formatted correctly, you can check it against the XSD (located at `C:\ProgramData\New Relic\.NET Agent\Extensions\extension.xsd`) using any XSD validator.
 

--- a/src/content/docs/apm/agents/net-agent/custom-instrumentation/create-transactions-xml-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/custom-instrumentation/create-transactions-xml-net.mdx
@@ -109,18 +109,18 @@ To create a custom instrumentation file:
    ```
 
 
-1. In the file you created, customize the attribute values `TransactionName`, `AssemblyName`, `NameSpace.ClassName`, and `MethodName`. Customize these values for both the trigger method and for any methods called by the trigger method. You can also use the optional `minVersion` and `maxVersion` attribute values to target specific versions of an Assembly, as shown in the third example. Note that this functionality requires agent 10.6.0 or higher.
+1. In the file you created, customize the attribute values `TransactionName`, `AssemblyName`, `NameSpace.ClassName`, and `MethodName`. Customize these values for both the trigger method and for any methods called by the trigger method. You can also use the optional `minVersion` and `maxVersion` attribute values to target specific versions of an assembly, as shown in the third example above. Note that this functionality requires agent 10.6.0 or higher.
 
    <Callout variant="tip">
      These values are case sensitive.
    </Callout>
 
-   * `TransactionName`: Defines the transaction name. The `metricName` attribute is optional. If omitted, the transaction name will be `NameSpace.ClassName/MethodName`. The transaction category will be `Custom`. The resulting full metric name will be `OtherTransaction/Custom/TransactionName` . If you wish to change the transaction category from `Custom`, use the [SetTransactionName](/docs/agents/net-agent/net-agent-api/settransactionname-net-agent-api) api call. The New Relic UI groups transactions under categories in the [transaction type field](/docs/apm/transactions/intro-transactions/transactions-new-relic-apm/#agent-net).
+   * `TransactionName`: Defines the transaction name. The `metricName` attribute is optional. If omitted, the transaction name will be `NameSpace.ClassName/MethodName`. The transaction category will be `Custom`. The resulting full metric name will be `OtherTransaction/Custom/TransactionName`. If you wish to change the transaction category from `Custom`, use the [SetTransactionName](/docs/agents/net-agent/net-agent-api/settransactionname-net-agent-api) API call. The New Relic UI groups transactions under categories in the [transaction type field](/docs/apm/transactions/intro-transactions/transactions-new-relic-apm/#agent-net).
    * `AssemblyName`: The assembly that contains the trigger method.
    * `NameSpace.ClassName`: The fully-qualified class name that contains the trigger method.
    * `MethodName`: The exact name of the trigger method.
-   * `minVersion`: Optional, can be removed. The minimum Assembly version to instrument, inclusive. If omitted, the minimum version is considered to be 0. Requires agent 10.6.0 or higher.
-   * `maxVersion`: Optional, can be removed. The maximum Assembly version to instrument, exclusive. If ommitted, there is no maximum version. Requires agent 10.6.0 or higher.
+   * `minVersion`: Optional (you can remove it). The minimum assembly version to instrument (inclusive). If omitted, the minimum version is considered to be 0. Requires agent 10.6.0 or higher.
+   * `maxVersion`: Optional (you can remove it). The maximum assembly version to instrument (exclusive). If ommitted, there is no maximum version. Requires agent 10.6.0 or higher.
 2. Adding additional methods must include the `"NewRelic.Agent.Core.Tracer.Factories.BackgroundThreadTracerFactory"` attribute to be defined as a transaction. Tags without this attribute will [add detail to existing transactions](/docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net) only.
 3. Optional: To check if the XML file is formatted correctly, you can check it against the XSD (located at `C:\ProgramData\New Relic\.NET Agent\Extensions\extension.xsd`) using any XSD validator.
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -757,7 +757,11 @@ Prior versions of Npgsql may also be instrumented, but duplicate and/or missing 
             * `ExecuteAsPost`
             * `DownloadData`
 
-            The agent supports RestSharp verions between 105.2.3 and 106.6.10. 
+			Minimum supported version: 105.2.3
+			
+			Verified compatible versions: 105.2.3, 106.0.0, 106.6.10, 106.11.0, 106.12.0, 106.13.0, 106.15.0
+			
+			Known incompatible versions: 106.8.0, 106.9.0, 106.10.0, 106.10.1
           </td>
         </tr>
 


### PR DESCRIPTION
Updates the .NET Agent documentation to describe a new custom instrumentation feature some new framework compatibilities. These changes will be valid with Agent 10.6.0, due to be released tomorrow (1/24/23).