### PR TITLE
fix: remove iframe for Video component

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition.mdx
@@ -166,7 +166,10 @@ We're going to customize these advanced signal settings for our condition that i
 
   You can learn more about sliding window aggregation in [this NRQL tutorial](/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/create-smoother-charts-sliding-windows/) or by watching this video.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/-5--8DZynFE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+  <Video
+    type="youtube"
+    id="-5--8DZynFE"
+  />
 
   </Collapser>
   


### PR DESCRIPTION
Removed an `iframe` to use the `Video` component to ensure machine translation workflows will run.