### PR TITLE
Added instructions for source map support

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
@@ -71,6 +71,13 @@ To install the Node.js agent:
   ```
   node -r newrelic ./dist/server.js
   ```
+  
+  Transpiled applications will show error stack traces through the built (and possibly minified) JS code. You can direct Node to show stack traces that reference your source code by enabling Node's source map support, like this: 
+  
+  ```
+  node --enable-source-maps -r newrelic ./dist/server.js
+  ```
+  
   If you are unable to `require('newrelic');` as the first line of your app's main module and you are unable to use the require flag as above (e.g. asynchronously loading api keys from a remote location during application bootstrapping), you may also add stock instrumentation to an already loaded [supported module](https://github.com/newrelic/node-newrelic/blob/0113eb5f0e707dc662a17d262a841503bab88841/lib/instrumentations.js#L6#L6) by using [`newrelic.instrumentLoadedModule`](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#instrumentLoadedModule):
   
   ```js


### PR DESCRIPTION
Transpiled applications in JS will show error traces pointing to built files. A developer reading these will have to translate these to understand which part of the source code was involved in the error. Node.js, however, supports enabling source maps, so that error traces can display files, line numbers, and function names from source code instead of built/transpiled/minified code. This produces a much more useful error trace.

Closes NEWRELIC-5806