### PR TITLE
fix: clean up references to require("newrelic") in favor of -r

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -96,7 +96,7 @@ Define your configuration rules from the most specific to the most general. The 
 Make sure that loading the New Relic module is the first thing your application does, as it needs to bootstrap itself before the rest of your application loads:
 
 ```js
-var newrelic = require('newrelic');
+const newrelic = require('newrelic');
 ```
 
 This returns the request naming API. You can safely require the module from multiple modules in your application, as it only initializes itself once.
@@ -191,7 +191,7 @@ Use these API calls to [expand your instrumentation with custom instrumentation]
     // load the agent
     const newrelic = require('newrelic');
 
-    // module loaded before newrelic 
+    // module loaded before newrelic
     const expressModule = require('express');
 
     // instrument express after the agent has been loaded
@@ -797,11 +797,11 @@ New Relic's Node.js agent includes additional API calls.
     ```
 
     Use this call if your app is doing its own error handling with domains or try/catch clauses, but you want all of the information about how many errors are coming out of the app to be centrally managed. Unlike other Node.js calls, this can be used outside of route handlers, but it will have additional context if called from within transaction scope.
-    
+
     `error` should be an `Error` or one of its subtypes, but the API will handle strings and objects that have an attached `.message` or `.stack` property.
 
     `customAttributes` is an optional object of any custom attributes to be displayed in the New Relic UI.
-    
+
     **Example:**
     ```js
     try {

--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/browser-monitoring-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/browser-monitoring-nodejs-agent.mdx
@@ -44,8 +44,8 @@ Here are some examples of how to set up browser monitoring with different framew
     In your `app.js`:
 
     ```js
-    var newrelic = require('newrelic');
-    var app = require('express')();
+    const newrelic = require('newrelic');
+    const app = require('express')();
     // in express, this lets you call newrelic from within a template
     app.locals.newrelic = newrelic;
 
@@ -78,13 +78,13 @@ Here are some examples of how to set up browser monitoring with different framew
     In your `app.js`:
 
     ```js
-    var newrelic = require('newrelic');
+    const newrelic = require('newrelic');
 
-    var http = require('http')
-    var path = require('path')
-    var swig = require('swig')
+    const http = require('http')
+    const path = require('path')
+    const swig = require('swig')
 
-    var app = require('express')();
+    const app = require('express')();
 
     app.locals.newrelic = newrelic;
 
@@ -125,9 +125,9 @@ Here are some examples of how to set up browser monitoring with different framew
     Using **hapi**, in your `app.js`:
 
     ```js
-    var newrelic = require('newrelic');
-    var Hapi = require('hapi');
-    var server = new Hapi.Server(parseInt(PORT), '0.0.0.0', {
+    const newrelic = require('newrelic');
+    const Hapi = require('hapi');
+    const server = new Hapi.Server(parseInt(PORT), '0.0.0.0', {
       views: {
         engines : {html: 'handlebars' },
         path : __dirname + '/templates'
@@ -135,7 +135,7 @@ Here are some examples of how to set up browser monitoring with different framew
     });
 
     function homepage(request, reply) {
-      var context = {
+      const context = {
         // pass in the header each request
         nreum : newrelic.getBrowserTimingHeader(),
         content : ...

--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation.mdx
@@ -97,9 +97,9 @@ In order to create custom [web transactions](/docs/apm/transactions/intro-transa
     This example instruments a `/websocket/ping` transaction, a `/websocket/update` transaction, and a `/websocket/new-message` transaction within `socket.io`. The `/ping` example is synchronous, while the `/new-message` and `/update` examples are asynchronous.
 
     ```js
-    var nr = require('newrelic');
-    var app = require('http').createServer();
-    var io = require('socket.io')(app);
+    const nr = require('newrelic');
+    const app = require('http').createServer();
+    const io = require('socket.io')(app);
 
     io.on('connection', function(socket) {
       socket.on('ping', function(data) {
@@ -111,7 +111,7 @@ In order to create custom [web transactions](/docs/apm/transactions/intro-transa
       socket.on('update', function(data) {
         nr.startWebTransaction('/websocket/update', function transactionHandler() {
           // Using API getTransaction
-          var transaction = nr.getTransaction();
+          const transaction = nr.getTransaction();
           updateChatWindow(data, function transactionHandler() {
             socket.emit('update-done');
             transaction.end();
@@ -201,14 +201,14 @@ To instrument background tasks, call [`startBackgroundTransaction`](/docs/agents
     This example instruments `update:cache` within `setInterval`:
 
     ```js
-    var nr = require('newrelic');
-    var redis = require('redis').createClient();
+    const nr = require('newrelic');
+    const redis = require('redis').createClient();
 
     // Using API getTransaction to manage ending the transaction
     setInterval(function() {
       nr.startBackgroundTransaction('update:cache', function transactionHandler() {
-        var newValue = someDataGenerator();
-        var transaction = nr.getTransaction();
+        const newValue = someDataGenerator();
+        const transaction = nr.getTransaction();
 
         redis.set('some:cache:key', newValue, function() {
           transaction.end();
@@ -373,7 +373,7 @@ To do this, wrap your callbacks in custom tracers. Custom tracers create and col
     This example shows how `startSegment` can be used to record a synchronous function that is responsible for assigning its return value to a variable.
 
     ```js
-    var result = nr.startSegment('calculateTotal', true, function() {
+    const result = nr.startSegment('calculateTotal', true, function() {
       return calculateTotal(outerVar1, outerVar2);
     });
     ```

--- a/src/content/docs/apm/agents/nodejs-agent/hosting-services/nodejs-agent-heroku.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/hosting-services/nodejs-agent-heroku.mdx
@@ -22,39 +22,39 @@ To install the New Relic add-on through the [Heroku website's Add-on page for Ne
 
 1. From Heroku's Add-on page for New Relic, select the [appropriate subscription plan](https://elements.heroku.com/addons/newrelic#pricing). Then run this toolbelt command:
 
-   ```
+   ```shell
    heroku addons:create newrelic:$planlevel
    ```
 2. From **Select an app**, select your New Relic app.
 3. Use this toolbelt command to give your app a [descriptive name](/docs/apm/new-relic-apm/installation-configuration/name-your-application):
 
-   ```
+   ```shell
    heroku config:set NEW_RELIC_APP_NAME='Your Application Name'
    ```
 4. If you are using environment variables instead of your `newrelic.js` config file settings to [customize your Node.js agent configuration](#variables), use this toolbelt command:
 
-   ```
+   ```shell
    heroku config:set NEW_RELIC_NO_CONFIG_FILE='true'
    ```
 5. Verify your New Relic app name, [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key), and [log setting](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#logging_config):
 
-   ```
+   ```shell
    heroku config
    ```
 6. Install the Node.js agent and save to your `npm` dependencies.
 
-   ```
+   ```shell
    npm install newrelic --save
    ```
-7. To ensure that the `newrelic` package is properly included in your `package.json` file when you push to Heroku, install the [New Relic Node.js agent package](/docs/agents/nodejs-agent/installation-configuration/installing-maintaining-nodejs) on your local system. Make sure you run your program with New Relic moduel loaded first by using `-r/--require` flag.
+7. To ensure that the `newrelic` package is included in your `package.json` file when you push to Heroku, install the [package for New Relic Node.js agent](/docs/agents/nodejs-agent/installation-configuration/installing-maintaining-nodejs) on your local system. Use Node.js `-r/--require` flag when you run your program to make sure New Relic's module is loaded:
 
-   ```
-   node -r newrelic your-program.js
+   ```shell
+   node -r newrelic YOUR_PROGRAM.js
    ```
 
 8. Run the following commands:
 
-   ```
+   ```shell
    git add . && git commit -m "Add New Relic"
    git push heroku master && heroku logs  --tail
    ```
@@ -73,7 +73,7 @@ You can customize the New Relic [`newrelic.js` config file](/docs/agents/nodejs-
 
 Here is an example of using the Heroku command line to set environment variables instead of using your `newrelic.js` config file.
 
-```
+```shell
 $ heroku config:set NEW_RELIC_LICENSE_KEY=your license key
 $ heroku config:set NEW_RELIC_APP_NAME=your production app name
 $ heroku config:set NEW_RELIC_NO_CONFIG_FILE='true'
@@ -81,7 +81,7 @@ $ heroku config:set NEW_RELIC_NO_CONFIG_FILE='true'
 
 To confirm your settings from the command line, use:
 
-```
+```shell
 $ heroku config
 ```
 
@@ -89,6 +89,6 @@ $ heroku config
 
 To upgrade your Node.js agent version if New Relic is already installed, use this toolbelt command:
 
-```
+```shell
 npm install newrelic --save
 ```

--- a/src/content/docs/apm/agents/nodejs-agent/hosting-services/nodejs-agent-heroku.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/hosting-services/nodejs-agent-heroku.mdx
@@ -46,11 +46,12 @@ To install the New Relic add-on through the [Heroku website's Add-on page for Ne
    ```
    npm install newrelic --save
    ```
-7. To ensure that the `newrelic` package is properly included in your `package.json` file when you push to Heroku, install the [New Relic Node.js agent package](/docs/agents/nodejs-agent/installation-configuration/installing-maintaining-nodejs) on your local system. Include New Relic on the first line of your app's main module:
+7. To ensure that the `newrelic` package is properly included in your `package.json` file when you push to Heroku, install the [New Relic Node.js agent package](/docs/agents/nodejs-agent/installation-configuration/installing-maintaining-nodejs) on your local system. Make sure you run your program with New Relic moduel loaded first by using `-r/--require` flag.
 
    ```
-   require ('newrelic');
+   node -r newrelic your-program.js
    ```
+
 8. Run the following commands:
 
    ```

--- a/src/content/docs/apm/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure.mdx
@@ -10,7 +10,7 @@ redirects:
   - /docs/nodejs/nodejs-agent-on-microsoft-azure
 ---
 
-Read on to learn about special considerations for using Microsoft Azure Web Apps as a hosting service with New Relic's Node.js agent.
+Learn about special considerations for using Microsoft Azure Web Apps as a hosting service with New Relic's Node.js agent.
 
 ## What you need [#compatibility]
 
@@ -23,7 +23,7 @@ In addition to the [Compatibility and requirements for the Node.js agent](/docs/
 
 To add the New Relic Node.js agent to your Azure application:
 
-1. In your app's root, verify that there is a `package.json` file. If there is not, create one via the command line:
+1. In your app's root, verify that there is a `package.json` file. If there's none, create one by running:
 
    ```bash
    touch package.json
@@ -42,11 +42,10 @@ To add the New Relic Node.js agent to your Azure application:
      }
    }
    ```
-3. Update where you run your program with `newrelic` module loaded first by using node's `-r/--require` flag. For example:
-
-```sh
-node -r newrelic server.js
-```
+3. To make sure the `newrelic` module is loaded first, use Node.js `-r/--require` flag to run the following:
+  ```shell
+  node -r newrelic server.js
+  ```
 
 ## Adding app settings in Azure [#azure_settings]
 

--- a/src/content/docs/apm/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure.mdx
@@ -42,18 +42,11 @@ To add the New Relic Node.js agent to your Azure application:
      }
    }
    ```
-3. Add `require('newrelic');` to the top of the `server.js` file. For example:
+3. Update where you run your program with `newrelic` module loaded first by using node's `-r/--require` flag. For example:
 
-   ```js
-   require('newrelic');
-
-   var http = require('http')
-   var port = process.env.PORT || 1337;
-   http.createServer(function(req, res) {
-     res.writeHead(200, { 'Content-Type': 'text/plain' });
-     res.end('Hello New Relic Node.js agent!\n');
-   }).listen(port);
-   ```
+```sh
+node -r newrelic server.js
+```
 
 ## Adding app settings in Azure [#azure_settings]
 

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-docker.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-docker.mdx
@@ -18,15 +18,15 @@ With just a few additions your existing Dockerfile can be used with our Node.js 
 
 1. Add `newrelic` to your `package.json`:
 
-   ```
+   ```json
    "newrelic": "latest",
    ```
 
    Install a specific version, or use any of the other options provided by the [`package.json` format](https://docs.npmjs.com/files/package.json#dependencies). Check [the Node.js agent release notes](/docs/release-notes/agent-release-notes/nodejs-release-notes) for information about past agent versions.
-2. Depending on how your container is setup you can edit the `ENTRYPOINT` to include `newrelic` module first with the `-r/--require` flag.  `node -r newrelic your-program.js`.  If you cannot control how your program is rung, you can load the `newrelic` module _before any other module_ in your program: `require('newrelic')`.
+2. Depending on how your container is setup, you can edit the `ENTRYPOINT` to include `newrelic` module first with Node.js `-r/--require` flag by running `node -r newrelic YOUR_PROGRAM.js`. If you can't control how your program runs, you can load the `newrelic` module before any other module in your program by adding `require('newrelic')`.
 
-<Callout variant="important">
-If you have a npm script to run your program(e.g. `npm start`), you can programatically modify this script by running `npm pkg set scripts.start="node -r newrelic your-program.js"`.
+<Callout variant="tip">
+  If you have an npm script to run your program such as `npm start`, you can programatically modify this script by running `npm pkg set scripts.start="node -r newrelic your-program.js"`.
 </Callout>
 
 3. Add the environment variable `NEW_RELIC_NO_CONFIG_FILE=true` to your Dockerfile so the agent can run without a configuration file.
@@ -38,10 +38,10 @@ If you have a npm script to run your program(e.g. `npm start`), you can programa
 4. Build your Docker image the way you normally do.
 5. To run your Docker app with the agent enabled, add [your license key](/docs/accounts/install-new-relic/account-setup/license-key) and [app name](/docs/agents/manage-apm-agents/app-naming/name-your-application) to your `docker run` command as environment variables:
 
-   ```
+   ```shell
    docker run -e NEW_RELIC_LICENSE_KEY=YOUR_LICENSE_KEY \
-         -e NEW_RELIC_APP_NAME="Your Application Name" \
-         your_image_name:latest
+         -e NEW_RELIC_APP_NAME="YOUR_APP_NAME" \
+         YOUR_IMAGE_NAME:latest
    ```
 
 <InstallFeedback />
@@ -49,21 +49,21 @@ If you have a npm script to run your program(e.g. `npm start`), you can programa
 ## Other configuration options [#configure]
 
 <Callout variant="caution">
-  Do not include your license key in your Dockerfile or Docker image. For more information, see [our documentation on license key security](/docs/accounts/install-new-relic/account-setup/license-key#license-key-security).
+  Don't include your license key in your Dockerfile or Docker image. For more information, see [our documentation on license key security](/docs/accounts/install-new-relic/account-setup/license-key#license-key-security).
 </Callout>
 
 In addition to setting your application name or license key, you can set [other configuration options](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration) by starting your container with the `-e` option. For example, to enable [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing), use:
 
-```
+```shell
 $ docker run -e NEW_RELIC_LICENSE_KEY=YOUR_LICENSE_KEY \
-        -e NEW_RELIC_APP_NAME="Your Application Name" \
+        -e NEW_RELIC_APP_NAME="YOUR_APP_NAME" \
         -e NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true \
-        your_image_name:latest
+        YOUR_IMAGE_NAME:latest
 ```
 
 You can also set configuration options in your Dockerfile using `ENV` directives:
 
-```
+```dockerfile
 ENV NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true \
     NEW_RELIC_LOG=stdout
     # etc.

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-docker.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-docker.mdx
@@ -23,7 +23,12 @@ With just a few additions your existing Dockerfile can be used with our Node.js 
    ```
 
    Install a specific version, or use any of the other options provided by the [`package.json` format](https://docs.npmjs.com/files/package.json#dependencies). Check [the Node.js agent release notes](/docs/release-notes/agent-release-notes/nodejs-release-notes) for information about past agent versions.
-2. In the first line of your app's main module, add `require('newrelic');`.
+2. Depending on how your container is setup you can edit the `ENTRYPOINT` to include `newrelic` module first with the `-r/--require` flag.  `node -r newrelic your-program.js`.  If you cannot control how your program is rung, you can load the `newrelic` module _before any other module_ in your program: `require('newrelic')`.
+
+<Callout variant="important">
+If you have a npm script to run your program(e.g. `npm start`), you can programatically modify this script by running `npm pkg set scripts.start="node -r newrelic your-program.js"`.
+</Callout>
+
 3. Add the environment variable `NEW_RELIC_NO_CONFIG_FILE=true` to your Dockerfile so the agent can run without a configuration file.
 
 <Callout variant="important">

--- a/src/content/docs/apm/agents/nodejs-agent/troubleshooting/troubleshoot-your-nodejs-installation.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/troubleshooting/troubleshoot-your-nodejs-installation.mdx
@@ -50,11 +50,21 @@ Some common problems users encounter after installing the New Relic Node.js agen
       <tbody>
         <tr>
           <td>
+            Run script
+          </td>
+
+          <td>
+            Ensure that you `newrelic` module is loaded first by using `-r/--require` flag: `node -r newrelic your-program.js`.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
             Main module
           </td>
 
           <td>
-            Ensure that you have added `require('newrelic');` as the first line of the app's main module. If the `require` is added later, the Node.js agent may not properly instrument your application.
+            If you cannot control how your main module is run, ensure that you have added `require('newrelic')` as the first line of the app's main module. If the require is added later, the Node.js agent may not properly instrument your application.
           </td>
         </tr>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->


## Give us some context

* What problems does this PR solve?
We have many places in our Node.js agent that still refer to manually editing your app and adding `require('newrelic')`.  The preferred way to do this now is via the `-r` flag to the Node.js runtime.  I updated all instances and still called out the legacy method in places where applicable.
