### PR TITLE
.NET Agent: Add 2.19.0 to list of verified compatible MongoDB.Driver versions

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -502,7 +502,7 @@ Prior versions of Npgsql may also be instrumented, but duplicate and/or missing 
           <td>
 Minimum supported version: 2.3.0
 
-Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1
+Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0
 
 Known incompatible versions: New methods added in 2.7 and above are not currently instrumented. 
           </td>

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -590,7 +590,7 @@ Known incompatible versions: Instance details are not available below version 2.
           <td>
 Minimum supported version: 2.3.0
 
-Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1
+Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0
 
 Known incompatible versions: New methods added in 2.7 and above are not currently instrumented. 
           </td>


### PR DESCRIPTION
Add 2.19.0 to the list of verified compatible MongoDB.Driver versions for the .NET Agent.