### PR TITLE
(81695) style(Sonic): Optimize API keys

### DIFF
--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -43,18 +43,18 @@ Our monitoring solutions and APIs use API keys to authenticate and verify your i
   src={accountsApiKeysUi}
 />
 
-<figcaption>
-  From [one.newrelic.com/launcher/api-keys-ui.api-keys-launcher](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher), you can create and manage license keys, browser keys, and user keys.
-</figcaption>
+To get started with API keys:
 
-You must be logged in to your New Relic account to use API keys. If you haven't already, [sign up for free](https://newrelic.com/signup) so you can start observing your data right away!
+1. [Sign up for your free account](https://newrelic.com/signup) if you haven't already
+2. Use our [agents and integrations](https://newrelic.com/instant-observability/?category=infrastructure-and-os) to begin ingesting data into New Relic
+3. Create and manage your API keys from the [API keys UI page](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher) so you can start observing your data right away
 
 ## Our main API keys [#overview-keys]
 
 <CollapserGroup>
 <Collapser
   className="freq-link"
-  id="api table"
+  id="api-table"
   title="API Keys"
 >
 
@@ -245,7 +245,7 @@ Besides the main API keys explained above, we have several other, older API keys
 <CollapserGroup>
   <Collapser
     className="freq-link"
-    id="older keys"
+    id="older-keys"
     title="Other API Keys"
   >
 <CollapserGroup>

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -47,7 +47,7 @@ Our monitoring solutions and APIs use API keys to authenticate and verify your i
   From [one.newrelic.com/launcher/api-keys-ui.api-keys-launcher](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher), you can create and manage license keys, browser keys, and user keys.
 </figcaption>
 
-If you haven't already, [set up your free New Relic account](https://newrelic.com/signup) so you can start observing your data today!
+You must be logged in to your New Relic account to use API keys. If you haven't already, [sign up for free](https://newrelic.com/signup) so you can start observing your data right away!
 
 ## Our main API keys [#overview-keys]
 

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -37,11 +37,7 @@ import accountsApiKeysUi from 'images/accounts_screenshot-crop_api-keys-ui.png'
 
 Our monitoring solutions and APIs use API keys to authenticate and verify your identity. The primary keys are the license key (for reporting data) and the user key (for working with NerdGraph, our GraphQL API). These keys allow only approved people in your organization to report data to New Relic, access that data, and configure features.
 
-If you’re just getting started using New Relic, you don’t need to manually find or input a key: [our guided install procedures](/docs/new-relic-one/install-configure/new-relic-guided-install-overview) will automatically include the keys for you. Not yet using New Relic? [Set up your New Relic account](https://newrelic.com/signup): it's free, forever!
-
-## View and manage API keys [#keys-ui]
-
-You can view and manage most API keys from the API keys UI page, which is at [one.newrelic.com/api-keys](https://one.newrelic.com/api-keys) (from the [account dropdown](/docs/glossary/glossary/#account-dropdown), click **API keys**).
+If you haven't already, [set up your free New Relic account](https://newrelic.com/signup) so you can start observing your data today!
 
 <img
   title="Screenshot of the API keys UI"
@@ -53,12 +49,14 @@ You can view and manage most API keys from the API keys UI page, which is at [on
   From [one.newrelic.com/launcher/api-keys-ui.api-keys-launcher](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher), you can create and manage license keys, browser keys, and user keys.
 </figcaption>
 
-Other ways to create and manage keys:
+## Our main API keys [#overview-keys]
 
-* For a programmatic way to manage license keys, browser keys, and user keys: [use our NerdGraph API](/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys)
-* For user keys: [Use NerdGraph explorer to view and create](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer)
-
-## Get to know our main API keys [#overview-keys]
+<CollapserGroup>
+<Collapser
+  className="freq-link"
+  id="api table"
+  title="API Keys"
+>
 
 <table>
   <thead>
@@ -160,6 +158,26 @@ Other ways to create and manage keys:
   </tbody>
 </table>
 
+</Collapser>
+</CollapserGroup>
+
+## View and manage API keys [#keys-ui]
+
+You can view and manage most API keys from the API keys UI page, which is at [one.newrelic.com/api-keys](https://one.newrelic.com/api-keys) (from the [account dropdown](/docs/glossary/glossary/#account-dropdown), click **API keys**).
+
+Other ways to create and manage keys:
+
+* For a programmatic way to manage license keys, browser keys, and user keys: [use our NerdGraph API](/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys)
+* For user keys: [Use NerdGraph explorer to view and create](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer)
+
+The [account ID](/docs/accounts/accounts-billing/account-setup/account-id) is another identifying number often required for reporting data to New Relic.
+
+## Copying keys from the UI [#copy-keys]
+
+When you go to [API keys UI page](https://one.newrelic.com/api-keys), you can copy existing API keys. Here are some details about the language used in the UI: 
+
+* **Copy key** versus **Copy key ID**: The first option copies the value of the key itself. In almost all cases, you'll use that. The second option copies the ID of the key, which is sometimes needed for referencing the key object via API.  
+* **Copy truncated key**: This option is available for keys that are not yours. It copies only a few digits from the key, which can be useful for your internal tracking of keys, or for talking with support. 
 ## Keep your API keys secure [#security-practices]
 
 If your API keys get into the wrong hands, it can present a security risk. For example:
@@ -175,13 +193,6 @@ You should treat your API keys securely, as you would passwords and other sensit
 * For user keys:
   * Instruct your team members to keep their user keys secure.
   * When members leave your organization, even if they're [basic users](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type), remove them from New Relic.
-
-## Copying keys from the UI [#copy-keys]
-
-When you go to [API keys UI page](https://one.newrelic.com/api-keys), you can copy existing API keys. Here are some details about the language used in the UI: 
-
-* **Copy key** versus **Copy key ID**: The first option copies the value of the key itself. In almost all cases, you'll use that. The second option copies the ID of the key, which is sometimes needed for referencing the key object via API.  
-* **Copy truncated key**: This option is available for keys that are not yours. It copies only a few digits from the key, which can be useful for your internal tracking of keys, or for talking with support. 
 
 ## Read more about our API keys [#key-details]
 
@@ -230,11 +241,14 @@ To create or manage API keys, use the UI at [one.newrelic.com/launcher/api-keys-
     To prevent a user from viewing or managing user keys, assign them a role without those capabilities: [original user model](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model#add-on) \| [newer user model](/docs/accounts/accounts-billing/new-relic-one-user-management/user-capabilities).
   </Collapser>
 </CollapserGroup>
+Besides the main API keys explained above, we have several other, older API keys that some New Relic customers still use. If you don't already use these keys, you likely don't need to start, but here's some info on these keys for you to learn about them:
 
-## Other keys [#other-keys]
-
-Besides our [main API keys explained above](#overview-keys), we have several other older API keys that some New Relic customers still use. If you don't already use these keys, you should have no reason to learn about them.
-
+<CollapserGroup>
+  <Collapser
+    className="freq-link"
+    id="older keys"
+    title="Other API Keys"
+  >
 <CollapserGroup>
   <Collapser
     id="insights-insert-key"
@@ -292,7 +306,5 @@ Besides our [main API keys explained above](#overview-keys), we have several oth
       To find and manage REST API keys: From the [user menu](/docs/accounts/accounts-billing/general-account-settings/intro-account-settings), click **API keys** (get [a direct link to the API keys page](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher)). Then click **REST API key**. Before you configure or delete an API key, ensure you are doing so for the correct account.
   </Collapser>
 </CollapserGroup>
-
-## Account ID [#account-id]
-
-The account ID is another identifying number often required for reporting data to New Relic. See [Account ID](/docs/accounts/accounts-billing/account-setup/account-id).
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -35,9 +35,7 @@ redirects:
 
 import accountsApiKeysUi from 'images/accounts_screenshot-crop_api-keys-ui.png'
 
-Our monitoring solutions and APIs use API keys to authenticate and verify your identity. The primary keys are the license key (for reporting data) and the user key (for working with NerdGraph, our GraphQL API). These keys allow only approved people in your organization to report data to New Relic, access that data, and configure features.
-
-If you haven't already, [set up your free New Relic account](https://newrelic.com/signup) so you can start observing your data today!
+Our monitoring solutions and APIs use API keys to authenticate and verify your identity. These keys allow only approved people in your organization to report data to New Relic, access that data, and configure features. The primary keys are the license key (for reporting data) and the user key (for working with NerdGraph, our GraphQL API). 
 
 <img
   title="Screenshot of the API keys UI"
@@ -48,6 +46,8 @@ If you haven't already, [set up your free New Relic account](https://newrelic.co
 <figcaption>
   From [one.newrelic.com/launcher/api-keys-ui.api-keys-launcher](https://one.newrelic.com/launcher/api-keys-ui.api-keys-launcher), you can create and manage license keys, browser keys, and user keys.
 </figcaption>
+
+If you haven't already, [set up your free New Relic account](https://newrelic.com/signup) so you can start observing your data today!
 
 ## Our main API keys [#overview-keys]
 
@@ -163,21 +163,20 @@ If you haven't already, [set up your free New Relic account](https://newrelic.co
 
 ## View and manage API keys [#keys-ui]
 
-You can view and manage most API keys from the API keys UI page, which is at [one.newrelic.com/api-keys](https://one.newrelic.com/api-keys) (from the [account dropdown](/docs/glossary/glossary/#account-dropdown), click **API keys**).
+You can view and manage most API keys from the [API keys UI page](https://one.newrelic.com/api-keys) by clicking **API keys** from the [account dropdown](/docs/glossary/glossary/#account-dropdown). You can also:
 
-Other ways to create and manage keys:
-
-* For a programmatic way to manage license keys, browser keys, and user keys: [use our NerdGraph API](/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys)
-* For user keys: [Use NerdGraph explorer to view and create](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer)
+* [Use NerdGraph explorer to view and create](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer) user keys
+* [Use our NerdGraph API](/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys) for a programmatic way to manage license keys, browser keys, and user keys
 
 The [account ID](/docs/accounts/accounts-billing/account-setup/account-id) is another identifying number often required for reporting data to New Relic.
 
 ## Copying keys from the UI [#copy-keys]
 
-When you go to [API keys UI page](https://one.newrelic.com/api-keys), you can copy existing API keys. Here are some details about the language used in the UI: 
+You can also copy existing API keys from the [API keys UI page](https://one.newrelic.com/api-keys). Here are some details about the language used in the UI: 
 
 * **Copy key** versus **Copy key ID**: The first option copies the value of the key itself. In almost all cases, you'll use that. The second option copies the ID of the key, which is sometimes needed for referencing the key object via API.  
 * **Copy truncated key**: This option is available for keys that are not yours. It copies only a few digits from the key, which can be useful for your internal tracking of keys, or for talking with support. 
+
 ## Keep your API keys secure [#security-practices]
 
 If your API keys get into the wrong hands, it can present a security risk. For example:
@@ -308,3 +307,5 @@ Besides the main API keys explained above, we have several other, older API keys
 </CollapserGroup>
   </Collapser>
 </CollapserGroup>
+
+Ready to try New Relic for yourself? [Sign up for your free New Relic account](https://newrelic.com/signup) and follow our [quick launch guide](/docs/new-relic-solutions/get-started/quick-launch-guide/) so you can start maximizing your data today!

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -163,7 +163,7 @@ You must be logged in to your New Relic account to use API keys. If you haven't 
 
 ## View and manage API keys [#keys-ui]
 
-You can view and manage most API keys from the [API keys UI page](https://one.newrelic.com/api-keys) by clicking **API keys** from the [account dropdown](/docs/glossary/glossary/#account-dropdown). You can also:
+You can view and manage most API keys from the [API keys UI page](https://one.newrelic.com/api-keys) by clicking **API keys** from [account dropdown](/docs/glossary/glossary/#account-dropdown). You can also:
 
 * [Use NerdGraph explorer to view and create](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph#explorer) user keys
 * [Use our NerdGraph API](/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys) for a programmatic way to manage license keys, browser keys, and user keys
@@ -240,7 +240,7 @@ To create or manage API keys, use the UI at [one.newrelic.com/launcher/api-keys-
     To prevent a user from viewing or managing user keys, assign them a role without those capabilities: [original user model](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model#add-on) \| [newer user model](/docs/accounts/accounts-billing/new-relic-one-user-management/user-capabilities).
   </Collapser>
 </CollapserGroup>
-Besides the main API keys explained above, we have several other, older API keys that some New Relic customers still use. If you don't already use these keys, you likely don't need to start, but here's some info on these keys for you to learn about them:
+Besides the main API keys explained above, we have several other, older API keys that some New Relic customers still use. If you don't already use these keys, you likely don't need to start.
 
 <CollapserGroup>
   <Collapser


### PR DESCRIPTION
- [x] Skeptical about value of this ¶: `If you’re just getting started using New Relic, you don’t need to manually find or input a key: our guided install procedures will automatically include the keys for you. Not yet using New Relic? Set up your New Relic account: it's free, forever!`

- [x] Can we move this set of bullets somewhere else to make the structure more straightforward? `Other ways to create and manage keys:`