### PR TITLE
feat(whats-new): synthetics checks pricing update

### DIFF
--- a/src/content/whats-new/2023/01/whats-new-1-25-in-synthetics-pricing.md
+++ b/src/content/whats-new/2023/01/whats-new-1-25-in-synthetics-pricing.md
@@ -1,0 +1,27 @@
+---
+title: 'Synthetics checks pricing update' 
+summary: 'Synthetics checks are now available above the free usage limit for a rate of $.005 per check' 
+releaseDate: '2023-01-25' 
+learnMoreLink: 'https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/getting-started/monitor-limits/' 
+---
+
+Synthetic monitoring is a suite of automated scriptable tools on the New Relic platform used to monitor websites, applications, critical business transactions, and API endpoints. If there is an error, failure, or anomaly affecting your customer-facing applications, then your synthetic check (i.e. monitor) will catch it and alert you before anyone is impacted.
+
+**Your number of free synthetic checks is based on the edition of New Relic:**
+
+* Free — 500 free checks/month
+* Standard — 10k free checks/month
+* Pro — 1M free checks/month
+* Enterprise — 10M free checks/month
+
+**Important details**
+
+* The add-on rate of $.005 per additional check is for all non-ping monitors (see [documentation](https://docs.newrelic.com/docs/licenses/license-information/usage-plans/new-relic-one-usage-plan-descriptions/#list-price)).
+* [Ping monitors](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/getting-started/types-synthetic-monitors/#types-monitors) will be included as part of every New Relic edition at no extra cost.
+* To increase the number of monthly synthetics checks without the add-on rate, you can upgrade your tier to help stay within included limits.
+
+You can use one of the queries outlined [here](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/monitor-limits/#consumption) to easily check your synthetics usage.
+
+**Note**: only [non-ping monitor checks](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/getting-started/types-synthetic-monitors/#types-monitors) will be billed based on overages. All ping monitors will continue to be included as part of your New Relic edition at no additional cost.
+
+For more, check out our [docs](https://docs.newrelic.com/docs/licenses/license-information/usage-plans/new-relic-one-usage-plan-descriptions/) page where we outline the usage plan, and review your current entitlement and [usage](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/monitor-limits/#consumption) so you have an understanding of how this may impact your usage and billing upon renewal.


### PR DESCRIPTION
This post provides updates on synthetics monitoring pricing, with synthetics checks now available above the free usage limit for a rate of $.005 per check. It should be posted as soon as possible and does not need additional review by another product marketing manager.