### PR TITLE
Remove ruby 2.2 and 2.3 support

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -78,8 +78,8 @@ The New Relic Ruby agent does not support experimental versions. Ruby versions s
         * ~~1.9.x~~
         * ~~2.0.x~~
         * ~~2.1.x~~
-        * 2.2.x - Deprecated
-        * 2.3.x - Deprecated
+        * ~~2.2.x~~
+        * ~~2.3.x~~
         * 2.4.x
         * 2.5.x
         * 2.6.x
@@ -90,6 +90,7 @@ The New Relic Ruby agent does not support experimental versions. Ruby versions s
       </td>
 
       <td>
+        * 2.2.x, 2.3.x Last supported agent: 8.16.0.
         * 2.0.x, 2.1.x Last supported agent: 6.15.0.
         * 1.8.7, 1.9.2, 1.9.3: Last supported agent was 3.18.1.330.
         * 1.8.6: Last supported agent was 3.6.8.168.


### PR DESCRIPTION
The Ruby agent will stop supporting Ruby 2.2. and 2.3 with major release 9.0. 

**Please do not merge until a member of the Ruby team reaches out.**

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.