### PR TITLE
Try adding option to mdx plugin to avoid build hangups

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -165,6 +165,7 @@ module.exports = {
         // https://github.com/mdx-js/mdx/issues/1283
         //
         // If this is addressed in MDX v2, we can safely remove this.
+        lessBabel: true,
         remarkPlugins: [],
         rehypePlugins: [
           require('./rehype-plugins/image-sizing'),


### PR DESCRIPTION
this was suggested by gatsby support to avoid builds that hang indefinitely on an mdx error instead of failing