### PR TITLE
Added page documenting Node.js source map support

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/enable-source-maps
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/enable-source-maps
@@ -1,0 +1,30 @@
+Transpiled applications, such as those written in TypeScript or Babel, will show error stacktraces that typically point to files, lines, and functions within the built files, rather than the source files. You can direct Node to show stack traces that reference your source code by enabling Node's source map support in the `node` command that starts your application: 
+
+  ```
+  node --enable-source-maps -r newrelic ./dist/server.js
+  ```
+  Starting your application with source maps enabled, you 
+  
+Enabling source map support in Node.js can provide developers with a more meaningful error trace which points to lines and functions within the source code. 
+
+As an example, an application run without source map support might display an error stack trace like this: 
+
+```shell
+Error: Failed to get all entries in model
+    at /dist/models/entries.js:41:23
+    ... (multiple functions in New Relic Node agent js files)
+    at /dist/models/entries.js:39:35
+    at Generator.next (<anonymous>)
+```
+Note that the trace refers to the built files in `/dist`.
+
+The same application with source map support enabled will instead reference the source code files: 
+```shell
+Error: Failed to get all entries in model
+    at <anonymous> (/src/models/entries.ts:28:13)
+    ... (multiple functions in New Relic Node agent js files)
+    at <anonymous> (/src/models/entries.ts:26:19)
+    at Generator.next (<anonymous>)    
+```
+This stack trace points to specific functions and line numbers within your source files, so you can find errors more easily. 
+

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/enable-source-maps
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/enable-source-maps
@@ -1,13 +1,13 @@
-Transpiled applications, such as those written in TypeScript or Babel, will show error stacktraces that typically point to files, lines, and functions within the built files, rather than the source files. You can direct Node to show stack traces that reference your source code by enabling Node's source map support in the `node` command that starts your application: 
+Transpiled applications, such as those written in TypeScript or Babel, will show error stacktraces that typically point to files, lines, and functions within the built files, rather than the source files. You can direct Node to show stack traces that reference your source code by enabling Node's source map support in the `node` command that starts your application:
 
   ```
   node --enable-source-maps -r newrelic ./dist/server.js
   ```
-  Starting your application with source maps enabled, you 
-  
-Enabling source map support in Node.js can provide developers with a more meaningful error trace which points to lines and functions within the source code. 
+  Starting your application with source maps enabled, you
 
-As an example, an application run without source map support might display an error stack trace like this: 
+Enabling source map support in Node.js can provide developers with a more meaningful error trace which points to lines and functions within the source code.
+
+As an example, an application run without source map support might display an error stack trace like this:
 
 ```shell
 Error: Failed to get all entries in model
@@ -18,13 +18,14 @@ Error: Failed to get all entries in model
 ```
 Note that the trace refers to the built files in `/dist`.
 
-The same application with source map support enabled will instead reference the source code files: 
+The same application with source map support enabled will instead reference the source code files:
 ```shell
 Error: Failed to get all entries in model
     at <anonymous> (/src/models/entries.ts:28:13)
     ... (multiple functions in New Relic Node agent js files)
     at <anonymous> (/src/models/entries.ts:26:19)
-    at Generator.next (<anonymous>)    
+    at Generator.next (<anonymous>)
 ```
-This stack trace points to specific functions and line numbers within your source files, so you can find errors more easily. 
+This stack trace points to specific functions and line numbers within your source files, so you can find errors more easily.
 
+You can observe this behavior by running our [source maps example application](https://github.com/newrelic/newrelic-node-examples/tree/main/source-maps), which makes it easy to compare error traces both with and without source maps enabled.

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/enable-source-maps.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/enable-source-maps.mdx
@@ -1,11 +1,22 @@
-Transpiled applications, such as those written in TypeScript or Babel, will show error stacktraces that typically point to files, lines, and functions within the built files, rather than the source files. You can direct Node to show stack traces that reference your source code by enabling Node's source map support in the `node` command that starts your application:
+---
+title: Enable source maps support
+tags:
+  - Agents
+  - Nodejs agent
+metaDescription: Enable source map support in Node.js to see more meaningful error traces.
+---
+
+Transpiled applications, such as those written in TypeScript or Babel, will show error stack traces that typically point to files, lines, and functions within the built files, rather than the source files.
+
+If you enable source mapping in Node.js, you'll get more meaningful error traces that point to lines and functions within the source code.
+## How to enable source mapping [#enable-command]
+
+You can enable Node's source map support in the `node` command that starts your application:
 
   ```
   node --enable-source-maps -r newrelic ./dist/server.js
   ```
-  Starting your application with source maps enabled, you
-
-Enabling source map support in Node.js can provide developers with a more meaningful error trace which points to lines and functions within the source code.
+## Example [#source-map-example]
 
 As an example, an application run without source map support might display an error stack trace like this:
 
@@ -19,6 +30,7 @@ Error: Failed to get all entries in model
 Note that the trace refers to the built files in `/dist`.
 
 The same application with source map support enabled will instead reference the source code files:
+
 ```shell
 Error: Failed to get all entries in model
     at <anonymous> (/src/models/entries.ts:28:13)

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/enable-source-maps.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/enable-source-maps.mdx
@@ -18,7 +18,7 @@ You can enable Node's source map support in the `node` command that starts your 
   ```
 ## Example [#source-map-example]
 
-As an example, an application run without source map support might display an error stack trace like this:
+An application run without source map support might display an error stack trace like this:
 
 ```shell
 Error: Failed to get all entries in model
@@ -27,7 +27,9 @@ Error: Failed to get all entries in model
     at /dist/models/entries.js:39:35
     at Generator.next (<anonymous>)
 ```
-Note that the trace refers to the built files in `/dist`.
+<Callout variant="tip">
+  Note that the trace refers to the built files in `/dist`.
+</Callout>
 
 The same application with source map support enabled will instead reference the source code files:
 

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -549,6 +549,8 @@ pages:
                 path: /docs/apm/agents/nodejs-agent/installation-configuration/es-modules
               - title: New Relic CodeStream integration for Node.js
                 path: /docs/apm/agents/nodejs-agent/installation-configuration/codestream-integration
+              - title: Enable source maps support
+                path: /docs/apm/agents/nodejs-agent/installation-configuration/enable-source-maps
               - title: Update the Node.js agent
                 path: /docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent
               - title: Uninstall the agent
@@ -1173,7 +1175,7 @@ pages:
               - title: Rake instrumentation
                 path: /docs/apm/agents/ruby-agent/background-jobs/rake-instrumentation
               - title: Redis instrumentation
-                path: /docs/apm/agents/ruby-agent/instrumented-gems/redis-instrumentation 
+                path: /docs/apm/agents/ruby-agent/instrumented-gems/redis-instrumentation
               - title: Resque instrumentation
                 path: /docs/apm/agents/ruby-agent/background-jobs/resque-instrumentation
               - title: Sequel instrumentation


### PR DESCRIPTION
Transpiled applications in JS will show error traces pointing to built files. A developer reading these will have to translate these to understand which part of the source code was involved in the error. Node.js, however, supports enabling source maps, so that error traces can display files, line numbers, and function names from source code instead of built/transpiled/minified code. This produces a much more useful error trace.

Closes NEWRELIC-5806