### PR TITLE
[FIX] CSP recommendations in Browser Compatibility Document

### DIFF
--- a/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
+++ b/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
@@ -37,10 +37,10 @@ For more information, review the [instrumentation for browser monitoring](/docs/
 
 The browser agent officially supports the following browser versions:
 
-* [Chrome](https://www.google.com/chrome/) (previous 5 major versions)
-* [Safari](https://www.apple.com/safari/) (previous 10 major versions)
-* [Firefox](https://www.mozilla.org/firefox/) (previous 10 major versions)
-* [Edge](https://www.microsoft.com/adge) (previous 10 major versions)
+* [Chrome](https://www.google.com/chrome/) (previous 10 versions)
+* [Safari](https://www.apple.com/safari/) (previous 10 versions)
+* [Firefox](https://www.mozilla.org/firefox/) (previous 10 versions)
+* [Edge](https://www.microsoft.com/adge) (previous 10 versions)
 
 Instrumentation and specific features may be compatible with other browsers or versions. 
 
@@ -249,16 +249,19 @@ In older browsers `image-src` or requests for images can be a possible exception
 
     <tr>
       <td>
-        `https://bam.nr-data.net`
-
-        `https://bam-cell.nr-data.net`
-
-        <Callout variant="important">
-          Add `https://gov-bam.nr-data.net` if you're using FedRAMP-compliant endpoints.
-        </Callout>
+        `*.nr-data.net`
       </td>
 
       <td>
+        The agent attempts to send payloads to subdomains of `nr-data.net`, which can vary by account type. If `*.nr-data.net` is too inclusive for your requirements, each individual subdomain will need to be added:
+        * US based accounts:
+            * `https://bam.nr-data.net`
+            * `https://bam-cell.nr-data.net`
+        * EU based accounts:
+            * `https://bam.eu01.nr-data.net`
+        * FedRAMP-compliant accounts:
+            * `https://gov-bam.nr-data.net`
+        
         * Add to the `script-src` directive or to the fallback `default-src` directive. This is where the agent sends its collected data. One of the calls to this URL is a JSONP call, which means that the URL must be allowed as a script source.
         * Add to the `connect-src` directive or to the fallback `default-src` directive. The `connect-src` directive affects the URLs that scripts can call (for example, using the XMLHttpRequest interface). If you have CSP restrictions specifically around this directive, then add this URL as an exception.
       </td>


### PR DESCRIPTION


## Give us some context
This PR updates the CSP section of the browser agent compatibility requirements doc, as recommended in https://issues.newrelic.com/browse/NR-77599 .  It was missing a route for EU customers.  But beyond this, the list of domains was getting long and could be included as `*.nr-data.net` if desired.  All specific subdomains should still be configurable if the `*` does not meet the customer's needs.

This PR also fixes an error in our "supported versions" in the same document.