### PR TITLE
Improve azure intro doc 

### DIFF
--- a/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations.mdx
@@ -1,5 +1,5 @@
 ---
-title: Activate Azure integrations
+title: Set up Azure monitoring integrations
 tags:
   - Integrations
   - Microsoft Azure integrations
@@ -13,29 +13,57 @@ redirects:
   - /docs/infrastructure/azure-integrations/getting-started/activate-azure-integrations
   - /docs/infrastructure/microsoft-azure-integrations/getting-started/activate-azure-integrations
   - /docs/integrations/microsoft-azure-integrations/getting-started/activate-azure-integrations
-  - /docs/infrastructure/integrations/integrations/azure-integrations
+  - /docs/infrastructure/integrations/integrations/azure-integrations 
 ---
 
-New Relic [infrastructure integrations](/docs/infrastructure/integrations/intro-infrastructure-integrations) allow you to report data from specific systems and supplement [infrastructure's](/docs/infrastructure/new-relic-infrastructure/getting-started/introduction-new-relic-infrastructure) default, automatic monitoring. The Microsoft Azure integrations report data from various Azure platform services to your New Relic account. This document explains how to activate Azure integrations.
+For all our solutions for Azure monitoring, see [Introduction to Azure integrations](/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations). 
+
+With our Azure [infrastructure integrations](/docs/infrastructure/integrations/intro-infrastructure-integrations), you can report data to New Relic from dozens of Azure platform services. 
 
 <Callout variant="tip">
-  You can use Terraform to automate the process of enabling cloud integrations. Read how in the [Terraform official documentation site](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/cloud_integrations_guide).
+  You can use Terraform to automate the process of enabling cloud integrations: see the [Terraform docs site](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/cloud_integrations_guide).
 </Callout>
 
-## Requirements [#reqs]
+## Features [#features]
 
-The Azure integration activation process requires you to:
+To monitor your Azure services, we query them on a regular [polling interval](/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-polling-intervals-infrastructure-integrations). With our Azure integrations, you can:
+
+* View performance data from [dashboards](/docs/infrastructure/integrations/find-use-infrastructure-integration-data) that automatically scale as you make changes to your ecosystem.
+* Set up [alerts](/docs/infrastructure/new-relic-infrastructure/configuration/infrastructure-alerts-add-edit-or-view-host-alert-information#integration) to get notifications when things go wrong. 
+* [Query your data](/docs/using-new-relic/data/understand-data/query-new-relic-data) and create custom charts and dashboards to meet the specific observability challenges you have. 
+
+## Requirements and limitations [#reqs]
+
+Requirements include: 
 
 * A New Relic account. Don't have one? [Sign up for free!](https://newrelic.com/signup) No credit card required.
-* Create a New Relic application and key in Azure.
-* Grant this application access to the Azure services you want to monitor.
-* Place required information in the **Integrations** UI.
+* Specific [Azure integrations](/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list) have their own requirements.
 
-To use these integration activation instructions directly from the Infrastructure UI, go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Infrastructure > Azure > Add an Azure account**.
+We cannot get data from Azure resources that: 
+
+* Are located in Azure Government
+* Were created through the [classic deployment model](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-deployment-model)
+
+## Cost considerations [#cost-considerations]
+
+When evaluating the cost of the Microsoft Azure integrations with New Relic, consider Azure's Monitor Pricing. Refer to the `Metric queries` cost item in the [Azure pricing documentation](https://azure.microsoft.com/en-us/pricing/details/monitor/#pricing). Pricing details: 
+
+* Pricing is based on the number of API calls per month.
+* An estimate of the API calls we make to Azure services can be found on your [account status dashboard](/docs/infrastructure/infrastructure-integrations/cloud-integrations/cloud-integrations-account-status-dashboard).
+
+## Overview of enabling Azure integrations [#overview]
+
+We'll describe the process of activating our Azure integrations in more detail below, but here's an overview of that process: 
+
+1. You'll create a New Relic application and key in Azure.
+2. You'll grant this application access to the Azure services you want to monitor.
+3. You'll place the required information in the **Integrations** UI.
+
+To use these integration activation instructions directly from our infrastructure UI, go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Infrastructure > Azure > Add an Azure account**.
 
 ## Step 1: Get Azure subscription and tenant IDs [#get-ids]
 
-To get your Azure account's subscription `id` and `tenantId`, use your local terminal if you have Azure's tools installed, or use [Azure's Cloud Shell](https://azure.microsoft.com/en-us/features/cloud-shell/) terminal in the Azure portal.
+To get your Azure account's subscription `id` and `tenantId`, use your local terminal if you have Azure's tools installed, or use [Azure's Cloud Shell](https://azure.microsoft.com/en-us/features/cloud-shell) terminal in the Azure portal.
 
 1. Open a terminal with access to your Azure account.
 2. Type the following:

--- a/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations.mdx
@@ -16,9 +16,7 @@ redirects:
   - /docs/infrastructure/integrations/integrations/azure-integrations 
 ---
 
-For all our solutions for Azure monitoring, see [Introduction to Azure integrations](/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations). 
-
-With our Azure [infrastructure integrations](/docs/infrastructure/integrations/intro-infrastructure-integrations), you can report data to New Relic from dozens of Azure platform services. 
+With our Azure infrastructure integrations, you can report data to New Relic from dozens of Azure platform services. For all our solutions for Azure monitoring, see [Introduction to Azure integrations](/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations). 
 
 ## Features [#features]
 

--- a/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations.mdx
@@ -20,10 +20,6 @@ For all our solutions for Azure monitoring, see [Introduction to Azure integrati
 
 With our Azure [infrastructure integrations](/docs/infrastructure/integrations/intro-infrastructure-integrations), you can report data to New Relic from dozens of Azure platform services. 
 
-<Callout variant="tip">
-  You can use Terraform to automate the process of enabling cloud integrations: see the [Terraform docs site](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/cloud_integrations_guide).
-</Callout>
-
 ## Features [#features]
 
 To monitor your Azure services, we query them on a regular [polling interval](/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-polling-intervals-infrastructure-integrations). With our Azure integrations, you can:
@@ -31,6 +27,10 @@ To monitor your Azure services, we query them on a regular [polling interval](/d
 * View performance data from [dashboards](/docs/infrastructure/integrations/find-use-infrastructure-integration-data) that automatically scale as you make changes to your ecosystem.
 * Set up [alerts](/docs/infrastructure/new-relic-infrastructure/configuration/infrastructure-alerts-add-edit-or-view-host-alert-information#integration) to get notifications when things go wrong. 
 * [Query your data](/docs/using-new-relic/data/understand-data/query-new-relic-data) and create custom charts and dashboards to meet the specific observability challenges you have. 
+
+<Callout variant="tip">
+  You can use Terraform to automate the process of enabling cloud integrations: see the [Terraform docs site](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/cloud_integrations_guide).
+</Callout>
 
 ## Requirements and limitations [#reqs]
 

--- a/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations.mdx
@@ -14,11 +14,7 @@ redirects:
   - /docs/infrastructure/microsoft-azure-integrations
 ---
 
-New Relic has several offerings for monitoring your [Microsoft Azure](https://azure.microsoft.com) applications and services. 
-
-## Overview of our Azure offerings [#offerings]
-
-Our Azure offerings include: 
+New Relic has several offerings for monitoring your [Microsoft Azure](https://azure.microsoft.com) applications and services. Our Azure offerings include: 
 
 * New Relic in Azure: With our [Azure Native New Relic Service](/docs/infrastructure/microsoft-azure-integrations/get-started/azure-native), you can deploy New Relic from the Azure Marketplace. 
 * Our Azure infrastructure integrations: We have [dozens of Azure integrations](/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations) to monitor the Azure services you use. 

--- a/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations.mdx
@@ -1,12 +1,12 @@
 ---
-title: New Relic Azure solutions
+title: Introduction to Azure monitoring solutions
 tags:
   - Integrations
   - Microsoft Azure integrations
   - Get started
 translate:
   - jp
-metaDescription: 'New Relic provides integration monitoring with Microsoft Azure products, giving a comprehensive view of your ecosystem as it changes.'
+metaDescription: 'New Relic has several options for monitoring Microsoft Azure services and products, giving a comprehensive view of your Azure ecosystem.'
 redirects:
   - /docs/integrations/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations
   - /docs/infrastructure/microsoft-azure-integrations/getting-started/introduction-azure-monitoring-integrations
@@ -14,10 +14,10 @@ redirects:
   - /docs/infrastructure/microsoft-azure-integrations
 ---
 
-New Relic has several offerings for monitoring your [Microsoft Azure](https://azure.microsoft.com) applications and services. Our Azure offerings include: 
+We have several ways for you to monitor your [Microsoft Azure](https://azure.microsoft.com) applications and services: 
 
-* New Relic in Azure: With our [Azure Native New Relic Service](/docs/infrastructure/microsoft-azure-integrations/get-started/azure-native), you can deploy New Relic from the Azure Marketplace. 
-* Our Azure infrastructure integrations: We have [dozens of Azure integrations](/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations) to monitor the Azure services you use. 
-* .NET APM: You can install [our .NET APM agent](/install/dotnet) to monitor your Azure application.  
+* New Relic in Azure: With our [Azure Native New Relic Service](/docs/infrastructure/microsoft-azure-integrations/get-started/azure-native), you can easily deploy New Relic directly from the Azure Marketplace. 
+* Our Azure integrations: Our [Azure integrations](/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations) report telemetry data from dozens of Azure services. 
+* .NET APM: You can install [our .NET APM agent](/install/dotnet) to monitor your Azure application and received detailed telemetry data. 
 
 

--- a/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations.mdx
@@ -1,5 +1,5 @@
 ---
-title: Introduction to Azure monitoring integrations
+title: New Relic Azure solutions
 tags:
   - Integrations
   - Microsoft Azure integrations
@@ -14,29 +14,14 @@ redirects:
   - /docs/infrastructure/microsoft-azure-integrations
 ---
 
-Our [Microsoft Azure](https://azure.microsoft.com/) integrations allow you to monitor and report data about your Azure services to New Relic, providing a comprehensive view of your entire architecture in one place. 
+New Relic has several offerings for monitoring your [Microsoft Azure](https://azure.microsoft.com) applications and services. 
 
-<Callout variant="tip">
-This doc covers our Azure monitoring integrations. We also offer integrations to [deploy New Relic within the Azure Marketplace](/docs/infrastructure/microsoft-azure-integrations/get-started/azure-native), and [support for Azure with our .NET agent](/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps/). 
-</Callout>
+## Overview of our Azure offerings [#offerings]
 
-## Requirements [#permissions]
+Our Azure offerings include: 
 
-Check the docs of our [Azure integrations](/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list) for requirements for specific integrations.
+* New Relic in Azure: With our [Azure Native New Relic Service](/docs/infrastructure/microsoft-azure-integrations/get-started/azure-native), you can deploy New Relic from the Azure Marketplace. 
+* Our Azure infrastructure integrations: We have [dozens of Azure integrations](/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations) to monitor the Azure services you use. 
+* .NET APM: You can install [our .NET APM agent](/install/dotnet) to monitor your Azure application.  
 
-New Relic cannot obtain monitoring data from resources that are located in Azure Government or that were created through the [classic deployment model](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-deployment-model).
 
-## Features [#features]
-
-New Relic queries your Azure platform services according to a regular [polling interval](/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-polling-intervals-infrastructure-integrations). You can use our integrations UI to:
-
-* View performance data from [Integrations dashboards](/docs/infrastructure/integrations/find-use-infrastructure-integration-data) that automatically scale as you make changes to your ecosystem.
-* Manage [alert conditions](/docs/infrastructure/new-relic-infrastructure/configuration/infrastructure-alerts-add-edit-or-view-host-alert-information#integration) with alerts.
-* [Query your data](/docs/using-new-relic/data/understand-data/query-new-relic-data).
-
-## Cost considerations [#cost-considerations]
-
-When evaluating the cost of the Microsoft Azure integrations with New Relic, consider Azure's Monitor Pricing. Refer to the "Metric queries" cost item in the [Azure pricing documentation](https://azure.microsoft.com/en-us/pricing/details/monitor/#pricing).
-
-* Pricing is based on the number of API calls per month.
-* An estimation of the API calls peformed by New Relic to the different Azure services can be seen in the UI, under **Infrastructure > Azure > Azure Status Dashboard**.

--- a/src/nav/infrastructure.yml
+++ b/src/nav/infrastructure.yml
@@ -461,7 +461,7 @@ pages:
         path: /docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations
       - title: Azure Native New Relic 
         path: /docs/infrastructure/microsoft-azure-integrations/get-started/azure-native
-      - title: Set up Azure integrations
+      - title: Connect Azure integrations
         path: /docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations
       - title: Understand and use data
         path: /docs/infrastructure/microsoft-azure-integrations/find-use-data/understand-use-integration-data

--- a/src/nav/infrastructure.yml
+++ b/src/nav/infrastructure.yml
@@ -457,11 +457,11 @@ pages:
             path: /docs/infrastructure/google-cloud-platform-integrations/troubleshooting/gcp-integration-api-authentication-errors
   - title: Microsoft Azure integrations
     pages:
-      - title: Introduction to Azure integrations
+      - title: Introduction to Azure integrations 
         path: /docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations
-      - title: Azure Native New Relic Service 
+      - title: Azure Native New Relic 
         path: /docs/infrastructure/microsoft-azure-integrations/get-started/azure-native
-      - title: Activate Azure integrations
+      - title: Set up Azure integrations
         path: /docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations
       - title: Understand and use data
         path: /docs/infrastructure/microsoft-azure-integrations/find-use-data/understand-use-integration-data


### PR DESCRIPTION
Liaison work: 

Making better general landing page for our azure-related offerings. 
Moving stuff from 'intro to azure integrations' into the 'set up azure integrations' and making that more of the landing page/intro for the azure infra integrations
