### PR TITLE
feat (agent release notes): add new fields

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -373,6 +373,10 @@ module.exports = {
                 subject
                 releaseDate(fromNow: false)
                 version
+                feature
+                bug
+                security
+                ingest
               }
               excerpt(pruneLength: 5000)
             }
@@ -386,6 +390,10 @@ module.exports = {
               agent: getAgentName(frontmatter.subject),
               date: frontmatter.releaseDate,
               version: frontmatter.version,
+              feature: frontmatter.feature,
+              bug: frontmatter.bug,
+              security: frontmatter.security,
+              ingest: frontmatter.ingest,
               description: excerpt,
             }))
             .filter(({ date, agent }) => Boolean(date && agent)),

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -326,6 +326,10 @@ exports.createSchemaCustomization = ({ actions }) => {
     translationType: String
     dataSource: String
     isTutorial: Boolean
+    feature: [String]
+    bug: [String]
+    security: [String]
+    ingest: [String]
   }
 
   `;
@@ -369,6 +373,22 @@ exports.createResolvers = ({ createResolvers }) => {
         resolve: (source) =>
           hasOwnProperty(source, 'isTutorial') ? source.isTutorial : null,
       },
+      feature: {
+        resolve: (source) =>
+          hasOwnProperty(source, 'feature') ? source.feature : null,
+      },
+      bug: {
+        resolve: (source) =>
+          hasOwnProperty(source, 'bug') ? source.bug : null,
+      },
+      security: {
+        resolve: (source) =>
+          hasOwnProperty(source, 'security') ? source.security : null,
+      },
+      ingest: {
+        resolve: (source) =>
+          hasOwnProperty(source, 'ingest') ? source.ingest : null,
+      }
     },
   });
 };

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8150.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8150.mdx
@@ -3,6 +3,7 @@ subject: Ruby agent
 releaseDate: '2023-01-09'
 version: 8.15.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.15.0.gem'
+feature: ['Add Support for Ruby 3.2.0', 'Add instrumentation for concurrent-ruby', 'Infinite Tracing: Use batching and compression by default', 'Add Support for Padrino 0.15.2 and Sinatra 3']
 ---
 
 <Callout variant="important">


### PR DESCRIPTION
## Give us some context
* The [FY23Q4 Agent Update Recommendations project (Internal)](https://newrelic.atlassian.net/wiki/spaces/TDP/pages/2700443968/APM+Agent+Updates+Recommendations+CDD) needs new fields added to agent release notes.
* Ticket: https://issues.newrelic.com/browse/NR-84934 

Preview link for agent-releases JSON: https://docswebsitedevelop-kaylareopelledocswebsiteagentu.gatsbyjs.io/api/agent-release-notes.json 

Example front matter for agent release note MDX:

```mdx
---
subject: Ruby agent
releaseDate: '2022-12-14'
version: 8.14.0
downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.14.0.gem'
features: ['first feature', 'second feature']
bugs: ['first bug']
security: ['first security']
ingest: ['first ingest','second ingest','third ingest']
---
```


Example new entry in agent-releases JSON:
```JSON
{
    "agent":"ruby",
    "date":"2020-07-13",
    "version":"6.12.0",
    "features":[
        "first feature",
        "second feature"
    ],
    "bugs":[
        "first bug"
    ],
    "security":[
        "first security"
    ],
    "ingest":[
        "first ingest",
        "second ingest",
        "third ingest"
    ],
    "description":"New Relic Ruby Agent Release Notes This is a test Features first second Bugs first Security first Ingest first second third"
}
```

cc @CliftonDobrich @clarkmcadoo 