### PR TITLE
Remove support for deprecated gems

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -137,9 +137,9 @@ Web servers supported by the Ruby agent include:
         * 6.0.x
       </td>
 
-      <td/>
+      </td>
 
-      <td/>
+      </td>
     </tr>
 
     <tr>
@@ -159,7 +159,7 @@ Web servers supported by the Ruby agent include:
         * 1.0.x
       </td>
 
-      <td/>
+      </td>
     </tr>
 
     <tr>
@@ -169,7 +169,7 @@ Web servers supported by the Ruby agent include:
 
       <td>
         * ~~4.5.0~~
-      <td/>
+      </td>
 
       <td>
         *  4.5.0: Last supported agent was 8.16.0.
@@ -185,9 +185,9 @@ Web servers supported by the Ruby agent include:
         * 1.x.x
       </td>
 
-      <td/>
+      </td>
 
-      <td/>
+    
     </tr>
 
     <tr>
@@ -207,7 +207,7 @@ Web servers supported by the Ruby agent include:
         * 3.0.x
       </td>
 
-      <td/>
+      
     </tr>
 
     <tr>
@@ -219,9 +219,9 @@ Web servers supported by the Ruby agent include:
         Supported for all agent-supported versions of Ruby
       </td>
 
-      <td/>
+      </td>
 
-      <td/>
+    
     </tr>
   </tbody>
 </table>

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -136,10 +136,6 @@ Web servers supported by the Ruby agent include:
         * 5.x.x
         * 6.0.x
       </td>
-
-      </td>
-
-      </td>
     </tr>
 
     <tr>
@@ -158,8 +154,6 @@ Web servers supported by the Ruby agent include:
       <td>
         * 1.0.x
       </td>
-
-      </td>
     </tr>
 
     <tr>
@@ -170,10 +164,11 @@ Web servers supported by the Ruby agent include:
       <td>
         * ~~4.5.0~~
       </td>
-
+      
       <td>
         *  4.5.0: Last supported agent was 8.16.0.
       </td>
+
     </tr>
 
     <tr>
@@ -184,10 +179,6 @@ Web servers supported by the Ruby agent include:
       <td>
         * 1.x.x
       </td>
-
-      </td>
-
-    
     </tr>
 
     <tr>
@@ -217,8 +208,6 @@ Web servers supported by the Ruby agent include:
 
       <td>
         Supported for all agent-supported versions of Ruby
-      </td>
-
       </td>
 
     

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -167,7 +167,7 @@ Web servers supported by the Ruby agent include:
         Rainbows!
       </td>
 
-      <td/>
+      <td>
         * ~~4.5.0~~
       <td/>
 

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -16,63 +16,47 @@ redirects:
   - /docs/ruby/rubinius
   - /docs/agents/ruby-agent/troubleshooting/new-relic-puma
 ---
