### PR TITLE
Remove unwanted link in Node.js agent to distributed tracing introduction

### DIFF
--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -564,8 +564,6 @@ pages:
                 path: /docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs
               - title: Node.js VMs statistics page
                 path: /docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-vms-statistics-page
-              - title: Distributed tracing
-                path: /docs/distributed-tracing/concepts/introduction-distributed-tracing
               - title: Message queues
                 path: /docs/apm/agents/nodejs-agent/extend-your-instrumentation/message-queues
               - title: Browser monitoring


### PR DESCRIPTION
The Node.js agent navigation tree had a link to the introduction to distributed tracing page under "Extend your instrumentation," but that meant that the left nav would light up for both Node.js and for the introduction to distributed tracing. Since we already have a distributed tracing topic under "Install and configure," I suggest we remove this left-navigation link.