### PR TITLE
fix(user mgmt): clarify admin access

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
@@ -73,22 +73,22 @@ Here are some resources to help you create or edit group access:
 
 ## Groups [#groups]
 
-A "group" represents a group of users. Putting users in a group allows the managing of permissions for multiple users at the same time. For example, if you're using our [automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) feature, you can import a custom group of users (for example, **External consultants**) from your identity provider service, and then [grant a role and an account](#understand-concepts) to that group. 
+In New Relic, placing users in a **group** allows the managing of permissions for multiple users at the same time. For example, if you're using our [automated user management](/docs/accounts/accounts/automated-user-management/automated-user-provisioning-single-sign) feature, you can import a custom group of users (for example, **External consultants**) from your identity provider service, and then [grant a role and an account](#understand-concepts) to that group. 
 
 A New Relic user must be in at least one group with access to a role and at least one account.
 
-Note that groups are **not** what restrict a user's New Relic permissions: it's the **role** assigned to the group that contains the actual capabilities.
+Note that groups are **not** what restrict a user's New Relic permissions: it's the **role** assigned to that group that grant access to New Relic capabilities.
 
-We have two default groups (see below). And Pro and Enterprise organizations can [create custom groups](/docs/accounts/accounts-billing/new-relic-one-user-management/tutorial-add-new-user-groups-roles-new-relic-one-user-model/#group-access).
+We have two simple user groups available by default (see below). And Pro and Enterprise organizations can [create custom groups](/docs/accounts/accounts-billing/new-relic-one-user-management/tutorial-add-new-user-groups-roles-new-relic-one-user-model/#group-access).
 
-Users and groups are located within an [authentication domain](/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more/), which is what controls settings related to how users are added and managed (for example, via SCIM provisioning) and how users log in to New Relic.
+Users and groups are located within an [authentication domain](/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more/), which is what controls settings related to how users are provisioned (for example, via an identity provider) and how users log in.
 
 ### Our default user groups [#default-groups]
 
 We have two default user groups:
 
-* **User**: This group allows a user to use and configure our observability and monitoring features but **not** perform account-level tasks like managing billing or managing other users. It has access to the [**All product admin**](#standard-roles) role, which gives access to our observability platform tools, but doesn't have any [administration settings](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts#admin-settings), which give access to the higher level account and user management capabilities.
-* **Admin**: has all capabilities, including the higher-level administration settings. This is the equivalent of having the [standard role](#standard-roles) of **All product admin** with all available [administration settings](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts#admin-settings). 
+* **User**: A user in this group can use and configure our observability and monitoring features but **not** perform account-level tasks like managing billing or managing other users. It has access to the [**All product admin**](#standard-roles) role, which grants control over all observability platform tools, but doesn't have any [administration settings](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts#admin-settings), which grant access to the higher level account and user management capabilities.
+* **Admin**: has the [**All product admin** role](#standard-roles) and in addition has all available [administration settings](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts#admin-settings). In effect, this default group has access to all features, including the higher-level admin features. 
 
 To change a user's group, use the [**User management** UI](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks#where).
 
@@ -139,7 +139,9 @@ Here's a table with our standard roles. To better understand the account-scoped 
       </td>
 
       <td>
-        This role includes all New Relic platform capabilities **except** the ability to manage organization-level settings, users, and billing. It's an admin role in the sense that it allows the configuration of our platform features (for example, the ability to configure APM settings), but it doesn't provide organization-level admin capabilities. This role is essentially the **Standard user** role plus the ability to configure platform features.
+        This role includes all New Relic platform capabilities **except** the ability to manage organization-level settings, users, and billing. It's an admin role in the sense that it allows the configuration of our platform features (for example, the ability to configure APM settings), but it doesn't provide organization-level admin capabilities (those require [the administration settings](#admin-settings)). 
+        
+        This role is essentially the **Standard user** role, below, with the added ability to configure observability features.
       </td>
 
       <td>
@@ -153,7 +155,9 @@ Here's a table with our standard roles. To better understand the account-scoped 
       </td>
 
       <td>
-        Provides access to our platform features (for example, APM UI and browser monitoring UI), but lacks permissions to configure those features and lacks organization-level and user management permissions. This role is essentially the **All product admin** role without the ability to configure platform features.
+        Provides access to our platform features (for example, APM UI and browser monitoring UI), but lacks permissions to configure those features and lacks organization-level and user management permissions. 
+        
+        This role is essentially the **All product admin** role without the ability to configure platform features.
       </td>
 
       <td>


### PR DESCRIPTION
Some liaison work: clarify what 'All product admin' role and 'Admin' group really mean, and make it clearer that they lack the 'administration settings'. 