### PR TITLE
Define redirect on Azure Monitor Integration docs

### DIFF
--- a/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor.mdx
@@ -1,5 +1,7 @@
 ---
 title: New Relic Azure Monitor integration
+redirects:
+  - /docs/azure-azure_monitor-integration
 ---
 
 import infrastructureAzureMonitorSelect from 'images/azure-monitor.png'


### PR DESCRIPTION
This fixes the broken link `Azure Monitor metrics Documentation`

<img width="1696" alt="Screenshot 2023-01-26 at 10 43 16" src="https://user-images.githubusercontent.com/16718039/214804658-5fad9b04-895f-4296-adb9-073b7f374230.png">
