### PR TITLE
FIX(Go agent) Release notes for 3.20.3 metadata correction

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-20-3.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-20-3.mdx
@@ -1,8 +1,8 @@
 ---
 subject: Go agent
-releaseDate: '2022-12-14'
-version: 3.20.2
-downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.20.2'
+releaseDate: '2023-01-19'
+version: 3.20.3
+downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.20.3'
 ---
 
 <Callout variant="important">
@@ -11,7 +11,9 @@ We recommend updating to the latest agent version as soon as it's available. If 
 
 ## 3.20.3
 
+<Callout variant="important">
  Please note that the v2 go agent is no longer supported according to our EOL policy. 
+</Callout>
 
  ### Fixed
  * Performance Improvements for compression


### PR DESCRIPTION
The previous 3.20.3 release notes doc had incorrect metadata. This corrects that so the correct release note shows as current.