### PR TITLE
Add change tracking topics to GraphQL tutorial list, and fix links

### DIFF
--- a/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
@@ -146,6 +146,15 @@ Account management
       </td>
     </tr>
 
+    <tr>
+      <td>
+        Change tracking
+      </td>
+      <td>
+        * [Track changes using NerdGraph](/docs/change-tracking/change-tracking-graphql/)
+        * [Track changes using the CLI](/docs/change-tracking/change-tracking-cli/#create-list)
+      </td>
+    </tr>
 
     <tr>
       <td>

--- a/src/content/docs/change-tracking/change-tracking-introduction.mdx
+++ b/src/content/docs/change-tracking/change-tracking-introduction.mdx
@@ -19,7 +19,7 @@ import changetrackingIntroDeploymentExample from 'images/tracking_screenshot-cro
 
     The UI provides details about each of the changes you track, such as errors, log attributes, issues, and anomalies. These details can help you understand the impact of changes on system performance and quality.
 
-    If you want to become acquainted with various aspects of the feature, check out our [Feature overview](#feature-overview) below, or look at the [different ways to start tracking changes](#start-tracking).
+    To become acquainted with various aspects of the feature, check out [Review the features](#feature-overview). If you're ready to designate which changes to monitor, jump to [Start tracking changes](#start-tracking).
   </Side>
 
   <Side>

--- a/src/content/docs/change-tracking/change-tracking-introduction.mdx
+++ b/src/content/docs/change-tracking/change-tracking-introduction.mdx
@@ -19,7 +19,7 @@ import changetrackingIntroDeploymentExample from 'images/tracking_screenshot-cro
 
     The UI provides details about each of the changes you track, such as errors, log attributes, issues, and anomalies. These details can help you understand the impact of changes on system performance and quality.
 
-    To become acquainted with various aspects of the feature, check out [Review the features](#feature-overview). If you're ready to designate which changes to monitor, jump to [Start tracking changes](#start-tracking).
+    To get acquainted with various aspects of change tracking , see [Review the features](#feature-overview). If you're ready to designate which changes to monitor, jump to [Start tracking changes](#start-tracking).
   </Side>
 
   <Side>

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -1383,7 +1383,7 @@ pages:
       - title: Events
         pages:
           - title: Record and view deployments
-            path: /docs/apm/apm-ui-pages/events/change-tracking/record-deployments
+            path: /docs/apm/apm-ui-pages/events/record-deployments
           - title: View alert history
             path: /docs/apm/applications-menu/events/view-alert-history
           - title: Thread profiler tool


### PR DESCRIPTION
Here are some fast-follow fixes from today's change tracking docs:

* Fix the link in the left navigation for the old deployment marker feature under APM.
* Clarify the anchor links in the third paragraph of the introduction to change tracking.
* Add change tracking as an item to the table in the introduction to NerdGraph.