### PR TITLE
whats new: tls eol feb2 23

### DIFF
--- a/src/content/whats-new/2023/02/what-new-02-01-tls-eol.md
+++ b/src/content/whats-new/2023/02/what-new-02-01-tls-eol.md
@@ -1,0 +1,12 @@
+---
+title: 'As of February 02, 2023 New Relic requires TLS 1.2'
+summary: 'Avoid interruptions on your data, upgrade your TLS stack to TLS 1.2 or above'
+releaseDate: '2023-02-02'
+
+getStartedLink: 'https://docs.newrelic.com/docs/new-relic-solutions/get-started/networks/#tls'
+learnMoreLink: 'https://discuss.newrelic.com/t/tls-1-0-1-1-to-be-disabled-for-all-inbound-connections-after-oct-24th-2022/188451'
+
+---
+Here at New Relic, security is our priority. This is why, **effective February 2, 2023**, we have updated our [Transport Layer Security (TLS)](https://en.wikipedia.org/wiki/Transport_Layer_Security) requirements for all inbound connections to a **minimum of version TLS 1.2**.
+
+For more information check out our this **[Explorer’s Hub post](https://discuss.newrelic.com/t/tls-1-0-1-1-to-be-disabled-for-all-inbound-connections-after-oct-24th-2022/188451)**, go to our  [documentation](https://docs.newrelic.com/docs/new-relic-solutions/get-started/networks/#tls), or contact [New Relic Support](https://support.newrelic.com/s/).


### PR DESCRIPTION
what's new announcing end of life for tls 1.0/1.1 requiring tls 1.2+.  Post should be done on 2 Feb 2023 to keep in calendar line with EOL activity on that day.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.