### PR TITLE
fix(stream data): various improvements

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing.mdx
@@ -45,7 +45,7 @@ Here are details about Data Plus features and availability:
 * Increased [max query duration](/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries/#query-duration) of two minutes for a regular query and 10 minutes for an [asynchronous query](/docs/apis/nerdgraph/examples/async-queries-nrql-tutorial). 
 * Increased retention of several important data types ([learn more](/docs/data-apis/manage-data/manage-data-retention)).
 * Our [log obfuscation UI](/docs/logs/ui-data/obfuscation-ui).
-* [Streaming data export](/docs/apis/nerdgraph/examples/nerdgraph-streaming-export), which lets you stream ingested data to AWS Kinesis.
+* [Streaming data export](/docs/apis/nerdgraph/examples/nerdgraph-streaming-export), which lets you stream New Relic data to AWS Kinesis or Azure Event Hub.
 * With [Enterprise edition](https://newrelic.com/pricing): [FedRAMP](/docs/security/security-privacy/compliance/fedramp-compliant-endpoints) and [HIPAA](/docs/security/security-privacy/compliance/hipaa-readiness-new-relic)-compliant data security, for eligible customers. (Enterprise edition not yet available for [Azure Native New Relic Service](/docs/infrastructure/microsoft-azure-integrations/get-started/azure-native).)
 * [Historical data export](/docs/apis/nerdgraph/examples/nerdgraph-historical-data-export), which lets you run larger queries with no timeout. (Not yet available for [Azure Native New Relic Service](/docs/infrastructure/microsoft-azure-integrations/get-started/azure-native).)
 * [Vulnerability Management](/docs/vulnerability-management/overview). (Not yet available for [Azure Native New Relic Service](/docs/infrastructure/microsoft-azure-integrations/get-started/azure-native).)

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/real-time-streaming.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/real-time-streaming.mdx
@@ -1,5 +1,5 @@
 ---
-title: Real time streaming
+title: Details on APM real-time streaming
 tags:
   - Agents
   - Manage APM agents
@@ -16,7 +16,9 @@ import apmRealTimeStreaming from 'images/apm_diagram_real-time-streaming.png'
 
 With real time streaming, your APM event data is sent to New Relic every five seconds. You can query and visualize your data for transactions, errors, and custom events in near real time. The smaller payloads result in faster chart refreshes and faster queries of data that is the most important to you.
 
-No configuration is needed to take advantage of real time streaming. All you need to do is ensure your [APM agent version](#enable) is up to date.
+For details on agents that support this feature, see [Agent versions](#enable).
+
+Looking to stream your New Relic data to the cloud? See [Streaming data export](/docs/apis/nerdgraph/examples/nerdgraph-streaming-export).
 
 ## Why it matters [#benefits]
 
@@ -38,25 +40,6 @@ Use real time streaming to quickly understand the impact when something has chan
 * Respond quickly to failure conditions and anomalies.
 * Get the most out of our [dashboards](#create).
 * Reduce mean time to detection with APM events reporting every five seconds.
-
-## Agent version to automatically enable [#enable]
-
-To enable real time streaming, [update](/docs/agents/manage-apm-agents/installation/update-new-relic-agent) to the latest APM agent. You don't need to configure anything to enable real time streaming; it will automatically report faster!
-
-Real time streaming is supported by all APM agents. Here are the minimum agent versions:
-
-* **C SDK:** [v1.3.0 or higher](/docs/release-notes/agent-release-notes/c-sdk-release-notes)
-* **Go:** [v2.8.0 or higher](/docs/release-notes/agent-release-notes/go-release-notes)
-* **Java:** [v5.5.0 or higher](/docs/release-notes/agent-release-notes/java-release-notes)
-* **.NET:** [v8.23.107.0 or higher](/docs/release-notes/agent-release-notes/net-release-notes)
-* **Node.js:** [v5.13.0 or higher](/docs/release-notes/agent-release-notes/nodejs-release-notes)
-* **PHP:** [v9.5.0.252 or higher](/docs/release-notes/agent-release-notes/php-release-notes)
-* **Python:** [v5.2.0.127 or higher](/docs/release-notes/agent-release-notes/python-release-notes)
-* **Ruby:** [v6.7.0.359 or higher](/docs/release-notes/agent-release-notes/ruby-release-notes)
-
-<Callout variant="caution">
-  If Transaction event reporting is [disabled](/docs/insights/use-insights-ui/manage-account-data/data-summary-page-manage-apps-reporting-insights#enable-disable), this can affect some UI elements throughout New Relic. You may see some empty charts on some UI pages that rely on this data.
-</Callout>
 
 ## Query real time streaming data [#nrql]
 
@@ -106,3 +89,20 @@ You can visualize the results of your NRQL query in through real time charts:
 2. Use the [Metrics & events explorer](/docs/query-your-data/explore-query-data/browse-data/introduction-data-explorer) to start building a chart.
 3. For applicable queries, hover over the query and click **Edit in query builder** to refine your query. 
 4. In your NRQL query, adjust the [`SINCE` and `TIMESERIES` clauses](#nrql) to take advantage of the 5 second refresh intervals.
+
+## Agent versions with this feature [#enable]
+
+Real time streaming is supported by all APM agents. Here are the minimum agent versions:
+
+* **C SDK:** [v1.3.0 or higher](/docs/release-notes/agent-release-notes/c-sdk-release-notes)
+* **Go:** [v2.8.0 or higher](/docs/release-notes/agent-release-notes/go-release-notes)
+* **Java:** [v5.5.0 or higher](/docs/release-notes/agent-release-notes/java-release-notes)
+* **.NET:** [v8.23.107.0 or higher](/docs/release-notes/agent-release-notes/net-release-notes)
+* **Node.js:** [v5.13.0 or higher](/docs/release-notes/agent-release-notes/nodejs-release-notes)
+* **PHP:** [v9.5.0.252 or higher](/docs/release-notes/agent-release-notes/php-release-notes)
+* **Python:** [v5.2.0.127 or higher](/docs/release-notes/agent-release-notes/python-release-notes)
+* **Ruby:** [v6.7.0.359 or higher](/docs/release-notes/agent-release-notes/ruby-release-notes)
+
+<Callout variant="caution">
+  If Transaction event reporting is [disabled](/docs/insights/use-insights-ui/manage-account-data/data-summary-page-manage-apps-reporting-insights#enable-disable), this can affect some UI elements throughout New Relic. You may see some empty charts on some UI pages that rely on this data.
+</Callout>


### PR DESCRIPTION
Add 'Azure' to data streaming in Data Plus doc. 
Clarify the 'streaming data' doc in APM is for APM, and made some improvements related to 'supported agent version' wording.