### PR TITLE
Releasing .NET Agent 10.6.0

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
@@ -30,6 +30,19 @@ Any versions not listed in the following table are no longer supported. Please [
 
     <tr>
       <td>
+        v10.6.0
+      </td>
+
+      <td>
+        Jan 24, 2023
+      </td>
+
+      <td>
+        Jan 24, 2024
+      </td>
+    </tr>
+    <tr>
+      <td>
         v10.5.1
       </td>
 
@@ -232,20 +245,6 @@ Any versions not listed in the following table are no longer supported. Please [
 
       <td>
         Feb 1, 2024
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        v9.4.0
-      </td>
-
-      <td>
-        Jan 4, 2022
-      </td>
-
-      <td>
-        Jan 4, 2023
       </td>
     </tr>
 


### PR DESCRIPTION
Adds 10.6.0 to EOL list, removes one older version that has reached EOL.