### PR TITLE
fix: remove unsupported html elements

### DIFF
--- a/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
+++ b/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
@@ -36,12 +36,11 @@ For more information, review the [instrumentation for browser monitoring](/docs/
 ## Browser types [#browser-types]
 
 The browser agent officially supports the following browser versions:
-<ul>
-  <li>[Chrome](https://www.google.com/chrome/) (previous 5 major versions)</li>
-  <li>[Safari](https://www.apple.com/safari/) (previous 10 major versions)</li>
-  <li>[Firefox](https://www.mozilla.org/firefox/) (previous 10 major versions)</li>
-  <li>[Edge](https://www.microsoft.com/adge) (previous 10 major versions)</li>
-</ul>
+
+* [Chrome](https://www.google.com/chrome/) (previous 5 major versions)
+* [Safari](https://www.apple.com/safari/) (previous 10 major versions)
+* [Firefox](https://www.mozilla.org/firefox/) (previous 10 major versions)
+* [Edge](https://www.microsoft.com/adge) (previous 10 major versions)
 
 Instrumentation and specific features may be compatible with other browsers or versions. 
 

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/elasticsearch/elasticsearch-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/elasticsearch/elasticsearch-integration.mdx
@@ -1694,7 +1694,7 @@ The Elasticsearch integration collects the following metrics. Each metric name i
           </td>
 
           <td>
-            The number of active threads in the listener pool.<br/><span style={{ fontSize: "0.9rem" }}>(Deprecated on Elasticsearch 8)</span>
+            The number of active threads in the listener pool.<br/>(Deprecated on Elasticsearch 8)
           </td>
         </tr>
 
@@ -1704,7 +1704,7 @@ The Elasticsearch integration collects the following metrics. Each metric name i
           </td>
 
           <td>
-            The number of queued threads in the listener pool.<br/><span style={{ fontSize: "0.9rem" }}>(Deprecated on Elasticsearch 8)</span>
+            The number of queued threads in the listener pool.<br/>(Deprecated on Elasticsearch 8)
           </td>
         </tr>
 
@@ -1714,7 +1714,7 @@ The Elasticsearch integration collects the following metrics. Each metric name i
           </td>
 
           <td>
-            The number of rejected threads in the listener pool.<br/><span style={{ fontSize: "0.9rem" }}>(Deprecated on Elasticsearch 8)</span>
+            The number of rejected threads in the listener pool.<br/>(Deprecated on Elasticsearch 8)
           </td>
         </tr>
 
@@ -1724,7 +1724,7 @@ The Elasticsearch integration collects the following metrics. Each metric name i
           </td>
 
           <td>
-            The number of threads in the listener pool.<br/><span style={{ fontSize: "0.9rem" }}>(Deprecated on Elasticsearch 8)</span>
+            The number of threads in the listener pool.<br/>(Deprecated on Elasticsearch 8)
           </td>
         </tr>
 


### PR DESCRIPTION
Removing the spans removes some extra styling, but I don't think it affects the readability of the text. 

with span
<img width="1178" alt="Screen Shot 2023-01-23 at 3 06 11 PM" src="https://user-images.githubusercontent.com/47728020/214172414-88126e07-4faf-4b58-ba45-09f079f36b71.png">

without
<img width="1178" alt="Screen Shot 2023-01-23 at 3 05 38 PM" src="https://user-images.githubusercontent.com/47728020/214172421-ff339273-de41-40d1-9dad-3185255fdbe6.png">
