### PR TITLE
fix(alerts ): fixing broken nav links

### DIFF
--- a/src/nav/alerts-applied-intelligence.yml
+++ b/src/nav/alerts-applied-intelligence.yml
@@ -83,10 +83,6 @@ pages:
         path: /docs/alerts-applied-intelligence/applied-intelligence/postmortems-applied-intelligence
   - title: Classic alerting features
     pages:
-      - title: Introduction to Alerts
-        path: /docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts
-      - title: Basic concepts and workflow
-        path: /docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/alerts-concepts-workflow
       - title: Technical rules and limits
         path: /docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts
       - title: Understand your violations


### PR DESCRIPTION
I deleted two deprecated docs in [this PR](https://github.com/newrelic/docs-website/pull/10979/files) but neglected to delete them from the nav. Fixing here. 