### PR TITLE
docs: Change curl command destination

### DIFF
--- a/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
@@ -55,7 +55,7 @@ The endpoint depends on your [data center region](/docs/accounts/accounts-billin
 To access the endpoint, you can use our [NerdGraph explorer](#explorer), or you can access it directly with a curl command similar to this:
 
 ```
-curl -X POST https://api.newrelic.com/graphiql \
+curl -X POST https://api.newrelic.com/graphql \
 -H 'Content-Type: application/json' \
 -H 'API-Key: YOUR_NEW_RELIC_USER_KEY' \
 -d '{ "query":  "{ requestContext { userId apiKey } }" } '


### PR DESCRIPTION
Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* Running the curl command with `https://api.newrelic.com/graphiql` does not work.
* Changing from `https://api.newrelic.com/graphiql` to `https://api.newrelic.com/graphql` works. Verified on my own terminal.