### PR TITLE
Adds support for ISO8601 timestamps in logs

### DIFF
--- a/src/content/docs/logs/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-api/introduction-log-api.mdx
@@ -202,11 +202,11 @@ You can send your JSON message using either a simplified or detailed set of attr
           </td>
 
           <td>
-            Integer
+            Integer, String
           </td>
 
           <td>
-            Either milliseconds or seconds since epoch
+            Milliseconds or seconds since epoch (when set as an Integer), or ISO8601-formatted timestamp (when set as a String)
           </td>
 
           <td>
@@ -214,7 +214,7 @@ You can send your JSON message using either a simplified or detailed set of attr
           </td>
 
           <td>
-            If the field is not specific as millisecond or seconds since epoch, the message will be timestamped using the ingest time
+            If this field is not present or incorrectly specified, the message will be timestamped using the ingest time
           </td>
         </tr>
 
@@ -478,7 +478,7 @@ Some specific attributes have additional restrictions:
 * `appId`: Must be an integer. When using a non-integer data type, the data will be ingested but becomes unqueryable.
 * `entity.guid`, `entity.name`, and `entity.type`: These attributes are used internally to identify entities. Any values submitted with these keys in the attributes section of a metric data point may cause undefined behavior such as missing entities in the UI or telemetry not associating with the expected entities. For more information please refer to [Entity synthesis](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/#entity-synthesis).
 * `eventType`: This is a reserved attribute name. If it is included, it will be dropped during ingest.
-* `timestamp`: Must be a Unix epoch timestamp. You can define timestamps either in seconds or in milliseconds.
+* `timestamp`: Must be a Unix epoch timestamp (either in seconds or in milliseconds) or an ISO8601-formatted timestamp.
 
 <Callout variant="important">
   Payloads with timestamps older than 48 hours may be dropped.
@@ -562,11 +562,11 @@ We accept any valid JSON payload. The payload must encoded as **UTF-8**.
           </td>
 
           <td>
-            Integer
+            Integer, String
           </td>
 
           <td>
-            Milliseconds or seconds since epoch
+            Milliseconds or seconds since epoch (when set as an Integer), or ISO8601-formatted timestamp (when set as a String)
           </td>
 
           <td>
@@ -641,11 +641,11 @@ We accept any valid JSON payload. The payload must encoded as **UTF-8**.
           </td>
 
           <td>
-            Integer
+            Integer, String
           </td>
 
           <td>
-            Milliseconds or seconds since epoch
+            Milliseconds or seconds since epoch (when set as an Integer), or ISO8601-formatted timestamp (when set as a String)
           </td>
 
           <td>
@@ -881,10 +881,10 @@ Content-Length: 319
      }
    },
    "logs": [{
-       "timestamp": <TIMESTAMP_IN_UNIX_EPOCH><,
+       "timestamp": <TIMESTAMP_IN_UNIX_EPOCH_OR_IS08601_FORMAT>,
        "message": "User 'xyz' logged in"
      },{
-       "timestamp": <TIMESTAMP_IN_UNIX_EPOCH,
+       "timestamp": <TIMESTAMP_IN_UNIX_EPOCH_OR_IS08601_FORMAT>,
        "message": "User 'xyz' logged out",
        "attributes": {
          "auditId": 123
@@ -1001,7 +1001,7 @@ Api-Key: <YOUR_LICENSE_KEY>
 Accept: */*
 Content-Length: 133
 {
-    "timestamp": <TIMESTAMP_IN_UNIX_EPOCH>,
+    "timestamp": <TIMESTAMP_IN_UNIX_EPOCH_OR_IS08601_FORMAT>,
     "message": "User 'xyz' logged in",
     "logtype": "accesslogs",
     "service": "login-service",

--- a/src/content/docs/logs/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-api/introduction-log-api.mdx
@@ -206,7 +206,7 @@ You can send your JSON message using either a simplified or detailed set of attr
           </td>
 
           <td>
-            Milliseconds or seconds since epoch (when set as an Integer), or ISO8601-formatted timestamp (when set as a String)
+            Milliseconds or seconds since epoch (when set as an integer), or ISO8601-formatted timestamp (when set as a string)
           </td>
 
           <td>
@@ -566,7 +566,7 @@ We accept any valid JSON payload. The payload must encoded as **UTF-8**.
           </td>
 
           <td>
-            Milliseconds or seconds since epoch (when set as an Integer), or ISO8601-formatted timestamp (when set as a String)
+            Milliseconds or seconds since epoch (when set as an integer), or ISO8601-formatted timestamp (when set as a string)
           </td>
 
           <td>
@@ -645,7 +645,7 @@ We accept any valid JSON payload. The payload must encoded as **UTF-8**.
           </td>
 
           <td>
-            Milliseconds or seconds since epoch (when set as an Integer), or ISO8601-formatted timestamp (when set as a String)
+            Milliseconds or seconds since epoch (when set as an integer), or ISO8601-formatted timestamp (when set as a string)
           </td>
 
           <td>


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
Adds documentation around ISO8601 timestamp support for Logs
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
N/A
* If your issue relates to an existing GitHub issue, please link to it.
N/A