### PR TITLE
Update create-nrql-alert-conditions.mdx (Please merge on Jan. 31st)

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -817,7 +817,7 @@ Gap filling lets you customize the values to use when your signals don't have an
 
 * **None**: (Default) Choose this if you don't want to take any action on empty aggregation windows. On evaluation, an empty aggregation window will reset the threshold duration timer. For example, if a condition says that all aggregation windows must have data points above the threshold for 5 minutes, and 1 of the 5 aggregation windows is empty, then the condition won't be in violation.
 * **Custom static value**: Choose this if you'd like to insert a custom static value into the empty aggregation windows before they're evaluated. This option has an additional, required parameter of `fillValue` (as named in the API) that specifies what static value should be used. This defaults to `0`.
-* **Last known value**: This option inserts the last seen value before evaluation occurs. We maintain the state of the last seen value for a minimum of 2 hours. If the configured threshold duration is longer than 2 hours, state is kept for that duration instead.
+* **Last known value**: This option inserts the last seen value before evaluation occurs. We maintain the state of the last seen value for a minimum of 2 hours. If the configured threshold duration is longer than 2 hours, this value is kept for that duration instead.
 
 <Callout variant="tip">
   The alerts system fills gaps in actively reported signals. This signal history is dropped after a period of inactivity and, for gap filling, data points received after this period of inactivity are treated as new signals. The inactivity length is either 2 hours or the configured threshold duration, whichever is longer.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -817,10 +817,10 @@ Gap filling lets you customize the values to use when your signals don't have an
 
 * **None**: (Default) Choose this if you don't want to take any action on empty aggregation windows. On evaluation, an empty aggregation window will reset the threshold duration timer. For example, if a condition says that all aggregation windows must have data points above the threshold for 5 minutes, and 1 of the 5 aggregation windows is empty, then the condition won't be in violation.
 * **Custom static value**: Choose this if you'd like to insert a custom static value into the empty aggregation windows before they're evaluated. This option has an additional, required parameter of `fillValue` (as named in the API) that specifies what static value should be used. This defaults to `0`.
-* **Last known value**: This option inserts the last seen value before evaluation occurs. We maintain the state of the last seen value for 2 hours.
+* **Last known value**: This option inserts the last seen value before evaluation occurs. We maintain the state of the last seen value for a minimum of 2 hours. If the configured threshold duration is longer than 2 hours, state is kept for that duration instead.
 
 <Callout variant="tip">
-  The alerts system fills gaps in actively reported signals. This signal history is dropped after 2 hours of inactivity. For gap filling, data points received after this period of inactivity are treated as new signals.
+  The alerts system fills gaps in actively reported signals. This signal history is dropped after a period of inactivity and, for gap filling, data points received after this period of inactivity are treated as new signals. The inactivity length is either 2 hours or the configured threshold duration, whichever is longer.
 
   To learn more about signal loss, gap filling, and how to request access to these features, see [this Explorers Hub post](https://discuss.newrelic.com/t/announcing-new-relic-one-streaming-alerts-for-nrql-conditions/115361).
 </Callout>


### PR DESCRIPTION
Update documentation for supporting up to 24 hour threshold durations.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
* This new support is scheduled to go live on January 31st, 2023.
* Updated any references to the maximum threshold duration, which were limited to the gap filling section.