### PR TITLE
fix(PHP agent): Add Codestream/CLM to compat page

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -27,7 +27,7 @@ New Relic supports PHP versions 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, and 8.1.
   Support for PHP 8.1 does not include Fibers.
 </Callout>
 
-* We recommend using a [supported release](http://php.net/supported-versions.php) of PHP, especially 7.4, 8.0, and 8.1.
+* We recommend using a [supported release](http://php.net/supported-versions.php) of PHP.
 * Release [9.19](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9190309) was the last release to support ZTS builds.
 
 ## Permissions [#permissions]
@@ -430,6 +430,10 @@ To disable collection of host information, use either of these options:
 
 To request instance-level information from datastores currently not listed for your New Relic agent, get support at [support.newrelic.com](https://support.newrelic.com).
 
+## Codesteam/Code-level metrics
+
+The PHP agent supports code-level metrics for PHP releases 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, and 8.1.
+
 ## Logs In Context [#logging]
 
 The PHP agent supports APM [logs in context](/docs/logs/logs-context/configure-logs-context-php/) for the following libraries:
@@ -470,6 +474,19 @@ The PHP agent integrates with other New Relic features to give you end-to-end vi
 
       <td>
         The PHP agent automatically injects the browser agent's JS code when you [enable auto-instrumentation](/docs/browser/new-relic-browser/installation/install-new-relic-browser-agent#select-apm-app). After enabling browser injection, you can view data in the [APM **Summary** page](/docs/apm/applications-menu/monitoring/apm-overview-page) and quickly switch between the APM and browser data for a particular app. For configuration options and manual instrumentation, see [Browser monitoring and the PHP agent](/docs/agents/php-agent/features/page-load-timing-php).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [Codestream/Code-level metrics](/docs/codestream/how-use-codestream/performance-monitoring/)
+      </td>
+
+      <td>
+        New Relic CodeStream allows developers to see how the code they're responsible for is performing in production
+        by bringing observability into the IDE and making it part of their daily routine.
+        The PHP agent reports code-level metrics (starting with release 10.4.0) on your application which enables
+        detailed insight into how your code is performing at the method level.
       </td>
     </tr>
 


### PR DESCRIPTION
Updates to the PHP agent compatibility page clarifying Codestream/CLM support as well as recommended PHP versions.