### PR TITLE
Feb 10 AM: new Python Release 8.6.0 docs

### DIFF
--- a/src/content/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy.mdx
@@ -712,20 +712,6 @@ Any versions not listed in the following table are no longer supported. Please [
         Feb 3, 2023
       </td>
     </tr>
-    
-    <tr>
-      <td>
-        v5.4.1.134
-      </td>
-
-      <td>
-        Dec 19, 2019
-      </td>
-
-      <td>
-        Dec 19, 2022
-      </td>
-    </tr>
 
   </tbody>
 </table>

--- a/src/content/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy.mdx
@@ -29,6 +29,20 @@ Any versions not listed in the following table are no longer supported. Please [
   <tbody>
     <tr>
       <td>
+        v8.6.0
+      </td>
+
+      <td>
+        Jan 26, 2023
+      </td>
+
+      <td>
+        Jan 26, 2024
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         v8.5.0
       </td>
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600.mdx
@@ -7,14 +7,21 @@ downloadLink: 'https://pypi.python.org/pypi/newrelic'
 
 ## Notes
 
-This release of the Python agent fixes a bug in metadata log decorating.
+This release of the Python agent adds support for elasticsearch 8, redis.asyncio, and exposes apdexPerfZone.
 
 Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](http://download.newrelic.com/python_agent/release).
 
 ## New features
 
+* **Add support for eleasicsearch 8**
+  Add instrumentation support for elasticsearch version 8.
+
 * **Add support for redis v4.4.1 and v4.4.2**
   Add support for new methods in the latest versions of redis.
+
+* **Add support for redis.asyncio**
+  aioredis is included to redis-py since version 4.2.0rc1 as redis.asyncio. Support this
+  new location.
 
 * **Add apdexPerfZone to Web transaction event attribute intrinsics**
   Expose nr.apdexPerfZone as apdexPerfZone in Web transaction event attribute intrinsics.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600.mdx
@@ -22,6 +22,7 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 * **Add support for redis.asyncio**
   aioredis is included to redis-py since version 4.2.0rc1 as redis.asyncio. Support this
   new location.
+  Thank you Thank you [@pauk-slon](https://github.com/pauk-slon) for your contribution!
 
 * **Add apdexPerfZone to Web transaction event attribute intrinsics**
   Expose nr.apdexPerfZone as apdexPerfZone in Web transaction event attribute intrinsics.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600.mdx
@@ -1,6 +1,6 @@
 ---
 subject: Python agent
-releaseDate: '2023-01-26'
+releaseDate: '2023-02-09'
 version: 8.6.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 ---
@@ -22,7 +22,7 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 * **Add support for redis.asyncio**
   aioredis is included to redis-py since version 4.2.0rc1 as redis.asyncio. Support this
   new location.
-  Thank you Thank you [@pauk-slon](https://github.com/pauk-slon) for your contribution!
+  Thank you [@pauk-slon](https://github.com/pauk-slon) for your contribution!
 
 * **Add apdexPerfZone to Web transaction event attribute intrinsics**
   Expose nr.apdexPerfZone as apdexPerfZone in Web transaction event attribute intrinsics.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600.mdx
@@ -16,11 +16,8 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 * **Add support for redis v4.4.1 and v4.4.2**
   Add support for new methods in the latest versions of redis.
 
-## Bug fixes
-
-* **Fix log decorating to be JSON compatible**
-
-  Previously metadata log decorating did not work when the log message was JSON. This has been fixed.
+* **Add apdexPerfZone to Web transaction event attribute intrinsics**
+  Expose nr.apdexPerfZone as apdexPerfZone in Web transaction event attribute intrinsics.
 
 ## Support statement
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600.mdx
@@ -11,7 +11,13 @@ This release of the Python agent fixes a bug in metadata log decorating.
 
 Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](http://download.newrelic.com/python_agent/release).
 
+## New features
+
+* **Add support for redis v4.4.1 and v4.4.2**
+  Add support for new methods in the latest versions of redis.
+
 ## Bug fixes
+
 * **Fix log decorating to be JSON compatible**
 
   Previously metadata log decorating did not work when the log message was JSON. This has been fixed.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600.mdx
@@ -1,0 +1,21 @@
+---
+subject: Python agent
+releaseDate: '2023-01-26'
+version: 8.6.0
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+---
+
+## Notes
+
+This release of the Python agent fixes a bug in log event metadata.
+
+Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](http://download.newrelic.com/python_agent/release).
+
+## Bug fixes
+* **Fix log decorating to be JSON compatible**
+
+  Previously metadata log decorating did not work when the log message was JSON. This has been fixed.
+
+## Support statement
+
+  New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.4.1.134](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-541134). More information can be found in the [EOL Policy Page](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/).

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600.mdx
@@ -7,7 +7,7 @@ downloadLink: 'https://pypi.python.org/pypi/newrelic'
 
 ## Notes
 
-This release of the Python agent fixes a bug in log event metadata.
+This release of the Python agent fixes a bug in metadata log decorating.
 
 Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](http://download.newrelic.com/python_agent/release).
 
@@ -18,4 +18,4 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## Support statement
 
-  New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.4.1.134](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-541134). More information can be found in the [EOL Policy Page](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/).
+  New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.6.0.135](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-541134). More information can be found in the [EOL Policy Page](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/).


### PR DESCRIPTION
# Summary
* Add release notes for version 8.6.0 of the Python Agent.
* Deprecate version 5.4.1.134.

READY FOR REVIEW
MERGE WITH MORNING RELEASE Feb 10th 2023.