-
 Before you [install New Relic's Ruby agent](/docs/agents/ruby-agent/installation-and-configuration/ruby-agent-installation), make sure you meet these requirements for compatible operating systems, security requirements, and supported frameworks.
-
 If you don't have one already, start by [creating a New Relic account](https://newrelic.com/signup). It's free, forever.
-
 ## Operating systems [#os]
-
 The Ruby agent supports UNIX-like operating systems such as Linux, Solaris, FreeBSD, and macOS.
-
 ## Security requirements [#security]
-
 As a standard [security measure for data collection](/docs/accounts-partnerships/accounts/security/data-security), your app server must support SHA-2 (256-bit). SHA-1 is not supported.
-
 ## Ruby versions [#ruby_versions]
-
 The New Relic Ruby agent does not support experimental versions. Ruby versions supported by the Ruby agent include:
-
 <table>
   <thead>
     <tr>
       <th style={{ width: "150px" }}>
         Ruby versions
       </th>
-
       <th style={{ width: "150px" }}>
         Supported
       </th>
-
       <th>
         Deprecated
       </th>
     </tr>
   </thead>
-
   <tbody>
     <tr>
       <td>
         JRuby
       </td>
-
       <td>
         * 9.0.x
         * 9.1.x
         * 9.2.x
         * 9.3.x
       </td>
-
       <td>
         * 1.7.x or earlier: Last supported agent was 3.18.1.330.
       </td>
     </tr>
-
     <tr>
       <td>
         CRuby
       </td>
-
       <td>
         * ~~1.8.7~~
         * ~~1.9.x~~
@@ -88,7 +72,6 @@ The New Relic Ruby agent does not support experimental versions. Ruby versions s
         * 3.1.x
         * 3.2.x
       </td>
-
       <td>
         * 2.0.x, 2.1.x Last supported agent: 6.15.0.
         * 1.8.7, 1.9.2, 1.9.3: Last supported agent was 3.18.1.330.
@@ -97,38 +80,30 @@ The New Relic Ruby agent does not support experimental versions. Ruby versions s
     </tr>
   </tbody>
 </table>
-
 ## Web servers [#web_servers]
-
 Web servers supported by the Ruby agent include:
-
 <table>
   <thead>
     <tr>
       <th style={{ width: "150px" }}>
         Web servers
       </th>
-
       <th>
         Supported
       </th>
-
       <th style={{ width: "150px" }}>
         Deprecated
       </th>
-
       <th style={{ width: "150px" }}>
         Experimental
       </th>
     </tr>
   </thead>
-
   <tbody>
     <tr>
       <td>
         Passenger
       </td>
-
       <td>
         * 2.2.x - Deprecated
         * 3.0.x - Deprecated
@@ -136,13 +111,13 @@ Web servers supported by the Ruby agent include:
         * 5.x.x
         * 6.0.x
       </td>
+      <td/>
+      <td/>
     </tr>
-
     <tr>
       <td>
         Puma
       </td>
-
       <td>
         * 2.0.x - Deprecated
         * 3.x.x
@@ -150,17 +125,15 @@ Web servers supported by the Ruby agent include:
         * 5.x.x
         * 6.x.x
       </td>
-
       <td>
         * 1.0.x
       </td>
+      <td/>
     </tr>
-
     <tr>
       <td>
         Rainbows!
       </td>
-
       <td>
         * ~~4.5.0~~
       </td>
@@ -168,80 +141,67 @@ Web servers supported by the Ruby agent include:
       <td>
         *  4.5.0: Last supported agent was 8.16.0.
       </td>
-
+      <td/>
     </tr>
-
     <tr>
       <td>
         Thin
       </td>
-
       <td>
         * 1.x.x
       </td>
+      <td/>
+      <td/>
     </tr>
-
     <tr>
       <td>
         Unicorn
       </td>
-
       <td>
         * 4.x.x
         * 5.x.x
         * 6.0.x
       </td>
-
       <td>
         * 1.0.x
         * 2.0.x
         * 3.0.x
       </td>
-
-      
+      <td/>
     </tr>
-
     <tr>
       <td>
         Webrick
       </td>
-
       <td>
         Supported for all agent-supported versions of Ruby
       </td>
-
-    
+      <td/>
+      <td/>
     </tr>
   </tbody>
 </table>
-
 ## Web frameworks [#web_frameworks]
-
 The Ruby agent does not support experimental versions. Web frameworks supported by the Ruby agent are listed below. Please note that Grape, Padrino, and Sinatra are not supported for Ruby 3.0+.
-
 <table>
   <thead>
     <tr>
       <th style={{ width: "150px" }}>
         Web frameworks
       </th>
-
       <th style={{ width: "200px" }}>
         Supported
       </th>
-
       <th>
         Deprecated
       </th>
     </tr>
   </thead>
-
   <tbody>
     <tr>
       <td>
         Grape
       </td>
-
       <td>
         * 0.2.0 - Deprecated
         * 0.19.2
@@ -252,45 +212,36 @@ The Ruby agent does not support experimental versions. Web frameworks supported 
         * 1.6.x
         * 1.7.x
       </td>
-
       <td/>
     </tr>
-
     <tr>
       <td>
         Padrino
       </td>
-
       <td>
         * 0.14.x - Deprecated
         * 0.15.1
         * 0.15.2
       </td>
-
       <td/>
     </tr>
-
     <tr>
       <td>
         Rack
       </td>
-
       <td>
         * 1.6.x
         * 2.x
         * 3.0.x
       </td>
-
       <td>
         * 1.0.x
       </td>
     </tr>
-
     <tr>
       <td>
         Rails
       </td>
-
       <td>
         * 3.2.x - Deprecated
         * 4.0.x
@@ -303,19 +254,16 @@ The Ruby agent does not support experimental versions. Web frameworks supported 
         * 6.1.x
         * 7.0.x
       </td>
-
       <td>
         * 2.1.x, 2.2.x, 2.3.x: Last supported agent was 3.18.1.330.
         * 2.0.x: Last supported agent was 3.6.8.168.
         * 3.0.x, 3.1.x: Last supported agent was 6.15.0.
       </td>
     </tr>
-
     <tr>
       <td>
         Sinatra
       </td>
-
       <td>
         * 1.4.x - Deprecated
         * 1.5.x - Deprecated
@@ -323,41 +271,33 @@ The Ruby agent does not support experimental versions. Web frameworks supported 
         * 2.1.x
         * 3.0.x
       </td>
-
       <td>
         * 1.2.x, 1.3.x: Last supported in agent version 6.15.0
       </td>
     </tr>
   </tbody>
 </table>
-
 ## Databases
-
 The Ruby agent does not support experimental versions. Databases supported by the Ruby agent include:
-
 <table>
   <thead>
     <tr>
       <th style={{ width: "150px" }}>
         Databases
       </th>
-
       <th style={{ width: "150px" }}>
         Supported
       </th>
-
       <th>
         Deprecated
       </th>
     </tr>
   </thead>
-
   <tbody>
     <tr>
       <td>
         ActiveRecord
       </td>
-
       <td>
         * 3.2.x
         * 4.0.x
@@ -370,19 +310,16 @@ The Ruby agent does not support experimental versions. Databases supported by th
         * 6.1.x
         * 7.0.x
       </td>
-
       <td>
         * 3.0.x, 3.1.x: Last supported in agent version 6.15.0.
         * 2.1.x, 2.2.x, 2.3.x: Last supported agent was 3.18.1.330.
         * 2.0.x Last supported agent was 3.6.8.168.
       </td>
     </tr>
-
     <tr>
       <td>
         DataMapper
       </td>
-
       <td>
         * ~~1.0~~
       </td>
@@ -390,28 +327,22 @@ The Ruby agent does not support experimental versions. Databases supported by th
       <td>
         * 1.0.x: Last supported agent: 8.16.0.
       </td>
-
       <td/>
     </tr>
-
     <tr>
       <td>
         Elasticsearch
       </td>
-
       <td>
         * 7.x
         * 8.x
       </td>
-
       <td/>
     </tr>
-
     <tr>
       <td>
         Mongo
       </td>
-
       <td>
         * 1.8.x or higher - Deprecated
         * 1.9.x - Deprecated
@@ -421,15 +352,12 @@ The Ruby agent does not support experimental versions. Databases supported by th
         * 2.3.x - Deprecated
         * 2.4.x or higher
       </td>
-
       <td/>
     </tr>
-
     <tr>
       <td>
         Redis
       </td>
-
       <td>
         * 3.x
         * 4.0.x
@@ -437,272 +365,213 @@ The Ruby agent does not support experimental versions. Databases supported by th
         * 4.2.x
         * 5.0.x
       </td>
-
       <td/>
     </tr>
-
     <tr>
       <td>
         Sequel
       </td>
-
       <td>
         * 3.37.x - Deprecated
         * 4.0.x - Deprecated
         * 4.45.x or higher
         * 5.x.x
       </td>
-
       <td/>
     </tr>
   </tbody>
 </table>
-
 ## Other APM software [#other-monitoring-software]
-
 If your application uses other application performance monitoring (APM) software besides our agent, we cannot guarantee that our agent will work correctly and we cannot offer technical support. For more information, see [Errors when using other monitoring software](/docs/apm/new-relic-apm/troubleshooting/errors-while-using-new-relic-apm-alongside-other-apm-software).
-
 ## Instance details [#instance_details]
-
 New Relic collects [instance details for a variety of databases and database drivers](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues). The ability to view specific instances and the types of database information in APM depends on your New Relic agent version.
-
 New Relic's Ruby agent [version 3.17.0 or higher](/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-3170325) supports the following ORM databases:
-
 <table>
   <thead>
     <tr>
       <th>
         ORM
       </th>
-
       <th>
         Database
       </th>
-
       <th>
         Adapter name
       </th>
-
       <th>
         Minimum agent version
       </th>
     </tr>
   </thead>
-
   <tbody>
     <tr>
       <td rowSpan={2}>
         ActiveRecord 5 or higher
       </td>
-
       <td>
         [PostgreSQL](https://www.postgresql.org/)
       </td>
-
       <td>
         [pg](https://rubygems.org/gems/pg)
       </td>
-
       <td>
         3.17.0
       </td>
     </tr>
-
     <tr>
       <td>
         [MySQL](https://www.mysql.com/)
       </td>
-
       <td>
         [mysql2](https://rubygems.org/gems/mysql2)
       </td>
-
       <td>
         3.17.0
       </td>
     </tr>
-
     <tr>
       <td rowSpan={3}>
         ActiveRecord 2.1 to 4
       </td>
-
       <td>
         [PostgreSQL](https://www.postgresql.org/)
       </td>
-
       <td>
         [pg](https://rubygems.org/gems/pg)
       </td>
-
       <td>
         3.17.0
       </td>
     </tr>
-
     <tr>
       <td>
         [MySQL](https://www.mysql.com/)
       </td>
-
       <td>
         [mysql](https://rubygems.org/gems/mysql)
       </td>
-
       <td>
         3.17.0
       </td>
     </tr>
-
     <tr>
       <td>
         [MySQL](https://www.mysql.com/)
       </td>
-
       <td>
         [mysql2](https://rubygems.org/gems/mysql2)
       </td>
-
       <td>
         3.17.0
       </td>
     </tr>
   </tbody>
 </table>
-
 The Ruby agent also supports these `gem` databases:
-
 <table>
   <thead>
     <tr>
       <th>
         Gem database
       </th>
-
       <th>
         Gem name
       </th>
-
       <th>
         Minimum gem version
       </th>
-
       <th>
         Minimum agent version
       </th>
     </tr>
   </thead>
-
   <tbody>
     <tr>
       <td>
         [Memcached](https://memcached.org/)
       </td>
-
       <td>
         * [Dalli](https://rubygems.org/gems/dalli)
         * [memcached](https://rubygems.org/gems/memcached)
         * [memcache-client](https://rubygems.org/gems/memcache-client)
       </td>
-
       <td>
         * 2.7.6
         * 1.8.0
         * 1.5.0
       </td>
-
       <td>
         3.17.0
       </td>
     </tr>
-
     <tr>
       <td>
         [Mongo DB](https://www.mongodb.com/)
       </td>
-
       <td>
         [mongo](https://rubygems.org/gems/mongo)
       </td>
-
       <td>
         1.8.6
       </td>
-
       <td>
         3.17.0
       </td>
     </tr>
-
     <tr>
       <td>
         [Redis](http://redis.io/)
       </td>
-
       <td>
         [redis-rb](https://rubygems.org/gems/redis)
       </td>
-
       <td>
         3.0.7
       </td>
-
       <td>
         3.17.0
       </td>
     </tr>
   </tbody>
 </table>
-
 To request instance-level information from datastores currently not listed for your New Relic agent, get support at [support.newrelic.com](https://support.newrelic.com).
-
 ## Background jobs [#background_jobs]
-
 Background jobs supported by the New Relic Ruby agent include:
-
 <table>
   <thead>
     <tr>
       <th>
         Background jobs
       </th>
-
       <th>
         Supported
       </th>
-
       <th>
         Deprecated
       </th>
     </tr>
   </thead>
-
   <tbody>
     <tr>
       <td>
         Delayed_Job
       </td>
-
       <td>
         * 2.0.x - Deprecated
         * 3.0.x - Deprecated
         * 4.0.x - Deprecated
         * 4.1.x
       </td>
-
       <td/>
     </tr>
-
     <tr>
       <td>
         Rake
       </td>
-
       <td>
         * 12.3.3 or higher
         * 13.x
       </td>
-
       <td>
         * 10.x
         * 11.x
@@ -710,46 +579,37 @@ Background jobs supported by the New Relic Ruby agent include:
           NOTE: Only 12.3.3 or higher tested due to [exploit potential](https://hackerone.com/reports/651518) in earlier versions.
       </td>
     </tr>
-
     <tr>
       <td>
         Resque
       </td>
-
       <td>
         * 1.23.x
         * 1.27.x
         * 2.0.0 or higher
       </td>
-
       <td>
         * 1.22.x and earlier
       </td>
     </tr>
-
     <tr>
       <td>
         Sidekiq
       </td>
-
       <td>
         * 4.2.x - Deprecated
         * 5.x
         * 6.x
         * 7.0.x
       </td>
-
       <td>
         * 2.8.x, 3.4.x, 4.0.x, and 4.1.x: Last supported in agent version 6.15.0
       </td>
     </tr>
   </tbody>
 </table>
-
 ## HTTP / network clients [#http_network_clients]
-
 HTTP clients supported by the Ruby agent include:
-
 * Curb: 0.8.1 or higher
 * Excon: 0.19.0 or higher (Versions lower than 0.55.0 are deprecated)
 * gRPC: 1.0.0 or higher
@@ -757,22 +617,13 @@ HTTP clients supported by the Ruby agent include:
 * HttpRb: 0.9.9 or higher (Versions 0.9.9 - 2.2.1 are deprecated)
 * Net::HTTP&#x3A; Supported for all [agent-supported versions](/docs/agents/ruby-agent/features/http-client-tracing-ruby) of Ruby.
 * Typhoeus: 0.5.3 or higher (Versions 0.5.3 - 1.2.x are deprecated)
-
 ## Message queuing [#http_clients]
-
 [Message queue instrumentation](/docs/agents/ruby-agent/features/message-queues) is only available with the [Ruby agent version 4.3.0 or higher](/docs/release-notes/agent-release-notes/ruby-release-notes). Currently supported message brokers:
-
 * RabbitMQ
-
 Currently supported gems that facilitate message brokers:
-
 * [Bunny](/docs/agents/ruby-agent/features/message-queues): 2.0 or higher (Versions 2.0.x - 2.6.x are Deprecated)
-
-
 ## Other
-
 APM's Ruby agent also supports:
-
 * ActiveMerchant: 1.25.0 or higher (Versions 1.25.0 - 1.64.x are Deprecated)
 * Acts_as_Solr: Last supported in agent version 8.16.0
 * authlogic: Last supported in agent version 8.16.0
@@ -780,50 +631,40 @@ APM's Ruby agent also supports:
 * Sunspot: Last supported in agent version 8.16.0
 * Tilt: 2.x for Ruby 2.2 or higher; 1.x for Ruby 2.7 or lower
 * Yajl-Ruby: 1.1.0 or higher
-
 ## Connect the agent to other parts of New Relic [#digital-intelligence-platform]
-
 The Ruby agent integrates with other New Relic capabilities to give you end-to-end visibility.
-
 <table>
   <thead>
     <tr>
       <th style={{ width: "200px" }}>
         Capability
       </th>
-
       <th>
         Integration
       </th>
     </tr>
   </thead>
-
   <tbody>
     <tr>
       <td>
         [Browser monitoring](/docs/browser/new-relic-browser/getting-started/introduction-browser-monitoring)
       </td>
-
       <td>
         The Ruby agent automatically injects the browser JavaScript agent when you [enable auto-instrumentation](/docs/browser/new-relic-browser/installation/install-browser-monitoring-agent#select-apm-app). After enabling browser injection, you can view browser data in the [APM Summary page](/docs/apm/applications-menu/monitoring/apm-overview-page-view-transaction-apdex-usage-data) and quickly switch between the APM and browser data for a particular app. For configuration options and manual instrumentation, see the [browser and Ruby agent documentation](/docs/agents/ruby-agent/features/new-relic-browser-ruby-agent).
       </td>
     </tr>
-
     <tr>
       <td>
         [Infrastructure monitoring](/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring)
       </td>
-
       <td>
         When you install the Infrastructure and APM agents on the same host, they automatically detect one another. You can then view a list of hosts in the APM UI, and filter your Infrastructure hosts by APM app in the Infrastructure UI. For more information, see [APM data in infrastructure monitoring](/docs/infrastructure/new-relic-infrastructure/data-instrumentation/new-relic-apm-data-infrastructure).
       </td>
     </tr>
-
     <tr>
       <td>
         [Synthetic monitoring](/docs/synthetics/synthetic-monitoring/getting-started/get-started-new-relic-synthetic-monitoring)
       </td>
-
       <td>
         [Synthetic transaction traces](/docs/synthetics/synthetic-monitoring/using-monitors/collect-synthetic-transaction-traces) connect requests from synthetic monitors to the underlying APM transaction.
       </td>

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -168,11 +168,11 @@ Web servers supported by the Ruby agent include:
       </td>
 
       <td/>
-
+        * ~~4.5.0~~
       <td/>
 
       <td>
-        * 4.5.0 - Deprecated
+        *  4.5.0: Last supported agent was 8.16.0.
       </td>
     </tr>
 
@@ -395,7 +395,11 @@ The Ruby agent does not support experimental versions. Databases supported by th
       </td>
 
       <td>
-        * 1.0 - Deprecated
+        * ~~1.0~~
+      </td>
+      
+      <td>
+        * 1.0.x: Last supported agent: 8.16.0.
       </td>
 
       <td/>
@@ -781,10 +785,10 @@ Currently supported gems that facilitate message brokers:
 APM's Ruby agent also supports:
 
 * ActiveMerchant: 1.25.0 or higher (Versions 1.25.0 - 1.64.x are Deprecated)
-* Acts_as_Solr: Deprecated
-* authlogic: Deprecated
+* Acts_as_Solr: Last supported in agent version 8.16.0
+* authlogic: Last supported in agent version 8.16.0
 * concurrent-ruby: 1.1.5 or higher
-* Sunspot: Deprecated
+* Sunspot: Last supported in agent version 8.16.0
 * Tilt: 2.x for Ruby 2.2 or higher; 1.x for Ruby 2.7 or lower
 * Yajl-Ruby: 1.1.0 or higher
 


### PR DESCRIPTION
This PR updates our support for gems that we will no longer instrument with the release of Ruby agent 9.0.0
 
**Note: Please do not merge until a member of the Ruby team reaches out.**