### PR TITLE
chore (ruby agent): Content for version 8.16.0

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -1439,6 +1439,42 @@ Use these settings to toggle instrumentation types during agent startup.
   If `true`, disables Action Cable instrumentation.
   </Collapser>
 
+  <Collapser id="disable_action_controller" title="disable_action_controller">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTION_CONTROLLER`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables Action Controller instrumentation.
+  </Collapser>
+
+  <Collapser id="disable_action_mailbox" title="disable_action_mailbox">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTION_MAILBOX`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables Action Mailbox instrumentation.
+  </Collapser>
+
+  <Collapser id="disable_action_mailer" title="disable_action_mailer">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTION_MAILER`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables Action Mailer instrumentation.
+  </Collapser>
+
   <Collapser id="disable_activejob" title="disable_activejob">
     <table>
       <tbody>
@@ -1448,7 +1484,7 @@ Use these settings to toggle instrumentation types during agent startup.
       </tbody>
     </table>
 
-  If `true`, disables ActiveJob instrumentation.
+  If `true`, disables Active Job instrumentation.
   </Collapser>
 
   <Collapser id="disable_active_storage" title="disable_active_storage">
@@ -1460,7 +1496,19 @@ Use these settings to toggle instrumentation types during agent startup.
       </tbody>
     </table>
 
-  If `true`, disables ActiveStorage instrumentation.
+  If `true`, disables Active Storage instrumentation.
+  </Collapser>
+
+  <Collapser id="disable_active_support" title="disable_active_support">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTIVE_SUPPORT`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables Active Support instrumentation.
   </Collapser>
 
   <Collapser id="disable_activerecord_instrumentation" title="disable_activerecord_instrumentation">
@@ -1472,7 +1520,7 @@ Use these settings to toggle instrumentation types during agent startup.
       </tbody>
     </table>
 
-  If `true`, disables active record instrumentation.
+  If `true`, disables Active Record instrumentation.
   </Collapser>
 
   <Collapser id="disable_active_record_notifications" title="disable_active_record_notifications">
@@ -1484,7 +1532,7 @@ Use these settings to toggle instrumentation types during agent startup.
       </tbody>
     </table>
 
-  If `true`, disables instrumentation for ActiveRecord 4, 5, and 6.
+  If `true`, disables instrumentation for Active Record 4+
   </Collapser>
 
   <Collapser id="disable_bunny" title="disable_bunny">

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -344,7 +344,7 @@ The Ruby agent does not support experimental versions. Web frameworks supported 
 
 ## Databases
 
-The Ruby agent does not support experimental versions. Databases supported by the Ruby agent include:
+The Ruby agent doesn't support experimental versions. Databases supported by the Ruby agent include:
 
 <table>
   <thead>
@@ -366,7 +366,7 @@ The Ruby agent does not support experimental versions. Databases supported by th
   <tbody>
     <tr>
       <td>
-        ActiveRecord
+        Active Record
       </td>
 
       <td>
@@ -467,7 +467,7 @@ The Ruby agent does not support experimental versions. Databases supported by th
 
 ## Other APM software [#other-monitoring-software]
 
-If your application uses other application performance monitoring (APM) software besides our agent, we cannot guarantee that our agent will work correctly and we cannot offer technical support. For more information, see [Errors when using other monitoring software](/docs/apm/new-relic-apm/troubleshooting/errors-while-using-new-relic-apm-alongside-other-apm-software).
+If your application uses other application performance monitoring (APM) software besides our agent, we can't guarantee that our agent will work correctly and we can't offer technical support. For more information, see [Errors when using other monitoring software](/docs/apm/new-relic-apm/troubleshooting/errors-while-using-new-relic-apm-alongside-other-apm-software).
 
 ## Instance details [#instance_details]
 
@@ -499,7 +499,7 @@ New Relic's Ruby agent [version 3.17.0 or higher](/docs/release-notes/agent-rele
   <tbody>
     <tr>
       <td rowSpan={2}>
-        ActiveRecord 5 or higher
+        Active Record 5 or higher
       </td>
 
       <td>
@@ -531,7 +531,7 @@ New Relic's Ruby agent [version 3.17.0 or higher](/docs/release-notes/agent-rele
 
     <tr>
       <td rowSpan={3}>
-        ActiveRecord 2.1 to 4
+        Active Record 2.1 to 4
       </td>
 
       <td>

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8160.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8160.mdx
@@ -1,6 +1,6 @@
 ---
 subject: Ruby agent
-releaseDate: '2023-02-01'
+releaseDate: '2023-02-06'
 version: 8.16.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.16.0.gem'
 ---

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8160.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8160.mdx
@@ -1,0 +1,40 @@
+---
+subject: Ruby agent
+releaseDate: '2023-02-01'
+version: 8.16.0
+downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.16.0.gem'
+---
+
+<Callout variant="important">
+We recommend updating to the latest agent version as soon as it's available. If you can't upgrade to the latest version, update your agents to a version at most 90 days old. Read more about [keeping agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+
+As of this release, the oldest supported version is [6.9.0.363](https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-690363)
+</Callout>
+
+## v8.16.0
+
+Version 8.16.0 introduces more Ruby on Rails instrumentation (especially for Rails 6 and 7) for various Action\*/Active\* libraries whose actions produce [Active Support notifications events](https://guides.rubyonrails.org/active_support_instrumentation.html).
+
+- **Add Various Ruby on Rails Library Instrumentations**
+
+  New instrumentation is now automatically provided by several Action\*/Active\* libaries that generate Active Support notifications. With each Ruby on Rails release, new the Rails libraries add new events and sometimes existing events have their payload parameters updated as well. The New Relic Ruby agent will now automatically process more of these events and parameters with New Relic segments created for each event. At a minimum, each segment gives timing information for the event. In several cases, all non-sensitive event payload parameters are also passed along in the segment.
+
+  The agent now newly supports or has updated support for the following libraries:
+
+  - Action Cable (for WebSockets) [PR#1749](https://github.com/newrelic/newrelic-ruby-agent/pull/1749)
+  - Action Controller (for the 'C' in MVC) [PR#1744](https://github.com/newrelic/newrelic-ruby-agent/pull/1744/)
+  - Action Mailbox (for sending mail) [PR#1740](https://github.com/newrelic/newrelic-ruby-agent/pull/1740)
+  - Action Mailer (for routing mail) [PR#1740](https://github.com/newrelic/newrelic-ruby-agent/pull/1740)
+  - Active Job (for background jobs) [PR#1742](https://github.com/newrelic/newrelic-ruby-agent/pull/1761)
+  - Active Support (for caching operations) [PR#1742](https://github.com/newrelic/newrelic-ruby-agent/pull/1742)
+
+  The instrumentations for each of these libaries are all enabled by default, but can be independently disabled via configuration by using the following parameters:
+
+  | Configuration name | Default | Behavior |
+  | ----- | ----- | ----- |
+  | `disable_action_cable` | `false` | If `true`, disables Action Cable instrumentation. |
+  | `disable_action_controller` | `false` | If `true`, disables Action Controller instrumentation. |
+  | `disable_action_mailbox` | `false` | If `true`, disables Action Mailbox instrumentation. |
+  | `disable_action_mailer` | `false` | If `true`, disables Action Mailer instrumentation. |
+  | `disable_activejob` | `false` | If `true`, disables Active Job instrumentation. |
+  | `disable_active_support` | `false` | If `true`, disables Active Support instrumentation. |


### PR DESCRIPTION
## Give us some context

The Ruby agent team is preparing to release version 8.16.0. This PR includes relevant documentation updates.