### PR TITLE
Update compatibility-requirements-java-agent.mdx

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -327,7 +327,7 @@ The agent automatically instruments these frameworks and libraries:
     * Glassfish 3.0 to latest
     * JBoss 7.0 to latest
     * JBoss EAP 6.0 to 7.3
-    * Jetty 7.0.0.M3 to latest
+    * Jetty 9.3.0.M1 to latest
     * Mule ESB 3.4 to 3.8.x
     * Netty 3.3.0.Alpha1 to 5.0.0.Alpha1
     * Resin 3.1.9 to 4.0.x
@@ -364,11 +364,13 @@ The agent automatically instruments these frameworks and libraries:
     * Hystrix 1.3.15 to latest
     * Jakarta RESTful WS API 2.1.x to 3.1.x
     * JAX-RS 1.0 to 2.0
+    * JBoss Logging 1.3.0.Final to latest (for our [logs in context](/docs/logs/logs-context/java-configure-logs-context-all/) feature)
     * [JCache API](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-3200) 1.0.0 to latest
     * Jersey 1.0.1 to latest
     * JSF (Java Server Faces)
     * JUL (Java util logging) (for our [logs in context](/docs/logs/logs-context/java-configure-logs-context-all/) feature)
-    * Log4j 2 2.6 to latest (for our [logs in context](/docs/logs/logs-context/java-configure-logs-context-all/) feature)
+    * Log4j1 1.2.17 to latest (for our [logs in context](/docs/logs/logs-context/java-configure-logs-context-all/) feature)
+    * Log4j2 2.6 to latest (for our [logs in context](/docs/logs/logs-context/java-configure-logs-context-all/) feature)
     * Logback 1.1 to latest (for our [logs in context](/docs/logs/logs-context/java-configure-logs-context-all/) feature)
     * Monix Tasks
       * Scala 2.11: 3.0.0 to 3.2.x
@@ -412,12 +414,12 @@ The agent automatically instruments these frameworks and libraries:
       * Scala 2.12: 0.21 - 0.22.0-M8
       * Scala 2.13: 0.21 - 0.22.0-M8
     * HttpAsyncClient 4.1 to latest
-    * Apache Httpclient from 3.0 to 4.5.x
+    * Apache Httpclient from 3.1 to 4.5.x
     * java.net.HttpURLConnection
     * JMS and Spring-JMS 1.1 to 5.3.24
     * [Kafka Clients](/docs/agents/java-agent/instrumentation/use-kafka-message-queues) 0.10.0.0 to latest (for metric and event data)
     * [Kafka Clients](/docs/agents/java-agent/instrumentation/use-kafka-message-queues) 0.11.0.0 to latest (for distributed tracing and event data)
-    * OkHttp 3.x to 4.3.x
+    * OkHttp 3.6.0 to latest
     * Ning AsyncHttpClient 1.x
     * Play WS
       * Scala 2.11: 2.6.0 to latest
@@ -440,9 +442,9 @@ The agent automatically instruments these frameworks and libraries:
     * Amazon v1 DynamoDB 1.11.106 to latest
     * Amazon v2 DynamoDB 2.1.0 to latest
     * Anorm from 2.0 to 2.5
-    * DataStax Cassandra 2.1.2 to latest (If you use [high security](/docs/accounts-partnerships/accounts/security/high-security), see the [configuration documentation for allow lists](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#tt-slow_query_whitelist).)
+    * DataStax Cassandra 3.0.0 to latest (If you use [high security](/docs/accounts-partnerships/accounts/security/high-security), see the [configuration documentation for allow lists](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#tt-slow_query_whitelist).)
     * DB2 9.1 to latest
-    * Derby 10.2.1.6 to latest
+    * Derby 10.11.1.1 to latest
     * Generic JDBC (any JDBC compliant driver)
     * H2 1.0.57 to latest
     * HSQL 1.7.2.2 to latest
@@ -454,7 +456,7 @@ The agent automatically instruments these frameworks and libraries:
     * MariaDB 1.1.7 or higher
     * Microsoft SQL Server 1.2 to latest
     * MongoDB
-      * Synchronous clients: 2.12.0-rc0 to latest
+      * Synchronous clients: 3.1.0-rc0 to latest
       * Asynchronous/Reactive streams clients: 3.4.0 thru 4.1.2
     * MySQL mysql-connector-java 3.0.8 to latest
     * Oracle ojdbc5, ojdbc6, ojdbc7, ojdbc8, ojdbc10, ojdbc14
@@ -482,10 +484,10 @@ The agent automatically instruments these frameworks and libraries:
     * Any [compatible JDBC driver](#JDBC)
     * Amazon DynamoDB 1.11.106 or higher
     * Amazon v2 DynamoDB 2.1.0 to latest
-    * DataStax Cassandra driver 2.1.2 to latest
+    * DataStax Cassandra driver 3.0.0 to latest
     * Jedis Redis driver 1.4 to 2.10.x, 3.0.0 to latest
     * MongoDB
-      * Synchronous clients: 2.12.0 to latest
+      * Synchronous clients: 3.1.0-rc0 to latest
       * Asynchronous/Reactive streams clients: 3.4.0 thru 4.1.2
     * Spymemcached 2.11.0 to latest
 


### PR DESCRIPTION
Please hold for upcoming 8.0.0 Java agent release. Current ETA is 1/26/2023.

We will notify the docs hero when this is ready to release.