### PR TITLE
Remove img lazy load to fix scroll

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -409,6 +409,7 @@ module.exports = {
         allPageHeaders: [
           'Referrer-Policy: no-referrer-when-downgrade',
           'Content-Security-Policy: frame-ancestors *.newrelic.com',
+          'Cache-Control: no-cache',
         ],
       },
     },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -409,7 +409,6 @@ module.exports = {
         allPageHeaders: [
           'Referrer-Policy: no-referrer-when-downgrade',
           'Content-Security-Policy: frame-ancestors *.newrelic.com',
-          'Cache-Control: no-cache',
         ],
       },
     },

--- a/src/components/MDXContainer.js
+++ b/src/components/MDXContainer.js
@@ -58,7 +58,6 @@ const defaultComponents = {
                   margin: '0 0.25rem',
                 }
           }
-          loading="lazy"
         />
       </Lightbox>
     ),


### PR DESCRIPTION
the scroll was scrolling to the point on the page where the header would be if all of the images had a height of 0. i think this was happening because the scroll height was getting calculated before the images had loaded due to lazy loading. turning that off seems to fix the issue completely 

example page:

old: https://docs.newrelic.com/docs/codestream/how-use-codestream/performance-monitoring/#investigating-errors

new: https://docswebsitedevelop-lizturnofflazyload.gatsbyjs.io/docs/codestream/how-use-codestream/performance-monitoring/#investigating-errors