### PR TITLE
chore: update links to correct locations

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/service-characterization-optimize-telemetry-data-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/service-characterization-optimize-telemetry-data-guide.mdx
@@ -159,13 +159,13 @@ In addition to NRU training, review and keep the following documentation resourc
 * [APM agent install](/docs/new-relic-one/install-configure/install-new-relic/#apm-install) and [configure](/docs/new-relic-one/install-configure/configure-new-relic-agents)
 * Instrumentation guides:
   * [C-SDK](/docs/apm/agents/c-sdk/instrumentation/instrument-your-app-c-sdk)
-  * [Go](/docs/agents/go-agent/instrumentation)
+  * [Go](/docs/apm/agents/go-agent/instrumentation)
   * [Java](/docs/apm/agents/java-agent/custom-instrumentation/java-custom-instrumentation)
   * [.NET](/docs/apm/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation)
   * [Node.js](/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation)
   * [PHP](/docs/apm/agents/php-agent/php-agent-api/)
-  * [Python](/docs/apm/agents/python-agent/custom-instrumentation)
-  * [Ruby](/docs/apm/agents/ruby-agent/api-guides)
+  * [Python](/docs/apm/agents/python-agent/custom-instrumentation/python-custom-instrumentation/)
+  * [Ruby](/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation/)
   * [OpenTelemetry SDKs](https://opensource.newrelic.com/projects/open-telemetry)
 * [Introduction to New Relic synthetic monitoring](/docs/synthetics/)
 


### PR DESCRIPTION
fix go, python, ruby links